### PR TITLE
feat: 内测版本更新 GUI 选项

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ MAA 的意思是 MAA Assistant Arknights
 ## 下载地址
 
 [稳定版](https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases/latest)  
-[测试版](https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases)
+[开发版](https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases)
 
 ## 使用说明
 

--- a/README_zh-TW.md
+++ b/README_zh-TW.md
@@ -49,7 +49,7 @@ MAA 的意思是 MAA Assistant Arknights
 ## 下載連結
 
 [穩定版](https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases/latest)  
-[測試版](https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases)
+[開發版](https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases)
 
 ## 使用說明
 

--- a/src/MeoAsstGui/Resources/Localizations/en-us.xaml
+++ b/src/MeoAsstGui/Resources/Localizations/en-us.xaml
@@ -122,6 +122,7 @@
 
     <system:String x:Key="UpdateAutoCheck">Auto check update</system:String>
     <system:String x:Key="UpdateAutoDownload">Auto download update</system:String>
+    <system:String x:Key="UpdateCheckStable">Stable release</system:String>
     <system:String x:Key="UpdateCheckBeta">Beta release</system:String>
     <system:String x:Key="UpdateCheckNightly">Nightly release</system:String>
     <system:String x:Key="DownloadWithAria2">Download via aria2</system:String>

--- a/src/MeoAsstGui/Resources/Localizations/en-us.xaml
+++ b/src/MeoAsstGui/Resources/Localizations/en-us.xaml
@@ -123,6 +123,7 @@
     <system:String x:Key="UpdateAutoCheck">Auto check update</system:String>
     <system:String x:Key="UpdateAutoDownload">Auto download update</system:String>
     <system:String x:Key="UpdateCheckBeta">Beta release</system:String>
+    <system:String x:Key="UpdateCheckNightly">Nightly release</system:String>
     <system:String x:Key="DownloadWithAria2">Download via aria2</system:String>
     <system:String x:Key="UpdateCheckNow">Check update</system:String>
 

--- a/src/MeoAsstGui/Resources/Localizations/en-us.xaml
+++ b/src/MeoAsstGui/Resources/Localizations/en-us.xaml
@@ -125,6 +125,7 @@
     <system:String x:Key="UpdateCheckStable">Stable release</system:String>
     <system:String x:Key="UpdateCheckBeta">Beta release</system:String>
     <system:String x:Key="UpdateCheckNightly">Nightly release</system:String>
+    <system:String x:Key="UpdateCheck">Update version</system:String>
     <system:String x:Key="DownloadWithAria2">Download via aria2</system:String>
     <system:String x:Key="UpdateCheckNow">Check update</system:String>
 

--- a/src/MeoAsstGui/Resources/Localizations/ja-jp.xaml
+++ b/src/MeoAsstGui/Resources/Localizations/ja-jp.xaml
@@ -124,8 +124,11 @@
 
     <system:String x:Key="UpdateAutoCheck">アップデートチェック</system:String>
     <system:String x:Key="UpdateAutoDownload">自動アップデート</system:String>
-    <system:String x:Key="UpdateCheckBeta">ベータ版を使う</system:String>
+    <system:String x:Key="UpdateCheckStable">安定版</system:String>
+    <system:String x:Key="UpdateCheckBeta">ベータ版</system:String>
+    <system:String x:Key="UpdateCheckNightly">内部テスト版</system:String>
     <system:String x:Key="DownloadWithAria2">aria2を使う</system:String>
+    <system:String x:Key="UpdateCheck">更新版</system:String>
     <system:String x:Key="UpdateCheckNow">アップデートを確認する</system:String>
 
     <system:String x:Key="TimerTip">時間のみを記入（例:15/午後3時に実行する）</system:String>

--- a/src/MeoAsstGui/Resources/Localizations/ko-kr.xaml
+++ b/src/MeoAsstGui/Resources/Localizations/ko-kr.xaml
@@ -122,7 +122,10 @@
 
     <system:String x:Key="UpdateAutoCheck">자동 업데이트</system:String>
     <system:String x:Key="UpdateAutoDownload">업데이트 파일을 자동 업데이트</system:String>
