### PR TITLE
修复雷电模拟器"退出模拟器"卡死的问题

### DIFF
--- a/src / MeoAsstGui / ViewModels /TaskQueueViewModel.cs
+++ b/src / MeoAsstGui / ViewModels /TaskQueueViewModel.cs
@@ -979,7 +979,7 @@ namespace MeoAsstGui
                 "夜神模拟器",
                 "逍遥模拟器",
                 "雷电模拟器(64)",
-                "雷电模拟器",
+                "雷电模拟器", 
                 "明日方舟 - MuMu模拟器",
                 "BlueStacks App Player",
                 "BlueStacks",

--- a/src / MeoAsstGui / ViewModels /TaskQueueViewModel.cs
+++ b/src / MeoAsstGui / ViewModels /TaskQueueViewModel.cs
@@ -979,6 +979,7 @@ namespace MeoAsstGui
                 "夜神模拟器",
                 "逍遥模拟器",
                 "雷电模拟器(64)",
+                "雷电模拟器",
                 "明日方舟 - MuMu模拟器",
                 "BlueStacks App Player",
                 "BlueStacks",


### PR DESCRIPTION
添加了"退出模拟器"时雷电模拟器的正确进程名