### PR TITLE
YostarEN Mr. Nothing, Shirayuki not recognized because of capitalization error / missing space in tasks.json

### DIFF
--- a/resource/global/YoStarEN/resource/tasks.json
+++ b/resource/global/YoStarEN/resource/tasks.json
@@ -1285,7 +1285,7 @@
                 "蓝毒"
             ],
             [
-                "ShiraYuki",
+                "Shirayuki",
                 "白雪"
             ],
             [
@@ -1561,7 +1561,7 @@
                 "霜华"
             ],
             [
-                "Mr.Nothing",
+                "Mr. Nothing",
                 "乌有"
             ],
             [


### PR DESCRIPTION
In-game names are different from the tasks.json.
It looks like the names are from Aceship. It capitalizes the `Y` in `ShiraYuki` which is wrong in-game. Same thing with `Mr. Nothing`, it removes a ` `, whereas in game there is one.

I still can't understand what's wrong with Nine-Colored Deer.
![2023-05-29_21-58-12-150_raw](https://github.com/MaaAssistantArknights/MaaAssistantArknights/assets/56174894/82597fb7-aa7b-4b9f-85b7-41bc37a03681)
The asst.log only shows 
![image](https://github.com/MaaAssistantArknights/MaaAssistantArknights/assets/56174894/d316ce9d-03b3-46a1-87f9-33160d205265)

