### PR TITLE
fix: 修复关卡掉落识别

### DIFF
--- a/src/MeoAssistant/StageDropsImageAnalyzer.cpp
+++ b/src/MeoAssistant/StageDropsImageAnalyzer.cpp
@@ -248,15 +248,15 @@ bool asst::StageDropsImageAnalyzer::analyze_baseline()
         // prefer gradient in vertical direction, make value of those pixels positive
         cv::sqrt(pdy.mul(pdy) - std::pow(std::tan(angle), 2.) * pdx.mul(pdx), temp);
 
-        // cropping after derivatives, not before
-        temp(utils::make_rect<cv::Rect>(task_ptr->roi)).convertTo(preprocessed_roi, CV_8U, 255);
+        temp.convertTo(preprocessed_roi, CV_8U, 255);
 
         // filling small gaps
         cv::dilate(preprocessed_roi, preprocessed_roi, cv::getStructuringElement(cv::MORPH_RECT, { 3, 1 }));
         // line must be thick enough
         cv::erode(preprocessed_roi, preprocessed_roi, cv::getStructuringElement(cv::MORPH_RECT, { 3, 2 }));
 
-        cv::cvtColor(preprocessed_roi, preprocessed_roi, cv::COLOR_BGR2GRAY);
+        // cropping after derivatives, dilation, and erosion
+        cv::cvtColor(preprocessed_roi(utils::make_rect<cv::Rect>(task_ptr->roi)), preprocessed_roi, cv::COLOR_BGR2GRAY);
     }
 
     cv::Mat preprocessed_bin;


### PR DESCRIPTION
原来是我自己写错了, 有些和周围像素相关的处理是不能放在裁剪之后的. 我当时写 #1657 的时候为了方便观察没有裁剪, 所以没发现这个问题

#1817