### PR TITLE
fix: 修复选完人全队补充后卡在演算开始界面的问题

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -9763,6 +9763,7 @@
         ]
     },
     "Reclamation@InitSupplyAll":{
+        "postDelay": 3000,
         "roi": [
             862,
             572,
@@ -9776,7 +9777,6 @@
         ]
     },
     "Reclamation@ConfirmStart":{
-        "postDelay": 2000,
         "roi": [
             874,
             503,

--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -9764,9 +9764,9 @@
     },
     "Reclamation@InitSupplyAll":{
         "roi": [
-            862, 
-            572, 
-            418, 
+            862,
+            572,
+            418,
             148
         ],
         "action": "ClickSelf",
@@ -9776,6 +9776,7 @@
         ]
     },
     "Reclamation@ConfirmStart":{
+        "postDelay": 2000,
         "roi": [
             874,
             503,
@@ -9816,9 +9817,9 @@
         ],
         "action": "ClickRect",
         "specificRect": [
-            1190, 
-            651, 
-            52, 
+            1190,
+            651,
+            52,
             48
         ],
         "next": [
@@ -10054,6 +10055,6 @@
         "action": "ClickSelf",
         "next": [
             "Reclamation@Begin"
-        ]   
+        ]
     }
 }


### PR DESCRIPTION
生息演算选完人全队补充后因为动画太长并且没设置延迟，导致无法及时识别到演算开始按钮，然后直接报错停止。
顺便删掉了一点多余的空格