### PR TITLE
重命名了asst::utils下的字符串编码转换函数，修复了ansi_to_utf8的wstr数组初始化不完全的问题

### DIFF
--- a/src/MeoAssistant/AbstractConfiger.cpp
+++ b/src/MeoAssistant/AbstractConfiger.cpp
@@ -10,7 +10,7 @@ bool asst::AbstractConfiger::load(const std::string& filename)
     LogTraceFunction;
 
 #ifdef _WIN32
-    Log.info("Load:", utils::gbk_2_utf8(filename));
+    Log.info("Load:", utils::ansi_to_utf8(filename));
 #else
     Log.info("Load:", filename);
 #endif

--- a/src/MeoAssistant/AsstCaller.cpp
+++ b/src/MeoAssistant/AsstCaller.cpp
@@ -40,7 +40,7 @@ static bool inited = false;
 bool AsstLoadResource(const char* path)
 {
 #ifdef _WIN32
-    std::string working_path = asst::utils::utf8_to_gbk(path);
+    std::string working_path = asst::utils::utf8_to_ansi(path);
 #else
     std::string working_path = std::string(path);
 #endif
@@ -86,7 +86,7 @@ bool AsstConnect(AsstHandle handle, const char* adb_path, const char* address, c
     }
 
 #ifdef _WIN32
-    return handle->connect(asst::utils::utf8_to_gbk(adb_path), address, config ? config : std::string());
+    return handle->connect(asst::utils::utf8_to_ansi(adb_path), address, config ? config : std::string());
 #else
     return handle->connect(adb_path, address, config ? config : std::string());
 #endif

--- a/src/MeoAssistant/AsstUtils.hpp
+++ b/src/MeoAssistant/AsstUtils.hpp
@@ -84,10 +84,10 @@ namespace asst
             return buff;
         }
 
-        inline std::string gbk_2_utf8(const std::string& gbk_str)
+        inline std::string ansi_to_utf8(const std::string& ansi_str)
         {
 #ifdef _WIN32
-            const char* src_str = gbk_str.c_str();
+            const char* src_str = ansi_str.c_str();
             int len = MultiByteToWideChar(CP_ACP, 0, src_str, -1, nullptr, 0);
             wchar_t* wstr = new wchar_t[len + 1U];
             memset(wstr, 0, len + 1U);
@@ -111,26 +111,26 @@ namespace asst
 #endif
         }
 
