### PR TITLE
refactor: 重构注入方式

### DIFF
--- a/src/MaaWpfGui/Helper/MaaHotKeys/MaaHotKeyActionHandler.cs
+++ b/src/MaaWpfGui/Helper/MaaHotKeys/MaaHotKeyActionHandler.cs
@@ -19,8 +19,9 @@ namespace MaaWpfGui.MaaHotKeys
 {
     public class MaaHotKeyActionHandler : IMaaHotKeyActionHandler
     {
-        private readonly IContainer _container;
         private readonly IMainWindowManager _mainWindowManager;
+
+        private readonly TaskQueueViewModel _taskQueueViewModel;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="MaaHotKeyActionHandler"/> class.
@@ -28,7 +29,7 @@ namespace MaaWpfGui.MaaHotKeys
         /// <param name="container"></param>
         public MaaHotKeyActionHandler(IContainer container)
         {
-            _container = container;
+            _taskQueueViewModel = container.Get<TaskQueueViewModel>();
             _mainWindowManager = container.Get<IMainWindowManager>();
         }
 
@@ -52,16 +53,14 @@ namespace MaaWpfGui.MaaHotKeys
 
         protected virtual void HandleLinkStart()
         {
-            var mainModel = _container.Get<TaskQueueViewModel>();
-
-            if (mainModel.Stopping)
+            if (_taskQueueViewModel.Stopping)
             {
                 return;
             }
 
-            if (mainModel.Idle)
+            if (_taskQueueViewModel.Idle)
             {
-                mainModel.LinkStart();
+                _taskQueueViewModel.LinkStart();
 
                 if (_mainWindowManager.GetWindowState() != WindowState.Minimized)
                 {
@@ -73,7 +72,7 @@ namespace MaaWpfGui.MaaHotKeys
             }
             else
             {
-                mainModel.Stop();
+                _taskQueueViewModel.Stop();
 
                 if (Application.Current.MainWindow == null ||
                     Application.Current.MainWindow.WindowState != WindowState.Minimized)

--- a/src/MaaWpfGui/Helper/StageManager.cs
+++ b/src/MaaWpfGui/Helper/StageManager.cs
@@ -36,8 +36,11 @@ namespace MaaWpfGui
         [DllImport("MaaCore.dll")]
         private static extern IntPtr AsstGetVersion();
 
-        private readonly IContainer _container;
+        // model references
+        private readonly TaskQueueViewModel _taskQueueViewModel;
+        private readonly SettingsViewModel _settingsViewModel;
 
+        // datas
         private Dictionary<string, StageInfo> _stages;
 
         /// <summary>
@@ -46,7 +49,8 @@ namespace MaaWpfGui
         /// <param name="container">The IoC container.</param>
         public StageManager(IContainer container)
         {
-            _container = container;
+            _taskQueueViewModel = container.Get<TaskQueueViewModel>();
+            _settingsViewModel = container.Get<SettingsViewModel>();
             UpdateStage(false);
 
             Execute.OnUIThread(async () =>
@@ -56,10 +60,10 @@ namespace MaaWpfGui
                     UpdateStage(true);
                 });
                 await task;
-                if (_container != null)
+                if (_taskQueueViewModel != null)
                 {
-                    _container.Get<TaskQueueViewModel>().UpdateDatePrompt();
-                    _container.Get<TaskQueueViewModel>().UpdateStageList(true);
+                    _taskQueueViewModel.UpdateDatePrompt();
+                    _taskQueueViewModel.UpdateStageList(true);
                 }
             });
         }
@@ -86,8 +90,7 @@ namespace MaaWpfGui
                    "yyyy/MM/dd HH:mm:ss",
                    CultureInfo.InvariantCulture).AddHours(-Convert.ToInt32(keyValuePairs?["TimeZone"].ToString() ?? "0"));
 
-            var settingsModel = _container.Get<SettingsViewModel>();
-            var clientType = settingsModel.ClientType;
+            var clientType = _settingsViewModel.ClientType;
 
             // 官服和B服使用同样的资源
             if (clientType == "Bilibili" || clientType == string.Empty)

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -152,6 +152,13 @@ namespace MaaWpfGui
 
         private readonly CallbackDelegate _callback;
 
+        // model references
+        private readonly SettingsViewModel _settingsViewModel;
+        private readonly TaskQueueViewModel _taskQueueViewModel;
+        private readonly RecruitViewModel _recruitViewModel;
+        private readonly CopilotViewModel _copilotViewModel;
+        private readonly DepotViewModel _depotViewModel;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="AsstProxy"/> class.
         /// </summary>
@@ -159,7 +166,12 @@ namespace MaaWpfGui
         /// <param name="windowManager">当前窗口。</param>
         public AsstProxy(IContainer container, IWindowManager windowManager)
         {
-            _container = container;
+            _settingsViewModel = container.Get<SettingsViewModel>();
+            _taskQueueViewModel = container.Get<TaskQueueViewModel>();
+            _recruitViewModel = container.Get<RecruitViewModel>();
+            _copilotViewModel = container.Get<CopilotViewModel>();
+            _depotViewModel = container.Get<DepotViewModel>();
+
             _windowManager = windowManager;
             _callback = CallbackFunction;
         }
@@ -185,15 +197,14 @@ namespace MaaWpfGui
         /// <returns>是否成功。</returns>
         public bool LoadResource()
         {
-            var settingsModel = _container.Get<SettingsViewModel>();
-            if (!ForcedReloadResource && settingsModel.ClientType == _curResource)
+            if (!ForcedReloadResource && _settingsViewModel.ClientType == _curResource)
             {
                 return true;
             }
 
             bool loaded = false;
-            if (settingsModel.ClientType == string.Empty
-                || settingsModel.ClientType == "Official" || settingsModel.ClientType == "Bilibili")
+            if (_settingsViewModel.ClientType == string.Empty
+                || _settingsViewModel.ClientType == "Official" || _settingsViewModel.ClientType == "Bilibili")
             {
                 // The resources of Official and Bilibili are the same
                 if (!ForcedReloadResource && (_curResource == "Official" || _curResource == "Bilibili"))
@@ -207,14 +218,14 @@ namespace MaaWpfGui
             {
                 // Load basic resources for CN client first
                 // Then load global incremental resources
-                loaded = AsstLoadResource(Directory.GetCurrentDirectory() + "\\resource\\global\\" + settingsModel.ClientType);
+                loaded = AsstLoadResource(Directory.GetCurrentDirectory() + "\\resource\\global\\" + _settingsViewModel.ClientType);
             }
             else
             {
                 // Load basic resources for CN client first
                 // Then load global incremental resources
                 loaded = AsstLoadResource(Directory.GetCurrentDirectory())
-                    && AsstLoadResource(Directory.GetCurrentDirectory() + "\\resource\\global\\" + settingsModel.ClientType);
+                    && AsstLoadResource(Directory.GetCurrentDirectory() + "\\resource\\global\\" + _settingsViewModel.ClientType);
             }
 
             if (!loaded)
@@ -231,13 +242,13 @@ namespace MaaWpfGui
                 });
             }
 
-            if (settingsModel.ClientType == string.Empty)
+            if (_settingsViewModel.ClientType == string.Empty)
             {
                 _curResource = "Official";
             }
             else
             {
-                _curResource = settingsModel.ClientType;
+                _curResource = _settingsViewModel.ClientType;
             }
 
             return loaded;
@@ -261,21 +272,19 @@ namespace MaaWpfGui
                 });
             }
 
-            var mainModel = _container.Get<TaskQueueViewModel>();
-            mainModel.SetInited();
-            mainModel.Idle = true;
-            var settingsModel = _container.Get<SettingsViewModel>();
-            settingsModel.UpdateInstanceSettings();
+            _taskQueueViewModel.SetInited();
+            _taskQueueViewModel.Idle = true;
+            _settingsViewModel.UpdateInstanceSettings();
             Execute.OnUIThread(async () =>
             {
                 var task = Task.Run(() =>
                 {
-                    settingsModel.TryToStartEmulator();
+                    _settingsViewModel.TryToStartEmulator();
                 });
                 await task;
-                if (settingsModel.RunDirectly)
+                if (_settingsViewModel.RunDirectly)
                 {
-                    mainModel.LinkStart();
+                    _taskQueueViewModel.LinkStart();
                 }
             });
         }
@@ -324,7 +333,6 @@ namespace MaaWpfGui
         }
 
         private readonly IWindowManager _windowManager;
-        private readonly IContainer _container;
         private IntPtr _handle;
 
         private void ProcMsg(AsstMsg msg, JObject details)
@@ -368,67 +376,64 @@ namespace MaaWpfGui
         private void ProcConnectInfo(JObject details)
         {
             var what = details["what"].ToString();
-            var svm = _container.Get<SettingsViewModel>();
-            var mainModel = _container.Get<TaskQueueViewModel>();
             switch (what)
             {
                 case "Connected":
                     connected = true;
                     connectedAdb = details["details"]["adb"].ToString();
                     connectedAddress = details["details"]["address"].ToString();
-                    svm.ConnectAddress = connectedAddress;
+                    _settingsViewModel.ConnectAddress = connectedAddress;
                     break;
 
                 case "UnsupportedResolution":
                     connected = false;
-                    mainModel.AddLog(Localization.GetString("ResolutionNotSupported"), UILogColor.Error);
+                    _taskQueueViewModel.AddLog(Localization.GetString("ResolutionNotSupported"), UILogColor.Error);
                     break;
 
                 case "ResolutionError":
                     connected = false;
-                    mainModel.AddLog(Localization.GetString("ResolutionAcquisitionFailure"), UILogColor.Error);
+                    _taskQueueViewModel.AddLog(Localization.GetString("ResolutionAcquisitionFailure"), UILogColor.Error);
                     break;
 
                 case "Reconnecting":
-                    mainModel.AddLog($"{Localization.GetString("TryToReconnect")}({Convert.ToUInt32(details["details"]["times"]) + 1})", UILogColor.Error);
+                    _taskQueueViewModel.AddLog($"{Localization.GetString("TryToReconnect")}({Convert.ToUInt32(details["details"]["times"]) + 1})", UILogColor.Error);
                     break;
 
                 case "Reconnected":
-                    mainModel.AddLog(Localization.GetString("ReconnectSuccess"));
+                    _taskQueueViewModel.AddLog(Localization.GetString("ReconnectSuccess"));
                     break;
 
                 case "Disconnect":
                     connected = false;
-                    mainModel.AddLog(Localization.GetString("ReconnectFailed"), UILogColor.Error);
-                    if (mainModel.Idle)
+                    _taskQueueViewModel.AddLog(Localization.GetString("ReconnectFailed"), UILogColor.Error);
+                    if (_taskQueueViewModel.Idle)
                     {
                         break;
                     }
 
                     AsstStop();
 
-                    var settingsModel = _container.Get<SettingsViewModel>();
                     Execute.OnUIThread(async () =>
                     {
-                        if (settingsModel.RetryOnDisconnected)
+                        if (_settingsViewModel.RetryOnDisconnected)
                         {
-                            mainModel.AddLog(Localization.GetString("TryToStartEmulator"), UILogColor.Error);
-                            mainModel.KillEmulator();
+                            _taskQueueViewModel.AddLog(Localization.GetString("TryToStartEmulator"), UILogColor.Error);
+                            _taskQueueViewModel.KillEmulator();
                             await Task.Delay(3000);
-                            mainModel.Stop();
-                            mainModel.SetStopped();
-                            mainModel.LinkStart();
+                            _taskQueueViewModel.Stop();
+                            _taskQueueViewModel.SetStopped();
+                            _taskQueueViewModel.LinkStart();
                         }
                     });
 
                     break;
 
                 case "ScreencapFailed":
-                    mainModel.AddLog(Localization.GetString("ScreencapFailed"), UILogColor.Error);
+                    _taskQueueViewModel.AddLog(Localization.GetString("ScreencapFailed"), UILogColor.Error);
                     break;
 
                 case "TouchModeNotAvaiable":
-                    mainModel.AddLog(Localization.GetString("TouchModeNotAvaiable"), UILogColor.Error);
+                    _taskQueueViewModel.AddLog(Localization.GetString("TouchModeNotAvaiable"), UILogColor.Error);
                     break;
             }
         }
