### PR TITLE
Changed translation en-us.xaml

### DIFF
--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -183,7 +183,7 @@
     <system:String x:Key="MinimizeAfterLaunch">Auto Minimize after launched</system:String>
     <system:String x:Key="ClientType">Client Type</system:String>
     <system:String x:Key="AutoRestartOption">Restart when game disconnects</system:String>
-    <system:String x:Key="HelpUsWithOverseasServersTip">Foreign server adaptation is unsalable, help us! You don't need to know programming.</system:String>
+    <system:String x:Key="HelpUsWithOverseasServersTip">The Global Servers' adaptation is very difficult and we need your help! No programming knowledge is required.</system:String>
     <system:String x:Key="OpenEmulatorAfterLaunch">Startup Emulator after launched</system:String>
     <system:String x:Key="MinimizingStartup">Minimizing the startup Emulator</system:String>
     <system:String x:Key="WaitForEmulator">Delay time (s)</system:String>


### PR DESCRIPTION
`"Foreign service adaptation is unsalable, help us! It's okay to not program."` is not proper English, especially "unsalable": it makes little to no sense. I've used the Japanese version and translated it to English, adding a bit of my own. I think this is better.