### PR TITLE
feat: 优化 minitouch 滑动操作

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -2,6 +2,7 @@
     "SlowlySwipeToTheLeft": {
         "algorithm": "JustReturn",
         "action": "Swipe",
+        "postDelay": 200,
         "specificRect": [
             300,
             310,
@@ -18,7 +19,8 @@
         "rectMove_Doc": "滑动终点",
         "specialParams": [
             200,
-            1
+            1,
+            -1
         ],
         "specialParams_Doc": [
             "滑动 duration",
@@ -32,6 +34,7 @@
     "SlowlySwipeToTheRight": {
         "algorithm": "JustReturn",
         "action": "Swipe",
+        "postDelay": 200,
         "specificRect": [
             880,
             310,
@@ -46,7 +49,8 @@
         ],
         "specialParams": [
             200,
-            1
+            1,
+            -1
         ],
         "next": [
             "#next"
@@ -69,6 +73,11 @@
             100,
             100
         ],
+        "specialParams": [
+            150,
+            0,
+            0.5
+        ],
         "next": [
             "#next"
         ],
@@ -89,6 +98,11 @@
             310,
             200,
             100
+        ],
+        "specialParams": [
+            150,
+            0,
+            0.5
         ],
         "next": [
             "#next"
@@ -6132,13 +6146,13 @@
         "algorithm": "JustReturn",
         "preDelay": 200,
         "postDelay": 100,
-        "Doc": "pre 是从点击干员，到干员信息弹出来等待的时间；rear 是干员上场，到设置朝向之间等待的时间"
+        "Doc": "pre 是从点击干员，到干员信息弹出来等待的时间；post 是干员上场，到设置朝向之间等待的时间"
     },
     "BattleSwipeOper": {
         "algorithm": "JustReturn",
         "preDelay": 200,
         "postDelay": 50,
-        "Doc": "pre 是将干员滑动到场上的 duration 系数；rear 是设置干员朝向滑动的 duration",
+        "Doc": "pre 是将干员滑动到场上的 duration 系数；post 是设置干员朝向滑动的 duration",
         "specialParams": [
             200
         ],

--- a/src/MeoAssistant/Controller.cpp
+++ b/src/MeoAssistant/Controller.cpp
@@ -1115,7 +1115,7 @@ bool asst::Controller::swipe_without_scale(const Point& p1, const Point& p2, int
 
     const auto& opt = Configer.get_options();
     if (m_minitouch_enabled && m_minitouch_avaiable) {
-        constexpr int MoveInterval = 1;
+        constexpr int MoveInterval = 5;
         input_to_minitouch(MinitouchCmd::down(static_cast<int>(x1 * m_minitouch_props.x_scaling),
                                               static_cast<int>(m_minitouch_props.y_scaling * y1), true, MoveInterval));
         if (duration == 0) {

--- a/src/MeoAssistant/Controller.cpp
+++ b/src/MeoAssistant/Controller.cpp
@@ -53,8 +53,8 @@ struct MinitouchCmd
         sprintf(buff, "d %d %d %d %d\n", contact, x, y, pressure);
         std::string str = buff;
 
-        if (with_commit) str += commit();
         if (wait_ms) str += wait(wait_ms);
+        if (with_commit) str += commit();
         return str;
     }
     inline static std::string move(int x, int y, bool with_commit = true, int wait_ms = 0, int contact = 0,
@@ -64,16 +64,17 @@ struct MinitouchCmd
         sprintf(buff, "m %d %d %d %d\n", contact, x, y, pressure);
         std::string str = buff;
 
-        if (with_commit) str += commit();
         if (wait_ms) str += wait(wait_ms);
+        if (with_commit) str += commit();
         return str;
     }
-    inline static std::string up(bool with_commit = true, int contact = 0)
+    inline static std::string up(bool with_commit = true, int wait_ms = 0, int contact = 0)
     {
         char buff[16] = { 0 };
         sprintf(buff, "u %d\n", contact);
         std::string str = buff;
 
+        if (wait_ms) str += wait(wait_ms);
         if (with_commit) str += commit();
         return str;
     }
@@ -1066,8 +1067,8 @@ bool asst::Controller::click_without_scale(const Point& p)
         constexpr int duration = 50; // 点击从按下到抬起之间的持续时间，以毫秒计
         constexpr int wait_ms = 50;  // 触点抬起后等待的时间，以毫秒计
         std::string minitouch_cmd =
-            MinitouchCmd::down(x, y, true, duration) + MinitouchCmd::up() + MinitouchCmd::wait(wait_ms);
-        return input_to_minitouch(minitouch_cmd, duration);
+            MinitouchCmd::down(x, y, true, duration) + MinitouchCmd::up(wait_ms);
+        return input_to_minitouch(minitouch_cmd, duration + wait_ms);
     }
     else {
         std::string cur_cmd =
@@ -1149,8 +1150,9 @@ bool asst::Controller::swipe_without_scale(const Point& p1, const Point& p2, int
             duration += opt.minitouch_extra_swipe_duration;
         }
         constexpr int ExtraWait = 50;
-        duration += ExtraWait;
-        return input_to_minitouch(MinitouchCmd::wait(ExtraWait) + MinitouchCmd::up(), duration);
+        duration += 2 * ExtraWait;
+        return input_to_minitouch(
+            MinitouchCmd::wait(ExtraWait /* 停留终点 */) + MinitouchCmd::up(ExtraWait /* 抬起后等待 */), duration);
     }
     else {
         std::string cur_cmd =

--- a/src/MeoAssistant/Controller.cpp
+++ b/src/MeoAssistant/Controller.cpp
@@ -1082,8 +1082,7 @@ bool asst::Controller::click_without_scale(const Rect& rect)
     return click_without_scale(rand_point_in_rect(rect));
 }
 
-bool asst::Controller::swipe(const Point& p1, const Point& p2, int duration, bool extra_swipe,
-                             double acceleration_coef)
+bool asst::Controller::swipe(const Point& p1, const Point& p2, int duration, bool extra_swipe, double acceleration_coef)
 {
     int x1 = static_cast<int>(p1.x * m_control_scale);
     int y1 = static_cast<int>(p1.y * m_control_scale);
@@ -1094,8 +1093,7 @@ bool asst::Controller::swipe(const Point& p1, const Point& p2, int duration, boo
     return swipe_without_scale(Point(x1, y1), Point(x2, y2), duration, extra_swipe, acceleration_coef);
 }
 
-bool asst::Controller::swipe(const Rect& r1, const Rect& r2, int duration, bool extra_swipe,
-                             double acceleration_coef)
+bool asst::Controller::swipe(const Rect& r1, const Rect& r2, int duration, bool extra_swipe, double acceleration_coef)
 {
     return swipe(rand_point_in_rect(r1), rand_point_in_rect(r2), duration, extra_swipe, acceleration_coef);
 }
@@ -1184,7 +1182,8 @@ bool asst::Controller::swipe_without_scale(const Point& p1, const Point& p2, int
 bool asst::Controller::swipe_without_scale(const Rect& r1, const Rect& r2, int duration, bool extra_swipe,
                                            double acceleration_coef)
 {
-    return swipe_without_scale(rand_point_in_rect(r1), rand_point_in_rect(r2), duration, extra_swipe, acceleration_coef);
+    return swipe_without_scale(rand_point_in_rect(r1), rand_point_in_rect(r2), duration, extra_swipe,
+                               acceleration_coef);
 }
 
 bool asst::Controller::connect(const std::string& adb_path, const std::string& address, const std::string& config)

--- a/src/MeoAssistant/Controller.h
+++ b/src/MeoAssistant/Controller.h
@@ -57,10 +57,14 @@ namespace asst
         bool click_without_scale(const Point& p);
         bool click_without_scale(const Rect& rect);
 
-        bool swipe(const Point& p1, const Point& p2, int duration = 0, bool extra_swipe = false);
-        bool swipe(const Rect& r1, const Rect& r2, int duration = 0, bool extra_swipe = false);
-        bool swipe_without_scale(const Point& p1, const Point& p2, int duration = 0, bool extra_swipe = false);
-        bool swipe_without_scale(const Rect& r1, const Rect& r2, int duration = 0, bool extra_swipe = false);
+        bool swipe(const Point& p1, const Point& p2, int duration = 0, bool extra_swipe = false,
+                   double acceleration_coef = 0);
+        bool swipe(const Rect& r1, const Rect& r2, int duration = 0, bool extra_swipe = false,
+                   double acceleration_coef = 0);
+        bool swipe_without_scale(const Point& p1, const Point& p2, int duration = 0, bool extra_swipe = false,
+                                 double acceleration_coef = 0);
+        bool swipe_without_scale(const Rect& r1, const Rect& r2, int duration = 0, bool extra_swipe = false,
+                                 double acceleration_coef = 0);
 
         std::pair<int, int> get_scale_size() const noexcept;
 

--- a/src/MeoAssistant/Task/Plugin/RoguelikeBattleTaskPlugin.cpp
+++ b/src/MeoAssistant/Task/Plugin/RoguelikeBattleTaskPlugin.cpp
@@ -726,11 +726,11 @@ bool asst::RoguelikeBattleTaskPlugin::auto_battle()
 
     // 将方向转换为实际的 swipe end 坐标点
     if (direction != Point::zero()) {
-        static const int coeff = Task.get("BattleSwipeOper")->special_params.at(0);
+        static const int coeff = swipe_oper_task_ptr->special_params.at(0);
         Point end_point = placed_point + (direction * coeff);
         m_ctrler->swipe(placed_point, end_point, swipe_oper_task_ptr->post_delay);
+        sleep(use_oper_task_ptr->post_delay);
     }
-    sleep(Task.get("BattleUseOper")->post_delay);
 
     if (opt_oper.role == BattleRole::Drone) {
         cancel_oper_selection();

--- a/src/MeoAssistant/Task/Sub/ProcessTask.cpp
+++ b/src/MeoAssistant/Task/Sub/ProcessTask.cpp
@@ -186,7 +186,8 @@ bool ProcessTask::_run()
         case ProcessTaskAction::Swipe:
             exec_swipe_task(m_cur_task_ptr->specific_rect, m_cur_task_ptr->rect_move,
                             m_cur_task_ptr->special_params.empty() ? 0 : m_cur_task_ptr->special_params.at(0),
-                            (m_cur_task_ptr->special_params.size() < 2) ? false : m_cur_task_ptr->special_params.at(1));
+                            (m_cur_task_ptr->special_params.size() < 2) ? false : m_cur_task_ptr->special_params.at(1),
+                            (m_cur_task_ptr->special_params.size() < 3) ? 0 : m_cur_task_ptr->special_params.at(2));
             break;
         case ProcessTaskAction::DoNothing:
             break;
@@ -305,8 +306,8 @@ void ProcessTask::exec_click_task(const Rect& matched_rect)
     m_ctrler->click(matched_rect);
 }
 
-void asst::ProcessTask::exec_swipe_task(const Rect& r1, const Rect& r2, int duration, bool extra_swipe)
+void asst::ProcessTask::exec_swipe_task(const Rect& r1, const Rect& r2, int duration, bool extra_swipe, double acceleration_coef)
 {
     MinitouchTempSwitcher switcher(m_ctrler);
-    m_ctrler->swipe(r1, r2, duration, extra_swipe);
+    m_ctrler->swipe(r1, r2, duration, extra_swipe, acceleration_coef);
 }

--- a/src/MeoAssistant/Task/Sub/ProcessTask.cpp
+++ b/src/MeoAssistant/Task/Sub/ProcessTask.cpp
@@ -306,7 +306,8 @@ void ProcessTask::exec_click_task(const Rect& matched_rect)
     m_ctrler->click(matched_rect);
 }
 
-void asst::ProcessTask::exec_swipe_task(const Rect& r1, const Rect& r2, int duration, bool extra_swipe, double acceleration_coef)
+void asst::ProcessTask::exec_swipe_task(const Rect& r1, const Rect& r2, int duration, bool extra_swipe,
+                                        double acceleration_coef)
 {
     MinitouchTempSwitcher switcher(m_ctrler);
     m_ctrler->swipe(r1, r2, duration, extra_swipe, acceleration_coef);

--- a/src/MeoAssistant/Task/Sub/ProcessTask.h
+++ b/src/MeoAssistant/Task/Sub/ProcessTask.h
@@ -42,7 +42,7 @@ namespace asst
 
         std::pair<int, TimesLimitType> calc_time_limit() const;
         void exec_click_task(const Rect& matched_rect);
-        void exec_swipe_task(const Rect& r1, const Rect& r2, int duration, bool extra_swipe);
+        void exec_swipe_task(const Rect& r1, const Rect& r2, int duration, bool extra_swipe, double acceleration_coef);
 
         std::shared_ptr<TaskInfo> m_cur_task_ptr = nullptr;
         std::vector<std::string> m_raw_tasks_name;


### PR DESCRIPTION
1. 增加滑动 interval
2. up 操作延迟 50ms
3. 增加滑动加速度参数 `acceleration_coef`：=0 表示匀速，>0 表示加速，<0 表示减速；超出 [1, -1] 会往反方向滑动一段

顺带一提，改之前在我的电脑上肉鸽是基本不能用的，改之后基本能用了：）