### PR TITLE
fix: 肉鸽招募逻辑修正

### DIFF
--- a/src/MeoAssistant/RoguelikeRecruitTaskPlugin.cpp
+++ b/src/MeoAssistant/RoguelikeRecruitTaskPlugin.cpp
@@ -78,13 +78,7 @@ bool asst::RoguelikeRecruitTaskPlugin::_run()
             const auto& char_opt = chars_map.find(oper_info.name);
 
             if (char_opt.has_value()) {
-                // 干员已在编队中
-                int elite = char_opt.value().get("elite", 0);
-                if (elite == 2) {
-                    // 干员已精二，忽略
-                    continue;
-                }
-
+                // 干员已在编队中，又出现在招募列表，只有待晋升和预备干员两种情况
                 if (recruit_info.is_alternate) {
                     // 预备干员可以重复招募
                     priority = recruit_info.recruit_priority;

--- a/src/MeoAssistant/RoguelikeRecruitTaskPlugin.cpp
+++ b/src/MeoAssistant/RoguelikeRecruitTaskPlugin.cpp
@@ -95,20 +95,29 @@ bool asst::RoguelikeRecruitTaskPlugin::_run()
                 }
             }
             else {
-                // 干员待招募
+                // 干员待招募，检查练度
                 if (oper_info.elite == 2) {
                     // TODO: 招募时已精二 (随机提升或对应分队) => promoted_priority
                     priority = recruit_info.recruit_priority;
                 }
-                else {
-                    // 招募时未精二
+                else if (oper_info.elite == 1 && oper_info.level >= 50) {
+                    // 精一50级以上
                     priority = recruit_info.recruit_priority;
+                }
+                else {
+                    // 精一50级以下，默认不招募
+                    Log.trace(__FUNCTION__, "| Ignored low level oper:", oper_info.name, oper_info.elite, oper_info.level);
                 }
             }
 
             // 已经划到后备干员，且已有候选干员，假定后面的干员优先级不会更高，不再划动
             if (recruit_info.is_alternate && !recruit_list.empty()) {
                 stop_swipe = true;
+            }
+
+            // 优先级为0，可能练度不够被忽略
+            if (priority == 0) {
+                continue;
             }
 
             // 添加到候选名单


### PR DESCRIPTION
修正 #1569 的部分逻辑：
- 不再招募精一50级以下的干员
- 删除多余的判断：编队中已精二的干员不会出现在招募列表
- 修正招募界面未检测到任何干员导致不断滑动重试的问题
  - 已验证触发原因：进入了晋升界面，但又没有任何干员可以晋升
- 已知问题：
  - 因为晋升和招募是同一个界面，会尝试滑动 5 次寻找候选干员
  - 偶尔会有识别失败的情况，保存的截图看不出任何问题