### PR TITLE
ci: Allow input nightly tag

### DIFF
--- a/.github/workflows/release-nightly-ota.yml
+++ b/.github/workflows/release-nightly-ota.yml
@@ -16,6 +16,9 @@ on:
         description: 'Number of releases to fetch from MaaRelease'
         required: false
         default: 30
+      tag_name:
+        description: 'Tag name to release'
+        required: false
 
 jobs:
   build-win-nightly:
@@ -37,6 +40,10 @@ jobs:
       - name: Set tag
         id: set_tag
         run: |
+          if ("${{ inputs.tag_name }}" -ne "") {
+            echo "tag=${{ inputs.tag_name }}" >> $env:GITHUB_OUTPUT
+            exit 0
+          }
           $described = $(git describe --tags --long --match 'v*')
           $ids = $($described -split "-")
           if ($ids.length -eq 3) {


### PR DESCRIPTION
不太会写 powershell，快帮我看看
这个 pr 是允许自定义发 nightly 版本的 tag。
例如自定义一个 `v4.6.7-beta.4.0+gddbcbd64` 就过不了旧版本的 isStdVersion，从而可以正常更新