### PR TITLE
fix: gui.log 在自重启后有几率无法正常写入

### DIFF
--- a/src/MaaWpfGui/Main/Bootstrapper.cs
+++ b/src/MaaWpfGui/Main/Bootstrapper.cs
@@ -200,6 +200,7 @@ namespace MaaWpfGui.Main
 
             _logger.Information("MaaAssistantArknights GUI exited");
             _logger.Information(string.Empty);
+            Log.CloseAndFlush();
             base.OnExit(e);
         }
 
@@ -214,6 +215,8 @@ namespace MaaWpfGui.Main
             _mutex = null;
             */
 
+            // 有时候软件自重启时 gui.log 会无法正常写入
+            Log.CloseAndFlush();
             System.Windows.Forms.Application.Restart();
         }
 


### PR DESCRIPTION
有时候在更新重启之后 gui.log 就无法写入，在定时自重启时也有概率发生。尝试修复一下，看看有没有效果。