### PR TITLE
feat: 优化Gui关卡选择逻辑

### DIFF
--- a/src/MeoAsstGui/Helper/StageActivityInfo.cs
+++ b/src/MeoAsstGui/Helper/StageActivityInfo.cs
@@ -1,0 +1,47 @@
+// <copyright file="StageActivityInfo.cs" company="MaaAssistantArknights">
+// MeoAsstGui - A part of the MeoAssistantArknights project
+// Copyright (C) 2021 MistEO and Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY
+// </copyright>
+
+using System;
+
+namespace MeoAsstGui
+{
+    /// <summary>
+    /// Stage activity info
+    /// </summary>
+    public class StageActivityInfo
+    {
+        /// <summary>
+        /// Gets or sets the activity tip
+        /// </summary>
+        public string Tip { get; set; }
+
+        /// <summary>
+        /// Gets or sets the activity UTC expire time
+        /// </summary>
+        public DateTime UtcExpireTime { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the activity is a resource collection activity
+        /// </summary>
+        /// <remarks>
+        /// Sets to true indicates a resource collection activity,
+        /// when the activity expires, <seealso cref="StageManager"/> will continue to check stage open days.
+        /// </remarks>
+        public bool IsResourceCollection { get; set; }
+
+        /// <summary>
+        /// Gets a value indicating whether the activity is expired
+        /// </summary>
+        public bool IsExpired => DateTime.UtcNow >= UtcExpireTime;
+    }
+}

--- a/src/MeoAsstGui/Helper/StageInfo.cs
+++ b/src/MeoAsstGui/Helper/StageInfo.cs
@@ -1,0 +1,115 @@
+// <copyright file="StageInfo.cs" company="MaaAssistantArknights">
+// MeoAsstGui - A part of the MeoAssistantArknights project
+// Copyright (C) 2021 MistEO and Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MeoAsstGui
+{
+    /// <summary>
+    /// Stage info
+    /// </summary>
+    public class StageInfo : CombData
+    {
+        /// <summary>
+        /// Gets or sets the stage tip
+        /// </summary>
+        public string Tip { get; set; }
+
+        /// <summary>
+        /// Gets or sets the stage open days
+        /// </summary>
+        public IEnumerable<DayOfWeek> OpenDays { get; set; }
+
+        /// <summary>
+        /// Gets or sets the stage associated activity
+        /// </summary>
+        public StageActivityInfo Activity { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the stage is hidden
+        /// </summary>
+        public bool IsHidden { get; set; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StageInfo"/> class.
+        /// </summary>
+        public StageInfo()
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StageInfo"/> class with tip and open days.
+        /// </summary>
+        /// <param name="name">Stage name</param>
+        /// <param name="tipKey">Localization key of tip</param>
+        /// <param name="openDays">Open days of week</param>
+        /// <param name="activity">Associated activity</param>
+        public StageInfo(string name, string tipKey, IEnumerable<DayOfWeek> openDays, StageActivityInfo activity)
+        {
+            Value = name;
+            Display = Localization.GetString(name);
+            OpenDays = openDays;
+            Activity = activity;
+
+            if (!string.IsNullOrEmpty(tipKey))
+            {
+                Tip = Localization.GetString(tipKey);
+            }
+        }
+
+        /// <summary>
+        /// Determine whether the stage associated activity is closed
+        /// </summary>
+        /// <param name="dayOfWeek">Current day of week</param>
+        /// <returns>Whether activity is closed</returns>
+        public bool IsActivityClosed()
+        {
+            return Activity != null && Activity.IsExpired && !Activity.IsResourceCollection;
+        }
+
+        /// <summary>
+        /// Determine whether the stage is open
+        /// </summary>
+        /// <param name="dayOfWeek">Current day of week</param>
+        /// <returns>Whether stage is open</returns>
+        public bool IsStageOpen(DayOfWeek dayOfWeek)
+        {
+            if (Activity != null)
+            {
+                if (!Activity.IsExpired)
+                {
+                    return true;
+                }
+
+                // expired activity
+                if (!Activity.IsResourceCollection)
+                {
+                    return false;
+                }
+
+                // expired resource activity, check open days
+            }
+
+            // resource stage
+            if (OpenDays != null && OpenDays.Count() > 0)
+            {
+                return OpenDays.Contains(dayOfWeek);
+            }
+
+            // regular stage, always open
+            return true;
+        }
+    }
+}

--- a/src/MeoAsstGui/Helper/StageManager.cs
+++ b/src/MeoAsstGui/Helper/StageManager.cs
@@ -1,0 +1,153 @@
+// <copyright file="StageManager.cs" company="MaaAssistantArknights">
+// MeoAsstGui - A part of the MeoAssistantArknights project
+// Copyright (C) 2021 MistEO and Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace MeoAsstGui
+{
+    /// <summary>
+    /// Stage manager
+    /// </summary>
+    public class StageManager
+    {
+        private readonly Dictionary<string, StageInfo> _stages;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="StageManager"/> class.
+        /// </summary>
+        public StageManager()
+        {
+            // var sideStory = new StageActivityInfo()
+            // {
+            //    Tip = "SideStory「理想城：长夏狂欢季」活动",
+            //    UtcExpireTime = new DateTime(2022, 9, 1, 4, 0, 0).AddHours(-8),
+            //    IsResourceCollection = false,
+            // };
+            var resourceCollection = new StageActivityInfo()
+            {
+                Tip = "「夏日嘉年华」，“资源收集”限时全天开放",
+                UtcExpireTime = new DateTime(2022, 9, 8, 4, 0, 0).AddHours(-8),
+                IsResourceCollection = true,
+            };
+
+            _stages = new Dictionary<string, StageInfo>
+            {
+                // SideStory「理想城：长夏狂欢季」活动
+                // { "IC-9", new StageInfo { Display = "IC-9", Value = "IC-9", Activity = sideStory } },
+                // { "IC-8", new StageInfo { Display = "IC-8", Value = "IC-8", Activity = sideStory } },
+                // { "IC-7", new StageInfo { Display = "IC-7", Value = "IC-7", Activity = sideStory } },
+
+                // 「当前/上次」关卡导航
+                { string.Empty, new StageInfo { Display = Localization.GetString("DefaultStage"), Value = string.Empty } },
+
+                // 主线关卡
+                { "1-7", new StageInfo { Display = "1-7", Value = "1-7" } },
+
+                // 资源本
+                { "CE-6", new StageInfo("CE-6", "CETip", new[] { DayOfWeek.Tuesday, DayOfWeek.Thursday, DayOfWeek.Saturday, DayOfWeek.Sunday }, resourceCollection) },
+                { "AP-5", new StageInfo("AP-5", "APTip", new[] { DayOfWeek.Monday, DayOfWeek.Thursday, DayOfWeek.Saturday, DayOfWeek.Sunday }, resourceCollection) },
+                { "CA-5", new StageInfo("CA-5", "CATip", new[] { DayOfWeek.Tuesday, DayOfWeek.Wednesday, DayOfWeek.Friday, DayOfWeek.Sunday }, resourceCollection) },
+                { "LS-6", new StageInfo("LS-6", "LSTip", new DayOfWeek[] { }, resourceCollection) },
+
+                // 碳本没做导航，只显示关卡提示
+                { "SK-5", new StageInfo("SK-5", "SKTip", new[] { DayOfWeek.Monday, DayOfWeek.Wednesday, DayOfWeek.Friday, DayOfWeek.Saturday }, resourceCollection) { IsHidden = true } },
+
+                // 剿灭模式
+                { "Annihilation", new StageInfo { Display = Localization.GetString("Annihilation"), Value = "Annihilation" } },
+
+                // 芯片本
+                { "PR-A-1", new StageInfo("PR-A-1", "PR-ATip", new[] { DayOfWeek.Monday, DayOfWeek.Thursday, DayOfWeek.Friday, DayOfWeek.Sunday }, resourceCollection) },
+                { "PR-A-2", new StageInfo("PR-A-2", string.Empty, new[] { DayOfWeek.Monday, DayOfWeek.Thursday, DayOfWeek.Friday, DayOfWeek.Sunday }, resourceCollection) },
+                { "PR-B-1", new StageInfo("PR-B-1", "PR-BTip", new[] { DayOfWeek.Monday, DayOfWeek.Tuesday, DayOfWeek.Friday, DayOfWeek.Saturday }, resourceCollection) },
+                { "PR-B-2", new StageInfo("PR-B-2", string.Empty, new[] { DayOfWeek.Monday, DayOfWeek.Tuesday, DayOfWeek.Friday, DayOfWeek.Saturday }, resourceCollection) },
+                { "PR-C-1", new StageInfo("PR-C-1", "PR-CTip", new[] { DayOfWeek.Wednesday, DayOfWeek.Thursday, DayOfWeek.Saturday, DayOfWeek.Sunday }, resourceCollection) },
+                { "PR-C-2", new StageInfo("PR-C-2", string.Empty, new[] { DayOfWeek.Wednesday, DayOfWeek.Thursday, DayOfWeek.Saturday, DayOfWeek.Sunday }, resourceCollection) },
+                { "PR-D-1", new StageInfo("PR-D-1", "PR-DTip", new[] { DayOfWeek.Tuesday, DayOfWeek.Wednesday, DayOfWeek.Saturday, DayOfWeek.Sunday }, resourceCollection) },
+                { "PR-D-2", new StageInfo("PR-D-2", string.Empty, new[] { DayOfWeek.Tuesday, DayOfWeek.Wednesday, DayOfWeek.Saturday, DayOfWeek.Sunday }, resourceCollection) },
+
+                // 周一和周日的关卡提示
+                { "Pormpt1", new StageInfo { Tip = Localization.GetString("Pormpt1"), OpenDays = new[] { DayOfWeek.Monday }, IsHidden = true } },
+                { "Pormpt2", new StageInfo { Tip = Localization.GetString("Pormpt2"), OpenDays = new[] { DayOfWeek.Sunday }, IsHidden = true } },
+
+                // 老版本「当前/上次」关卡导航
+                // new StageInfo { Display = Localization.GetString("CurrentStage"), Value = string.Empty },
+                // new StageInfo { Display = Localization.GetString("LastBattle"), Value = "LastBattle" },
+            };
+        }
+
+        /// <summary>
+        /// Gets stage by name
+        /// </summary>
+        /// <param name="stage">Stage name</param>
+        /// <returns>Stage info</returns>
+        public StageInfo GetStageInfo(string stage)
+        {
+            _stages.TryGetValue(stage, out var stageInfo);
+            return stageInfo;
+        }
+
+        /// <summary>
+        /// Determine whether stage is open
+        /// </summary>
+        /// <param name="stage">Stage name</param>
+        /// <param name="dayOfWeek">Current day of week</param>
+        /// <returns>Whether stage is open</returns>
+        public bool IsStageOpen(string stage, DayOfWeek dayOfWeek)
+        {
+            return GetStageInfo(stage)?.IsStageOpen(dayOfWeek) == true;
+        }
+
+        /// <summary>
+        /// Gets open stage tips at specified day of week
+        /// </summary>
+        /// <param name="dayOfWeek">Day of week</param>
+        /// <returns>Open stages</returns>
+        public string GetStageTips(DayOfWeek dayOfWeek)
+        {
+            var builder = new StringBuilder();
+
+            var stages = _stages.Where(pair => pair.Value.OpenDays?.Count() > 0);
+            foreach (var item in stages)
+            {
+                if (item.Value.OpenDays.Contains(dayOfWeek) && !string.IsNullOrEmpty(item.Value.Tip))
+                {
+                    builder.AppendLine(item.Value.Tip);
+                }
+            }
+
+            return builder.ToString();
+        }
+
+        /// <summary>
+        /// Gets open stage list at specified day of week
+        /// </summary>
+        /// <param name="dayOfWeek">Day of week</param>
+        /// <returns>Open stage list</returns>
+        public IEnumerable<CombData> GetStageList(DayOfWeek dayOfWeek)
+        {
+            return _stages.Values.Where(stage => !stage.IsHidden && stage.IsStageOpen(dayOfWeek));
+        }
+
+        /// <summary>
+        /// Gets all stage list
+        /// </summary>
+        /// <returns>All stage list</returns>
+        public IEnumerable<CombData> GetStageList()
+        {
+            return _stages.Values.Where(stage => !stage.IsHidden);
+        }
+    }
+}

--- a/src/MeoAsstGui/MeoAsstGui.csproj
+++ b/src/MeoAsstGui/MeoAsstGui.csproj
@@ -113,6 +113,9 @@
     <Compile Include="Helper\MessageBoxManager.cs" />
     <Compile Include="Helper\ToastNotification.cs" />
     <Compile Include="Helper\ScrollViewerBinding.cs" />
+    <Compile Include="Helper\StageActivityInfo.cs" />
+    <Compile Include="Helper\StageInfo.cs" />
+    <Compile Include="Helper\StageManager.cs" />
     <Compile Include="Helper\ViewStatusStorage.cs" />
     <Compile Include="Helper\FlowDocumentPagePadding.cs" />
     <Compile Include="UserControl\GUISettingsUserControl.xaml.cs">

--- a/src/MeoAsstGui/ViewModels/SettingsViewModel.cs
+++ b/src/MeoAsstGui/ViewModels/SettingsViewModel.cs
@@ -1696,7 +1696,7 @@ namespace MeoAsstGui
                 }
 
                 var mainModel = _container.Get<TaskQueueViewModel>();
-                mainModel.UpdateStageList();
+                mainModel.UpdateStageList(true);
             }
         }
 

