### PR TITLE
fix: 修正 Android 12 上无法结束游戏进程的问题

### DIFF
--- a/resource/config.json
+++ b/resource/config.json
@@ -76,7 +76,7 @@
             "screencapEncode": "[Adb] -s [AdbSerial] exec-out screencap -p",
             "release": "[Adb] kill-server",
             "start": "[Adb] -s [AdbSerial] shell am start -n [Intent]",
-            "stop": "[Adb] -s [AdbSerial] shell \"am force-stop `dumpsys activity activities 2>/dev/null | grep Activities= 2>/dev/null | grep -m 1 -i -o -E [^\\ ]*arknights[^/]*`\"",
+            "stop": "[Adb] -s [AdbSerial] shell \"am force-stop `dumpsys activity activities 2>/dev/null | grep -E '(packageName|Activities)=[^\\n]+arknights' 2>/dev/null | grep -i -o -E '[^= ]*arknights[^ /\\n]*' | head -n 1`\"",
             "abilist": "[Adb] -s [AdbSerial] shell getprop ro.product.cpu.abilist",
             "orientation": "[Adb] -s [AdbSerial] shell dumpsys input | grep SurfaceOrientation | grep -m 1 -o -E [0-9]",
             "pushMinitouch": "[Adb] -s [AdbSerial] push \"[minitouchLocalPath]\" \"/data/local/tmp/[minitouchWorkingFile]\"",


### PR DESCRIPTION
Fix #4045

已在蓝叠中国版的 Android 7 32位、 Android 7 64位、 Android 9、 Android 11 版本，和 Mumu X 模拟器（Android 12 版本）上测试，均能正确输出 `com.hypergryph.arknights`。

下列是导出的 `dumpsys activity activities 2>/dev/null` 的结果，可用以测试：

[Android_7_32_bs_cn.txt](https://github.com/MaaAssistantArknights/MaaAssistantArknights/files/11414988/Android_7_32_bs_cn.txt) | [Android_7_64_bs_cn.txt](https://github.com/MaaAssistantArknights/MaaAssistantArknights/files/11414990/Android_7_64_bs_cn.txt) | [Android_9_bs_cn.txt](https://github.com/MaaAssistantArknights/MaaAssistantArknights/files/11414991/Android_9_bs_cn.txt) | [Android_11_bs_cn.txt](https://github.com/MaaAssistantArknights/MaaAssistantArknights/files/11414992/Android_11_bs_cn.txt) | [Android_12_mumu_x.txt](https://github.com/MaaAssistantArknights/MaaAssistantArknights/files/11414993/Android_12_mumu_x.txt)

<hr>

补充：经过测试，搭载 MIUI 14 的小米 13 Pro 上的 Android 13 版本，也能正确输出 `com.hypergryph.arknights`。导出的 `dumpsys activity activities 2>/dev/null`：[Android_13_MIUI_14_Xiaomi_13_pro.txt](https://github.com/MaaAssistantArknights/MaaAssistantArknights/files/11415134/Android_13_MIUI_14_Xiaomi_13_pro.txt)。
