### PR TITLE
feat: 更新基建作业243一日四换至2022年11月版本

### DIFF
--- a/resource/custom_infrast/243_layout_4_times_per_day.json
+++ b/resource/custom_infrast/243_layout_4_times_per_day.json
@@ -1,17 +1,19 @@
 {
-    "title": "顶配版243，极限效率，一天四换",
-    "description": "请不要直接在原文件上修改，更新会覆盖\n在内置版243一天三换基础上，做到了007但书+007巫恋+007龙舌兰，最大化肥鸭效率\n远山可换见行者，自行添加skip字段可以提高效率，添加period可以配合自启动实现自动化，宿舍如果无法满员可以手动添加固定干员或者勾选空余位置蹭信赖\n\n作业作者：OCEANUS\n感谢公孙长乐大佬提供数据及方案支持！",
+    "title": "顶配版243，极限效率，一天四换，2022年11月版本",
+    "description": "请不要直接在原文件上修改，更新会覆盖\n在内置版243一天三换基础上，做到了007但书+007巫恋+007龙舌兰，最大化肥鸭效率\n添加period可以配合自启动实现自动化，括号内举例了一个可能的时间段；宿舍已经手动写死，可以自行更改\n\n作业作者：OCEANUS\n感谢公孙长乐大佬提供数据及方案支持！",
     "plans": [
         {
-            "name": "A+B 组 前8小时",
+            "name": "A+B 组 前8小时，比如：【16:00-24:00】",
             "description": "最高效率长班\n下次换班在8小时后进行",
+            "drones": {
+                "order": "post",
+                "room": "trading",
+                "index": 1
+            },
             "Fiammetta": {
                 "target": "巫恋"
             },
-            "drones": {
-                "room": "manufacture",
-                "index": 1
-            },
+            
             "rooms": {
                 "control": [
                     {
@@ -106,138 +108,7 @@
                     {
                         "operators": [
                             "陈",
-                            "红"
-                        ]
-                    }
-                ],
-                "dormitory": [
-                    {
-                        "operators": [
-                            "菲亚梅塔"
-                        ],
-                        "autofill": true
-                    },
-                    {
-                        "autofill": true
-                    },
-                    {
-                        "autofill": true
-                    },
-                    {
-                        "operators": [
-                            "爱丽丝",
-                            "车尔尼"
-                        ],
-                        "autofill": true
-                    }
-                ]
-            }
-        },
-        {
-            "name": "A+B 组 后8小时",
-            "description": "最高效率长班，中途用一次肥鸭，同时清体力,skip掉宿舍避免不满人\n下次换班在8小时后进行",
-            "Fiammetta": {
-                "target": "龙舌兰"
-            },
-            "drones": {
-                "room": "manufacture",
-                "index": 1
-            },
-            "rooms": {
-                "control": [
-                    {
-                        "operators": [
-                            "阿米娅",
-                            "凯尔希",
-                            "琴柳",
-                            "令",
-                            "夕"
-                        ]
-                    }
-                ],
-                "trading": [
-                    {
-                        "operators": [
-                            "柏喙",
-                            "龙舌兰",
-                            "巫恋"
-                        ],
-                        "sort": true,
-                        "product": "LMD"
-                    },
-                    {
-                        "operators": [
-                            "但书",
-                            "空弦",
-                            "黑键"
-                        ],
-                        "product": "LMD"
-                    }
-                ],
-                "manufacture": [
-                    {
-                        "operators": [
-                            "红云",
-                            "稀音",
-                            "帕拉斯"
-                        ],
-                        "sort": true,
-                        "product": "Battle Record"
-                    },
-                    {
-                        "operators": [
-                            "食铁兽",
-                            "断罪者",
-                            "槐琥"
-                        ],
-                        "product": "Battle Record"
-                    },
-                    {
-                        "operators": [
-                            "清流",
-                            "温蒂",
-                            "森蚺"
-                        ],
-                        "product": "Pure Gold"
-                    },
-                    {
-                        "operators": [
-                            "砾",
-                            "至简",
-                            "迷迭香"
-                        ],
-                        "product": "Pure Gold"
-                    }
-                ],
-                "power": [
-                    {
-                        "operators": [
-                            "承曦格雷伊"
-                        ]
-                    },
-                    {
-                        "operators": [
-                            "澄闪"
-                        ]
-                    },
-                    {
-                        "operators": [
-                            "炎狱炎熔"
-                        ]
-                    }
-                ],
-                "hire": [
-                    {
-                        "operators": [
-                            "絮雨"
-                        ]
-                    }
-                ],
-                "meeting": [
-                    {
-                        "operators": [
-                            "陈",
-                            "红"
+                            "伺夜"
                         ]
                     }
                 ],
@@ -245,45 +116,207 @@
                     {
                         "operators": [
                             "菲亚梅塔",
-                            "夜莺",
-                            "闪灵"
-                        ],
-                        "autofill": true
+                            "焰尾",
+                            "老鲤",
+                            "诗怀雅",
+                            "灵知"
+                        ]
                     },
                     {
                         "operators": [
-                            "流明"
-                        ],
-                        "autofill": true,
-                        "skip": true
+                            "孑",
+                            "银灰",
+                            "水月",
+                            "海沫",
+                            "多萝西"
+                            
+                        ]
                     },
                     {
                         "operators": [
-                            "杜林"
-                        ],
-                        "autofill": true,
-                        "skip": true
+                            "灰毫",
+                            "野鬃",
+                            "远牙",
+                            "正义骑士号",
+                            "雷蛇"
+                            
+                        ]
                     },
                     {
                         "operators": [
                             "爱丽丝",
-                            "车尔尼"
-                        ],
-                        "autofill": true,
-                        "skip": true
+                            "车尔尼",
+                            "斥罪",
+                            "星极",
+                            "红"
+                        ]
+                        
                     }
                 ]
             }
         },
         {
-            "name": "B+C 组",
+            "name": "A+B 组 后8小时，例如：【00:00-08:00】",
+            "description": "最高效率长班，中途用一次肥鸭，同时清体力\n下次换班在8小时后进行",
+            "drones": {
+                "order": "post",
+                "room": "trading",
+                "index": 1
+            },
+            "Fiammetta": {
+                "target": "龙舌兰"
+            },
+            "rooms": {
+                "control": [
+                    {
+                        "operators": [
+                            "阿米娅",
+                            "凯尔希",
+                            "琴柳",
+                            "令",
+                            "夕"
+                        ]
+                    }
+                ],
+                "trading": [
+                    {
+                        "operators": [
+                            "柏喙",
+                            "龙舌兰",
+                            "巫恋"
+                        ],
+                        "sort": true,
+                        "product": "LMD"
+                    },
+                    {
+                        "operators": [
+                            "但书",
+                            "空弦",
+                            "黑键"
+                        ],
+                        "product": "LMD"
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "operators": [
+                            "红云",
+                            "稀音",
+                            "帕拉斯"
+                        ],
+                        "sort": true,
+                        "product": "Battle Record"
+                    },
+                    {
+                        "operators": [
+                            "食铁兽",
+                            "断罪者",
+                            "槐琥"
+                        ],
+                        "product": "Battle Record"
+                    },
+                    {
+                        "operators": [
+                            "清流",
+                            "温蒂",
+                            "森蚺"
+                        ],
+                        "product": "Pure Gold"
+                    },
+                    {
+                        "operators": [
+                            "砾",
+                            "至简",
+                            "迷迭香"
+                        ],
+                        "product": "Pure Gold"
+                    }
+                ],
+                "power": [
+                    {
+                        "operators": [
+                            "承曦格雷伊"
+                        ]
+                    },
+                    {
+                        "operators": [
+                            "澄闪"
+                        ]
+                    },
+                    {
+                        "operators": [
+                            "炎狱炎熔"
+                        ]
+                    }
+                ],
+                "hire": [
+                    {
+                        "operators": [
+                            "絮雨"
+                        ]
+                    }
+                ],
+                "meeting": [
+                    {
+                        "operators": [
+                            "陈",
+                            "伺夜"
+                        ]
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "operators": [
+                            "菲亚梅塔",
+                            "焰尾",
+                            "老鲤",
+                            "诗怀雅",
+                            "灵知"
+                        ]
+                    },
+                    {
+                        "operators": [
+                            "孑",
+                            "银灰",
+                            "水月",
+                            "海沫",
+                            "多萝西"
+                            
+                        ]
+                    },
+                    {
+                        "operators": [
+                            "灰毫",
+                            "野鬃",
+                            "远牙",
+                            "雷蛇",
+                            "年"
+                            
+                        ]
+                    },
+                    {
+                        "operators": [
+                            "爱丽丝",
+                            "车尔尼",
+                            "九色鹿",
+                            "瑕光",
+                            "泥岩"
+                        ]
+                        
+                    }
+                ]
+            }
+        },
+        {
+            "name": "B+C 组，例如【08:00-12:00】",
             "description": "次高效替补 1 班, 令工作20小时\n下次换班在4小时后进行",
+            "drones": {
+                "order": "post",
+                "room": "trading",
+                "index": 1
+            },
             "Fiammetta": {
                 "target": "但书"
-            },
-            "drones": {
-                "room": "manufacture",
-                "index": 1
             },
             "rooms": {
                 "control": [
@@ -379,7 +412,7 @@
                     {
                         "operators": [
                             "陈",
-                            "红"
+                            "伺夜"
                         ]
                     }
                 ],
@@ -387,40 +420,52 @@
                     {
                         "operators": [
                             "菲亚梅塔",
-                            "夜莺",
-                            "闪灵"
-                        ],
-                        "autofill": true
+                            "凯尔希",
+                            "夕",
+                            "清流",
+                            "斥罪"
+                        ]
                     },
                     {
                         "operators": [
-                            "流明"
-                        ],
-                        "autofill": true
+                            "流明",
+                            "温蒂",
+                            "森蚺",
+                            "红云",
+                            "帕拉斯"
+                            
+                        ]
                     },
                     {
                         "operators": [
                             "杜林",
-                            "蜜莓"
-                        ],
-                        "autofill": true
+                            "稀音",
+                            "承曦格雷伊",
+                            "炎狱炎熔",
+                            "年"
+                            
+                        ]
                     },
                     {
                         "operators": [
                             "爱丽丝",
                             "车尔尼",
-                            "黑"
+                            "九色鹿",
+                            "瑕光"
+                            
                         ],
                         "autofill": true
+                        
                     }
                 ]
             }
         },
         {
-            "name": "A+C 组",
+            "name": "A+C 组，例如【12:00-16:00】",
             "description": "次高效替补 2 班\n下次换班在4小时后进行",
             "drones": {
-                "room": "manufacture",
+                "order": "post",
+                "room": "trading",
                 "index": 1
             },
             "rooms": {
@@ -510,7 +555,7 @@
                 "hire": [
                     {
                         "operators": [
-                            "艾雅法拉"
+                            "斥罪"
                         ]
                     }
                 ],
@@ -518,35 +563,53 @@
                     {
                         "operators": [
                             "星极",
-                            "远山"
+                            "红"
                         ]
                     }
                 ],
                 "dormitory": [
                     {
                         "operators": [
-                            "菲亚梅塔"
-                        ],
-                        "autofill": true
+                            "菲亚梅塔",
+                            "阿米娅",
+                            "柏喙",
+                            "琴柳",
+                            "夜莺"
+                        ]
                     },
                     {
                         "operators": [
-                            "流明"
-                        ],
-                        "autofill": true
-                    },
-                    {
-                        "autofill": true
+                            "流明",
+                            "黑键",
+                            "空弦",
+                            "迷迭香",
+                            "砾"
+                            
+                        ]
                     },
                     {
                         "operators": [
-                            "爱丽丝",
-                            "车尔尼"
-                        ],
-                        "autofill": true
+                            "杜林",
+                            "至简",
+                            "槐琥",
+                            "食铁兽",
+                            "断罪者"
+                            
+                        ]
+                    },
+                    {
+                        "operators": [
+                            "澄闪",
+                            "絮雨",
+                            "陈",
+                            "伺夜",
+                            "令"
+                        ]
+                        
                     }
                 ]
             }
         }
+        
     ]
 }


### PR DESCRIPTION
https://docs.google.com/spreadsheets/d/10Wljo-5TroDXD-7OWVcK1oQP1hGJ_-KYsrzPyfFm5Dg/edit?usp=sharing

具体换班表看这里。版本新增干员之后的例行维护。