### PR TITLE
fix: Mac 默认禁用 Gzip 以避免内存泄漏

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 - 新增 自定义基建排班 内置配置文件选择 @MistEO @ABA2396
 - 新增 始终自动检测模拟器连接 选项 @lhhxxxxx
 - 修复 界面 弹出通知时崩溃的问题 @zzyyyl
+- 修复 Mac 默认禁用Gzip以避免内存泄漏 @hguandl
 - 更新 文档、界面、作业群、频道链接 @ABA2396 @horror-proton

--- a/resource/config.json
+++ b/resource/config.json
@@ -209,6 +209,27 @@
             "pushMinitouch": "[Adb] -s [AdbSerial] push \"[minitouchLocalPath]\" \"/data/local/tmp/[minitouchWorkingFile]\"",
             "chmodMinitouch": "[Adb] -s [AdbSerial] shell chmod 700 \"/data/local/tmp/[minitouchWorkingFile]\"",
             "callMinitouch": "[Adb] -s [AdbSerial] shell \"/data/local/tmp/[minitouchWorkingFile]\" -i"
+        },
+        "CompatMac": {
+            "devices": "[Adb] devices",
+            "addressRegex": "(.+)\tdevice",
+            "connect": "[Adb] connect [AdbSerial]",
+            "uuid": "[Adb] -s [AdbSerial] shell echo 111111",
+            "click": "[Adb] -s [AdbSerial] shell input tap [x] [y]",
+            "swipe": "[Adb] -s [AdbSerial] shell input swipe [x1] [y1] [x2] [y2] [duration]",
+            "display": "[Adb] -s [AdbSerial] shell dumpsys window displays | grep -o -E cur=+[^\\ ]+ | grep -o -E [0-9]+",
+            "displayFormat": "%d%d",
+            "screencapRawByNC": "[Adb] -s [AdbSerial] exec-out \"screencap | nc -w 3 [NcAddress] [NcPort]\"",
+            "ncAddress": "[Adb] -s [AdbSerial] shell \" cat /proc/net/arp | grep : \"",
+            "ncPort": 6723,
+            "screencapRawWithGzip": "",
+            "screencapEncode": "[Adb] -s [AdbSerial] exec-out screencap -p",
+            "release": "[Adb] kill-server",
+            "start": "[Adb] -s [AdbSerial] shell am start -n [Intent]",
+            "stop": "[Adb] -s [AdbSerial] shell \"am force-stop `dumpsys activity activities 2>/dev/null | grep Activities= 2>/dev/null | grep -m 1 -i -o -E [^\\ ]*arknights[^/]*`\"",
+            "pushMinitouch": "[Adb] -s [AdbSerial] push \"[minitouchLocalPath]\" \"/data/local/tmp/[minitouchWorkingFile]\"",
+            "chmodMinitouch": "[Adb] -s [AdbSerial] shell chmod 700 \"/data/local/tmp/[minitouchWorkingFile]\"",
+            "callMinitouch": "[Adb] -s [AdbSerial] shell \"/data/local/tmp/[minitouchWorkingFile]\" -i"
         }
     }
 }


### PR DESCRIPTION
#2710