### PR TITLE
fix: 修复在特殊情况下【借助战赚信用】功能无效 #2903

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -6010,7 +6010,8 @@
             244,
             167
         ],
-        "postDelay": 1000,
+        "preDelay": 1000,
+        "postDelay": 2000,
         "next": [
             "BattleSupportUnitFormationSelect"
         ]
@@ -6023,7 +6024,8 @@
             1165,
             75
         ],
-        "postDelay": 1000
+        "preDelay": 1000,
+        "postDelay": 2000
     },
     "BattleQuickFormation": {
         "action": "ClickSelf",


### PR DESCRIPTION
fix: 修复在特殊情况下【借助战赚信用】功能无效 #2903 
姑且给助战编队加了延迟
另外，如果要在tasks.json里写“等待，直到识别到开始按钮”是不是只能写成这样：
"WaitUntilBattleStartNormal": {
        "algorithm": "JustReturn",
        "action": "DoNothing",
        "next": [
            "BattleStartNormal",
            "WaitUntilBattleStartNormal"
        ]
    },

"BattleStartNormal": {
        "baseTask": "BattleStart"
    },
