### PR TITLE
feat: 增加模板任务逻辑

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -1934,18 +1934,18 @@
         "algorithm": "JustReturn",
         "action": "DoNothing",
         "next": [
-            "GameStart",
-            "StartToWakeUp",
-            "StartUpConnectingFlag",
-            "StartLoginBServer",
-            "BServerPrivacyPolicy",
-            "Terminal@Main",
-            "Terminal@CloseAnno",
-            "Terminal@TodaysSupplies",
-            "Terminal@ReturnTo",
-            "OfflineConfirm",
-            "EndOfAction",
-            "StageSNFlag"
+            "StartUp@GameStart",
+            "StartUp@StartToWakeUp",
+            "StartUp@StartUpConnectingFlag",
+            "StartUp@StartLoginBServer",
+            "StartUp@BServerPrivacyPolicy",
+            "StartUp@Main",
+            "StartUp@CloseAnno",
+            "StartUp@TodaysSupplies",
+            "StartUp@ReturnTo",
+            "StartUp@OfflineConfirm",
+            "StartUp@EndOfAction",
+            "StartUp@FromStageSN"
         ]
     },
     "BServerPrivacyPolicy": {
@@ -1963,52 +1963,11 @@
             "StartUpConnectingFlag",
             "StartLoginBServer",
             "BServerPrivacyPolicy",
-            "Terminal@Main",
-            "Terminal@CloseAnno",
-            "OfflineConfirm",
-            "Terminal@TodaysSupplies"
-        ]
-    },
-    "Annihilation": {
-        "doc": "剿灭作战，一般本周的满了也不会有人再刷的，所以只识别右上角ToDoList里的剿灭就可以了",
-        "template": "StageAnnihilation.png",
-        "templThreshold": 0.6,
-        "cache": false,
-        "action": "ClickSelf",
-        "roi": [
-            900,
-            70,
-            380,
-            400
-        ],
-        "maskRange": [
-            1,
-            255
-        ]
-    },
-    "StageBegin": {
-        "algorithm": "JustReturn",
-        "action": "DoNothing",
-        "next": [
-            "Terminal@ReturnTo",
-            "Terminal@Main",
-            "Terminal@CloseAnno",
-            "Terminal@FromStageSN",
-            "Terminal@TodaysSupplies"
-        ]
-    },
-    "FightBegin": {
-        "algorithm": "JustReturn",
-        "action": "DoNothing",
-        "next": [
-            "UsePrts-Annihilation",
-            "UsePrts",
-            "UsePrts-StageSN",
-            "StartButton1",
-            "PRTS3",
-            "PRTS",
-            "PRTS2",
-            "EndOfAction"
+            "Main",
+            "CloseAnno",
+            "TodaysSupplies",
+            "ReturnTo",
+            "OfflineConfirm"
         ]
     },
     "GameStart": {
@@ -2036,10 +1995,47 @@
             "StartUpConnectingFlag",
             "StartLoginBServer",
             "BServerPrivacyPolicy",
-            "Terminal@Main",
-            "Terminal@CloseAnno",
+            "Main",
+            "CloseAnno",
             "OfflineConfirm",
-            "Terminal@TodaysSupplies"
+            "TodaysSupplies"
+        ]
+    },
+    "StartToWakeUp": {
+        "action": "ClickSelf",
+        "roi": [
+            520,
+            460,
+            240,
+            100
+        ],
+        "next": [
+            "StartToWakeUp",
+            "StartUpConnectingFlag",
+            "StartLoginBServer",
+            "BServerPrivacyPolicy",
+            "Main",
+            "CloseAnno",
+            "OfflineConfirm",
+            "TodaysSupplies"
+        ]
+    },
+    "StartLoginBServer": {
+        "action": "ClickSelf",
+        "roi": [
+            400,
+            350,
+            500,
+            150
+        ],
+        "next": [
+            "StartUpConnectingFlag",
+            "StartLoginBServer",
+            "BServerPrivacyPolicy",
+            "Main",
+            "CloseAnno",
+            "OfflineConfirm",
+            "TodaysSupplies"
         ]
     },
     "StartUpConnectingFlag": {
@@ -2055,28 +2051,61 @@
             "StartLoginBServer",
             "BServerPrivacyPolicy",
             "StartUpConnectingFlag",
-            "Terminal@Main",
-            "Terminal@CloseAnno",
+            "Main",
+            "CloseAnno",
             "OfflineConfirm",
-            "Terminal@TodaysSupplies"
+            "TodaysSupplies"
         ]
     },
-    "StartLoginBServer": {
-        "action": "ClickSelf",
+    "StartUp@Main": {
+        "template": "Terminal.png",
+        "action": "Stop",
         "roi": [
-            400,
-            350,
+            880,
+            100,
+            180,
+            120
+        ]
+    },
+    "CloseAnno": {
+        "Doc": "base_task",
+        "action": "ClickSelf",
+        "cache": false,
+        "roi": [
+            1100,
+            0,
+            180,
+            200
+        ],
+        "next": [
+            "Main",
+            "CloseAnno",
+            "ReturnTo",
+            "FromStageSN",
+            "TodaysSupplies"
+        ]
+    },
+    "TodaysSupplies": {
+        "algorithm": "OcrDetect",
+        "text": [
+            "今日配给"
+        ],
+        "action": "ClickRect",
+        "specificRect": [
+            1000,
+            1,
+            270,
+            340
+        ],
+        "roi": [
             500,
+            50,
+            300,
             150
         ],
         "next": [
-            "StartUpConnectingFlag",
-            "StartLoginBServer",
-            "BServerPrivacyPolicy",
-            "Terminal@Main",
-            "Terminal@CloseAnno",
-            "OfflineConfirm",
-            "Terminal@TodaysSupplies"
+            "CloseAnno",
+            "Main"
         ]
     },
     "ReturnTo": {
@@ -2114,6 +2143,150 @@
             "FromStageSN",
             "TodaysSupplies",
             "ReturnToConfirm"
+        ]
+    },
+    "OfflineConfirm": {
+        "action": "DoNothing",
+        "roi": [
+            310,
+            409,
+            648,
+            165
+        ],
+        "reduceOtherTimes": [
+            "StartButton1",
+            "StartButton2"
+        ],
+        "next": [
+            "OfflineConfirmImpl"
+        ]
+    },
+    "OfflineConfirmImpl": {
+        "Doc": "防止 reduceOtherTimes 两次",
+        "template": "OfflineConfirm.png",
+        "action": "ClickSelf",
+        "roi": [
+            310,
+            409,
+            648,
+            165
+        ],
+        "maskRange": [
+            100,
+            255
+        ],
+        "next": [
+            "CloseAnno",
+            "StartToWakeUp",
+            "StartUpConnectingFlag",
+            "StartLoginBServer",
+            "BServerPrivacyPolicy",
+            "OfflineConfirmImpl",
+            "TodaysSupplies"
+        ]
+    },
+    "StartUp@AfterEndOfAction": {
+        "ClickCorner_Doc": "点击屏幕右边，不会点到掉落物品，且不会关掉关卡选择的一块区域",
+        "algorithm": "JustReturn",
+        "action": "ClickRect",
+        "specificRect": [
+            1000,
+            120,
+            270,
+            10
+        ],
+        "next": [
+            "StartUp@ReturnTo",
+            "StartUp@Main",
+            "StartUp@CloseAnno",
+            "StartUp@FromStageSN",
+            "StartUp@TodaysSupplies",
+            "StartUp@OfflineConfirm"
+        ],
+        "onErrorNext": [
+            "StartUp@RestartGameAndContinue"
+        ]
+    },
+    "FromStageSN": {
+        "template": "StageSNReturnFlag.png",
+        "action": "ClickRect",
+        "cache": false,
+        "roi": [
+            284,
+            509,
+            242,
+            141
+        ],
+        "specificRect": [
+            20,
+            20,
+            135,
+            35
+        ],
+        "next": [
+            "ReturnTo"
+        ]
+    },
+    "Annihilation": {
+        "doc": "剿灭作战，一般本周的满了也不会有人再刷的，所以只识别右上角ToDoList里的剿灭就可以了",
+        "template": "StageAnnihilation.png",
+        "templThreshold": 0.6,
+        "cache": false,
+        "action": "ClickSelf",
+        "roi": [
+            900,
+            70,
+            380,
+            400
+        ],
+        "maskRange": [
+            1,
+            255
+        ]
+    },
+    "StageBegin": {
+        "algorithm": "JustReturn",
+        "action": "DoNothing",
+        "next": [
+            "Fight@ReturnTo",
+            "Fight@Main",
+            "Fight@CloseAnno",
+            "Fight@FromStageSN",
+            "Fight@TodaysSupplies"
+        ]
+    },
+    "FightBegin": {
+        "Docs": "Fight@前缀保证各种任务的Main可以自动寻到Fight@Main",
+        "algorithm": "JustReturn",
+        "action": "DoNothing",
+        "next": [
+            "Fight@UsePrts-Annihilation",
+            "Fight@UsePrts",
+            "Fight@UsePrts-StageSN",
+            "Fight@StartButton1",
+            "Fight@PRTS3",
+            "Fight@PRTS",
+            "Fight@PRTS2",
+            "Fight@EndOfAction"
+        ]
+    },
+    "LastOrCurBattleBegin": {
+        "algorithm": "JustReturn",
+        "action": "DoNothing",
+        "next": [
+            "Fight@GoLastBattle",
+            "Fight@StartButton1",
+            "Fight@UsePrts",
+            "Fight@UsePrts-StageSN",
+            "Fight@ReturnTo",
+            "Fight@Main",
+            "Fight@CloseAnno",
+            "Fight@FromStageSN",
+            "Fight@TodaysSupplies",
+            "Fight@PRTS3",
+            "Fight@PRTS",
+            "Fight@PRTS2",
+            "Fight@EndOfAction"
         ]
     },
     "UsePrts": {
@@ -2225,46 +2398,6 @@
         ],
         "next": [
             "Stop"
-        ]
-    },
-    "Visit@FromStageSN": {
-        "template": "StageSNReturnFlag.png",
-        "action": "ClickRect",
-        "cache": false,
-        "roi": [
-            284,
-            509,
-            242,
-            141
-        ],
-        "specificRect": [
-            20,
-            20,
-            135,
-            35
-        ],
-        "next": [
-            "Visit@ReturnTo"
-        ]
-    },
-    "FromStageSN": {
-        "template": "StageSNReturnFlag.png",
-        "action": "ClickRect",
-        "cache": false,
-        "roi": [
-            284,
-            509,
-            242,
-            141
-        ],
-        "specificRect": [
-            20,
-            20,
-            135,
-            35
-        ],
-        "next": [
-            "ReturnTo"
         ]
     },
     "StartButton2": {
@@ -2420,7 +2553,7 @@
             "OfflineConfirm"
         ],
         "onErrorNext": [
-            "RestartGameAndContinueFighting"
+            "RestartGameAndContinue"
         ]
     },
     "EndOfAction": {
@@ -2436,7 +2569,7 @@
             "FightMissionFailed"
         ],
         "next": [
-            "ClickCorner"
+            "AfterEndOfAction"
         ]
     },
     "EndOfActionAnnihilation": {
@@ -2453,14 +2586,14 @@
         ],
         "action": "DoNothing",
         "next": [
-            "ClickCorner"
+            "AfterEndOfAction"
         ]
     },
     "StageDrops": {
         "algorithm": "JustReturn",
         "preDelay": 5000
     },
