### PR TITLE
feat: 支持直接读取蓝叠模拟器Hyper-V版本非多开模式下使用的核心

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ MAA 的意思是 MAA Assistant Arknights
 
 **目前项目组非常缺前端大佬，若您有相关经验，欢迎加入我们！**
 
-- 全新 GUI：[MaaAsstElectronUI](https://github.com/MaaAssistantArknights/MaaAsstElectronUI) （正在开发中，欢迎加入！）
+- 全新 GUI：[MaaX](https://github.com/MaaAssistantArknights/MaaX) （正在开发中，欢迎加入！）
 - [作业站](https://prts.plus) 前端：[maa-copilot-frontend](https://github.com/MaaAssistantArknights/maa-copilot-frontend) （正在开发中，欢迎加入！）
 - [作业站](https://prts.plus) 后端：[MaaBackendCenter](https://github.com/MaaAssistantArknights/MaaBackendCenter)
 - [官网](https://maa.plus)：[前端](https://github.com/MaaAssistantArknights/maa-website)

--- a/docs/1.3-模拟器支持.md
+++ b/docs/1.3-模拟器支持.md
@@ -38,18 +38,18 @@ _若网络环境较差可尝试下载 [离线安装包](https://support.bluestac
 
     5. LinkStart！
 
-- 如果你还需要多开或者你使用蓝叠 Pie 核心 Hyper-V 模拟器，可以再修改 MAA 检测配置文件的关键字。<br>
-    参照上述步骤，添加 `Bluestacks.Config.Keyword` 字段，内容为`"bst.instance.模拟器编号.status.adb_port"`，模拟器编号可在模拟器路径的`BlueStacks_nxt\Engine`中看到。<br>
+- 如果你启用了多开功能或是安装了多个模拟器核心，那么你需要进行额外设置来指定使用的模拟器编号 <br>
+  在`gui.json`中添加 `Bluestacks.Config.Keyword` 字段，内容为`"bst.instance.模拟器编号.status.adb_port"`，模拟器编号可在模拟器路径的`BlueStacks_nxt\Engine`中看到。<br>
     示例：
 
+    Nougat64核心：
     ```jsonc
     "Bluestacks.Config.Keyword":"bst.instance.Nougat64.status.adb_port",
     ```
 
-    Pie 核心 Hyper-V 模拟器示例：
-
+    Pie64_2核心：（核心名称后的数字代表这是一个多开核心）
     ```jsonc
-    "Bluestacks.Config.Keyword": "bst.instance.Pie64.status.adb_port",
+    "Bluestacks.Config.Keyword": "bst.instance.Pie64_2.status.adb_port",
     ```
 
 ## ✅ [夜神模拟器](https://www.yeshen.com/)

--- a/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
@@ -2225,14 +2225,14 @@ namespace MaaWpfGui.ViewModels.UI
         }
 
         private readonly string _bluestacksConfig = ConfigurationHelper.GetValue(ConfigurationKeys.BluestacksConfigPath, string.Empty);
-        private readonly string _bluestacksKeyWord = ConfigurationHelper.GetValue(ConfigurationKeys.BluestacksConfigKeyword, "bst.instance.Nougat64.status.adb_port");
+        private string _bluestacksKeyWord = ConfigurationHelper.GetValue(ConfigurationKeys.BluestacksConfigKeyword, string.Empty);
 
         /// <summary>
         /// Tries to set Bluestack Hyper V address.
         /// </summary>
         public void TryToSetBlueStacksHyperVAddress()
         {
-            if (_bluestacksConfig.Length == 0)
+            if (String.IsNullOrEmpty(_bluestacksConfig))
             {
                 return;
             }
@@ -2244,12 +2244,27 @@ namespace MaaWpfGui.ViewModels.UI
             }
 
             var all_lines = File.ReadAllLines(_bluestacksConfig);
+
+            if (String.IsNullOrEmpty(_bluestacksKeyWord))
+            {
+                foreach (var line in all_lines)
+                {
+                    if (line.StartsWith("bst.installed_images"))
+                    {
+                        var images = line.Split('"')[1].Split(',');
+                        _bluestacksKeyWord = "bst.instance." + images[0] + ".status.adb_port";
+                        break;
+                    }
+                }
+            }
+
             foreach (var line in all_lines)
             {
                 if (line.StartsWith(_bluestacksKeyWord))
                 {
                     var sp = line.Split('"');
                     ConnectAddress = "127.0.0.1:" + sp[1];
+                    break;
                 }
             }
         }

--- a/src/Python/asst/emulator.py
+++ b/src/Python/asst/emulator.py
@@ -3,15 +3,18 @@ import subprocess
 
 class Bluestacks:
     @staticmethod
-    def get_hyperv_port(conf_path=r"C:\ProgramData\BlueStacks_nxt\bluestacks.conf", instance_name="Pie64") -> int:
+    def get_hyperv_port(conf_path=r"C:\ProgramData\BlueStacks_nxt\bluestacks.conf", instance_name="Pie64", read_imageinfo_from_config=False) -> int:
         """ 获取Hyper-v版蓝叠的adb port
 
         :param conf_path: bluestacks.conf 的路径+文件名
         :param instance_name: 多开的名称，在bluestacks.conf中以类似bst.instance.<instance_name>.status.adb_port的形式出现，如Nougat64，Pie64，Pie64_1等
         :return: adb端口
         """
-        with open(conf_path) as f:
+        with open(conf_path, encoding="UTF-8") as f:
             configs = dict(list(map(lambda line: line.replace('\n', '').split('='), f.readlines())))
+            if read_imageinfo_from_config:
+                instances = [i.strip('"') for i in configs['bst.installed_images'].split(',')]
+                instance_name = instances[0]
         return int(configs[f'bst.instance.{instance_name}.status.adb_port'].replace('"', ""))
     
     @staticmethod


### PR DESCRIPTION
bluestacks.conf 中的 `bst.installed_images` 一项其实已经指明了使用的核心，可以直接读取
以及根据 #4616 的讨论完善文档