### PR TITLE
修正基建243 1天4换作业bug

### DIFF
--- a/resource/custom_infrast/243_layout_4_times_per_day.json
+++ b/resource/custom_infrast/243_layout_4_times_per_day.json
@@ -1,6 +1,6 @@
 {
     "title": "顶配版243，极限效率，一天四换",
-    "description": "在内置版243一天三换基础上，做到了007但书+007巫恋+007龙舌兰，最大化肥鸭效率\n远山可换见行者，自行添加skip字段可以提高效率，宿舍如果无法满员可以手动添加固定干员或者勾选挂信赖\n\n作业作者：OCEANUS\n感谢公孙长乐大佬提供数据及方案支持！",
+    "description": "请不要直接在原文件上修改，更新会覆盖\n在内置版243一天三换基础上，做到了007但书+007巫恋+007龙舌兰，最大化肥鸭效率\n远山可换见行者，自行添加skip字段可以提高效率，添加period可以配合自启动实现自动化，宿舍如果无法满员可以手动添加固定干员或者勾选空余位置蹭信赖\n\n作业作者：OCEANUS\n感谢公孙长乐大佬提供数据及方案支持！",
     "plans": [
         {
             "name": "A+B 组 前8小时",
@@ -113,9 +113,9 @@
                 "dormitory": [
                     {
                         "operators": [
-                            "爱丽丝",
-                            "车尔尼",
                             "菲亚梅塔"
+                            
+                            
                         ],
                         "autofill": true
                     },
@@ -126,14 +126,13 @@
                         "autofill": true
                     },
                     {
-                        "operators": [
-                            "杜林"
-                        ],
+                        
                         "autofill": true
                     },
                     {
                         "operators": [
-                            "夜莺"
+                            "爱丽丝",
+                            "车尔尼"
                         ],
                         "autofill": true
                     }
@@ -142,7 +141,7 @@
         },
         {
             "name": "A+B 组 后8小时",
-            "description": "最高效率长班，中途用一次肥鸭，同时清体力\n下次换班在8小时后进行",
+            "description": "最高效率长班，中途用一次肥鸭，同时清体力,skip掉宿舍避免不满人\n下次换班在8小时后进行",
             "Fiammetta": {
                 "target": "龙舌兰"
             },
@@ -251,9 +250,10 @@
                 "dormitory": [
                     {
                         "operators": [
-                            "爱丽丝",
-                            "车尔尼",
-                            "菲亚梅塔"
+                            "菲亚梅塔",
+                            "夜莺",
+                            "闪灵"
+                            
                         ],
                         "autofill": true
                     },
@@ -261,19 +261,23 @@
                         "operators": [
                             "流明"
                         ],
-                        "autofill": true
+                        "autofill": true,
+                        "skip": true
                     },
                     {
                         "operators": [
                             "杜林"
                         ],
-                        "autofill": true
+                        "autofill": true,
+                        "skip": true
                     },
                     {
                         "operators": [
-                            "夜莺"
+                            "爱丽丝",
+                            "车尔尼"
                         ],
-                        "autofill": true
+                        "autofill": true,
+                        "skip": true
                     }
                 ]
             }
@@ -389,9 +393,10 @@
                 "dormitory": [
                     {
                         "operators": [
-                            "爱丽丝",
-                            "车尔尼",
-                            "菲亚梅塔"
+                            "菲亚梅塔",
+                            "夜莺",
+                            "闪灵"
+                            
                         ],
                         "autofill": true
                     },
@@ -403,13 +408,16 @@
                     },
                     {
                         "operators": [
-                            "杜林"
+                            "杜林",
+                            "蜜莓"
                         ],
                         "autofill": true
                     },
                     {
                         "operators": [
-                            "夜莺"
+                            "爱丽丝",
+                            "车尔尼",
+                            "黑"
                         ],
                         "autofill": true
                     }
@@ -498,7 +506,7 @@
                     },
                     {
                         "operators": [
-                            "雷蛇"
+                            "正义骑士号"
                         ]
                     },
                     {
@@ -525,9 +533,8 @@
                 "dormitory": [
                     {
                         "operators": [
-                            "爱丽丝",
-                            "车尔尼",
                             "菲亚梅塔"
+                            
                         ],
                         "autofill": true
                     },
@@ -539,18 +546,20 @@
                     },
                     {
                         "operators": [
-                            "杜林"
+                            
                         ],
                         "autofill": true
                     },
                     {
                         "operators": [
-                            "夜莺"
+                            "爱丽丝",
+                            "车尔尼"
                         ],
                         "autofill": true
                     }
                 ]
             }
         }
+        
     ]
 }


### PR DESCRIPTION
修正了以下几点：
1. 根据新版本的自定义基建操作，把车尔尼和爱丽丝放在菲亚梅塔的宿舍会影响操作速度。故下移至第四宿舍。

2. 仔细排查之后，主力队上半场换班的时间点会造成宿舍溢出（见图，需要换班的有19个），故移除了宿舍技能的干员以确保足够位置。
![QQ图片20221010032718](https://user-images.githubusercontent.com/31065340/194846482-d0dcb666-45bf-49d2-9f8e-37b3481b1271.png)


3.上一个版本中，正义骑士号没有完全对准红松林组（见图），造成了“以10%发电站效率换取5%制造站效率”的局面。已修正。
![QQ图片20221010033007](https://user-images.githubusercontent.com/31065340/194846793-02ffc18d-6f00-4a53-9b08-9cfeb1ae1a4d.png)
![QQ图片20221010033015](https://user-images.githubusercontent.com/31065340/194846789-d540fca4-0abd-4d0e-9a57-bbde700c8940.png)

4. 在替补1班 替补2版额外插入了更多的宿舍干员，以确保更容易达成满员（强制填满宿舍的功能啥时候出啊敲碗.jpg）

