### PR TITLE
修复加载信用商店内容卡顿导致的收取信用失败

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -3027,6 +3027,7 @@
             100
         ],
         "next": [
+            "CollectCredit",
             "CloseCollectCredit"
         ],
         "rearDelay": 2000


### PR DESCRIPTION
也许能够修复 https://github.com/MaaAssistantArknights/MaaAssistantArknights/issues/1218 的情况