-    "ClickCorner": {
+    "AfterEndOfAction": {
         "ClickCorner_Doc": "点击屏幕右边，不会点到掉落物品，且不会关掉关卡选择的一块区域",
         "algorithm": "JustReturn",
         "action": "ClickRect",
@@ -2479,23 +2612,7 @@
             "EndOfAction"
         ],
         "onErrorNext": [
-            "RestartGameAndContinueFighting"
-        ]
-    },
-    "RestartGameAndContinueFighting": {
-        "algorithm": "JustReturn",
-        "action": "DoNothing",
-        "rearDelay": 5000,
-        "next": [
-            "GameStart",
-            "StartToWakeUp",
-            "StartUpConnectingFlag",
-            "StartLoginBServer",
-            "BServerPrivacyPolicy",
-            "Terminal@Main",
-            "Terminal@CloseAnno",
-            "Terminal@TodaysSupplies",
-            "OfflineConfirm"
+            "RestartGameAndContinue"
         ]
     },
     "UseMedicine": {
@@ -2617,6 +2734,28 @@
             "OfflineConfirmAfterBattle"
         ]
     },
+    "OfflineConfirmAfterBattle": {
+        "template": "PopupConfirm.png",
+        "action": "ClickSelf",
+        "roi": [
+            630,
+            400,
+            650,
+            160
+        ],
+        "next": [
+            "PRTS3",
+            "PRTS",
+            "PRTS2",
+            "PrtsErrorConfirm",
+            "OfflineConfirm",
+            "StartToWakeUp",
+            "StartUpConnectingFlag",
+            "StartLoginBServer",
+            "BServerPrivacyPolicy",
+            "OfflineConfirmAfterBattle"
+        ]
+    },
     "AbandonAction": {
         "action": "ClickSelf",
         "reduceOtherTimes": [
@@ -2683,101 +2822,23 @@
             269
         ]
     },
-    "OfflineConfirmAfterBattle": {
-        "template": "PopupConfirm.png",
-        "action": "ClickSelf",
-        "roi": [
-            630,
-            400,
-            650,
-            160
-        ],
-        "next": [
-            "PRTS3",
-            "PRTS",
-            "PRTS2",
-            "PrtsErrorConfirm",
-            "OfflineConfirm",
-            "StartToWakeUp",
-            "StartUpConnectingFlag",
-            "StartLoginBServer",
-            "BServerPrivacyPolicy",
-            "OfflineConfirmAfterBattle"
-        ]
-    },
-    "OfflineConfirm": {
+    "RestartGameAndContinue": {
+        "Doc": "base_task",
+        "algorithm": "JustReturn",
         "action": "DoNothing",
-        "roi": [
-            310,
-            409,
-            648,
-            165
-        ],
-        "reduceOtherTimes": [
-            "StartButton1",
-            "StartButton2"
-        ],
+        "rearDelay": 5000,
         "next": [
-            "OfflineConfirmImpl"
-        ]
-    },
-    "OfflineConfirmImpl": {
-        "template": "OfflineConfirm.png",
-        "action": "ClickSelf",
-        "roi": [
-            310,
-            409,
-            648,
-            165
-        ],
-        "maskRange": [
-            100,
-            255
-        ],
-        "next": [
-            "Terminal@CloseAnno",
+            "GameStart",
             "StartToWakeUp",
             "StartUpConnectingFlag",
             "StartLoginBServer",
             "BServerPrivacyPolicy",
-            "OfflineConfirmImpl",
-            "Terminal@TodaysSupplies"
-        ]
-    },
-    "StartToWakeUp": {
-        "action": "ClickSelf",
-        "roi": [
-            520,
-            460,
-            240,
-            100
-        ],
-        "next": [
-            "StartToWakeUp",
-            "StartUpConnectingFlag",
-            "StartLoginBServer",
-            "BServerPrivacyPolicy",
-            "Terminal@Main",
-            "Terminal@CloseAnno",
-            "OfflineConfirm",
-            "Terminal@TodaysSupplies"
-        ]
-    },
-    "CloseAnno": {
-        "action": "ClickSelf",
-        "cache": false,
-        "roi": [
-            1100,
-            0,
-            180,
-            200
-        ],
-        "next": [
+            "ReturnTo",
             "Main",
             "CloseAnno",
-            "ReturnTo",
             "FromStageSN",
-            "TodaysSupplies"
+            "TodaysSupplies",
+            "OfflineConfirm"
         ]
     },
     "Main": {
@@ -2785,7 +2846,7 @@
         "algorithm": "JustReturn",
         "action": "DoNothing"
     },
-    "Terminal@Main": {
+    "Fight@Main": {
         "template": "Terminal.png",
         "action": "ClickSelf",
         "roi": [
@@ -2795,60 +2856,18 @@
             120
         ],
         "exceededNext": [
-            "Terminal@TodaysSupplies",
-            "Terminal@CloseAnno",
+            "Fight@TodaysSupplies",
+            "Fight@CloseAnno",
             "Stop"
         ],
         "next": [
-            "GoLastBattle",
-            "Terminal@Main",
-            "Terminal@CloseAnno",
-            "Terminal@TodaysSupplies",
+            "Fight@GoLastBattle",
+            "Fight@Main",
+            "Fight@CloseAnno",
+            "Fight@TodaysSupplies",
             "Stop"
         ],
         "rearDelay": 3000
-    },
-    "TodaysSupplies": {
-        "algorithm": "OcrDetect",
-        "text": [
-            "今日配给"
-        ],
-        "action": "ClickRect",
-        "specificRect": [
-            1000,
-            1,
-            270,
-            340
-        ],
-        "roi": [
-            500,
-            50,
-            300,
-            150
-        ],
-        "next": [
-            "CloseAnno",
-            "Main"
-        ]
-    },
-    "LastOrCurBattleBegin": {
-        "algorithm": "JustReturn",
-        "action": "DoNothing",
-        "next": [
-            "GoLastBattle",
-            "StartButton1",
-            "UsePrts",
-            "UsePrts-StageSN",
-            "Terminal@ReturnTo",
-            "Terminal@Main",
-            "Terminal@CloseAnno",
-            "Terminal@FromStageSN",
-            "Terminal@TodaysSupplies",
-            "PRTS3",
-            "PRTS",
-            "PRTS2",
-            "EndOfAction"
-        ]
     },
     "GoLastBattle": {
         "algorithm": "OcrDetect",

--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -1939,10 +1939,10 @@
             "StartUpConnectingFlag",
             "StartLoginBServer",
             "BServerPrivacyPolicy",
-            "Terminal",
-            "CloseAnno",
-            "TodaysSupplies",
-            "ReturnToTerminal",
+            "Terminal@Main",
+            "Terminal@CloseAnno",
+            "Terminal@TodaysSupplies",
+            "Terminal@ReturnTo",
             "OfflineConfirm",
             "EndOfAction",
             "StageSNFlag"
@@ -1963,10 +1963,10 @@
             "StartUpConnectingFlag",
             "StartLoginBServer",
             "BServerPrivacyPolicy",
-            "Terminal",
-            "CloseAnno",
+            "Terminal@Main",
+            "Terminal@CloseAnno",
             "OfflineConfirm",
-            "TodaysSupplies"
+            "Terminal@TodaysSupplies"
         ]
     },
     "Annihilation": {
@@ -1990,11 +1990,11 @@
         "algorithm": "JustReturn",
         "action": "DoNothing",
         "next": [
-            "ReturnToTerminal",
-            "Terminal",
-            "CloseAnno",
-            "StageSNReturnToTerminal",
-            "TodaysSupplies"
+            "Terminal@ReturnTo",
+            "Terminal@Main",
+            "Terminal@CloseAnno",
+            "Terminal@StageSNReturnTo",
+            "Terminal@TodaysSupplies"
         ]
     },
     "FightBegin": {
@@ -2036,10 +2036,10 @@
             "StartUpConnectingFlag",
             "StartLoginBServer",
             "BServerPrivacyPolicy",
-            "Terminal",
-            "CloseAnno",
+            "Terminal@Main",
+            "Terminal@CloseAnno",
             "OfflineConfirm",
-            "TodaysSupplies"
+            "Terminal@TodaysSupplies"
         ]
     },
     "StartUpConnectingFlag": {
@@ -2055,10 +2055,10 @@
             "StartLoginBServer",
             "BServerPrivacyPolicy",
             "StartUpConnectingFlag",
-            "Terminal",
-            "CloseAnno",
+            "Terminal@Main",
+            "Terminal@CloseAnno",
             "OfflineConfirm",
-            "TodaysSupplies"
+            "Terminal@TodaysSupplies"
         ]
     },
     "StartLoginBServer": {
@@ -2073,13 +2073,13 @@
             "StartUpConnectingFlag",
             "StartLoginBServer",
             "BServerPrivacyPolicy",
-            "Terminal",
-            "CloseAnno",
+            "Terminal@Main",
+            "Terminal@CloseAnno",
             "OfflineConfirm",
-            "TodaysSupplies"
+            "Terminal@TodaysSupplies"
         ]
     },
