### PR TITLE
chore: 自动触发 release-ota 时设定默认值

### DIFF
--- a/.github/workflows/release-ota.yml
+++ b/.github/workflows/release-ota.yml
@@ -21,7 +21,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           mkdir -pv build-ota && cd build-ota
-          ../tools/OTAPacker/build.sh 'MaaAssistantArknights/MaaAssistantArknights' ${{ inputs.limit }}
+          ../tools/OTAPacker/build.sh 'MaaAssistantArknights/MaaAssistantArknights' ${{ inputs.limit || 51 }}
       - name: "Set tag"
         id: set_tag
         run: |


### PR DESCRIPTION
inputs.limit 自动触发的话不是默认值而是直接为空, 上次所以按照脚本里面的默认参数只打了 5 个 😿 