### PR TITLE
feat: 选择刷源石锭策略时强制启用投资选项

### DIFF
--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -1557,6 +1557,12 @@ namespace MaaWpfGui.Main
                 ["stop_when_investment_full"] = stop_when_full,
                 ["theme"] = theme,
             };
+
+            if (mode == 1)
+            {
+                task_params["investment_enabled"] = true;
+            }
+
             if (squad.Length > 0)
             {
                 task_params["squad"] = squad;


### PR DESCRIPTION
解决可能有人选了刷源石锭策略但是高级设置内未勾选投资源石锭选项的问题