### PR TITLE
perf: 使用 demangle 来获得更准确的类型名称

### DIFF
--- a/src/MeoAssistant/AbstractTask.cpp
+++ b/src/MeoAssistant/AbstractTask.cpp
@@ -98,7 +98,7 @@ void asst::AbstractTask::clear_plugin() noexcept
 json::value asst::AbstractTask::basic_info() const
 {
     if (m_basic_info_cache.empty()) {
-        std::string class_name = typeid(*this).name();
+        std::string class_name = utils::demangle(typeid(*this).name());
         std::string task_name;
         // typeid.name() 结果可能和编译器有关，所以这里使用正则尽可能保证结果正确。
         // 但还是不能完全保证，如果不行的话建议 override

--- a/src/MeoAssistant/AsstUtils.hpp
+++ b/src/MeoAssistant/AsstUtils.hpp
@@ -360,11 +360,11 @@ namespace asst::utils
         std::free(p);
         return result;
 #else
-        std::string result = name_from_typeid;
-        if (result.substr(0, 6) == "class ") result = result.substr(6);
-        if (result.substr(0, 7) == "struct ") result = result.substr(7);
-        if (result.substr(0, 5) == "enum ") result = result.substr(5);
-        return result;
+        std::string_view temp(name_from_typeid);
+        if (temp.substr(0, 6) == "class ") return std::string(temp.substr(6));
+        if (temp.substr(0, 7) == "struct ") return std::string(temp.substr(7));
+        if (temp.substr(0, 5) == "enum ") return std::string(temp.substr(5));
+        return std::string(temp);
 #endif
     }
 } // namespace asst::utils

--- a/src/MeoAssistant/AsstUtils.hpp
+++ b/src/MeoAssistant/AsstUtils.hpp
@@ -16,6 +16,9 @@
 #include <sys/wait.h>
 #include <unistd.h>
 #endif
+#ifndef _MSC_VER
+#include <cxxabi.h>
+#endif
 
 namespace asst::utils
 {
@@ -344,5 +347,24 @@ namespace asst::utils
         }
 #endif
         return pipe_str;
+    }
+
+    inline std::string demangle(const char* name_from_typeid)
+    {
+#ifndef _MSC_VER
+        int status = 0;
+        std::size_t size = 0;
+        char* p = abi::__cxa_demangle(name_from_typeid, NULL, &size, &status);
+        if (!p) return name_from_typeid;
+        std::string result(p);
+        std::free(p);
+        return result;
+#else
+        std::string result = name_from_typeid;
+        if (result.substr(0, 6) == "class ") result = result.substr(6);
+        if (result.substr(0, 7) == "struct ") result = result.substr(7);
+        if (result.substr(0, 5) == "enum ") result = result.substr(5);
+        return result;
+#endif
     }
 } // namespace asst::utils


### PR DESCRIPTION
抄了一下 boost 的写法
https://github.com/boostorg/core/blob/414dfb466878af427d33b36e6ccf84d21c0e081b/include/boost/core/type_name.hpp#L66-L104
MSVC 上的效果应该只是把 `class ` 前缀去掉了.
话说这两个字段有在什么地方被使用吗