### PR TITLE
perf: 加快相邻排班变化不大时的干员选取速度

### DIFF
--- a/src/MeoAssistant/Task/Sub/InfrastAbstractTask.cpp
+++ b/src/MeoAssistant/Task/Sub/InfrastAbstractTask.cpp
@@ -233,8 +233,8 @@ bool asst::InfrastAbstractTask::swipe_and_select_custom_opers(bool is_dorm_order
     }
     // 如果只选了一个人没必要排序
     if (room_config.sort && room_config.selected > 1) {
-        click_clear_button();
         order_opers_selection(opers_order);
+        click_clear_button();
     }
 
     return room_config.names.empty();


### PR DESCRIPTION
先”排序“，后”清空选择“，可保证已选干员在前，且顺序不变。有利于干员变化较少，或对进驻顺序有要求时的排班速度。 宿舍和中枢的改善能明细感觉到。宿舍习惯放杜林等干员时，改善更为明显。