### PR TITLE
fix: 修复macOS启动卡住的问题

### DIFF
--- a/resource/config.json
+++ b/resource/config.json
@@ -238,7 +238,7 @@
             "display": "[Adb] -s [AdbSerial] shell dumpsys window displays | grep -o -E cur=+[^\\ ]+ | grep -o -E [0-9]+",
             "displayFormat": "%d%d",
             "screencapRawByNC": "[Adb] -s [AdbSerial] exec-out \"screencap | nc -w 3 [NcAddress] [NcPort]\"",
-            "ncAddress": "[Adb] -s [AdbSerial] shell \" cat /proc/net/arp | grep : \"",
+            "ncAddress": "[Adb] -s [AdbSerial] shell \"cat /proc/net/arp | grep : | sort\"",
             "ncPort": 6723,
             "screencapRawWithGzip": "",
             "screencapEncode": "[Adb] -s [AdbSerial] exec-out screencap -p",


### PR DESCRIPTION
### 启动卡住的问题

MAA 的 ncAddress 命令在 AVD 下获取错误结果。根据 Android 模拟器文档，宿主机的 IP 一般都是 10.0.2.2。使用这条命令获取的 IP 有时候会是 10.0.2.3。

```
stdout output:
10.0.2.3         0x1         0x2         52:55:0a:00:02:03     *        wlan0
10.0.2.2         0x1         0x2         52:55:0a:00:02:02     *        eth0
10.0.2.2         0x1         0x2         52:55:0a:00:02:02     *        wlan0
10.0.2.3         0x1         0x2         52:55:0a:00:02:03     *        eth0
```

目前的解决方案是加一个 sort，让 10.0.2.2 排在前面。

### macOS 版 App 经常忘记同步的问题

因为我现在没有 MAA 主仓库的 push 权限，我所有对 MeoAsstMac 的修改都只能通过 PR 的形式合并，有时候会忘记。我们要不写个什么 action，让主仓库可以自动 pull。