### PR TITLE
perf: 优化 MaaBuilder

### DIFF
--- a/tools/MaaBuilder/Builder/Helper/Build.Helper.Bundler.cs
+++ b/tools/MaaBuilder/Builder/Helper/Build.Helper.Bundler.cs
@@ -79,7 +79,7 @@ public partial class Build
     
     static void RemoveDebugSymbols(AbsolutePath outputDir)
     {
-        var files = outputDir.GlobFiles("*.pdb", "*.lib", "*.exp", "*.exe.config");
+        var files = outputDir.GlobFiles("*.pdb", "*.lib", "*.exp", "*.exe.config", "*.xml");
 
         foreach (var file in files)
         {

--- a/tools/MaaBuilder/Builder/Helper/Build.Helper.Bundler.cs
+++ b/tools/MaaBuilder/Builder/Helper/Build.Helper.Bundler.cs
@@ -9,6 +9,7 @@ using MaaBuilder.Models;
 using Microsoft.Extensions.FileSystemGlobbing;
 using Nuke.Common;
 using Nuke.Common.IO;
+using Serilog;
 
 namespace MaaBuilder;
 
@@ -34,7 +35,9 @@ public partial class Build
         var sourceDirectory = new DirectoryInfo(input);
         var allFiles = sourceDirectory.GetFiles("*.*", SearchOption.AllDirectories);
         var allHashes = allFiles
-            .Select(x => FileSystemTasks.GetFileHash(x.FullName).ToUpperInvariant())
+            .Select(x => FileSystemTasks.GetFileHash(x.FullName).ToUpperInvariant() +
+                         ((AbsolutePath)x.FullName).GetUnixRelativePathTo(input))
+            .Select(GetStringMd5)
             .OrderBy(x => x);
         var hashCombinedBuilder = new StringBuilder();
         foreach (var h in allHashes)


### PR DESCRIPTION
- 移除 C# 产生的 XML 文档
- File Identity 可以正确反应文件的移动产生的变化了