### PR TITLE
fix: 点击技能启动按钮时，验证按钮已消失，防止卡死在子弹时间中

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -6814,6 +6814,11 @@
             64
         ]
     },
+    "BattleSkillClickConfirmed": {
+        "algorithm": "JustReturn",
+        "action": "DoNothing",
+        "Doc": "战斗中开启技能时用于确保技能按钮已消失，并返回成功结果"
+    },
     "BattleSkillReadyOnClick": {
         "roi": [
             748,
@@ -6830,19 +6835,35 @@
             90,
             90
         ],
-        "postDelay": 300
+        "postDelay": 300,
+        "next": [
+            "BattleSkillReadyOnClick",
+            "BattleSkillClickConfirmed"
+        ]
     },
     "BattleSkillReadyOnClick-SquareMap": {
         "baseTask": "BattleSkillReadyOnClick",
-        "template": "BattleSkillReadyOnClick-SquareMap"
+        "template": "BattleSkillReadyOnClick-SquareMap",
+        "next": [
+            "BattleSkillReadyOnClick-SquareMap",
+            "BattleSkillClickConfirmed"
+        ]
     },
     "BattleSkillStopOnClick": {
         "baseTask": "BattleSkillReadyOnClick",
-        "template": "BattleSkillStopOnClick"
+        "template": "BattleSkillStopOnClick",
+        "next": [
+            "BattleSkillStopOnClick",
+            "BattleSkillClickConfirmed"
+        ]
     },
     "BattleSkillStopOnClick-SquareMap": {
         "baseTask": "BattleSkillReadyOnClick",
-        "template": "BattleSkillStopOnClick-SquareMap"
+        "template": "BattleSkillStopOnClick-SquareMap",
+        "next": [
+            "BattleSkillStopOnClick-SquareMap",
+            "BattleSkillClickConfirmed"
+        ]
     },
     "BattleUseOper": {
         "algorithm": "JustReturn",

--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -6814,11 +6814,6 @@
             64
         ]
     },
-    "BattleSkillClickConfirmed": {
-        "algorithm": "JustReturn",
-        "action": "DoNothing",
-        "Doc": "战斗中开启技能时用于确保技能按钮已消失，并返回成功结果"
-    },
     "BattleSkillReadyOnClick": {
         "roi": [
             748,
@@ -6837,33 +6832,21 @@
         ],
         "postDelay": 300,
         "next": [
-            "BattleSkillReadyOnClick",
-            "BattleSkillClickConfirmed"
+            "#self",
+            "Stop"
         ]
     },
     "BattleSkillReadyOnClick-SquareMap": {
         "baseTask": "BattleSkillReadyOnClick",
-        "template": "BattleSkillReadyOnClick-SquareMap",
-        "next": [
-            "BattleSkillReadyOnClick-SquareMap",
-            "BattleSkillClickConfirmed"
-        ]
+        "template": "BattleSkillReadyOnClick-SquareMap"
     },
     "BattleSkillStopOnClick": {
         "baseTask": "BattleSkillReadyOnClick",
-        "template": "BattleSkillStopOnClick",
-        "next": [
-            "BattleSkillStopOnClick",
-            "BattleSkillClickConfirmed"
-        ]
+        "template": "BattleSkillStopOnClick"
     },
     "BattleSkillStopOnClick-SquareMap": {
         "baseTask": "BattleSkillReadyOnClick",
-        "template": "BattleSkillStopOnClick-SquareMap",
-        "next": [
-            "BattleSkillStopOnClick-SquareMap",
-            "BattleSkillClickConfirmed"
-        ]
+        "template": "BattleSkillStopOnClick-SquareMap"
     },
     "BattleUseOper": {
         "algorithm": "JustReturn",


### PR DESCRIPTION
相关issue: #5373

为点击技能启动按钮的任务添加了检查启动按钮已消失的后续任务，这样在技能启动失败，界面仍处于选中干员的状态下时，可以重新尝试点击按钮。这一逻辑与其他类似确认操作已完成的逻辑一致，例如 [OFToOF-Chapter](https://github.com/MaaAssistantArknights/MaaAssistantArknights/blob/dev/resource/tasks.json#L1684)

此PR部分修复 #5373 以及其关联 issue, 可以防止该bug的触发将游戏状态卡死在子弹时间状态下，并通过反复尝试点击来让技能释放最终成功。但无法解决错误点击导致干员选择取消，从而跳过copolit设定的手动技能释放的情况。该bug仍需对识别和点击坐标的进一步调试。