### PR TITLE
chore: 使 CMake 能自动定义 `MAA_VERSION`

### DIFF
--- a/.github/workflows/dev-build-mac.yml
+++ b/.github/workflows/dev-build-mac.yml
@@ -31,6 +31,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: recursive
+          fetch-depth: 100
       - name: Cache Homebrew
         uses: actions/cache@v3
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,3 +90,43 @@ if (BUILD_XCFRAMEWORK)
         DEPENDS MeoAssistant MeoAssistant.xcframework
     )
 endif (BUILD_XCFRAMEWORK)
+
+# define MAA_VERSION from git
+if (NOT MAA_VERSION)
+    find_package(Git)
+endif ()
+if (GIT_FOUND)
+    execute_process(
+        COMMAND "${GIT_EXECUTABLE}" describe --tags --dirty --broken --abbrev=40
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+        RESULT_VARIABLE result
+        OUTPUT_VARIABLE output
+        ERROR_VARIABLE err
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    if (result EQUAL 0)
+        set(MAA_VERSION "${output}")
+    else ()
+        message(WARNING "git describe returning ${result}, output:\n${err}")
+    endif()
+endif ()
+if (NOT MAA_VERSION AND GIT_FOUND)
+    execute_process(
+        COMMAND "${GIT_EXECUTABLE}" rev-parse HEAD
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+        RESULT_VARIABLE result
+        OUTPUT_VARIABLE output
+        ERROR_VARIABLE err
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    if (result EQUAL 0)
+        set(MAA_VERSION "${output}")
+    else ()
+        message(WARNING "git rev-parse returning ${result}, output:\n${err}")
+    endif ()
+endif ()
+if (NOT MAA_VERSION)
+    set(MAA_VERSION "DEBUG VERSION")
+endif ()
+message(STATUS "MAA_VERSION=${MAA_VERSION}")
+add_compile_definitions(MAA_VERSION="${MAA_VERSION}")


### PR DESCRIPTION
使用 `git describe --tags --dirty --broken --abbrev=40` 的输出
当前如果在 tag 上结果就是 `v4.6.4`, 如果不在 tag 上大概会长这样
```
v4.6.4-58-g96814e1c4ef70c892c31630b8e985e22ff26b948-dirty
```
表示 `HEAD` 在 `v4.6.4` 前面 58 个 commit, hash 是 `9681...`, 有尚未提交的更改

~~坏了 GitHub action 的 checkout 好像是 shallow fetch~~