### PR TITLE
fix.修复某些情况下肉鸽掉落物识别错误的问题

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -778,6 +778,7 @@
         ],
         "next": [
             "StartToWakeUp",
+            "StartUpConnectingFlag",
             "Terminal",
             "CloseAnno",
             "OfflineConfirm",

--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -4944,6 +4944,7 @@
             1280,
             157
         ],
+        "templThreshold": 0.85,
         "next": [
             "Roguelike1DropsFlag"
         ]
@@ -4958,6 +4959,7 @@
             1280,
             157
         ],
+        "templThreshold": 0.85,
         "next": [
             "Roguelike1DropsFlag",
             "Roguelike1ClickToDrops"
@@ -4973,6 +4975,7 @@
             1280,
             157
         ],
+        "templThreshold": 0.85,
         "next": [
             "Roguelike1ClickToDrops"
         ]


### PR DESCRIPTION
尝试修复 #340 中提到的问题，增加肉鸽的掉落物匹配的阈值。