--- a/src/MeoAsstGui/ViewModels/TaskQueueViewModel.cs
+++ b/src/MeoAsstGui/ViewModels/TaskQueueViewModel.cs
@@ -16,7 +16,9 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Runtime.InteropServices;
+using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Windows;
@@ -141,7 +143,7 @@ namespace MeoAsstGui
             if (CheckAndUpdateDayOfWeek())
             {
                 UpdateDatePrompt();
-                UpdateStageList();
+                UpdateStageList(false);
             }
 
             int intMinute = DateTime.Now.Minute;
@@ -238,8 +240,6 @@ namespace MeoAsstGui
             }
         }
 
-        private readonly string _closedStage = "_ClosedStage";
-
         /// <summary>
         /// Initializes items.
         /// </summary>
@@ -306,200 +306,77 @@ namespace MeoAsstGui
             }
 
             TaskItemViewModels = new ObservableCollection<DragItemViewModel>(temp_order_list);
-
-            _stageAvailableInfo = new Dictionary<string, Tuple<List<DayOfWeek>, string>>
-            {
-                { "CE-6", new Tuple<List<DayOfWeek>, string>(new List<DayOfWeek> { DayOfWeek.Tuesday, DayOfWeek.Thursday, DayOfWeek.Saturday, DayOfWeek.Sunday }, Localization.GetString("CETip")) },
-                { "AP-5", new Tuple<List<DayOfWeek>, string>(new List<DayOfWeek> { DayOfWeek.Monday, DayOfWeek.Thursday, DayOfWeek.Saturday, DayOfWeek.Sunday }, Localization.GetString("APTip")) },
-                { "CA-5", new Tuple<List<DayOfWeek>, string>(new List<DayOfWeek> { DayOfWeek.Tuesday, DayOfWeek.Wednesday, DayOfWeek.Friday, DayOfWeek.Sunday }, Localization.GetString("CATip")) },
-                { "LS-6", new Tuple<List<DayOfWeek>, string>(new List<DayOfWeek> { DayOfWeek.Monday, DayOfWeek.Tuesday, DayOfWeek.Wednesday, DayOfWeek.Thursday, DayOfWeek.Friday, DayOfWeek.Saturday, DayOfWeek.Sunday }, Localization.GetString("LSTip")) },
-
-                // 碳本没做导航
-                { "SK-5", new Tuple<List<DayOfWeek>, string>(new List<DayOfWeek> { DayOfWeek.Monday, DayOfWeek.Wednesday, DayOfWeek.Friday, DayOfWeek.Saturday }, Localization.GetString("SKTip")) },
-                { "PR-A-1", new Tuple<List<DayOfWeek>, string>(new List<DayOfWeek> { DayOfWeek.Monday, DayOfWeek.Thursday, DayOfWeek.Friday, DayOfWeek.Sunday }, Localization.GetString("PR-ATip")) },
-                { "PR-A-2", new Tuple<List<DayOfWeek>, string>(new List<DayOfWeek> { DayOfWeek.Monday, DayOfWeek.Thursday, DayOfWeek.Friday, DayOfWeek.Sunday }, string.Empty) },
-                { "PR-B-1", new Tuple<List<DayOfWeek>, string>(new List<DayOfWeek> { DayOfWeek.Monday, DayOfWeek.Tuesday, DayOfWeek.Friday, DayOfWeek.Saturday }, Localization.GetString("PR-BTip")) },
-                { "PR-B-2", new Tuple<List<DayOfWeek>, string>(new List<DayOfWeek> { DayOfWeek.Monday, DayOfWeek.Tuesday, DayOfWeek.Friday, DayOfWeek.Saturday }, string.Empty) },
-                { "PR-C-1", new Tuple<List<DayOfWeek>, string>(new List<DayOfWeek> { DayOfWeek.Wednesday, DayOfWeek.Thursday, DayOfWeek.Saturday, DayOfWeek.Sunday }, Localization.GetString("PR-CTip")) },
-                { "PR-C-2", new Tuple<List<DayOfWeek>, string>(new List<DayOfWeek> { DayOfWeek.Wednesday, DayOfWeek.Thursday, DayOfWeek.Saturday, DayOfWeek.Sunday }, string.Empty) },
-                { "PR-D-1", new Tuple<List<DayOfWeek>, string>(new List<DayOfWeek> { DayOfWeek.Tuesday, DayOfWeek.Wednesday, DayOfWeek.Saturday, DayOfWeek.Sunday }, Localization.GetString("PR-DTip")) },
-                { "PR-D-2", new Tuple<List<DayOfWeek>, string>(new List<DayOfWeek> { DayOfWeek.Tuesday, DayOfWeek.Wednesday, DayOfWeek.Saturday, DayOfWeek.Sunday }, string.Empty) },
-
-                // 下面的不支持导航
-                { "Pormpt1", new Tuple<List<DayOfWeek>, string>(new List<DayOfWeek> { DayOfWeek.Monday }, Localization.GetString("Pormpt1")) },
-                { "Pormpt2", new Tuple<List<DayOfWeek>, string>(new List<DayOfWeek> { DayOfWeek.Sunday }, Localization.GetString("Pormpt2")) },
-            };
+            _stageManager = new StageManager();
 
             InitDrops();
             CheckAndUpdateDayOfWeek();
             UpdateDatePrompt();
