### PR TITLE
fix: 修复使用 clang 在 Linux 和 macOS 平台的编译问题

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,11 @@ else ()
     target_include_directories(MeoAssistant PRIVATE ${ZLIB_INCLUDE_DIRS})
     target_link_libraries(MeoAssistant ${ZLIB_LIBRARY})
 
+    if (CMAKE_CXX_COMPILER_ID MATCHES ".*Clang")
+        find_package(range-v3 REQUIRED)
+        target_link_libraries(MeoAssistant range-v3::range-v3)
+    endif ()
+
     target_link_libraries(MeoAssistant ppocr paddle_inference protobuf cryptopp gflags glog utf8proc xxhash iomp5 mkldnn mklml_intel)
 
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -idirafter ${PROJECT_SOURCE_DIR}/3rdparty/include")

--- a/src/MeoAssistant/Resource/RecruitConfiger.h
+++ b/src/MeoAssistant/Resource/RecruitConfiger.h
@@ -25,7 +25,16 @@ namespace asst
         friend std::strong_ordering operator<=>(const RecruitOperInfo& lhs, const RecruitOperInfo& rhs)
         {
             if (lhs.level != rhs.level) return lhs.level <=> rhs.level; // increment order
+#ifdef __clang__
+            if (rhs.name < lhs.name)
+                return std::strong_ordering::less;
+            else if (rhs.name > lhs.name)
+                return std::strong_ordering::greater;
+            else
+                return std::strong_ordering::equal;
+#else
             return rhs.name <=> lhs.name;                               // decrement order (print reversely)
+#endif
         }
 
         friend bool operator==(const RecruitOperInfo& lhs, const RecruitOperInfo& rhs)

--- a/src/MeoAssistant/Utils/AsstHttp.hpp
+++ b/src/MeoAssistant/Utils/AsstHttp.hpp
@@ -49,7 +49,7 @@ namespace asst::http
                     m_status_code = std::atoi(word.data());
                 }
                 else {
-                    m_status_code_info = std::string_view(word.begin(), status_line.end());
+                    m_status_code_info = utils::make_string_view(word.begin(), status_line.end());
                     return true;
                 }
             }
@@ -109,7 +109,7 @@ namespace asst::http
                 }
                 // data
                 else {
-                    m_body = std::string_view(line.begin(), this_view.end());
+                    m_body = utils::make_string_view(line.begin(), this_view.end());
                     return;
                 }
             }

--- a/src/MeoAssistant/Utils/AsstUtils.hpp
+++ b/src/MeoAssistant/Utils/AsstUtils.hpp
@@ -34,11 +34,25 @@ namespace asst::utils
     {
         return std::basic_string_view(std::addressof(*rng.begin()), ranges::distance(rng));
     }
+
+    template <std::forward_iterator It, std::sized_sentinel_for<It> End>
+    requires(requires(It beg, End end) { std::basic_string_view(std::addressof(*beg), std::distance(beg, end)); })
+    inline auto make_string_view(It beg, End end)
+    {
+        return std::basic_string_view(std::addressof(*beg), std::distance(beg, end));
+    }
 #else
     template <ranges::contiguous_range Rng>
     inline auto make_string_view(Rng rng)
     {
         return std::basic_string_view(rng.begin(), rng.end());
+    }
+
+    template <std::contiguous_iterator It, std::sized_sentinel_for<It> End>
+    requires(requires(It beg, End end) { std::basic_string_view(beg, end); })
+    inline auto make_string_view(It beg, End end)
+    {
+        return std::basic_string_view(beg, end);
     }
 #endif
 
@@ -132,7 +146,7 @@ namespace asst::utils
         time_t nowtime = tv.tv_sec;
         struct tm* tm_info = localtime(&nowtime);
         strftime(buff, sizeof(buff), "%Y-%m-%d %H:%M:%S", tm_info);
-        sprintf(buff, "%s.%03ld", buff, tv.tv_usec / 1000);
+        sprintf(buff, "%s.%03ld", buff, static_cast<long int>(tv.tv_usec / 1000));
 #endif // END _WIN32
         return buff;
     }

--- a/src/MeoAssistant/Utils/Logger.hpp
+++ b/src/MeoAssistant/Utils/Logger.hpp
@@ -15,6 +15,10 @@
 #include "SingletonHolder.hpp"
 #include "Version.h"
 
+#if defined (__APPLE__) || defined (__linux__)
+#include <unistd.h>
+#endif
+
 namespace asst
 {
     template <typename Stream, typename T>


### PR DESCRIPTION
- 添加 POSIX 头文件
- 实现 `std::string` 的 `<=>` 运算符
- 使用兼容的 string_view 构造函数
- 添加 range-v3 依赖