-    <system:String x:Key="UpdateCheckBeta">베타 버전을 자동 업데이트</system:String>
+    <system:String x:Key="UpdateCheckStable">안정적인 버전</system:String>
+    <system:String x:Key="UpdateCheckBeta">베타 버전</system:String>
+    <system:String x:Key="UpdateCheckNightly">내부 베타 버전</system:String>
+    <system:String x:Key="UpdateCheck">업데이트에 사용된 버전</system:String>
     <system:String x:Key="DownloadWithAria2">aria2로 다운로드</system:String>
     <system:String x:Key="UpdateCheckNow">지금 업데이트</system:String>
 

--- a/src/MeoAsstGui/Resources/Localizations/pallas.xaml
+++ b/src/MeoAsstGui/Resources/Localizations/pallas.xaml
@@ -122,7 +122,10 @@
 
     <system:String x:Key="UpdateAutoCheck">🍸🍺🍷🍸🕺🕺🍻</system:String>
     <system:String x:Key="UpdateAutoDownload">🍺🍷🍺🍸🍷🍷🍺🍷</system:String>
-    <system:String x:Key="UpdateCheckBeta">🍻💃🍸🕺🍻🍷🍷🍺🍻</system:String>
+    <system:String x:Key="UpdateCheckStable">🍻💃🍸🕺</system:String>
+    <system:String x:Key="UpdateCheckBeta">🍷🍺🍸🍷</system:String>
+    <system:String x:Key="UpdateCheckNightly">🍸🕺🍷🍺</system:String>
+    <system:String x:Key="UpdateCheck">🕺🍻🍷🍷🍺🍸</system:String>
     <system:String x:Key="DownloadWithAria2">🍸🍻🍺🍻🍸🍻💃🍸🍸🍷🍷🕺🍷🍺</system:String>
     <system:String x:Key="UpdateCheckNow">🍺🍻🍷🍻🕺</system:String>
 

--- a/src/MeoAsstGui/Resources/Localizations/zh-cn.xaml
+++ b/src/MeoAsstGui/Resources/Localizations/zh-cn.xaml
@@ -123,6 +123,7 @@
     <system:String x:Key="UpdateAutoCheck">自动检查更新</system:String>
     <system:String x:Key="UpdateAutoDownload">自动下载更新包</system:String>
     <system:String x:Key="UpdateCheckBeta">检查测试版本更新</system:String>
+    <system:String x:Key="UpdateCheckNightly">检查内测版本更新</system:String>
     <system:String x:Key="DownloadWithAria2">使用 aria2 进行下载</system:String>
     <system:String x:Key="UpdateCheckNow">检查更新</system:String>
 

--- a/src/MeoAsstGui/Resources/Localizations/zh-cn.xaml
+++ b/src/MeoAsstGui/Resources/Localizations/zh-cn.xaml
@@ -122,8 +122,9 @@
 
     <system:String x:Key="UpdateAutoCheck">自动检查更新</system:String>
     <system:String x:Key="UpdateAutoDownload">自动下载更新包</system:String>
-    <system:String x:Key="UpdateCheckBeta">检查测试版本更新</system:String>
-    <system:String x:Key="UpdateCheckNightly">检查内测版本更新</system:String>
+    <system:String x:Key="UpdateCheckStable">稳定版</system:String>
+    <system:String x:Key="UpdateCheckBeta">测试版</system:String>
+    <system:String x:Key="UpdateCheckNightly">内测版</system:String>
     <system:String x:Key="DownloadWithAria2">使用 aria2 进行下载</system:String>
     <system:String x:Key="UpdateCheckNow">检查更新</system:String>
 

--- a/src/MeoAsstGui/Resources/Localizations/zh-cn.xaml
+++ b/src/MeoAsstGui/Resources/Localizations/zh-cn.xaml
@@ -123,8 +123,9 @@
     <system:String x:Key="UpdateAutoCheck">自动检查更新</system:String>
     <system:String x:Key="UpdateAutoDownload">自动下载更新包</system:String>
     <system:String x:Key="UpdateCheckStable">稳定版</system:String>
-    <system:String x:Key="UpdateCheckBeta">测试版</system:String>
+    <system:String x:Key="UpdateCheckBeta">开发版</system:String>
     <system:String x:Key="UpdateCheckNightly">内测版</system:String>
+    <system:String x:Key="UpdateCheck">更新版本</system:String>
     <system:String x:Key="DownloadWithAria2">使用 aria2 进行下载</system:String>
     <system:String x:Key="UpdateCheckNow">检查更新</system:String>
 