@@ -446,39 +451,34 @@ namespace MaaWpfGui
             {
                 if (msg == AsstMsg.TaskChainError)
                 {
-                    var recruitModel = _container.Get<RecruitViewModel>();
-                    recruitModel.RecruitInfo = Localization.GetString("IdentifyTheMistakes");
+                    _recruitViewModel.RecruitInfo = Localization.GetString("IdentifyTheMistakes");
                 }
             }
-
-            var mainModel = _container.Get<TaskQueueViewModel>();
-            var settingsModel = _container.Get<SettingsViewModel>();
-            var copilotModel = _container.Get<CopilotViewModel>();
 
             bool isCoplitTaskChain = taskChain == "Copilot";
 
             switch (msg)
             {
                 case AsstMsg.TaskChainStopped:
-                    mainModel.SetStopped();
+                    _taskQueueViewModel.SetStopped();
                     if (isCoplitTaskChain)
                     {
-                        copilotModel.Idle = true;
+                        _copilotViewModel.Idle = true;
                     }
 
                     break;
 
                 case AsstMsg.TaskChainError:
-                    mainModel.AddLog(Localization.GetString("TaskError") + taskChain, UILogColor.Error);
+                    _taskQueueViewModel.AddLog(Localization.GetString("TaskError") + taskChain, UILogColor.Error);
                     if (isCoplitTaskChain)
                     {
-                        copilotModel.Idle = true;
-                        copilotModel.AddLog(Localization.GetString("CombatError"), UILogColor.Error);
+                        _copilotViewModel.Idle = true;
+                        _copilotViewModel.AddLog(Localization.GetString("CombatError"), UILogColor.Error);
                     }
 
-                    if (taskChain == "Fight" && (mainModel.Stage == "Annihilation"))
+                    if (taskChain == "Fight" && (_taskQueueViewModel.Stage == "Annihilation"))
                     {
-                        mainModel.AddLog(Localization.GetString("AnnihilationTaskFailed"), UILogColor.Warning);
+                        _taskQueueViewModel.AddLog(Localization.GetString("AnnihilationTaskFailed"), UILogColor.Warning);
                     }
 
                     break;
@@ -486,34 +486,34 @@ namespace MaaWpfGui
                 case AsstMsg.TaskChainStart:
                     if (taskChain == "Fight")
                     {
-                        mainModel.FightTaskRunning = true;
+                        _taskQueueViewModel.FightTaskRunning = true;
                     }
                     else if (taskChain == "Infrast")
                     {
-                        mainModel.InfrastTaskRunning = true;
+                        _taskQueueViewModel.InfrastTaskRunning = true;
                     }
 
-                    mainModel.AddLog(Localization.GetString("StartTask") + taskChain);
+                    _taskQueueViewModel.AddLog(Localization.GetString("StartTask") + taskChain);
                     break;
 
                 case AsstMsg.TaskChainCompleted:
                     if (taskChain == "Infrast")
                     {
-                        mainModel.IncreaseCustomInfrastPlanIndex();
+                        _taskQueueViewModel.IncreaseCustomInfrastPlanIndex();
                     }
                     else if (taskChain == "Mall")
                     {
-                        if (settingsModel.CreditFightTaskEnabled)
+                        if (_settingsViewModel.CreditFightTaskEnabled)
                         {
-                            settingsModel.LastCreditFightTaskTime = Utils.GetYJTimeDateString();
+                            _settingsViewModel.LastCreditFightTaskTime = Utils.GetYJTimeDateString();
                         }
                     }
 
-                    mainModel.AddLog(Localization.GetString("CompleteTask") + taskChain);
+                    _taskQueueViewModel.AddLog(Localization.GetString("CompleteTask") + taskChain);
                     if (isCoplitTaskChain)
                     {
-                        copilotModel.Idle = true;
-                        copilotModel.AddLog(Localization.GetString("CompleteCombat"), UILogColor.Info);
+                        _copilotViewModel.Idle = true;
+                        _copilotViewModel.AddLog(Localization.GetString("CompleteCombat"), UILogColor.Info);
                     }
 
                     break;
@@ -537,32 +537,32 @@ namespace MaaWpfGui
                     }
 
                     bool buy_wine = false;
-                    if (_latestTaskId.ContainsKey(TaskType.Mall) && settingsModel.DidYouBuyWine())
+                    if (_latestTaskId.ContainsKey(TaskType.Mall) && _settingsViewModel.DidYouBuyWine())
                     {
                         buy_wine = true;
                     }
 
                     _latestTaskId.Clear();
 
-                    mainModel.Idle = true;
-                    mainModel.UseStone = false;
-                    copilotModel.Idle = true;
+                    _taskQueueViewModel.Idle = true;
+                    _taskQueueViewModel.UseStone = false;
+                    _copilotViewModel.Idle = true;
 
                     if (isMainTaskQueueAllCompleted)
                     {
-                        mainModel.AddLog(Localization.GetString("AllTasksComplete"));
+                        _taskQueueViewModel.AddLog(Localization.GetString("AllTasksComplete"));
                         using (var toast = new ToastNotification(Localization.GetString("AllTasksComplete")))
                         {
                             toast.Show();
                         }
 
-                        // mainModel.CheckAndShutdown();
-                        mainModel.CheckAfterCompleted();
+                        // _taskQueueViewModel.CheckAndShutdown();
+                        _taskQueueViewModel.CheckAfterCompleted();
                     }
 
                     if (buy_wine)
                     {
-                        settingsModel.Cheers = true;
+                        _settingsViewModel.Cheers = true;
                     }
 
                     break;
@@ -575,7 +575,6 @@ namespace MaaWpfGui
             // string taskChain = details["taskchain"].ToString();
             // string classType = details["class"].ToString();
 
