### PR TITLE
Update YostarEN tasks.json Mizuki Roguelike: map drop Triple Recruit permit exception leads to abandon

### DIFF
--- a/resource/global/YoStarEN/resource/tasks.json
+++ b/resource/global/YoStarEN/resource/tasks.json
@@ -2435,7 +2435,7 @@
         "templThreshold": 0.7
     },
     "Mizuki@Roguelike@GetDropSelectRecruit": {
-        "templThreshold": 0.8
+        "templThreshold": 0.75
     },
     "Mizuki@Roguelike@NextLevel": {
         "text": [


### PR DESCRIPTION
[issue.log](https://github.com/MaaAssistantArknights/MaaAssistantArknights/files/11617845/issue.log)

### Extract from the log
`match_templ | Mizuki@Roguelike@GetDropSelectRecruit.png score: 0.795256 rect: [ 885, 488, 168, 40 ] roi: [ 0, 420, 1280, 175 ]`
Threshold 0.8 is just a bit too high for score: 0.795256.
### Debug image 1st example
![2023-05-31_10-52-45-764_raw](https://github.com/MaaAssistantArknights/MaaAssistantArknights/assets/56174894/d5821b45-1875-454d-bd30-1dc401f0b074)
### Debug image 2nd example
![2023-05-31_07-16-27-845_raw](https://github.com/MaaAssistantArknights/MaaAssistantArknights/assets/56174894/e0ae0b20-70df-495c-93f9-63f12dbbfe4a)

The images are from 1920×1080. For systems with higher resolutions the problem might not exist.