-    "ReturnToTerminal": {
+    "ReturnTo": {
         "template": "Return.png",
         "templThreshold": 0.7,
         "action": "ClickSelf",
@@ -2090,14 +2090,15 @@
             80
         ],
         "next": [
-            "ReturnToTerminal",
-            "Terminal",
-            "ReturnToTerminalConfirm",
+            "ReturnTo",
+            "Main",
+            "ReturnToConfirm",
             "CloseAnno",
-            "StageSNReturnToTerminal"
+            "StageSNReturnTo",
+            "TodaysSupplies"
         ]
     },
-    "ReturnToTerminalConfirm": {
+    "ReturnToConfirm": {
         "template": "PopupConfirm.png",
         "action": "ClickSelf",
         "roi": [
@@ -2107,11 +2108,11 @@
             160
         ],
         "next": [
-            "ReturnToTerminal",
-            "Terminal",
+            "ReturnTo",
+            "Main",
             "CloseAnno",
-            "StageSNReturnToTerminal",
-            "ReturnToTerminalConfirm"
+            "StageSNReturnTo",
+            "TodaysSupplies"
         ]
     },
     "UsePrts": {
@@ -2225,26 +2226,6 @@
             "Stop"
         ]
     },
-    "StageSNReturnToAward": {
-        "template": "StageSNReturnFlag.png",
-        "action": "ClickRect",
-        "cache": false,
-        "roi": [
-            284,
-            509,
-            242,
-            141
-        ],
-        "specificRect": [
-            20,
-            20,
-            135,
-            35
-        ],
-        "next": [
-            "ReturnToAward"
-        ]
-    },
     "StageSNReturnToFriends": {
         "template": "StageSNReturnFlag.png",
         "action": "ClickRect",
@@ -2345,7 +2326,7 @@
             "ReturnToRoguelike1"
         ]
     },
-    "StageSNReturnToTerminal": {
+    "StageSNReturnTo": {
         "template": "StageSNReturnFlag.png",
         "action": "ClickRect",
         "cache": false,
@@ -2362,7 +2343,7 @@
             35
         ],
         "next": [
-            "ReturnToTerminal"
+            "ReturnTo"
         ]
     },
     "StartButton2": {
@@ -2590,9 +2571,9 @@
             "StartUpConnectingFlag",
             "StartLoginBServer",
             "BServerPrivacyPolicy",
-            "Terminal",
-            "CloseAnno",
-            "TodaysSupplies",
+            "Terminal@Main",
+            "Terminal@CloseAnno",
+            "Terminal@TodaysSupplies",
             "OfflineConfirm"
         ]
     },
@@ -2833,13 +2814,13 @@
             255
         ],
         "next": [
-            "CloseAnno",
+            "Terminal@CloseAnno",
             "StartToWakeUp",
             "StartUpConnectingFlag",
             "StartLoginBServer",
             "BServerPrivacyPolicy",
             "OfflineConfirmImpl",
-            "TodaysSupplies"
+            "Terminal@TodaysSupplies"
         ]
     },
     "StartToWakeUp": {
@@ -2855,10 +2836,10 @@
             "StartUpConnectingFlag",
             "StartLoginBServer",
             "BServerPrivacyPolicy",
-            "Terminal",
-            "CloseAnno",
+            "Terminal@Main",
+            "Terminal@CloseAnno",
             "OfflineConfirm",
-            "TodaysSupplies"
+            "Terminal@TodaysSupplies"
         ]
     },
     "CloseAnno": {
@@ -2871,12 +2852,19 @@
             200
         ],
         "next": [
-            "Terminal",
+            "Main",
             "CloseAnno",
+            "ReturnTo",
+            "StageSNReturnTo",
             "TodaysSupplies"
         ]
     },
-    "Terminal": {
+    "Main": {
+        "Doc": "base_task: Main",
+        "template": "empty.png"
+    },
+    "Terminal@Main": {
+        "template": "Terminal.png",
         "action": "ClickSelf",
         "roi": [
             880,
@@ -2885,15 +2873,15 @@
             120
         ],
         "exceededNext": [
-            "TodaysSupplies",
-            "CloseAnno",
+            "Terminal@TodaysSupplies",
+            "Terminal@CloseAnno",
             "Stop"
         ],
         "next": [
             "GoLastBattle",
-            "Terminal",
-            "CloseAnno",
-            "TodaysSupplies",
+            "Terminal@Main",
+            "Terminal@CloseAnno",
+            "Terminal@TodaysSupplies",
             "Stop"
         ],
         "rearDelay": 3000
@@ -2918,7 +2906,7 @@
         ],
         "next": [
             "CloseAnno",
-            "Terminal"
+            "Main"
         ]
     },
     "LastOrCurBattleBegin": {
@@ -2929,11 +2917,11 @@
             "StartButton1",
             "UsePrts",
             "UsePrts-StageSN",
-            "ReturnToTerminal",
-            "Terminal",
-            "CloseAnno",
-            "StageSNReturnToTerminal",
-            "TodaysSupplies",
+            "Terminal@ReturnTo",
+            "Terminal@Main",
+            "Terminal@CloseAnno",
+            "Terminal@StageSNReturnTo",
+            "Terminal@TodaysSupplies",
             "PRTS3",
             "PRTS",
             "PRTS2",
@@ -3414,40 +3402,17 @@
         "algorithm": "JustReturn",
         "action": "DoNothing",
         "next": [
-            "ReturnToAward",
-            "Award",
+            "Award@ReturnTo",
+            "Award@Main",
             "ReceiveAward",
             "DailyTask",
             "WeeklyTask",
-            "ReturnToAwardCloseAnno",
-            "StageSNReturnToAward",
-            "TodaysSuppliesToAward"
+            "Award@CloseAnno",
+            "Award@StageSNReturnTo",
+            "Award@TodaysSupplies"
         ]
     },