-            // var mainModel = _container.Get<TaskQueueViewModel>();
             switch (msg)
             {
                 case AsstMsg.SubTaskError:
@@ -600,34 +599,32 @@ namespace MaaWpfGui
         {
             string subTask = details["subtask"].ToString();
 
-            var mainModel = _container.Get<TaskQueueViewModel>();
-
             switch (subTask)
             {
                 case "StartGameTask":
-                    mainModel.AddLog(Localization.GetString("FailedToOpenClient"), UILogColor.Error);
+                    _taskQueueViewModel.AddLog(Localization.GetString("FailedToOpenClient"), UILogColor.Error);
                     break;
 
                 case "AutoRecruitTask":
                     {
                         var why_str = details.TryGetValue("why", out var why) ? why.ToString() : Localization.GetString("ErrorOccurred");
-                        mainModel.AddLog(why_str + "，" + Localization.GetString("HasReturned"), UILogColor.Error);
+                        _taskQueueViewModel.AddLog(why_str + "，" + Localization.GetString("HasReturned"), UILogColor.Error);
                         break;
                     }
 
                 case "RecognizeDrops":
-                    mainModel.AddLog(Localization.GetString("DropRecognitionError"), UILogColor.Error);
+                    _taskQueueViewModel.AddLog(Localization.GetString("DropRecognitionError"), UILogColor.Error);
                     break;
 
                 case "ReportToPenguinStats":
                     {
                         var why = details["why"].ToString();
-                        mainModel.AddLog(why + "，" + Localization.GetString("GiveUpUploadingPenguins"), UILogColor.Error);
+                        _taskQueueViewModel.AddLog(why + "，" + Localization.GetString("GiveUpUploadingPenguins"), UILogColor.Error);
                         break;
                     }
 
                 case "CheckStageValid":
-                    mainModel.AddLog(Localization.GetString("TheEX"), UILogColor.Error);
+                    _taskQueueViewModel.AddLog(Localization.GetString("TheEX"), UILogColor.Error);
                     break;
             }
         }
@@ -636,8 +633,6 @@ namespace MaaWpfGui
         {
             string subTask = details["subtask"].ToString();
 
-            var mainModel = _container.Get<TaskQueueViewModel>();
-            var copilotModel = _container.Get<CopilotViewModel>();
             if (subTask == "ProcessTask")
             {
                 string taskName = details["details"]["task"].ToString();
@@ -647,108 +642,108 @@ namespace MaaWpfGui
                 {
                     case "StartButton2":
                     case "AnnihilationConfirm":
-                        mainModel.AddLog(Localization.GetString("MissionStart") + $" {execTimes} " + Localization.GetString("UnitTime"), UILogColor.Info);
+                        _taskQueueViewModel.AddLog(Localization.GetString("MissionStart") + $" {execTimes} " + Localization.GetString("UnitTime"), UILogColor.Info);
                         break;
 
                     case "MedicineConfirm":
-                        mainModel.AddLog(Localization.GetString("MedicineUsed") + $" {execTimes} " + Localization.GetString("UnitTime"), UILogColor.Info);
+                        _taskQueueViewModel.AddLog(Localization.GetString("MedicineUsed") + $" {execTimes} " + Localization.GetString("UnitTime"), UILogColor.Info);
                         break;
 
                     case "StoneConfirm":
-                        mainModel.AddLog(Localization.GetString("StoneUsed") + $" {execTimes} " + Localization.GetString("UnitTime"), UILogColor.Info);
+                        _taskQueueViewModel.AddLog(Localization.GetString("StoneUsed") + $" {execTimes} " + Localization.GetString("UnitTime"), UILogColor.Info);
                         break;
 
                     case "AbandonAction":
-                        mainModel.AddLog(Localization.GetString("ActingCommandError"), UILogColor.Error);
+                        _taskQueueViewModel.AddLog(Localization.GetString("ActingCommandError"), UILogColor.Error);
                         break;
 
                     case "RecruitRefreshConfirm":
-                        mainModel.AddLog(Localization.GetString("LabelsRefreshed"), UILogColor.Info);
+                        _taskQueueViewModel.AddLog(Localization.GetString("LabelsRefreshed"), UILogColor.Info);
                         break;
 
                     case "RecruitConfirm":
-                        mainModel.AddLog(Localization.GetString("RecruitConfirm"), UILogColor.Info);
+                        _taskQueueViewModel.AddLog(Localization.GetString("RecruitConfirm"), UILogColor.Info);
                         break;
 
                     case "InfrastDormDoubleConfirmButton":
-                        mainModel.AddLog(Localization.GetString("InfrastDormDoubleConfirmed"), UILogColor.Error);
+                        _taskQueueViewModel.AddLog(Localization.GetString("InfrastDormDoubleConfirmed"), UILogColor.Error);
                         break;
 
                     /* 肉鸽相关 */
                     case "StartExplore":
-                        mainModel.AddLog(Localization.GetString("BegunToExplore") + $" {execTimes} " + Localization.GetString("UnitTime"), UILogColor.Info);
+                        _taskQueueViewModel.AddLog(Localization.GetString("BegunToExplore") + $" {execTimes} " + Localization.GetString("UnitTime"), UILogColor.Info);
                         break;
 
                     case "StageTraderInvestConfirm":
-                        mainModel.AddLog(Localization.GetString("HasInvested") + $" {execTimes} " + Localization.GetString("UnitTime"), UILogColor.Info);
+                        _taskQueueViewModel.AddLog(Localization.GetString("HasInvested") + $" {execTimes} " + Localization.GetString("UnitTime"), UILogColor.Info);
                         break;
 
                     case "ExitThenAbandon":
-                        mainModel.AddLog(Localization.GetString("ExplorationAbandoned"));
+                        _taskQueueViewModel.AddLog(Localization.GetString("ExplorationAbandoned"));
                         break;
 
                     // case "StartAction":
-                    //    mainModel.AddLog("开始战斗");
+                    //    _taskQueueViewModel.AddLog("开始战斗");
                     //    break;
                     case "MissionCompletedFlag":
-                        mainModel.AddLog(Localization.GetString("FightCompleted"));
+                        _taskQueueViewModel.AddLog(Localization.GetString("FightCompleted"));
                         break;
 
                     case "MissionFailedFlag":
-                        mainModel.AddLog(Localization.GetString("FightFailed"));
+                        _taskQueueViewModel.AddLog(Localization.GetString("FightFailed"));
                         break;
 
                     case "StageTraderEnter":
-                        mainModel.AddLog(Localization.GetString("Trader"));
+                        _taskQueueViewModel.AddLog(Localization.GetString("Trader"));
                         break;
 
                     case "StageSafeHouseEnter":
-                        mainModel.AddLog(Localization.GetString("SafeHouse"));
+                        _taskQueueViewModel.AddLog(Localization.GetString("SafeHouse"));
                         break;
 
                     case "StageEncounterEnter":
-                        mainModel.AddLog(Localization.GetString("Encounter"));
+                        _taskQueueViewModel.AddLog(Localization.GetString("Encounter"));
                         break;
 
                     // case "StageBoonsEnter":
-                    //    mainModel.AddLog("古堡馈赠");
+                    //    _taskQueueViewModel.AddLog("古堡馈赠");
                     //    break;
                     case "StageCambatDpsEnter":
-                        mainModel.AddLog(Localization.GetString("CambatDps"));
+                        _taskQueueViewModel.AddLog(Localization.GetString("CambatDps"));
                         break;
 
                     case "StageEmergencyDps":
-                        mainModel.AddLog(Localization.GetString("EmergencyDps"));
+                        _taskQueueViewModel.AddLog(Localization.GetString("EmergencyDps"));
                         break;
 
                     case "StageDreadfulFoe":
                     case "StageDreadfulFoe-5Enter":
-                        mainModel.AddLog(Localization.GetString("DreadfulFoe"));
+                        _taskQueueViewModel.AddLog(Localization.GetString("DreadfulFoe"));
                         break;
 
                     case "StageTraderInvestSystemFull":
-                        mainModel.AddLog(Localization.GetString("UpperLimit"), UILogColor.Info);
+                        _taskQueueViewModel.AddLog(Localization.GetString("UpperLimit"), UILogColor.Info);
                         break;
 
                     case "RestartGameAndContinue":
-                        mainModel.AddLog(Localization.GetString("GameCrash"), UILogColor.Warning);
+                        _taskQueueViewModel.AddLog(Localization.GetString("GameCrash"), UILogColor.Warning);
                         break;
 
                     case "OfflineConfirm":
-                        mainModel.AddLog(Localization.GetString("GameDrop"), UILogColor.Warning);
+                        _taskQueueViewModel.AddLog(Localization.GetString("GameDrop"), UILogColor.Warning);
                         break;
 
                     case "GamePass":
-                        mainModel.AddLog(Localization.GetString("RoguelikeGamePass"), UILogColor.RareOperator);
+                        _taskQueueViewModel.AddLog(Localization.GetString("RoguelikeGamePass"), UILogColor.RareOperator);
                         break;
 
                     case "BattleStartAll":
-                        copilotModel.AddLog(Localization.GetString("MissionStart"), UILogColor.Info);
+                        _copilotViewModel.AddLog(Localization.GetString("MissionStart"), UILogColor.Info);
                         break;
 
                     /* 生息演算 */
                     case "StartAlgorithm":
-                        mainModel.AddLog(Localization.GetString("MissionStart") + $" {execTimes} " + Localization.GetString("UnitTime"), UILogColor.Info);
+                        _taskQueueViewModel.AddLog(Localization.GetString("MissionStart") + $" {execTimes} " + Localization.GetString("UnitTime"), UILogColor.Info);
                         break;
                 }
             }
@@ -770,15 +765,11 @@ namespace MaaWpfGui
             var subTaskDetails = details["details"];
             if (taskChain == "Depot")
             {
-                var depotModel = _container.Get<DepotViewModel>();
-                depotModel.Parse((JObject)subTaskDetails);
+                _depotViewModel.Parse((JObject)subTaskDetails);
             }
 
             string what = details["what"].ToString();
 
-            var mainModel = _container.Get<TaskQueueViewModel>();
-            var copilotModel = _container.Get<CopilotViewModel>();
-            var settingsModel = _container.Get<SettingsViewModel>();
             switch (what)
             {
                 case "StageDrops":
@@ -800,17 +791,17 @@ namespace MaaWpfGui
                         }
 
                         all_drops = all_drops.EndsWith("\n") ? all_drops.TrimEnd('\n') : Localization.GetString("NoDrop");
-                        mainModel.AddLog(Localization.GetString("TotalDrop") + "\n" + all_drops);
+                        _taskQueueViewModel.AddLog(Localization.GetString("TotalDrop") + "\n" + all_drops);
                     }
 
                     break;
 
                 case "EnterFacility":
-                    mainModel.AddLog(Localization.GetString("ThisFacility") + subTaskDetails["facility"] + " " + (int)subTaskDetails["index"]);
+                    _taskQueueViewModel.AddLog(Localization.GetString("ThisFacility") + subTaskDetails["facility"] + " " + (int)subTaskDetails["index"]);
                     break;
 
                 case "ProductIncorrect":
-                    mainModel.AddLog(Localization.GetString("ProductIncorrect"), UILogColor.Error);
+                    _taskQueueViewModel.AddLog(Localization.GetString("ProductIncorrect"), UILogColor.Error);
                     break;
 
                 case "RecruitTagsDetected":
@@ -824,7 +815,7 @@ namespace MaaWpfGui
                         }
 
                         log_content = log_content.EndsWith("\n") ? log_content.TrimEnd('\n') : Localization.GetString("Error");
-                        mainModel.AddLog(Localization.GetString("RecruitingResults") + "\n" + log_content);
+                        _taskQueueViewModel.AddLog(Localization.GetString("RecruitingResults") + "\n" + log_content);
                     }
 
                     break;
@@ -832,7 +823,7 @@ namespace MaaWpfGui
                 case "RecruitSpecialTag":
                     {
                         string special = subTaskDetails["tag"].ToString();
-                        if (special == "支援机械" && settingsModel.NotChooseLevel1 == false)
+                        if (special == "支援机械" && _settingsViewModel.NotChooseLevel1 == false)
                         {
                             break;
                         }
@@ -862,11 +853,11 @@ namespace MaaWpfGui
                                 toast.AppendContentText(new string('★', level)).ShowRecruit(row: 2);
                             }
 
-                            mainModel.AddLog(level + " ★ Tags", UILogColor.RareOperator, "Bold");
+                            _taskQueueViewModel.AddLog(level + " ★ Tags", UILogColor.RareOperator, "Bold");
                         }
                         else
                         {
-                            mainModel.AddLog(level + " ★ Tags", UILogColor.Info);
+                            _taskQueueViewModel.AddLog(level + " ★ Tags", UILogColor.Info);
                         }
 
                         /*
@@ -878,7 +869,7 @@ namespace MaaWpfGui
                                 toast.AppendContentText(new string('★', 1)).ShowRecruitRobot(row: 2);
                             }
 
-                            mainModel.AddLog(1 + " ★ Tag", LogColor.RobotOperator, "Bold");
+                            _taskQueueViewModel.AddLog(1 + " ★ Tag", LogColor.RobotOperator, "Bold");
                         }
                         */
                     }
@@ -896,7 +887,7 @@ namespace MaaWpfGui
 
                         selected_log = selected_log.EndsWith("\n") ? selected_log.TrimEnd('\n') : Localization.GetString("NoDrop");
 
-                        mainModel.AddLog(Localization.GetString("Choose") + " Tags：\n" + selected_log);
+                        _taskQueueViewModel.AddLog(Localization.GetString("Choose") + " Tags：\n" + selected_log);
                     }
 
                     break;
@@ -904,13 +895,13 @@ namespace MaaWpfGui
                 case "RecruitTagsRefreshed":
                     {
                         int refresh_count = (int)subTaskDetails["count"];
-                        mainModel.AddLog(Localization.GetString("Refreshed") + refresh_count + Localization.GetString("UnitTime"));
+                        _taskQueueViewModel.AddLog(Localization.GetString("Refreshed") + refresh_count + Localization.GetString("UnitTime"));
                         break;
                     }
 
                 case "NotEnoughStaff":
                     {
-                        mainModel.AddLog(Localization.GetString("NotEnoughStaff"), UILogColor.Error);
+                        _taskQueueViewModel.AddLog(Localization.GetString("NotEnoughStaff"), UILogColor.Error);
                     }
 
                     break;
