### PR TITLE
fix. 修复复刻活动stageId识别错误

### DIFF
--- a/src/MeoAssistant/StageDropsConfiger.cpp
+++ b/src/MeoAssistant/StageDropsConfiger.cpp
@@ -1,5 +1,6 @@
 #include "StageDropsConfiger.h"
 
+#include <limits>
 #include <meojson/json.hpp>
 
 bool asst::StageDropsConfiger::parse(const json::value& json)
@@ -32,8 +33,16 @@ bool asst::StageDropsConfiger::parse(const json::value& json)
 			m_all_item_id.emplace(item_id);
 		}
 
+		for(const auto& [server_name, server_json] : stage_json.at("existence").as_object()) {
+			if(!server_json.at("exist").as_boolean()) {
+				continue;
+			}
+			info.openTime = (unsigned long)server_json.get("openTime",(time_t)0);
+			info.closeTime = (unsigned long)server_json.get("closeTime", (std::numeric_limits<time_t>::max()));
+			StageKey server_key = {key.code + server_name, key.difficulty};
+			m_stage_info.insert_or_assign(std::move(server_key), info);
+		}
 		m_all_stage_code.emplace(code);
-		m_stage_info.emplace(std::move(key), std::move(info));
 	}
 	return true;
 }

--- a/src/MeoAssistant/StageDropsConfiger.h
+++ b/src/MeoAssistant/StageDropsConfiger.h
@@ -5,6 +5,7 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+#include <ctime>
 
 namespace asst
 {
@@ -45,6 +46,7 @@ namespace asst
     {
         std::string stage_id;
         int ap_cost = 0;
+        unsigned long openTime = 0, closeTime = 0;
         std::unordered_map<StageDropType, std::vector<std::string>> drops;
     };
     struct StageDropInfo
@@ -64,9 +66,12 @@ namespace asst
 
         const auto& get_stage_info(const std::string& code, StageDifficulty difficulty) const
         {
+            unsigned long current = (unsigned long)time(0)*1000;
             StageKey key{ code, difficulty };
             if (auto find_iter = m_stage_info.find(key);
-                find_iter != m_stage_info.end()) {
+                find_iter != m_stage_info.end() &&
+                current >= find_iter->second.openTime &&
+                current < find_iter->second.closeTime) {
                 return find_iter->second;
             }
             else {

--- a/src/MeoAssistant/StageDropsImageAnalyzer.cpp
+++ b/src/MeoAssistant/StageDropsImageAnalyzer.cpp
@@ -410,7 +410,7 @@ std::string asst::StageDropsImageAnalyzer::match_item(const Rect& roi, StageDrop
 
     std::string result;
     if (!m_stage_code.empty()) {
-        auto& drops = Resrc.drops().get_stage_info(m_stage_code, m_difficulty).drops;
+        auto& drops = Resrc.drops().get_stage_info(m_stage_code + m_server, m_difficulty).drops;
         if (auto find_iter = drops.find(type); find_iter != drops.end()) {
             result = match_item_with_templs(find_iter->second);
         }

--- a/src/MeoAssistant/StageDropsImageAnalyzer.h
+++ b/src/MeoAssistant/StageDropsImageAnalyzer.h
@@ -9,6 +9,11 @@ namespace asst
     public:
         using AbstractImageAnalyzer::AbstractImageAnalyzer;
         virtual ~StageDropsImageAnalyzer() = default;
+        StageDropsImageAnalyzer(const cv::Mat image, const std::string server)
+            : StageDropsImageAnalyzer(image)
+        {
+            m_server = server;
+        }
 
         virtual bool analyze() override;
 
@@ -33,6 +38,7 @@ namespace asst
         std::string match_item(const Rect& roi, StageDropType type, int index, int size);
 
         std::string m_stage_code;
+        std::string m_server = "CN";
         StageDifficulty m_difficulty = StageDifficulty::Normal;
         int m_stars = 0;
         std::vector<std::pair<Rect, StageDropType>> m_baseline;

--- a/src/MeoAssistant/StageDropsTaskPlugin.cpp
+++ b/src/MeoAssistant/StageDropsTaskPlugin.cpp
@@ -96,7 +96,7 @@ bool asst::StageDropsTaskPlugin::recognize_drops()
         return false;
     }
 
-    StageDropsImageAnalyzer analyzer(m_ctrler->get_image());
+    StageDropsImageAnalyzer analyzer(m_ctrler->get_image(), m_server);
     if (!analyzer.analyze()) {
         auto info = basic_info();
         info["subtask"] = "RecognizeDrops";
@@ -158,7 +158,7 @@ void asst::StageDropsTaskPlugin::drop_info_callback()
     json::value& stage = details["stage"];
     stage["stageCode"] = m_stage_code;
     if (!m_stage_code.empty()) {
-        stage["stageId"] = Resrc.drops().get_stage_info(m_stage_code, m_stage_difficulty).stage_id;
+        stage["stageId"] = Resrc.drops().get_stage_info(m_stage_code + m_server, m_stage_difficulty).stage_id;
     }
 
     callback(AsstMsg::SubTaskExtraInfo, info);


### PR DESCRIPTION
复刻活动必定晚于插曲，因此在 stage.json 中必定位于下方，而复刻关闭
后 drops 为空，会被直接忽略，只需让晚出现的 stageId 覆盖早出现的即
可返回正确的 stageId。
而为了能够正确识别不同服务器活动开启时间不同的情况，在 StageInfo
中加入了 openTime 和 closeTime 来进行判断，同时在 stageCode 后加
入 "_server" 来进行区别。