### PR TITLE
fix.修复某些情况下肉鸽选人希望不够的情况

### DIFF
--- a/resource/combat_recruit.json
+++ b/resource/combat_recruit.json
@@ -1,0 +1,1416 @@
+{
+    "Lancet-2": {
+        "level": 1,
+        "profession": "MEDIC",
+        "subProfession": "physician",
+        "position": "RANGED"
+    },
+    "Castle-3": {
+        "level": 1,
+        "profession": "WARRIOR",
+        "subProfession": "fearless",
+        "position": "MELEE"
+    },
+    "THRM-EX": {
+        "level": 1,
+        "profession": "SPECIAL",
+        "subProfession": "executor",
+        "position": "MELEE"
+    },
+    "正义骑士号": {
+        "level": 1,
+        "profession": "SNIPER",
+        "subProfession": "fastshot",
+        "position": "RANGED"
+    },
+    "夜刀": {
+        "level": 2,
+        "profession": "PIONEER",
+        "subProfession": "pioneer",
+        "position": "MELEE"
+    },
+    "黑角": {
+        "level": 2,
+        "profession": "TANK",
+        "subProfession": "protector",
+        "position": "MELEE"
+    },
+    "巡林者": {
+        "level": 2,
+        "profession": "SNIPER",
+        "subProfession": "fastshot",
+        "position": "RANGED"
+    },
+    "杜林": {
+        "level": 2,
+        "profession": "CASTER",
+        "subProfession": "corecaster",
+        "position": "RANGED"
+    },
+    "12F": {
+        "level": 2,
+        "profession": "CASTER",
+        "subProfession": "splashcaster",
+        "position": "RANGED"
+    },
+    "芬": {
+        "level": 3,
+        "profession": "PIONEER",
+        "subProfession": "pioneer",
+        "position": "MELEE"
+    },
+    "香草": {
+        "level": 3,
+        "profession": "PIONEER",
+        "subProfession": "pioneer",
+        "position": "MELEE"
+    },
+    "预备干员-近战": {
+        "level": 3,
+        "profession": "PIONEER",
+        "subProfession": "pioneer",
+        "position": "MELEE"
+    },
+    "预备干员": {
+        "Doc": "事实上没有叫这个名字的干员，但为了避免肉鸽中，requires设置了但找不到的问题，增设这个干员。",
+        "level": 3
+    },
+    "翎羽": {
+        "level": 3,
+        "profession": "PIONEER",
+        "subProfession": "charger",
+        "position": "MELEE"
+    },
+    "玫兰莎": {
+        "level": 3,
+        "profession": "WARRIOR",
+        "subProfession": "fearless",
+        "position": "MELEE"
+    },
+    "泡普卡": {
+        "level": 3,
+        "profession": "WARRIOR",
+        "subProfession": "centurion",
+        "position": "MELEE"
+    },
+    "卡缇": {
+        "level": 3,
+        "profession": "TANK",
+        "subProfession": "protector",
+        "position": "MELEE"
+    },
+    "米格鲁": {
+        "level": 3,
+        "profession": "TANK",
+        "subProfession": "protector",
+        "position": "MELEE"
+    },
+    "斑点": {
+        "level": 3,
+        "profession": "TANK",
+        "subProfession": "guardian",
+        "position": "MELEE"
+    },
+    "克洛丝": {
+        "level": 3,
+        "profession": "SNIPER",
+        "subProfession": "fastshot",
+        "position": "RANGED"
+    },
+    "安德切尔": {
+        "level": 3,
+        "profession": "SNIPER",
+        "subProfession": "fastshot",
+        "position": "RANGED"
+    },
+    "预备干员-狙击": {
+        "level": 3,
+        "profession": "SNIPER",
+        "subProfession": "fastshot",
+        "position": "RANGED"
+    },
+    "炎熔": {
+        "level": 3,
+        "profession": "CASTER",
+        "subProfession": "splashcaster",
+        "position": "RANGED"
+    },
+    "芙蓉": {
+        "level": 3,
+        "profession": "MEDIC",
+        "subProfession": "physician",
+        "position": "RANGED"
+    },
+    "安赛尔": {
+        "level": 3,
+        "profession": "MEDIC",
+        "subProfession": "physician",
+        "position": "RANGED"
+    },
+    "预备干员-后勤": {
+        "level": 3,
+        "profession": "MEDIC",
+        "subProfession": "physician",
+        "position": "RANGED"
+    },
+    "史都华德": {
+        "level": 3,
+        "profession": "CASTER",
+        "subProfession": "corecaster",
+        "position": "RANGED"
+    },
+    "预备干员-术师": {
+        "level": 3,
+        "profession": "CASTER",
+        "subProfession": "corecaster",
+        "position": "RANGED"
+    },
+    "梓兰": {
+        "level": 3,
+        "profession": "SUPPORT",
+        "subProfession": "slower",
+        "position": "RANGED"
+    },
+    "夜烟": {
+        "level": 4,
+        "profession": "CASTER",
+        "subProfession": "corecaster",
+        "position": "RANGED"
+    },
+    "远山": {
+        "level": 4,
+        "profession": "CASTER",
+        "subProfession": "splashcaster",
+        "position": "RANGED"
+    },
+    "格雷伊": {
+        "level": 4,
+        "profession": "CASTER",
+        "subProfession": "splashcaster",
+        "position": "RANGED"
+    },
+    "卡达": {
+        "level": 4,
+        "profession": "CASTER",
+        "subProfession": "funnel",
+        "position": "RANGED"
+    },
+    "深靛": {
+        "level": 4,
+        "profession": "CASTER",
+        "subProfession": "mystic",
+        "position": "RANGED"
+    },
+    "布丁": {
+        "level": 4,
+        "profession": "CASTER",
+        "subProfession": "chain",
+        "position": "RANGED"
+    },
+    "杰西卡": {
+        "level": 4,
+        "profession": "SNIPER",
+        "subProfession": "fastshot",
+        "position": "RANGED"
+    },
+    "流星": {
+        "level": 4,
+        "profession": "SNIPER",
+        "subProfession": "fastshot",
+        "position": "RANGED"
+    },
+    "红云": {
+        "level": 4,
+        "profession": "SNIPER",
+        "subProfession": "fastshot",
+        "position": "RANGED"
+    },
+    "梅": {
+        "level": 4,
+        "profession": "SNIPER",
+        "subProfession": "fastshot",
+        "position": "RANGED"
+    },
+    "白雪": {
+        "level": 4,
+        "profession": "SNIPER",
+        "subProfession": "aoesniper",
+        "position": "RANGED"
+    },
+    "松果": {
+        "level": 4,
+        "profession": "SNIPER",
+        "subProfession": "reaperrange",
+        "position": "RANGED"
+    },
+    "安比尔": {
+        "level": 4,
+        "profession": "SNIPER",
+        "subProfession": "longrange",
+        "position": "RANGED"
+    },
+    "酸糖": {
+        "level": 4,
+        "profession": "SNIPER",
+        "subProfession": "closerange",
+        "position": "RANGED"
+    },
+    "讯使": {
+        "level": 4,
+        "profession": "PIONEER",
+        "subProfession": "pioneer",
+        "position": "MELEE"
+    },
+    "清道夫": {
+        "level": 4,
+        "profession": "PIONEER",
+        "subProfession": "pioneer",
+        "position": "MELEE"
+    },
+    "红豆": {
+        "level": 4,
+        "profession": "PIONEER",
+        "subProfession": "charger",
+        "position": "MELEE"
+    },
+    "桃金娘": {
+        "level": 4,
+        "profession": "PIONEER",
+        "subProfession": "bearer",
+        "position": "MELEE"
+    },
+    "豆苗": {
+        "level": 4,
+        "profession": "PIONEER",
+        "subProfession": "tactician",
+        "position": "RANGED"
+    },
+    "杜宾": {
+        "level": 4,
+        "profession": "WARRIOR",
+        "subProfession": "instructor",
+        "position": "MELEE"
+    },
+    "缠丸": {
+        "level": 4,
+        "profession": "WARRIOR",
+        "subProfession": "fearless",
+        "position": "MELEE"
+    },
+    "霜叶": {
+        "level": 4,
+        "profession": "WARRIOR",
+        "subProfession": "lord",
+        "position": "MELEE"
+    },
+    "艾丝黛尔": {
+        "level": 4,
+        "profession": "WARRIOR",
+        "subProfession": "centurion",
+        "position": "MELEE"
+    },
+    "慕斯": {
+        "level": 4,
+        "profession": "WARRIOR",
+        "subProfession": "artsfghter",
+        "position": "MELEE"
+    },
+    "刻刀": {
+        "level": 4,
+        "profession": "WARRIOR",
+        "subProfession": "sword",
+        "position": "MELEE"
+    },
+    "宴": {
+        "level": 4,
+        "profession": "WARRIOR",
+        "subProfession": "musha",
+        "position": "MELEE"
+    },
+    "芳汀": {
+        "level": 4,
+        "profession": "WARRIOR",
+        "subProfession": "lord",
+        "position": "MELEE"
+    },
+    "砾": {
+        "level": 4,
+        "profession": "SPECIAL",
+        "subProfession": "executor",
+        "position": "MELEE"
+    },
+    "孑": {
+        "level": 4,
+        "profession": "SPECIAL",
+        "subProfession": "merchant",
+        "position": "MELEE"
+    },
+    "暗索": {
+        "level": 4,
+        "profession": "SPECIAL",
+        "subProfession": "hookmaster",
+        "position": "MELEE"
+    },
+    "末药": {
+        "level": 4,
+        "profession": "MEDIC",
+        "subProfession": "physician",
+        "position": "RANGED"
+    },
+    "嘉维尔": {
+        "level": 4,
+        "profession": "MEDIC",
+        "subProfession": "physician",
+        "position": "RANGED"
+    },
+    "苏苏洛": {
+        "level": 4,
+        "profession": "MEDIC",
+        "subProfession": "physician",
+        "position": "RANGED"
+    },
+    "调香师": {
+        "level": 4,
+        "profession": "MEDIC",
+        "subProfession": "ringhealer",
+        "position": "RANGED"
+    },
+    "清流": {
+        "level": 4,
+        "profession": "MEDIC",
+        "subProfession": "healer",
+        "position": "RANGED"
+    },
+    "角峰": {
+        "level": 4,
+        "profession": "TANK",
+        "subProfession": "protector",
+        "position": "MELEE"
+    },
+    "蛇屠箱": {
+        "level": 4,
+        "profession": "TANK",
+        "subProfession": "protector",
+        "position": "MELEE"
+    },
+    "泡泡": {
+        "level": 4,
+        "profession": "TANK",
+        "subProfession": "protector",
+        "position": "MELEE"
+    },
+    "古米": {
+        "level": 4,
+        "profession": "TANK",
+        "subProfession": "guardian",
+        "position": "MELEE"
+    },
+    "坚雷": {
+        "level": 4,
+        "profession": "TANK",
+        "subProfession": "artsprotector",
+        "position": "MELEE"
+    },
+    "深海色": {
+        "level": 4,
+        "profession": "SUPPORT",
+        "subProfession": "summoner",
+        "position": "RANGED"
+    },
+    "地灵": {
+        "level": 4,
+        "profession": "SUPPORT",
+        "subProfession": "slower",
+        "position": "RANGED"
+    },
+    "波登可": {
+        "level": 4,
+        "profession": "SUPPORT",
+        "subProfession": "slower",
+        "position": "RANGED"
+    },
+    "罗比菈塔": {
+        "level": 4,
+        "profession": "SUPPORT",
+        "subProfession": "craftsman",
+        "position": "MELEE"
+    },
+    "伊桑": {
+        "level": 4,
+        "profession": "SPECIAL",
+        "subProfession": "stalker",
+        "position": "MELEE"
+    },
+    "阿消": {
+        "level": 4,
+        "profession": "SPECIAL",
+        "subProfession": "pusher",
+        "position": "MELEE"
+    },
+    "白面鸮": {
+        "level": 5,
+        "profession": "MEDIC",
+        "subProfession": "ringhealer",
+        "position": "RANGED"
+    },
+    "微风": {
+        "level": 5,
+        "profession": "MEDIC",
+        "subProfession": "ringhealer",
+        "position": "RANGED"
+    },
+    "凛冬": {
+        "level": 5,
+        "profession": "PIONEER",
+        "subProfession": "pioneer",
+        "position": "MELEE"
+    },
+    "德克萨斯": {
+        "level": 5,
+        "profession": "PIONEER",
+        "subProfession": "pioneer",
+        "position": "MELEE"
+    },
+    "贾维": {
+        "level": 5,
+        "profession": "PIONEER",
+        "subProfession": "pioneer",
+        "position": "MELEE"
+    },
+    "苇草": {
+        "level": 5,
+        "profession": "PIONEER",
+        "subProfession": "charger",
+        "position": "MELEE"
+    },
+    "野鬃": {
+        "level": 5,
+        "profession": "PIONEER",
+        "subProfession": "charger",
+        "position": "MELEE"
+    },
+    "极境": {
+        "level": 5,
+        "profession": "PIONEER",
+        "subProfession": "bearer",
+        "position": "MELEE"
+    },
+    "夜半": {
+        "level": 5,
+        "profession": "PIONEER",
+        "subProfession": "tactician",
+        "position": "RANGED"
+    },
+    "诗怀雅": {
+        "level": 5,
+        "profession": "WARRIOR",
+        "subProfession": "instructor",
+        "position": "MELEE"
+    },
+    "鞭刃": {
+        "level": 5,
+        "profession": "WARRIOR",
+        "subProfession": "instructor",
+        "position": "MELEE"
+    },
+    "芙兰卡": {
+        "level": 5,
+        "profession": "WARRIOR",
+        "subProfession": "fearless",
+        "position": "MELEE"
+    },
+    "炎客": {
+        "level": 5,
+        "profession": "WARRIOR",
+        "subProfession": "fearless",
+        "position": "MELEE"
+    },
+    "Sharp": {
+        "level": 5,
+        "profession": "WARRIOR",
+        "subProfession": "fearless",
+        "position": "MELEE"
+    },
+    "因陀罗": {
+        "level": 5,
+        "profession": "WARRIOR",
+        "subProfession": "fighter",
+        "position": "MELEE"
+    },
+    "燧石": {
+        "level": 5,
+        "profession": "WARRIOR",
+        "subProfession": "fighter",
+        "position": "MELEE"
+    },
+    "拉普兰德": {
+        "level": 5,
+        "profession": "WARRIOR",
+        "subProfession": "lord",
+        "position": "MELEE"
+    },
+    "断崖": {
+        "level": 5,
+        "profession": "WARRIOR",
+        "subProfession": "lord",
+        "position": "MELEE"
+    },
+    "柏喙": {
+        "level": 5,
+        "profession": "WARRIOR",
+        "subProfession": "sword",
+        "position": "MELEE"
+    },
+    "战车": {
+        "level": 5,
+        "profession": "WARRIOR",
+        "subProfession": "sword",
+        "position": "MELEE"
+    },
+    "幽灵鲨": {
+        "level": 5,
+        "profession": "WARRIOR",
+        "subProfession": "centurion",
+        "position": "MELEE"
+    },
+    "布洛卡": {
+        "level": 5,
+        "profession": "WARRIOR",
+        "subProfession": "centurion",
+        "position": "MELEE"
+    },
+    "星极": {
+        "level": 5,
+        "profession": "WARRIOR",
+        "subProfession": "artsfghter",
+        "position": "MELEE"
+    },
+    "铸铁": {
+        "level": 5,
+        "profession": "WARRIOR",
+        "subProfession": "artsfghter",
+        "position": "MELEE"
+    },
+    "赤冬": {
+        "level": 5,
+        "profession": "WARRIOR",
+        "subProfession": "musha",
+        "position": "MELEE"
+    },
+    "羽毛笔": {
+        "level": 5,
+        "profession": "WARRIOR",
+        "subProfession": "reaper",
+        "position": "MELEE"
+    },
+    "龙舌兰": {
+        "level": 5,
+        "profession": "WARRIOR",
+        "subProfession": "librator",
+        "position": "MELEE"
+    },
+    "蓝毒": {
+        "level": 5,
+        "profession": "SNIPER",
+        "subProfession": "fastshot",
+        "position": "RANGED"
+    },
+    "白金": {
+        "level": 5,
+        "profession": "SNIPER",
+        "subProfession": "fastshot",
+        "position": "RANGED"
+    },
+    "灰喉": {
+        "level": 5,
+        "profession": "SNIPER",
+        "subProfession": "fastshot",
+        "position": "RANGED"
+    },
+    "Stormeye": {
+        "level": 5,
+        "profession": "SNIPER",
+        "subProfession": "fastshot",
+        "position": "RANGED"
+    },
+    "四月": {
+        "level": 5,
+        "profession": "SNIPER",
+        "subProfession": "fastshot",
+        "position": "RANGED"
+    },
+    "寒芒克洛丝": {
+        "level": 5,
+        "profession": "SNIPER",
+        "subProfession": "fastshot",
+        "position": "RANGED"
+    },
+    "陨星": {
+        "level": 5,
+        "profession": "SNIPER",
+        "subProfession": "aoesniper",
+        "position": "RANGED"
+    },
+    "慑砂": {
+        "level": 5,
+        "profession": "SNIPER",
+        "subProfession": "aoesniper",
+        "position": "RANGED"
+    },
+    "送葬人": {
+        "level": 5,
+        "profession": "SNIPER",
+        "subProfession": "reaperrange",
+        "position": "RANGED"
+    },
+    "奥斯塔": {
+        "level": 5,
+        "profession": "SNIPER",
+        "subProfession": "reaperrange",
+        "position": "RANGED"
+    },
+    "阿米娅": {
+        "level": 5,
+        "profession": "CASTER",
+        "subProfession": "corecaster",
+        "position": "RANGED"
+    },
+    "苦艾": {
+        "level": 5,
+        "profession": "CASTER",
+        "subProfession": "corecaster",
+        "position": "RANGED"
+    },
+    "特米米": {
+        "level": 5,
+        "profession": "CASTER",
+        "subProfession": "corecaster",
+        "position": "RANGED"
+    },
+    "天火": {
+        "level": 5,
+        "profession": "CASTER",
+        "subProfession": "splashcaster",
+        "position": "RANGED"
+    },
+    "Pith": {
+        "level": 5,
+        "profession": "CASTER",
+        "subProfession": "splashcaster",
+        "position": "RANGED"
+    },
+    "惊蛰": {
+        "level": 5,
+        "profession": "CASTER",
+        "subProfession": "chain",
+        "position": "RANGED"
+    },
+    "蜜蜡": {
+        "level": 5,
+        "profession": "CASTER",
+        "subProfession": "phalanx",
+        "position": "RANGED"
+    },
+    "莱恩哈特": {
+        "level": 5,
+        "profession": "CASTER",
+        "subProfession": "splashcaster",
+        "position": "RANGED"
+    },
+    "薄绿": {
+        "level": 5,
+        "profession": "CASTER",
+        "subProfession": "phalanx",
+        "position": "RANGED"
+    },
+    "爱丽丝": {
+        "level": 5,
+        "profession": "CASTER",
+        "subProfession": "mystic",
+        "position": "RANGED"
+    },
+    "炎狱炎熔": {
+        "level": 5,
+        "profession": "CASTER",
+        "subProfession": "splashcaster",
+        "position": "RANGED"
+    },
+    "蚀清": {
+        "level": 5,
+        "profession": "CASTER",
+        "subProfession": "blastcaster",
+        "position": "RANGED"
+    },
+    "耶拉": {
+        "level": 5,
+        "profession": "CASTER",
+        "subProfession": "funnel",
+        "position": "RANGED"
+    },
+    "梅尔": {
+        "level": 5,
+        "profession": "SUPPORT",
+        "subProfession": "summoner",
+        "position": "RANGED"
+    },
+    "稀音": {
+        "level": 5,
+        "profession": "SUPPORT",
+        "subProfession": "summoner",
+        "position": "RANGED"
+    },
+    "赫默": {
+        "level": 5,
+        "profession": "MEDIC",
+        "subProfession": "physician",
+        "position": "RANGED"
+    },
+    "华法琳": {
+        "level": 5,
+        "profession": "MEDIC",
+        "subProfession": "physician",
+        "position": "RANGED"
+    },
+    "亚叶": {
+        "level": 5,
+        "profession": "MEDIC",
+        "subProfession": "physician",
+        "position": "RANGED"
+    },
+    "Touch": {
+        "level": 5,
+        "profession": "MEDIC",
+        "subProfession": "physician",
+        "position": "RANGED"
+    },
+    "锡兰": {
+        "level": 5,
+        "profession": "MEDIC",
+        "subProfession": "healer",
+        "position": "RANGED"
+    },
+    "絮雨": {
+        "level": 5,
+        "profession": "MEDIC",
+        "subProfession": "healer",
+        "position": "RANGED"
+    },
+    "图耶": {
+        "level": 5,
+        "profession": "MEDIC",
+        "subProfession": "physician",
+        "position": "RANGED"
+    },
+    "桑葚": {
+        "level": 5,
+        "profession": "MEDIC",
+        "subProfession": "wandermedic",
+        "position": "RANGED"
+    },
+    "蜜莓": {
+        "level": 5,
+        "profession": "MEDIC",
+        "subProfession": "wandermedic",
+        "position": "RANGED"
+    },
+    "临光": {
+        "level": 5,
+        "profession": "TANK",
+        "subProfession": "guardian",
+        "position": "MELEE"
+    },
+    "吽": {
+        "level": 5,
+        "profession": "TANK",
+        "subProfession": "guardian",
+        "position": "MELEE"
+    },
+    "红": {
+        "level": 5,
+        "profession": "SPECIAL",
+        "subProfession": "executor",
+        "position": "MELEE"
+    },
+    "槐琥": {
+        "level": 5,
+        "profession": "SPECIAL",
+        "subProfession": "executor",
+        "position": "MELEE"
+    },
+    "卡夫卡": {
+        "level": 5,
+        "profession": "SPECIAL",
+        "subProfession": "executor",
+        "position": "MELEE"
+    },
+    "乌有": {
+        "level": 5,
+        "profession": "SPECIAL",
+        "subProfession": "merchant",
+        "position": "MELEE"
+    },
+    "雷蛇": {
+        "level": 5,
+        "profession": "TANK",
+        "subProfession": "protector",
+        "position": "MELEE"
+    },
+    "可颂": {
+        "level": 5,
+        "profession": "TANK",
+        "subProfession": "protector",
+        "position": "MELEE"
+    },
+    "拜松": {
+        "level": 5,
+        "profession": "TANK",
+        "subProfession": "protector",
+        "position": "MELEE"
+    },
+    "火神": {
+        "level": 5,
+        "profession": "TANK",
+        "subProfession": "unyield",
+        "position": "MELEE"
+    },
+    "石棉": {
+        "level": 5,
+        "profession": "TANK",
+        "subProfession": "artsprotector",
+        "position": "MELEE"
+    },
+    "暮落": {
+        "level": 5,
+        "profession": "TANK",
+        "subProfession": "artsprotector",
+        "position": "MELEE"
+    },
+    "闪击": {
+        "level": 5,
+        "profession": "TANK",
+        "subProfession": "protector",
+        "position": "MELEE"
+    },
+    "暴雨": {
+        "level": 5,
+        "profession": "TANK",
+        "subProfession": "protector",
+        "position": "MELEE"
+    },
+    "灰毫": {
+        "level": 5,
+        "profession": "TANK",
+        "subProfession": "fortress",
+        "position": "MELEE"
+    },
+    "极光": {
+        "level": 5,
+        "profession": "TANK",
+        "subProfession": "duelist",
+        "position": "MELEE"
+    },
+    "普罗旺斯": {
+        "level": 5,
+        "profession": "SNIPER",
+        "subProfession": "closerange",
+        "position": "RANGED"
+    },
+    "守林人": {
+        "level": 5,
+        "profession": "SNIPER",
+        "subProfession": "longrange",
+        "position": "RANGED"
+    },
+    "安哲拉": {
+        "level": 5,
+        "profession": "SNIPER",
+        "subProfession": "longrange",
+        "position": "RANGED"
+    },
+    "熔泉": {
+        "level": 5,
+        "profession": "SNIPER",
+        "subProfession": "siegesniper",
+        "position": "RANGED"
+    },
+    "崖心": {
+        "level": 5,
+        "profession": "SPECIAL",
+        "subProfession": "hookmaster",
+        "position": "MELEE"
+    },
+    "雪雉": {
+        "level": 5,
+        "profession": "SPECIAL",
+        "subProfession": "hookmaster",
+        "position": "MELEE"
+    },
+    "初雪": {
+        "level": 5,
+        "profession": "SUPPORT",
+        "subProfession": "underminer",
+        "position": "RANGED"
+    },
+    "巫恋": {
+        "level": 5,
+        "profession": "SUPPORT",
+        "subProfession": "underminer",
+        "position": "RANGED"
+    },
+    "真理": {
+        "level": 5,
+        "profession": "SUPPORT",
+        "subProfession": "slower",
+        "position": "RANGED"
+    },
+    "格劳克斯": {
+        "level": 5,
+        "profession": "SUPPORT",
+        "subProfession": "slower",
+        "position": "RANGED"
+    },
+    "空": {
+        "level": 5,
+        "profession": "SUPPORT",
+        "subProfession": "bard",
+        "position": "RANGED"
+    },
+    "月禾": {
+        "level": 5,
+        "profession": "SUPPORT",
+        "subProfession": "blessing",
+        "position": "RANGED"
+    },
+    "九色鹿": {
+        "level": 5,
+        "profession": "SUPPORT",
+        "subProfession": "blessing",
+        "position": "RANGED"
+    },
+    "夏栎": {
+        "level": 5,
+        "profession": "SUPPORT",
+        "subProfession": "blessing",
+        "position": "RANGED"
+    },
+    "狮蝎": {
+        "level": 5,
+        "profession": "SPECIAL",
+        "subProfession": "stalker",
+        "position": "MELEE"
+    },
+    "绮良": {
+        "level": 5,
+        "profession": "SPECIAL",
+        "subProfession": "stalker",
+        "position": "MELEE"
+    },
+    "食铁兽": {
+        "level": 5,
+        "profession": "SPECIAL",
+        "subProfession": "pusher",
+        "position": "MELEE"
+    },
+    "见行者": {
+        "level": 5,
+        "profession": "SPECIAL",
+        "subProfession": "pusher",
+        "position": "MELEE"
+    },
+    "罗宾": {
+        "level": 5,
+        "profession": "SPECIAL",
+        "subProfession": "traper",
+        "position": "RANGED"
+    },
+    "霜华": {
+        "level": 5,
+        "profession": "SPECIAL",
+        "subProfession": "traper",
+        "position": "RANGED"
+    },
+    "贝娜": {
+        "level": 5,
+        "profession": "SPECIAL",
+        "subProfession": "dollkeeper",
+        "position": "MELEE"
+    },
+    "风丸": {
+        "level": 5,
+        "profession": "SPECIAL",
+        "subProfession": "dollkeeper",
+        "position": "MELEE"
+    },
+    "能天使": {
+        "level": 6,
+        "profession": "SNIPER",
+        "subProfession": "fastshot",
+        "position": "RANGED"
+    },
+    "空弦": {
+        "level": 6,
+        "profession": "SNIPER",
+        "subProfession": "fastshot",
+        "position": "RANGED"
+    },
+    "灰烬": {
+        "level": 6,
+        "profession": "SNIPER",
+        "subProfession": "fastshot",
+        "position": "RANGED"
+    },
+    "黑": {
+        "level": 6,
+        "profession": "SNIPER",
+        "subProfession": "closerange",
+        "position": "RANGED"
+    },
+    "远牙": {
+        "level": 6,
+        "profession": "SNIPER",
+        "subProfession": "longrange",
+        "position": "RANGED"
+    },
+    "W": {
+        "level": 6,
+        "profession": "SNIPER",
+        "subProfession": "aoesniper",
+        "position": "RANGED"
+    },
+    "菲亚梅塔": {
+        "level": 6,
+        "profession": "SNIPER",
+        "subProfession": "aoesniper",
+        "position": "RANGED"
+    },
+    "早露": {
+        "level": 6,
+        "profession": "SNIPER",
+        "subProfession": "siegesniper",
+        "position": "RANGED"
+    },
+    "迷迭香": {
+        "level": 6,
+        "profession": "SNIPER",
+        "subProfession": "bombarder",
+        "position": "RANGED"
+    },
+    "假日威龙陈": {
+        "level": 6,
+        "profession": "SNIPER",
+        "subProfession": "reaperrange",
+        "position": "RANGED"
+    },
+    "推进之王": {
+        "level": 6,
+        "profession": "PIONEER",
+        "subProfession": "pioneer",
+        "position": "MELEE"
+    },
+    "风笛": {
+        "level": 6,
+        "profession": "PIONEER",
+        "subProfession": "charger",
+        "position": "MELEE"
+    },
+    "嵯峨": {
+        "level": 6,
+        "profession": "PIONEER",
+        "subProfession": "pioneer",
+        "position": "MELEE"
+    },
+    "琴柳": {
+        "level": 6,
+        "profession": "PIONEER",
+        "subProfession": "bearer",
+        "position": "MELEE"
+    },
+    "焰尾": {
+        "level": 6,
+        "profession": "PIONEER",
+        "subProfession": "pioneer",
+        "position": "MELEE"
+    },
+    "伊芙利特": {
+        "level": 6,
+        "profession": "CASTER",
+        "subProfession": "blastcaster",
+        "position": "RANGED"
+    },
+    "莫斯提马": {
+        "level": 6,
+        "profession": "CASTER",
+        "subProfession": "splashcaster",
+        "position": "RANGED"
+    },
+    "艾雅法拉": {
+        "level": 6,
+        "profession": "CASTER",
+        "subProfession": "corecaster",
+        "position": "RANGED"
+    },
+    "刻俄柏": {
+        "level": 6,
+        "profession": "CASTER",
+        "subProfession": "corecaster",
+        "position": "RANGED"
+    },
+    "夕": {
+        "level": 6,
+        "profession": "CASTER",
+        "subProfession": "splashcaster",
+        "position": "RANGED"
+    },
+    "异客": {
+        "level": 6,
+        "profession": "CASTER",
+        "subProfession": "chain",
+        "position": "RANGED"
+    },
+    "卡涅利安": {
+        "level": 6,
+        "profession": "CASTER",
+        "subProfession": "phalanx",
+        "position": "RANGED"
+    },
+    "澄闪": {
+        "level": 6,
+        "profession": "CASTER",
+        "subProfession": "funnel",
+        "position": "RANGED"
+    },
+    "灵知": {
+        "level": 6,
+        "profession": "SUPPORT",
+        "subProfession": "underminer",
+        "position": "RANGED"
+    },
+    "安洁莉娜": {
+        "level": 6,
+        "profession": "SUPPORT",
+        "subProfession": "slower",
+        "position": "RANGED"
+    },
+    "铃兰": {
+        "level": 6,
+        "profession": "SUPPORT",
+        "subProfession": "slower",
+        "position": "RANGED"
+    },
+    "麦哲伦": {
+        "level": 6,
+        "profession": "SUPPORT",
+        "subProfession": "summoner",
+        "position": "RANGED"
+    },
+    "浊心斯卡蒂": {
+        "level": 6,
+        "profession": "SUPPORT",
+        "subProfession": "bard",
+        "position": "RANGED"
+    },
+    "令": {
+        "level": 6,
+        "profession": "SUPPORT",
+        "subProfession": "summoner",
+        "position": "RANGED"
+    },
+    "傀影": {
+        "level": 6,
+        "profession": "SPECIAL",
+        "subProfession": "executor",
+        "position": "MELEE"
+    },
+    "老鲤": {
+        "level": 6,
+        "profession": "SPECIAL",
+        "subProfession": "merchant",
+        "position": "MELEE"
+    },
+    "温蒂": {
+        "level": 6,
+        "profession": "SPECIAL",
+        "subProfession": "pusher",
+        "position": "MELEE"
+    },
+    "阿": {
+        "level": 6,
+        "profession": "SPECIAL",
+        "subProfession": "geek",
+        "position": "RANGED"
+    },
+    "歌蕾蒂娅": {
+        "level": 6,
+        "profession": "SPECIAL",
+        "subProfession": "hookmaster",
+        "position": "MELEE"
+    },
+    "水月": {
+        "level": 6,
+        "profession": "SPECIAL",
+        "subProfession": "stalker",
+        "position": "MELEE"
+    },
+    "闪灵": {
+        "level": 6,
+        "profession": "MEDIC",
+        "subProfession": "physician",
+        "position": "RANGED"
+    },
+    "夜莺": {
+        "level": 6,
+        "profession": "MEDIC",
+        "subProfession": "ringhealer",
+        "position": "RANGED"
+    },
+    "凯尔希": {
+        "level": 6,
+        "profession": "MEDIC",
+        "subProfession": "physician",
+        "position": "RANGED"
+    },
+    "星熊": {
+        "level": 6,
+        "profession": "TANK",
+        "subProfession": "protector",
+        "position": "MELEE"
+    },
+    "塞雷娅": {
+        "level": 6,
+        "profession": "TANK",
+        "subProfession": "guardian",
+        "position": "MELEE"
+    },
+    "瑕光": {
+        "level": 6,
+        "profession": "TANK",
+        "subProfession": "guardian",
+        "position": "MELEE"
+    },
+    "年": {
+        "level": 6,
+        "profession": "TANK",
+        "subProfession": "protector",
+        "position": "MELEE"
+    },
+    "泥岩": {
+        "level": 6,
+        "profession": "TANK",
+        "subProfession": "unyield",
+        "position": "MELEE"
+    },
+    "森蚺": {
+        "level": 6,
+        "profession": "TANK",
+        "subProfession": "duelist",
+        "position": "MELEE"
+    },
+    "山": {
+        "level": 6,
+        "profession": "WARRIOR",
+        "subProfession": "fighter",
+        "position": "MELEE"
+    },
+    "银灰": {
+        "level": 6,
+        "profession": "WARRIOR",
+        "subProfession": "lord",
+        "position": "MELEE"
+    },
+    "棘刺": {
+        "level": 6,
+        "profession": "WARRIOR",
+        "subProfession": "lord",
+        "position": "MELEE"
+    },
+    "陈": {
+        "level": 6,
+        "profession": "WARRIOR",
+        "subProfession": "sword",
+        "position": "MELEE"
+    },
+    "煌": {
+        "level": 6,
+        "profession": "WARRIOR",
+        "subProfession": "centurion",
+        "position": "MELEE"
+    },
+    "史尔特尔": {
+        "level": 6,
+        "profession": "WARRIOR",
+        "subProfession": "artsfghter",
+        "position": "MELEE"
+    },
+    "赫拉格": {
+        "level": 6,
+        "profession": "WARRIOR",
+        "subProfession": "musha",
+        "position": "MELEE"
+    },
+    "帕拉斯": {
+        "level": 6,
+        "profession": "WARRIOR",
+        "subProfession": "instructor",
+        "position": "MELEE"
+    },
+    "耀骑士临光": {
+        "level": 6,
+        "profession": "WARRIOR",
+        "subProfession": "fearless",
+        "position": "MELEE"
+    },
+    "暴行": {
+        "level": 5,
+        "profession": "WARRIOR",
+        "subProfession": "centurion",
+        "position": "MELEE"
+    },
+    "空爆": {
+        "level": 3,
+        "profession": "SNIPER",
+        "subProfession": "aoesniper",
+        "position": "RANGED"
+    },
+    "月见夜": {
+        "level": 3,
+        "profession": "WARRIOR",
+        "subProfession": "lord",
+        "position": "MELEE"
+    },
+    "猎蜂": {
+        "level": 4,
+        "profession": "WARRIOR",
+        "subProfession": "fighter",
+        "position": "MELEE"
+    },
+    "杰克": {
+        "level": 4,
+        "profession": "WARRIOR",
+        "subProfession": "fighter",
+        "position": "MELEE"
+    },
+    "夜魔": {
+        "level": 5,
+        "profession": "CASTER",
+        "subProfession": "corecaster",
+        "position": "RANGED"
+    },
+    "格拉尼": {
+        "level": 5,
+        "profession": "PIONEER",
+        "subProfession": "charger",
+        "position": "MELEE"
+    },
+    "斯卡蒂": {
+        "level": 6,
+        "profession": "WARRIOR",
+        "subProfession": "fearless",
+        "position": "MELEE"
+    },
+    "断罪者": {
+        "level": 4,
+        "profession": "WARRIOR",
+        "subProfession": "fearless",
+        "position": "MELEE"
+    }
+}

