### PR TITLE
fix: 修复商店任务因网络波动有时不能正确完成的问题

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -3006,7 +3006,7 @@
         "next": [
             "CollectCredit",
             "MallLoading",
-            "Stop"
+            "CreditStoreOcr"
         ]
     },
     "CollectCredit": {

--- a/src/MeoAssistant/MallTask.cpp
+++ b/src/MeoAssistant/MallTask.cpp
@@ -9,7 +9,8 @@ asst::MallTask::MallTask(const AsstCallback& callback, void* callback_arg)
     m_shopping_first_task_ptr(std::make_shared<CreditShoppingTask>(callback, callback_arg, TaskType)),
     m_shopping_task_ptr(std::make_shared<CreditShoppingTask>(callback, callback_arg, TaskType))
 {
-    m_mall_task_ptr->set_tasks({ "MallBegin" });
+    m_mall_task_ptr->set_tasks({ "MallBegin" })
+        .set_times_limit("CreditStoreOcr", 3);
     m_shopping_first_task_ptr->set_enable(false).set_retry_times(1);
     m_shopping_task_ptr->set_enable(false).set_retry_times(1);
 


### PR DESCRIPTION
不知道这个逻辑能不能解决问题，开个 pr 给大家评价一下
原来的逻辑是点一次信用交易所就停，现在最多点三次并且没进入应该会报错（之前直接stop，不会报错）

fix #1182