### PR TITLE
docs: 补全蓝叠模拟器Hyper-V版本的指示

### DIFF
--- a/docs/1.3-模拟器支持.md
+++ b/docs/1.3-模拟器支持.md
@@ -25,6 +25,7 @@ _若网络环境较差可尝试下载 [离线安装包](https://support.bluestac
        - 中国内地版默认路径为 `C:\ProgramData\BlueStacks_nxt_cn\bluestacks.conf`
 
     2. 如果是第一次使用，请开启一次 MAA，会在 MAA 的 `config` 目录下生成 `gui.json`。
+
     3. **先关闭** MAA，**然后** 打开 `gui.json`，新增一个字段 `Bluestacks.Config.Path`，填入 `bluestacks.conf` 的完整路径。（注意斜杠要用转义 `\\`）<br>
     示例：（以 `C:\ProgramData\BlueStacks_nxt\bluestacks.conf` 为例）
 
@@ -32,7 +33,10 @@ _若网络环境较差可尝试下载 [离线安装包](https://support.bluestac
         "Bluestacks.Config.Path":"C:\\ProgramData\\BlueStacks_nxt\\bluestacks.conf",
         ```
 
-    4. 开启 MAA，LinkStart！
+    4. 开启 MAA， 在 `设置` - `连接设置` 中设置 `连接配置` 为 `蓝叠模拟器`，连接地址不需要设置 <br>
+    ⚠️ 不要启用 `自动检测连接` 功能，会导致连接失败
+
+    5. LinkStart！
 
 - 如果你还需要多开或者你使用蓝叠 Pie 核心 Hyper-V 模拟器，可以再修改 MAA 检测配置文件的关键字。<br>
     参照上述步骤，添加 `Bluestacks.Config.Keyword` 字段，内容为`"bst.instance.模拟器编号.status.adb_port"`，模拟器编号可在模拟器路径的`BlueStacks_nxt\Engine`中看到。<br>


### PR DESCRIPTION
#4616
如题，对于蓝叠模拟器Hyper-V版本，启用`自动检测连接` 功能，会导致连接失败
在文档中做了补充说明