### PR TITLE
chore: 使 CHANGELOG 里的贡献者名字自动带上链接

### DIFF
--- a/tools/MaaBuilder/Build.Job.Changelog.cs
+++ b/tools/MaaBuilder/Build.Job.Changelog.cs
@@ -8,7 +8,7 @@ public partial class Build
 {
     static string AddContributorLink(string text)
     {
-        return Regex.Replace(text, @"@(\w*)", "[@$1](https://github.com/$1)");
+        return Regex.Replace(text, @"@(\w+)", "[@$1](https://github.com/$1)");
     }
     Target UseMaaChangeLog => _ => _
         .Triggers(SetMaaChangeLog)

--- a/tools/MaaBuilder/Build.Job.Changelog.cs
+++ b/tools/MaaBuilder/Build.Job.Changelog.cs
@@ -18,8 +18,15 @@ public partial class Build
             if (File.Exists(Parameters.MaaChangelogFile))
             {
                 Information($"找到 {Parameters.MaaChangelogFile} 文件，读取内容作为更新日志");
-                var text = AddContributorLink(File.ReadAllText(Parameters.MaaChangelogFile));
-                ChangeLog = text;
+                var text = File.ReadAllText(Parameters.MaaChangelogFile);
+                try
+                {
+                    ChangeLog = AddContributorLink(text);
+                }
+                catch
+                {
+                    ChangeLog = text;
+                }
             }
             else
             {

--- a/tools/MaaBuilder/Build.Job.Changelog.cs
+++ b/tools/MaaBuilder/Build.Job.Changelog.cs
@@ -1,10 +1,15 @@
-﻿using System.IO;
+using System.IO;
 using Nuke.Common;
+using System.Text.RegularExpressions;
 
 namespace MaaBuilder;
 
 public partial class Build
 {
+    static string AddContributorLink(string text)
+    {
+        return Regex.Replace(text, @"@(\w*)", "[@$1](https://github.com/$1)");
+    }
     Target UseMaaChangeLog => _ => _
         .Triggers(SetMaaChangeLog)
         .After(UseTagVersion)
@@ -13,7 +18,7 @@ public partial class Build
             if (File.Exists(Parameters.MaaChangelogFile))
             {
                 Information($"找到 {Parameters.MaaChangelogFile} 文件，读取内容作为更新日志");
-                var text = File.ReadAllText(Parameters.MaaChangelogFile);
+                var text = AddContributorLink(File.ReadAllText(Parameters.MaaChangelogFile));
                 ChangeLog = text;
             }
             else


### PR DESCRIPTION
之前的 _**弹窗 CHANGELOG**_ 和 _**tg 群 bot**_ 并不能正确给 contributor 加上链接的问题，给 CHANGELOG 的生成做一个小优化