-    "TodaysSuppliesToAward": {
-        "algorithm": "OcrDetect",
-        "text": [
-            "今日配给"
-        ],
-        "action": "ClickRect",
-        "specificRect": [
-            1000,
-            1,
-            270,
-            340
-        ],
-        "roi": [
-            500,
-            50,
-            300,
-            150
-        ],
-        "next": [
-            "ReturnToAwardCloseAnno",
-            "Award"
-        ]
-    },
-    "Award": {
+    "Award@Main": {
         "template": "Task.png",
         "action": "ClickSelf",
         "roi": [
@@ -3460,9 +3425,9 @@
             "ReceiveAward",
             "DailyTask",
             "WeeklyTask",
-            "Award",
-            "ReturnToAwardCloseAnno",
-            "TodaysSuppliesToAward"
+            "Award@Main",
+            "Award@CloseAnno",
+            "Award@TodaysSupplies"
         ]
     },
     "ReceiveAward": {
@@ -3546,61 +3511,6 @@
         "next": [
             "ReceiveAward",
             "Stop"
-        ]
-    },
-    "ReturnToAward": {
-        "template": "Return.png",
-        "templThreshold": 0.7,
-        "action": "ClickSelf",
-        "roi": [
-            0,
-            0,
-            180,
-            80
-        ],
-        "next": [
-            "Award",
-            "ReturnToAward",
-            "ReturnToAwardConfirm",
-            "ReturnToAwardCloseAnno",
-            "StageSNReturnToAward",
-            "TodaysSuppliesToAward"
-        ]
-    },
-    "ReturnToAwardConfirm": {
-        "template": "PopupConfirm.png",
-        "action": "ClickSelf",
-        "roi": [
-            630,
-            400,
-            650,
-            160
-        ],
-        "next": [
-            "Award",
-            "ReturnToAward",
-            "ReturnToAwardCloseAnno",
-            "StageSNReturnToAward",
-            "TodaysSuppliesToAward",
-            "ReturnToAwardConfirm"
-        ]
-    },
-    "ReturnToAwardCloseAnno": {
-        "template": "CloseAnno.png",
-        "action": "ClickSelf",
-        "cache": false,
-        "roi": [
-            1100,
-            0,
-            180,
-            200
-        ],
-        "next": [
-            "Award",
-            "ReturnToAwardCloseAnno",
-            "ReturnToAward",
-            "StageSNReturnToAward",
-            "TodaysSuppliesToAward"
         ]
     },
     "VisitBegin": {

--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -1993,7 +1993,7 @@
             "Terminal@ReturnTo",
             "Terminal@Main",
             "Terminal@CloseAnno",
-            "Terminal@StageSNReturnTo",
+            "Terminal@FromStageSN",
             "Terminal@TodaysSupplies"
         ]
     },
@@ -2090,11 +2090,11 @@
             80
         ],
         "next": [
-            "ReturnTo",
             "Main",
+            "ReturnTo",
             "ReturnToConfirm",
             "CloseAnno",
-            "StageSNReturnTo",
+            "FromStageSN",
             "TodaysSupplies"
         ]
     },
@@ -2111,8 +2111,9 @@
             "ReturnTo",
             "Main",
             "CloseAnno",
-            "StageSNReturnTo",
-            "TodaysSupplies"
+            "FromStageSN",
+            "TodaysSupplies",
+            "ReturnToConfirm"
         ]
     },
     "UsePrts": {
@@ -2226,7 +2227,7 @@
             "Stop"
         ]
     },
-    "StageSNReturnToFriends": {
+    "Visit@FromStageSN": {
         "template": "StageSNReturnFlag.png",
         "action": "ClickRect",
         "cache": false,
@@ -2243,70 +2244,10 @@
             35
         ],
         "next": [
-            "ReturnToFriends"
+            "Visit@ReturnTo"
         ]
     },
-    "StageSNReturnToInfrast": {
-        "template": "StageSNReturnFlag.png",
-        "action": "ClickRect",
-        "cache": false,
-        "roi": [
-            284,
-            509,
-            242,
-            141
-        ],
-        "specificRect": [
-            20,
-            20,
-            135,
-            35
-        ],
-        "next": [
-            "ReturnToInfrast"
-        ]
-    },
-    "StageSNReturnToMall": {
-        "template": "StageSNReturnFlag.png",
-        "action": "ClickRect",
-        "cache": false,
-        "roi": [
-            284,
-            509,
-            242,
-            141
-        ],
-        "specificRect": [
-            20,
-            20,
-            135,
-            35
-        ],
-        "next": [
-            "ReturnToMall"
-        ]
-    },
-    "StageSNReturnToRoguelike1": {
-        "template": "StageSNReturnFlag.png",
-        "action": "ClickRect",
-        "cache": false,
-        "roi": [
-            284,
-            509,
-            242,
-            141
-        ],
-        "specificRect": [
-            20,
-            20,
-            135,
-            35
-        ],
-        "next": [
-            "ReturnToRoguelike1"
-        ]
-    },
-    "StageSNReturnTo": {
+    "FromStageSN": {
         "template": "StageSNReturnFlag.png",
         "action": "ClickRect",
         "cache": false,
@@ -2835,13 +2776,14 @@
             "Main",
             "CloseAnno",
             "ReturnTo",
-            "StageSNReturnTo",
+            "FromStageSN",
             "TodaysSupplies"
         ]
     },
     "Main": {
         "Doc": "base_task: Main",
-        "template": "empty.png"
+        "algorithm": "JustReturn",
+        "action": "DoNothing"
     },
     "Terminal@Main": {
         "template": "Terminal.png",
@@ -2900,7 +2842,7 @@
             "Terminal@ReturnTo",
             "Terminal@Main",
             "Terminal@CloseAnno",
-            "Terminal@StageSNReturnTo",
+            "Terminal@FromStageSN",
             "Terminal@TodaysSupplies",
             "PRTS3",
             "PRTS",
@@ -2937,7 +2879,7 @@
             "Recruit@Main",
             "Recruit@ReturnTo",
             "Recruit@CloseAnno",
-            "Recruit@StageSNReturnTo",
+            "Recruit@FromStageSN",
             "Recruit@TodaysSupplies"
         ]
     },
@@ -3311,7 +3253,7 @@
             "DailyTask",
             "WeeklyTask",
             "Award@CloseAnno",
-            "Award@StageSNReturnTo",
+            "Award@FromStageSN",
             "Award@TodaysSupplies"
         ]
     },
@@ -3420,96 +3362,19 @@
         "algorithm": "JustReturn",
         "action": "DoNothing",
         "next": [
-            "Friends",
+            "Visit@Main",
             "FriendsList",
             "StartToVisit",
             "VisitNext",
             "VisitNextBlack",
-            "ReturnToFriends",
-            "ReturnToFriendsCloseAnno",
-            "StageSNReturnToFriends",
-            "TodaysSuppliesToVisit"
+            "Visit@ReturnTo",
+            "Visit@CloseAnno",
+            "Visit@FromStageSN",
+            "Visit@TodaysSupplies"
         ]
     },
-    "TodaysSuppliesToVisit": {
-        "algorithm": "OcrDetect",
-        "text": [
-            "今日配给"
-        ],
-        "action": "ClickRect",
-        "specificRect": [
-            1000,
-            1,
-            270,
-            340
-        ],
-        "roi": [
-            500,
-            50,
-            300,
-            150
-        ],
-        "next": [
-            "ReturnToFriendsCloseAnno",
-            "Friends"
-        ]
-    },
-    "ReturnToFriends": {
-        "template": "Return.png",
-        "templThreshold": 0.7,
-        "action": "ClickSelf",
-        "roi": [
-            0,
-            0,
-            180,
-            80
-        ],
-        "next": [
-            "Friends",
-            "ReturnToFriends",
-            "ReturnToFriendsConfirm",
-            "ReturnToFriendsCloseAnno",
-            "StageSNReturnToFriends",
-            "TodaysSuppliesToVisit"
-        ]
-    },
-    "ReturnToFriendsConfirm": {
-        "template": "PopupConfirm.png",
-        "action": "ClickSelf",
-        "roi": [
-            630,
-            400,
-            650,
-            160
-        ],
-        "next": [
-            "Friends",
-            "ReturnToFriends",
-            "ReturnToFriendsCloseAnno",
-            "StageSNReturnToFriends",
-            "TodaysSuppliesToVisit",
-            "ReturnToFriendsConfirm"
-        ]
-    },
-    "ReturnToFriendsCloseAnno": {
-        "template": "CloseAnno.png",
-        "action": "ClickSelf",
-        "cache": false,
-        "roi": [
-            1100,
-            0,
-            180,
-            200
-        ],
-        "next": [
-            "Friends",
-            "ReturnToFriends",
-            "ReturnToFriendsCloseAnno",
-            "StageSNReturnToFriends",
-            "TodaysSuppliesToVisit"
-        ]
-    },
-    "Friends": {
+    "Visit@Main": {
+        "template": "Friends.png",
         "templThreshold": 0.7,
         "action": "ClickSelf",
         "roi": [
@@ -3520,9 +3385,9 @@
         ],
         "next": [
             "FriendsList",
-            "Friends",
-            "ReturnToFriendsCloseAnno",
-            "TodaysSuppliesToVisit"
+            "Visit@Main",
+            "Visit@CloseAnno",
+            "Visit@TodaysSupplies"
         ]
     },
     "FriendsList": {
@@ -3551,7 +3416,7 @@
         ],
         "action": "DoNothing",
         "next": [
-            "ReturnToHome"
+            "Home@ReturnTo"
         ]
     },
     "StartToVisit": {
@@ -3608,92 +3473,14 @@
         "algorithm": "JustReturn",
         "action": "DoNothing",
         "next": [
-            "ReturnToMall",
-            "Mall",
-            "ReturnToMallCloseAnno",
-            "StageSNReturnToMall",
-            "TodaysSuppliesToMall"
+            "Mall@ReturnTo",
+            "Mall@Main",
+            "Mall@CloseAnno",
+            "Mall@FromStageSN",
+            "Mall@TodaysSupplies"
         ]
     },
