### PR TITLE
fix: 优化 Controller

### DIFF
--- a/src/MeoAssistant/Assistant.cpp
+++ b/src/MeoAssistant/Assistant.cpp
@@ -62,12 +62,19 @@ bool asst::Assistant::connect(const std::string& adb_path, const std::string& ad
 
     std::unique_lock<std::mutex> lock(m_mutex);
 
-    stop(false);
+    // 仍有任务进行，connect 前需要 stop
+    if (!m_thread_idle) {
+        return false;
+    }
+
+    m_thread_idle = false;
 
     bool ret = m_ctrler->connect(adb_path, address, config.empty() ? "General" : config);
     if (ret) {
         m_uuid = m_ctrler->get_uuid();
     }
+
+    m_thread_idle = true;
     return ret;
 }
 

--- a/src/MeoAssistant/Controller.cpp
+++ b/src/MeoAssistant/Controller.cpp
@@ -694,8 +694,8 @@ bool asst::Controller::screencap()
     case AdbProperty::ScreencapMethod::UnknownYet: {
         using namespace std::chrono;
         Log.info("Try to find the fastest way to screencap");
-        try_release(); // 这个地方应该是 inited() == false 的，不会 release，因为 connect 函数调用前会 clear_info
         auto min_cost = milliseconds(LLONG_MAX);
+        clear_lf_info();
 
         auto start_time = high_resolution_clock::now();
         if (m_support_socket && m_server_started && screencap(m_adb.screencap_raw_by_nc, decode_raw, true)) {
@@ -742,7 +742,7 @@ bool asst::Controller::screencap()
         }
         Log.info("The fastest way is", static_cast<int>(m_adb.screencap_method), ", cost:", min_cost.count(), "ms");
         clear_lf_info();
-        return inited();
+        return m_adb.screencap_method != AdbProperty::ScreencapMethod::UnknownYet;
     } break;
     case AdbProperty::ScreencapMethod::RawByNc: {
         return screencap(m_adb.screencap_raw_by_nc, decode_raw, true);

--- a/src/MeoAssistant/Controller.cpp
+++ b/src/MeoAssistant/Controller.cpp
@@ -440,7 +440,7 @@ std::optional<std::string> asst::Controller::call_command(const std::string& cmd
             callback(AsstMsg::ConnectionInfo, reconnect_info);
 
             std::this_thread::sleep_for(10s);
-            auto reconnect_ret = call_command(m_adb.connect, 60LL * 1000, false /* 禁止重连避免无限递归 */);
+            auto reconnect_ret = call_command(m_adb.connect, 60LL * 1000, false, false /* 禁止重连避免无限递归 */);
             bool is_reconnect_success = false;
             if (reconnect_ret) {
                 auto& reconnect_str = reconnect_ret.value();

--- a/src/MeoAssistant/Controller.cpp
+++ b/src/MeoAssistant/Controller.cpp
@@ -423,7 +423,7 @@ std::optional<std::string> asst::Controller::call_command(const std::string& cmd
     if (!exit_ret) {
         return recv_by_socket ? sock_data : pipe_data;
     }
-    else if (allow_reconnect) {
+    else if (inited() && allow_reconnect) {
         // 之前可以运行，突然运行不了了，这种情况多半是 adb 炸了。所以重新连接一下
         json::value reconnect_info = json::object {
             { "uuid", m_uuid },

--- a/src/MeoAssistant/Controller.cpp
+++ b/src/MeoAssistant/Controller.cpp
@@ -1021,7 +1021,7 @@ bool asst::Controller::connect(const std::string& adb_path, const std::string& a
     /* connect */
     {
         m_adb.connect = cmd_replace(adb_cfg.connect);
-        auto connect_ret = call_command(m_adb.connect, 60LL * 1000);
+        auto connect_ret = call_command(m_adb.connect, 60LL * 1000, false, false /* adb 连接时不允许重试 */);
         // 端口即使错误，命令仍然会返回0，TODO 对connect_result进行判断
         bool is_connect_success = false;
         if (connect_ret) {
@@ -1040,7 +1040,7 @@ bool asst::Controller::connect(const std::string& adb_path, const std::string& a
 
     /* get uuid (imei) */
     {
-        auto uuid_ret = call_command(cmd_replace(adb_cfg.uuid));
+        auto uuid_ret = call_command(cmd_replace(adb_cfg.uuid), 20000, false, false /* adb 连接时不允许重试 */);
         if (!uuid_ret) {
             json::value info = get_info_json() | json::object {
                 { "what", "ConnectFailed" },

--- a/src/MeoAssistant/Controller.h
+++ b/src/MeoAssistant/Controller.h
@@ -78,6 +78,7 @@ namespace asst
                                                 bool recv_by_socket = false, bool allow_reconnect = true);
         int push_cmd(const std::string& cmd);
         bool release();
+        void kill_adb_daemon();
         bool set_inited(bool inited);
 
         void try_to_close_socket() noexcept;
@@ -158,6 +159,8 @@ namespace asst
         } m_adb;
 
         std::string m_uuid;
+        inline static std::string m_adb_release; // 开了 adb daemon，但是没连上模拟器的时候，
+                                                 // m_adb 并不会存下 release 的命令，但最后仍然需要一次释放。
         std::pair<int, int> m_scale_size = { WindowWidthDefault, WindowHeightDefault };
         double m_control_scale = 1.0;
         int m_width = 0;

--- a/src/MeoAssistant/Controller.h
+++ b/src/MeoAssistant/Controller.h
@@ -81,11 +81,12 @@ namespace asst
         bool release();
         void set_inited() noexcept;
 
+        void try_to_close_socket() noexcept;
         std::optional<unsigned short> try_to_init_socket(const std::string& local_address);
 
         using DecodeFunc = std::function<bool(std::string_view)>;
         bool screencap();
-        bool screencap(const std::string& cmd, const DecodeFunc& decode_func, bool by_nc = false);
+        bool screencap(const std::string& cmd, const DecodeFunc& decode_func, bool by_socket = false);
         void clear_lf_info();
         cv::Mat get_resized_image() const;
 
@@ -110,7 +111,7 @@ namespace asst
 
         ASST_AUTO_DEDUCED_ZERO_INIT_START
         WSADATA m_wsa_data {};
-        SOCKET m_server_sock = 0ULL;
+        SOCKET m_server_sock = INVALID_SOCKET;
         sockaddr_in m_server_addr {};
         LPFN_ACCEPTEX m_AcceptEx = nullptr;
         ASST_AUTO_DEDUCED_ZERO_INIT_END

--- a/src/MeoAssistant/Controller.h
+++ b/src/MeoAssistant/Controller.h
@@ -35,7 +35,6 @@ namespace asst
         ~Controller();
 
         bool connect(const std::string& adb_path, const std::string& address, const std::string& config);
-        bool try_release();
         bool inited() const noexcept;
         void set_exit_flag(bool* flag);
 
@@ -79,7 +78,7 @@ namespace asst
                                                 bool recv_by_socket = false, bool allow_reconnect = true);
         int push_cmd(const std::string& cmd);
         bool release();
-        void set_inited() noexcept;
+        bool set_inited(bool inited);
 
         void try_to_close_socket() noexcept;
         std::optional<unsigned short> try_to_init_socket(const std::string& local_address);

--- a/src/MeoAssistant/Controller.h
+++ b/src/MeoAssistant/Controller.h
@@ -35,7 +35,7 @@ namespace asst
         ~Controller();
 
         bool connect(const std::string& adb_path, const std::string& address, const std::string& config);
-        bool release();
+        bool try_release();
         bool inited() const noexcept;
         void set_exit_flag(bool* flag);
 
@@ -76,8 +76,10 @@ namespace asst
         bool need_exit() const;
         void pipe_working_proc();
         std::optional<std::string> call_command(const std::string& cmd, int64_t timeout = 20000,
-                                                bool recv_by_socket = false);
+                                                bool recv_by_socket = false, bool allow_reconnect = true);
         int push_cmd(const std::string& cmd);
+        bool release();
+        void set_inited() noexcept;
 
         std::optional<unsigned short> try_to_init_socket(const std::string& local_address);
 

--- a/src/MeoAsstGui/Helper/AsstProxy.cs
+++ b/src/MeoAsstGui/Helper/AsstProxy.cs
@@ -371,6 +371,11 @@ namespace MeoAsstGui
                 case "Disconnect":
                     connected = false;
                     mainModel.AddLog(Localization.GetString("ReconnectFailed"), LogColor.Error);
+                    if (mainModel.Idle)
+                    {
+                        break;
+                    }
+
                     AsstStop();
 
                     var settingsModel = _container.Get<SettingsViewModel>();
@@ -1002,6 +1007,11 @@ namespace MeoAsstGui
             {
                 foreach (var address in settings.DefaultAddress[settings.ConnectConfig])
                 {
+                    if (settings.Idle)
+                    {
+                        break;
+                    }
+
                     ret = AsstConnect(_handle, settings.AdbPath, address, settings.ConnectConfig);
                     if (ret)
                     {

--- a/src/MeoAsstGui/Resources/Localizations/en-us.xaml
+++ b/src/MeoAsstGui/Resources/Localizations/en-us.xaml
@@ -235,6 +235,7 @@
     <system:String x:Key="ConnectingToEmulator">Connecting to emulator...</system:String>
     <system:String x:Key="UnselectedTask">Unselected task</system:String>
     <system:String x:Key="Running">Running...</system:String>
+    <system:String x:Key="Stopping">Stopping...</system:String>
     <system:String x:Key="Stopped">Has stopped</system:String>
     <system:String x:Key="UnknownErrorOccurs">Unknown error occurred</system:String>
     <system:String x:Key="SetSuccessfully">Set successfully</system:String>

--- a/src/MeoAsstGui/Resources/Localizations/ja-jp.xaml
+++ b/src/MeoAsstGui/Resources/Localizations/ja-jp.xaml
@@ -235,6 +235,7 @@
     <system:String x:Key="ConnectingToEmulator">エミュレータ接続中……</system:String>
     <system:String x:Key="UnselectedTask">タスクが選択されていません</system:String>
     <system:String x:Key="Running">動作中……</system:String>
+    <system:String x:Key="Stopping">動作停止中……</system:String><!-- need help -->
     <system:String x:Key="Stopped">動作停止</system:String>
     <system:String x:Key="UnknownErrorOccurs">不明なエラーが発生しました</system:String>
     <system:String x:Key="SetSuccessfully">設定に成功しました</system:String>

--- a/src/MeoAsstGui/Resources/Localizations/ko-kr.xaml
+++ b/src/MeoAsstGui/Resources/Localizations/ko-kr.xaml
@@ -234,7 +234,8 @@
     <system:String x:Key="ConnectingToEmulator">에뮬레이터에 연결중...</system:String>
     <system:String x:Key="UnselectedTask">선택된 작업이 없다</system:String>
     <system:String x:Key="Running">실행중...</system:String>
-    <system:String x:Key="Stopped">정지됐다</system:String>
+    <system:String x:Key="Stopping">멎는...</system:String>
+    <system:String x:Key="Stopped">멈췄다</system:String>
     <system:String x:Key="UnknownErrorOccurs">예상치 못한 오류가 발생했습니다</system:String>
     <system:String x:Key="SetSuccessfully">설정 성공</system:String>
     <system:String x:Key="SetFailed">설정 실패</system:String>

--- a/src/MeoAsstGui/Resources/Localizations/pallas.xaml
+++ b/src/MeoAsstGui/Resources/Localizations/pallas.xaml
@@ -234,6 +234,7 @@
     <system:String x:Key="ConnectingToEmulator">🍸🕺🍻💃🕺</system:String>
     <system:String x:Key="UnselectedTask">🍺🍸🍻</system:String>
     <system:String x:Key="Running">🍷🍻🍷🍺</system:String>
+    <system:String x:Key="Stopping">🍷💃🍸</system:String>
     <system:String x:Key="Stopped">💃🍺</system:String>
     <system:String x:Key="UnknownErrorOccurs">🕺🍸🍻🍷</system:String>
     <system:String x:Key="SetSuccessfully">🍸🍸🍺</system:String>

--- a/src/MeoAsstGui/Resources/Localizations/zh-cn.xaml
+++ b/src/MeoAsstGui/Resources/Localizations/zh-cn.xaml
@@ -235,6 +235,7 @@
     <system:String x:Key="ConnectingToEmulator">正在连接模拟器……</system:String>
     <system:String x:Key="UnselectedTask">未选择任务</system:String>
     <system:String x:Key="Running">正在运行中……</system:String>
+    <system:String x:Key="Stopping">正在停止……</system:String>
     <system:String x:Key="Stopped">已停止</system:String>
     <system:String x:Key="UnknownErrorOccurs">出现未知错误</system:String>
     <system:String x:Key="SetSuccessfully">设置成功</system:String>

--- a/src/MeoAsstGui/Resources/Localizations/zh-tw.xaml
+++ b/src/MeoAsstGui/Resources/Localizations/zh-tw.xaml
@@ -235,6 +235,7 @@
     <system:String x:Key="ConnectingToEmulator">正在連接模擬器……</system:String>
     <system:String x:Key="UnselectedTask">未選擇任務</system:String>
     <system:String x:Key="Running">正在運行中……</system:String>
+    <system:String x:Key="Stopping">正在停止……</system:String>
     <system:String x:Key="Stopped">已停止</system:String>
     <system:String x:Key="UnknownErrorOccurs">出現未知錯誤</system:String>
     <system:String x:Key="SetSuccessfully">設定成功</system:String>

--- a/src/MeoAsstGui/Views/TaskQueueView.xaml
+++ b/src/MeoAsstGui/Views/TaskQueueView.xaml
@@ -140,14 +140,15 @@
                     Command="{s:Action LinkStart}"
                     Content="{DynamicResource LinkStart}"
                     IsEnabled="{Binding Inited}"
-                    Visibility="{c:Binding Path='Idle or !Inited'}" />
+                    Visibility="{c:Binding Path='(Idle and !Stopping) or !Inited'}" />
                 <Button
                     Width="100"
                     Height="50"
                     Margin="5"
                     Command="{s:Action Stop}"
                     Content="{DynamicResource Stop}"
-                    Visibility="{c:Binding Path='!Idle and Inited'}" />
+                    IsEnabled="{c:Binding Path='!Stopping'}"
+                    Visibility="{c:Binding Path='(!Idle or Stopping) and Inited'}" />
             </Grid>
 
             <!--<StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment ="Center" >-->


### PR DESCRIPTION
1. `call_command` 不再通过 `m_inited` 来判断是否处于递归；  
    增加一个参数 `allow_reconnect` 表示是否允许重连，默认为 `true`，递归时为 `false`；
2. `release()` 函数不再直接调用；
3. 把 `m_inited` 的值和 `m_instance_count` 的增减绑定；  
    外部不再直接调用 `m_inited` 和 `m_instance_count`，改为调用 `set_inited(true)` `set_inited(false)`；
4. 修复 UI 上连接模拟器时点击 `停止` 按钮卡顿的问题

<!-- Add core -->