### PR TITLE
修改截图命令 && 添加Python额外配置(触控, 暂停下干员等)接口

### DIFF
--- a/resource/config.json
+++ b/resource/config.json
@@ -125,8 +125,6 @@
         {
             "configName": "GeneralWithoutScreencapErr",
             "baseConfig": "General",
-            "screencapRawByNC": "[Adb] -s [AdbSerial] exec-out \"screencap 2>/tmp/maa-assistant-arknights.log | nc -w 3 [NcAddress] [NcPort]\"",
-            "screencapRawWithGzip": "[Adb] -s [AdbSerial] exec-out \"screencap 2>/tmp/maa-assistant-arknights.log | gzip -1\"",
             "screencapEncode": "[Adb] -s [AdbSerial] exec-out screencap -p 2>/tmp/maa-assistant-arknights.log"
         }
     ]

--- a/resource/config.json
+++ b/resource/config.json
@@ -61,11 +61,11 @@
             "pressEsc": "[Adb] -s [AdbSerial] shell input keyevent 111",
             "display": "[Adb] -s [AdbSerial] shell dumpsys window displays | grep -o -E cur=+[^\\ ]+ | grep -o -E [0-9]+",
             "displayFormat": "%d%d",
-            "screencapRawByNC": "[Adb] -s [AdbSerial] exec-out \"screencap 2>/dev/null | nc -w 3 [NcAddress] [NcPort]\"",
+            "screencapRawByNC": "[Adb] -s [AdbSerial] exec-out \"screencap | nc -w 3 [NcAddress] [NcPort]\"",
             "ncAddress": "[Adb] -s [AdbSerial] shell \" cat /proc/net/arp | grep : \"",
             "ncPort": 6723,
-            "screencapRawWithGzip": "[Adb] -s [AdbSerial] exec-out \"screencap 2>/dev/null | gzip -1\"",
-            "screencapEncode": "[Adb] -s [AdbSerial] exec-out screencap -p 2>/dev/null",
+            "screencapRawWithGzip": "[Adb] -s [AdbSerial] exec-out \"screencap | gzip -1\"",
+            "screencapEncode": "[Adb] -s [AdbSerial] exec-out screencap -p",
             "release": "[Adb] kill-server",
             "start": "[Adb] -s [AdbSerial] shell am start -n [Intent]",
             "stop": "[Adb] -s [AdbSerial] shell \"am force-stop `dumpsys activity activities 2>/dev/null | grep Activities= 2>/dev/null | grep -m 1 -i -o -E [^\\ ]*arknights[^/]*`\"",
