### PR TITLE
fix: 打开 debug 模式下的任务 JustReturn 检查

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -2922,8 +2922,8 @@
         "next": [
             "PRTS#next",
             "EndOfAction",
-            "#self@LoadingText",
-            "#self@LoadingIcon",
+            "WaitAfterPRTS@LoadingText",
+            "WaitAfterPRTS@LoadingIcon",
             "ClickCornerAfterPRTS"
         ]
     },
@@ -2942,7 +2942,7 @@
         "postDelay": 3000,
         "next": [
             "EndOfAction",
-            "((ClickCorner + WaitAfterPRTS + StartUpThemes)#next ^ ClickCornerAfterPRTS)",
+            "(ClickCorner + WaitAfterPRTS + StartUpThemes)#next ^ #self",
             "#self"
         ],
         "exceededNext": [
@@ -3018,7 +3018,7 @@
             "UseMedicine",
             "UseStone",
             "NoStone",
-            "#self@LoadingIcon",
+            "ClickCorner@LoadingIcon",
             "#self"
         ],
         "exceededNext": [
@@ -11342,7 +11342,9 @@
         ]
     },
     "StartWithDefaultFormation@Reclamation@ConfirmStart": {
-        "next": [
+        "next": [],
+        "next_Old_Doc": "这里原先有个stop，但是会导致StartWithDefaultFormation@Reclamation@Begin中间多出一个Stop，姑且当成是不小心加的删了。",
+        "next_Old": [
             "Stop"
         ]
     },

--- a/src/MaaCore/Config/TaskData.cpp
+++ b/src/MaaCore/Config/TaskData.cpp
@@ -3,6 +3,10 @@
 #include <algorithm>
 #include <meojson/json.hpp>
 
+#ifdef ASST_DEBUG
+#include <queue>
+#endif
+
 #include "Common/AsstTypes.h"
 #include "GeneralConfig.h"
 #include "TemplResource.h"
@@ -151,14 +155,25 @@ bool asst::TaskData::parse(const json::value& json)
 
 #ifdef ASST_DEBUG
     {
+        // 非 debug 的情况等到一个任务被第一次 get 的时候才展开。
+        // debug 时为了做语法检查，会提前展开。
+
         bool validity = true;
 
-        // 语法检查
+        std::queue<std::string_view> task_queue;
+        std::unordered_set<std::string_view> checking_task_set;
         for (const auto& [name, task_json] : json_obj) [[likely]] {
+            // 语法检查
             validity &= syntax_check(name, task_json);
+            task_queue.push(name);
+            checking_task_set.insert(name);
         }
 
-        for (const auto& [name, task] : m_all_tasks_info) {
+        const size_t MAX_CHECKING_SIZE = 3000;
+        while (!task_queue.empty() || checking_task_set.size() > MAX_CHECKING_SIZE) {
+            std::string_view name = task_queue.front();
+            task_queue.pop();
+            auto task = get(name); // 这里会提前展开任务
             auto check_tasklist = [&](const tasklist_t& task_list, std::string_view list_type,
                                       bool enable_justreturn_check = false) {
                 std::unordered_set<std::string_view> tasks_set {};
@@ -167,10 +182,15 @@ bool asst::TaskData::parse(const json::value& json)
                     if (tasks_set.contains(task_name)) [[unlikely]] {
                         continue;
                     }
+                    if (!checking_task_set.contains(task_name)) {
+                        task_queue.emplace(task_name_view(task_name));
+                        checking_task_set.emplace(task_name_view(task_name));
+                    }
                     // 检查是否有 JustReturn 任务不是最后一个任务
                     if (enable_justreturn_check && !justreturn_task_name.empty()) [[unlikely]] {
                         Log.error((std::string(name) += "->") += list_type,
                                   "has a not-final JustReturn task:", justreturn_task_name);
+                        justreturn_task_name = "";
                         validity = false;
                     }
 
@@ -187,13 +207,24 @@ bool asst::TaskData::parse(const json::value& json)
 
                 return true;
             };
-            check_tasklist(task->next, "next", true);
+            bool enable_justreturn_check = true;
+            if (name.ends_with("LoadingText") || name.ends_with("LoadingIcon")) {
+                // 放宽对 Loading 类任务的限制，不然 JustReturn 的任务如果本身有 JR 的 next，就不能 @Loading 了
+                enable_justreturn_check = false;
+            }
+            check_tasklist(task->next, "next", enable_justreturn_check);
             check_tasklist(task->sub, "sub");
-            check_tasklist(task->exceeded_next, "exceeded_next", true);
-            check_tasklist(task->on_error_next, "on_error_next", true);
+            check_tasklist(task->exceeded_next, "exceeded_next", enable_justreturn_check);
+            check_tasklist(task->on_error_next, "on_error_next", enable_justreturn_check);
             check_tasklist(task->reduce_other_times, "reduce_other_times");
         }
-
+        if (checking_task_set.size() > MAX_CHECKING_SIZE) {
+            // 生成超出上限一般是出现了会导致无限隐式生成的任务。比如 "#self@LoadingText". 这里给个警告.
+            Log.warn("Generating exceeded limit when syntax_check.");
+        }
+        else {
+            Log.trace(checking_task_set.size(), "tasks checked.");
+        }
         if (!validity) return false;
     }
 #endif


### PR DESCRIPTION
JustReturn 检查: 任务的 next 系列属性中，JustReturn 类的任务只能作为列表最后一个出现（否则后面的任务运行不到）

忽略了 Loading 相关的检查（因为如果 JustReturn 的任务 A 如果本身有 JR 的 next，A@Loading 就会有非最后的 JR）