### PR TITLE
perf: 在关卡掉落识别中使用边缘检测判断线条位置

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -8311,7 +8311,7 @@
         "specialThreshold": 100,
         "specialThreshold_Doc": "基建长度阈值（不小于120）",
         "maskRange": [
-            35,
+            70,
             255
         ],
         "rectMove": [

--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -8309,7 +8309,7 @@
         "templThreshold": 17,
         "templThreshold_Doc": "这里用来作为基线间距阈值",
         "specialThreshold": 100,
-        "specialThreshold_Doc": "基建长度阈值（不小于120）",
+        "specialThreshold_Doc": "基线长度阈值（不小于100）",
         "maskRange": [
             70,
             255


### PR DESCRIPTION
之前在群里提到过的一个想法, 大概就是竖直方向变化减去水平方向变化. 
给图片加一个预处理, 用 Sobel 算符求出偏导数 $\partial_y I$ 和 $\partial_x I$, 因为材料下面的线条是水平的而且只有两个像素粗, 所以减一下把梯度偏太多的像素过滤掉
$$V = \sqrt{(\partial_y I)^2 - (\tan\alpha \cdot \partial_x I)^2},$$
这样只有梯度方向朝上或者朝下的像素可以得出正值, 偏离多于 $\frac{\pi}{2}-\alpha$ 的像素都是负值. 

----
<details><summary>2022-07-20_21-29-36.169_raw.png</summary>

![2022-07-20_21-29-36.169_raw](https://github.com/MaaAssistantArknights/MaaTestSet/blob/856281d4f1371cff8378d17ba9cdc862a70cfa72/drops/screenshots/2022-07-20_21-29-36.169_raw.png?raw=true)
![2022-07-20_21-29-36.169_raw](https://user-images.githubusercontent.com/107091537/186436345-262f2bb3-8676-4543-8416-2676259b089b.png)

</details>

----
<details><summary>2022-07-24_23-22-10.387_raw.png</summary>

![2022-07-24_23-22-10.387_raw](https://github.com/MaaAssistantArknights/MaaTestSet/blob/856281d4f1371cff8378d17ba9cdc862a70cfa72/drops/screenshots/2022-07-24_23-22-10.387_raw.png?raw=true)
![2022-07-24_23-22-10.387_raw](https://user-images.githubusercontent.com/107091537/186438720-b5e50259-dd4a-4ada-a822-604d083c34c3.png)

</details>

----
<details><summary>2022-08-14_13-46-36.453_raw.png</summary>

![2022-08-14_13-46-36.453_raw](https://github.com/MaaAssistantArknights/MaaTestSet/blob/856281d4f1371cff8378d17ba9cdc862a70cfa72/drops/screenshots/2022-08-14_13-46-36.453_raw.png?raw=true)
![2022-08-14_13-46-36.453_raw](https://user-images.githubusercontent.com/107091537/186440426-2e5df629-31de-4c7f-a149-2f5867dbf90d.png)

</details>

----

如果出现中间断开一个像素的情况, 可以用水平方向的 `cv::dilate` 填起来 (把每个像素值换成周围一定区域内的最大值), 然后再 `cv::erode` 回去 (可以防止探测出的线条比实际长).
因为边缘检测得到的线条有四个像素宽, 在竖直方向允许 `cv::erode` 成两个像素, 可以尽量排除干员皮肤中横线的干扰 (感觉不大会有这种干扰吧).

测试集全部都能通过, 但是因为原理不一样, 不知道会不会有意料之外的翻车情况