-            UpdateStageList();
+            UpdateStageList(true);
         }
 
-        private Dictionary<string, Tuple<List<DayOfWeek>, string>> _stageAvailableInfo;
+        private StageManager _stageManager;
         private DayOfWeek _curDayOfWeek;
+
+        /// <summary>
+        /// Determine whether the specified stage is open
+        /// </summary>
+        /// <param name="name">stage name</param>
+        /// <returns>Whether the specified stage is open</returns>
+        private bool IsStageOpen(string name)
+        {
+            return _stageManager.IsStageOpen(name, _curDayOfWeek);
+        }
 
         /// <summary>
         /// Updates stage list.
         /// </summary>
-        public void UpdateStageList()
+        /// <param name="forceUpdate">Whether or not to update the stage list for selection forcely</param>
+        public void UpdateStageList(bool forceUpdate)
         {
-            AllStageList = new List<CombData>();
-            var limitTime = new DateTime(2022, 9, 3, 4, 0, 0);
-            var limit = new List<CombData>
-            {
-                // SideStory「理想城：长夏狂欢季」活动
-                new CombData { Display = "IC-9", Value = "IC-9" },
-                new CombData { Display = "IC-8", Value = "IC-8" },
-                new CombData { Display = "IC-7", Value = "IC-7" },
-
-                // SideStory「绿野幻梦」活动
-                // new CombData { Display = "DV-6", Value = "DV-6" },
-                // new CombData { Display = "DV-7", Value = "DV-7" },
-                // new CombData { Display = "DV-8", Value = "DV-8" },
-
-                // SideStory「尘影余音」活动
-                // new CombData { Display = "LE-7", Value = "LE-7" },
-                // new CombData { Display = "LE-6", Value = "LE-6" },
-                // new CombData { Display = "LE-5", Value = "LE-5" },
-
-                // SideStory「愚人号」活动关卡
-                // new CombData { Display = "SN-8", Value = "SN-8" },
-                // new CombData { Display = "SN-9", Value = "SN-9" },
-                // new CombData { Display = "SN-10", Value = "SN-10" },
-
-                // SideStory「风雪过境」活动关卡
-                // new CombData { Display = "BI-7", Value = "BI-7" },
-                // new CombData { Display = "BI-8", Value = "BI-8" }
-            };
-            if (DateTime.Compare(DateTime.UtcNow.AddHours(8), limitTime) < 0)
-            {
-                AllStageList.AddRange(limit);
-            }
-            else
-            {
-                AllStageList.Add(new CombData { Display = Localization.GetString("ClosedStage"), Value = _closedStage });
-            }
-
-            var resident = new List<CombData>
-            {
-                // 「当前/上次」关卡导航
-                new CombData { Display = Localization.GetString("DefaultStage"), Value = string.Empty },
-
-                // 主线关卡
-                new CombData { Display = "1-7", Value = "1-7" },
-
-                // 资源本
-                new CombData { Display = Localization.GetString("CE-6"), Value = "CE-6" },
-                new CombData { Display = Localization.GetString("AP-5"), Value = "AP-5" },
-                new CombData { Display = Localization.GetString("CA-5"), Value = "CA-5" },
-                new CombData { Display = Localization.GetString("LS-6"), Value = "LS-6" },
-
-                // 剿灭模式
-                new CombData { Display = Localization.GetString("Annihilation"), Value = "Annihilation" },
-
-                // 芯片本
-                new CombData { Display = Localization.GetString("PR-A-1"), Value = "PR-A-1" },
-                new CombData { Display = Localization.GetString("PR-A-2"), Value = "PR-A-2" },
-                new CombData { Display = Localization.GetString("PR-B-1"), Value = "PR-B-1" },
-                new CombData { Display = Localization.GetString("PR-B-2"), Value = "PR-B-2" },
-                new CombData { Display = Localization.GetString("PR-C-1"), Value = "PR-C-1" },
-                new CombData { Display = Localization.GetString("PR-C-2"), Value = "PR-C-2" },
-                new CombData { Display = Localization.GetString("PR-D-1"), Value = "PR-D-1" },
-                new CombData { Display = Localization.GetString("PR-D-2"), Value = "PR-D-2" },
-
-                // 老版本「当前/上次」关卡导航
-                // new CombData { Display = Localization.GetString("CurrentStage"), Value = string.Empty },
-                // new CombData { Display = Localization.GetString("LastBattle"), Value = "LastBattle" },
-            };
-            AllStageList.AddRange(resident);
-
-            ObservableCollection<CombData> newList;
             var settingsModel = _container.Get<SettingsViewModel>();
             if (settingsModel.HideUnavailableStage)
             {
-                newList = new ObservableCollection<CombData>();
-                foreach (var item in AllStageList)
+                // update available stage list
+                var stage1 = Stage1;
+                StageList = new ObservableCollection<CombData>(_stageManager.GetStageList(_curDayOfWeek));
+
+                // reset closed stage1 to "Last/Current"
+                if (stage1 == null || !_stageManager.IsStageOpen(stage1, _curDayOfWeek))
                 {
-                    if (_stageAvailableInfo.ContainsKey(item.Value))
-                    {
-                        var info = _stageAvailableInfo[item.Value];
-                        if (info.Item1.Contains(_curDayOfWeek))
-                        {
-                            newList.Add(item);
-                        }
-                    }
-                    else
-                    {
-                        newList.Add(item);
-                    }
+                    Stage1 = string.Empty;
                 }
             }
             else
             {
-                newList = new ObservableCollection<CombData>(AllStageList);
-            }
-
-            if (StageList == newList)
-            {
-                return;
-            }
-
-            if (settingsModel.HideUnavailableStage)
-            {
-                var stage1 = Stage1;
-                StageList = newList;
-
-                if (stage1 == null)
+                // initializing or settings changing, update stage list forcely
+                if (forceUpdate)
                 {
-                    Stage1 = string.Empty;
+                    var stage1 = Stage1;
+                    var stage2 = Stage2;
+                    var stage3 = Stage3;
+
+                    StageList = new ObservableCollection<CombData>(_stageManager.GetStageList());
+
+                    // reset closed stages to "Last/Current"
+                    if (stage1 == null || !_stageManager.IsStageOpen(stage1, _curDayOfWeek))
+                    {
+                        Stage1 = string.Empty;
+                    }
+
+                    if (stage2 == null || !_stageManager.IsStageOpen(stage2, _curDayOfWeek))
+                    {
+                        Stage2 = string.Empty;
+                    }
+
+                    if (stage3 == null || !_stageManager.IsStageOpen(stage3, _curDayOfWeek))
+                    {
+                        Stage3 = string.Empty;
+                    }
                 }
                 else
                 {
-                    foreach (var item in StageList)
-                    {
-                        if (item.Value == stage1)
-                        {
-                            Stage1 = stage1;
-                            return;
-                        }
-                    }
-
-                    Stage1 = string.Empty;
+                    // do nothing
                 }
-            }
-            else
-            {
-                // StageList更新会导致stage1，stage2，stage3变成null，要先备份一下
-                var stage1 = Stage1;
-                var stage2 = Stage2;
-                var stage3 = Stage3;
-                StageList = newList;
-
-                if (DateTime.Compare(DateTime.UtcNow.AddHours(8), limitTime) >= 0)
-                {
-                    foreach (var item in limit)
-                    {
-                        if (item.Value == stage1)
-                        {
-                            stage1 = _closedStage;
-                        }
-
-                        if (item.Value == stage2)
-                        {
-                            stage2 = _closedStage;
-                        }
-
-                        if (item.Value == stage2)
-                        {
-                            stage3 = _closedStage;
-                        }
-                    }
-                }
-
-                Stage1 = stage1;
-                Stage2 = stage2;
-                Stage3 = stage3;
             }
         }
 