--- a/src/MeoAsstGui/Resources/Localizations/zh-tw.xaml
+++ b/src/MeoAsstGui/Resources/Localizations/zh-tw.xaml
@@ -122,7 +122,10 @@
 
     <system:String x:Key="UpdateAutoCheck">自動檢查更新</system:String>
     <system:String x:Key="UpdateAutoDownload">自動下載更新包</system:String>
-    <system:String x:Key="UpdateCheckBeta">檢查測試版本更新</system:String>
+    <system:String x:Key="UpdateCheckStable">穩定版</system:String>
+    <system:String x:Key="UpdateCheckBeta">開發版</system:String>
+    <system:String x:Key="UpdateCheckNightly">内測版</system:String>
+    <system:String x:Key="UpdateCheck">更新版本</system:String>
     <system:String x:Key="DownloadWithAria2">使用 aria2 進行下載</system:String>
     <system:String x:Key="UpdateCheckNow">檢查更新</system:String>
 

--- a/src/MeoAsstGui/UserControl/VersionUpdateSettingsUserControl.xaml
+++ b/src/MeoAsstGui/UserControl/VersionUpdateSettingsUserControl.xaml
@@ -43,7 +43,7 @@
                         Margin="10"
                         Block.TextAlignment="Center"
                         Style="{StaticResource TextBlockDefault}"
-                        Text="{DynamicResource UpdateCheckNow}" />
+                        Text="{DynamicResource UpdateCheck}" />
                     <ComboBox
                         Width="85"
                         Margin="10"

--- a/src/MeoAsstGui/UserControl/VersionUpdateSettingsUserControl.xaml
+++ b/src/MeoAsstGui/UserControl/VersionUpdateSettingsUserControl.xaml
@@ -36,20 +36,23 @@
                     Content="{DynamicResource UpdateAutoDownload}"
                     IsChecked="{Binding AutoDownloadUpdatePackage}"
                     IsEnabled="{Binding UpdateCheck}" />
-                <CheckBox
-                    Margin="10"
-                    HorizontalAlignment="Left"
+                <StackPanel
                     VerticalAlignment="Center"
-                    Content="{DynamicResource UpdateCheckBeta}"
-                    IsChecked="{Binding UpdateBeta}"
-                    IsEnabled="{Binding UpdateCheck}" />
-                <CheckBox
-                    Margin="10"
-                    HorizontalAlignment="Left"
-                    VerticalAlignment="Center"
-                    Content="{DynamicResource UpdateCheckNightly}"
-                    IsChecked="{Binding UpdateNightly}"
-                    IsEnabled="{Binding UpdateCheck}" />
+                    Orientation="Horizontal">
+                    <TextBlock
+                        Margin="10"
+                        Block.TextAlignment="Center"
+                        Style="{StaticResource TextBlockDefault}"
+                        Text="{DynamicResource UpdateCheckNow}" />
+                    <ComboBox
+                        Width="85"
+                        Margin="10"
+                        DisplayMemberPath="Display"
+                        IsEnabled="{Binding UpdateCheck}"
+                        ItemsSource="{Binding VersionTypeList}"
+                        SelectedValue="{Binding VersionType}"
+                        SelectedValuePath="Value" />
+                </StackPanel>
                 <CheckBox
                     Margin="10"
                     HorizontalAlignment="Left"

--- a/src/MeoAsstGui/UserControl/VersionUpdateSettingsUserControl.xaml
+++ b/src/MeoAsstGui/UserControl/VersionUpdateSettingsUserControl.xaml
@@ -47,6 +47,13 @@
                     Margin="10"
                     HorizontalAlignment="Left"
                     VerticalAlignment="Center"
+                    Content="{DynamicResource UpdateCheckNightly}"
+                    IsChecked="{Binding UpdateNightly}"
+                    IsEnabled="{Binding UpdateCheck}" />
+                <CheckBox
+                    Margin="10"
+                    HorizontalAlignment="Left"
+                    VerticalAlignment="Center"
                     Content="{DynamicResource DownloadWithAria2}"
                     IsChecked="{Binding UseAria2}"
                     IsEnabled="{Binding UpdateCheck}" />