--- a/src/MeoAssistant/AsstBattleDef.h
+++ b/src/MeoAssistant/AsstBattleDef.h
@@ -93,5 +93,8 @@ namespace asst
         std::string name;
         size_t index;
         bool cooling = false;
+        bool operator== (const std::string& oper_name) const noexcept {
+            return name == oper_name;
+        }
     };
 }

--- a/src/MeoAssistant/CombatRecruitConfiger.cpp
+++ b/src/MeoAssistant/CombatRecruitConfiger.cpp
@@ -1,0 +1,30 @@
+#include "CombatRecruitConfiger.h"
+
+#include <algorithm>
+
+#include <meojson/json.hpp>
+
+#include "Logger.hpp"
+
+bool asst::CombatRecruitConfiger::parse(const json::value& json)
+{
+    LogTraceFunction;
+
+    for (const auto& [name, oper_json] : json.as_object()) {
+        CombatRecruitOperInfo oper_temp;
+        oper_temp.name = name;
+        oper_temp.type = oper_json.get("profession", "unknown");
+        oper_temp.subProfession = oper_json.get("subProfession", "unknown");
+        oper_temp.position = oper_json.get("position", "unknown");
+        oper_temp.level = oper_json.get("level", 0);
+        m_all_opers.emplace(name, std::move(oper_temp));
+        m_all_opers_name.emplace_back(name);
+    }
+
+    // // 按干员等级排个序
+    // std::sort(m_all_opers.begin(), m_all_opers.end(), [](const auto& lhs, const auto& rhs) -> bool {
+    //     return lhs.level > rhs.level;
+    // });
+
+    return true;
+}

