### PR TITLE
feat:更好的退出模拟器方式

### DIFF
--- a/src/MaaWpfGui/Main/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/Main/TaskQueueViewModel.cs
@@ -960,7 +960,7 @@ namespace MaaWpfGui
         private static extern int GetWindowThreadProcessId(IntPtr hwnd, out int id);
         
         /// <summary>
-        /// 一个用于判断关闭模拟器窗口的方式的方法
+        /// 一个根据连接配置判断使用关闭模拟器的方式的方法
         /// </summary>
         public bool KillEmulatorModeSwitcher()
         {

--- a/src/MaaWpfGui/Main/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/Main/TaskQueueViewModel.cs
@@ -964,7 +964,7 @@ namespace MaaWpfGui
         /// </summary>
         public bool KillEmulatorModeSwitcher()
         {
-            string emulatorMode = ViewStatusStorage.Get("Connect.ConnectConfig", "General");
+            string emulatorMode = _settingsViewModel.ConnectConfig;
             switch (emulatorMode)
             {
                 case "Nox":
@@ -982,7 +982,7 @@ namespace MaaWpfGui
         /// </summary>
         public bool KillEmulatorLDPlayer()
         {
-            string address = ViewStatusStorage.Get("Connect.Address", string.Empty);
+            string address = _settingsViewModel.Address;
             int emuIndex;
             if (address.Contains(":"))
             {
@@ -1015,7 +1015,7 @@ namespace MaaWpfGui
         /// </summary>
         public bool KillEmulatorNox()
         {
-            string address = ViewStatusStorage.Get("Connect.Address", string.Empty);
+            string address = _settingsViewModel.Address;
             int emuIndex;
             if (address == "127.0.0.1:62001")
             {
@@ -1046,7 +1046,7 @@ namespace MaaWpfGui
         /// </summary>
         public bool KillEmulatorXYAZ()
         {
-            string address = ViewStatusStorage.Get("Connect.Address", string.Empty);
+            string address = _settingsViewModel.Address;
             int emuIndex;
             string portStr = address.Split(':')[1];
             int port = int.Parse(portStr);

--- a/src/MaaWpfGui/Main/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/Main/TaskQueueViewModel.cs
@@ -964,7 +964,7 @@ namespace MaaWpfGui
         /// </summary>
         public bool KillEmulatorModeSwitcher()
         {
-            string emulatorMode = ViewStatusStorage.Get("Connect.ConnectConfig", "General");
+            string emulatorMode = _settingsViewModel.ConnectConfig;
             switch (emulatorMode)
             {
                 case "Nox":
@@ -983,7 +983,7 @@ namespace MaaWpfGui
         /// </summary>
         public bool KillEmulatorLDPlayer()
         {
-            string address = ViewStatusStorage.Get("Connect.Address", string.Empty);
+            string address = _settingsViewModel.ConnectAddress;
             int emuIndex;
             if (address.Contains(":"))
             {
@@ -1022,7 +1022,7 @@ namespace MaaWpfGui
         /// </summary>
         public bool KillEmulatorNox()
         {
-            string address = ViewStatusStorage.Get("Connect.Address", string.Empty);
+            string address = _settingsViewModel.ConnectAddress;
             int emuIndex;
             if (address == "127.0.0.1:62001")
             {
@@ -1059,7 +1059,7 @@ namespace MaaWpfGui
         /// </summary>
         public bool KillEmulatorXYAZ()
         {
-            string address = ViewStatusStorage.Get("Connect.Address", string.Empty);
+            string address = _settingsViewModel.ConnectAddress;
             int emuIndex;
             string portStr = address.Split(':')[1];
             int port = int.Parse(portStr);

--- a/src/MaaWpfGui/Main/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/Main/TaskQueueViewModel.cs
@@ -982,17 +982,17 @@ namespace MaaWpfGui
         /// </summary>
         public bool KillEmulatorLDPlayer()
         {
-            string emuAddress = ViewStatusStorage.Get("Connect.Address", string.Empty);
+            string address = ViewStatusStorage.Get("Connect.Address", string.Empty);
             int emuIndex;
-            if (emuAddress.Contains(":"))
+            if (address.Contains(":"))
             {
-                string portStr = emuAddress.Split(':')[1];
+                string portStr = address.Split(':')[1];
                 int port = int.Parse(portStr);
                 emuIndex = (port - 5555) / 2;
             }
             else
             {
-                string portStr = emuAddress.Split('-')[1];
+                string portStr = address.Split('-')[1];
                 int port = int.Parse(portStr);
                 emuIndex = (port - 5554) / 2;
             }
@@ -1015,15 +1015,15 @@ namespace MaaWpfGui
         /// </summary>
         public bool KillEmulatorNox()
         {
-            string emuAddress = ViewStatusStorage.Get("Connect.Address", string.Empty);
+            string address = ViewStatusStorage.Get("Connect.Address", string.Empty);
             int emuIndex;
-            if (emuAddress == "127.0.0.1:62001")
+            if (address == "127.0.0.1:62001")
             {
                 emuIndex = 0;
             }
             else
             {
-                string portStr = emuAddress.Split(':')[1];
+                string portStr = address.Split(':')[1];
                 int port = int.Parse(portStr);
                 emuIndex = port - 62024;
             }
@@ -1046,9 +1046,9 @@ namespace MaaWpfGui
         /// </summary>
         public bool KillEmulatorXYAZ()
         {
-            string emuAddress = ViewStatusStorage.Get("Connect.Address", string.Empty);
+            string address = ViewStatusStorage.Get("Connect.Address", string.Empty);
             int emuIndex;
-            string portStr = emuAddress.Split(':')[1];
+            string portStr = address.Split(':')[1];
             int port = int.Parse(portStr);
             emuIndex = (port - 21503) / 10;
 
@@ -1076,10 +1076,6 @@ namespace MaaWpfGui
             var windowname = new[]
             {
                 "明日方舟",
-                "夜神模拟器",
-                "逍遥模拟器",
-                "雷电模拟器(64)",
-                "雷电模拟器",
                 "明日方舟 - MuMu模拟器",
                 "BlueStacks App Player",
                 "BlueStacks",

--- a/src/MaaWpfGui/Main/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/Main/TaskQueueViewModel.cs
@@ -964,7 +964,7 @@ namespace MaaWpfGui
         /// </summary>
         public bool KillEmulatorModeSwitcher()
         {
-            string emulatorMode = _settingsViewModel.ConnectConfig;
+            string emulatorMode = ViewStatusStorage.Get("Connect.ConnectConfig", "General");
             switch (emulatorMode)
             {
                 case "Nox":
@@ -977,6 +977,7 @@ namespace MaaWpfGui
                     return KillEumlatorbyWindow();
             }
         }
+        
         /// <summary>
         /// 一个用于调用雷电模拟器控制台关闭雷电模拟器的方法
         /// </summary>
@@ -1002,14 +1003,20 @@ namespace MaaWpfGui
             {
                 string emuLocation = processes[0].MainModule.FileName;
                 emuLocation = Path.GetDirectoryName(emuLocation);
-                string ldconsolePath = Path.Combine(emuLocation, "ldconsole.exe");
-                Process.Start(ldconsolePath, $"quit --index {emuIndex}");
+                string consolePath = Path.Combine(emuLocation, "ldconsole.exe");
+                
+                ProcessStartInfo startInfo = new ProcessStartInfo(consolePath);
+                startInfo.Arguments = $"quit --index {emuIndex}";
+                startInfo.CreateNoWindow = true;
+                startInfo.UseShellExecute = false;
+                Process.Start(startInfo);
         
                 return KillEmulator();
             }
     
             return false;
         }
+        
         /// <summary>
         /// 一个用于调用夜神模拟器控制台关闭夜神模拟器的方法
         /// </summary>
@@ -1033,14 +1040,20 @@ namespace MaaWpfGui
             {
                 string emuLocation = processes[0].MainModule.FileName;
                 emuLocation = Path.GetDirectoryName(emuLocation);
-                string noxConsolePath = Path.Combine(emuLocation, "NoxConsole.exe");
-                Process.Start(noxConsolePath, $"quit -index:{emuIndex}");
+                string consolePath = Path.Combine(emuLocation, "NoxConsole.exe");
+                
+                ProcessStartInfo startInfo = new ProcessStartInfo(consolePath);
+                startInfo.Arguments = $"quit -index:{emuIndex}";
+                startInfo.CreateNoWindow = true;
+                startInfo.UseShellExecute = false;
+                Process.Start(startInfo);
         
                 return KillEmulator();
             }
     
             return false;
         }
+        
         /// <summary>
         /// 一个用于调用逍遥模拟器控制台关闭逍遥模拟器的方法
         /// </summary>
@@ -1057,14 +1070,20 @@ namespace MaaWpfGui
             {
                 string emuLocation = processes[0].MainModule.FileName;
                 emuLocation = Path.GetDirectoryName(emuLocation);
-                string memucPath = Path.Combine(emuLocation, "memuc.exe");
-                Process.Start(memucPath, $"stop -i {emuIndex}");
+                string consolePath = Path.Combine(emuLocation, "memuc.exe");
+                
+                ProcessStartInfo startInfo = new ProcessStartInfo(consolePath);
+                startInfo.Arguments = $"stop -i {emuIndex}";
+                startInfo.CreateNoWindow = true;
+                startInfo.UseShellExecute = false;
+                Process.Start(startInfo);
         
                 return KillEmulator();
             }
     
             return false;
         }
+        
         /// <summary>
         /// Kills emulator by Window hwnd.
         /// </summary>

--- a/src/MaaWpfGui/Main/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/Main/TaskQueueViewModel.cs
@@ -982,7 +982,7 @@ namespace MaaWpfGui
         /// </summary>
         public bool KillEmulatorLDPlayer()
         {
-            string address = _settingsViewModel.Address;
+            string address = ViewStatusStorage.Get("Connect.Address", string.Empty);
             int emuIndex;
             if (address.Contains(":"))
             {
@@ -1015,7 +1015,7 @@ namespace MaaWpfGui
         /// </summary>
         public bool KillEmulatorNox()
         {
-            string address = _settingsViewModel.Address;
+            string address = ViewStatusStorage.Get("Connect.Address", string.Empty);
             int emuIndex;
             if (address == "127.0.0.1:62001")
             {
@@ -1046,7 +1046,7 @@ namespace MaaWpfGui
         /// </summary>
         public bool KillEmulatorXYAZ()
         {
-            string address = _settingsViewModel.Address;
+            string address = ViewStatusStorage.Get("Connect.Address", string.Empty);
             int emuIndex;
             string portStr = address.Split(':')[1];
             int port = int.Parse(portStr);

--- a/src/MaaWpfGui/Main/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/Main/TaskQueueViewModel.cs
@@ -958,7 +958,113 @@ namespace MaaWpfGui
 
         [DllImport("User32.dll", CharSet = CharSet.Auto)]
         private static extern int GetWindowThreadProcessId(IntPtr hwnd, out int id);
+        
+        /// <summary>
+        /// 一个用于判断关闭模拟器窗口的方式的方法
+        /// </summary>
+        public bool KillEmulatorModeSwitcher()
+        {
+            string emulatorMode = ViewStatusStorage.Get("Connect.ConnectConfig", "General");
+            switch (emulatorMode)
+            {
+                case "Nox":
+                    return KillEmulatorNox();
+                case "LDPlayer":
+                    return KillEmulatorLDPlayer();
+                case "XYAZ":
+                    return KillEmulatorXYAZ();
+                default:
+                    return KillEumlatorbyWindow();
+            }
+        }
+        /// <summary>
+        /// 一个用于调用雷电模拟器控制台关闭雷电模拟器的方法
+        /// </summary>
+        public bool KillEmulatorLDPlayer()
+        {
+            string emuAddress = ViewStatusStorage.Get("Connect.Address", string.Empty);
+            int emuIndex;
+            if (emuAddress.Contains(":"))
+            {
+                string portStr = emuAddress.Split(':')[1];
+                int port = int.Parse(portStr);
+                emuIndex = (port - 5555) / 2;
+            }
+            else
+            {
+                string portStr = emuAddress.Split('-')[1];
+                int port = int.Parse(portStr);
+                emuIndex = (port - 5554) / 2;
+            }
 
+            Process[] processes = Process.GetProcessesByName("dnplayer");
+            if (processes.Length > 0)
+            {
+                string emuLocation = processes[0].MainModule.FileName;
+                emuLocation = Path.GetDirectoryName(emuLocation);
+                string ldconsolePath = Path.Combine(emuLocation, "ldconsole.exe");
+                Process.Start(ldconsolePath, $"quit --index {emuIndex}");
+        
+                return KillEmulator();
+            }
+    
+            return false;
+        }
+        /// <summary>
+        /// 一个用于调用夜神模拟器控制台关闭夜神模拟器的方法
+        /// </summary>
+        public bool KillEmulatorNox()
+        {
+            string emuAddress = ViewStatusStorage.Get("Connect.Address", string.Empty);
+            int emuIndex;
+            if (emuAddress == "127.0.0.1:62001")
+            {
+                emuIndex = 0;
+            }
+            else
+            {
+                string portStr = emuAddress.Split(':')[1];
+                int port = int.Parse(portStr);
+                emuIndex = port - 62024;
+            }
+
+            Process[] processes = Process.GetProcessesByName("Nox");
+            if (processes.Length > 0)
+            {
+                string emuLocation = processes[0].MainModule.FileName;
+                emuLocation = Path.GetDirectoryName(emuLocation);
+                string noxConsolePath = Path.Combine(emuLocation, "NoxConsole.exe");
+                Process.Start(noxConsolePath, $"quit -index:{emuIndex}");
+        
+                return KillEmulator();
+            }
+    
+            return false;
+        }
+        /// <summary>
+        /// 一个用于调用逍遥模拟器控制台关闭逍遥模拟器的方法
+        /// </summary>
+        public bool KillEmulatorXYAZ()
+        {
+            string emuAddress = ViewStatusStorage.Get("Connect.Address", string.Empty);
+            int emuIndex;
+            string portStr = emuAddress.Split(':')[1];
+            int port = int.Parse(portStr);
+            emuIndex = (port - 21503) / 10;
+
+            Process[] processes = Process.GetProcessesByName("MEmu");
+            if (processes.Length > 0)
+            {
+                string emuLocation = processes[0].MainModule.FileName;
+                emuLocation = Path.GetDirectoryName(emuLocation);
+                string memucPath = Path.Combine(emuLocation, "memuc.exe");
+                Process.Start(memucPath, $"stop -i {emuIndex}");
+        
+                return KillEmulator();
+            }
+    
+            return false;
+        }
         /// <summary>
         /// Kills emulator by Window hwnd.
         /// </summary>
@@ -1203,7 +1309,7 @@ namespace MaaWpfGui
                     break;
 
                 case ActionType.ExitEmulator:
-                    if (!KillEumlatorbyWindow())
+                    if (!KillEmulatorModeSwitcher())
                     {
                         AddLog(Localization.GetString("ExitEmulatorFailed"), UILogColor.Error);
                     }
@@ -1211,7 +1317,7 @@ namespace MaaWpfGui
                     break;
 
                 case ActionType.ExitEmulatorAndSelf:
-                    if (!KillEumlatorbyWindow())
+                    if (!KillEmulatorModeSwitcher())
                     {
                         AddLog(Localization.GetString("ExitEmulatorFailed"), UILogColor.Error);
                     }
@@ -1252,7 +1358,7 @@ namespace MaaWpfGui
 
                 case ActionType.ExitEmulatorAndSelfAndHibernate:
                 case ActionType.ExitEmulatorAndSelfAndHibernateWithoutPersist:
-                    if (!KillEumlatorbyWindow())
+                    if (!KillEmulatorModeSwitcher())
                     {
                         AddLog(Localization.GetString("ExitEmulatorFailed"), UILogColor.Error);
                     }

--- a/src/MaaWpfGui/Main/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/Main/TaskQueueViewModel.cs
@@ -1005,15 +1005,23 @@ namespace MaaWpfGui
                 emuLocation = Path.GetDirectoryName(emuLocation);
                 string consolePath = Path.Combine(emuLocation, "ldconsole.exe");
                 
-                ProcessStartInfo startInfo = new ProcessStartInfo(consolePath);
-                startInfo.Arguments = $"quit --index {emuIndex}";
-                startInfo.CreateNoWindow = true;
-                startInfo.UseShellExecute = false;
-                Process.Start(startInfo);
-        
-                return KillEmulator();
+                if (File.Exists(consolePath))
+                {
+                    ProcessStartInfo startInfo = new ProcessStartInfo(consolePath);
+                    startInfo.Arguments = $"quit --index {emuIndex}";
+                    startInfo.CreateNoWindow = true;
+                    startInfo.UseShellExecute = false;
+                    Process.Start(startInfo);
+                   
+                    return KillEmulator();
+                }
+                else
+                {
+                    AsstProxy.AsstLog($"Error: {consolePath} not found, try to kill eumlator by window");
+                    return KillEumlatorbyWindow();
+                }
             }
-    
+            
             return false;
         }
         
@@ -1042,15 +1050,23 @@ namespace MaaWpfGui
                 emuLocation = Path.GetDirectoryName(emuLocation);
                 string consolePath = Path.Combine(emuLocation, "NoxConsole.exe");
                 
-                ProcessStartInfo startInfo = new ProcessStartInfo(consolePath);
-                startInfo.Arguments = $"quit -index:{emuIndex}";
-                startInfo.CreateNoWindow = true;
-                startInfo.UseShellExecute = false;
-                Process.Start(startInfo);
-        
-                return KillEmulator();
+                if (File.Exists(consolePath))
+                {
+                    ProcessStartInfo startInfo = new ProcessStartInfo(consolePath);
+                    startInfo.Arguments = $"quit -index:{emuIndex}";
+                    startInfo.CreateNoWindow = true;
+                    startInfo.UseShellExecute = false;
+                    Process.Start(startInfo);                
+
+                    return KillEmulator();
+                }
+                else
+                {
+                    AsstProxy.AsstLog($"Error: {consolePath} not found, try to kill eumlator by window");
+                    return KillEumlatorbyWindow();
+                }
             }
-    
+            
             return false;
         }
         
@@ -1072,13 +1088,21 @@ namespace MaaWpfGui
                 emuLocation = Path.GetDirectoryName(emuLocation);
                 string consolePath = Path.Combine(emuLocation, "memuc.exe");
                 
-                ProcessStartInfo startInfo = new ProcessStartInfo(consolePath);
-                startInfo.Arguments = $"stop -i {emuIndex}";
-                startInfo.CreateNoWindow = true;
-                startInfo.UseShellExecute = false;
-                Process.Start(startInfo);
-        
-                return KillEmulator();
+                if (File.Exists(consolePath))
+                {
+                    ProcessStartInfo startInfo = new ProcessStartInfo(consolePath);
+                    startInfo.Arguments = $"stop -i {emuIndex}";
+                    startInfo.CreateNoWindow = true;
+                    startInfo.UseShellExecute = false;
+                    Process.Start(startInfo);                
+
+                    return KillEmulator();
+                }
+                else
+                {
+                    AsstProxy.AsstLog($"Error: {consolePath} not found, try to kill eumlator by window");
+                    return KillEumlatorbyWindow();
+                }
             }
     
             return false;


### PR DESCRIPTION
方案思路来源：https://github.com/MaaAssistantArknights/MaaAssistantArknights/issues/3966
经过测试后已经能正常退出`雷电模拟器`的对应进程。
同时由于`逍遥模拟器`、与`夜神模拟器`使用同种方案，因此理应也是测试通过的。
可以合并了