### PR TITLE
chore: fix rpath for macos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,9 @@ set_target_properties(MaaCore PROPERTIES
     PUBLIC_HEADER "${MaaCore_PUBLIC_HEADERS}"
 )
 
-if(UNIX)
+if(APPLE)
+    set_target_properties(MaaCore PROPERTIES INSTALL_RPATH "@loader_path/")
+elseif(UNIX)
     set_target_properties(MaaCore PROPERTIES INSTALL_RPATH "$ORIGIN/")
 endif()
 


### PR DESCRIPTION
@mole828 指出 Python 脚本在 macos 下没法正常运行, 可能是这个问题
(我没有 macos 设备, 得测下对不对~~