### PR TITLE
feat: 新增在ADB重连失败断开连接时重启模拟器重试的选项，默认关闭

### DIFF
--- a/src/MeoAssistant/Controller.cpp
+++ b/src/MeoAssistant/Controller.cpp
@@ -376,7 +376,7 @@ std::optional<std::vector<uchar>> asst::Controller::call_command(const std::stri
                   { "cmd", cmd },
               } },
         };
-        constexpr static int ReconnectTimes = 5;
+        constexpr static int ReconnectTimes = 20;
         for (int i = 0; i < ReconnectTimes; ++i) {
             if (need_exit()) {
                 break;

--- a/src/MeoAssistant/Controller.cpp
+++ b/src/MeoAssistant/Controller.cpp
@@ -376,7 +376,7 @@ std::optional<std::vector<uchar>> asst::Controller::call_command(const std::stri
                   { "cmd", cmd },
               } },
         };
-        constexpr static int ReconnectTimes = 20;
+        constexpr static int ReconnectTimes = 5;
         for (int i = 0; i < ReconnectTimes; ++i) {
             if (need_exit()) {
                 break;

--- a/src/MeoAsstGui/Helper/AsstProxy.cs
+++ b/src/MeoAsstGui/Helper/AsstProxy.cs
@@ -325,7 +325,7 @@ namespace MeoAsstGui
                     break;
 
                 case "Reconnecting":
-                    mainModel.AddLog(Localization.GetString("TryToReconnect"), LogColor.Error);
+                    mainModel.AddLog($"{Localization.GetString("TryToReconnect")}({Convert.ToUInt32(details["details"]["times"]) + 1})", LogColor.Error);
                     break;
 
                 case "Reconnected":
@@ -336,6 +336,20 @@ namespace MeoAsstGui
                     connected = false;
                     mainModel.AddLog(Localization.GetString("ReconnectFailed"), LogColor.Error);
                     AsstStop();
+
+                    var settingsModel = _container.Get<SettingsViewModel>();
+                    Execute.OnUIThread(async () =>
+                    {
+                        if (settingsModel.RetryOnDisconnected)
+                        {
+                            mainModel.AddLog(Localization.GetString("TryToStartEmulator"), LogColor.Error);
+                            mainModel.killEmulator();
+                            await Task.Delay(3000);
+                            mainModel.Stop();
+                            mainModel.LinkStart();
+                        }
+                    });
+
                     break;
 
                 case "ScreencapFailed":

--- a/src/MeoAsstGui/Resources/Localizations/en-us.xaml
+++ b/src/MeoAsstGui/Resources/Localizations/en-us.xaml
@@ -150,6 +150,8 @@
     <system:String x:Key="ConnectionAddress">Connection address</system:String>
     <system:String x:Key="ConnectionAddressTip">It will be filled in automatically when you use it for the first time. If you encounter any problems, you can try to manually modify it</system:String>
     <system:String x:Key="ConnectionPreset">Connection Preset</system:String>
+    <system:String x:Key="RetryOnDisconnected">Auto restart emulator when adb reconnection fails</system:String>
+    <system:String x:Key="RetryOnDisconnectedTip">Try restarting the emulator after 20 failed reconnect attempts, Must be checked when using a background timed task and setting the task to close the emulator when finished</system:String>
     <!--  Settings  -->
 
     <!--  Farming  -->

--- a/src/MeoAsstGui/Resources/Localizations/ja-jp.xaml
+++ b/src/MeoAsstGui/Resources/Localizations/ja-jp.xaml
@@ -150,6 +150,8 @@
     <system:String x:Key="ConnectionAddress">接続先アドレス</system:String>
     <system:String x:Key="ConnectionAddressTip">初めて使うと自動で記入されますので、問題があれば手動で修正してみてください</system:String>
     <system:String x:Key="ConnectionPreset">接続構成</system:String>
+    <system:String x:Key="RetryOnDisconnected">adb再接続失敗時のエミュレータの自動再起動</system:String>
+    <system:String x:Key="RetryOnDisconnectedTip">再接続に20回失敗した後、エミュレータを再起動してみてください，バックグラウンドのタイムドタスクを使用し、終了時にエミュレータを終了させるタスクを設定する場合は、必ずチェックを入れること</system:String>
     <!--  設定  -->
 
     <!--  スタート  -->

--- a/src/MeoAsstGui/Resources/Localizations/ko-kr.xaml
+++ b/src/MeoAsstGui/Resources/Localizations/ko-kr.xaml
@@ -150,6 +150,8 @@
     <system:String x:Key="ConnectionAddress">연결 주소</system:String>
     <system:String x:Key="ConnectionAddressTip">처음 사용할 때는 자동으로 작성되며, 문제가 있으면 수동으로 수정하십시오</system:String>
     <system:String x:Key="ConnectionPreset">연결 사전 설정</system:String>
+    <system:String x:Key="RetryOnDisconnected">adb 재연결이 실패하면 자동으로 에뮬레이터를 다시 시작합니다</system:String>
+    <system:String x:Key="RetryOnDisconnectedTip">20번의 재연결 실패 후 에뮬레이터를 다시 시작하십시오, 백그라운드 시간 지정 작업을 사용하고 작업이 완료되면 시뮬레이터를 닫도록 설정하려면 다음을 선택해야 합니다</system:String>
     <!--  설정  -->
 
     <!--  메인 화면  -->

--- a/src/MeoAsstGui/Resources/Localizations/pallas.xaml
+++ b/src/MeoAsstGui/Resources/Localizations/pallas.xaml
@@ -150,6 +150,8 @@
     <system:String x:Key="ConnectionAddress">🍻🕺🍻</system:String>
     <system:String x:Key="ConnectionAddressTip">🍷🍷🍷🍺🍺🍻💃🍻🍺🍺🍷🍻🕺🍻🕺💃🕺🍸💃🍸🍷🍷🍺🕺🍸</system:String>
     <system:String x:Key="ConnectionPreset">🍸🍷🍻</system:String>
+    <system:String x:Key="RetryOnDisconnected">🍺🍷🍺🍸🍷🍻🕺🕺🍺🍷🍻🍺🍸🍻🍸🍺</system:String>
+    <system:String x:Key="RetryOnDisconnectedTip">🍻🍺🍸🍻🍷🍻🍷🍻🍷🍻🍻🍸🕺🍺🍺🍸🍺🍺🍺🍺🍸🕺🍻🍷🍸🕺🍷🕺🕺🍻🍷🍻🍺🕺🍺🍻🍷🍷💃💃🍺🍸</system:String>
     <!--  设置  -->
 
     <!--  一键长草  -->

--- a/src/MeoAsstGui/Resources/Localizations/zh-cn.xaml
+++ b/src/MeoAsstGui/Resources/Localizations/zh-cn.xaml
@@ -150,7 +150,8 @@
     <system:String x:Key="ConnectionAddress">连接地址</system:String>
     <system:String x:Key="ConnectionAddressTip">第一次使用会自动填写，若遇到问题可尝试手动修改</system:String>
     <system:String x:Key="ConnectionPreset">连接配置</system:String>
-    <system:String x:Key="RetryOnDisconnected">ADB重连失败时尝试重启模拟器后再次重连（后台使用定时任务挂机且设置任务完成自动关闭模拟器必须勾选该项）</system:String>
+    <system:String x:Key="RetryOnDisconnected">adb重连失败时自动重启模拟器</system:String>
+    <system:String x:Key="RetryOnDisconnectedTip">重连失败20次后尝试重启模拟器，使用后台定时任务且设置任务完成关闭模拟器时必须勾选</system:String>
     <!--  设置  -->
 
     <!--  一键长草  -->

--- a/src/MeoAsstGui/Resources/Localizations/zh-cn.xaml
+++ b/src/MeoAsstGui/Resources/Localizations/zh-cn.xaml
@@ -150,6 +150,7 @@
     <system:String x:Key="ConnectionAddress">连接地址</system:String>
     <system:String x:Key="ConnectionAddressTip">第一次使用会自动填写，若遇到问题可尝试手动修改</system:String>
     <system:String x:Key="ConnectionPreset">连接配置</system:String>
+    <system:String x:Key="RetryOnDisconnected">ADB重连失败时尝试重启模拟器后再次重连（后台使用定时任务挂机且设置任务完成自动关闭模拟器必须勾选该项）</system:String>
     <!--  设置  -->
 
     <!--  一键长草  -->

--- a/src/MeoAsstGui/Resources/Localizations/zh-tw.xaml
+++ b/src/MeoAsstGui/Resources/Localizations/zh-tw.xaml
@@ -150,6 +150,8 @@
     <system:String x:Key="ConnectionAddress">連接地址</system:String>
     <system:String x:Key="ConnectionAddressTip">第一次使用會自動填寫，若遇到問題可嘗試手動修改</system:String>
     <system:String x:Key="ConnectionPreset">連接配置</system:String>
+    <system:String x:Key="RetryOnDisconnected">adb重連失敗時自動重啟模擬器</system:String>
+    <system:String x:Key="RetryOnDisconnectedTip">重連失敗20次後嘗試重啟模擬器，使用後台定時任務且設置任務完成關閉模擬器時必須勾選</system:String>
     <!--  設定  -->
 
     <!--  一鍵長草  -->

--- a/src/MeoAsstGui/UserControl/ConnectSettingsUserControl.xaml
+++ b/src/MeoAsstGui/UserControl/ConnectSettingsUserControl.xaml
@@ -96,7 +96,7 @@
         <CheckBox
             Grid.Row="4"
             Grid.ColumnSpan="4"
-            Margin="10,0,0,0"
+            Margin="50,0,0,0"
             VerticalAlignment="Center"
             IsChecked="{Binding RetryOnDisconnected}"
             Content="{DynamicResource RetryOnDisconnected}"

--- a/src/MeoAsstGui/UserControl/ConnectSettingsUserControl.xaml
+++ b/src/MeoAsstGui/UserControl/ConnectSettingsUserControl.xaml
@@ -22,6 +22,7 @@
             <RowDefinition />
             <RowDefinition />
             <RowDefinition />
+            <RowDefinition />
         </Grid.RowDefinitions>
         <TextBlock
             Grid.Row="0"
@@ -91,5 +92,15 @@
             ItemsSource="{Binding ConnectConfigList}"
             SelectedValue="{Binding ConnectConfig}"
             SelectedValuePath="Value" />
+
+        <CheckBox
+            Grid.Row="4"
+            Grid.ColumnSpan="4"
+            Margin="10,0,0,0"
+            VerticalAlignment="Center"
+            IsChecked="{Binding RetryOnDisconnected}"
+            HorizontalAlignment="Left">
+            <TextBlock TextWrapping="Wrap" Text="{DynamicResource RetryOnDisconnected}" />
+        </CheckBox>
     </Grid>
 </UserControl>

--- a/src/MeoAsstGui/UserControl/ConnectSettingsUserControl.xaml
+++ b/src/MeoAsstGui/UserControl/ConnectSettingsUserControl.xaml
@@ -99,8 +99,8 @@
             Margin="10,0,0,0"
             VerticalAlignment="Center"
             IsChecked="{Binding RetryOnDisconnected}"
-            HorizontalAlignment="Left">
-            <TextBlock TextWrapping="Wrap" Text="{DynamicResource RetryOnDisconnected}" />
-        </CheckBox>
+            Content="{DynamicResource RetryOnDisconnected}"
+            ToolTip="{DynamicResource RetryOnDisconnectedTip}"
+            HorizontalAlignment="Left" />
     </Grid>
 </UserControl>

--- a/src/MeoAsstGui/ViewModels/SettingsViewModel.cs
+++ b/src/MeoAsstGui/ViewModels/SettingsViewModel.cs
@@ -1428,6 +1428,21 @@ namespace MeoAsstGui
             }
         }
 