--- a/src/MeoAsstGui/UserControl/VersionUpdateSettingsUserControl.xaml
+++ b/src/MeoAsstGui/UserControl/VersionUpdateSettingsUserControl.xaml
@@ -36,23 +36,6 @@
                     Content="{DynamicResource UpdateAutoDownload}"
                     IsChecked="{Binding AutoDownloadUpdatePackage}"
                     IsEnabled="{Binding UpdateCheck}" />
-                <StackPanel
-                    VerticalAlignment="Center"
-                    Orientation="Horizontal">
-                    <TextBlock
-                        Margin="10"
-                        Block.TextAlignment="Center"
-                        Style="{StaticResource TextBlockDefault}"
-                        Text="{DynamicResource UpdateCheck}" />
-                    <ComboBox
-                        Width="85"
-                        Margin="10"
-                        DisplayMemberPath="Display"
-                        IsEnabled="{Binding UpdateCheck}"
-                        ItemsSource="{Binding VersionTypeList}"
-                        SelectedValue="{Binding VersionType}"
-                        SelectedValuePath="Value" />
-                </StackPanel>
                 <CheckBox
                     Margin="10"
                     HorizontalAlignment="Left"
@@ -60,6 +43,23 @@
                     Content="{DynamicResource DownloadWithAria2}"
                     IsChecked="{Binding UseAria2}"
                     IsEnabled="{Binding UpdateCheck}" />
+                <StackPanel
+                    VerticalAlignment="Center"
+                    Orientation="Horizontal">
+                    <TextBlock
+                        Margin="10,10,0,10"
+                        Block.TextAlignment="Center"
+                        Style="{StaticResource TextBlockDefault}"
+                        Text="{DynamicResource UpdateCheck}" />
+                    <ComboBox
+                        Width="120"
+                        Margin="10"
+                        DisplayMemberPath="Display"
+                        IsEnabled="{Binding UpdateCheck}"
+                        ItemsSource="{Binding VersionTypeList}"
+                        SelectedValue="{Binding VersionType}"
+                        SelectedValuePath="Value" />
+                </StackPanel>
             </StackPanel>
         </StackPanel>
         <StackPanel

--- a/src/MeoAsstGui/ViewModels/SettingsViewModel.cs
+++ b/src/MeoAsstGui/ViewModels/SettingsViewModel.cs
@@ -232,9 +232,9 @@ namespace MeoAsstGui
 
             VersionTypeList = new List<CombData>
             {
-                new CombData { Display = Localization.GetString("UpdateCheckStable"), Value = "Stable" },
-                new CombData { Display = Localization.GetString("UpdateCheckBeta"), Value = "Beta" },
                 new CombData { Display = Localization.GetString("UpdateCheckNightly"), Value = "Nightly" },
+                new CombData { Display = Localization.GetString("UpdateCheckBeta"), Value = "Beta" },
+                new CombData { Display = Localization.GetString("UpdateCheckStable"), Value = "Stable" },
             };
 
             LanguageList = new List<CombData>();

--- a/src/MeoAsstGui/ViewModels/SettingsViewModel.cs
+++ b/src/MeoAsstGui/ViewModels/SettingsViewModel.cs
@@ -1379,6 +1379,21 @@ namespace MeoAsstGui
         }
 
         /* 软件更新设置 */
+        private bool _updateNightly = Convert.ToBoolean(ViewStatusStorage.Get("VersionUpdate.UpdateNightly", bool.FalseString));
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to update nightly.
+        /// </summary>
+        public bool UpdateNightly
+        {
+            get => _updateNightly;
+            set
+            {
+                SetAndNotify(ref _updateNightly, value);
+                ViewStatusStorage.Set("VersionUpdate.UpdateNightly", value.ToString());
+            }
+        }
+
         private bool _updateBeta = Convert.ToBoolean(ViewStatusStorage.Get("VersionUpdate.UpdateBeta", bool.FalseString));
 
         /// <summary>

--- a/src/MeoAsstGui/ViewModels/SettingsViewModel.cs
+++ b/src/MeoAsstGui/ViewModels/SettingsViewModel.cs
@@ -230,6 +230,13 @@ namespace MeoAsstGui
                 new CombData { Display = Localization.GetString("Switchable"), Value = "ClearInverse" },
             };
 