@@ -528,16 +405,26 @@ namespace MeoAsstGui
         /// </summary>
         public void UpdateDatePrompt()
         {
-            var prompt = Localization.GetString("TodaysStageTip") + "\n";
+            var builder = new StringBuilder(Localization.GetString("TodaysStageTip") + "\n");
 
-            foreach (var item in _stageAvailableInfo)
+            // Closed activity stages
+            var stages = new[] { Stage1, Stage2, Stage3 };
+            foreach (var stage in stages)
             {
-                if (item.Value.Item1.Contains(_curDayOfWeek) && item.Value.Item2 != string.Empty)
+                if (_stageManager.GetStageInfo(stage)?.IsActivityClosed() == true)
                 {
-                    prompt += item.Value.Item2 + "\n";
+                    builder.Append(stage).Append(": ").AppendLine(Localization.GetString("ClosedStage"));
                 }
             }
 
+            // Open stages today
+            var openStages = _stageManager.GetStageTips(_curDayOfWeek);
+            if (!string.IsNullOrEmpty(openStages))
+            {
+                builder.Append(openStages);
+            }
+
+            var prompt = builder.ToString();
             if (StagesOfToday == prompt)
             {
                 return;
@@ -1404,11 +1291,6 @@ namespace MeoAsstGui
         }
         */
 
-        /// <summary>
-        /// Gets or sets the list of all stages.
-        /// </summary>
-        public List<CombData> AllStageList { get; set; }
-
         private ObservableCollection<CombData> _stageList = new ObservableCollection<CombData>();
 
         /// <summary>
@@ -1430,64 +1312,25 @@ namespace MeoAsstGui
                 var settingsModel = _container.Get<SettingsViewModel>();
                 if (settingsModel.UseAlternateStage)
                 {
-                    ObservableCollection<CombData> newList;
-                    newList = new ObservableCollection<CombData>();
-                    foreach (var item in AllStageList)
+                    if (IsStageOpen(_stage1))
                     {
-                        if (_stageAvailableInfo.ContainsKey(item.Value))
-                        {
-                            var info = _stageAvailableInfo[item.Value];
-                            if (info.Item1.Contains(_curDayOfWeek))
-                            {
-                                newList.Add(item);
-                            }
-                        }
-                        else
-                        {
-                            newList.Add(item);
-                        }
+                        return _stage1;
                     }
 
-                    if (_stage1 != _closedStage)
+                    if (IsStageOpen(_stage2))
                     {
-                        foreach (var stage in newList)
-                        {
-                            if (stage.Value == _stage1)
-                            {
-                                return _stage1;
-                            }
-                        }
+                        return _stage2;
                     }
 
-                    if (_stage2 != _closedStage)
+                    if (IsStageOpen(_stage3))
                     {
-                        foreach (var stage in newList)
-                        {
-                            if (stage.Value == _stage2)
-                            {
-                                return _stage2;
-                            }
-                        }
+                        return _stage3;
                     }
 
-                    if (_stage3 != _closedStage)
-                    {
-                        foreach (var stage in newList)
-                        {
-                            if (stage.Value == _stage3)
-                            {
-                                return _stage3;
-                            }
-                        }
-                    }
+                    return string.Empty;
                 }
 
-                if (_stage1 != _closedStage)
-                {
-                    return _stage1;
-                }
-
-                return string.Empty;
+                return IsStageOpen(_stage1) ? _stage1 : string.Empty;
             }
         }
 