+        private bool _retryOnDisconnected = Convert.ToBoolean(ViewStatusStorage.Get("Connect.RetryOnDisconnected", bool.FalseString));
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to retry task after adb disconnected.
+        /// </summary>
+        public bool RetryOnDisconnected
+        {
+            get => _retryOnDisconnected;
+            set
+            {
+                SetAndNotify(ref _retryOnDisconnected, value);
+                ViewStatusStorage.Set("Connect.RetryOnDisconnected", value.ToString());
+            }
+        }
+
         private readonly Dictionary<string, List<string>> _defaultAddress = new Dictionary<string, List<string>>
         {
             { "General", new List<string> { string.Empty } },


### PR DESCRIPTION
BUG：开启定时任务并设置任务完成后自动关闭模拟器时，仅有第一次定时任务可以成功执行，第二次定时任务只会尝试重连ADB不会自动启动模拟器，重连20次后进入失败状态且任务不会停止，后续定时任务均无法执行。同#1369
REASON：如果在MAA当前与模拟器ADB处于已连接状态时关闭模拟器（如设置定时任务完成后关闭模拟器或手动关闭模拟器），会导致下次任务开始时模拟器只会尝试重连ADB，重连次数耗尽时直接断开连接并停止任务，不会触发自动启动模拟器。
FIX：该PR将ADB重连次数减少为5次，并新增选项在ADB重连次数耗尽时重试任务，此时会尝试启动模拟器后再重新连接ADB，该选项默认关闭。开启该选项后可将MAA定时任务常驻后台，并选择任务完成后自动关闭模拟器，启动模拟器->执行定时任务->关闭模拟器的循环，无需模拟器常驻后台占用资源。