### PR TITLE
chore: 加快更新包构建速度

### DIFF
--- a/.github/workflows/release-nightly-ota.yml
+++ b/.github/workflows/release-nightly-ota.yml
@@ -144,8 +144,7 @@ jobs:
         run: |
           mkdir -pv build-ota && cd build-ota
           cd ${{ needs.build-win-nightly.outputs.tag }}
-          mkdir -pv content
-          unzip -q -O GB2312 -o *.zip -x '*.lib' -x '*.pdb' -x '*.exp' -x '*.config' -x '*.xml' -d content
+          zip -d *.zip '*.lib' '*.pdb' '*.exp' '*.config' '*.xml'
           cd ..
 
           gh release list --repo 'MaaAssistantArknights/MaaAssistantArknights' --limit ${{ inputs.limit || 30 }} | tee ./release_maa.txt

--- a/.github/workflows/release-ota.yml
+++ b/.github/workflows/release-ota.yml
@@ -54,10 +54,8 @@ jobs:
         run: |
           mkdir -pv build-ota/${{ env.release_tag }}
           cd build-ota/${{ env.release_tag }}
-          mkdir -pv content
           gh release download ${{ env.release_tag }} --repo 'MaaAssistantArknights/MaaAssistantArknights' --pattern "MAA-${{ env.release_tag }}-win-${{ matrix.target }}.zip" --clobber
-          unzip -q -O GB2312 -o "*.zip" -d 'content'
-          mv *.zip ..
+          cp *.zip ..
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: "Build OTA"

--- a/src/MaaWpfGui/ViewModels/UI/VersionUpdateViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/VersionUpdateViewModel.cs
@@ -252,7 +252,7 @@ namespace MaaWpfGui.ViewModels.UI
             foreach (var file in Directory.GetFiles(extractDir, "*", SearchOption.AllDirectories))
             {
                 var fileName = Path.GetFileName(file);
-                if (fileName == "removelist.txt" || fileName == "md5sum.txt")
+                if (fileName == "removelist.txt" || fileName == "filelist.txt")
                 {
                     continue;
                 }

--- a/src/Python/asst/updater.py
+++ b/src/Python/asst/updater.py
@@ -201,9 +201,9 @@ class Updater:
                 f.close()
             remove_with_print(removelist_path)
 
-        md5sum_path = os.path.join(self.path, 'md5sum.txt')
-        if os.path.isfile(md5sum_path):
-            remove_with_print(md5sum_path)
+        filelist_path = os.path.join(self.path, 'filelist.txt')
+        if os.path.isfile(filelist_path):
+            remove_with_print(filelist_path)
         for file in os.listdir(self.path):
             if 'OTA' in file:
                 file_path = os.path.join(self.path, file)

--- a/tools/OTAPacker/build.sh
+++ b/tools/OTAPacker/build.sh
@@ -15,32 +15,27 @@ latest_tag=$(head -n 1 "$releases_txt")
 while read tag; do
     echo "::group::$tag"
 
-    if [ ! -d "$tag"/content ]; then
+    if [ ! -f "$tag"/MAA-$tag-win-$arch.zip ]; then
         mkdir -pv "$tag"
-        cd "$tag"
         echo "Downloading $tag"
         gh release download "$tag" --repo $source_repo --pattern "MAA-$tag-win-$arch.zip" --clobber \
             || gh release download "$tag" --repo $source_repo_fallback --pattern "MAA-$tag-win-$arch.zip" --clobber \
             || { echo "::warning:: win $arch not found in release $tag skipping."; echo "::endgroup::"; continue; }
-        mkdir -pv 'content'
-        unzip -q -O GB2312 -o "*.zip" -d 'content'
-        rm -fv *.zip
-        cd $working_dir
+        mv MAA-$tag-win-$arch.zip $tag
     else
-        echo "$tag"/content/ already exists
+        echo "$tag"/MAA-$tag-win-$arch.zip already exists
     fi
 
     if [[ "$tag" == "$latest_tag" ]]; then
-        cd "$latest_tag"/content/
-        find * -type f -exec md5sum '{}' \; > md5sum.txt
-        cd $working_dir
+        find "$latest_tag"
     else
-        echo "Comparing and installing files $tag...$latest_tag"
-        mkdir -pv "$tag"/pkg
-        "$script_dir"/makeota.sh "$tag"/content "$latest_tag"/content "$tag"/pkg
-        echo "Creating zip archive"
-        cd "$tag"/pkg
-        zip -q -9 -r "$working_dir"/"MAAComponent-OTA-${tag}_${latest_tag}-win-$arch.zip" .
+        "$script_dir"/zipota.sh \
+            $tag/MAA-$tag-win-$arch.zip \
+            $latest_tag/MAA-$latest_tag-win-$arch.zip \
+            "$working_dir"/"MAAComponent-OTA-${tag}_${latest_tag}-win-$arch.zip"
+
+        rm -fv $tag/MAA-$tag-win-$arch.zip
+
         cd $working_dir
     fi
 

--- a/tools/OTAPacker/ziplist.sh
+++ b/tools/OTAPacker/ziplist.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+zipinfo -O GB2312 -v $1 \
+    | sed -n -e '/^Central directory entry/,+3p' -e '/32-bit CRC value (hex):/p' | grep '^  ' \
+    | sed -e 's/^  //g' | sed -z 's/\n32-bit CRC value (hex):\s*/\t/g' \
+    | awk '{last = $NF; $NF=""; print last,$0}'

--- a/tools/OTAPacker/zipota.sh
+++ b/tools/OTAPacker/zipota.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+script_dir="$(dirname $(realpath "$0"))"
+
+from_zip="$1"
+to_zip="$2"
+out_zip="$3"
+
+from_list="$("$script_dir"/ziplist.sh "$from_zip" | sort)"
+to_list="$("$script_dir"/ziplist.sh "$to_zip" | sort)"
+
+# files with same name and content
+comm_list="$(comm -12 <(echo "$from_list") <(echo "$to_list"))"
+
+from_fn="$(echo "$from_list" | cut -d\  -f2- | sort)"
+to_fn="$(echo "$to_list" | cut -d\  -f2- | sort)"
+
+cp -v "$to_zip" "$out_zip"
+
+echo "$comm_list" | cut -d\  -f2- | xargs zip --delete "$out_zip"
+
+tmpdir=$(mktemp -d /tmp/zipota-files.XXX)
+
+comm -23 <(echo "$from_fn") <(echo "$to_fn") > "$tmpdir"/removelist.txt
+echo "$to_fn" > "$tmpdir"/filelist.txt
+
+zip -r -j "$out_zip" "$tmpdir"/removelist.txt "$tmpdir"/filelist.txt
+
+rm -rf $tmpdir


### PR DESCRIPTION
使用 zip 格式内部 crc 来比较文件, 去掉 `md5sum.txt` 改为 `filelist.txt`

~~危险的修改, 准备好 revert~~ (