### PR TITLE
chore: 增加 OTA 打包的 action workflow

### DIFF
--- a/.github/workflows/release-ota.yml
+++ b/.github/workflows/release-ota.yml
@@ -8,7 +8,7 @@ on:
       limit:
         description: 'Number of releases to fetch, 2 at least'
         required: false
-        default: 21
+        default: 51
         type: number
 
 jobs:

--- a/.github/workflows/release-ota.yml
+++ b/.github/workflows/release-ota.yml
@@ -1,0 +1,38 @@
+name: release-ota
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      limit:
+        description: 'Number of releases to fetch, 2 at least'
+        required: false
+        default: 21
+        type: number
+
+jobs:
+  make-ota:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v3
+      - name: "Build OTA"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -pv build-ota && cd build-ota
+          ../tools/OTAPacker/build.sh 'MaaAssistantArknights/MaaAssistantArknights' ${{ inputs.limit }}
+      - name: "Set tag"
+        id: set_tag
+        run: |
+          echo "release_tag=$(head -n 1 build-ota/releases)" >> $GITHUB_ENV
+      - name: "Upload to MaaRelease"
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_name: ${{ format('{0}/{1}', github.repository_owner, 'MaaRelease') }}
+          repo_token: ${{ secrets.MAARELEASE_RELEASE }}
+          file_glob: true
+          file: build-ota/*.zip
+          tag: ${{ env.release_tag }}
+          overwrite: true
+

--- a/tools/OTAPacker/build.sh
+++ b/tools/OTAPacker/build.sh
@@ -29,7 +29,11 @@ while read tag; do
 
     cd $working_dir
 
-    if [[ "$tag" != "$latest_tag" ]]; then
+    if [[ "$tag" == "$latest_tag" ]]; then
+        cd "$latest_tag"/content/
+        find -type f -exec md5sum '{}' \; > ../../md5sum.txt
+        cd $working_dir
+    else
         echo "comparing files $tag...$latest_tag"
         rsync -ancv --delete --info=FLIST0 "$latest_tag"/content/ "$tag"/content/ \
             | grep -v '/$' \
@@ -38,6 +42,8 @@ while read tag; do
 
         echo "installing files"
         mkdir -pv "$tag"/pkg
+
+        install -DCv md5sum.txt "$tag"/pkg
 
         while read file; do
             if [[ $file == "deleting "* ]]; then

--- a/tools/OTAPacker/build.sh
+++ b/tools/OTAPacker/build.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+source_repo=$1
+limit=${2:-6}
+
+ghrepo() {
+    gh $@ --repo $source_repo
+}
+
+working_dir=$(pwd)
+echo "working_dir: $working_dir"
+
+echo "fetching $limit release info from $source_repo"
+ghrepo release list --limit=$limit | awk '{ print $1 }' | tee releases
+
+latest_tag=$(head -n 1 ./releases)
+
+while read tag; do
+    (
+        mkdir -pv "$tag"
+        cd "$tag"
+        echo "Downloading $tag"
+        ghrepo release download "$tag" --pattern "MAA-$tag-win-x64.zip" --pattern "MaaBundle-$tag.zip" --clobber
+        mkdir -pv 'content'
+        echo "Unzip" *.zip
+        unzip -qq -O gbk -o "*.zip" -d 'content'
+        rm -fv *.zip
+    )
+
+    cd $working_dir
+
+    if [[ "$tag" != "$latest_tag" ]]; then
+        echo "comparing files $tag...$latest_tag"
+        rsync -ancv --delete --info=FLIST0 "$latest_tag"/content/ "$tag"/content/ \
+            | grep -v '/$' \
+            | head -n -3 \
+            | tee "$tag"/files.txt
+
+        echo "installing files"
+        mkdir -pv "$tag"/pkg
+
+        while read file; do
+            if [[ $file == "deleting "* ]]; then
+                echo ${file#"deleting "} >> "$tag"/pkg/deleted.txt
+            else
+                install -DCv "$latest_tag"/content/"$file" "$tag"/pkg/"$file"
+            fi
+        done < "$tag"/files.txt
+
+        echo "Creating zip archive"
+        cd "$tag"/pkg
+        zip -q -9 -r "$working_dir"/"${tag}_${latest_tag}.zip" .
+        cd $working_dir
+    fi
+done < ./releases
+

--- a/tools/OTAPacker/build.sh
+++ b/tools/OTAPacker/build.sh
@@ -31,23 +31,23 @@ while read tag; do
 
     if [[ "$tag" == "$latest_tag" ]]; then
         cd "$latest_tag"/content/
-        find -type f -exec md5sum '{}' \; > ../../md5sum.txt
+        find * -type f -exec md5sum '{}' \; > ../md5sum.txt
         cd $working_dir
     else
-        echo "comparing files $tag...$latest_tag"
+        echo "Comparing files $tag...$latest_tag"
         rsync -ancv --delete --info=FLIST0 "$latest_tag"/content/ "$tag"/content/ \
             | grep -v '/$' \
             | head -n -3 \
             | tee "$tag"/files.txt
 
-        echo "installing files"
+        echo "Installing files"
         mkdir -pv "$tag"/pkg
 
-        install -DCv md5sum.txt "$tag"/pkg
+        install -DCv "$latest_tag"/md5sum.txt "$tag"/pkg
 
         while read file; do
             if [[ $file == "deleting "* ]]; then
-                echo ${file#"deleting "} >> "$tag"/pkg/deleted.txt
+                echo ${file#"deleting "} >> "$tag"/pkg/removelist.txt
             else
                 install -DCv "$latest_tag"/content/"$file" "$tag"/pkg/"$file"
             fi
@@ -55,7 +55,7 @@ while read tag; do
 
         echo "Creating zip archive"
         cd "$tag"/pkg
-        zip -q -9 -r "$working_dir"/"${tag}_${latest_tag}.zip" .
+        zip -q -9 -r "$working_dir"/"MAAComponent-OTA-${tag}_${latest_tag}-win-x64.zip" .
         cd $working_dir
     fi
 done < ./releases


### PR DESCRIPTION
- 在每次发版的时候自动打 20 个 OTA 包并上传至 MaaRelease 的同名 release, 现在包名如 https://github.com/horror-proton/MaaRelease/releases 
- 被删除的文件列在 `deleted.txt` 中, 新版本所有文件的和校验和在 `md5sum.txt` 中

为了正常工作, 需要在 `MaaAssistantArknights/MaaAssistantArknights` 的 Repository secrets 里增加一个名字为 `MAARELEASE_RELEASE` 的项用来保存对 MaaAssistantArknights/MaaRelease 仓库有 release 权限的 token