### PR TITLE
fix: 修复快速点击 `停止` 和 `LinkStart！` 导致的 bug

### DIFF
--- a/src/MeoAsstGui/ViewModels/TaskQueueViewModel.cs
+++ b/src/MeoAsstGui/ViewModels/TaskQueueViewModel.cs
@@ -358,7 +358,7 @@ namespace MeoAsstGui
             var asstProxy = _container.Get<AsstProxy>();
             asstProxy.AsstStop();
             AddLog("已停止");
-            Idle = true;
+            // Idle = true;
         }
 
         /// <summary>


### PR DESCRIPTION
延迟 Idle=true 的时间。
在 Stop 的时候 Idle 不变，等到 core 返回 `AllTasksCompleted` 的时候才 Idle。
这样就没问题了吧？

fix #943