@@ -918,25 +909,24 @@ namespace MaaWpfGui
                 /* Roguelike */
                 case "StageInfo":
                     {
-                        mainModel.AddLog(Localization.GetString("StartCombat") + subTaskDetails["name"]);
+                        _taskQueueViewModel.AddLog(Localization.GetString("StartCombat") + subTaskDetails["name"]);
                     }
 
                     break;
 
                 case "StageInfoError":
                     {
-                        mainModel.AddLog(Localization.GetString("StageInfoError"), UILogColor.Error);
+                        _taskQueueViewModel.AddLog(Localization.GetString("StageInfoError"), UILogColor.Error);
                     }
 
                     break;
 
                 case "PenguinId":
                     {
-                        var settings = _container.Get<SettingsViewModel>();
-                        if (settings.PenguinId == string.Empty)
+                        if (_settingsViewModel.PenguinId == string.Empty)
                         {
                             string id = subTaskDetails["id"].ToString();
-                            settings.PenguinId = id;
+                            _settingsViewModel.PenguinId = id;
 
                             // AsstSetPenguinId(id);
                         }
@@ -945,11 +935,11 @@ namespace MaaWpfGui
                     break;
 
                 case "BattleFormation":
-                    copilotModel.AddLog(Localization.GetString("BattleFormation") + "\n" + JsonConvert.SerializeObject(subTaskDetails["formation"]));
+                    _copilotViewModel.AddLog(Localization.GetString("BattleFormation") + "\n" + JsonConvert.SerializeObject(subTaskDetails["formation"]));
                     break;
 
                 case "BattleFormationSelected":
-                    copilotModel.AddLog(Localization.GetString("BattleFormationSelected") + subTaskDetails["selected"]);
+                    _copilotViewModel.AddLog(Localization.GetString("BattleFormationSelected") + subTaskDetails["selected"]);
                     break;
 
                 case "CopilotAction":
@@ -958,10 +948,10 @@ namespace MaaWpfGui
                         if (doc.Length != 0)
                         {
                             string color = subTaskDetails["doc_color"].ToString();
-                            copilotModel.AddLog(doc, color.Length == 0 ? UILogColor.Message : color);
+                            _copilotViewModel.AddLog(doc, color.Length == 0 ? UILogColor.Message : color);
                         }
 
-                        copilotModel.AddLog(
+                        _copilotViewModel.AddLog(
                             string.Format(Localization.GetString("CurrentSteps"),
                                 subTaskDetails["action"].ToString(),
                                 subTaskDetails["target"].ToString()));
@@ -971,27 +961,27 @@ namespace MaaWpfGui
 
                 case "SSSStage":
                     {
-                        copilotModel.AddLog("CurrentStage: " + subTaskDetails["stage"].ToString(), UILogColor.Info);
+                        _copilotViewModel.AddLog("CurrentStage: " + subTaskDetails["stage"].ToString(), UILogColor.Info);
                     }
 
                     break;
 
                 case "SSSSettlement":
                     {
-                        copilotModel.AddLog(details["why"].ToString(), UILogColor.Info);
+                        _copilotViewModel.AddLog(details["why"].ToString(), UILogColor.Info);
                     }
 
                     break;
 
                 case "SSSGamePass":
                     {
-                        copilotModel.AddLog(Localization.GetString("SSSGamePass"), UILogColor.RareOperator);
+                        _copilotViewModel.AddLog(Localization.GetString("SSSGamePass"), UILogColor.RareOperator);
                     }
 
                     break;
 
                 case "UnsupportedLevel":
-                    copilotModel.AddLog(Localization.GetString("UnsupportedLevel"), UILogColor.Error);
+                    _copilotViewModel.AddLog(Localization.GetString("UnsupportedLevel"), UILogColor.Error);
                     break;
 
                 case "CustomInfrastRoomOperators":
@@ -1006,13 +996,13 @@ namespace MaaWpfGui
                         nameStr = nameStr.Remove(nameStr.Length - 2);
                     }
 
-                    mainModel.AddLog(nameStr.ToString());
+                    _taskQueueViewModel.AddLog(nameStr.ToString());
                     break;
 
                 /* 生息演算 */
                 case "ReclamationReport":
                     {
-                        mainModel.AddLog(Localization.GetString("AlgorithmFinish") + "\n" +
+                        _taskQueueViewModel.AddLog(Localization.GetString("AlgorithmFinish") + "\n" +
                             Localization.GetString("AlgorithmBadge") + ": " + $"{(int)subTaskDetails["total_badges"]}(+{(int)subTaskDetails["badges"]})" + "\n" +
                             Localization.GetString("AlgorithmConstructionPoint") + ": " + $"{(int)subTaskDetails["total_construction_points"]}(+{(int)subTaskDetails["construction_points"]})");
                     }
@@ -1026,8 +1016,6 @@ namespace MaaWpfGui
             string what = details["what"].ToString();
             var subTaskDetails = details["details"];
 
-            var recruitModel = _container.Get<RecruitViewModel>();
-
             switch (what)
             {
                 case "RecruitTagsDetected":
@@ -1040,7 +1028,7 @@ namespace MaaWpfGui
                             info_content += tag_str + "    ";
                         }
 
-                        recruitModel.RecruitInfo = info_content;
+                        _recruitViewModel.RecruitInfo = info_content;
                     }
 
                     break;
@@ -1068,7 +1056,7 @@ namespace MaaWpfGui
                             resultContent += "\n\n";
                         }
 
-                        recruitModel.RecruitResult = resultContent;
+                        _recruitViewModel.RecruitResult = resultContent;
                     }
 
                     break;
@@ -1093,42 +1081,40 @@ namespace MaaWpfGui
                 return false;
             }
 
-            var settings = _container.Get<SettingsViewModel>();
+            _settingsViewModel.TryToSetBlueStacksHyperVAddress();
 
-            settings.TryToSetBlueStacksHyperVAddress();
-
-            if (!settings.AutoDetectConnection
+            if (!_settingsViewModel.AutoDetectConnection
                 && connected
-                && connectedAdb == settings.AdbPath
-                && connectedAddress == settings.ConnectAddress)
+                && connectedAdb == _settingsViewModel.AdbPath
+                && connectedAddress == _settingsViewModel.ConnectAddress)
             {
                 return true;
             }
 
-            if (settings.AutoDetectConnection)
+            if (_settingsViewModel.AutoDetectConnection)
             {
-                if (!settings.DetectAdbConfig(ref error))
+                if (!_settingsViewModel.DetectAdbConfig(ref error))
                 {
                     return false;
                 }
             }
 
-            bool ret = AsstConnect(_handle, settings.AdbPath, settings.ConnectAddress, settings.ConnectConfig);
+            bool ret = AsstConnect(_handle, _settingsViewModel.AdbPath, _settingsViewModel.ConnectAddress, _settingsViewModel.ConnectConfig);
 
             // 尝试默认的备选端口
-            if (!ret && settings.AutoDetectConnection)
+            if (!ret && _settingsViewModel.AutoDetectConnection)
             {
-                foreach (var address in settings.DefaultAddress[settings.ConnectConfig])
+                foreach (var address in _settingsViewModel.DefaultAddress[_settingsViewModel.ConnectConfig])
                 {
-                    if (settings.Idle)
+                    if (_settingsViewModel.Idle)
                     {
                         break;
                     }
 
-                    ret = AsstConnect(_handle, settings.AdbPath, address, settings.ConnectConfig);
+                    ret = AsstConnect(_handle, _settingsViewModel.AdbPath, address, _settingsViewModel.ConnectConfig);
                     if (ret)
                     {
-                        settings.ConnectAddress = address;
+                        _settingsViewModel.ConnectAddress = address;
                         break;
                     }
                 }
@@ -1136,9 +1122,9 @@ namespace MaaWpfGui
 
             if (ret)
             {
-                if (!settings.AlwaysAutoDetectConnection)
+                if (!_settingsViewModel.AlwaysAutoDetectConnection)
                 {
-                    settings.AutoDetectConnection = false;
+                    _settingsViewModel.AutoDetectConnection = false;
                 }
             }
             else
@@ -1202,11 +1188,10 @@ namespace MaaWpfGui
                 };
             }
 
-            var settings = _container.Get<SettingsViewModel>();
-            task_params["client_type"] = settings.ClientType;
-            task_params["penguin_id"] = settings.PenguinId;
-            task_params["DrGrandet"] = settings.IsDrGrandet;
-            task_params["server"] = settings.ServerType;
+            task_params["client_type"] = _settingsViewModel.ClientType;
+            task_params["penguin_id"] = _settingsViewModel.PenguinId;
+            task_params["DrGrandet"] = _settingsViewModel.IsDrGrandet;
+            task_params["server"] = _settingsViewModel.ServerType;
             return task_params;
         }
 
@@ -1365,9 +1350,8 @@ namespace MaaWpfGui
 
             task_params["report_to_penguin"] = true;
             task_params["report_to_yituliu"] = true;
-            var settings = _container.Get<SettingsViewModel>();
-            task_params["penguin_id"] = settings.PenguinId;
-            task_params["server"] = settings.ServerType;
+            task_params["penguin_id"] = _settingsViewModel.PenguinId;
+            task_params["server"] = _settingsViewModel.ServerType;
 
             AsstTaskId id = AsstAppendTaskWithEncoding("Recruit", task_params);
             _latestTaskId[TaskType.Recruit] = id;
@@ -1555,10 +1539,9 @@ namespace MaaWpfGui
                 ["report_to_penguin"] = true,
                 ["report_to_yituliu"] = true,
             };
-            var settings = _container.Get<SettingsViewModel>();
-            task_params["penguin_id"] = settings.PenguinId;
-            task_params["yituliu_id"] = settings.PenguinId; // 一图流说随便传个uuid就行，让client自己生成，所以先直接嫖一下企鹅的（
-            task_params["server"] = settings.ServerType;
+            task_params["penguin_id"] = _settingsViewModel.PenguinId;
+            task_params["yituliu_id"] = _settingsViewModel.PenguinId; // 一图流说随便传个uuid就行，让client自己生成，所以先直接嫖一下企鹅的（
+            task_params["server"] = _settingsViewModel.ServerType;
 
             AsstTaskId id = AsstAppendTaskWithEncoding("Recruit", task_params);
             _latestTaskId[TaskType.RecruitCalc] = id;

--- a/src/MaaWpfGui/Main/Bootstrapper.cs
+++ b/src/MaaWpfGui/Main/Bootstrapper.cs
@@ -124,6 +124,7 @@ namespace MaaWpfGui
             builder.Bind<IMaaHotKeyManager>().To<MaaHotKeyManager>().InSingletonScope();
             builder.Bind<IMaaHotKeyActionHandler>().To<MaaHotKeyActionHandler>().InSingletonScope();
             builder.Bind<IMainWindowManager>().To<MainWindowManager>().InSingletonScope();
