### PR TITLE
优化萨米肉鸽死囚之夜战斗逻辑

### DIFF
--- a/resource/roguelike/copilot.json
+++ b/resource/roguelike/copilot.json
@@ -28,7 +28,7 @@
             {
                 "groups": ["M3", "近卫"],
                 "location": [3, 4],
-                "direction": "left"
+                "direction": "right"
             },
             {
                 "groups": ["处决者"],
@@ -51,8 +51,8 @@
             },
             {
                 "groups": ["单奶", "群奶", "术师", "狙击", "辅助", "其他高台"],
-                "location": [5, 3],
-                "direction": "down"
+                "location": [6, 4],
+                "direction": "left"
             },
             {
                 "groups": ["近卫", "挡人先锋"],


### PR DESCRIPTION
![2c819255f8eb1332cd6e7cba2ae73483](https://github.com/MaaAssistantArknights/MaaAssistantArknights/assets/75826243/ef64320f-b16f-41c5-96c8-c79b92de95e6)

现在的打法是百嘉朝左，打不到开局的几个小怪，并且医疗和狙击放置位置是如上图所示的（5,3）朝下，相当于浪费掉了医疗干员，突袭就很容易死并且开局几个小怪会把石头打穿。所以我改成了百嘉朝右，医狙（6,4）朝左，个人认为（6,4）的覆盖范围应该是完全优于（5,3）的。
tips：实测15难度普通死囚之夜百嘉这个位置朝右就能单刷（~~不过要卡轴~~

![image](https://github.com/MaaAssistantArknights/MaaAssistantArknights/assets/75826243/7f767524-84d7-4ea2-9c40-956eb0a42132)

