### PR TITLE
Update YostarEN tasks.json for OperBox detection patch / suggestion

### DIFF
--- a/resource/global/YoStarEN/resource/tasks.json
+++ b/resource/global/YoStarEN/resource/tasks.json
@@ -757,6 +757,10 @@
                 "幽灵鲨"
             ],
             [
+                ".*Radiant Knight",
+                "Nearl the Radiant Knight"
+            ],
+            [
                 "Nearl the Radiant Knight",
                 "耀骑士临光"
             ],
@@ -1189,6 +1193,10 @@
                 "远牙"
             ],
             [
+                ".*the Holungday",
+                "Ch'en the Holungday"
+            ],
+            [
                 "Ch'en the Holungday",
                 "假日威龙陈"
             ],
@@ -1459,6 +1467,10 @@
             [
                 "^Dusk$",
                 "夕"
+            ],
+            [
+                ".*the Purgatory",
+                "Lava the Purgatory"
             ],
             [
                 "Lava the Purgatory",
@@ -1737,6 +1749,10 @@
                 "高能源石炸弹"
             ],
             [
+                ".*the Keen Glint",
+                "Kroos the Keen Glint"
+            ],
+            [
                 "Kroos the Keen Glint",
                 "寒芒克洛丝"
             ],
@@ -1799,6 +1815,10 @@
             [
                 "Heidi",
                 "海蒂"
+            ],
+            [
+                ".*Deer",
+                "Nine-Colored Deer"
             ],
             [
                 "Nine-Colored Deer",
@@ -2029,6 +2049,10 @@
                 "可靠电池"
             ],
             [
+                ".*the Unchained",
+                "Specter the Unchained"
+            ],
+            [
                 "Specter the Unchained",
                 "归溟幽灵鲨"
             ],
@@ -2055,6 +2079,10 @@
             [
                 "Czerny",
                 "车尔尼"
+            ],
+            [
+                ".*the Purifier",
+                "Hibiscus the Purifier"
             ],
             [
                 "Hibiscus the Purifier",
@@ -2121,7 +2149,11 @@
                 "鸿雪"
             ],
             [
-                "Gavial the.*",
+                ".*Invincible",
+                "Gavial the Invincible"
+            ],
+            [
+                "Gavial the Invincible",
                 "百炼嘉维尔"
             ],
             [
@@ -2167,6 +2199,10 @@
             [
                 "Astgenne",
                 "星源"
+            ],
+            [
+                ".*Lightni.*bearer",
+                "Greyy the Lightningbearer"
             ],
             [
                 "Greyy the Lightningbearer",
@@ -2295,6 +2331,10 @@
             [
                 "Wolfpack",
                 "狼群"
+            ],
+            [
+                ".*the Omertosa",
+                "Texas the Omertosa"
             ],
             [
                 "Texas the Omertosa",


### PR DESCRIPTION
Found a way to make alters detectable. (kind of)

Ch'en the Holungday 假日威龙陈 and Gavial the Invincible 百炼嘉维尔 still can't be detected
Line 461 and line 716 [asst.log](https://github.com/MaaAssistantArknights/MaaAssistantArknights/files/11643351/asst.log)

258 / 260 operators are detected. (260 is the max number of ops in as of today). _**I'm open to other solutions**_ because honestly don't really like what I did to detected alters (Ch'En and Gavial are still not detected).

I feel like the OperBox detection should have it's own dedicated section in the tasks.json because for the alters, having double lines to make sure it works in every other detection I don't think is good.

Also Yostar really tried their best to fuck up how the names are rendered in the operator box, by giving alters stupid long names. Nearl Alter and still fit in one line (24 chars), Skadi Alter doesn't fit (26 chars) and Greyy Alter doesn't fit (25 chars).
I feel like the Oper Box task needs custom ROI values. Maybe not for all operators but only for certain ones. From my understanding it's not possible to add ROI to the ocrReplace because it works for every single char replacement.