### PR TITLE
feat: 加速肉鸽招募时滑动

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -9104,6 +9104,7 @@
         ]
     },
     "RoguelikeRecruitOcrFlag": {
+        "maxTimes": 5,
         "roi": [
             525,
             110,
@@ -9116,13 +9117,13 @@
         "baseTask": "SlowlySwipeToTheLeft",
         "Doc": "为了保证每次滑动至少多出一列 且 不能跳过一列，应保证滑动距离在400-500之间。",
         "specificRect": [
-            620,
+            500,
             340,
             20,
             20
         ],
         "rectMove": [
-            1100,
+            980,
             340,
             20,
             20
@@ -9131,13 +9132,13 @@
     "RoguelikeRecruitOperListSlowlySwipeToTheRight": {
         "baseTask": "SlowlySwipeToTheRight",
         "specificRect": [
-            1100,
+            1150,
             340,
             20,
             20
         ],
         "rectMove": [
-            620,
+            670,
             340,
             20,
             20

--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -9104,7 +9104,6 @@
         ]
     },
     "RoguelikeRecruitOcrFlag": {
-        "maxTimes": 5,
         "roi": [
             525,
             110,
@@ -9170,7 +9169,7 @@
     "RoguelikeRecruitSwipeMaxTime": {
         "algorithm": "JustReturn",
         "maxTimes_Doc": "这个参数是肉鸽招募时，向右划动的最大次数",
-        "maxTimes": 4
+        "maxTimes": 5
     },
     "RoguelikeSkillSelectionFlag": {
         "templThreshold": 0.9,

--- a/src/MaaCore/Controller.cpp
+++ b/src/MaaCore/Controller.cpp
@@ -896,6 +896,11 @@ bool asst::Controller::support_swipe_with_pause() const noexcept
     return m_minitouch_enabled && m_minitouch_available && m_swipe_with_pause_enabled && !m_adb.press_esc.empty();
 }
 
+bool asst::Controller::support_swipe_without_adb() const noexcept
+{
+    return m_minitouch_enabled && m_minitouch_available;
+}
+
 bool asst::Controller::connect(const std::string& adb_path, const std::string& address, const std::string& config)
 {
     LogTraceFunction;

--- a/src/MaaCore/Controller.cpp
+++ b/src/MaaCore/Controller.cpp
@@ -896,7 +896,7 @@ bool asst::Controller::support_swipe_with_pause() const noexcept
     return m_minitouch_enabled && m_minitouch_available && m_swipe_with_pause_enabled && !m_adb.press_esc.empty();
 }
 
-bool asst::Controller::support_swipe_without_adb() const noexcept
+bool asst::Controller::support_precise_swipe() const noexcept
 {
     return m_minitouch_enabled && m_minitouch_available;
 }

--- a/src/MaaCore/Controller.h
+++ b/src/MaaCore/Controller.h
@@ -65,7 +65,7 @@ namespace asst
 
         bool press_esc();
         bool support_swipe_with_pause() const noexcept;
-        bool support_swipe_without_adb() const noexcept;
+        bool support_precise_swipe() const noexcept;
 
         std::pair<int, int> get_scale_size() const noexcept;
 

--- a/src/MaaCore/Controller.h
+++ b/src/MaaCore/Controller.h
@@ -65,6 +65,7 @@ namespace asst
 
         bool press_esc();
         bool support_swipe_with_pause() const noexcept;
+        bool support_swipe_without_adb() const noexcept;
 
         std::pair<int, int> get_scale_size() const noexcept;
 

--- a/src/MaaCore/Task/Roguelike/RoguelikeRecruitTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeRecruitTaskPlugin.cpp
@@ -529,6 +529,7 @@ void asst::RoguelikeRecruitTaskPlugin::slowly_swipe(bool to_left, int swipe_dist
             (swipe_task->special_params.size() < 2) ? false : swipe_task->special_params.at(1),
             (swipe_task->special_params.size() < 3) ? 1 : swipe_task->special_params.at(2),
             (swipe_task->special_params.size() < 4) ? 1 : swipe_task->special_params.at(3));
+        sleep(swipe_task->post_delay);
     }
     else {
         auto swipe_task = Task.get("RoguelikeRecruitOperListSlowlySwipeToTheRight");
@@ -540,5 +541,6 @@ void asst::RoguelikeRecruitTaskPlugin::slowly_swipe(bool to_left, int swipe_dist
             (swipe_task->special_params.size() < 2) ? false : swipe_task->special_params.at(1),
             (swipe_task->special_params.size() < 3) ? 1 : swipe_task->special_params.at(2),
             (swipe_task->special_params.size() < 4) ? 1 : swipe_task->special_params.at(3));
+        sleep(swipe_task->post_delay);
     }
 }

--- a/src/MaaCore/Task/Roguelike/RoguelikeRecruitTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeRecruitTaskPlugin.cpp
@@ -519,28 +519,22 @@ void asst::RoguelikeRecruitTaskPlugin::swipe_to_the_left_of_operlist(int loop_ti
 
 void asst::RoguelikeRecruitTaskPlugin::slowly_swipe(bool to_left, int swipe_dist)
 {
-    if (to_left) {
-        auto swipe_task = Task.get("RoguelikeRecruitOperListSlowlySwipeToTheLeft");
-        const Rect& StartPoint = swipe_task->specific_rect;
-        ctrler()->swipe(
-            StartPoint,
-            { StartPoint.x + swipe_dist - StartPoint.width, StartPoint.y, StartPoint.width, StartPoint.height },
-            swipe_task->special_params.empty() ? 0 : swipe_task->special_params.at(0),
-            (swipe_task->special_params.size() < 2) ? false : swipe_task->special_params.at(1),
-            (swipe_task->special_params.size() < 3) ? 1 : swipe_task->special_params.at(2),
-            (swipe_task->special_params.size() < 4) ? 1 : swipe_task->special_params.at(3));
-        sleep(swipe_task->post_delay);
+    std::string swipe_task_name =
+        to_left ? "RoguelikeRecruitOperListSlowlySwipeToTheLeft" : "RoguelikeRecruitOperListSlowlySwipeToTheRight";
+    if (!ctrler()->support_swipe_without_adb()) { // adb 容易滑飞，不方便精细控制，不使用 swipe_dist 参数
+        ProcessTask(*this, { swipe_task_name }).run();
+        return;
     }
-    else {
-        auto swipe_task = Task.get("RoguelikeRecruitOperListSlowlySwipeToTheRight");
-        const Rect& StartPoint = swipe_task->specific_rect;
-        ctrler()->swipe(
-            StartPoint,
-            { StartPoint.x - swipe_dist - StartPoint.width, StartPoint.y, StartPoint.width, StartPoint.height },
-            swipe_task->special_params.empty() ? 0 : swipe_task->special_params.at(0),
-            (swipe_task->special_params.size() < 2) ? false : swipe_task->special_params.at(1),
-            (swipe_task->special_params.size() < 3) ? 1 : swipe_task->special_params.at(2),
-            (swipe_task->special_params.size() < 4) ? 1 : swipe_task->special_params.at(3));
-        sleep(swipe_task->post_delay);
-    }
+
+    if (!to_left) swipe_dist = -swipe_dist;
+    auto swipe_task = Task.get(swipe_task_name);
+    const Rect& StartPoint = swipe_task->specific_rect;
+    ctrler()->swipe(
+        StartPoint,
+        { StartPoint.x + swipe_dist - StartPoint.width, StartPoint.y, StartPoint.width, StartPoint.height },
+        swipe_task->special_params.empty() ? 0 : swipe_task->special_params.at(0),
+        (swipe_task->special_params.size() < 2) ? false : swipe_task->special_params.at(1),
+        (swipe_task->special_params.size() < 3) ? 1 : swipe_task->special_params.at(2),
+        (swipe_task->special_params.size() < 4) ? 1 : swipe_task->special_params.at(3));
+    sleep(swipe_task->post_delay);
 }

--- a/src/MaaCore/Task/Roguelike/RoguelikeRecruitTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeRecruitTaskPlugin.cpp
@@ -521,7 +521,7 @@ void asst::RoguelikeRecruitTaskPlugin::slowly_swipe(bool to_left, int swipe_dist
 {
     std::string swipe_task_name =
         to_left ? "RoguelikeRecruitOperListSlowlySwipeToTheLeft" : "RoguelikeRecruitOperListSlowlySwipeToTheRight";
-    if (!ctrler()->support_swipe_without_adb()) { // adb 容易滑飞，不方便精细控制，不使用 swipe_dist 参数
+    if (!ctrler()->support_precise_swipe()) { // 不能精准滑动时不使用 swipe_dist 参数
         ProcessTask(*this, { swipe_task_name }).run();
         return;
     }
@@ -529,12 +529,11 @@ void asst::RoguelikeRecruitTaskPlugin::slowly_swipe(bool to_left, int swipe_dist
     if (!to_left) swipe_dist = -swipe_dist;
     auto swipe_task = Task.get(swipe_task_name);
     const Rect& StartPoint = swipe_task->specific_rect;
-    ctrler()->swipe(
-        StartPoint,
-        { StartPoint.x + swipe_dist - StartPoint.width, StartPoint.y, StartPoint.width, StartPoint.height },
-        swipe_task->special_params.empty() ? 0 : swipe_task->special_params.at(0),
-        (swipe_task->special_params.size() < 2) ? false : swipe_task->special_params.at(1),
-        (swipe_task->special_params.size() < 3) ? 1 : swipe_task->special_params.at(2),
-        (swipe_task->special_params.size() < 4) ? 1 : swipe_task->special_params.at(3));
+    ctrler()->swipe(StartPoint,
+                    { StartPoint.x + swipe_dist - StartPoint.width, StartPoint.y, StartPoint.width, StartPoint.height },
+                    swipe_task->special_params.empty() ? 0 : swipe_task->special_params.at(0),
+                    (swipe_task->special_params.size() < 2) ? false : swipe_task->special_params.at(1),
+                    (swipe_task->special_params.size() < 3) ? 1 : swipe_task->special_params.at(2),
+                    (swipe_task->special_params.size() < 4) ? 1 : swipe_task->special_params.at(3));
     sleep(swipe_task->post_delay);
 }

--- a/src/MaaCore/Task/Roguelike/RoguelikeRecruitTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/RoguelikeRecruitTaskPlugin.h
@@ -26,7 +26,7 @@ namespace asst
         // 滑动到干员列表的最左侧
         void swipe_to_the_left_of_operlist(int loop_times = 2);
         // 缓慢向干员列表的左侧/右侧滑动
-        void slowly_swipe(bool to_left);
+        void slowly_swipe(bool to_left, int swipe_dist = 500);
 
     private:
         bool check_support_char();


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/74587068/220940869-b1bdd12f-1d75-4cb1-bb59-04a04b9ecf52.png)

***图中数据标错了，左边是 350，右边是 210***

以上图为例，假设最后识别到的是 海蒂 一列，那么格劳克斯一列在滑动后不能被挡住。
注意到再肉鸽里识别一个干员时用到的最左边的东西是干员等级，也就是说滑动之后格劳克斯一列的干员等级不能被挡住。
假设海蒂的左端点 x 坐标 = pos_x，那么如图所示，最长滑动距离约为 `pos_x + 210 - 350 = pos_x - 140`。
代码中使用 `pos_x - 200` 保证容错。

以这种方式滑动，基本能够保证每次都多 8 个干员。

link to #3811