### PR TITLE
解决无法带命令启动模拟器

### DIFF
--- a/src/MeoAsstGui/ViewModels/SettingsViewModel.cs
+++ b/src/MeoAsstGui/ViewModels/SettingsViewModel.cs
@@ -218,12 +218,16 @@ namespace MeoAsstGui
         public void TryToStartEmulator()
         {
             if (!StartEmulator
-                || EmulatorPath.Length == 0
-                || !File.Exists(EmulatorPath))
+                || EmulatorPath.Length == 0)
             {
                 return;
             }
-            System.Diagnostics.Process.Start(EmulatorPath);
+            Process emuProcess = new Process();
+            emuProcess.StartInfo.FileName = "cmd.exe";
+            emuProcess.StartInfo.RedirectStandardInput = true;
+            emuProcess.StartInfo.UseShellExecute = false;
+            emuProcess.Start();
+            emuProcess.StandardInput.WriteLine(EmulatorPath);
             int delay = 0;
             if (!int.TryParse(EmulatorWaitSeconds, out delay))
             {


### PR DESCRIPTION
解决#822 的问题，调cmd执行命令，但不再判定模拟器程序是否存在，地址出错会继续运行直至连不上模拟器
WSA能正常启动（C:\Users\cvcgl\AppData\Local\Microsoft\WindowsApps\MicrosoftCorporationII.WindowsSubsystemForAndroid_8wekyb3d8bbwe\WsaClient.exe /launch wsa://com.hypergryph.arknights）