### PR TITLE
fix: 修复宿舍选人时变量未初始化导致死循环无限右滑

### DIFF
--- a/src/MaaCore/Task/Infrast/InfrastDormTask.cpp
+++ b/src/MaaCore/Task/Infrast/InfrastDormTask.cpp
@@ -84,6 +84,7 @@ bool asst::InfrastDormTask::opers_choose(asst::infrast::CustomRoomConfig const& 
     size_t num_of_fulltrust = 0;
     bool to_fill = false;
     int swipe_times = 0;
+    m_next_step = NextStep::Rest;
 
     while (num_of_selected < max_num_of_opers()) {
         if (need_exit()) {


### PR DESCRIPTION
在函数opers_choose，成员变量m_next_step没有进行初始化，在宿舍0选完人后，m_next_step会变为NextStep::Trust，导致在后续宿舍中选人时可能进入死循环无限向右滑动。

只需要在每次进入函数时将m_next_step初始化为NextStep::Rest即可解决。

疑问：为什么不用局部变量而用成员变量呢？