-        inline std::string utf8_to_gbk(const std::string& utf8_str)
+        inline std::string utf8_to_ansi(const std::string& utf8_str)
         {
 #ifdef _WIN32
             const char* src_str = utf8_str.c_str();
             int len = MultiByteToWideChar(CP_UTF8, 0, src_str, -1, nullptr, 0);
-            wchar_t* wszGBK = new wchar_t[len + 1];
-            memset(wszGBK, 0, len * 2LLU + 2LLU);
-            MultiByteToWideChar(CP_UTF8, 0, src_str, -1, wszGBK, len);
-            len = WideCharToMultiByte(CP_ACP, 0, wszGBK, -1, nullptr, 0, nullptr, nullptr);
-            char* szGBK = new char[len + 1];
-            memset(szGBK, 0, len + 1LLU);
-            WideCharToMultiByte(CP_ACP, 0, wszGBK, -1, szGBK, len, nullptr, nullptr);
-            std::string strTemp(szGBK);
-            if (wszGBK) {
-                delete[] wszGBK;
-                wszGBK = nullptr;
+            wchar_t* wsz_ansi = new wchar_t[len + 1];
+            memset(wsz_ansi, 0, len * 2LLU + 2LLU);
+            MultiByteToWideChar(CP_UTF8, 0, src_str, -1, wsz_ansi, len);
+            len = WideCharToMultiByte(CP_ACP, 0, wsz_ansi, -1, nullptr, 0, nullptr, nullptr);
+            char* sz_ansi = new char[len + 1];
+            memset(sz_ansi, 0, len + 1LLU);
+            WideCharToMultiByte(CP_ACP, 0, wsz_ansi, -1, sz_ansi, len, nullptr, nullptr);
+            std::string strTemp(sz_ansi);
+            if (wsz_ansi) {
+                delete[] wsz_ansi;
+                wsz_ansi = nullptr;
             }
-            if (szGBK) {
-                delete[] szGBK;
-                szGBK = nullptr;
+            if (sz_ansi) {
+                delete[] sz_ansi;
+                sz_ansi = nullptr;
             }
             return strTemp;
 #else   // Don't fucking use gbk in linux!
@@ -267,7 +267,7 @@ namespace asst
             return pipe_str;
         }
 
-        //template<typename T,
+        // template<typename T,
         //	typename = typename std::enable_if<std::is_constructible<T, std::string>::value>::type>
         //	std::string VectorToString(const std::vector<T>& vector, bool to_gbk = false) {
         //	if (vector.empty()) {
@@ -277,7 +277,7 @@ namespace asst
         //	std::string str;
         //	for (const T& ele : vector) {
         //		if (to_gbk) {
-        //			str += utils::utf8_to_gbk(ele) + inter;
+        //			str += utils::utf8_to_ansi(ele) + inter;
         //		}
         //		else {
         //			str += ele + inter;

--- a/src/MeoAssistant/AsstUtils.hpp
+++ b/src/MeoAssistant/AsstUtils.hpp
@@ -89,14 +89,18 @@ namespace asst
 #ifdef _WIN32
             const char* src_str = ansi_str.c_str();
             int len = MultiByteToWideChar(CP_ACP, 0, src_str, -1, nullptr, 0);
-            wchar_t* wstr = new wchar_t[len + 1U];
-            memset(wstr, 0, len + 1U);
+            const std::size_t wstr_length = static_cast<std::size_t>(len) + 1U;
+            wchar_t *wstr = new wchar_t[wstr_length];
+            memset(wstr, 0, sizeof(wstr[0]) * wstr_length);
             MultiByteToWideChar(CP_ACP, 0, src_str, -1, wstr, len);
+
             len = WideCharToMultiByte(CP_UTF8, 0, wstr, -1, nullptr, 0, nullptr, nullptr);
-            char* str = new char[len + 1];
-            memset(str, 0, len + 1);
+            const std::size_t str_length = static_cast<std::size_t>(len) + 1;
+            char *str = new char[str_length];
+            memset(str, 0, sizeof(str[0]) * str_length);
             WideCharToMultiByte(CP_UTF8, 0, wstr, -1, str, len, nullptr, nullptr);
             std::string strTemp = str;
+
             if (wstr) {
                 delete[] wstr;
                 wstr = nullptr;
@@ -116,14 +120,18 @@ namespace asst
 #ifdef _WIN32
             const char* src_str = utf8_str.c_str();
             int len = MultiByteToWideChar(CP_UTF8, 0, src_str, -1, nullptr, 0);
-            wchar_t* wsz_ansi = new wchar_t[len + 1];
-            memset(wsz_ansi, 0, len * 2LLU + 2LLU);
+            const std::size_t wsz_ansi_length = static_cast<std::size_t>(len) + 1;
+            wchar_t *wsz_ansi = new wchar_t[wsz_ansi_length];
+            memset(wsz_ansi, 0, sizeof(wsz_ansi[0]) * wsz_ansi_length);
             MultiByteToWideChar(CP_UTF8, 0, src_str, -1, wsz_ansi, len);
+
             len = WideCharToMultiByte(CP_ACP, 0, wsz_ansi, -1, nullptr, 0, nullptr, nullptr);
-            char* sz_ansi = new char[len + 1];
-            memset(sz_ansi, 0, len + 1LLU);
+            const std::size_t sz_ansi_length = static_cast<std::size_t>(len) + 1;
+            char *sz_ansi = new char[sz_ansi_length];
+            memset(sz_ansi, 0, sizeof(sz_ansi[0]) * sz_ansi_length);
             WideCharToMultiByte(CP_ACP, 0, wsz_ansi, -1, sz_ansi, len, nullptr, nullptr);
             std::string strTemp(sz_ansi);
+
             if (wsz_ansi) {
                 delete[] wsz_ansi;
                 wsz_ansi = nullptr;

--- a/src/MeoAssistant/Logger.hpp
+++ b/src/MeoAssistant/Logger.hpp
@@ -117,7 +117,7 @@ namespace asst
             trace("Version", asst::Version);
             trace("Build DataTime", __DATE__, __TIME__);
 #ifdef _WIN32 // 输出到日志的时候统一编码utf8
-            trace("Working Path", asst::utils::gbk_2_utf8(m_dirname));
+            trace("Working Path", asst::utils::ansi_to_utf8(m_dirname));
 #else
             trace("Working Path", m_dirname);
 #endif
@@ -188,7 +188,7 @@ namespace asst
             inline void operator()(std::ostream& os, T&& first)
             {
 #ifdef _WIN32
-                os << utils::utf8_to_gbk(first) << " ";
+                os << utils::utf8_to_ansi(first) << " ";
 #else
                 os << first << " "; // Don't fucking use gbk in linux
 #endif


### PR DESCRIPTION
gbk_2_utf8 改为 ansi_to_utf8
utf8_to_gbk 改为 utf8_to_ansi

在这些函数中的memset调用统一改为类似 memset(ptr, 0, sizeof(ptr[0]) * 数组长度) 的形式

相关PR #499 