--- a/src/MeoAssistant/CombatRecruitConfiger.h
+++ b/src/MeoAssistant/CombatRecruitConfiger.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "AbstractConfiger.h"
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "AsstTypes.h"
+
+namespace asst
+{
+    // 干员信息，战斗相关
+    struct CombatRecruitOperInfo
+    {
+        std::string name;
+        // ["MEDIC","WARRIOR","SPECIAL","SNIPER","PIONEER","TANK","SUPPORT","CASTER"]
+        std::string type;
+        int level = 0;
+        std::string subProfession;
+        std::string position; // 高台--RANGED, 地面--MELEE
+    };
+    class CombatRecruitConfiger : public AbstractConfiger
+    {
+    public:
+        virtual ~CombatRecruitConfiger() = default;
+
+        const std::unordered_map<std::string, CombatRecruitOperInfo>& get_all_opers() const noexcept
+        {
+            return m_all_opers;
+        }
+
+        const std::vector<std::string>& get_all_opers_name() const noexcept
+        {
+            return m_all_opers_name;
+        }
+
+    protected:
+        virtual bool parse(const json::value& json) override;
+
+        std::unordered_map<std::string, CombatRecruitOperInfo> m_all_opers;
+        std::vector<std::string> m_all_opers_name;
+    };
+}

