### PR TITLE
chore:修复在Windows下因CMake脚本缺少宏定义导致构建失败的问题

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,6 @@ add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/W4;/WX>")
 add_compile_options("$<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall;-Wextra;-Wpedantic>")
 
 add_definitions(
-    -DNDEBUG
     -D_CONSOLE
     -DASST_DLL_EXPORTS
     -D_WINDLL

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,12 +19,13 @@ endif ()
 add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/W4;/WX>")
 add_compile_options("$<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall;-Wextra;-Wpedantic>")
 
-add_definitions(
-    -D_CONSOLE
-    -DASST_DLL_EXPORTS
-    -D_WINDLL
-    -D_UNICODE
-    -DUNICODE)
+add_definitions(-DASST_DLL_EXPORTS)
+if(WIN32)
+    #注意：相比VS版本缺少了 -D_CONSOLE -D_WINDLL 两项
+    add_definitions(
+        -D_UNICODE
+        -DUNICODE)
+endif()
 
 include_directories(include 3rdparty/include)
 aux_source_directory(src/MeoAssistant SRC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,13 @@ endif ()
 add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/W4;/WX>")
 add_compile_options("$<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall;-Wextra;-Wpedantic>")
 
-add_definitions(-DASST_DLL_EXPORTS)
+add_definitions(
+    -DNDEBUG
+    -D_CONSOLE
+    -DASST_DLL_EXPORTS
+    -D_WINDLL
+    -D_UNICODE
+    -DUNICODE)
 
 include_directories(include 3rdparty/include)
 aux_source_directory(src/MeoAssistant SRC)


### PR DESCRIPTION
参考了VS的工程，将里面的宏定义复制了过来。