### PR TITLE
chore: 更正注释

### DIFF
--- a/.github/issue-checker.yml
+++ b/.github/issue-checker.yml
@@ -284,7 +284,7 @@ labels:
   - remove module
   - remove recruit
 
-# `module: recruit`
+# `module: GUI`
 - name: GUI
   content: "module: GUI"
   regexes:


### PR DESCRIPTION
remove了半天 #4165 的copilot label但是死活删不掉
乱翻配置看到了顺手改一下
(所以说 remove `copilot` 这个comment为什么触发不了bot 明明匹配上了表达式)