+            builder.Bind<StageManager>().ToSelf();
         }
 
         /// <inheritdoc/>

--- a/src/MaaWpfGui/Main/CopilotViewModel.cs
+++ b/src/MaaWpfGui/Main/CopilotViewModel.cs
@@ -37,10 +37,11 @@ namespace MaaWpfGui
     /// </summary>
     public class CopilotViewModel : Screen
     {
-#pragma warning disable IDE0052
         private readonly IWindowManager _windowManager;
-#pragma warning restore IDE0052
         private readonly IContainer _container;
+
+        private AsstProxy _asstProxy;
+        private SettingsViewModel _settingsViewModel;
 
         /// <summary>
         /// Gets or sets the view models of log items.
@@ -66,6 +67,13 @@ namespace MaaWpfGui
                 "3. " + Localization.GetString("CopilotTip4"),
                 /* Localization.GetString("CopilotTip5"),*/
                 UILogColor.Message);
+        }
+
+        protected override void OnInitialActivate()
+        {
+            base.OnInitialActivate();
+            _asstProxy = _container.Get<AsstProxy>();
+            _settingsViewModel = _container.Get<SettingsViewModel>();
         }
 
         /// <summary>
@@ -445,11 +453,10 @@ namespace MaaWpfGui
 
             AddLog(Localization.GetString("ConnectingToEmulator"));
 
-            var asstProxy = _container.Get<AsstProxy>();
             string errMsg = string.Empty;
             var task = Task.Run(() =>
             {
-                return asstProxy.AsstConnect(ref errMsg);
+                return _asstProxy.AsstConnect(ref errMsg);
             });
             _caught = await task;
             if (!_caught)
@@ -463,13 +470,12 @@ namespace MaaWpfGui
                 AddLog(errMsg, UILogColor.Error);
             }
 
-            bool ret = asstProxy.AsstStartCopilot(_isDataFromWeb ? TempCopilotFile : Filename, Form, TaskType,
+            bool ret = _asstProxy.AsstStartCopilot(_isDataFromWeb ? TempCopilotFile : Filename, Form, TaskType,
                 Loop ? LoopTimes : 1);
             if (ret)
             {
                 AddLog(Localization.GetString("Running"));
-                var settingsModel = _container.Get<SettingsViewModel>();
-                if (!settingsModel.AdbReplaced && !settingsModel.IsAdbTouchMode())
+                if (!_settingsViewModel.AdbReplaced && !_settingsViewModel.IsAdbTouchMode())
                 {
                     AddLog(Localization.GetString("AdbReplacementTips"), UILogColor.Info);
                 }
@@ -486,8 +492,7 @@ namespace MaaWpfGui
         /// </summary>
         public void Stop()
         {
-            var asstProxy = _container.Get<AsstProxy>();
-            asstProxy.AsstStop();
+            _asstProxy.AsstStop();
             Idle = true;
         }
 

--- a/src/MaaWpfGui/Main/DepotViewModel.cs
+++ b/src/MaaWpfGui/Main/DepotViewModel.cs
@@ -25,10 +25,10 @@ namespace MaaWpfGui
     /// </summary>
     public class DepotViewModel : Screen
     {
-#pragma warning disable IDE0052
         private readonly IWindowManager _windowManager;
-#pragma warning restore IDE0052
         private readonly IContainer _container;
+
+        private AsstProxy _asstProxy;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DepotViewModel"/> class.
@@ -40,6 +40,12 @@ namespace MaaWpfGui
             _container = container;
             _windowManager = windowManager;
             DisplayName = Localization.GetString("DepotRecognition");
+        }
+
+        protected override void OnInitialActivate()
+        {
+            base.OnInitialActivate();
+            _asstProxy = _container.Get<AsstProxy>();
         }
 
         private string _depotInfo = Localization.GetString("DepotRecognitionTip");
@@ -150,12 +156,11 @@ namespace MaaWpfGui
         /// </summary>
         public async void Start()
         {
-            var asstProxy = _container.Get<AsstProxy>();
             string errMsg = string.Empty;
             DepotInfo = Localization.GetString("ConnectingToEmulator");
             var task = Task.Run(() =>
             {
-                return asstProxy.AsstConnect(ref errMsg);
+                return _asstProxy.AsstConnect(ref errMsg);
             });
             bool caught = await task;
             if (!caught)
@@ -167,7 +172,7 @@ namespace MaaWpfGui
             DepotInfo = Localization.GetString("Identifying");
             Clear();
 
-            asstProxy.AsstStartDepot();
+            _asstProxy.AsstStartDepot();
         }
     }
 }

--- a/src/MaaWpfGui/Main/RecruitViewModel.cs
+++ b/src/MaaWpfGui/Main/RecruitViewModel.cs
@@ -23,10 +23,10 @@ namespace MaaWpfGui
     /// </summary>
     public class RecruitViewModel : Screen
     {
-#pragma warning disable IDE0052
         private readonly IWindowManager _windowManager;
-#pragma warning restore IDE0052
         private readonly IContainer _container;
+
+        private AsstProxy _asstProxy;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RecruitViewModel"/> class.
@@ -38,6 +38,12 @@ namespace MaaWpfGui
             _container = container;
             _windowManager = windowManager;
             DisplayName = Localization.GetString("RecruitmentRecognition");
+        }
+
+        protected override void OnInitialActivate()
+        {
+            base.OnInitialActivate();
+            _asstProxy = _container.Get<AsstProxy>();
         }
 
         private string _recruitInfo = Localization.GetString("RecruitmentRecognitionTip");
@@ -144,12 +150,11 @@ namespace MaaWpfGui
         /// </summary>
         public async void StartCalc()
         {
-            var asstProxy = _container.Get<AsstProxy>();
             string errMsg = string.Empty;
             RecruitInfo = Localization.GetString("ConnectingToEmulator");
             var task = Task.Run(() =>
             {
-                return asstProxy.AsstConnect(ref errMsg);
+                return _asstProxy.AsstConnect(ref errMsg);
             });
             _caught = await task;
             if (!_caught)
@@ -183,7 +188,7 @@ namespace MaaWpfGui
                 levelList.Add(6);
             }
 
-            asstProxy.AsstStartRecruitCalc(levelList.ToArray(), AutoSetTime);
+            _asstProxy.AsstStartRecruitCalc(levelList.ToArray(), AutoSetTime);
         }
     }
 }

--- a/src/MaaWpfGui/Main/SettingsViewModel.cs
+++ b/src/MaaWpfGui/Main/SettingsViewModel.cs
@@ -14,7 +14,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
@@ -29,6 +28,7 @@ using IWshRuntimeLibrary;
 using MaaWpfGui.Helper;
 using MaaWpfGui.MaaHotKeys;
 using Stylet;
+using StyletIoC;
 
 namespace MaaWpfGui
 {
@@ -38,8 +38,13 @@ namespace MaaWpfGui
     public class SettingsViewModel : Screen
     {
         private readonly IWindowManager _windowManager;
-        private readonly StyletIoC.IContainer _container;
-        private readonly IMaaHotKeyManager _maaHotKeyManager;
+        private readonly IContainer _container;
+        private IMaaHotKeyManager _maaHotKeyManager;
+        private TrayIcon _trayIcon;
+        private IMainWindowManager _mainWindowManager;
+        private TaskQueueViewModel _taskQueueViewModel;
+        private AsstProxy _asstProxy;
+        private VersionUpdateViewModel _versionUpdateViewModel;
 
         [DllImport("MaaCore.dll")]
         private static extern IntPtr AsstGetVersion();
@@ -76,13 +81,12 @@ namespace MaaWpfGui
         /// </summary>
         /// <param name="container">The IoC container.</param>
         /// <param name="windowManager">The window manager.</param>
-        public SettingsViewModel(StyletIoC.IContainer container, IWindowManager windowManager)
+        public SettingsViewModel(IContainer container, IWindowManager windowManager)
         {
             _container = container;
             _windowManager = windowManager;
-            _maaHotKeyManager = _container.Get<IMaaHotKeyManager>();
-            DisplayName = Localization.GetString("Settings");
 
+            DisplayName = Localization.GetString("Settings");
             _listTitle.Add(Localization.GetString("GameSettings"));
             _listTitle.Add(Localization.GetString("BaseSettings"));
             _listTitle.Add(Localization.GetString("RoguelikeSettings"));
@@ -99,13 +103,6 @@ namespace MaaWpfGui
 
             InfrastInit();
 
-            var trayObj = _container.Get<TrayIcon>();
-            var mainWindowManager = _container.Get<IMainWindowManager>();
-            trayObj.SetVisible(UseTray);
-            trayObj.SetSettingsViewModel(this);
-            mainWindowManager.SetMinimizeToTaskbar(MinimizeToTray);
-            Bootstrapper.SetTrayIconInSettingsViewModel(this);
-
             if (Hangover)
             {
                 _windowManager.ShowMessageBox(
@@ -114,6 +111,22 @@ namespace MaaWpfGui
                     MessageBoxButton.OK, MessageBoxImage.Hand);
                 Hangover = false;
             }
+        }
+
+        protected override void OnInitialActivate()
+        {
+            base.OnInitialActivate();
+            _maaHotKeyManager = _container.Get<IMaaHotKeyManager>();
+            _trayIcon = _container.Get<TrayIcon>();
+            _mainWindowManager = _container.Get<IMainWindowManager>();
+            _taskQueueViewModel = _container.Get<TaskQueueViewModel>();
+            _asstProxy = _container.Get<AsstProxy>();
+            _versionUpdateViewModel = _container.Get<VersionUpdateViewModel>();
+
+            _trayIcon.SetVisible(UseTray);
+            _trayIcon.SetSettingsViewModel(this);
+            _mainWindowManager.SetMinimizeToTaskbar(MinimizeToTray);
+            Bootstrapper.SetTrayIconInSettingsViewModel(this);
 
             if (LoadGUIParameters && SaveGUIParametersOnClosing)
             {
@@ -551,8 +564,8 @@ namespace MaaWpfGui
                 Utils.ClientType = value;
                 ViewStatusStorage.Set("Start.ClientType", value);
                 UpdateWindowTitle(); /* 每次修改客户端时更新WindowTitle */
-                _container.Get<TaskQueueViewModel>().UpdateStageList(true);
-                _container.Get<TaskQueueViewModel>().UpdateDatePrompt();
+                _taskQueueViewModel.UpdateStageList(true);
+                _taskQueueViewModel.UpdateDatePrompt();
             }
         }
 
@@ -837,8 +850,7 @@ namespace MaaWpfGui
             {
                 SetAndNotify(ref _customInfrastEnabled, value);
                 ViewStatusStorage.Set("Infrast.CustomInfrastEnabled", value.ToString());
-                var mainModel = _container.Get<TaskQueueViewModel>();
-                mainModel.CustomInfrastEnabled = value;
+                _taskQueueViewModel.CustomInfrastEnabled = value;
             }
         }
 
@@ -869,8 +881,7 @@ namespace MaaWpfGui
             {
                 SetAndNotify(ref _customInfrastFile, value);
                 ViewStatusStorage.Set("Infrast.CustomInfrastFile", value);
-                var mainModel = _container.Get<TaskQueueViewModel>();
-                mainModel.RefreshCustonInfrastPlan();
+                _taskQueueViewModel.RefreshCustonInfrastPlan();
             }
         }
 
