### PR TITLE
fix: Fix CustomInfrastGenerator URL

### DIFF
--- a/src/MaaWpfGui/Helper/MaaUrls.cs
+++ b/src/MaaWpfGui/Helper/MaaUrls.cs
@@ -30,7 +30,7 @@ namespace MaaWpfGui
 
         public static string MapPrts => "https://map.ark-nights.com/areas?coord_override=maa";
 
-        public static string CustomInfrastGenerator => "https://yituliu.site/riicCal";
+        public static string CustomInfrastGenerator => "https://yituliu.site/riicCal/";
 
         public static string QqGroups => "https://ota.maa.plus/MaaAssistantArknights/api/qqgroup/index.html";
 


### PR DESCRIPTION
缺少的斜杠导致一图流站点导航栏出现不正确高亮的bug。

其实应该在一图流前端修的，如果不想合并的话也行。