### PR TITLE
降低因进入主界面时间太长 StartUp 提前退出的概率

### DIFF
--- a/src/MeoAssistant/StartUpTask.cpp
+++ b/src/MeoAssistant/StartUpTask.cpp
@@ -12,7 +12,8 @@ asst::StartUpTask::StartUpTask(AsstCallback callback, void* callback_arg)
     m_start_up_task_ptr->set_tasks({ "StartUp" })
         .set_times_limit("ReturnToTerminal", 0)
         .set_times_limit("Terminal", 0)
-        .set_times_limit("EndOfAction", 0);
+        .set_times_limit("EndOfAction", 0)
+        .set_task_delay(1000).set_retry_times(30);
     m_subtasks.emplace_back(m_start_game_task_ptr);
     m_subtasks.emplace_back(m_start_up_task_ptr);
 }


### PR DESCRIPTION
StartUp 任务每次重试间隔过短, 如果在无法识别的界面 (如 `StartUpConnectingFlag.png` 进度条走完之后, 进入主界面之前的小提示部分) 停留过长会导致重试次数耗尽, 任务退出, 没有处理后面出现的 `"TodaysSupplies"` 和 `"CloseAnno"`. 

表现为卡死在签到页面, 无法进行后续任务.

ref: https://github.com/MaaAssistantArknights/MaaAssistantArknights/issues/1084

