### PR TITLE
fix: 解决生息演算中退出按钮循环点击过快导致无法按下确认按钮的bug

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -9910,6 +9910,7 @@
         ]
     },
     "Reclamation@ClickExitLevel":{
+        "postDelay": 2000,
         "action": "ClickRect",
         "roi": [
             100, 0, 164, 166


### PR DESCRIPTION
生息演算里面退出按钮点击完成之后没做延迟，导致他连续按退出无法识别确认按钮，进而导致无限循环卡住，这里添加上这条延迟