### PR TITLE
perf: AsstHttp 的各种优化

### DIFF
--- a/src/MeoAssistant/AsstHttp.hpp
+++ b/src/MeoAssistant/AsstHttp.hpp
@@ -13,6 +13,8 @@ namespace asst::http
     class Response
     {
     private:
+        static const inline std::unordered_set<std::string_view> _accepted_protocol_version = { "HTTP/1.1",
+                                                                                                "HTTP/2.0" };
         std::string m_raw_data;
         std::string m_last_error;
         unsigned m_status_code = 0;
@@ -20,9 +22,8 @@ namespace asst::http
         std::string_view m_status_code_info;
         std::string_view m_body;
         std::unordered_map<std::string_view, std::string_view> m_headers;
-        static const inline std::unordered_set<std::string_view> _accepted_protocol_version = { "HTTP/1.1",
-                                                                                                "HTTP/2.0" };
-        bool _analyze_status_line(std::string_view status_line)
+
+        bool _analyze_status_line(const std::string_view& status_line)
         {
             size_t _word_count = 0;
             for (const auto& word : utils::string_split(status_line, " ")) {
@@ -56,7 +57,7 @@ namespace asst::http
             m_last_error = "status line too short";
             return false;
         }
-        bool _analyze_headers_line(std::string_view status_line)
+        bool _analyze_headers_line(const std::string_view& status_line)
         {
             size_t _colon_pos = status_line.find(':');
             if (_colon_pos == status_line.npos) {
@@ -108,18 +109,20 @@ namespace asst::http
         }
 
         Response() = default;
-        ~Response() = default;
+        ~Response() noexcept = default;
 
-        Response(Response&&) = default;
-        Response& operator=(Response&&) = default;
+        Response(Response&&) noexcept = default;
+        Response& operator=(Response&&) noexcept = default;
 
+        // string_view 类型的成员在复制时，其指向的 string 可能被析构
+        // 虽然应该有更高效的复制方式，不过在这里还是直接调用 Args&&... 的构造函数
         Response(const Response&) = delete;
         Response& operator=(const Response&) = delete;
 
-        unsigned status_code() const { return m_status_code; }
-        std::string_view protocol_version() const { return m_protocol_version; }
-        std::string_view status_code_info() const { return m_status_code_info; }
-        std::string_view body() const { return m_body; }
+        unsigned status_code() const noexcept { return m_status_code; }
+        std::string_view protocol_version() const noexcept { return m_protocol_version; }
+        std::string_view status_code_info() const noexcept { return m_status_code_info; }
+        std::string_view body() const noexcept { return m_body; }
         std::optional<std::string_view> find_header(const std::string_view& key) const
         {
             if (auto iter = m_headers.find(key); iter != m_headers.cend()) {
@@ -129,14 +132,14 @@ namespace asst::http
                 return std::nullopt;
             }
         }
-        const auto& headers() const { return m_headers; }
-        const std::string& get_last_error() const { return m_last_error; }
-        operator std::string() const { return m_raw_data; }
+        const auto& headers() const noexcept { return m_headers; }
+        const std::string& get_last_error() const noexcept { return m_last_error; }
+        operator std::string() const noexcept { return m_raw_data; }
 
-        bool success() const { return m_status_code == 200; }
-        bool status_2xx() const { return m_status_code >= 200 && m_status_code < 300; }
-        bool status_3xx() const { return m_status_code >= 300 && m_status_code < 400; }
-        bool status_4xx() const { return m_status_code >= 400 && m_status_code < 500; }
-        bool status_5xx() const { return m_status_code >= 500 && m_status_code < 600; }
+        bool success() const noexcept { return m_status_code == 200; }
+        bool status_2xx() const noexcept { return m_status_code >= 200 && m_status_code < 300; }
+        bool status_3xx() const noexcept { return m_status_code >= 300 && m_status_code < 400; }
+        bool status_4xx() const noexcept { return m_status_code >= 400 && m_status_code < 500; }
+        bool status_5xx() const noexcept { return m_status_code >= 500 && m_status_code < 600; }
     };
 } // namespace asst::http

--- a/src/MeoAssistant/AsstHttp.hpp
+++ b/src/MeoAssistant/AsstHttp.hpp
@@ -10,23 +10,25 @@
 
 namespace asst::http
 {
-    class Response : public std::string
+    class Response
     {
     private:
+        std::string m_raw_data;
         std::string m_last_error;
         unsigned m_status_code = 0;
         std::string_view m_protocol_version;
         std::string_view m_status_code_info;
-        std::string_view m_data;
+        std::string_view m_body;
         std::unordered_map<std::string, std::string_view> m_headers;
+        static const inline std::unordered_set<std::string_view> _accepted_protocol_version = { "HTTP/1.1",
+                                                                                                "HTTP/2.0" };
         bool _analyze_status_line(std::string_view status_line)
         {
             size_t _word_count = 0;
             for (const auto& word : utils::string_split(status_line, " ")) {
                 ++_word_count;
                 if (_word_count == 1) {
-                    static const std::unordered_set<std::string_view> accepted_protocol_version = { "HTTP/1.1" };
-                    if (!accepted_protocol_version.contains(word)) {
+                    if (!_accepted_protocol_version.contains(word)) {
                         m_last_error = "unsupported protocol version`" + std::string(word) + "`";
                         return false;
                     }
@@ -58,7 +60,7 @@ namespace asst::http
         {
             size_t _colon_pos = status_line.find(':');
             if (_colon_pos == status_line.npos) {
-                m_last_error = "connot decode header `" + std::string(status_line) + "`";
+                m_last_error = "cannot decode header `" + std::string(status_line) + "`";
                 return false;
             }
             m_headers[utils::view_cast<std::string>(status_line.substr(0, _colon_pos) | views::transform([](char c) {
@@ -71,10 +73,11 @@ namespace asst::http
     public:
         template <typename... Args>
         requires std::is_constructible_v<std::string, Args...>
-        Response(Args&&... args) : std::string(std::forward<Args>(args)...)
+        Response(Args&&... args) : m_raw_data(std::forward<Args>(args)...)
         {
-            std::string_view this_view = *this;
+            std::string_view this_view = m_raw_data;
             bool _is_status_line = true;
+            bool _is_data_line = false;
             for (const auto& line : utils::string_split(this_view, "\r\n")) {
                 // status
                 if (_is_status_line) {
@@ -84,23 +87,37 @@ namespace asst::http
                     _is_status_line = false;
                 }
                 // headers
-                else if (!line.empty()) {
-                    if (!_analyze_headers_line(line)) {
-                        return;
+                else if (!_is_data_line) {
+                    if (!line.empty()) {
+                        if (!_analyze_headers_line(line)) {
+                            return;
+                        }
+                    }
+                    else {
+                        _is_data_line = true; // 当前行是空行，则下一行开始都是 data 段
                     }
                 }
                 // data
                 else {
-                    m_data = std::string_view(line.begin(), this_view.end());
+                    m_body = std::string_view(line.begin(), this_view.end());
                     return;
                 }
             }
         }
 
+        Response() = default;
+        ~Response() = default;
+
+        Response(Response&&) = default;
+        Response& operator=(Response&&) = default;
+
+        Response(const Response&) = delete;
+        Response& operator=(const Response&) = delete;
+
         unsigned status_code() const { return m_status_code; }
         std::string_view protocol_version() const { return m_protocol_version; }
         std::string_view status_code_info() const { return m_status_code_info; }
-        std::string_view data() const { return m_data; }
+        std::string_view body() const { return m_body; }
         std::optional<std::string_view> find_header(const std::string& key) const
         {
             if (auto iter = m_headers.find(key); iter != m_headers.cend()) {
@@ -111,7 +128,8 @@ namespace asst::http
             }
         }
         const auto& headers() const { return m_headers; }
-        const std::string& get_last_error() const noexcept { return m_last_error; }
+        const std::string& get_last_error() const { return m_last_error; }
+        operator std::string() const { return m_raw_data; }
 
         bool success() const { return m_status_code == 200; }
         bool status_2xx() const { return m_status_code >= 200 && m_status_code < 300; }

--- a/src/MeoAssistant/AsstUtils.hpp
+++ b/src/MeoAssistant/AsstUtils.hpp
@@ -31,13 +31,6 @@ namespace asst::utils
     template <typename... Unused>
     constexpr bool always_false = false;
 
-    template <typename dst_t, typename src_t>
-    requires ranges::range<src_t> && ranges::range<dst_t>
-    dst_t view_cast(src_t&& src)
-    {
-        return dst_t(src.begin(), src.end());
-    }
-
     template <typename char_t = char>
     using pair_of_string_view = std::pair<std::basic_string_view<char_t>, std::basic_string_view<char_t>>;
 

--- a/src/MeoAssistant/AsstUtils.hpp
+++ b/src/MeoAssistant/AsstUtils.hpp
@@ -149,7 +149,7 @@ namespace asst::utils
 
             constexpr _iterator& operator++()
             {
-                const auto _end = _pre->_rng.cend();
+                auto _end = _pre->_rng.cend();
 
                 if (_cur = _nxt.cbegin(); _cur == _end) {
                     _trailing_empty = false;

--- a/src/MeoAssistant/AsstUtils.hpp
+++ b/src/MeoAssistant/AsstUtils.hpp
@@ -201,6 +201,13 @@ namespace asst::utils
         {}
 
         template <typename rng_t>
+        constexpr string_split_view(rng_t&& rang, char_t&& elem)
+        {
+            // 摆烂辣！解决不了临时变量导致 _pat 悬垂的问题
+            ASST_STATIC_ASSERT_FALSE("please use `views::split` instead ^_^", rng_t);
+        }
+
+        template <typename rng_t>
         constexpr string_split_view(rng_t&& rang, const char_t& elem) noexcept
             : _rng(std::forward<rng_t>(rang)), _pat(&elem, 1)
         {}

--- a/src/MeoAssistant/AutoRecruitTask.cpp
+++ b/src/MeoAssistant/AutoRecruitTask.cpp
@@ -736,7 +736,7 @@ void asst::AutoRecruitTask::upload_to_yituliu(const json::value& details)
 
     m_report_yituliu_task_ptr->set_report_type(ReportType::YituliuBigData)
         .set_body(body.to_string())
-        .set_retry_times(1)
+        .set_retry_times(0)
         .run();
 }
 

--- a/src/MeoAssistant/Logger.hpp
+++ b/src/MeoAssistant/Logger.hpp
@@ -145,14 +145,11 @@ namespace asst
         }
 
         template <typename Stream, typename T, typename Enable = void>
-        struct has_stream_insertion_operator : std::false_type
-        {};
+        static constexpr bool has_stream_insertion_operator = false;
 
         template <typename Stream, typename T>
-        struct has_stream_insertion_operator<Stream, T,
-                                             std::void_t<decltype(std::declval<Stream&>() << std::declval<T>())>>
-            : std::true_type
-        {};
+        static constexpr bool has_stream_insertion_operator<
+            Stream, T, std::void_t<decltype(std::declval<Stream&>() << std::declval<T>())>> = true;
 
         template <bool ToAnsi, typename Stream>
         static Stream& stream_put(Stream& s, std::filesystem::path&& v)
@@ -170,7 +167,7 @@ namespace asst
                     s << std::string(std::forward<T>(v));
                 return s;
             }
-            else if constexpr (has_stream_insertion_operator<Stream, T>::value) {
+            else if constexpr (has_stream_insertion_operator<Stream, T>) {
                 s << std::forward<T>(v);
                 return s;
             }


### PR DESCRIPTION
1. 修复不了 string_split_view 传入左值 char_t 时 _pat 悬垂的问题，传入左值的时候 static_assert false
2. `Response` 类不再从 `std::string` 继承，而是使用一个 `string` 类型的 `m_raw_data`
3. 对于 headers，直接修改 `m_raw_data` 的大小写，不再重新创建 `string`
4. 移除 `view_cast`
5. 增加一些 `noexcept`, `const&`
6. 修正一些 typo