### PR TITLE
chore: 修复 Clang / GCC 编译warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ if (MSVC)
     
     set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 else ()
-    add_compile_options("-Wall;-Wextra;-Wpedantic")
+    add_compile_options("-Wall;-Werror;-Wextra;-Wpedantic;-Wno-missing-field-initializers")
 endif ()
 
 

--- a/src/MaaCore/Assistant.cpp
+++ b/src/MaaCore/Assistant.cpp
@@ -107,6 +107,8 @@ bool asst::Assistant::set_instance_option(InstanceOptionKey key, const std::stri
             return true;
         }
         break;
+    default:
+        break;
     }
     Log.error("Unknown key or value", value);
     return false;

--- a/src/MaaCore/Config/TaskData.cpp
+++ b/src/MaaCore/Config/TaskData.cpp
@@ -256,7 +256,7 @@ bool asst::TaskData::explain_tasks(tasklist_t& new_tasks, const tasklist_t& raw_
         "none",               // 18
     };
 
-    auto is_symbl_name = [&](symbl_t x) { return x >= symbl_name_start; };
+    [[maybe_unused]] auto is_symbl_name = [&](symbl_t x) { return x >= symbl_name_start; };
     auto is_symbl_subtask_type = [&](symbl_t x) {
         switch (x) {
         case symbl_name_sub:
@@ -269,7 +269,7 @@ bool asst::TaskData::explain_tasks(tasklist_t& new_tasks, const tasklist_t& raw_
             return false;
         }
     };
-    auto is_symbl_sharp_type = [&](symbl_t x) {
+    [[maybe_unused]] auto is_symbl_sharp_type = [&](symbl_t x) {
         switch (x) {
         case symbl_name_self:
         case symbl_name_back:

--- a/src/MaaCore/Task/Fight/StageNavigationTask.cpp
+++ b/src/MaaCore/Task/Fight/StageNavigationTask.cpp
@@ -49,7 +49,7 @@ bool asst::StageNavigationTask::set_stage_name(const std::string& stage_name)
     if (!difficulty.empty()) {
         std::string upper_difficulty = difficulty;
         upper_difficulty[0] = static_cast<char>(::toupper(upper_difficulty[0]));
-        for (int i = 1; i < upper_difficulty.size(); ++i) {
+        for (size_t i = 1; i < upper_difficulty.size(); ++i) {
             upper_difficulty[i] = static_cast<char>(::tolower(upper_difficulty[i]));
         }
         static const std::string DifficultyTaskPrefix = "ChapterDifficulty";

--- a/src/MaaCore/Task/Infrast/InfrastAbstractTask.cpp
+++ b/src/MaaCore/Task/Infrast/InfrastAbstractTask.cpp
@@ -76,7 +76,7 @@ asst::infrast::CustomRoomConfig& asst::InfrastAbstractTask::current_room_config(
         return empty;
     }
 
-    if (m_cur_facility_index < m_custom_config.size()) {
+    if (static_cast<size_t>(m_cur_facility_index) < m_custom_config.size()) {
         return m_custom_config[m_cur_facility_index];
     }
     else {
@@ -97,7 +97,7 @@ bool asst::InfrastAbstractTask::enter_facility(int index)
 {
     LogTraceFunction;
 
-    if (m_is_custom && index >= m_custom_config.size()) {
+    if (m_is_custom && static_cast<size_t>(m_cur_facility_index) >= m_custom_config.size()) {
         Log.warn("index is lager than config size", index, m_custom_config.size());
         return false;
     }
@@ -176,7 +176,7 @@ bool asst::InfrastAbstractTask::swipe_and_select_custom_opers(bool is_dorm_order
         if (!select_custom_opers(partial_result)) {
             return false;
         }
-        if (room_config.selected >= max_num_of_opers() ||
+        if (static_cast<size_t>(room_config.selected) >= max_num_of_opers() ||
             (room_config.names.empty() && room_config.candidates.empty())) {
             break;
         }
@@ -268,7 +268,7 @@ bool asst::InfrastAbstractTask::select_opers_review(infrast::CustomRoomConfig co
         Log.warn("select opers review fail: 选中干员数与期望不符");
         return false;
     }
-    if (facility_name() != "Dorm" && (!m_is_custom || room_config.names.empty() && room_config.candidates.empty())) {
+    if (facility_name() != "Dorm" && (!m_is_custom || (room_config.names.empty() && room_config.candidates.empty()))) {
         return true;
     }
     if (selected_count < room_config.names.size()) {
@@ -363,7 +363,7 @@ bool asst::InfrastAbstractTask::select_custom_opers(std::vector<std::string>& pa
         if (!oper.selected) {
             ctrler()->click(oper.rect);
         }
-        if (++room_config.selected >= max_num_of_opers()) {
+        if (static_cast<size_t>(++room_config.selected) >= max_num_of_opers()) {
             break;
         }
     }

--- a/src/MaaCore/Task/Infrast/InfrastProductionTask.cpp
+++ b/src/MaaCore/Task/Infrast/InfrastProductionTask.cpp
@@ -78,7 +78,7 @@ bool asst::InfrastProductionTask::shift_facility_list()
     }
     const auto tab_task_ptr = Task.get("InfrastFacilityListTab" + facility_name());
 
-    for (; m_cur_facility_index < m_facility_list_tabs.size(); ++m_cur_facility_index) {
+    for (; static_cast<size_t>(m_cur_facility_index) < m_facility_list_tabs.size(); ++m_cur_facility_index) {
         Rect tab = m_facility_list_tabs.at(m_cur_facility_index);
         if (need_exit()) {
             return false;
@@ -86,7 +86,7 @@ bool asst::InfrastProductionTask::shift_facility_list()
         if (m_cur_facility_index != 0) {
             callback(AsstMsg::SubTaskExtraInfo, basic_info_with_what("EnterFacility"));
             if (m_is_custom) {
-                if (m_cur_facility_index < m_custom_config.size()) {
+                if (static_cast<size_t>(m_cur_facility_index) < m_custom_config.size()) {
                     current_room_config() = m_custom_config.at(m_cur_facility_index);
                 }
                 else {
@@ -332,7 +332,7 @@ bool asst::InfrastProductionTask::optimal_calc()
     }
 
     std::unordered_map<std::string, int> skills_num;
-    for (int i = 0; i != m_all_available_opers.size(); ++i) {
+    for (size_t i = 0; i != m_all_available_opers.size(); ++i) {
         const auto& comb = all_available_combs.at(i);
 
         bool out_of_num = false;
@@ -353,7 +353,7 @@ bool asst::InfrastProductionTask::optimal_calc()
             ++skills_num[skill.id];
         }
 
-        if (optimal_combs.size() >= cur_max_num_of_opers) {
+        if (optimal_combs.size() >= static_cast<size_t>(cur_max_num_of_opers)) {
             break;
         }
     }
@@ -437,7 +437,7 @@ bool asst::InfrastProductionTask::optimal_calc()
         // 可能有多个干员有同样的技能，所以这里需要循环找同一个技能，直到找不到为止
         for (const infrast::SkillsComb& opt : optional) {
             auto find_iter = cur_available_opers.cbegin();
-            while (cur_combs.size() != cur_max_num_of_opers) {
+            while (cur_combs.size() != static_cast<size_t>(cur_max_num_of_opers)) {
                 find_iter = std::find_if(find_iter, cur_available_opers.cend(),
                                          [&](const infrast::SkillsComb& arg) -> bool { return arg == opt; });
                 if (find_iter != cur_available_opers.cend()) {
@@ -472,7 +472,7 @@ bool asst::InfrastProductionTask::optimal_calc()
         }
 
         // 说明可选的没凑满人
-        if (cur_combs.size() < cur_max_num_of_opers) {
+        if (cur_combs.size() < static_cast<size_t>(cur_max_num_of_opers)) {
             // 允许外部的话，就把单个干员凑进来
             if (group.allow_external) {
                 size_t substitutes = cur_max_num_of_opers - cur_combs.size();

--- a/src/MaaCore/Task/Interface/CopilotTask.cpp
+++ b/src/MaaCore/Task/Interface/CopilotTask.cpp
@@ -62,7 +62,7 @@ bool asst::CopilotTask::set_params(const json::value& params)
     if (loop_times > 1) {
         m_subtasks.reserve(m_subtasks.size() * loop_times);
         auto raw_end = m_subtasks.end();
-        for (int i = 1; i < loop_times; ++i) {
+        for (size_t i = 1; i < loop_times; ++i) {
             // FIXME: 如果多次调用 set_params，这里复制的会有问题
             m_subtasks.insert(m_subtasks.end(), m_subtasks.begin(), raw_end);
         }

--- a/src/MaaCore/Task/Interface/SSSCopilotTask.cpp
+++ b/src/MaaCore/Task/Interface/SSSCopilotTask.cpp
@@ -75,7 +75,7 @@ bool asst::SSSCopilotTask::set_params(const json::value& params)
     if (loop_times > 1) {
         m_subtasks.reserve(m_subtasks.size() * loop_times);
         auto raw_end = m_subtasks.end();
-        for (int i = 1; i < loop_times; ++i) {
+        for (size_t i = 1; i < loop_times; ++i) {
             // FIXME: 如果多次调用 set_params，这里复制的会有问题
             m_subtasks.insert(m_subtasks.end(), m_subtasks.begin(), raw_end);
         }

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -94,6 +94,8 @@ bool asst::BattleFormationTask::add_additional()
         case Filter::Trust:
             // TODO
             break;
+        default:
+            break;
         }
         if (!filter_name.empty()) {
             ProcessTask(*this, { "BattleQuickFormationFilter" }).run();
@@ -110,7 +112,7 @@ bool asst::BattleFormationTask::add_additional()
             auto opers_result = analyzer_opers();
 
             // TODO 这里要识别一下干员之前有没有被选中过
-            for (int i = 0; i < number && i < opers_result.size(); ++i) {
+            for (size_t i = 0; i < static_cast<size_t>(number) && i < opers_result.size(); ++i) {
                 const auto& oper = opers_result.at(i);
                 ctrler()->click(oper.rect);
             }

--- a/src/MaaCore/Task/Miscellaneous/BattleProcessTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleProcessTask.cpp
@@ -311,7 +311,7 @@ bool asst::BattleProcessTask::wait_condition(const Action& action)
             }
             size_t cooling_count = ranges::count_if(m_cur_deployment_opers | views::values,
                                                     [](const auto& oper) -> bool { return oper.cooling; });
-            if (cooling_count == action.cooling) {
+            if (cooling_count == static_cast<size_t>(action.cooling)) {
                 break;
             }
             do_strategy_and_update_image();

--- a/src/MaaCore/Task/Roguelike/RoguelikeBattleTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeBattleTaskPlugin.cpp
@@ -437,6 +437,8 @@ void asst::RoguelikeBattleTaskPlugin::postproc_of_deployment_conditions(const ba
             }
         }
         break;
+    default:
+        break;
     }
 
     if (m_force_air_defense.has_finished_deploy_air_defense && position != OperPosition::AirDefense) {
@@ -523,6 +525,8 @@ std::optional<asst::battle::DeploymentOper> asst::RoguelikeBattleTaskPlugin::cal
         case Role::Medic:
             has_medic = true;
             break;
+        default:
+            break;
         }
 
         const auto& position = get_role_position(role);
@@ -532,6 +536,8 @@ std::optional<asst::battle::DeploymentOper> asst::RoguelikeBattleTaskPlugin::cal
             break;
         case OperPosition::AirDefense:
             has_air_defense = true;
+            break;
+        default:
             break;
         }
 

--- a/src/MaaCore/Task/SSS/SSSBattleProcessTask.cpp
+++ b/src/MaaCore/Task/SSS/SSSBattleProcessTask.cpp
@@ -176,7 +176,7 @@ bool asst::SSSBattleProcessTask::check_if_start_over(const battle::copilot::Acti
             cur_counts[oper.role] += 1;
         }
         for (const auto& [role, number] : action.role_counts) {
-            if (cur_counts[role] < number) {
+            if (cur_counts[role] < static_cast<size_t>(number)) {
                 to_abandon = true;
                 break;
             }

--- a/src/MaaCore/Vision/Infrast/InfrastFacilityImageAnalyzer.h
+++ b/src/MaaCore/Vision/Infrast/InfrastFacilityImageAnalyzer.h
@@ -32,7 +32,7 @@ namespace asst
                 return {};
             }
             else {
-                if (index < 0 || index >= iter->second.size()) {
+                if (index < 0 || static_cast<size_t>(index) >= iter->second.size()) {
                     return {};
                 }
                 else {

--- a/src/MaaCore/Vision/Miscellaneous/ProcessTaskImageAnalyzer.cpp
+++ b/src/MaaCore/Vision/Miscellaneous/ProcessTaskImageAnalyzer.cpp
@@ -12,8 +12,8 @@
 
 asst::ProcessTaskImageAnalyzer::ProcessTaskImageAnalyzer(const cv::Mat& image, std::vector<std::string> tasks_name,
                                                          Assistant* inst)
-    : AbstractImageAnalyzer(image, inst), m_tasks_name(std::move(tasks_name)), m_ocr_analyzer(nullptr),
-      m_ocr_with_preprocess_analyzer(nullptr), m_match_analyzer(nullptr)
+    : AbstractImageAnalyzer(image, inst), m_ocr_analyzer(nullptr), m_ocr_with_preprocess_analyzer(nullptr),
+      m_match_analyzer(nullptr), m_tasks_name(std::move(tasks_name))
 {}
 
 asst::ProcessTaskImageAnalyzer::~ProcessTaskImageAnalyzer() = default;

--- a/src/MaaCore/Vision/Miscellaneous/StageDropsImageAnalyzer.cpp
+++ b/src/MaaCore/Vision/Miscellaneous/StageDropsImageAnalyzer.cpp
@@ -473,6 +473,8 @@ std::string asst::StageDropsImageAnalyzer::match_item(const Rect& roi, StageDrop
         return "AP_GAMEPLAY"; // 理智返还
     case StageDropType::Reward:
         return "4003"; // 合成玉
+    default:
+        break;
     }
 
     auto match_item_with_templs = [&](const std::vector<std::string>& templs_list) -> std::string {


### PR DESCRIPTION
### Clang
- 为 switch 添加 default 
- int 和 size_t 比较之前先 static_cast
- 添加两处 [[maybe_unused]]
- 修正一处参数列表的顺序

### GCC
- 显式忽略一处 missing field initializers

### CMake
- 由于目前的所有 warning 都修复了，编译参数就添加了 -Werror（希望不会造成后续的不便）