### PR TITLE
perf: 改进肉鸽招募逻辑

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -7005,7 +7005,7 @@
             640,
             500
         ],
-        "templThreshold": 0.95
+        "templThreshold": 0.9
     },
     "Roguelike1RecruitOcr": {
         "algorithm": "OcrDetect",

--- a/src/MeoAssistant/AsstBattleDef.h
+++ b/src/MeoAssistant/AsstBattleDef.h
@@ -127,7 +127,6 @@ namespace asst
         Rect rect;
         int elite = 0;
         int level = 0;
-        bool required = false;
     };
 
     using BattleAttackRange = std::vector<Point>;

--- a/src/MeoAssistant/RoguelikeRecruitImageAnalyzer.cpp
+++ b/src/MeoAssistant/RoguelikeRecruitImageAnalyzer.cpp
@@ -19,10 +19,6 @@ bool asst::RoguelikeRecruitImageAnalyzer::analyze()
         return false;
     }
 
-    const auto& order = Resrc.roguelike_recruit().get_oper_order();
-    analyzer.set_required(order);
-    analyzer.sort_result_by_required();
-
     for (const auto& [_, rect, name] : analyzer.get_result()) {
         int elite = match_elite(rect);
         int level = match_level(rect);
@@ -32,20 +28,10 @@ bool asst::RoguelikeRecruitImageAnalyzer::analyze()
         info.name = name;
         info.elite = elite;
         info.level = level;
-        info.required = ranges::find(order, name) != order.cend();
 
         Log.info(__FUNCTION__, name, elite, level, rect.to_string());
         m_result.emplace_back(std::move(info));
     }
-
-    auto first_un_req = ranges::find_if(m_result, std::not_fn(std::mem_fn(&BattleRecruitOperInfo::required)));
-    std::sort(first_un_req, m_result.end(),
-        [&](const auto& lhs, const auto& rhs) -> bool {
-            if (lhs.elite == rhs.elite) {
-                return lhs.level > rhs.level;
-            }
-            return lhs.elite > rhs.elite;
-        });
 
     return !m_result.empty();
 }


### PR DESCRIPTION
### 改进肉鸽招募逻辑
- 删除旧逻辑遗留的招募结果排序及 required 字段
  - 如果我没理解错：```RoguelikeRecruitImageAnalyzer::analyze``` 是先识别干员，再 ```set_required``` 并 ```sort_result_by_required```，即：```oper_order``` (干员名字列表) 并不影响识别结果，只用于排序。由于后续已经有优先级排序，此处不再需要排序。进而，```required``` 字段也没有必要
- 以下情况自动停止滑动 (fix #1642)：
  - 滑动前识别的干员少于8个（初始页面可以显示2列，8个干员）
  - 滑动后识别的干员少于4个（滑动后至少能显示1列，4个干员）
  - 滑动后识别失败（没有识别结果，通常是干员不可选）
  - 滑了没动，任意干员名字的位置没有变化（x 偏移低于阈值20像素）

识别区域如图所示，滑动后至少能显示1列：
![2022-08-17_21-22-20 197_raw](https://user-images.githubusercontent.com/1037590/185145649-7feee6ad-b089-48b8-84ea-7ea5d0e1c823.png)
