### PR TITLE
perf.简化启动模拟器的逻辑

### DIFF
--- a/src/MeoAsstGui/ViewModels/SettingsViewModel.cs
+++ b/src/MeoAsstGui/ViewModels/SettingsViewModel.cs
@@ -249,23 +249,12 @@ namespace MeoAsstGui
             }
             if (EmulatorAddCommand.Length != 0)
             {
-                string StartCommand = "";
-                if (EmulatorPath.StartsWith("\""))
-                {
-                    StartCommand += EmulatorPath.ToString();
-                }
-                else StartCommand = "\"" + EmulatorPath.ToString() + "\"";
-                StartCommand += " ";
-                StartCommand += EmulatorAddCommand.ToString();
-                Process emuProcess = new Process();
-                emuProcess.StartInfo.FileName = "cmd.exe";
-                emuProcess.StartInfo.RedirectStandardInput = true;
-                emuProcess.StartInfo.UseShellExecute = false;
-                emuProcess.Start();
-                emuProcess.StandardInput.WriteLine(StartCommand);
-                emuProcess.StandardInput.WriteLine("exit");
+                Process.Start(EmulatorPath, EmulatorAddCommand);
             }
-            else Process.Start(EmulatorPath);
+            else
+            {
+                Process.Start(EmulatorPath);
+            }
             int delay = 0;
             if (!int.TryParse(EmulatorWaitSeconds, out delay))
             {


### PR DESCRIPTION
踢掉了cmd，WSA和蓝叠Hyper-V测试可用
请告知用户不要在模拟器路径两侧加引号
我之前写了一堆什么屎山……