### PR TITLE
fix: 修复Python更新器中重试次数的问题

### DIFF
--- a/src/Python/asst/__init__.py
+++ b/src/Python/asst/__init__.py
@@ -1,1 +1,1 @@
-__all__ = ['asst', 'updater', 'utils']
+__all__ = ['asst', 'emulator', 'updater', 'utils']

--- a/src/Python/asst/updater.py
+++ b/src/Python/asst/updater.py
@@ -230,14 +230,15 @@ class Updater:
         for i in range(max_retry):
             url = self.assets_object['browser_download_url']
             file = os.path.join(self.path, url.split('/')[-1])
-            if i < 2:
-                url = url.replace(replace_list[i][0], replace_list[i][1])
-                try:
-                    Updater.custom_print(f'开始下载更新包，URL：{url}')
-                    request.urlretrieve(url, file)
-                    break
-                except (HTTPError, URLError) as e:
-                    Updater.custom_print(e)
+
+            replace_attempt = replace_list[i % len(replace_list)]
+            url = url.replace(replace_attempt[0], replace_attempt[1])
+            try:
+                Updater.custom_print(f'开始下载更新包，URL：{url}')
+                request.urlretrieve(url, file)
+                break
+            except (HTTPError, URLError) as e:
+                Updater.custom_print(e)
 
         # 解压
         Updater.custom_print('开始安装更新，请不要关闭')


### PR DESCRIPTION
原代码中重试次数超过2后失效
修改后，重试次数将在所有备用下载站间均匀分配