### PR TITLE
feat: 优化肉鸽掉落的招募券二选一选择逻辑

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -7774,9 +7774,153 @@
         ],
         "rearDelay": 2000,
         "next": [
+            "Roguelike1GetDropSelectRecruitWarrior",
+            "Roguelike1GetDropSelectRecruitPioneer",
+            "Roguelike1GetDropSelectRecruitTank",
+            "Roguelike1GetDropSelectRecruitSniper",
+            "Roguelike1GetDropSelectRecruitCaster",
+            "Roguelike1GetDropSelectRecruitMedic",
             "Roguelike1GetDropSelectRecruit",
             "Roguelike1GetDropSelectReward",
             "Roguelike1ChooseOperFlag"
+        ]
+    },
+    "Roguelike1GetDropSelectRecruitWarrior": {
+        "action": "ClickSelf",
+        "algorithm": "OcrDetect",
+        "text": [
+            "近卫招募券"
+        ],
+        "roi": [
+            0,
+            300,
+            1280,
+            100
+        ],
+        "rectMove": [
+            -50,
+            150,
+            220,
+            50
+        ],
+        "next": [
+            "Roguelike1ChooseOperFlag",
+            "Roguelike1GetDropSelectRecruit"
+        ]
+    },
+    "Roguelike1GetDropSelectRecruitPioneer": {
+        "action": "ClickSelf",
+        "algorithm": "OcrDetect",
+        "text": [
+            "先锋招募券"
+        ],
+        "roi": [
+            0,
+            300,
+            1280,
+            100
+        ],
+        "rectMove": [
+            -50,
+            150,
+            220,
+            50
+        ],
+        "next": [
+            "Roguelike1ChooseOperFlag",
+            "Roguelike1GetDropSelectRecruit"
+        ]
+    },
+    "Roguelike1GetDropSelectRecruitTank": {
+        "action": "ClickSelf",
+        "algorithm": "OcrDetect",
+        "text": [
+            "重装招募券"
+        ],
+        "roi": [
+            0,
+            300,
+            1280,
+            100
+        ],
+        "rectMove": [
+            -50,
+            150,
+            220,
+            50
+        ],
+        "next": [
+            "Roguelike1ChooseOperFlag",
+            "Roguelike1GetDropSelectRecruit"
+        ]
+    },
+    "Roguelike1GetDropSelectRecruitSniper": {
+        "action": "ClickSelf",
+        "algorithm": "OcrDetect",
+        "text": [
+            "狙击招募券"
+        ],
+        "roi": [
+            0,
+            300,
+            1280,
+            100
+        ],
+        "rectMove": [
+            -50,
+            150,
+            220,
+            50
+        ],
+        "next": [
+            "Roguelike1ChooseOperFlag",
+            "Roguelike1GetDropSelectRecruit"
+        ]
+    },
+    "Roguelike1GetDropSelectRecruitCaster": {
+        "action": "ClickSelf",
+        "algorithm": "OcrDetect",
+        "text": [
+            "术师招募券"
+        ],
+        "roi": [
+            0,
+            300,
+            1280,
+            100
+        ],
+        "rectMove": [
+            -50,
+            150,
+            220,
+            50
+        ],
+        "next": [
+            "Roguelike1ChooseOperFlag",
+            "Roguelike1GetDropSelectRecruit"
+        ]
+    },
+    "Roguelike1GetDropSelectRecruitMedic": {
+        "action": "ClickSelf",
+        "algorithm": "OcrDetect",
+        "text": [
+            "医疗招募券"
+        ],
+        "roi": [
+            0,
+            300,
+            1280,
+            100
+        ],
+        "rectMove": [
+            -50,
+            150,
+            220,
+            50
+        ],
+        "next": [
+            "Roguelike1ChooseOperFlag",
+            "Roguelike1GetDropSelectRecruit"
         ]
     },
     "Roguelike1GetDropSelectRecruit": {


### PR DESCRIPTION
- 肉鸽掉落的招募券二选一会按照以下顺序选择：
  - 近卫 > 先锋 > 重装 > 狙击 > 术师 > 医疗（顺序可能需要重新调整）
- 不会主动选择特种和辅助招募券
- 如果出现特种和辅助二选一，则按默认逻辑，选左边那个
- 后续会考虑写一个插件，实现智能选择：
  - 根据当前选择的分队，优先选择自动精二的职业
  - 自动选择编队中缺少的职业
  - 自动选择编队中需要精二的职业
  - 如果希望不够就随便选一个3星可以凑数的职业（医疗、先锋、重装）