### PR TITLE
fix: 修复公招错误

### DIFF
--- a/src/MeoAssistant/RecruitTask.cpp
+++ b/src/MeoAssistant/RecruitTask.cpp
@@ -14,7 +14,7 @@ asst::RecruitTask::RecruitTask(const AsstCallback& callback, void* callback_arg)
     m_recruit_only_calc_task_ptr->set_enable(false);
 
     m_subtasks.emplace_back(m_recruit_begin_task_ptr);
-    m_subtasks.emplace_back(m_auto_recruit_task_ptr)->set_retry_times(1);
+    m_subtasks.emplace_back(m_auto_recruit_task_ptr)->set_retry_times(5);
     m_subtasks.emplace_back(m_recruit_only_calc_task_ptr);
 }
 


### PR DESCRIPTION
fix #995 

按照 @horror-proton 所说，刷新次数不计入 `cur_retry_times`，并把 `ResruitTask.cpp` 中对重试次数的设置由 1 改到 5.