@@ -79,9 +79,9 @@
         {
             "configName": "CapWithShell",
             "baseConfig": "General",
-            "screencapRawByNC": "[Adb] -s [AdbSerial] shell \"screencap 2>/dev/null | nc -w 3 [NcAddress] [NcPort]\"",
-            "screencapRawWithGzip": "[Adb] -s [AdbSerial] shell \"screencap 2>/dev/null | gzip -1\"",
-            "screencapEncode": "[Adb] -s [AdbSerial] shell screencap -p 2>/dev/null"
+            "screencapRawByNC": "[Adb] -s [AdbSerial] shell \"screencap | nc -w 3 [NcAddress] [NcPort]\"",
+            "screencapRawWithGzip": "[Adb] -s [AdbSerial] shell \"screencap | gzip -1\"",
+            "screencapEncode": "[Adb] -s [AdbSerial] shell screencap -p"
         },
         {
             "configName": "BlueStacks",

--- a/resource/config.json
+++ b/resource/config.json
@@ -61,11 +61,11 @@
             "pressEsc": "[Adb] -s [AdbSerial] shell input keyevent 111",
             "display": "[Adb] -s [AdbSerial] shell dumpsys window displays | grep -o -E cur=+[^\\ ]+ | grep -o -E [0-9]+",
             "displayFormat": "%d%d",
-            "screencapRawByNC": "[Adb] -s [AdbSerial] exec-out \"screencap | nc -w 3 [NcAddress] [NcPort]\"",
+            "screencapRawByNC": "[Adb] -s [AdbSerial] exec-out \"screencap 2>/dev/null | nc -w 3 [NcAddress] [NcPort]\"",
             "ncAddress": "[Adb] -s [AdbSerial] shell \" cat /proc/net/arp | grep : \"",
             "ncPort": 6723,
-            "screencapRawWithGzip": "[Adb] -s [AdbSerial] exec-out \"screencap | gzip -1\"",
-            "screencapEncode": "[Adb] -s [AdbSerial] exec-out screencap -p",
+            "screencapRawWithGzip": "[Adb] -s [AdbSerial] exec-out \"screencap 2>/dev/null | gzip -1\"",
+            "screencapEncode": "[Adb] -s [AdbSerial] exec-out screencap -p 2>/dev/null",
             "release": "[Adb] kill-server",
             "start": "[Adb] -s [AdbSerial] shell am start -n [Intent]",
             "stop": "[Adb] -s [AdbSerial] shell \"am force-stop `dumpsys activity activities 2>/dev/null | grep Activities= 2>/dev/null | grep -m 1 -i -o -E [^\\ ]*arknights[^/]*`\"",
@@ -79,9 +79,9 @@
         {
             "configName": "CapWithShell",
             "baseConfig": "General",
-            "screencapRawByNC": "[Adb] -s [AdbSerial] shell \"screencap | nc -w 3 [NcAddress] [NcPort]\"",
-            "screencapRawWithGzip": "[Adb] -s [AdbSerial] shell \"screencap | gzip -1\"",
-            "screencapEncode": "[Adb] -s [AdbSerial] shell screencap -p"
+            "screencapRawByNC": "[Adb] -s [AdbSerial] shell \"screencap 2>/dev/null | nc -w 3 [NcAddress] [NcPort]\"",
+            "screencapRawWithGzip": "[Adb] -s [AdbSerial] shell \"screencap 2>/dev/null | gzip -1\"",
+            "screencapEncode": "[Adb] -s [AdbSerial] shell screencap -p 2>/dev/null"
         },
         {
             "configName": "BlueStacks",

--- a/resource/config.json
+++ b/resource/config.json
@@ -121,6 +121,13 @@
             "baseConfig": "Compatible",
             "ncAddress": "[Adb] -s [AdbSerial] shell \"cat /proc/net/arp | grep : | sort\"",
             "screencapRawWithGzip": ""
+        },
+        {
+            "configName": "GeneralWithoutScreencapErr",
+            "baseConfig": "General",
+            "screencapRawByNC": "[Adb] -s [AdbSerial] exec-out \"screencap 2>/tmp/maa-assistant-arknights.log | nc -w 3 [NcAddress] [NcPort]\"",
+            "screencapRawWithGzip": "[Adb] -s [AdbSerial] exec-out \"screencap 2>/tmp/maa-assistant-arknights.log | gzip -1\"",
+            "screencapEncode": "[Adb] -s [AdbSerial] exec-out screencap -p 2>/tmp/maa-assistant-arknights.log"
         }
     ]
 }

--- a/resource/config.json
+++ b/resource/config.json
@@ -126,7 +126,7 @@
             "configName": "GeneralWithoutScreencapErr",
             "baseConfig": "General",
             "screencapRawWithGzip": "[Adb] -s [AdbSerial] exec-out \"screencap 2>/tmp/maa-assistant-arknights.log | gzip -1\"",
-            "screencapEncode": "[Adb] -s [AdbSerial] exec-out screencap -p 2>/tmp/maa-assistant-arknights.log"
+            "screencapEncode": "[Adb] -s [AdbSerial] exec-out \"screencap -p 2>/tmp/maa-assistant-arknights.log\""
         }
     ]
 }

--- a/resource/config.json
+++ b/resource/config.json
@@ -125,6 +125,8 @@
         {
             "configName": "GeneralWithoutScreencapErr",
             "baseConfig": "General",
+            "screencapRawByNC": "[Adb] -s [AdbSerial] exec-out \"screencap 2>/tmp/maa-assistant-arknights.log | nc -w 3 [NcAddress] [NcPort]\"",
+            "screencapRawWithGzip": "[Adb] -s [AdbSerial] exec-out \"screencap 2>/tmp/maa-assistant-arknights.log | gzip -1\"",
             "screencapEncode": "[Adb] -s [AdbSerial] exec-out screencap -p 2>/tmp/maa-assistant-arknights.log"
         }
     ]