-    "TodaysSuppliesToMall": {
-        "algorithm": "OcrDetect",
-        "text": [
-            "今日配给"
-        ],
-        "action": "ClickRect",
-        "specificRect": [
-            1000,
-            1,
-            270,
-            340
-        ],
-        "roi": [
-            500,
-            50,
-            300,
-            150
-        ],
-        "next": [
-            "ReturnToMallCloseAnno",
-            "Mall"
-        ]
-    },
-    "ReturnToMall": {
-        "template": "Return.png",
-        "templThreshold": 0.7,
-        "action": "ClickSelf",
-        "roi": [
-            0,
-            0,
-            180,
-            80
-        ],
-        "next": [
-            "Mall",
-            "ReturnToMallConfirm",
-            "ReturnToMall",
-            "ReturnToMallCloseAnno",
-            "StageSNReturnToMall",
-            "TodaysSuppliesToMall"
-        ]
-    },
-    "ReturnToMallConfirm": {
-        "template": "PopupConfirm.png",
-        "action": "ClickSelf",
-        "roi": [
-            630,
-            400,
-            650,
-            160
-        ],
-        "next": [
-            "ReturnToMall",
-            "Mall",
-            "ReturnToMallCloseAnno",
-            "StageSNReturnToMall",
-            "TodaysSuppliesToMall",
-            "ReturnToMallConfirm"
-        ]
-    },
-    "ReturnToMallCloseAnno": {
-        "template": "CloseAnno.png",
-        "action": "ClickSelf",
-        "cache": false,
-        "roi": [
-            1100,
-            0,
-            180,
-            200
-        ],
-        "next": [
-            "Mall",
-            "ReturnToMallCloseAnno",
-            "ReturnToMall",
-            "StageSNReturnToMall",
-            "TodaysSuppliesToMall"
-        ]
-    },
-    "Mall": {
+    "Mall@Main": {
         "algorithm": "OcrDetect",
         "action": "ClickSelf",
         "text": [
@@ -3707,9 +3494,9 @@
         ],
         "next": [
             "CreditStoreOcr",
-            "Mall",
-            "ReturnToMallCloseAnno",
-            "TodaysSuppliesToMall"
+            "Mall@Main",
+            "Mall@CloseAnno",
+            "Mall@TodaysSupplies"
         ]
     },
     "CreditStoreOcr": {
@@ -3799,7 +3586,7 @@
             140
         ],
         "next": [
-            "ReturnToHome"
+            "Home@ReturnTo"
         ]
     },
     "VisitNextBlack": {
@@ -3811,59 +3598,10 @@
             130
         ],
         "next": [
-            "ReturnToHome"
+            "Home@ReturnTo"
         ]
     },
