### PR TITLE
Update roguelike_copilot.json

### DIFF
--- a/resource/roguelike_copilot.json
+++ b/resource/roguelike_copilot.json
@@ -69,8 +69,24 @@
         ],
         "blacklist_location": [
             [
-                5,
+                6,
                 5
+            ],
+            [
+                2,
+                3
+            ],
+            [
+                3,
+                3
+            ],
+            [
+                4,
+                3
+            ],
+            [
+                5,
+                3
             ]
         ]
     },
@@ -87,8 +103,24 @@
         ],
         "blacklist_location": [
             [
-                5,
+                6,
                 5
+            ],
+            [
+                2,
+                3
+            ],
+            [
+                3,
+                3
+            ],
+            [
+                4,
+                3
+            ],
+            [
+                5,
+                3
             ]
         ]
     },
@@ -97,7 +129,7 @@
         "replacement_home": [
             {
                 "location": [
-                    3,
+                    2,
                     2
                 ],
                 "direction": "right"
@@ -109,10 +141,10 @@
         "replacement_home": [
             {
                 "location": [
-                    5,
+                    6,
                     2
                 ],
-                "direction": "up"
+                "direction": "left"
             }
         ]
     },
@@ -127,6 +159,48 @@
                 ],
                 "direction": "right"
             }
+        ]
+    },
+    {
+        "stage_name": "巢穴",
+        "blacklist_location": [
+            [
+                2,
+                3
+            ],
+            [
+                2,
+                4
+            ],
+            [
+                2,
+                5
+            ]
+        ]
+    },
+    {
+        "stage_name": "狩猎场",
+        "blacklist_location": [
+            [
+                2,
+                3
+            ],
+            [
+                2,
+                4
+            ],
+            [
+                2,
+                5
+            ],
+            [
+                2,
+                6
+            ],
+            [
+                2,
+                2
+            ]
         ]
     },
     {


### PR DESCRIPTION
阻止”巢穴“和”狩猎场“中将干员放在左侧路送死的情况
将”纠错“和”订正“的中间一路设为黑名单，看看效果（自测通过可能性提高了一点）
把”海神的信者“中打错的方向改成”左“，并且蓝门右移一格
把”无声呼号“的蓝门左移一格