--- a/src/MeoAssistant/OcrImageAnalyzer.cpp
+++ b/src/MeoAssistant/OcrImageAnalyzer.cpp
@@ -73,6 +73,15 @@ bool asst::OcrImageAnalyzer::analyze()
     return !m_ocr_result.empty();
 }
 
+void asst::OcrImageAnalyzer::filter(const TextRectProc& filter_func)
+{
+    for(auto x = m_ocr_result.begin(); x != m_ocr_result.end(); )
+        if(!filter_func(*x))
+            x = m_ocr_result.erase(x);
+        else
+            ++x;
+}
+
 void asst::OcrImageAnalyzer::set_use_cache(bool is_use) noexcept
 {
     m_use_cache = is_use;
@@ -145,6 +154,25 @@ void asst::OcrImageAnalyzer::sort_result()
             }
             else {
                 return lhs.rect.y < rhs.rect.y;
+            }
+        }
+    );
+}
+
+void asst::OcrImageAnalyzer::sort_result_x_y()
+{
+    // 按位置排个序（顺序如下）
+    // +---+
+    // |1 3|
+    // |2 4|
+    // +---+
+    std::sort(m_ocr_result.begin(), m_ocr_result.end(),
+        [](const TextRect& lhs, const TextRect& rhs) -> bool {
+            if (std::abs(lhs.rect.x - rhs.rect.x) < 5) { // x差距较小则理解为是同一排的，按y排序
+                return lhs.rect.y < rhs.rect.y;
+            }
+            else {
+                return lhs.rect.x < rhs.rect.x;
             }
         }
     );

--- a/src/MeoAssistant/OcrImageAnalyzer.h
+++ b/src/MeoAssistant/OcrImageAnalyzer.h
@@ -17,7 +17,10 @@ namespace asst
 
         virtual bool analyze() override;
 
-        void sort_result();             // 按位置排序，左上角的排在前面
+        void filter(const TextRectProc& filter_func);
+
+        void sort_result();             // 按位置排序，左上角的排在前面，右上角在左下角前面
+        void sort_result_x_y();         // 按位置排序，左上角的排在前面，左下角在右上角前面
         void sort_result_by_score();    // 按分数排序，得分最高的在前面
         void sort_result_by_required(); // 按传入的需求数组排序，传入的在前面结果接在前面
 

--- a/src/MeoAssistant/Resource.cpp
+++ b/src/MeoAssistant/Resource.cpp
@@ -16,6 +16,7 @@ bool asst::Resource::load(const std::string& dir)
     constexpr static const char* TemplsFilename = "template";
     constexpr static const char* GeneralCfgFilename = "config.json";
     constexpr static const char* TaskDataFilename = "tasks.json";
+    constexpr static const char* CombatRecruitCfgFilename = "combat_recruit.json";
     constexpr static const char* RecruitCfgFilename = "recruit.json";
     constexpr static const char* ItemCfgFilename = "item_index.json";
     constexpr static const char* InfrastCfgFilename = "infrast.json";
@@ -57,6 +58,16 @@ bool asst::Resource::load(const std::string& dir)
         overload = true;
     }
 