-    "ReturnToHome": {
-        "template": "Return.png",
-        "templThreshold": 0.7,
-        "action": "ClickSelf",
-        "roi": [
-            0,
-            0,
-            180,
-            80
-        ],
-        "next": [
-            "HomeFlag",
-            "ReturnToHome",
-            "ReturnToHomeConfirm",
-            "ReturnToHomeCloseAnno"
-        ]
-    },
-    "ReturnToHomeConfirm": {
-        "template": "PopupConfirm.png",
-        "action": "ClickSelf",
-        "roi": [
-            630,
-            400,
-            650,
-            160
-        ],
-        "next": [
-            "HomeFlag",
-            "ReturnToHome",
-            "ReturnToHomeCloseAnno",
-            "ReturnToHomeConfirm"
-        ]
-    },
-    "ReturnToHomeCloseAnno": {
-        "template": "CloseAnno.png",
-        "action": "ClickSelf",
-        "cache": false,
-        "roi": [
-            1100,
-            0,
-            180,
-            200
-        ],
-        "next": [
-            "HomeFlag",
-            "ReturnToHome",
-            "ReturnToHomeCloseAnno"
-        ]
-    },
-    "HomeFlag": {
+    "Home@Main": {
         "template": "Terminal.png",
         "action": "Stop",
         "roi": [
@@ -4103,39 +3841,16 @@
         "algorithm": "JustReturn",
         "action": "DoNothing",
         "next": [
-            "EnterInfrast",
+            "Infrast@Main",
             "InfrastEnteredFlag",
             "InfrastNotification",
-            "ReturnToInfrast",
-            "ReturnToInfrastCloseAnno",
-            "StageSNReturnToInfrast",
-            "TodaysSuppliesToInfrast"
+            "Infrast@ReturnTo",
+            "Infrast@CloseAnno",
+            "Infrast@FromStageSN",
+            "Infrast@TodaysSupplies"
         ]
     },
-    "TodaysSuppliesToInfrast": {
-        "algorithm": "OcrDetect",
-        "text": [
-            "今日配给"
-        ],
-        "action": "ClickRect",
-        "specificRect": [
-            1000,
-            1,
-            270,
-            340
-        ],
-        "roi": [
-            500,
-            50,
-            300,
-            150
-        ],
-        "next": [
-            "ReturnToInfrast",
-            "EnterInfrast"
-        ]
-    },
-    "ReturnToInfrast": {
+    "Infrast@ReturnTo": {
         "template": "Return.png",
         "templThreshold": 0.7,
         "roi": [
@@ -4146,17 +3861,17 @@
         ],
         "action": "ClickSelf",
         "next": [
-            "EnterInfrast",
+            "Infrast@Main",
             "InfrastNotification",
             "InfrastEnteredFlag",
-            "ReturnToInfrast",
-            "ReturnToInfrastConfirm",
-            "ReturnToInfrastCloseAnno",
-            "StageSNReturnToInfrast",
-            "TodaysSuppliesToInfrast"
+            "Infrast@ReturnTo",
+            "Infrast@ReturnToConfirm",
+            "Infrast@CloseAnno",
+            "Infrast@FromStageSN",
+            "Infrast@TodaysSupplies"
         ]
     },
-    "ReturnToInfrastConfirm": {
+    "Infrast@ReturnToConfirm": {
         "template": "PopupConfirm.png",
         "action": "ClickSelf",
         "roi": [
@@ -4166,17 +3881,17 @@
             160
         ],
         "next": [
-            "EnterInfrast",
+            "Infrast@Main",
             "InfrastNotification",
             "InfrastEnteredFlag",
-            "ReturnToInfrast",
-            "ReturnToInfrastCloseAnno",
-            "StageSNReturnToInfrast",
-            "TodaysSuppliesToInfrast",
-            "ReturnToInfrastConfirm"
+            "Infrast@ReturnTo",
+            "Infrast@CloseAnno",
+            "Infrast@FromStageSN",
+            "Infrast@TodaysSupplies",
+            "Infrast@ReturnToConfirm"
         ]
     },
-    "ReturnToInfrastCloseAnno": {
+    "Infrast@CloseAnno": {
         "template": "CloseAnno.png",
         "action": "ClickSelf",
         "cache": false,
@@ -4187,13 +3902,13 @@
             200
         ],
         "next": [
-            "EnterInfrast",
+            "Infrast@Main",
             "InfrastNotification",
             "InfrastEnteredFlag",
-            "ReturnToInfrast",
-            "ReturnToInfrastCloseAnno",
-            "StageSNReturnToInfrast",
-            "TodaysSuppliesToInfrast"
+            "Infrast@ReturnTo",
+            "Infrast@CloseAnno",
+            "Infrast@FromStageSN",
+            "Infrast@TodaysSupplies"
         ]
     },
     "Return": {
@@ -4201,7 +3916,8 @@
         "templThreshold": 0.7,
         "rearDelay": 2000
     },
-    "EnterInfrast": {
+    "Infrast@Main": {
+        "template": "EnterInfrast.png",
         "roi": [
             900,
             540,
@@ -4211,9 +3927,9 @@
         "action": "ClickSelf",
         "next": [
             "InfrastEnteredFlag",
-            "EnterInfrast",
-            "ReturnToInfrastCloseAnno",
-            "TodaysSuppliesToInfrast"
+            "Infrast@Main",
+            "Infrast@CloseAnno",
+            "Infrast@TodaysSupplies"
         ],
         "rearDelay": 5000
     },
@@ -6813,7 +6529,7 @@
             30
         ]
     },
-    "StartToWakeUpToRoguelike1": {
+    "Roguelike1@StartToWakeUp": {
         "template": "StartToWakeUp.png",
         "action": "ClickSelf",
         "roi": [
@@ -6823,14 +6539,14 @@
             100
         ],
         "next": [
-            "StartToWakeUpToRoguelike1",
-            "StartUpConnectingToRoguelike1",
-            "TerminalToRoguelike1",
-            "CloseAnnoToRoguelike1",
-            "TodaysSuppliesToRoguelike1"
+            "Roguelike1@StartToWakeUp",
+            "Roguelike1@StartUpConnecting",
+            "Roguelike1@Main",
+            "Roguelike1@CloseAnno",
+            "Roguelike1@TodaysSupplies"
         ]
     },
-    "StartUpConnectingToRoguelike1": {
+    "Roguelike1@StartUpConnecting": {
         "template": "StartUpConnectingFlag.png",
         "action": "DoNothing",
         "roi": [
@@ -6840,53 +6556,14 @@
             85
         ],
         "next": [
-            "StartToWakeUpToRoguelike1",
-            "StartUpConnectingToRoguelike1",
-            "TerminalToRoguelike1",
-            "CloseAnnoToRoguelike1",
-            "TodaysSuppliesToRoguelike1"
+            "Roguelike1@StartToWakeUp",
+            "Roguelike1@StartUpConnecting",
+            "Roguelike1@Main",
+            "Roguelike1@CloseAnno",
+            "Roguelike1@TodaysSupplies"
         ]
     },
-    "TodaysSuppliesToRoguelike1": {
-        "algorithm": "OcrDetect",
-        "text": [
-            "今日配给"
-        ],
-        "action": "ClickRect",
-        "specificRect": [
-            1000,
-            1,
-            270,
-            340
-        ],
-        "roi": [
-            500,
-            50,
-            300,
-            150
-        ],
-        "next": [
-            "CloseAnnoToRoguelike1",
-            "TerminalToRoguelike1"
-        ]
-    },
-    "CloseAnnoToRoguelike1": {
-        "template": "CloseAnno.png",
-        "action": "ClickSelf",
-        "cache": false,
-        "roi": [
-            1100,
-            0,
-            180,
-            200
-        ],
-        "next": [
-            "TerminalToRoguelike1",
-            "CloseAnnoToRoguelike1",
-            "TodaysSuppliesToRoguelike1"
-        ]
-    },
-    "TerminalToRoguelike1": {
+    "Roguelike1@Main": {
         "template": "Terminal.png",
         "action": "ClickSelf",
         "roi": [
@@ -6896,8 +6573,8 @@
             120
         ],
         "next": [
-            "TerminalToRoguelike1",
-            "CloseAnnoToRoguelike1",
+            "Roguelike1@Main",
+            "Roguelike1@CloseAnno",
             "Roguelike1TodoEnter",
             "IntegratedStrategies"
         ],
@@ -6951,7 +6628,7 @@
             "Roguelike1Begin"
         ]
     },
-    "ReturnToRoguelike1": {
+    "Roguelike1@ReturnTo": {
         "template": "Return.png",
         "templThreshold": 0.7,
         "cache": false,
@@ -6967,31 +6644,14 @@
             "Roguelike1Start",
             "Roguelike1ExitThenAbandon",
             "Roguelike1Abandon",
-            "TerminalToRoguelike1",
-            "ReturnToRoguelike1",
-            "ReturnToRoguelike1Confirm",
-            "CloseAnnoToRoguelike1",
-            "StageSNReturnToRoguelike1"
+            "Roguelike1@Main",
+            "Roguelike1@ReturnTo",
+            "Roguelike1@ReturnToConfirm",
+            "Roguelike1@CloseAnno",
+            "Roguelike1@FromStageSN"
         ]
     },
-    "ReturnToRoguelike1Confirm": {
-        "template": "PopupConfirm.png",
-        "action": "ClickSelf",
-        "roi": [
-            630,
-            400,
-            650,
-            160
-        ],
-        "next": [
-            "TerminalToRoguelike1",
-            "ReturnToRoguelike1",
-            "CloseAnnoToRoguelike1",
-            "StageSNReturnToRoguelike1",
-            "ReturnToRoguelike1Confirm"
-        ]
-    },
-    "OfflineConfirmToRoguelike1": {
+    "Roguelike1@OfflineConfirm": {
         "template": "OfflineConfirm.png",
         "action": "ClickSelf",
         "roi": [
@@ -7005,10 +6665,10 @@
             255
         ],
         "next": [
-            "CloseAnnoToRoguelike1",
-            "StartToWakeUpToRoguelike1",
-            "StartUpConnectingToRoguelike1",
-            "OfflineConfirmToRoguelike1"
+            "Roguelike1@CloseAnno",
+            "Roguelike1@StartToWakeUp",
+            "Roguelike1@StartUpConnecting",
+            "Roguelike1@OfflineConfirm"
         ]
     },
     "Roguelike1Begin": {
@@ -7036,17 +6696,17 @@
             "Roguelike2NextLevel",
             "Roguelike1ExitThenAbandon",
             "Roguelike1Abandon",
-            "TodaysSuppliesToRoguelike1",
-            "TerminalToRoguelike1",
-            "CloseAnnoToRoguelike1",
+            "Roguelike1@TodaysSupplies",
+            "Roguelike1@Main",
+            "Roguelike1@CloseAnno",
             "Roguelike1TodoEnter",
             "Roguelike1Continue",
-            "ReturnToRoguelike1",
-            "ReturnToRoguelike1Confirm",
-            "OfflineConfirmToRoguelike1",
-            "StartToWakeUpToRoguelike1",
-            "StartUpConnectingToRoguelike1",
-            "StageSNReturnToRoguelike1"
+            "Roguelike1@ReturnTo",
+            "Roguelike1@ReturnToConfirm",
+            "Roguelike1@OfflineConfirm",
+            "Roguelike1@StartToWakeUp",
+            "Roguelike1@StartUpConnecting",
+            "Roguelike1@FromStageSN"
         ]
     },
     "Roguelike1Continue": {
@@ -8662,12 +8322,12 @@
             "Roguelike1TraderRandomShopping",
             "Roguelike1StageTraderLeave",
             "Roguelike1DropsFlag",
-            "TodaysSuppliesToRoguelike1",
-            "TerminalToRoguelike1",
-            "CloseAnnoToRoguelike1",
-            "OfflineConfirmToRoguelike1",
-            "StartToWakeUpToRoguelike1",
-            "StartUpConnectingToRoguelike1",
+            "Roguelike1@TodaysSupplies",
+            "Roguelike1@Main",
+            "Roguelike1@CloseAnno",
+            "Roguelike1@OfflineConfirm",
+            "Roguelike1@StartToWakeUp",
+            "Roguelike1@StartUpConnecting",
             "Roguelike1ClickToDrops"
         ]
     },
@@ -8979,16 +8639,16 @@
             "Roguelike2CloseCollectionContinue",
             "Roguelike2CloseCollectionClose",
             "Roguelike1GamePass",
-            "TodaysSuppliesToRoguelike1",
-            "TerminalToRoguelike1",
-            "CloseAnnoToRoguelike1",
+            "Roguelike1@TodaysSupplies",
+            "Roguelike1@Main",
+            "Roguelike1@CloseAnno",
             "Roguelike1TodoEnter",
             "Roguelike1Continue",
-            "ReturnToRoguelike1",
-            "ReturnToRoguelike1Confirm",
-            "OfflineConfirmToRoguelike1",
-            "StartToWakeUpToRoguelike1",
-            "StartUpConnectingToRoguelike1",
+            "Roguelike1@ReturnTo",
+            "Roguelike1@ReturnToConfirm",
+            "Roguelike1@OfflineConfirm",
+            "Roguelike1@StartToWakeUp",
+            "Roguelike1@StartUpConnecting",
             "Roguelike1ClickToStartPoint"
         ]
     },

--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -6548,40 +6548,6 @@
             30
         ]
     },
-    "Roguelike1@StartToWakeUp": {
-        "template": "StartToWakeUp.png",
-        "action": "ClickSelf",
-        "roi": [
-            520,
-            460,
-            240,
-            100
-        ],
-        "next": [
-            "Roguelike1@StartToWakeUp",
-            "Roguelike1@StartUpConnecting",
-            "Roguelike1@Main",
-            "Roguelike1@CloseAnno",
-            "Roguelike1@TodaysSupplies"
-        ]
-    },
-    "Roguelike1@StartUpConnecting": {
-        "template": "StartUpConnectingFlag.png",
-        "action": "DoNothing",
-        "roi": [
-            0,
-            635,
-            450,
-            85
-        ],
-        "next": [
-            "Roguelike1@StartToWakeUp",
-            "Roguelike1@StartUpConnecting",
-            "Roguelike1@Main",
-            "Roguelike1@CloseAnno",
-            "Roguelike1@TodaysSupplies"
-        ]
-    },
     "Roguelike1@Main": {
         "template": "Terminal.png",
         "action": "ClickSelf",
@@ -6668,26 +6634,6 @@
             "Roguelike1@ReturnToConfirm",
             "Roguelike1@CloseAnno",
             "Roguelike1@FromStageSN"
-        ]
-    },
-    "Roguelike1@OfflineConfirm": {
-        "template": "OfflineConfirm.png",
-        "action": "ClickSelf",
-        "roi": [
-            310,
-            409,
-            648,
-            165
-        ],
-        "maskRange": [
-            100,
-            255
-        ],
-        "next": [
-            "Roguelike1@CloseAnno",
-            "Roguelike1@StartToWakeUp",
-            "Roguelike1@StartUpConnecting",
-            "Roguelike1@OfflineConfirm"
         ]
     },
     "Roguelike1Begin": {

--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -2286,26 +2286,6 @@
             "ReturnToMall"
         ]
     },
-    "StageSNReturnToRecruit": {
-        "template": "StageSNReturnFlag.png",
-        "action": "ClickRect",
-        "cache": false,
-        "roi": [
-            284,
-            509,
-            242,
-            141
-        ],
-        "specificRect": [
-            20,
-            20,
-            135,
-            35
-        ],
-        "next": [
-            "ReturnToRecruit"
-        ]
-    },
     "StageSNReturnToRoguelike1": {
         "template": "StageSNReturnFlag.png",
         "action": "ClickRect",
@@ -2954,92 +2934,15 @@
         "action": "DoNothing",
         "next": [
             "RecruitFlag",
-            "Recruit",
-            "ReturnToRecruit",
-            "ReturnToRecruitCloseAnno",
-            "StageSNReturnToRecruit",
-            "TodaysSuppliesToRecruit"
+            "Recruit@Main",
+            "Recruit@ReturnTo",
+            "Recruit@CloseAnno",
+            "Recruit@StageSNReturnTo",
+            "Recruit@TodaysSupplies"
         ]
     },
