### PR TITLE
fix. 修复目录带空格时无法自启的问题

### DIFF
--- a/src/MeoAsstGui/ViewModels/StartSelfModel.cs
+++ b/src/MeoAsstGui/ViewModels/StartSelfModel.cs
@@ -49,7 +49,7 @@ namespace MeoAsstGui
         {
             if (set)
             {
-                _key.SetValue("MeoAsst", fileValue);
+                _key.SetValue("MeoAsst", "\"" + fileValue + "\"");
                 return CheckStart();
             }
             else


### PR DESCRIPTION
<!-- MODULE:GUI --!>
自己写的bug自己修2.0

fix#1505 ，用户需要在更新后取消勾选开机自启并重新勾选
建议检查一下其他地方有没有目录一类的东西可能带空格没加引号的