### PR TITLE
修改第一层提丰放置顺序以及站位

### DIFF
--- a/resource/roguelike/copilot.json
+++ b/resource/roguelike/copilot.json
@@ -14,6 +14,13 @@
         "deploy_plan": [
             {
                 "groups": [
+                    "提丰"
+                ],
+                "location": [7, 4],
+                "direction": "left"
+            },
+            {
+                "groups": [
                     "凯尔希",
                     "召唤",
                     "水陈",
@@ -56,7 +63,6 @@
                     "术师",
                     "狙击",
                     "辅助",
-                    "提丰",
                     "其他高台"
                 ],
                 "location": [6, 4],
@@ -104,6 +110,13 @@
         ],
         "deploy_plan": [
             {
+                "groups": [
+                    "提丰"
+                ],
+                "location": [1, 2],
+                "direction": "right"
+            },
+            {
                 "groups": ["M3", "近卫", "情报官", "挡人先锋", "其他地面"],
                 "location": [2, 3],
                 "direction": "right"
@@ -148,7 +161,6 @@
                     "术师",
                     "狙击",
                     "辅助",
-                    "提丰",
                     "其他高台"
                 ],
                 "location": [1, 4],
@@ -202,6 +214,13 @@
         ],
         "deploy_plan": [
             {
+                "groups": [
+                    "提丰"
+                ],
+                "location": [2, 2],
+                "direction": "right"
+            },
+            {
                 "groups": ["凯尔希", "召唤", "速狙", "术师", "狙击", "辅助"],
                 "location": [6, 2],
                 "direction": "down"
@@ -210,11 +229,6 @@
                 "groups": ["M3", "近卫", "情报官", "挡人先锋", "其他地面"],
                 "location": [7, 3],
                 "direction": "left"
-            },
-            {
-                "groups": ["提丰"],
-                "location": [2, 2],
-                "direction": "right"
             },
             {
                 "groups": ["水陈", "单奶", "术师", "狙击", "辅助", "其他高台"],


### PR DESCRIPTION
1、将第一层除兽群外所有关卡的提丰首下
2、修改”死囚之夜“提丰位置为[ 7, 4 ]
3、修改”度假村冤魂”提丰位置为[ 1, 2 ]
4、修改“苔手”提丰位置为[ 2, 2 ]