### PR TITLE
feat: 优化 changelog 弹窗

### DIFF
--- a/src/MaaWpfGui/Main/RootViewModel.cs
+++ b/src/MaaWpfGui/Main/RootViewModel.cs
@@ -85,6 +85,7 @@ namespace MaaWpfGui
         {
             if (_versionUpdateViewModel.IsFirstBootAfterUpdate)
             {
+                _versionUpdateViewModel.IsFirstBootAfterUpdate = false;
                 _windowManager.ShowWindow(_versionUpdateViewModel);
             }
             else
@@ -93,6 +94,7 @@ namespace MaaWpfGui
 
                 if (ret == VersionUpdateViewModel.CheckUpdateRetT.OK)
                 {
+                    _versionUpdateViewModel.IsFirstBootAfterUpdate = true;
                     _versionUpdateViewModel.AskToRestart();
                 }
             }

--- a/src/MaaWpfGui/Main/VersionUpdateViewModel.cs
+++ b/src/MaaWpfGui/Main/VersionUpdateViewModel.cs
@@ -22,7 +22,10 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Windows;
+using System.Windows.Documents;
 using MaaWpfGui.Helper;
+using Markdig;
+using Neo.Markdig.Xaml;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Stylet;
@@ -107,6 +110,9 @@ namespace MaaWpfGui
                 ViewStatusStorage.Set("VersionUpdate.body", value);
             }
         }
+
+        public FlowDocument UpdateInfoDoc => MarkdownXaml.ToFlowDocument(UpdateInfo,
+                new MarkdownPipelineBuilder().UseXamlSupportedExtensions().Build());
 
         private string _updateUrl;
 

--- a/src/MaaWpfGui/Main/VersionUpdateViewModel.cs
+++ b/src/MaaWpfGui/Main/VersionUpdateViewModel.cs
@@ -125,10 +125,20 @@ namespace MaaWpfGui
             set => SetAndNotify(ref _updateUrl, value);
         }
 
+        private bool _isFirstBootAfterUpdate = Convert.ToBoolean(ViewStatusStorage.Get("VersionUpdate.isfirstboot", bool.FalseString));
+
         /// <summary>
-        /// Gets a value indicating whether it is the first boot after updating.
+        /// Gets or sets a value indicating whether it is the first boot after updating.
         /// </summary>
-        public bool IsFirstBootAfterUpdate => UpdateTag != string.Empty && UpdateTag == _curVersion;
+        public bool IsFirstBootAfterUpdate
+        {
+            get => _isFirstBootAfterUpdate;
+            set
+            {
+                SetAndNotify(ref _isFirstBootAfterUpdate, value);
+                ViewStatusStorage.Set("VersionUpdate.isfirstboot", value.ToString());
+            }
+        }
 
         private string _updatePackageName = ViewStatusStorage.Get("VersionUpdate.package", string.Empty);
 
@@ -958,16 +968,6 @@ namespace MaaWpfGui
             {
                 File.Copy(newPath, newPath.Replace(sourcePath, targetPath), true);
             }
-        }
-
-        /// <summary>
-        /// Closes view model.
-        /// </summary>
-        public void Close()
-        {
-            RequestClose();
-            /* UpdateTag = string.Empty; */
-            /* UpdateInfo = string.Empty; */
         }
 
         /// <summary>

--- a/src/MaaWpfGui/Views/VersionUpdateView.xaml
+++ b/src/MaaWpfGui/Views/VersionUpdateView.xaml
@@ -5,7 +5,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:maa="clr-namespace:MaaWpfGui.Helper.CustomStyle"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-    xmlns:mdxam="clr-namespace:MdXaml;assembly=MdXaml"
+    xmlns:mdg="clr-namespace:Neo.Markdig.Xaml;assembly=Neo.Markdig.Xaml"
     xmlns:s="https://github.com/canton7/Stylet"
     xmlns:vm="clr-namespace:MaaWpfGui"
     Title="{DynamicResource VersionUpdated}"
