### PR TITLE
fix: `call_command_posix` in socket mode should return after child process finished

### DIFF
--- a/src/MaaCore/Controller.cpp
+++ b/src/MaaCore/Controller.cpp
@@ -1,7 +1,6 @@
 #include "Controller.h"
 
 #include "Utils/Platform.hpp"
-#include <sys/socket.h>
 
 #ifdef _WIN32
 #include <ws2tcpip.h>
@@ -9,6 +8,7 @@
 #include <fcntl.h>
 #include <signal.h>
 #include <sys/errno.h>
+#include <sys/socket.h>
 #ifndef __APPLE__
 #include <sys/prctl.h>
 #endif

--- a/src/MaaCore/Controller.cpp
+++ b/src/MaaCore/Controller.cpp
@@ -1,6 +1,7 @@
 #include "Controller.h"
 
 #include "Utils/Platform.hpp"
+#include <sys/socket.h>
 
 #ifdef _WIN32
 #include <ws2tcpip.h>
@@ -1608,6 +1609,7 @@ std::optional<int> asst::Controller::call_command_posix(const std::string& cmd, 
                 sock_data.insert(sock_data.end(), sock_buffer.get(), sock_buffer.get() + read_num);
                 read_num = ::read(client_socket, sock_buffer.get(), sock_buffer.size());
             }
+            ::shutdown(client_socket, SHUT_RDWR);
             ::close(client_socket);
         }
         else {

--- a/src/MaaCore/Controller.cpp
+++ b/src/MaaCore/Controller.cpp
@@ -1590,37 +1590,36 @@ std::optional<int> asst::Controller::call_command_posix(const std::string& cmd, 
     }
     else if (m_child > 0) {
         // parent process
-        do {
-            if (recv_by_socket) {
-                sockaddr addr {};
-                socklen_t len = sizeof(addr);
-                sock_buffer = asst::platform::single_page_buffer<char>();
+        if (recv_by_socket) {
+            sockaddr addr {};
+            socklen_t len = sizeof(addr);
+            sock_buffer = asst::platform::single_page_buffer<char>();
 
-                int client_socket = ::accept(m_server_sock, &addr, &len);
-                if (client_socket < 0) {
-                    Log.error("accept failed:", strerror(errno));
-                    ::kill(m_child, SIGKILL);
-                    return std::nullopt;
-                }
-
-                ssize_t read_num = ::read(client_socket, sock_buffer.get(), sock_buffer.size());
-
-                while (read_num > 0) {
-                    sock_data.insert(sock_data.end(), sock_buffer.get(), sock_buffer.get() + read_num);
-                    read_num = ::read(client_socket, sock_buffer.get(), sock_buffer.size());
-                }
-
-                ::close(client_socket);
+            int client_socket = ::accept(m_server_sock, &addr, &len);
+            if (client_socket < 0) {
+                Log.error("accept failed:", strerror(errno));
+                ::kill(m_child, SIGKILL);
+                ::waitpid(m_child, &exit_ret, 0); 
+                return std::nullopt;
             }
-            else {
-                ssize_t read_num = ::read(m_pipe_out[PIPE_READ], pipe_buffer.get(), pipe_buffer.size());
 
+            ssize_t read_num = ::read(client_socket, sock_buffer.get(), sock_buffer.size());
+            while (read_num > 0) {
+                sock_data.insert(sock_data.end(), sock_buffer.get(), sock_buffer.get() + read_num);
+                read_num = ::read(client_socket, sock_buffer.get(), sock_buffer.size());
+            }
+            ::close(client_socket);
+        }
+        else {
+            do {
+                ssize_t read_num = ::read(m_pipe_out[PIPE_READ], pipe_buffer.get(), pipe_buffer.size());
                 while (read_num > 0) {
                     pipe_data.insert(pipe_data.end(), pipe_buffer.get(), pipe_buffer.get() + read_num);
                     read_num = ::read(m_pipe_out[PIPE_READ], pipe_buffer.get(), pipe_buffer.size());
                 }
-            }
-        } while (::waitpid(m_child, &exit_ret, WNOHANG) == 0 && !check_timeout());
+            } while (::waitpid(m_child, &exit_ret, WNOHANG) == 0 && !check_timeout());
+        }
+        ::waitpid(m_child, &exit_ret, 0); // if ::waitpid(m_child, &exit_ret, WNOHANG) == 0, repeat it will cause ECHILD, so not check the return value
     }
     else {
         // failed to create child process


### PR DESCRIPTION
`recv_by_socket`模式下直接使用break跳出while循环, 未等待子进程结束. 由于短时间多次调用该API(大概是失败重试机制), fork的大量子进程也由于饥饿无法调度到结束. 
导致出现数次以下LOG后系统全局进程资源不足

```log
[2023-02-06 20:20:42.595][ERR][Px11c40][Tx72b5ddf9be091e81] Call ` /Applications/MAA.app/Contents/MacOS/adb -s 127.0.0.1:5555 exec-out "screencap | nc -w 3 10.0.2.2 51412" ` create process failed, child: -1
[2023-02-06 20:20:42.595][ERR][Px11c40][Tx72b5ddf9be091e81] data is empty!
[2023-02-06 20:20:42.595][ERR][Px11c40][Tx72b5ddf9be091e81] Call ` /Applications/MAA.app/Contents/MacOS/adb -s 127.0.0.1:5555 exec-out "screencap | nc -w 3 10.0.2.2 51412" ` create process failed, child: -1
[2023-02-06 20:20:42.595][ERR][Px11c40][Tx72b5ddf9be091e81] data is empty!
[2023-02-06 20:20:42.595][ERR][Px11c40][Tx72b5ddf9be091e81] Call ` /Applications/MAA.app/Contents/MacOS/adb -s 127.0.0.1:5555 exec-out "screencap | nc -w 3 10.0.2.2 51412" ` create process failed, child: -1
[2023-02-06 20:20:42.595][ERR][Px11c40][Tx72b5ddf9be091e81] data is empty!
[2023-02-06 20:20:42.595][ERR][Px11c40][Tx72b5ddf9be091e81] Call ` /Applications/MAA.app/Contents/MacOS/adb -s 127.0.0.1:5555 exec-out "screencap | nc -w 3 10.0.2.2 51412" ` create process failed, child: -1
[2023-02-06 20:20:42.595][ERR][Px11c40][Tx72b5ddf9be091e81] data is empty!
```