### PR TITLE
YostarEN: Skadi Alter / Wild Mane fixed in oper recognition

### DIFF
--- a/resource/global/YoStarEN/resource/tasks.json
+++ b/resource/global/YoStarEN/resource/tasks.json
@@ -926,6 +926,10 @@
             ],
             [
                 "Skadi the Corrup.*ing.*",
+                "Skadi the Corrupting Heart"
+            ],
+            [
+                "Skadi the Corrupting Heart",
                 "浊心斯卡蒂"
             ],
             [

--- a/resource/global/YoStarEN/resource/tasks.json
+++ b/resource/global/YoStarEN/resource/tasks.json
@@ -925,7 +925,7 @@
                 "空"
             ],
             [
-                "Skadi the Corrupting Heart",
+                "Skadi the Corrup.*ing.*",
                 "浊心斯卡蒂"
             ],
             [
@@ -1097,7 +1097,7 @@
                 "焰尾"
             ],
             [
-                "Wildmane",
+                "Wild.*Mane",
                 "野鬃"
             ],
             [


### PR DESCRIPTION
Wild Mane has whitespace in between in-game.
From asst.log:
[2023-05-30 12:04:25.156][TRC][Px20dc][Tx3444] asst::WordOcr [{ Wild Mane: [ 0, 0, 84, 22 ], score: 0.994166 }] by OCR Rec , cost 6 ms
[2023-05-30 12:04:25.157][TRC][Px20dc][Tx3444] Proced []
Skadi Alter has name with new line.
<img width="60" alt="image" src="https://github.com/MaaAssistantArknights/MaaAssistantArknights/assets/56174894/b99bf595-e7f2-46b5-b3db-96c8300f467d">
Also bot only recognizes Skadi the Corrup***e***ing.
From asst.log:
[2023-05-30 12:04:13.814][TRC][Px20dc][Tx3444] asst::WordOcr [{ Skadi the Corrupeing: [ 0, 0, 108, 22 ], score: 0.986404 }] by OCR Rec , cost 5 ms
[2023-05-30 12:04:13.814][TRC][Px20dc][Tx3444] Proced []

ALSO
Every alter operator has the first name missing probably because the scope for searching the name is too small
Nearl Alter for example:
<img width="78" alt="image" src="https://github.com/MaaAssistantArknights/MaaAssistantArknights/assets/56174894/7b097fd4-58ba-4cfe-86ed-8d336e928b4b">

Gavial Alter for example:
<img width="70" alt="image" src="https://github.com/MaaAssistantArknights/MaaAssistantArknights/assets/56174894/ac7ab698-6882-440d-9bcb-010de0ddf3d4">