@@ -15,9 +15,9 @@
     mc:Ignorable="d">
     <Grid>
         <Grid.RowDefinitions>
-            <RowDefinition Height="80" />
+            <RowDefinition Height="50" />
             <RowDefinition Height="*" />
-            <RowDefinition Height="120" />
+            <RowDefinition Height="20" />
         </Grid.RowDefinitions>
 
         <StackPanel
@@ -25,42 +25,43 @@
             HorizontalAlignment="Center"
             Orientation="Horizontal">
             <maa:TextBlock
-                Margin="0,20"
-                FontSize="24"
+                Margin="0,10,0,5"
+                FontSize="20"
                 Style="{StaticResource TextBlockDefaultBold}"
                 Text="{DynamicResource VersionUpdatedTo}"
-                TextWrapping="Wrap" />
+                TextWrapping="Wrap" VerticalAlignment="Bottom" />
             <maa:TextBlock
-                Margin="0,20"
-                FontSize="24"
+                Margin="0,10,0,5"
+                FontSize="20"
                 Style="{StaticResource TextBlockDefaultBold}"
                 Text="{Binding UpdateTag}"
-                TextWrapping="Wrap" />
+                TextWrapping="Wrap" VerticalAlignment="Bottom" />
         </StackPanel>
 
-
-        <mdxam:MarkdownScrollViewer
+        <FlowDocumentScrollViewer
             x:Name="UpdateInfoMarkdownDocument"
+            Document="{Binding UpdateInfoDoc}"
             Grid.Row="1"
             Margin="16,0"
-            ClickAction="DisplayWithRelativePath"
-            Language="zh-CN"
-            Markdown="{Binding UpdateInfo}"
-            MarkdownStyleName="GithubLike" />
+            Zoom="90"
+            IsSelectionEnabled="False">
 
+            <FlowDocumentScrollViewer.Template>
+                <ControlTemplate TargetType="FlowDocumentScrollViewer">
+                    <Border
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        Focusable="False">
+                        <ScrollViewer x:Name="PART_ContentHost" />
+                    </Border>
+                </ControlTemplate>
+            </FlowDocumentScrollViewer.Template>
 
-        <StackPanel
-            Grid.Row="2"
-            HorizontalAlignment="Center"
-            Orientation="Horizontal">
-            <!--<Button Command="{s:Action Download}" Content="前往下载" Margin="20" Width="120" Height="60" />-->
-            <!--<Button Command="{s:Action Ignore}" Content="不再提示" Margin="20" Width="120" Height="60" />-->
-            <Button
-                Width="120"
-                Height="60"
-                Margin="20"
-                Command="{s:Action Close}"
-                Content="{DynamicResource UpdateNotificationOK}" />
-        </StackPanel>
+            <FlowDocumentScrollViewer.CommandBindings>
+                <CommandBinding
+                    Command="{x:Static mdg:MarkdownXaml.Hyperlink}"
+                    Executed="{s:Action OpenHyperlink}" />
+            </FlowDocumentScrollViewer.CommandBindings>
+        </FlowDocumentScrollViewer>
     </Grid>
 </Window>


### PR DESCRIPTION
重新使用了 [NeoMarkdigXaml](https://github.com/neolithos/NeoMarkdigXaml/tree/0fedd1a48de1585f10dfa967db7e57ddca10b5f3)，现在能插入 `[!]()` 形式的图片，并且会隐藏 `<!-- -->` 形式的注释


<details>
<summary>效果</summary>

![image](https://user-images.githubusercontent.com/74587068/222948992-f0cf040d-c37f-4e9c-936a-9351268f7fd1.png)
![image](https://user-images.githubusercontent.com/74587068/222949117-428e4b0b-f68c-4b4e-a1a4-13899353dd82.png)

ps: 好像字体有点丑，但我不知道怎么改（x

</details>

另外，我把 ”好的“ 按钮删了，感觉有点占空间（点右上角的 x 不就好了么），这样能显示更多的 changelog