### PR TITLE
fix: 修复手动终止任务时有概率出现的“任务出错”

### DIFF
--- a/src/MeoAssistant/Assistant.cpp
+++ b/src/MeoAssistant/Assistant.cpp
@@ -264,7 +264,7 @@ void Assistant::working_proc()
             lock.unlock();
 
             // We don't consider a task failed when user stop it.
-            auto msg = ret || m_thread_idle ? AsstMsg::TaskChainSuccess : AsstMsg::TaskChainFailed;
+            auto msg = ret || m_thread_idle ? AsstMsg::TaskChainCompleted : AsstMsg::TaskChainError;
             task_callback(msg, callback_json, this);
 
             if (!m_thread_idle && m_tasks_list.empty()) {

--- a/src/MeoAssistant/Assistant.cpp
+++ b/src/MeoAssistant/Assistant.cpp
@@ -263,7 +263,9 @@ void Assistant::working_proc()
             }
             lock.unlock();
 
-            task_callback(ret ? AsstMsg::TaskChainCompleted : AsstMsg::TaskChainError, callback_json, this);
+            // We don't consider a task failed when user stop it.
+            auto msg = ret || m_thread_idle ? AsstMsg::TaskChainSuccess : AsstMsg::TaskChainFailed;
+            task_callback(msg, callback_json, this);
 
             if (!m_thread_idle && m_tasks_list.empty()) {
                 callback_json["finished_tasks"] = json::array(finished_tasks);


### PR DESCRIPTION
close https://github.com/MaaAssistantArknights/MaaAssistantArknights/issues/2331

详细描述见 https://github.com/MaaAssistantArknights/MaaAssistantArknights/issues/2331

## 测试

手动测试，使用编译的 maa 多次连续点击 “Link Start” 和 “停止”，未出现“任务出错”。

![image](https://user-images.githubusercontent.com/30543181/196013987-c99eeaf9-dedb-4534-9e8d-f905549c4d3e.png)
