### PR TITLE
Update tasks.json for OperBoxNameOCR YostarEN

### DIFF
--- a/resource/global/YoStarEN/resource/tasks.json
+++ b/resource/global/YoStarEN/resource/tasks.json
@@ -2169,7 +2169,7 @@
                 "星源"
             ],
             [
-                ".*Lightnin.*bearer",
+                ".*Lightni.*bearer",
                 "Greyy the Lightningbearer"
             ],
             [

--- a/resource/global/YoStarEN/resource/tasks.json
+++ b/resource/global/YoStarEN/resource/tasks.json
@@ -2121,7 +2121,7 @@
                 "鸿雪"
             ],
             [
-                "Gavial the.*",
+                "Gavial the Invincible",
                 "百炼嘉维尔"
             ],
             [
@@ -2167,6 +2167,10 @@
             [
                 "Astgenne",
                 "星源"
+            ],
+            [
+                ".*Lightnin.*bearer",
+                "Greyy the Lightningbearer"
             ],
             [
                 "Greyy the Lightningbearer",
@@ -2326,6 +2330,15 @@
             ]
         ]
     },
+    "OperBoxNameOCR": {
+        "specialParams": [
+            160,
+            4,
+            6,
+            0
+        ]
+    },
+
     "ClickChapter1": {
         "text": [
             "Hour of An Awakening",


### PR DESCRIPTION
260/260 operators detected, finally fixed.

@MistEO the
`        "specialParams": [`
`            160,`
`            4,`
`            6,`
`            0`
`        ]`
from #5004 with [2] = 6 was a godbless, basically all the work that I had been doing this week has been rendered useless XD. I just tried tonight changing it and everything fixed itself. It took me a week because I had to understand a bit better the tasks.json and the MaaCore.

### ISSUE
The only that is left is Operator's names that have a new line in them, such as Skadi the Corrupting Heart and Greyy the Lightningbearer.