### PR TITLE
优化肉鸽招募逻辑

### DIFF
--- a/resource/roguelike/recruitment.json
+++ b/resource/roguelike/recruitment.json
@@ -596,7 +596,7 @@
                 {
                     "name": "罗比菈塔",
                     "skill": 2,
-                    "recruit_priority": 290,
+                    "recruit_priority": 100,
                     "promote_priority": 0,
                     "recruit_priority_offsets": [
                         {
@@ -3084,7 +3084,7 @@
                 {
                     "name": "罗比菈塔",
                     "skill": 2,
-                    "recruit_priority": 290,
+                    "recruit_priority": 100,
                     "promote_priority": 0,
                     "is_key": true,
                     "recruit_priority_offsets": [

--- a/resource/roguelike/recruitment.json
+++ b/resource/roguelike/recruitment.json
@@ -598,7 +598,6 @@
                     "skill": 2,
                     "recruit_priority": 290,
                     "promote_priority": 0,
-                    "is_key": true,
                     "recruit_priority_offsets": [
                         {
                             "groups": [ "重装" ],
@@ -697,7 +696,6 @@
                     "skill": 1,
                     "recruit_priority": 455,
                     "promote_priority": 70,
-                    "is_key": true,
                     "recruit_priority_offsets": [
                         {
                             "groups": [ "水陈", "速狙" ],
@@ -709,7 +707,6 @@
                 {
                     "name": "寒芒克洛丝",
                     "skill": 2,
-                    "is_key": true,
                     "recruit_priority": 550,
                     "promote_priority": 70,
                     "recruit_priority_offsets": [
@@ -857,7 +854,6 @@
                     "alternate_skill": 1,
                     "recruit_priority": 722,
                     "promote_priority": 410,
-                    "is_key": true,
                     "recruit_priority_offsets": [
                         {
                             "groups": [ "单奶", "群奶" ],
@@ -964,7 +960,6 @@
                     "skill": 1,
                     "recruit_priority": 132,
                     "promote_priority": 0,
-                    "is_key": true,
                     "recruit_priority_offsets": [
                         {
                             "groups": [ "单奶", "群奶" ],
@@ -985,7 +980,6 @@
                     "skill": 1,
                     "recruit_priority": 131,
                     "promote_priority": 0,
-                    "is_key": true,
                     "recruit_priority_offsets": [
                         {
                             "groups": [ "单奶", "群奶" ],
@@ -1072,7 +1066,6 @@
                     "skill": 1,
                     "recruit_priority": 687,
                     "promote_priority": 0,
-                    "is_key": true,
                     "recruit_priority_offsets": [
                         {
                             "groups": [ "单奶", "群奶" ],
@@ -2432,7 +2425,6 @@
                     "skill": 1,
                     "recruit_priority": 132,
                     "promote_priority": 0,
-                    "is_key": true,
                     "recruit_priority_offsets": [
                         {
                             "groups": [ "单奶", "群奶", "焰苇" ],
@@ -2453,7 +2445,6 @@
                     "skill": 1,
                     "recruit_priority": 131,
                     "promote_priority": 0,
-                    "is_key": true,
                     "recruit_priority_offsets": [
                         {
                             "groups": [ "单奶", "群奶", "焰苇" ],

--- a/resource/roguelike/recruitment.json
+++ b/resource/roguelike/recruitment.json
@@ -557,17 +557,6 @@
                 },
                 {
                     "name": "罗比菈塔",
-                    "skill": 2,
-                    "recruit_priority": 100,
-                    "promote_priority": 0,
-                    "recruit_priority_offsets": [
-                        {
-                            "groups": [ "重装" ],
-                            "threshold": 0,
-                            "is_less": true,
-                            "offset": 282
-                        }
-                    ]
                 },
                 {
                     "name": "泡泡"
@@ -3052,18 +3041,6 @@
                 },
                 {
                     "name": "罗比菈塔",
-                    "skill": 2,
-                    "recruit_priority": 100,
-                    "promote_priority": 0,
-                    "is_key": true,
-                    "recruit_priority_offsets": [
-                        {
-                            "groups": [ "重装" ],
-                            "threshold": 0,
-                            "is_less": true,
-                            "offset": 282
-                        }
-                    ]
                 },
                 {
                     "name": "泡泡"

--- a/resource/roguelike/recruitment.json
+++ b/resource/roguelike/recruitment.json
@@ -6,7 +6,6 @@
             "玛恩纳",
             "水陈",
             "焰苇",
-            "处决者",
             "近卫",
             "重装",
             "速狙",
@@ -26,10 +25,6 @@
         "team_complete_condition": [
             {
                 "groups": [ "玛恩纳", "水陈" ],
-                "threshold": 1
-            },
-            {
-                "groups": [ "处决者" ],
                 "threshold": 1
             },
             {
@@ -139,39 +134,6 @@
                             "threshold": 1,
                             "is_less": true,
                             "offset": -100
-                        }
-                    ]
-                }
-            ]
-        },
-        "处决者": {
-            "opers": [
-                {
-                    "name": "麒麟X夜刀",
-                    "skill": 2,
-                    "is_key": true,
-                    "recruit_priority": 960,
-                    "promote_priority": 971,
-                    "recruit_priority_offsets": [
-                        {
-                            "groups": [ "处决者" ],
-                            "threshold": 1,
-                            "offset": -300
-                        }
-                    ]
-                },
-                {
-                    "name": "缄默德克萨斯",
-                    "skill": 3,
-                    "alternate_skill": 2,
-                    "is_key": true,
-                    "recruit_priority": 950,
-                    "promote_priority": 961,
-                    "recruit_priority_offsets": [
-                        {
-                            "groups": [ "处决者" ],
-                            "threshold": 1,
-                            "offset": -300
                         }
                     ]
                 }

--- a/resource/roguelike/recruitment.json
+++ b/resource/roguelike/recruitment.json
@@ -1451,7 +1451,14 @@
                     "name": "泡普卡",
                     "skill": 1,
                     "recruit_priority": 460,
-                    "is_key": true
+                    "is_key": true,
+                    "recruit_priority_offsets": [
+                        {
+                            "groups": [ "焰苇" ],
+                            "threshold": 1,
+                            "offset": 300
+                        }
+                    ]
                 },
                 {
                     "name": "月见夜",

--- a/resource/roguelike/recruitment.json
+++ b/resource/roguelike/recruitment.json
@@ -556,7 +556,7 @@
                     "is_alternate": true
                 },
                 {
-                    "name": "罗比菈塔",
+                    "name": "罗比菈塔"
                 },
                 {
                     "name": "泡泡"
@@ -3040,7 +3040,7 @@
                     "is_alternate": true
                 },
                 {
-                    "name": "罗比菈塔",
+                    "name": "罗比菈塔"
                 },
                 {
                     "name": "泡泡"


### PR DESCRIPTION
+ 不知道为什么波登可被标记为关键干员，导致出现 #5379 #4675 提到的问题
+ MAA 现在还不会用罗比菈塔的召唤物，于是先 ban 了
+ 根据 #5607 的建议，焰苇打法优先抓泡普卡