--- a/resource/config.json
+++ b/resource/config.json
@@ -125,7 +125,6 @@
         {
             "configName": "GeneralWithoutScreencapErr",
             "baseConfig": "General",
-            "screencapRawByNC": "[Adb] -s [AdbSerial] exec-out \"screencap 2>/tmp/maa-assistant-arknights.log | nc -w 3 [NcAddress] [NcPort]\"",
             "screencapRawWithGzip": "[Adb] -s [AdbSerial] exec-out \"screencap 2>/tmp/maa-assistant-arknights.log | gzip -1\"",
             "screencapEncode": "[Adb] -s [AdbSerial] exec-out screencap -p 2>/tmp/maa-assistant-arknights.log"
         }

--- a/src/MaaWpfGui/Main/SettingsViewModel.cs
+++ b/src/MaaWpfGui/Main/SettingsViewModel.cs
@@ -171,6 +171,7 @@ namespace MaaWpfGui
             ConnectConfigList = new List<CombData>
             {
                 new CombData { Display = Localization.GetString("General"), Value = "General" },
+                new CombData { Display = Localization.GetString("GeneralWithoutScreencapErr"), Value = "GeneralWithoutScreencapErr" },
                 new CombData { Display = Localization.GetString("BlueStacks"), Value = "BlueStacks" },
                 new CombData { Display = Localization.GetString("MuMuEmulator"), Value = "MuMuEmulator" },
                 new CombData { Display = Localization.GetString("LDPlayer"), Value = "LDPlayer" },

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -55,6 +55,7 @@
     <system:String x:Key="CustomInfrastPlanIndexAutoSwitch">Auto save for next plan</system:String>
 
     <system:String x:Key="General">General Mode</system:String>
+    <system:String x:Key="GeneralWithoutScreencapErr">General Mode(Blocked screenshot's error)</system:String>
     <system:String x:Key="BlueStacks">BlueStacks</system:String>
     <system:String x:Key="MuMuEmulator">MuMu Emulator</system:String>
     <system:String x:Key="LDPlayer">LD Player</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -48,6 +48,7 @@
     <system:String x:Key="CustomInfrastPlanIndexAutoSwitch">Auto save for next plan</system:String>
 
     <system:String x:Key="General">一般モード</system:String>
+    <system:String x:Key="GeneralWithoutScreencapErr">一般モード(ブロックされたスクリーンショットエラー)</system:String>
     <system:String x:Key="BlueStacks">BlueStacks</system:String>
     <system:String x:Key="MuMuEmulator">MuMuPlayer</system:String>
     <system:String x:Key="LDPlayer">LDPlayer</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -54,6 +54,7 @@
     <system:String x:Key="CustomInfrastPlanIndexAutoSwitch">다음 계획용으로 자동 저장</system:String>
 
     <system:String x:Key="General">일반 모드</system:String>
+    <system:String x:Key="GeneralWithoutScreencapErr">일반 모드(차단된 스크린샷 오류)</system:String>
     <system:String x:Key="BlueStacks">BlueStacks</system:String>
     <system:String x:Key="MuMuEmulator">MuMu Player</system:String>
     <system:String x:Key="LDPlayer">LD Player</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -55,6 +55,7 @@
     <system:String x:Key="CustomInfrastPlanIndexAutoSwitch">自动保存为下个计划</system:String>
 
     <system:String x:Key="General">通用模式</system:String>
+    <system:String x:Key="GeneralWithoutScreencapErr">通用模式(屏蔽截图报错)</system:String>
     <system:String x:Key="BlueStacks">蓝叠模拟器</system:String>
     <system:String x:Key="MuMuEmulator">MuMu 模拟器</system:String>
     <system:String x:Key="LDPlayer">雷电模拟器</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -47,6 +47,7 @@
     <system:String x:Key="CustomInfrastPlanIndexAutoSwitch">自動保存爲下個計劃</system:String>
 
     <system:String x:Key="General">通用模式</system:String>
+    <system:String x:Key="GeneralWithoutScreencapErr">通用模式(屏蔽截圖報錯)</system:String>
     <system:String x:Key="BlueStacks">藍疊模擬器</system:String>
     <system:String x:Key="MuMuEmulator">MuMu 模擬器</system:String>
     <system:String x:Key="LDPlayer">雷電模擬器</system:String>

--- a/src/Python/asst.py
+++ b/src/Python/asst.py
@@ -10,6 +10,11 @@ from enum import Enum, unique, auto
 JSON = Union[Dict[str, Any], List[Any], int, str, float, bool, Type[None]]
 
 
+
+class ExternalConfigType(Enum):
+    touch_type: 2
+    deployment_with_pause: 3
+
 class Asst:
     CallBackType = ctypes.CFUNCTYPE(
         None, ctypes.c_int, ctypes.c_char_p, ctypes.c_void_p)
@@ -73,6 +78,21 @@ class Asst:
         Asst.__lib.AsstDestroy(self.__ptr)
         self.__ptr = None
 
+    def set_external_config(self, config_type: ExternalConfigType, config_value: str):
+        """
+        设置额外配置
+        参见${MaaAssistantArknights}/src/MaaCore/Assistant.cpp#set_instance_option
+
+        :params:
+            ``externa_config``: 额外配置类型
+            ``config_value``:   额外配置的值
+
+        :return: 是否设置成功
+        """
+        return Asst.__lib.AsstSetInstanceOption(self.__ptr,
+                                                config_type, config_value.encode('utf-8'))
+
+
     def connect(self, adb_path: str, address: str, config: str = 'General', touch_config: str = 'minitouch'):
         """
         连接设备
@@ -81,13 +101,9 @@ class Asst:
             ``adb_path``:       adb 程序的路径
             ``address``:        adb 地址+端口
             ``config``:         adb 配置，可参考 resource/config.json
-            ``touch_config``:   触控配置, 参见 ${MaaAssistantArknights}/src/MaaCore/AsstCaller.cpp#AsstSetInstanceOption
-                                默认配置为'minitouch', 可选配置'adb', 'maatouch'
 
         :return: 是否连接成功
         """
-        Asst.__lib.AsstSetInstanceOption(self.__ptr,
-                                         2, touch_config.encode('utf-8'))
         return Asst.__lib.AsstConnect(self.__ptr,
                                       adb_path.encode('utf-8'), address.encode('utf-8'), config.encode('utf-8'))
 

--- a/src/Python/asst.py
+++ b/src/Python/asst.py
@@ -10,10 +10,10 @@ from enum import Enum, unique, auto
 JSON = Union[Dict[str, Any], List[Any], int, str, float, bool, Type[None]]
 
 
-
-class ExternalConfigType(Enum):
+class InstanceOptionType(Enum):
     touch_type: 2
     deployment_with_pause: 3
+
 
 class Asst:
     CallBackType = ctypes.CFUNCTYPE(
@@ -78,7 +78,7 @@ class Asst:
         Asst.__lib.AsstDestroy(self.__ptr)
         self.__ptr = None
 
-    def set_external_config(self, config_type: ExternalConfigType, config_value: str):
+    def set_instance_option(self, option_type: InstanceOptionType, option_value: str):
         """
         设置额外配置
         参见${MaaAssistantArknights}/src/MaaCore/Assistant.cpp#set_instance_option
@@ -90,7 +90,7 @@ class Asst:
         :return: 是否设置成功
         """
         return Asst.__lib.AsstSetInstanceOption(self.__ptr,
-                                                config_type, config_value.encode('utf-8'))
+                                                option_type, option_value.encode('utf-8'))
 
 
     def connect(self, adb_path: str, address: str, config: str = 'General', touch_config: str = 'minitouch'):

--- a/src/Python/asst.py
+++ b/src/Python/asst.py
@@ -73,17 +73,22 @@ class Asst:
         Asst.__lib.AsstDestroy(self.__ptr)
         self.__ptr = None
 
-    def connect(self, adb_path: str, address: str, config: str = 'General'):
+    def connect(self, adb_path: str, address: str, config: str = 'General', touch_config: str = 'Default'):
         """
         连接设备
 
         :params:
-            ``adb_path``:   adb 程序的路径
-            ``address``:    adb 地址+端口
-            ``config``:     adb 配置，可参考 resource/config.json
+            ``adb_path``:       adb 程序的路径
+            ``address``:        adb 地址+端口
+            ``config``:         adb 配置，可参考 resource/config.json
+            ``touch_config``:   触控配置, 参见 ${MaaAssistantArknights}/src/MaaCore/AsstCaller.cpp#AsstSetInstanceOption
+                                默认配置为'minitouch', 可选配置'adb', 'maatouch'
 
         :return: 是否连接成功
         """
+        if touch_config != 'Default':
+            Asst.__lib.AsstSetInstanceOption(self.__ptr,
+                                             2, touch_config.encode('utf-8'))
         return Asst.__lib.AsstConnect(self.__ptr,
                                       adb_path.encode('utf-8'), address.encode('utf-8'), config.encode('utf-8'))
 

--- a/src/Python/asst.py
+++ b/src/Python/asst.py
@@ -73,7 +73,7 @@ class Asst:
         Asst.__lib.AsstDestroy(self.__ptr)
         self.__ptr = None
 
-    def connect(self, adb_path: str, address: str, config: str = 'General', touch_config: str = 'Default'):
+    def connect(self, adb_path: str, address: str, config: str = 'General', touch_config: str = 'minitouch'):
         """
         连接设备
 
@@ -86,9 +86,8 @@ class Asst:
 
         :return: 是否连接成功
         """
-        if touch_config != 'Default':
-            Asst.__lib.AsstSetInstanceOption(self.__ptr,
-                                             2, touch_config.encode('utf-8'))
+        Asst.__lib.AsstSetInstanceOption(self.__ptr,
+                                         2, touch_config.encode('utf-8'))
         return Asst.__lib.AsstConnect(self.__ptr,
                                       adb_path.encode('utf-8'), address.encode('utf-8'), config.encode('utf-8'))
 
@@ -180,6 +179,10 @@ class Asst:
             ctypes.c_void_p, ctypes.c_void_p,)
 
         Asst.__lib.AsstDestroy.argtypes = (ctypes.c_void_p,)
+
+        Asst.__lib.AsstSetInstanceOption.restype = ctypes.c_bool
+        Asst.__lib.AsstSetInstanceOption.argtypes = (
+            ctypes.c_void_p, ctypes.c_int, ctypes.c_char_p,)
 
         Asst.__lib.AsstConnect.restype = ctypes.c_bool
         Asst.__lib.AsstConnect.argtypes = (

--- a/src/Python/sample.py
+++ b/src/Python/sample.py
@@ -2,7 +2,7 @@ import json
 import pathlib
 import time
 
-from asst import Asst, Message
+from asst import ExternalConfigType, Asst, Message
 
 
 @Asst.CallBackType
@@ -25,6 +25,12 @@ if __name__ == "__main__":
     # 若需要获取详细执行信息，请传入 callback 参数
     # 例如 asst = Asst(callback=my_callback)
     asst = Asst()
+
+    ## 设置额外配置
+    # 触控方案配置
+    # asst.set_external_config(ExternalConfigType.touch_type, 'maatouch')
+    # 暂停下干员
+    # asst.set_external_config(ExternalConfigType.deployment_with_pause, '1')
 
     # 请自行配置 adb 环境变量，或修改为 adb 可执行程序的路径
     if asst.connect('adb.exe', '127.0.0.1:5555'):

--- a/src/Python/sample.py
+++ b/src/Python/sample.py
@@ -2,7 +2,7 @@ import json
 import pathlib
 import time
 
-from asst import ExternalConfigType, Asst, Message
+from asst import InstanceOptionType, Asst, Message
 
 
 @Asst.CallBackType
@@ -28,9 +28,9 @@ if __name__ == "__main__":
 
     ## 设置额外配置
     # 触控方案配置
-    # asst.set_external_config(ExternalConfigType.touch_type, 'maatouch')
+    # asst.set_instance_option(InstanceOptionType.touch_type, 'maatouch')
     # 暂停下干员
-    # asst.set_external_config(ExternalConfigType.deployment_with_pause, '1')
+    # asst.set_instance_option(InstanceOptionType.deployment_with_pause, '1')
 
     # 请自行配置 adb 环境变量，或修改为 adb 可执行程序的路径
     if asst.connect('adb.exe', '127.0.0.1:5555'):


### PR DESCRIPTION
丢弃截图命令的stderr. 如Amd显卡+Waydroid时, screencap会先输出一行报错, 再输出图片信息, 通过丢弃stderr让adb exec-out能得到仅图片信息, 防止MAA解码失败.

py接口新增额外配置(触控, 暂停下干员等)方法.