@@ -1199,8 +1210,7 @@ namespace MaaWpfGui
         {
             get
             {
-                var task = _container.Get<TaskQueueViewModel>();
-                if (task.Stage == string.Empty)
+                if (_taskQueueViewModel.Stage == string.Empty)
                 {
                     return false;
                 }
@@ -1307,13 +1317,13 @@ namespace MaaWpfGui
 
         public class TimerModel
         {
-            public class TimerProperties : INotifyPropertyChanged
+            public class TimerProperties : System.ComponentModel.INotifyPropertyChanged
             {
-                public event PropertyChangedEventHandler PropertyChanged;
+                public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
 
                 protected void OnPropertyChanged([CallerMemberName] string name = null)
                 {
-                    PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+                    PropertyChanged?.Invoke(this, new System.ComponentModel.PropertyChangedEventArgs(name));
                 }
 
                 public int TimerId { get; set; }
@@ -1673,10 +1683,9 @@ namespace MaaWpfGui
         // TODO: 你确定要用 async void 不是 async Task？
         public async void ManualUpdate()
         {
-            var updateModel = _container.Get<VersionUpdateViewModel>();
             var task = Task.Run(() =>
             {
-                return updateModel.CheckAndDownloadUpdate(true);
+                return _versionUpdateViewModel.CheckAndDownloadUpdate(true);
             });
             var ret = await task;
 
@@ -1703,7 +1712,7 @@ namespace MaaWpfGui
                     break;
 
                 case VersionUpdateViewModel.CheckUpdateRetT.OK:
-                    updateModel.AskToRestart();
+                    _versionUpdateViewModel.AskToRestart();
                     break;
 
                 case VersionUpdateViewModel.CheckUpdateRetT.NewVersionIsBeingBuilt:
@@ -1998,10 +2007,9 @@ namespace MaaWpfGui
 
         public void UpdateInstanceSettings()
         {
-            var asstProxy = _container.Get<AsstProxy>();
-            asstProxy.AsstSetInstanceOption(InstanceOptionKey.TouchMode, TouchMode);
-            asstProxy.AsstSetInstanceOption(InstanceOptionKey.DeploymentWithPause, DeploymentWithPause ? "1" : "0");
-            asstProxy.AsstSetInstanceOption(InstanceOptionKey.AdbLiteEnabled, AdbLiteEnabled ? "1" : "0");
+            _asstProxy.AsstSetInstanceOption(InstanceOptionKey.TouchMode, TouchMode);
+            _asstProxy.AsstSetInstanceOption(InstanceOptionKey.DeploymentWithPause, DeploymentWithPause ? "1" : "0");
+            _asstProxy.AsstSetInstanceOption(InstanceOptionKey.AdbLiteEnabled, AdbLiteEnabled ? "1" : "0");
         }
 
         private static readonly string GoogleAdbDownloadUrl = "https://dl.google.com/android/repository/platform-tools-latest-windows.zip";
@@ -2087,8 +2095,7 @@ namespace MaaWpfGui
             {
                 SetAndNotify(ref _useTray, value);
                 ViewStatusStorage.Set("GUI.UseTray", value.ToString());
-                var trayObj = _container.Get<TrayIcon>();
-                trayObj.SetVisible(value);
+                _trayIcon.SetVisible(value);
 
                 if (!Convert.ToBoolean(value))
                 {
@@ -2109,8 +2116,7 @@ namespace MaaWpfGui
             {
                 SetAndNotify(ref _minimizeToTray, value);
                 ViewStatusStorage.Set("GUI.MinimizeToTray", value.ToString());
-                var mainWindowManager = _container.Get<IMainWindowManager>();
-                mainWindowManager.SetMinimizeToTaskbar(value);
+                _mainWindowManager.SetMinimizeToTaskbar(value);
             }
         }
 
@@ -2226,8 +2232,7 @@ namespace MaaWpfGui
             set
             {
                 SetAndNotify(ref _useAlternateStage, value);
-                var taskQueueViewModel = _container.Get<TaskQueueViewModel>();
-                taskQueueViewModel.AlternateStageDisplay = value;
+                _taskQueueViewModel.AlternateStageDisplay = value;
                 ViewStatusStorage.Set("GUI.UseAlternateStage", value.ToString());
                 if (value)
                 {
@@ -2244,8 +2249,7 @@ namespace MaaWpfGui
             set
             {
                 SetAndNotify(ref _useRemainingSanityStage, value);
-                var mainModel = _container.Get<TaskQueueViewModel>();
-                mainModel.UseRemainingSanityStage = value;
+                _taskQueueViewModel.UseRemainingSanityStage = value;
                 ViewStatusStorage.Set("Fight.UseRemainingSanityStage", value.ToString());
             }
         }
@@ -2268,8 +2272,7 @@ namespace MaaWpfGui
                     UseAlternateStage = false;
                 }
 
-                var mainModel = _container.Get<TaskQueueViewModel>();
-                mainModel.UpdateStageList(true);
+                _taskQueueViewModel.UpdateStageList(true);
             }
         }
 
@@ -2285,8 +2288,7 @@ namespace MaaWpfGui
             {
                 SetAndNotify(ref _customStageCode, value);
                 ViewStatusStorage.Set("GUI.CustomStageCode", value.ToString());
-                var mainModel = _container.Get<TaskQueueViewModel>();
-                mainModel.CustomStageCode = value;
+                _taskQueueViewModel.CustomStageCode = value;
             }
         }
 
@@ -2317,24 +2319,23 @@ namespace MaaWpfGui
 
                 SetAndNotify(ref _inverseClearMode, tempEnumValue);
                 ViewStatusStorage.Set("GUI.InverseClearMode", value);
-                var taskQueueModel = _container.Get<TaskQueueViewModel>();
                 switch (tempEnumValue)
                 {
                     case InverseClearType.Clear:
-                        taskQueueModel.InverseMode = false;
-                        taskQueueModel.ShowInverse = false;
-                        taskQueueModel.SelectedAllWidth = 90;
+                        _taskQueueViewModel.InverseMode = false;
+                        _taskQueueViewModel.ShowInverse = false;
+                        _taskQueueViewModel.SelectedAllWidth = 90;
                         break;
 
                     case InverseClearType.Inverse:
-                        taskQueueModel.InverseMode = true;
-                        taskQueueModel.ShowInverse = false;
-                        taskQueueModel.SelectedAllWidth = 90;
+                        _taskQueueViewModel.InverseMode = true;
+                        _taskQueueViewModel.ShowInverse = false;
+                        _taskQueueViewModel.SelectedAllWidth = 90;
                         break;
 
                     case InverseClearType.ClearInverse:
-                        taskQueueModel.ShowInverse = true;
-                        taskQueueModel.SelectedAllWidth = TaskQueueViewModel.SelectedAllWidthWhenBoth;
+                        _taskQueueViewModel.ShowInverse = true;
+                        _taskQueueViewModel.SelectedAllWidth = TaskQueueViewModel.SelectedAllWidthWhenBoth;
                         break;
                 }
             }

--- a/src/MaaWpfGui/Main/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/Main/TaskQueueViewModel.cs
@@ -39,6 +39,11 @@ namespace MaaWpfGui
         private readonly IWindowManager _windowManager;
         private readonly IContainer _container;
 
+        private StageManager _stageManager;
+        private SettingsViewModel _settingsViewModel;
+        private AsstProxy _asstProxy;
+        private TrayIcon _trayIcon;
+
         /// <summary>
         /// Gets or sets the view models of task items.
         /// </summary>
@@ -106,14 +111,24 @@ namespace MaaWpfGui
         /// <param name="windowManager">The window manager.</param>
         public TaskQueueViewModel(IContainer container, IWindowManager windowManager)
         {
-            _container = container;
             _windowManager = windowManager;
+            _container = container;
+        }
+
+        protected override void OnInitialActivate()
+        {
+            base.OnInitialActivate();
+            _settingsViewModel = _container.Get<SettingsViewModel>();
+            _asstProxy = _container.Get<AsstProxy>();
+            _trayIcon = _container.Get<TrayIcon>();
+            _stageManager = _container.Get<StageManager>();
+
+            _trayIcon.SetTaskQueueViewModel(this);
+
             DisplayName = Localization.GetString("Farming");
             LogItemViewModels = new ObservableCollection<LogItemViewModel>();
             InitializeItems();
             InitTimer();
-            var trayIcon = _container.Get<TrayIcon>();
-            trayIcon.SetTaskQueueViewModel(this);
         }
 
         /*
@@ -159,13 +174,12 @@ namespace MaaWpfGui
 
             int intMinute = DateTime.Now.Minute;
             int intHour = DateTime.Now.Hour;
-            var settings = _container.Get<SettingsViewModel>();
             var timeToStart = false;
             for (int i = 0; i < 8; ++i)
             {
-                if (settings.TimerModels.Timers[i].IsOn &&
-                    settings.TimerModels.Timers[i].Hour == intHour &&
-                    settings.TimerModels.Timers[i].Min == intMinute)
+                if (_settingsViewModel.TimerModels.Timers[i].IsOn &&
+                    _settingsViewModel.TimerModels.Timers[i].Hour == intHour &&
+                    _settingsViewModel.TimerModels.Timers[i].Min == intMinute)
                 {
                     timeToStart = true;
                     break;
@@ -243,7 +257,6 @@ namespace MaaWpfGui
 
             TaskItemViewModels = new ObservableCollection<DragItemViewModel>(temp_order_list);
 
-            _stageManager = new StageManager(_container);
             RemainingSanityStageList = new ObservableCollection<CombData>(_stageManager.GetStageList())
             {
                 // It's Cur/Last option
@@ -257,7 +270,6 @@ namespace MaaWpfGui
             RefreshCustonInfrastPlan();
         }
 
-        private StageManager _stageManager;
         private DayOfWeek _curDayOfWeek;
 
         /// <summary>
@@ -276,8 +288,7 @@ namespace MaaWpfGui
         /// <param name="forceUpdate">Whether or not to update the stage list for selection forcely</param>
         public void UpdateStageList(bool forceUpdate)
         {
-            var settingsModel = _container.Get<SettingsViewModel>();
-            if (settingsModel.HideUnavailableStage)
+            if (_settingsViewModel.HideUnavailableStage)
             {
                 // update available stage list
                 var stage1 = Stage1 ??= string.Empty;
@@ -571,17 +582,16 @@ namespace MaaWpfGui
 
             // 虽然更改时已经保存过了，不过保险起见还是在点击开始之后再保存一次任务及基建列表
             TaskItemSelectionChanged();
-            _container.Get<SettingsViewModel>().InfrastOrderSelectionChanged();
+            _settingsViewModel.InfrastOrderSelectionChanged();
 
             ClearLog();
 
             AddLog(Localization.GetString("ConnectingToEmulator"));
 
-            var asstProxy = _container.Get<AsstProxy>();
             string errMsg = string.Empty;
             var task = Task.Run(() =>
             {
-                return asstProxy.AsstConnect(ref errMsg);
+                return _asstProxy.AsstConnect(ref errMsg);
             });
             bool caught = await task;
 
@@ -596,15 +606,14 @@ namespace MaaWpfGui
             {
                 AddLog(errMsg, UILogColor.Error);
                 AddLog(Localization.GetString("ConnectFailed") + "\n" + Localization.GetString("TryToStartEmulator"));
-                var settingsModel = _container.Get<SettingsViewModel>();
                 var subtask = Task.Run(() =>
                 {
-                    settingsModel.TryToStartEmulator(true);
+                    _settingsViewModel.TryToStartEmulator(true);
                 });
                 await subtask;
                 task = Task.Run(() =>
                 {
-                    return asstProxy.AsstConnect(ref errMsg);
+                    return _asstProxy.AsstConnect(ref errMsg);
                 });
                 caught = await task;
                 if (!caught)
@@ -657,7 +666,7 @@ namespace MaaWpfGui
                 }
                 else if (item.OriginalName == "Mission")
                 {
-                    ret &= asstProxy.AsstAppendAward();
+                    ret &= _asstProxy.AsstAppendAward();
                 }
                 else if (item.OriginalName == "AutoRoguelike")
                 {
@@ -690,13 +699,12 @@ namespace MaaWpfGui
                 return;
             }
 
-            ret &= asstProxy.AsstStart();
+            ret &= _asstProxy.AsstStart();
 
             if (ret)
             {
                 AddLog(Localization.GetString("Running"));
-                var settingsModel = _container.Get<SettingsViewModel>();
-                if (!settingsModel.AdbReplaced && !settingsModel.IsAdbTouchMode())
+                if (!_settingsViewModel.AdbReplaced && !_settingsViewModel.IsAdbTouchMode())
                 {
                     AddLog(Localization.GetString("AdbReplacementTips"), UILogColor.Info);
                 }
@@ -714,10 +722,7 @@ namespace MaaWpfGui
         {
             Stopping = true;
             AddLog(Localization.GetString("Stopping"));
-            var task = Task.Run(() =>
-            {
-                return _container.Get<AsstProxy>().AsstStop();
-            });
+            var task = Task.Run(_asstProxy.AsstStop);
             await task;
         }
 
@@ -734,11 +739,9 @@ namespace MaaWpfGui
 
         private bool appendStart()
         {
-            var settings = _container.Get<SettingsViewModel>();
-            var asstProxy = _container.Get<AsstProxy>();
-            var mode = settings.ClientType;
+            var mode = _settingsViewModel.ClientType;
             var enable = mode.Length != 0;
-            return asstProxy.AsstAppendStartUp(mode, enable);
+            return _asstProxy.AsstAppendStartUp(mode, enable);
         }
 
         private bool appendFight()
@@ -779,23 +782,22 @@ namespace MaaWpfGui
                 }
             }
 
-            var asstProxy = _container.Get<AsstProxy>();
-            bool mainFightRet = asstProxy.AsstAppendFight(Stage, medicine, stone, times, DropsItemId, drops_quantity);
+            bool mainFightRet = _asstProxy.AsstAppendFight(Stage, medicine, stone, times, DropsItemId, drops_quantity);
 
-            if (mainFightRet && (Stage == "Annihilation") && _container.Get<SettingsViewModel>().UseAlternateStage)
+            if (mainFightRet && (Stage == "Annihilation") && _settingsViewModel.UseAlternateStage)
             {
                 foreach (var stage in new[] { Stage1, Stage2, Stage3 })
                 {
                     if (IsStageOpen(stage) && (stage != Stage))
                     {
-                        mainFightRet = asstProxy.AsstAppendFight(stage, medicine, 0, int.MaxValue, string.Empty, 0);
+                        mainFightRet = _asstProxy.AsstAppendFight(stage, medicine, 0, int.MaxValue, string.Empty, 0);
                     }
                 }
             }
 
             if (mainFightRet && UseRemainingSanityStage && (RemainingSanityStage != string.Empty))
             {
-                return asstProxy.AsstAppendFight(RemainingSanityStage, 0, 0, int.MaxValue, string.Empty, 0, false);
+                return _asstProxy.AsstAppendFight(RemainingSanityStage, 0, 0, int.MaxValue, string.Empty, 0, false);
             }
 
             return mainFightRet;
@@ -846,41 +848,33 @@ namespace MaaWpfGui
                     }
                 }
 
-                var asstProxy = _container.Get<AsstProxy>();
-                asstProxy.AsstSetFightTaskParams(Stage, medicine, stone, times, DropsItemId, drops_quantity);
+                _asstProxy.AsstSetFightTaskParams(Stage, medicine, stone, times, DropsItemId, drops_quantity);
             }
         }
 
         public void SetFightRemainingSanityParams()
         {
-            var asstProxy = _container.Get<AsstProxy>();
-            asstProxy.AsstSetFightTaskParams(RemainingSanityStage, 0, 0, int.MaxValue, string.Empty, 0, false);
+            _asstProxy.AsstSetFightTaskParams(RemainingSanityStage, 0, 0, int.MaxValue, string.Empty, 0, false);
         }
 
         public void SetInfrastParams()
         {
-            var settings = _container.Get<SettingsViewModel>();
-            var order = settings.GetInfrastOrderList();
-            var asstProxy = _container.Get<AsstProxy>();
-            asstProxy.AsstSetInfrastTaskParams(order.ToArray(), settings.UsesOfDrones, settings.DormThreshold / 100.0, settings.DormFilterNotStationedEnabled, settings.DormTrustEnabled, settings.OriginiumShardAutoReplenishment,
-                settings.CustomInfrastEnabled, settings.CustomInfrastFile, CustomInfrastPlanIndex);
+            var order = _settingsViewModel.GetInfrastOrderList();
+            _asstProxy.AsstSetInfrastTaskParams(order.ToArray(), _settingsViewModel.UsesOfDrones, _settingsViewModel.DormThreshold / 100.0, _settingsViewModel.DormFilterNotStationedEnabled, _settingsViewModel.DormTrustEnabled, _settingsViewModel.OriginiumShardAutoReplenishment,
+                _settingsViewModel.CustomInfrastEnabled, _settingsViewModel.CustomInfrastFile, CustomInfrastPlanIndex);
         }
 
         private bool appendInfrast()
         {
-            var settings = _container.Get<SettingsViewModel>();
-            var order = settings.GetInfrastOrderList();
-            var asstProxy = _container.Get<AsstProxy>();
-            return asstProxy.AsstAppendInfrast(order.ToArray(), settings.UsesOfDrones, settings.DormThreshold / 100.0, settings.DormFilterNotStationedEnabled, settings.DormTrustEnabled, settings.OriginiumShardAutoReplenishment,
-                settings.CustomInfrastEnabled, settings.CustomInfrastFile, CustomInfrastPlanIndex);
+            var order = _settingsViewModel.GetInfrastOrderList();
+            return _asstProxy.AsstAppendInfrast(order.ToArray(), _settingsViewModel.UsesOfDrones, _settingsViewModel.DormThreshold / 100.0, _settingsViewModel.DormFilterNotStationedEnabled, _settingsViewModel.DormTrustEnabled, _settingsViewModel.OriginiumShardAutoReplenishment,
+                _settingsViewModel.CustomInfrastEnabled, _settingsViewModel.CustomInfrastFile, CustomInfrastPlanIndex);
         }
 
         private bool appendMall()
         {
-            var settings = _container.Get<SettingsViewModel>();
-            var asstProxy = _container.Get<AsstProxy>();
-            var buy_first = settings.CreditFirstList.Split(new char[] { ';', '；' });
-            var black_list = settings.CreditBlackList.Split(new char[] { ';', '；' });
+            var buy_first = _settingsViewModel.CreditFirstList.Split(new char[] { ';', '；' });
+            var black_list = _settingsViewModel.CreditBlackList.Split(new char[] { ';', '；' });
             for (var i = 0; i < buy_first.Length; ++i)
             {
                 buy_first[i] = buy_first[i].Trim();
@@ -891,15 +885,13 @@ namespace MaaWpfGui
                 black_list[i] = black_list[i].Trim();
             }
 
-            return asstProxy.AsstAppendMall(settings.CreditFightTaskEnabled, settings.CreditShopping, buy_first, black_list, settings.CreditForceShoppingIfCreditFull);
+            return _asstProxy.AsstAppendMall(_settingsViewModel.CreditFightTaskEnabled, _settingsViewModel.CreditShopping, buy_first, black_list, _settingsViewModel.CreditForceShoppingIfCreditFull);
         }
 
         private bool appendRecruit()
         {
             // for debug
-            var settings = _container.Get<SettingsViewModel>();
-
-            if (!int.TryParse(settings.RecruitMaxTimes, out var max_times))
+            if (!int.TryParse(_settingsViewModel.RecruitMaxTimes, out var max_times))
             {
                 max_times = 0;
             }
@@ -907,47 +899,43 @@ namespace MaaWpfGui
             var reqList = new List<int>();
             var cfmList = new List<int>();
 
-            if (settings.ChooseLevel3)
+            if (_settingsViewModel.ChooseLevel3)
             {
                 cfmList.Add(3);
             }
 
-            if (settings.ChooseLevel4)
+            if (_settingsViewModel.ChooseLevel4)
             {
                 reqList.Add(4);
                 cfmList.Add(4);
             }
 
-            if (settings.ChooseLevel5)
+            if (_settingsViewModel.ChooseLevel5)
             {
                 reqList.Add(5);
                 cfmList.Add(5);
             }
 
-            var asstProxy = _container.Get<AsstProxy>();
-            return asstProxy.AsstAppendRecruit(
+            return _asstProxy.AsstAppendRecruit(
                 max_times, reqList.ToArray(), cfmList.ToArray(),
-                settings.RefreshLevel3, settings.UseExpedited,
-                settings.NotChooseLevel1, settings.IsLevel3UseShortTime);
+                _settingsViewModel.RefreshLevel3, _settingsViewModel.UseExpedited,
+                _settingsViewModel.NotChooseLevel1, _settingsViewModel.IsLevel3UseShortTime);
         }
 
         private bool AppendRoguelike()
         {
-            var settings = _container.Get<SettingsViewModel>();
-            int.TryParse(settings.RoguelikeMode, out var mode);
+            int.TryParse(_settingsViewModel.RoguelikeMode, out var mode);
 
-            var asstProxy = _container.Get<AsstProxy>();
-            return asstProxy.AsstAppendRoguelike(
-                mode, settings.RoguelikeStartsCount,
-                settings.RoguelikeInvestmentEnabled, settings.RoguelikeInvestsCount, settings.RoguelikeStopWhenInvestmentFull,
-                settings.RoguelikeSquad, settings.RoguelikeRoles, settings.RoguelikeCoreChar, settings.RoguelikeUseSupportUnit,
-                settings.RoguelikeEnableNonfriendSupport, settings.RoguelikeTheme);
+            return _asstProxy.AsstAppendRoguelike(
+                mode, _settingsViewModel.RoguelikeStartsCount,
+                _settingsViewModel.RoguelikeInvestmentEnabled, _settingsViewModel.RoguelikeInvestsCount, _settingsViewModel.RoguelikeStopWhenInvestmentFull,
+                _settingsViewModel.RoguelikeSquad, _settingsViewModel.RoguelikeRoles, _settingsViewModel.RoguelikeCoreChar, _settingsViewModel.RoguelikeUseSupportUnit,
+                _settingsViewModel.RoguelikeEnableNonfriendSupport, _settingsViewModel.RoguelikeTheme);
         }
 
         private bool AppendReclamation()
         {
-            var asstProxy = _container.Get<AsstProxy>();
-            return asstProxy.AsstAppendReclamation();
+            return _asstProxy.AsstAppendReclamation();
         }
 
         [DllImport("User32.dll", EntryPoint = "FindWindow")]
@@ -1188,8 +1176,7 @@ namespace MaaWpfGui
                     break;
 
                 case ActionType.StopGame:
-                    var asstProxy = _container.Get<AsstProxy>();
-                    if (!asstProxy.AsstStartCloseDown())
+                    if (!_asstProxy.AsstStartCloseDown())
                     {
                         AddLog(Localization.GetString("CloseArknightsFailed"), UILogColor.Error);
                     }
@@ -1300,8 +1287,7 @@ namespace MaaWpfGui
             set
             {
                 SetAndNotify(ref _idle, value);
-                var settings = _container.Get<SettingsViewModel>();
-                settings.Idle = value;
+                _settingsViewModel.Idle = value;
                 if (value)
                 {
                     FightTaskRunning = false;
@@ -1413,13 +1399,12 @@ namespace MaaWpfGui
         {
             get
             {
-                var settingsModel = _container.Get<SettingsViewModel>();
                 if (CustomStageCode)
                 {
                     return Stage1;
                 }
 
-                if (settingsModel.UseAlternateStage)
+                if (_settingsViewModel.UseAlternateStage)
                 {
                     if (IsStageOpen(Stage1))
                     {
@@ -1544,9 +1529,8 @@ namespace MaaWpfGui
             set
             {
                 SetAndNotify(ref _useRemainingSanityStage, value);
-                var settingsModel = _container.Get<SettingsViewModel>();
-                RemainingSanityStageDisplay1 = value && !settingsModel.CustomStageCode;
-                RemainingSanityStageDisplay2 = value && settingsModel.CustomStageCode;
+                RemainingSanityStageDisplay1 = value && !_settingsViewModel.CustomStageCode;
+                RemainingSanityStageDisplay2 = value && _settingsViewModel.CustomStageCode;
             }
         }
 
@@ -1579,8 +1563,7 @@ namespace MaaWpfGui
             set
             {
                 SetAndNotify(ref _customStageCode, value);
-                var settingsModel = _container.Get<SettingsViewModel>();
-                AlternateStageDisplay = !value && settingsModel.UseAlternateStage;
+                AlternateStageDisplay = !value && _settingsViewModel.UseAlternateStage;
             }
         }
 
@@ -1691,15 +1674,14 @@ namespace MaaWpfGui
                 return;
             }
 
-            var settingsModel = _container.Get<SettingsViewModel>();
-            if (!File.Exists(settingsModel.CustomInfrastFile))
+            if (!File.Exists(_settingsViewModel.CustomInfrastFile))
             {
                 return;
             }
 
             try
             {
-                string jsonStr = File.ReadAllText(settingsModel.CustomInfrastFile);
+                string jsonStr = File.ReadAllText(_settingsViewModel.CustomInfrastFile);
                 var root = (JObject)JsonConvert.DeserializeObject(jsonStr);
 
                 if (_customInfrastInfoOutput && root.ContainsKey("title"))

--- a/src/MaaWpfGui/Main/VersionUpdateViewModel.cs
+++ b/src/MaaWpfGui/Main/VersionUpdateViewModel.cs
@@ -35,20 +35,18 @@ namespace MaaWpfGui
     /// </summary>
     public class VersionUpdateViewModel : Screen
     {
-#pragma warning disable IDE0052
-        private readonly IWindowManager _windowManager;
-#pragma warning restore IDE0052
-        private readonly IContainer _container;
+        private readonly SettingsViewModel _settingsViewModel;
+        private readonly TaskQueueViewModel _taskQueueViewModel;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="VersionUpdateViewModel"/> class.
         /// </summary>
         /// <param name="container">The IoC container.</param>
         /// <param name="windowManager">The window manager.</param>
-        public VersionUpdateViewModel(IContainer container, IWindowManager windowManager)
+        public VersionUpdateViewModel(IContainer container)
         {
-            _container = container;
-            _windowManager = windowManager;
+            _settingsViewModel = container.Get<SettingsViewModel>();
+            _taskQueueViewModel = container.Get<TaskQueueViewModel>();
         }
 
         [DllImport("MaaCore.dll")]
@@ -334,8 +332,7 @@ namespace MaaWpfGui
         /// <returns>操作成功返回 <see langword="true"/>，反之则返回 <see langword="false"/>。</returns>
         public CheckUpdateRetT CheckAndDownloadUpdate(bool force = false)
         {
-            var svm = _container.Get<SettingsViewModel>();
-            svm.IsCheckingForUpdates = true;
+            _settingsViewModel.IsCheckingForUpdates = true;
 
             var checkResult = ((Func<CheckUpdateRetT>)(() =>
             {
@@ -387,9 +384,8 @@ namespace MaaWpfGui
                 UpdateInfo = body;
                 UpdateUrl = _latestJson["html_url"]?.ToString();
 
-                var settings = _container.Get<SettingsViewModel>();
                 bool otaFound = _assetsObject != null;
-                bool goDownload = otaFound && settings.AutoDownloadUpdatePackage;
+                bool goDownload = otaFound && _settingsViewModel.AutoDownloadUpdatePackage;
 #pragma warning disable IDE0042
                 var openUrlToastButton = (
                     text: Localization.GetString("NewVersionFoundButtonGoWebpage"),
@@ -449,7 +445,7 @@ namespace MaaWpfGui
                 };
 
                 string rawUrl = _assetsObject["browser_download_url"]?.ToString();
-                var downloader = settings.UseAria2 ? Downloader.Aria2 : Downloader.Native;
+                var downloader = _settingsViewModel.UseAria2 ? Downloader.Aria2 : Downloader.Native;
                 const int DownloadRetryMaxTimes = 1;
                 for (int i = 0; i <= DownloadRetryMaxTimes && !downloaded; i++)
                 {
@@ -487,7 +483,7 @@ namespace MaaWpfGui
                 return CheckUpdateRetT.OK;
             }))();
 
-            svm.IsCheckingForUpdates = false;
+            _settingsViewModel.IsCheckingForUpdates = false;
             return checkResult;
         }
 
@@ -517,10 +513,8 @@ namespace MaaWpfGui
         /// <returns>检查到更新返回 <see langword="true"/>，反之则返回 <see langword="false"/>。</returns>
         private CheckUpdateRetT CheckUpdate(bool force = false)
         {
-            var settings = _container.Get<SettingsViewModel>();
-
             // 自动更新或者手动触发
-            if (!(settings.UpdateCheck || force))
+            if (!(_settingsViewModel.UpdateCheck || force))
             {
                 return CheckUpdateRetT.NoNeedToUpdate;
             }
@@ -534,7 +528,7 @@ namespace MaaWpfGui
             const int RequestRetryMaxTimes = 2;
             try
             {
-                if (!settings.UpdateBeta && !settings.UpdateNightly)
+                if (!_settingsViewModel.UpdateBeta && !_settingsViewModel.UpdateNightly)
                 {
                     // 稳定版更新使用主仓库 /latest 接口
                     // 直接使用 MaaRelease 的话，30 个可能会找不到稳定版，因为有可能 Nightly 发了很多
@@ -570,7 +564,7 @@ namespace MaaWpfGui
                     _latestJson = null;
                     foreach (var item in releaseArray)
                     {
-                        if (!settings.UpdateNightly && !isStdVersion(item["tag_name"].ToString()))
+                        if (!_settingsViewModel.UpdateNightly && !isStdVersion(item["tag_name"].ToString()))
                         {
                             continue;
                         }
@@ -588,7 +582,7 @@ namespace MaaWpfGui
                 _latestVersion = _latestJson["tag_name"].ToString();
                 var releaseAssets = _latestJson["assets"] as JArray;
 
-                if (settings.UpdateNightly)
+                if (_settingsViewModel.UpdateNightly)
                 {
                     if (_curVersion == _latestVersion)
                     {
@@ -675,14 +669,14 @@ namespace MaaWpfGui
         private bool DownloadGithubAssets(string url, JObject assetsObject,
             Downloader downloader = Downloader.Native, string saveTo = null)
         {
-            _logItemViewModels = _container.Get<TaskQueueViewModel>().LogItemViewModels;
+            _logItemViewModels = _taskQueueViewModel.LogItemViewModels;
             return DownloadFile(
                 url: url,
                 fileName: assetsObject["name"].ToString(), contentType:
                 assetsObject["content_type"].ToString(),
                 downloader: downloader,
                 saveTo: saveTo,
-                proxy: _container.Get<SettingsViewModel>().Proxy);
+                proxy: _settingsViewModel.Proxy);
         }
 
         /// <summary>


### PR DESCRIPTION
- 将AsstProxy和工具类注入更改为构造器注入
- 在业务代码中不再使用`_container.Get<T>`方法
- 从`Screen`类继承的Model，在第一次显示Model时进行注入，这样做是避免已经存在的循环依赖导致构造堆栈溢出
- `VersionUpdateViewModel`是特殊的，因为它有可能不显示，所以它仍然采用构造器注入的方式
- `StageManager`为非单例类，`_container.Get<StageManager>()`会返回一个新的实例