### PR TITLE
feat: 水月肉鸽支持活用安全屋选项

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -8760,6 +8760,7 @@
     "Mizuki@Roguelike@StageSafeHouseReuse": {
         "algorithm": "OcrDetect",
         "action": "ClickSelf",
+        "cache": false,
         "roi": [
             880,
             200,
@@ -8770,8 +8771,9 @@
             "活用",
             "再利用"
         ],
+        "preDelay": 500,
         "next": [
-            "Mizuki@Roguelike@StageEncounterLeaveConfirm"
+            "Mizuki@Roguelike@StageEncounterOption#next"
         ]
     },
     "Mizuki@Roguelike@StageEncounterOptions": {

--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -8757,9 +8757,27 @@
         "templThreshold": 0.91
     },
     "Mizuki@Roguelike@StageEncounterOptionWonderland": {},
+    "Mizuki@Roguelike@StageSafeHouseReuse": {
+        "algorithm": "OcrDetect",
+        "action": "ClickSelf",
+        "roi": [
+            880,
+            200,
+            220,
+            120
+        ],
+        "text": [
+            "活用",
+            "再利用"
+        ],
+        "next": [
+            "Mizuki@Roguelike@StageEncounterLeaveConfirm"
+        ]
+    },
     "Mizuki@Roguelike@StageEncounterOptions": {
         "next": [
             "Mizuki@Roguelike@StageEncounterOptionFree",
+            "Mizuki@Roguelike@StageSafeHouseReuse",
             "Mizuki@Roguelike@StageEncounterOptionLeave",
             "Mizuki@Roguelike@StageEncounterOptionUnknown",
             "Mizuki@Roguelike@StageEncounterOptionWonderland",


### PR DESCRIPTION
fix #2055

#2055 提到已经可以了，但似乎目前 dev 分支和 master 都不会活用安全屋。

应该是因为 Encounter 中匹配多个选项的时候会优先选择下方的选项？

改了之后在 Encounter 节点中找完 Free 选项就会去找活用安全屋选项，没有才会离开。