@@ -1503,6 +1346,7 @@ namespace MeoAsstGui
             {
                 SetAndNotify(ref _stage1, value);
                 ViewStatusStorage.Set("MainFunction.Stage1", value);
+                UpdateDatePrompt();
             }
         }
 
@@ -1518,6 +1362,7 @@ namespace MeoAsstGui
             {
                 SetAndNotify(ref _stage2, value);
                 ViewStatusStorage.Set("MainFunction.Stage2", value);
+                UpdateDatePrompt();
             }
         }
 
@@ -1533,6 +1378,7 @@ namespace MeoAsstGui
             {
                 SetAndNotify(ref _stage3, value);
                 ViewStatusStorage.Set("MainFunction.Stage3", value);
+                UpdateDatePrompt();
             }
         }
 


### PR DESCRIPTION
重构并优化关卡选择逻辑：

- 添加 ```StageInfo``` 类
  - 继承自 ```CombData``` 类，实现原有的 ```AllStageList``` 功能
  - 整合 ```_stageAvailableInfo``` 的相关功能和字段（```Tuple<DayOfWeek[] openDays, string tip>```）
  - 可以关联限时活动 ```StageActivityInfo```
  - 可以设置隐藏（例如某些关卡仅用于每日关卡提示、不显示在关卡列表）
