### PR TITLE
Update 1.3-模拟器支持.md

### DIFF
--- a/docs/1.3-模拟器支持.md
+++ b/docs/1.3-模拟器支持.md
@@ -30,12 +30,16 @@
 
     4. 开启 MAA，LinkStart！
 
-- 如果你还需要多开（不使用多开请忽略这步），可以再修改 MAA 检测配置文件的关键字。  
+- 如果你还需要多开或者你使用蓝叠Pie核心Hyper-V模拟器（不使用多开请忽略这步），可以再修改 MAA 检测配置文件的关键字。  
     参照上述步骤，添加 `Bluestacks.Config.Keyword` 字段  
     示例：
 
     ```jsonc
     "Bluestacks.Config.Keyword":"bst.instance.Nougat64.status.adb_port",
+    ```
+    蓝叠Pie核心Hyper-V模拟器示例：
+    ```jsonc
+    "Bluestacks.Config.Keyword": "bst.instance.Pie64.status.adb_port",
     ```
 
 ## ✅ [夜神模拟器](https://www.yeshen.com/)

--- a/docs/1.3-模拟器支持.md
+++ b/docs/1.3-模拟器支持.md
@@ -30,14 +30,15 @@
 
     4. 开启 MAA，LinkStart！
 
-- 如果你还需要多开或者你使用蓝叠Pie核心Hyper-V模拟器（不使用多开请忽略这步），可以再修改 MAA 检测配置文件的关键字。  
+- 如果你还需要多开或者你使用蓝叠 Pie 核心 Hyper-V 模拟器（不使用多开请忽略这步），可以再修改 MAA 检测配置文件的关键字。  
     参照上述步骤，添加 `Bluestacks.Config.Keyword` 字段  
     示例：
 
     ```jsonc
     "Bluestacks.Config.Keyword":"bst.instance.Nougat64.status.adb_port",
     ```
-    蓝叠Pie核心Hyper-V模拟器示例：
+
+    Pie 核心 Hyper-V 模拟器示例：
     ```jsonc
     "Bluestacks.Config.Keyword": "bst.instance.Pie64.status.adb_port",
     ```


### PR DESCRIPTION
对与使用蓝叠Pie核心版Hyper-V模拟器的情况 需要同时怎加"Bluestacks.Config.Keyword": "bst.instance.Pie64.status.adb_port"才能正确识别adb端口