-    "TodaysSuppliesToRecruit": {
-        "algorithm": "OcrDetect",
-        "text": [
-            "今日配给"
-        ],
-        "action": "ClickRect",
-        "specificRect": [
-            1000,
-            1,
-            270,
-            340
-        ],
-        "roi": [
-            500,
-            50,
-            300,
-            150
-        ],
-        "next": [
-            "ReturnToRecruitCloseAnno",
-            "Recruit"
-        ]
-    },
-    "ReturnToRecruit": {
-        "template": "Return.png",
-        "templThreshold": 0.7,
-        "action": "ClickSelf",
-        "roi": [
-            0,
-            0,
-            180,
-            80
-        ],
-        "next": [
-            "Recruit",
-            "ReturnToRecruit",
-            "ReturnToRecruitConfirm",
-            "ReturnToRecruitCloseAnno",
-            "StageSNReturnToRecruit",
-            "TodaysSuppliesToRecruit"
-        ]
-    },
-    "ReturnToRecruitConfirm": {
-        "template": "PopupConfirm.png",
-        "action": "ClickSelf",
-        "roi": [
-            630,
-            400,
-            650,
-            160
-        ],
-        "next": [
-            "Recruit",
-            "ReturnToRecruit",
-            "ReturnToRecruitCloseAnno",
-            "StageSNReturnToRecruit",
-            "TodaysSuppliesToRecruit",
-            "ReturnToRecruitConfirm"
-        ]
-    },
-    "ReturnToRecruitCloseAnno": {
-        "template": "CloseAnno.png",
-        "action": "ClickSelf",
-        "cache": false,
-        "roi": [
-            1100,
-            0,
-            180,
-            200
-        ],
-        "next": [
-            "Recruit",
-            "ReturnToRecruitCloseAnno",
-            "ReturnToRecruit",
-            "StageSNReturnToRecruit",
-            "TodaysSuppliesToRecruit"
-        ]
-    },
-    "Recruit": {
+    "Recruit@Main": {
+        "template": "Recruit.png",
         "action": "ClickSelf",
         "roi": [
             900,
@@ -3071,7 +2974,7 @@
         ],
         "next": [
             "RecruitBeginLoading",
-            "Recruit",
+            "Recruit@Main",
             "RecruitBegin"
         ]
     },

--- a/src/MeoAssistant/Task/StartUpTask.cpp
+++ b/src/MeoAssistant/Task/StartUpTask.cpp
@@ -9,9 +9,7 @@ asst::StartUpTask::StartUpTask(AsstCallback callback, void* callback_arg)
       m_start_game_task_ptr(std::make_shared<StartGameTaskPlugin>(m_callback, m_callback_arg, TaskType)),
       m_start_up_task_ptr(std::make_shared<ProcessTask>(m_callback, m_callback_arg, TaskType))
 {
-    m_start_up_task_ptr->set_tasks({ "StartUp" })
-        .set_task_delay(1000)
-        .set_retry_times(30);
+    m_start_up_task_ptr->set_tasks({ "StartUp" }).set_task_delay(1000).set_retry_times(30);
     m_subtasks.emplace_back(m_start_game_task_ptr);
     m_subtasks.emplace_back(m_start_up_task_ptr);
 }

--- a/src/MeoAssistant/Task/StartUpTask.cpp
+++ b/src/MeoAssistant/Task/StartUpTask.cpp
@@ -10,8 +10,8 @@ asst::StartUpTask::StartUpTask(AsstCallback callback, void* callback_arg)
       m_start_up_task_ptr(std::make_shared<ProcessTask>(m_callback, m_callback_arg, TaskType))
 {
     m_start_up_task_ptr->set_tasks({ "StartUp" })
-        .set_times_limit("ReturnToTerminal", 0)
-        .set_times_limit("Terminal", 0)
+        .set_times_limit("Terminal@ReturnTo", 0)
+        .set_times_limit("Terminal@Main", 0)
         .set_times_limit("EndOfAction", 0)
         .set_task_delay(1000)
         .set_retry_times(30);

--- a/src/MeoAssistant/Task/StartUpTask.cpp
+++ b/src/MeoAssistant/Task/StartUpTask.cpp
@@ -10,9 +10,6 @@ asst::StartUpTask::StartUpTask(AsstCallback callback, void* callback_arg)
       m_start_up_task_ptr(std::make_shared<ProcessTask>(m_callback, m_callback_arg, TaskType))
 {
     m_start_up_task_ptr->set_tasks({ "StartUp" })
-        .set_times_limit("Terminal@ReturnTo", 0)
-        .set_times_limit("Terminal@Main", 0)
-        .set_times_limit("EndOfAction", 0)
         .set_task_delay(1000)
         .set_retry_times(30);
     m_subtasks.emplace_back(m_start_game_task_ptr);

--- a/src/MeoAssistant/Task/Sub/ProcessTask.cpp
+++ b/src/MeoAssistant/Task/Sub/ProcessTask.cpp
@@ -137,9 +137,21 @@ bool ProcessTask::_run()
 
         int max_times = m_cur_task_ptr->max_times;
         TimesLimitType limit_type = TimesLimitType::Pre;
-        if (auto iter = m_times_limit.find(cur_name); iter != m_times_limit.cend()) {
-            max_times = iter->second.times;
-            limit_type = iter->second.type;
+        {
+            std::string_view cur_base_name = cur_name;
+            while (true) {
+                if (auto iter = m_times_limit.find(cur_base_name.data()); iter != m_times_limit.cend()) {
+                    max_times = iter->second.times;
+                    limit_type = iter->second.type;
+                    break;
+                }
+                if (size_t at_pos = cur_base_name.find('@'); at_pos == std::string::npos) {
+                    break;
+                }
+                else {
+                    cur_base_name = cur_base_name.substr(at_pos + 1);
+                }
+            }
         }
 
         if (limit_type == TimesLimitType::Pre && exec_times >= max_times) {

--- a/src/MeoAssistant/Task/Sub/ProcessTask.cpp
+++ b/src/MeoAssistant/Task/Sub/ProcessTask.cpp
@@ -138,9 +138,9 @@ bool ProcessTask::_run()
         int max_times = m_cur_task_ptr->max_times;
         TimesLimitType limit_type = TimesLimitType::Pre;
         {
-            std::string_view cur_base_name = cur_name;
+            std::string cur_base_name = cur_name;
             while (true) {
-                if (auto iter = m_times_limit.find(cur_base_name.data()); iter != m_times_limit.cend()) {
+                if (auto iter = m_times_limit.find(cur_base_name); iter != m_times_limit.cend()) {
                     max_times = iter->second.times;
                     limit_type = iter->second.type;
                     break;

--- a/src/MeoAssistant/Task/Sub/ProcessTask.cpp
+++ b/src/MeoAssistant/Task/Sub/ProcessTask.cpp
@@ -135,24 +135,7 @@ bool ProcessTask::_run()
 
         int& exec_times = m_exec_times[cur_name];
 
-        int max_times = m_cur_task_ptr->max_times;
-        TimesLimitType limit_type = TimesLimitType::Pre;
-        {
-            std::string cur_base_name = cur_name;
-            while (true) {
-                if (auto iter = m_times_limit.find(cur_base_name); iter != m_times_limit.cend()) {
-                    max_times = iter->second.times;
-                    limit_type = iter->second.type;
-                    break;
-                }
-                if (size_t at_pos = cur_base_name.find('@'); at_pos == std::string::npos) {
-                    break;
-                }
-                else {
-                    cur_base_name = cur_base_name.substr(at_pos + 1);
-                }
-            }
-        }
+        auto [max_times, limit_type] = calc_time_limit();
 
         if (limit_type == TimesLimitType::Pre && exec_times >= max_times) {
             info["what"] = "ExceededLimit";
@@ -297,6 +280,21 @@ bool asst::ProcessTask::on_run_fails()
 
     set_tasks(m_cur_task_ptr->on_error_next);
     return run();
+}
+
+std::pair<int, asst::ProcessTask::TimesLimitType> asst::ProcessTask::calc_time_limit() const
+{
+    // eg. "C@B@A" 的 max_times 取 "C@B@A", "B@A", "A" 中有 max_times 定义的最靠前者
+    for (std::string cur_base_name = m_cur_task_ptr->name;;) {
+        if (auto iter = m_times_limit.find(cur_base_name); iter != m_times_limit.cend()) {
+            return { iter->second.times, iter->second.type };
+        }
+        size_t at_pos = cur_base_name.find('@');
+        if (at_pos == std::string::npos) {
+            return { m_cur_task_ptr->max_times, TimesLimitType::Pre };
+        }
+        cur_base_name = cur_base_name.substr(at_pos + 1);
+    }
 }
 
 json::value asst::ProcessTask::basic_info() const

--- a/src/MeoAssistant/Task/Sub/ProcessTask.h
+++ b/src/MeoAssistant/Task/Sub/ProcessTask.h
@@ -6,7 +6,7 @@
 namespace asst
 {
     // 流程任务，按照配置文件里的设置的流程运行
-    class ProcessTask : public AbstractTask
+    class ProcessTask final : public AbstractTask
     {
     public:
         enum class TimesLimitType
@@ -40,6 +40,7 @@ namespace asst
         virtual bool on_run_fails() override;
         virtual json::value basic_info() const override;
 
+        std::pair<int, TimesLimitType> calc_time_limit() const;
         void exec_click_task(const Rect& matched_rect);
         void exec_swipe_task(ProcessTaskAction action);
         void exec_slowly_swipe_task(ProcessTaskAction action);

--- a/src/MeoAssistant/TaskData.cpp
+++ b/src/MeoAssistant/TaskData.cpp
@@ -170,7 +170,7 @@ bool asst::TaskData::parse(const json::value& json)
 #ifdef ASST_DEBUG
     for (const auto& [name, task] : m_all_tasks_info) {
         for (const auto& next : task->next) {
-            if (m_all_tasks_info.find(next) == m_all_tasks_info.cend()) {
+            if (get(next) == nullptr) {
                 Log.error(name, "'s next", next, "is null");
                 return false;
             }

--- a/src/MeoAssistant/TaskData.h
+++ b/src/MeoAssistant/TaskData.h
@@ -57,8 +57,8 @@ namespace asst
         virtual const std::unordered_set<std::string>& get_templ_required() const noexcept override;
 
         template <typename TargetTaskInfoType = TaskInfo>
-        requires (std::derived_from<TargetTaskInfoType, TaskInfo> ||
-                  std::same_as<TargetTaskInfoType, TaskInfo>) // Parameter must be a TaskInfo
+        requires(std::derived_from<TargetTaskInfoType, TaskInfo> ||
+                 std::same_as<TargetTaskInfoType, TaskInfo>) // Parameter must be a TaskInfo
         std::shared_ptr<TargetTaskInfoType> get(const std::string& name)
         {
             auto it = m_all_tasks_info.find(name);

--- a/src/MeoAssistant/TaskData.h
+++ b/src/MeoAssistant/TaskData.h
@@ -56,7 +56,7 @@ namespace asst
                         task_list.emplace_back(base);
                     }
                     else {
-                        task_list.emplace_back(task_prefix + base);
+                        task_list.emplace_back(task_prefix + "@" + base);
                     }
                 }
             };

--- a/src/MeoAssistant/TaskData.h
+++ b/src/MeoAssistant/TaskData.h
@@ -7,6 +7,9 @@
 #include <unordered_set>
 
 #include "Utils/AsstTypes.h"
+#ifdef ASST_DEBUG
+#include "Utils/Logger.hpp"
+#endif
 
 namespace asst
 {
@@ -33,22 +36,36 @@ namespace asst
                 task_info_ptr = std::make_shared<TaskInfo>(*base_ptr);
                 break;
             }
-            task_info_ptr->reduce_other_times = {};
-            for (const std::string& reduce_other_times : base_ptr->reduce_other_times) {
-                task_info_ptr->reduce_other_times.emplace_back(task_prefix + reduce_other_times);
-            }
-            task_info_ptr->on_error_next = {};
-            for (const std::string& on_error_next : base_ptr->on_error_next) {
-                task_info_ptr->on_error_next.emplace_back(task_prefix + on_error_next);
-            }
-            task_info_ptr->exceeded_next = {};
-            for (const std::string& exceeded_next : base_ptr->exceeded_next) {
-                task_info_ptr->exceeded_next.emplace_back(task_prefix + exceeded_next);
-            }
-            task_info_ptr->next = {};
-            for (const std::string& next : base_ptr->next) {
-                task_info_ptr->next.emplace_back(task_prefix + next);
-            }
+            using tasklist_t = std::vector<std::string>;
+            auto generate_tasks = [&](tasklist_t& task_list, const tasklist_t& base_task_list) {
+                task_list = {};
+                for (const std::string& base : base_task_list) {
+                    std::string_view base_view = base;
+                    size_t l = 0;
+                    bool has_same_prefix = false;
+                    // base 任务里已经存在相同前缀，则不加前缀
+                    // https://github.com/MaaAssistantArknights/MaaAssistantArknights/pull/2116#issuecomment-1270115238
+                    for (size_t r = base_view.find('@'); r != std::string_view::npos; r = base_view.find('@', l)) {
+                        if (task_prefix == base_view.substr(l, r - l)) {
+                            has_same_prefix = true;
+                            break;
+                        }
+                        l = r + 1;
+                    }
+                    if (has_same_prefix) {
+                        task_list.emplace_back(base);
+                    }
+                    else {
+                        task_list.emplace_back(task_prefix + base);
+                    }
+                }
+            };
+
+            generate_tasks(task_info_ptr->next, base_ptr->next);
+            generate_tasks(task_info_ptr->exceeded_next, base_ptr->exceeded_next);
+            generate_tasks(task_info_ptr->on_error_next, base_ptr->on_error_next);
+            generate_tasks(task_info_ptr->reduce_other_times, base_ptr->reduce_other_times);
+
             return task_info_ptr;
         }
 
@@ -61,6 +78,7 @@ namespace asst
                  std::same_as<TargetTaskInfoType, TaskInfo>) // Parameter must be a TaskInfo
         std::shared_ptr<TargetTaskInfoType> get(const std::string& name)
         {
+            // 普通 task 或已经生成过的 `@` 型 task
             if (auto it = m_all_tasks_info.find(name); it != m_all_tasks_info.cend()) [[likely]] {
                 if constexpr (std::same_as<TargetTaskInfoType, TaskInfo>) {
                     return it->second;
@@ -70,12 +88,14 @@ namespace asst
                 }
             }
 
-            if (size_t name_split_pos = name.find('@'); name_split_pos == std::string::npos) [[unlikely]] {
+            size_t at_pos = name.find('@'); 
+            if (at_pos == std::string::npos) [[unlikely]] {
                 return nullptr;
             }
 
-            size_t name_len = name_split_pos + 1;
-            auto base_task_iter = get(name.substr(name_len));
+            // `@` 前面的字符长度
+            size_t name_len = at_pos;
+            auto base_task_iter = get(name.substr(name_len + 1));
             if (base_task_iter == nullptr) [[unlikely]] {
                 return nullptr;
             }
@@ -86,7 +106,16 @@ namespace asst
                 return nullptr;
             }
 
-            m_all_tasks_info.emplace(name, task_info_ptr);
+            // tasks 个数超过上限时不再 emplace，返回临时值
+            constexpr size_t MAX_TASKS_SIZE = 65535;
+            if (m_all_tasks_info.size() < MAX_TASKS_SIZE) {
+                m_all_tasks_info.emplace(name, task_info_ptr);
+            }
+#ifdef ASST_DEBUG
+            else {
+                Log.debug("Task count has exceeded the upper limit:", MAX_TASKS_SIZE, "current task:", name);
+            }
+#endif // ASST_DEBUG
 
             if constexpr (std::same_as<TargetTaskInfoType, TaskInfo>) {
                 return task_info_ptr;

--- a/src/MeoAssistant/TaskData.h
+++ b/src/MeoAssistant/TaskData.h
@@ -18,8 +18,8 @@ namespace asst
     class TaskData final : public SingletonHolder<TaskData>, public AbstractConfigerWithTempl
     {
     private:
-        std::shared_ptr<TaskInfo> generate_task_info(const std::shared_ptr<TaskInfo>& base_ptr,
-                                                     const std::string& task_prefix) const
+        static std::shared_ptr<TaskInfo> generate_task_info(const std::shared_ptr<TaskInfo>& base_ptr,
+                                                            const std::string& task_prefix)
         {
             std::shared_ptr<TaskInfo> task_info_ptr;
             switch (base_ptr->algorithm) {
@@ -88,7 +88,7 @@ namespace asst
                 }
             }
 
-            size_t at_pos = name.find('@'); 
+            size_t at_pos = name.find('@');
             if (at_pos == std::string::npos) [[unlikely]] {
                 return nullptr;
             }


### PR DESCRIPTION
允许把某个 task（例如 "A"）当作模板，然后 "B@A" 表示由 "A" 生成的任务。

例如：
在 `tasks.json` 中定义
```jsonc
"A": {
    "template": "A.png",
    ...,
    "next": { "N1", "N2", "N3", "N4" }
}
```
- 如果 `tasks.json` 中没有定义任务 "B@A"，那么除了 `next`, `onErrorNext`, `exceededNext`, `reduceOtherTimes` 增加 `B@` 前缀，其余都直接使用任务 "A" 的参数。就是说相当于定义了
  ```jsonc
    "B@A": {
        "template": "A.png",
        ...,
        "next": { "B@N1", "B@N2", "B@N3", "B@N4" }
    }
  ```
- 如果 `tasks.json` 中定义了任务 "B@A"，则优先使用 "B@A"（类似 cpp 的模板特化）。
