### PR TITLE
chore: 新增发 nightly 版本的 workflow

### DIFF
--- a/.github/workflows/release-nightly-ota.yml
+++ b/.github/workflows/release-nightly-ota.yml
@@ -21,7 +21,7 @@ jobs:
   build-win-nightly:
     runs-on: windows-latest
     outputs:
-      hash: ${{ steps.set_hash.outputs.hash }}
+      tag: ${{ steps.set_tag.outputs.tag }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -32,15 +32,28 @@ jobs:
       - name: Checkout ref
         run: |
           git checkout --progress --recurse-submodules ${{ inputs.ref || 'dev' }}
-      - name: Set hash
-        id: set_hash
+      - run: |
+          npm install --global --progress semver
+      - name: Set tag
+        id: set_tag
         run: |
-          # "hash=c$(Get-Date -Format 'yyMMdd')-$(git rev-parse --short HEAD)" >> $env:GITHUB_OUTPUT
-          "hash=$(git describe --tags --long)" >> $env:GITHUB_OUTPUT
+          $described = $(git describe --tags --long --match 'v*')
+          $ids = $($described -split "-")
+          if ($ids.length -eq 3) {
+            $ver = "v$(semver --increment $ids[0].Substring(1))"
+            echo "tag=$ver-alpha.0.$($ids[1]).$($ids[2])" >> $env:GITHUB_OUTPUT
+            exit 0
+          }
+          if ($ids.length -eq 4) {
+            echo "tag=$($ids[0])-$($ids[1]).$($ids[2]).$($ids[3])" >> $env:GITHUB_OUTPUT
+            exit 0
+          }
+          exit 1
       - name: Run './build.cmd DevBuild'
         run: |
-          $env:GITHUB_WORKFLOW='dev-build-win' # pretend this is a dev-build-win workflow
-          $env:MAA_BUILDER_MAA_VERSION="${{steps.set_hash.outputs.hash}}"
+          $env:GITHUB_WORKFLOW = 'dev-build-win' # pretend this is a dev-build-win workflow
+          $env:MAA_BUILDER_MAA_VERSION = "${{steps.set_tag.outputs.tag}}"
+          echo "tag: " $env:MAA_BUILDER_MAA_VERSION
           ./build.cmd DevBuild
         env:
           Reason: 'Build nightly version'
@@ -54,7 +67,7 @@ jobs:
     needs: build-win-nightly
     runs-on: ubuntu-latest
     steps:
-      - run: echo ${{ needs.build-win-nightyl.outputs.hash }}
+      - run: echo ${{ needs.build-win-nightyl.outputs.tag }}
       - name: "Fetch MaaRelease"
         uses: actions/checkout@v3
         with:
@@ -68,20 +81,20 @@ jobs:
       - uses: actions/download-artifact@v3
         with:
           name: MAA-win-x64
-          path: ${{ format('{0}/{1}', 'build-ota', needs.build-win-nightly.outputs.hash) }}
+          path: ${{ format('{0}/{1}', 'build-ota', needs.build-win-nightly.outputs.tag) }}
       - name: "Fetch release info"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           mkdir -pv build-ota && cd build-ota
-          cd ${{ needs.build-win-nightly.outputs.hash }}
+          cd ${{ needs.build-win-nightly.outputs.tag }}
           mkdir -pv content
           unzip -q *.zip -d content
           cd ..
 
           gh release list --repo 'MaaAssistantArknights/MaaAssistantArknights' --limit ${{ inputs.limit || 30 }} | tee ./release_maa.txt
           gh release list --repo "${{ github.repository_owner }}/MaaRelease" --limit ${{ inputs.limit_2 || 30 }} | tee ./release_mr.txt
-          echo ${{ needs.build-win-nightly.outputs.hash }} > ./config
+          echo ${{ needs.build-win-nightly.outputs.tag }} > ./config
 
           cat ./release_maa.txt | awk '{ print $1 }' > ./tags_maa.txt
           cat ./release_mr.txt | awk '{ print $1 }' > ./tags_mr.txt
@@ -98,17 +111,17 @@ jobs:
         run: |
           cd build-ota
           $GITHUB_WORKSPACE/MaaAssistantArknights/tools/OTAPacker/build.sh 'MaaAssistantArknights/MaaAssistantArknights' ./config "${{ github.repository_owner }}/MaaRelease"
-          mv -v ${{ needs.build-win-nightly.outputs.hash }}/*.zip ./MAA-${{ env.release_tag }}-win-x64.zip
+          mv -v ${{ needs.build-win-nightly.outputs.tag }}/*.zip ./MAA-${{ env.release_tag }}-win-x64.zip
       - name: "Commit and setup tag"
         run: |
           cd MaaRelease
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
-          git checkout --orphan temp
+          git checkout --orphan __temp
           git rm -rf .
           git commit --allow-empty --message ${{ env.release_tag }}
           git tag ${{ env.release_tag }} || exit 0 # do nothing if the tag already exists
-          git push --tags $PUSH_REMOTE
+          git push --tags
       - name: "Upload to MaaRelease"
         uses: svenstaro/upload-release-action@v2
         with:

--- a/.github/workflows/release-nightly-ota.yml
+++ b/.github/workflows/release-nightly-ota.yml
@@ -1,0 +1,121 @@
+name: release-nightly-ota
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Commit to build (git checkout)'
+        type: string
+        required: true
+      limit:
+        description: 'Number of releases to fetch from MaaAssistantArknights'
+        required: false
+        default: 30
+        type: number
+      limit_2:
+        description: 'Number of releases to fetch from MaaRelease'
+        required: false
+        default: 30
+
+jobs:
+  build-win-nightly:
+    runs-on: windows-latest
+    outputs:
+      hash: ${{ steps.set_hash.outputs.hash }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          # repository: 'MaaAssistantArknights/MaaAssistantArknights'
+          submodules: recursive
+          #ref: ${{ inputs.ref }}
+          fetch-depth: 0
+      - name: Checkout ref
+        run: |
+          git checkout --progress --recurse-submodules ${{ inputs.ref || 'dev' }}
+      - name: Set hash
+        id: set_hash
+        run: |
+          # "hash=c$(Get-Date -Format 'yyMMdd')-$(git rev-parse --short HEAD)" >> $env:GITHUB_OUTPUT
+          "hash=$(git describe --tags --long)" >> $env:GITHUB_OUTPUT
+      - name: Run './build.cmd DevBuild'
+        run: |
+          $env:GITHUB_WORKFLOW='dev-build-win' # pretend this is a dev-build-win workflow
+          $env:MAA_BUILDER_MAA_VERSION="${{steps.set_hash.outputs.hash}}"
+          ./build.cmd DevBuild
+        env:
+          Reason: 'Build nightly version'
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/upload-artifact@v3
+        with:
+          name: MAA-win-x64
+          path: artifacts
+
+  make-ota:
+    needs: build-win-nightly
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ${{ needs.build-win-nightyl.outputs.hash }}
+      - name: "Fetch MaaRelease"
+        uses: actions/checkout@v3
+        with:
+          repository: ${{ format('{0}/{1}', github.repository_owner, 'MaaRelease') }}
+          path: MaaRelease
+          fetch-depth: 0
+          token: ${{ secrets.MAARELEASE_RELEASE }}
+      - uses: actions/checkout@v3
+        with:
+          path: MaaAssistantArknights
+      - uses: actions/download-artifact@v3
+        with:
+          name: MAA-win-x64
+          path: ${{ format('{0}/{1}', 'build-ota', needs.build-win-nightly.outputs.hash) }}
+      - name: "Fetch release info"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -pv build-ota && cd build-ota
+          cd ${{ needs.build-win-nightly.outputs.hash }}
+          mkdir -pv content
+          unzip -q *.zip -d content
+          cd ..
+
+          gh release list --repo 'MaaAssistantArknights/MaaAssistantArknights' --limit ${{ inputs.limit || 30 }} | tee ./release_maa.txt
+          gh release list --repo "${{ github.repository_owner }}/MaaRelease" --limit ${{ inputs.limit_2 || 30 }} | tee ./release_mr.txt
+          echo ${{ needs.build-win-nightly.outputs.hash }} > ./config
+
+          cat ./release_maa.txt | awk '{ print $1 }' > ./tags_maa.txt
+          cat ./release_mr.txt | awk '{ print $1 }' > ./tags_mr.txt
+
+          comm <(sort ./tags_maa.txt) <(sort ./tags_mr.txt) | awk '{ print $1 }' >> ./config
+
+          echo "config:"
+          cat ./config
+
+          echo "release_tag=$(head -n 1 ./config)" >> $GITHUB_ENV
+      - name: "Build OTA"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cd build-ota
+          $GITHUB_WORKSPACE/MaaAssistantArknights/tools/OTAPacker/build.sh 'MaaAssistantArknights/MaaAssistantArknights' ./config "${{ github.repository_owner }}/MaaRelease"
+          mv -v ${{ needs.build-win-nightly.outputs.hash }}/*.zip ./MAA-${{ env.release_tag }}-win-x64.zip
+      - name: "Commit and setup tag"
+        run: |
+          cd MaaRelease
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git checkout --orphan temp
+          git rm -rf .
+          git commit --allow-empty --message ${{ env.release_tag }}
+          git tag ${{ env.release_tag }} || exit 0 # do nothing if the tag already exists
+          git push --tags $PUSH_REMOTE
+      - name: "Upload to MaaRelease"
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_name: ${{ format('{0}/{1}', github.repository_owner, 'MaaRelease') }}
+          repo_token: ${{ secrets.MAARELEASE_RELEASE }}
+          file_glob: true
+          file: build-ota/*.zip
+          tag: ${{ env.release_tag }}
+          prerelease: true
+          overwrite: true

--- a/.github/workflows/release-nightly-ota.yml
+++ b/.github/workflows/release-nightly-ota.yml
@@ -49,6 +49,13 @@ jobs:
             exit 0
           }
           exit 1
+      - name: Cache .nuke/temp, ~/.nuget/packages
+        uses: actions/cache@v3
+        with:
+          path: |
+            .nuke/temp
+            ~/.nuget/packages
+          key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj') }}
       - name: Run './build.cmd DevBuild'
         run: |
           $env:GITHUB_WORKFLOW = 'dev-build-win' # pretend this is a dev-build-win workflow

--- a/.github/workflows/release-ota.yml
+++ b/.github/workflows/release-ota.yml
@@ -6,10 +6,14 @@ on:
   workflow_dispatch:
     inputs:
       limit:
-        description: 'Number of releases to fetch, 2 at least'
+        description: 'Number of releases to fetch from MaaAssistantArknights, 2 at least'
         required: false
-        default: 51
+        default: 31
         type: number
+      limit_2:
+        description: 'Number of releases to fetch from MaaRelease'
+        required: false
+        default: 30
 
 jobs:
   make-ota:
@@ -30,26 +34,36 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           mkdir -pv build-ota && cd build-ota
-          gh release list --repo 'MaaAssistantArknights/MaaAssistantArknights' --limit ${{ inputs.limit || 51 }} | tee ./release_list.txt
-          echo "prerelease=$([ $(head -n 1 release_list.txt | awk '{ print $2}') = 'Pre-release' ] && echo true || echo false)" >> $GITHUB_ENV
-          cat ./release_list.txt | awk '{ print $1 }' > ./releases
-          echo "release_tag=$(head -n 1 ./releases)" >> $GITHUB_ENV
+          gh release list --repo 'MaaAssistantArknights/MaaAssistantArknights' --limit ${{ inputs.limit || 31 }} | tee ./release_maa.txt
+          gh release list --repo "${{ github.repository_owner }}/MaaRelease" --limit ${{ inputs.limit_2 || 30 }} | tee ./release_mr.txt
+          head -n 1 ./release_maa.txt | awk '{ print $1 }' > ./config
+
+          tail -n +1 ./release_maa.txt | awk '{ print $1 }' > ./tags_maa.txt
+          cat ./release_mr.txt | awk '{ print $1 }' > ./tags_mr.txt
+
+          comm <(sort ./tags_maa.txt) <(sort ./tags_mr.txt) | awk '{ print $1 }' >> ./config
+
+          echo "config:"
+          cat ./config
+
+          echo "prerelease=$([ $(head -n 1 release_maa.txt | awk '{ print $2}') = 'Pre-release' ] && echo true || echo false)" >> $GITHUB_ENV
+          echo "release_tag=$(head -n 1 ./config)" >> $GITHUB_ENV
       - name: "Build OTA"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cd build-ota
-          $GITHUB_WORKSPACE/MaaAssistantArknights/tools/OTAPacker/build.sh 'MaaAssistantArknights/MaaAssistantArknights' ./releases
+          $GITHUB_WORKSPACE/MaaAssistantArknights/tools/OTAPacker/build.sh 'MaaAssistantArknights/MaaAssistantArknights' ./config
       - name: "Commit and setup tag"
         run: |
           cd MaaRelease
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
-          git checkout --orphan temp
+          git checkout --orphan __temp
           git rm -rf .
           git commit --allow-empty --message ${{ env.release_tag }}
           git tag ${{ env.release_tag }} || exit 0 # do nothing if the tag already exists
-          git push --tags $PUSH_REMOTE
+          git push --tags
         env:
           PUSH_REMOTE: https://github-actions[bot]:${{ secrets.MAARELEASE_RELEASE }}@github.com/${{ github.repository_owner }}/MaaRelease
       - name: "Upload to MaaRelease"


### PR DESCRIPTION
脚本还比较丑, 有一些重复的内容, 不过应该勉强能用 (
效果如 https://github.com/horror-proton/MaaRelease/releases 的最新几个 release

可以在 Action tab 里面选择这个 workflow, 然后点右边的 Run workflow, 输入要打的 nightly release 对应的分支名或者 commit SHA 值