- 添加 ```StageActivityInfo``` 类
  - 用于限时活动（SideStory、故事集或资源收集活动）
  - 普通活动结束时，关联的关卡也随之关闭
  - 资源收集活动 (```IsResourceCollection == true``` ) 结束时，会继续检查资源关卡的轮换时间
- 添加 ```StageManager``` 类
  - 用于管理所有关卡
  - 原有的 ```AllStageList``` 和 ```_stageAvailableInfo``` 合并为 ```Dictionary<string, StageInfo> _stages```
  - 添加 ```IsStageOpen``` 方法判断关卡是否开放
  - 添加 ```GetStageTips``` 方法获取今日关卡提示
  - 选择了已关闭的活动关卡时，今日关卡提示会显示 “活动已结束”
- 重构 ```TaskQueueViewModel.UpdateStageList```：
  - 原有的 ```AllStageList``` 已移至 ```StageManager``` 类
  - 未勾选 “隐藏不开放关卡” 时，只在初始化或选项改变时更新 ```StageList```，```Timer``` 中不再实时更新
- 重构 ```TaskQueueViewModel.Stage { get; } ```：
  - 不再使用 ```AllStageList``` 和 ```_stageAvailableInfo```
  - 改用 ```StageManager.IsStageOpen``` 判断关卡是否开放
- fix #1703
