### PR TITLE
fix: 修复关闭模拟器后台进程不完全

### DIFF
--- a/src/MeoAsstGui/ViewModels/TaskQueueViewModel.cs
+++ b/src/MeoAsstGui/ViewModels/TaskQueueViewModel.cs
@@ -978,11 +978,11 @@ namespace MeoAsstGui
                         return killEmulator();
                     }
 
-                    return true;
+                    return killEmulator();
                 }
                 else
                 {
-                    return true;
+                    return killEmulator();
                 }
             }
             else

--- a/src/MeoAsstGui/ViewModels/TaskQueueViewModel.cs
+++ b/src/MeoAsstGui/ViewModels/TaskQueueViewModel.cs
@@ -975,20 +975,11 @@ namespace MeoAsstGui
                     }
                     catch
                     {
-                        return killEmulator();
                     }
+                }
+            }
 
-                    return killEmulator();
-                }
-                else
-                {
-                    return killEmulator();
-                }
-            }
-            else
-            {
-                return killEmulator();
-            }
+            return killEmulator();
         }
 
         /// <summary>


### PR DESCRIPTION
蓝叠模拟器一共有4个进程
![image](https://user-images.githubusercontent.com/46482682/191183013-847dfad6-51a5-468b-a2ac-1f4fd76260fd.png)
关闭模拟器时，只使用killEumlatorbyWindow()会留下两个进程，其中一个内存占用特别大
![image](https://user-images.githubusercontent.com/46482682/191183308-36bfdc06-6529-4d43-947e-a903301bf7eb.png)
如果先调用killEumlatorbyWindow()，再调用killEmulator()，就可以把那个内存占用特别大的进程关掉
![image](https://user-images.githubusercontent.com/46482682/191183606-4fcd2065-3e2c-4f0f-9bf6-bca467b13ac5.png)

所以在killEumlatorbyWindow()之后添加了killEmulator()
