### PR TITLE
perf: 加快相邻排班变化不大时的干员选取速度

### DIFF
--- a/src/MeoAssistant/Task/Sub/InfrastAbstractTask.cpp
+++ b/src/MeoAssistant/Task/Sub/InfrastAbstractTask.cpp
@@ -158,6 +158,7 @@ void asst::InfrastAbstractTask::await_swipe()
     sleep(extra_delay);
 }
 
+/// @brief 按技能排序->清空干员->选择定制干员->按指定顺序排序
 bool asst::InfrastAbstractTask::swipe_and_select_custom_opers(bool is_dorm_order)
 {
     LogTraceFunction;
@@ -174,6 +175,8 @@ bool asst::InfrastAbstractTask::swipe_and_select_custom_opers(bool is_dorm_order
     if (!is_dorm_order) {
         ProcessTask(*this, { "InfrastOperListTabSkillUnClicked", "Stop" }).run();
     }
+
+    click_clear_button();   //先排序后清空，加速干员变化不大时的选择速度
 
     std::vector<std::string> opers_order = room_config.names;
     opers_order.insert(opers_order.end(), room_config.candidates.cbegin(), room_config.candidates.cend());

--- a/src/MeoAssistant/Task/Sub/InfrastControlTask.cpp
+++ b/src/MeoAssistant/Task/Sub/InfrastControlTask.cpp
@@ -23,7 +23,6 @@ bool asst::InfrastControlTask::_run()
         if (need_exit()) {
             return false;
         }
-        click_clear_button();
 
         if (is_use_custom_opers()) {
             bool name_select_ret = swipe_and_select_custom_opers();
@@ -35,6 +34,8 @@ bool asst::InfrastControlTask::_run()
                 continue;
             }
         }
+
+        click_clear_button();
 
         if (!opers_detect_with_swipe()) {
             return false;

--- a/src/MeoAssistant/Task/Sub/InfrastDormTask.cpp
+++ b/src/MeoAssistant/Task/Sub/InfrastDormTask.cpp
@@ -41,10 +41,11 @@ bool asst::InfrastDormTask::_run()
             return false;
         }
 
-        click_clear_button();
-
         if (is_use_custom_opers()) {
             swipe_and_select_custom_opers(true);
+        }
+        else {
+            click_clear_button();   //宿舍若未指定干员，则清空后按照原约定逻辑选择干员
         }
 
         Log.trace("m_dorm_notstationed_enabled:", m_dorm_notstationed_enabled);

--- a/src/MeoAssistant/Task/Sub/InfrastProductionTask.cpp
+++ b/src/MeoAssistant/Task/Sub/InfrastProductionTask.cpp
@@ -163,7 +163,6 @@ bool asst::InfrastProductionTask::shift_facility_list()
             if (need_exit()) {
                 return false;
             }
-            click_clear_button();
 
             if (is_use_custom_opers()) {
                 bool name_select_ret = swipe_and_select_custom_opers();
@@ -175,6 +174,8 @@ bool asst::InfrastProductionTask::shift_facility_list()
                     continue;
                 }
             }
+
+            click_clear_button();
 
             if (m_all_available_opers.empty()) {
                 if (!opers_detect_with_swipe()) {

--- a/src/MeoAssistant/Task/Sub/InfrastReceptionTask.cpp
+++ b/src/MeoAssistant/Task/Sub/InfrastReceptionTask.cpp
@@ -175,7 +175,6 @@ bool asst::InfrastReceptionTask::shift()
         if (need_exit()) {
             return false;
         }
-        click_clear_button();
 
         if (is_use_custom_opers()) {
             bool name_select_ret = swipe_and_select_custom_opers();
@@ -187,6 +186,8 @@ bool asst::InfrastReceptionTask::shift()
                 continue;
             }
         }
+
+        click_clear_button();
 
         if (!opers_detect_with_swipe()) {
             return false;


### PR DESCRIPTION
用/不用配置文件，用/不用 `autofill` 均已测试