### PR TITLE
修改萨米肉鸽关卡“饥渴祭坛”摆放

### DIFF
--- a/resource/roguelike/copilot.json
+++ b/resource/roguelike/copilot.json
@@ -845,6 +845,20 @@
                 "direction": "left"
             }
         ],
+        "blacklist_location": [
+            [
+                7,
+                5
+            ],
+            [
+                8,
+                5
+            ],
+            [
+                9,
+                5
+            ]
+        ],
         "deploy_plan": [
             {
                 "groups": ["近卫"],


### PR DESCRIPTION
禁止部署干员到蓝门左下方的三个格子
（因为可能会出现以下情况）
![屏幕截图 2023-07-17 225958](https://github.com/MaaAssistantArknights/MaaAssistantArknights/assets/92996760/6d506ae3-dbce-4787-bf60-32ddc5933bf0)