+            VersionTypeList = new List<CombData>
+            {
+                new CombData { Display = Localization.GetString("UpdateCheckStable"), Value = "Stable" },
+                new CombData { Display = Localization.GetString("UpdateCheckBeta"), Value = "Beta" },
+                new CombData { Display = Localization.GetString("UpdateCheckNightly"), Value = "Nightly" },
+            };
+
             LanguageList = new List<CombData>();
             foreach (var pair in Localization.SupportedLanguages)
             {
@@ -493,6 +500,11 @@ namespace MeoAsstGui
         /// Gets or sets the list of inverse clear modes.
         /// </summary>
         public List<CombData> InverseClearModeList { get; set; }
+
+        /// <summary>
+        /// Gets or sets the list of the version type.
+        /// </summary>
+        public List<CombData> VersionTypeList { get; set; }
 
         /// <summary>
         /// Gets or sets the language list.
@@ -1379,34 +1391,35 @@ namespace MeoAsstGui
         }
 
         /* 软件更新设置 */
-        private bool _updateNightly = Convert.ToBoolean(ViewStatusStorage.Get("VersionUpdate.UpdateNightly", bool.FalseString));
+        private string _versionType = ViewStatusStorage.Get("VersionUpdate.VersionType", "Stable");
 
         /// <summary>
-        /// Gets or sets a value indicating whether to update nightly.
+        /// Gets or sets the type of version to update.
         /// </summary>
-        public bool UpdateNightly
+        public string VersionType
         {
-            get => _updateNightly;
+            get => _versionType;
             set
             {
-                SetAndNotify(ref _updateNightly, value);
-                ViewStatusStorage.Set("VersionUpdate.UpdateNightly", value.ToString());
+                SetAndNotify(ref _versionType, value);
+                ViewStatusStorage.Set("VersionUpdate.VersionType", value);
             }
         }
 
-        private bool _updateBeta = Convert.ToBoolean(ViewStatusStorage.Get("VersionUpdate.UpdateBeta", bool.FalseString));
+        /// <summary>
+        /// Gets a value indicating whether to update nightly.
+        /// </summary>
+        public bool UpdateNightly
+        {
+            get => _versionType == "Nightly";
+        }
 
         /// <summary>
-        /// Gets or sets a value indicating whether to update beta version.
+        /// Gets a value indicating whether to update beta version.
         /// </summary>
         public bool UpdateBeta
         {
-            get => _updateBeta;
-            set
-            {
-                SetAndNotify(ref _updateBeta, value);
-                ViewStatusStorage.Set("VersionUpdate.UpdateBeta", value.ToString());
-            }
+            get => _versionType == "Beta";
         }
 
         private bool _updateCheck = Convert.ToBoolean(ViewStatusStorage.Get("VersionUpdate.UpdateCheck", bool.TrueString));

--- a/src/MeoAsstGui/ViewModels/VersionUpdateViewModel.cs
+++ b/src/MeoAsstGui/ViewModels/VersionUpdateViewModel.cs
@@ -464,7 +464,7 @@ namespace MeoAsstGui
                     _latestJson = null;
                     foreach (var item in releaseArray)
                     {
-                        if (!settings.UpdateNightly && isStableVersion(item["tag_name"].ToString()))
+                        if (!settings.UpdateNightly && !isStableVersion(item["tag_name"].ToString()))
                         {
                             continue;
                         }

--- a/src/MeoAsstGui/ViewModels/VersionUpdateViewModel.cs
+++ b/src/MeoAsstGui/ViewModels/VersionUpdateViewModel.cs
@@ -530,8 +530,15 @@ namespace MeoAsstGui
                     return true;
                 }
 
-                var errorView = new ErrorView("Download Failed", "It was not possible to find a suitable OTA file to download.", false);
-                errorView.ShowDialog();
+                Execute.OnUIThread(() =>
+                {
+                    using (var toast = new ToastNotification("找不到合适的更新文件"))
+                    {
+                        toast.AppendContentText("新版本：" + _latestVersion)
+                            .AppendContentText("请自行下载完整包更新！")
+                            .ShowUpdateVersion();
+                    }
+                });
                 return false;
             }
             catch (Exception e)


### PR DESCRIPTION
勾选内测版更新后，在 MaaRelease 仓库中若最新者不是当前版本，则直接使用该版本。
测试版和稳定版检测版本号是否为v开头的版本，内测版不做检查。