### PR TITLE
feat: 在 minitouch 滑动操作中使用三次插值

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -20,11 +20,14 @@
         "specialParams": [
             200,
             1,
-            -1
+            0,
+            0
         ],
         "specialParams_Doc": [
             "滑动 duration",
-            "额外滑动？"
+            "额外滑动？",
+            "slope in (zero means smooth, 1 means linear)",
+            "slope out"
         ],
         "next": [
             "#next"
@@ -50,7 +53,8 @@
         "specialParams": [
             200,
             1,
-            -1
+            0,
+            0
         ],
         "next": [
             "#next"
@@ -76,7 +80,8 @@
         "specialParams": [
             150,
             0,
-            0.5
+            1,
+            1
         ],
         "next": [
             "#next"
@@ -102,7 +107,8 @@
         "specialParams": [
             150,
             0,
-            0.5
+            1,
+            1
         ],
         "next": [
             "#next"

--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -20,7 +20,7 @@
         "specialParams": [
             200,
             1,
-            0,
+            2,
             0
         ],
         "specialParams_Doc": [
@@ -53,7 +53,7 @@
         "specialParams": [
             200,
             1,
-            0,
+            2,
             0
         ],
         "next": [

--- a/src/MeoAssistant/Controller.cpp
+++ b/src/MeoAssistant/Controller.cpp
@@ -1079,10 +1079,10 @@ bool asst::Controller::swipe_without_scale(const Point& p1, const Point& p2, int
             }
         };
         minitouch_move(x1, y1, x2, y2, duration);
-        constexpr int ExtraEndDelay = 100; // 停留终点
-        toucher.wait(ExtraEndDelay);
 
         if (extra_swipe && opt.minitouch_extra_swipe_duration > 0) {
+            constexpr int ExtraEndDelay = 100; // 停留终点
+            toucher.wait(ExtraEndDelay);
             minitouch_move(x2, y2, x2, y2 - opt.minitouch_extra_swipe_dist, opt.minitouch_extra_swipe_duration);
             duration += opt.minitouch_extra_swipe_duration;
         }

--- a/src/MeoAssistant/Controller.cpp
+++ b/src/MeoAssistant/Controller.cpp
@@ -1016,7 +1016,8 @@ bool asst::Controller::click_without_scale(const Rect& rect)
     return click_without_scale(rand_point_in_rect(rect));
 }
 
-bool asst::Controller::swipe(const Point& p1, const Point& p2, int duration, bool extra_swipe, double acceleration_coef)
+bool asst::Controller::swipe(const Point& p1, const Point& p2, int duration, bool extra_swipe, double slope_in,
+                             double slope_out)
 {
     int x1 = static_cast<int>(p1.x * m_control_scale);
     int y1 = static_cast<int>(p1.y * m_control_scale);
@@ -1024,16 +1025,17 @@ bool asst::Controller::swipe(const Point& p1, const Point& p2, int duration, boo
     int y2 = static_cast<int>(p2.y * m_control_scale);
     // log.trace("Swipe, raw:", p1.x, p1.y, p2.x, p2.y, "corr:", x1, y1, x2, y2);
 
-    return swipe_without_scale(Point(x1, y1), Point(x2, y2), duration, extra_swipe, acceleration_coef);
+    return swipe_without_scale(Point(x1, y1), Point(x2, y2), duration, extra_swipe, slope_in, slope_out);
 }
 
-bool asst::Controller::swipe(const Rect& r1, const Rect& r2, int duration, bool extra_swipe, double acceleration_coef)
+bool asst::Controller::swipe(const Rect& r1, const Rect& r2, int duration, bool extra_swipe, double slope_in,
+                             double slope_out)
 {
-    return swipe(rand_point_in_rect(r1), rand_point_in_rect(r2), duration, extra_swipe, acceleration_coef);
+    return swipe(rand_point_in_rect(r1), rand_point_in_rect(r2), duration, extra_swipe, slope_in, slope_out);
 }
 
 bool asst::Controller::swipe_without_scale(const Point& p1, const Point& p2, int duration, bool extra_swipe,
-                                           double acceleration_coef)
+                                           double slope_in, double slope_out)
 {
     int x1 = p1.x, y1 = p1.y;
     int x2 = p2.x, y2 = p2.y;
@@ -1052,16 +1054,21 @@ bool asst::Controller::swipe_without_scale(const Point& p1, const Point& p2, int
         if (duration == 0) {
             duration = 150;
         }
-        auto minitouch_move = [&](int _x1, int _y1, int _x2, int _y2, int _duration) {
-            double accelerationx = acceleration_coef * static_cast<double>(_x2 - _x1) / (_duration * _duration);
-            double accelerationy = acceleration_coef * static_cast<double>(_y2 - _y1) / (_duration * _duration);
-            double v0x = static_cast<double>(_x2 - _x1) / _duration - accelerationx * _duration;
-            double v0y = static_cast<double>(_y2 - _y1) / _duration - accelerationy * _duration;
 
-            constexpr int TimeInterval = Minitoucher::DefaultSwipeDelay;
+        constexpr int TimeInterval = Minitoucher::DefaultSwipeDelay;
+
+        auto cubic_spline = [](double slope_0, double slope_1, double t) {
+            const double a = slope_0;
+            const double b = -(2 * slope_0 + slope_1 - 3);
+            const double c = -(-slope_0 - slope_1 + 2);
+            return a * t + b * std::pow(t, 2) + c * std::pow(t, 3);
+        }; // TODO: move this to math.hpp
+
+        auto minitouch_move = [&](int _x1, int _y1, int _x2, int _y2, int _duration) {
             for (int cur_time = TimeInterval; cur_time < _duration; cur_time += TimeInterval) {
-                int cur_x = _x1 + static_cast<int>(v0x * cur_time + accelerationx * cur_time * cur_time);
-                int cur_y = _y1 + static_cast<int>(v0y * cur_time + accelerationy * cur_time * cur_time);
+                double progress = cubic_spline(slope_in, slope_out, static_cast<double>(cur_time) / duration);
+                int cur_x = static_cast<int>(std::lerp(_x1, _x2, progress));
+                int cur_y = static_cast<int>(std::lerp(_y1, _y2, progress));
                 if (cur_x < 0 || cur_x > m_minitouch_props.max_x || cur_y < 0 || cur_y > m_minitouch_props.max_y) {
                     continue;
                 }
@@ -1108,11 +1115,10 @@ bool asst::Controller::swipe_without_scale(const Point& p1, const Point& p2, int
     }
 }
 
-bool asst::Controller::swipe_without_scale(const Rect& r1, const Rect& r2, int duration, bool extra_swipe,
-                                           double acceleration_coef)
+bool asst::Controller::swipe_without_scale(const Rect& r1, const Rect& r2, int duration, bool extra_swipe, double v0,
+                                           double v1)
 {
-    return swipe_without_scale(rand_point_in_rect(r1), rand_point_in_rect(r2), duration, extra_swipe,
-                               acceleration_coef);
+    return swipe_without_scale(rand_point_in_rect(r1), rand_point_in_rect(r2), duration, extra_swipe, v0, v1);
 }
 
 bool asst::Controller::connect(const std::string& adb_path, const std::string& address, const std::string& config)

--- a/src/MeoAssistant/Controller.h
+++ b/src/MeoAssistant/Controller.h
@@ -57,14 +57,14 @@ namespace asst
         bool click_without_scale(const Point& p);
         bool click_without_scale(const Rect& rect);
 
-        bool swipe(const Point& p1, const Point& p2, int duration = 0, bool extra_swipe = false,
-                   double acceleration_coef = 0);
-        bool swipe(const Rect& r1, const Rect& r2, int duration = 0, bool extra_swipe = false,
-                   double acceleration_coef = 0);
+        bool swipe(const Point& p1, const Point& p2, int duration = 0, bool extra_swipe = false, double slope_in = 1,
+                   double slope_out = 1);
+        bool swipe(const Rect& r1, const Rect& r2, int duration = 0, bool extra_swipe = false, double slope_in = 1,
+                   double slope_out = 1);
         bool swipe_without_scale(const Point& p1, const Point& p2, int duration = 0, bool extra_swipe = false,
-                                 double acceleration_coef = 0);
+                                 double slope_in = 1, double slope_out = 1);
         bool swipe_without_scale(const Rect& r1, const Rect& r2, int duration = 0, bool extra_swipe = false,
-                                 double acceleration_coef = 0);
+                                 double slope_in = 1, double slope_out = 1);
 
         std::pair<int, int> get_scale_size() const noexcept;
 

--- a/src/MeoAssistant/Task/Plugin/RoguelikeBattleTaskPlugin.cpp
+++ b/src/MeoAssistant/Task/Plugin/RoguelikeBattleTaskPlugin.cpp
@@ -721,7 +721,7 @@ bool asst::RoguelikeBattleTaskPlugin::auto_battle()
         placed_point, { opt_oper.rect.x + opt_oper.rect.width / 2, opt_oper.rect.y + opt_oper.rect.height / 2 }));
     // 1000 是随便取的一个系数，把整数的 pre_delay 转成小数用的
     int duration = static_cast<int>(dist / 800.0 * swipe_oper_task_ptr->pre_delay);
-    m_ctrler->swipe(opt_oper.rect, placed_rect, duration);
+    m_ctrler->swipe(opt_oper.rect, placed_rect, duration, false, 0, 0);
     sleep(use_oper_task_ptr->post_delay);
 
     // 将方向转换为实际的 swipe end 坐标点

--- a/src/MeoAssistant/Task/Sub/BattleProcessTask.cpp
+++ b/src/MeoAssistant/Task/Sub/BattleProcessTask.cpp
@@ -548,7 +548,7 @@ bool asst::BattleProcessTask::oper_deploy(const BattleAction& action, bool only_
         Point::distance(placed_point, { oper_rect.x + oper_rect.width / 2, oper_rect.y + oper_rect.height / 2 }));
     // 1000 是随便取的一个系数，把整数的 pre_delay 转成小数用的
     int duration = static_cast<int>(dist / 800.0 * swipe_oper_task_ptr->pre_delay);
-    m_ctrler->swipe(oper_rect, placed_rect, duration);
+    m_ctrler->swipe(oper_rect, placed_rect, duration, false, 0, 0);
 
     sleep(use_oper_task_ptr->post_delay);
 

--- a/src/MeoAssistant/Task/Sub/ProcessTask.cpp
+++ b/src/MeoAssistant/Task/Sub/ProcessTask.cpp
@@ -187,7 +187,8 @@ bool ProcessTask::_run()
             exec_swipe_task(m_cur_task_ptr->specific_rect, m_cur_task_ptr->rect_move,
                             m_cur_task_ptr->special_params.empty() ? 0 : m_cur_task_ptr->special_params.at(0),
                             (m_cur_task_ptr->special_params.size() < 2) ? false : m_cur_task_ptr->special_params.at(1),
-                            (m_cur_task_ptr->special_params.size() < 3) ? 0 : m_cur_task_ptr->special_params.at(2));
+                            (m_cur_task_ptr->special_params.size() < 3) ? 1 : m_cur_task_ptr->special_params.at(2),
+                            (m_cur_task_ptr->special_params.size() < 4) ? 1 : m_cur_task_ptr->special_params.at(3));
             break;
         case ProcessTaskAction::DoNothing:
             break;
@@ -306,9 +307,9 @@ void ProcessTask::exec_click_task(const Rect& matched_rect)
     m_ctrler->click(matched_rect);
 }
 
-void asst::ProcessTask::exec_swipe_task(const Rect& r1, const Rect& r2, int duration, bool extra_swipe,
-                                        double acceleration_coef)
+void asst::ProcessTask::exec_swipe_task(const Rect& r1, const Rect& r2, int duration, bool extra_swipe, double slope_in,
+                                        double slope_out)
 {
     MinitouchTempSwitcher switcher(m_ctrler);
-    m_ctrler->swipe(r1, r2, duration, extra_swipe, acceleration_coef);
+    m_ctrler->swipe(r1, r2, duration, extra_swipe, slope_in, slope_out);
 }

--- a/src/MeoAssistant/Task/Sub/ProcessTask.h
+++ b/src/MeoAssistant/Task/Sub/ProcessTask.h
@@ -42,7 +42,8 @@ namespace asst
 
         std::pair<int, TimesLimitType> calc_time_limit() const;
         void exec_click_task(const Rect& matched_rect);
-        void exec_swipe_task(const Rect& r1, const Rect& r2, int duration, bool extra_swipe, double acceleration_coef);
+        void exec_swipe_task(const Rect& r1, const Rect& r2, int duration, bool extra_swipe, double slope_in,
+                             double slope_out);
 
         std::shared_ptr<TaskInfo> m_cur_task_ptr = nullptr;
         std::vector<std::string> m_raw_tasks_name;


### PR DESCRIPTION
- 增加 `slope_in` 和 `slope_out` 参数
  - 当数值都为 1 时相当于线性插值
  - 为 0 表示平缓 (开始/结束时速度为 0, [如果都为 0 就是先加速后减速](https://www.wolframalpha.com/input?i=plot+3x%5E2+-+2x%5E3%2C+0%3Cx%3C1))
  - 如果为负数会先 overshoot 再移回来 (没试过)
- 修改 swipe 结束时的 wait (~~我乱改的, 不大清楚这个是干什么用的~~)

感觉对精确划动来说三次样条插值还不够平缓, 再好点恐怕得搞点贝塞尔插值或者把两个 $\exp(-x^2)$ 拼接起来