### PR TITLE
fix: update InfrastFilterMenuNotStationedButton for EN

### DIFF
--- a/resource/global/YoStarEN/resource/tasks.json
+++ b/resource/global/YoStarEN/resource/tasks.json
@@ -1950,6 +1950,9 @@
             "Assign"
         ]
     },
+    "InfrastFilterMenuNotStationedButton": {
+        "templThreshold": 0.75
+    },
     "InfrastReward": {
         "text": [
             "Collectable",


### PR DESCRIPTION
The OCR fails for the `InfrastFilterMenuNotStationedButton` task at higher resolutions, so I lowered the threshold a bit.

Logs for `1600x900` client:

```
[TRC][Px6fc0][Txfaa4] match_templ | InfrastFilterMenuNotStationedButton.png score: 0.785273 rect: [ 396, 343, 119, 37 ] roi: [ 300, 300, 250, 150 ]
```