### PR TITLE
feat: Difficulty selection for YostarEN

### DIFF
--- a/resource/global/YoStarEN/resource/tasks.json
+++ b/resource/global/YoStarEN/resource/tasks.json
@@ -8,6 +8,16 @@
         ],
         "template": "Task.png"
     },
+    "EnterChapterDifficultyHard": {
+        "text": [
+            "Start Operation"
+        ]
+    },
+    "EnterChapterDifficultyNormal": {
+        "text": [
+            "Start Operation"
+        ]
+    },
     "BattleStageName": {
         "Doc": "该任务的 ocrReplace 被所有涉及Rouge-like的English识别任务复用",
         "ocrReplace": [


### PR DESCRIPTION
Normal / Adverse difficulty selection implemented from resource/tasks.json in YostarEN
from findmissingJsonTranslate.py:
EnterChapterDifficultyHard ['进入作战']
EnterChapterDifficultyNormal ['进入作战']