+    if (!m_combatrecruit_cfg_unique_ins.load(dir + CombatRecruitCfgFilename)) {
+        if (!m_loaded) {
+            m_last_error = std::string(CombatRecruitCfgFilename) + ": " + m_combatrecruit_cfg_unique_ins.get_last_error();
+            return false;
+        }
+    }
+    else {
+        overload = true;
+    }
+
     if (!m_item_cfg_unique_ins.load(dir + ItemCfgFilename)) {
         if (!m_loaded) {
             m_last_error = std::string(ItemCfgFilename) + ": " + m_item_cfg_unique_ins.get_last_error();
@@ -72,7 +83,7 @@ bool asst::Resource::load(const std::string& dir)
             continue;
         }
         if (!m_battle_cfg_unique_ins.load(entry.path().u8string())) {
-            m_last_error = entry.path().u8string() + " Load faild";
+            m_last_error = entry.path().u8string() + " Load failed";
             return false;
         }
     }

--- a/src/MeoAssistant/Resource.h
+++ b/src/MeoAssistant/Resource.h
@@ -5,6 +5,7 @@
 #include <memory>
 #include <utility>
 
+#include "CombatRecruitConfiger.h"
 #include "GeneralConfiger.h"
 #include "InfrastConfiger.h"
 #include "ItemConfiger.h"
