### PR TITLE
在 log 函数的参数中支持 range-expression

### DIFF
--- a/src/MeoAssistant/AsstUtils.hpp
+++ b/src/MeoAssistant/AsstUtils.hpp
@@ -307,4 +307,11 @@ namespace asst::utils
     //	}
     //	return str;
     //}
+
+    template <typename T, T Val, typename... Unused>
+    struct integral_constant_at_template_instantiation : std::integral_constant<T, Val> {};
 }
+
+//  delete instantiation of template with message, when static_assert(false, Message) does not work
+#define ASST_STATIC_ASSERT_FALSE(Message, ...) \
+static_assert(::asst::utils::integral_constant_at_template_instantiation<bool, false, __VA_ARGS__>::value, Message)

--- a/src/MeoAssistant/Logger.hpp
+++ b/src/MeoAssistant/Logger.hpp
@@ -179,6 +179,8 @@ namespace asst
             {
 #ifdef _WIN32
                 s << utils::utf8_to_ansi(std::forward<T>(value));
+#else
+                s << std::forward<T>(value);
 #endif
                 return s;
             }

--- a/src/MeoAssistant/Logger.hpp
+++ b/src/MeoAssistant/Logger.hpp
@@ -208,10 +208,10 @@ namespace asst
                 return s;
             } else {
                 ASST_STATIC_ASSERT_FALSE(
-                        "\nunsupported type, one of following required \n"
+                        "\nunsupported type, one of the following expected\n"
                         "\t1. those can be converted to string;\n"
                         "\t2. those can be inserted to stream with operator<< directly;\n"
-                        "\t3. container or nested container containing one of 1. 2. or 3. and iterable with range-based for",
+                        "\t3. container or nested container containing 1. 2. or 3. and iterable with range-based for",
                         Stream, T);
             }
         }


### PR DESCRIPTION
如果容器能用 `for (auto const& element : container)` 这种范围 for 语句遍历, 而且元素也是可以打印的, 那这个容器也能直接作为 log 函数的参数