### PR TITLE
fix(avatarcachemanager): avatar saved at wrong path in set_avatar()

### DIFF
--- a/src/MaaCore/Config/ResourceLoader.cpp
+++ b/src/MaaCore/Config/ResourceLoader.cpp
@@ -109,12 +109,13 @@ bool asst::ResourceLoader::load(const std::filesystem::path& path)
         }                                                                                        \
     }
 
-#define LoadCacheWithoutRet(Config, Dir)                             \
-    {                                                                \
-        auto full_path = UserDir.get() / "cache"_p / Dir;            \
-        if (std::filesystem::exists(full_path)) {                    \
-            SingletonHolder<Config>::get_instance().load(full_path); \
-        }                                                            \
+#define LoadCacheWithoutRet(Config, Dir)                         \
+    {                                                            \
+        auto full_path = UserDir.get() / "cache"_p / Dir;        \
+        if (!std::filesystem::exists(full_path)) {               \
+            std::filesystem::create_directories(full_path);      \
+        }                                                        \
+        SingletonHolder<Config>::get_instance().load(full_path); \
     }
 
     LogTraceFunction;


### PR DESCRIPTION
m_save_path is empty & ::load() never called when cache folder does not exist.