@@ -43,6 +44,10 @@ namespace asst
         {
             return m_recruit_cfg_unique_ins;
         }
+        CombatRecruitConfiger& combatrecruit() noexcept
+        {
+            return m_combatrecruit_cfg_unique_ins;
+        }
         ItemConfiger& item() noexcept
         {
             return m_item_cfg_unique_ins;
@@ -80,6 +85,10 @@ namespace asst
         {
             return m_recruit_cfg_unique_ins;
         }
+        const CombatRecruitConfiger& combatrecruit() const noexcept
+        {
+            return m_combatrecruit_cfg_unique_ins;
+        }
         const ItemConfiger& item() const noexcept
         {
             return m_item_cfg_unique_ins;
@@ -114,6 +123,7 @@ namespace asst
         TemplResource m_templ_resource_unique_ins;
         GeneralConfiger m_general_cfg_unique_ins;
         RecruitConfiger m_recruit_cfg_unique_ins;
+        CombatRecruitConfiger m_combatrecruit_cfg_unique_ins;
         BattleConfiger m_battle_cfg_unique_ins;
         ItemConfiger m_item_cfg_unique_ins;
         InfrastConfiger m_infrast_cfg_unique_ins;

--- a/src/MeoAssistant/RoguelikeBattleTaskPlugin.cpp
+++ b/src/MeoAssistant/RoguelikeBattleTaskPlugin.cpp
@@ -67,7 +67,7 @@ bool asst::RoguelikeBattleTaskPlugin::get_stage_info()
         sleep(stage_name_task_ptr->pre_delay);
 
         constexpr int StageNameRetryTimes = 50;
-        for (int i = 0; i != StageNameRetryTimes; ++i) {
+        for (int i = 0; i != StageNameRetryTimes; ++i, sleep(200)) {
             cv::Mat image = m_ctrler->get_image();
             OcrImageAnalyzer name_analyzer(image);
 

--- a/src/MeoAssistant/RoguelikeRecruitTaskPlugin.cpp
+++ b/src/MeoAssistant/RoguelikeRecruitTaskPlugin.cpp
@@ -3,6 +3,8 @@
 #include "OcrImageAnalyzer.h"
 #include "Controller.h"
 #include "TaskData.h"
+#include "Resource.h"
+#include "Logger.hpp"
 
 void asst::RoguelikeRecruitTaskPlugin::set_opers(std::vector<std::string> opers)
 {
@@ -26,16 +28,63 @@ bool asst::RoguelikeRecruitTaskPlugin::verify(AsstMsg msg, const json::value& de
 
 bool asst::RoguelikeRecruitTaskPlugin::_run()
 {
+    LogTraceFunction;
+
     OcrImageAnalyzer analyzer(m_ctrler->get_image());
     analyzer.set_task_info("Roguelike1RecruitData");
-    analyzer.set_required(m_opers);
 
-    if (!analyzer.analyze()) {
+    //这里原来用m_opers作参数，但由于新的算法需要取左上角干员，将m_opers移到下面的demand_filter
+    analyzer.set_required(Resrc.combatrecruit().get_all_opers_name());
+
+    if (!analyzer.analyze())
         return false;
-    }
 
+    analyzer.sort_result_x_y();
+
+    std::string visible_opers = ""; // 界面上所有干员
+    for(const auto& oper: analyzer.get_result()) visible_opers += oper.text + ", ";
+    Log.info("visible opers count：", analyzer.get_result().size());
+    Log.info("visible opers：", visible_opers);
+
+    // 1. 根据出现在界面左上角的干员确定最高星级（此前应已判断第一个是否为临时招募）
+    const auto& all_opers = Resrc.combatrecruit().get_all_opers();
+    std::string first_oper = analyzer.get_result().front().text;
+
+    // demand_filter
+    analyzer.filter([&](const TextRect& x) -> bool {
+            return find(m_opers.begin(), m_opers.end(), x.text) != m_opers.end();
+        }
+    );
+
+    std::string required_opers = ""; // visible_opers 的基础上, 在 m_opers 里的干员
+    for(const auto& oper: analyzer.get_result()) required_opers += oper.text + ", ";
+    Log.info("required opers count：", analyzer.get_result().size());
+    Log.info("required opers：", required_opers);
+    
+    if (all_opers.find(first_oper) != all_opers.end()) { 
+        int allow_level = all_opers.at(first_oper).level;
+        Log.info("allow level：", allow_level);
+        // availability_filter (based on level)
+        analyzer.filter([&](const TextRect& x) -> bool {
+                if (all_opers.find(x.text) != all_opers.end())
+                    return all_opers.at(x.text).level <= allow_level;
+                else
+                    return false;
+            }
+        );
+    }
+    else
+        Log.error("Cannot recognize first oper：", first_oper);
+
+    Log.info("available opers count：", analyzer.get_result().size());
+    std::string available_opers = ""; // required_opers 的基础上, 能用的干员
+    for(const auto& oper: analyzer.get_result()) available_opers += oper.text + ", ";
+    Log.info("available opers：", available_opers);
+    // 2. 根据指定的干员的先后顺序决定人选（越靠前优先级越高）
+    analyzer.set_required(m_opers);
+    analyzer.sort_result_by_required();
     Rect target = analyzer.get_result().front().rect;
     m_ctrler->click(target);
-
+    Log.info("Choose：", analyzer.get_result().front().text);
     return true;
 }

--- a/src/MeoAssistant/StageDropsTaskPlugin.cpp
+++ b/src/MeoAssistant/StageDropsTaskPlugin.cpp
@@ -57,6 +57,7 @@ bool asst::StageDropsTaskPlugin::set_penguin_id(std::string id)
 bool asst::StageDropsTaskPlugin::set_server(std::string server)
 {
     m_server = std::move(server);
+    return true;
 }
 
 bool asst::StageDropsTaskPlugin::_run()


### PR DESCRIPTION
主要修改：
#### 肉鸽选人
具体的做法是：
1. 取当前页所有干员`visible_opers`；
2. 识别左上角干员的名字并在`CombatRecruitConfiger`中找到他的`level`；
3. 取`visiable_opers`中在`m_opers`中的所有干员`required_opers`；
4. 取`required_opers`中小于等于`level`的所有干员`available_opers`；
5. 取`available_opers`中`m_opers`（用户设置）优先级最高的`favour_oper`。

最后得到的`favour_oper`即为招募的干员。

（另外我写了识别初始四星临时招募的代码，但是不在这个PR里。感觉用这个队伍成功率会比近卫辅助医疗高一些吧，大概）

#### 肉鸽战斗
在干员被击败后尝试释放格子。具体做法是：
1. 检测到的干员数增加时，先对冷却中的干员遍历寻找其曾经放置的格子并释放，不够则继续对不在冷却的干员重复这个步骤

这个做法对召唤物很不友好（有召唤物的情况应该有bug），如果觉得不好就删了吧（