### PR TITLE
fix: Visiting only 1 Friend Clue Exchange in YostarEN

### DIFF
--- a/resource/global/YoStarEN/resource/tasks.json
+++ b/resource/global/YoStarEN/resource/tasks.json
@@ -4667,6 +4667,9 @@
     "UsePrts": {
         "templThreshold": 0.7
     },
+    "VisitNextBlack": {
+        "templThreshold": 0.85
+    },
     "VisitLimited": {
         "text": [
             "limit",

--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -4342,6 +4342,7 @@
     },
     "VisitNextBlack": {
         "action": "DoNothing",
+        "templThreshold": 0.85,
         "roi": [
             1080,
             570,

--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -4342,7 +4342,6 @@
     },
     "VisitNextBlack": {
         "action": "DoNothing",
-        "templThreshold": 0.85,
         "roi": [
             1080,
             570,


### PR DESCRIPTION
VisitNextBlack has default threshold (0.8 score) --> Gets detected even when the image is VisitNext (0.98 score)
Bumped the threshold up to 0.85.

Without this, MAA would visit only one friend and leave next.
1/10 friends visited.

extract from log:
[2023-07-15 18:37:27.463][TRC][Px888][Txfd8] asst::PipelineAnalyzer::analyze VisitNextBlack
[2023-07-15 18:37:27.464][TRC][Px888][Txfd8] match_templ | VisitNextBlack.png _**score: 0.808517**_ rect: [ 1116, 608, 122, 52 ] roi: [ 1080, 570, 195, 130 ]
