### PR TITLE
未勾选"强制定时启动"时就不必重启了

### DIFF
--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -277,6 +277,7 @@ namespace MaaWpfGui.ViewModels.UI
                     else if (currentTime == startTime)
                     {
                         timeToStart = true;
+                        configIndex = i;
                         break;
                     }
                 }
@@ -294,6 +295,7 @@ namespace MaaWpfGui.ViewModels.UI
 
             if (timeToStart)
             {
+
                 if (Instances.SettingsViewModel.ForceScheduledStart)
                 {
                     if (!runningState.GetIdle())
@@ -307,6 +309,10 @@ namespace MaaWpfGui.ViewModels.UI
                     }
 
                     ResetFightVariables();
+                }
+                if (Instances.SettingsViewModel.CurrentConfiguration != Instances.SettingsViewModel.TimerModels.Timers[configIndex].TimerConfig)
+                {
+                    return;
                 }
 
                 LinkStart();

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -284,7 +284,7 @@ namespace MaaWpfGui.ViewModels.UI
 
             if (timeToChangeConfig)
             {
-                if (Instances.SettingsViewModel.CustomConfig)
+                if (Instances.SettingsViewModel.CustomConfig && (runningState.GetIdle() || Instances.SettingsViewModel.ForceScheduledStart))
                 {
                     // CurrentConfiguration设置后会重启
                     Instances.SettingsViewModel.CurrentConfiguration = Instances.SettingsViewModel.TimerModels.Timers[configIndex].TimerConfig;

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -295,7 +295,6 @@ namespace MaaWpfGui.ViewModels.UI
 
             if (timeToStart)
             {
-
                 if (Instances.SettingsViewModel.ForceScheduledStart)
                 {
                     if (!runningState.GetIdle())


### PR DESCRIPTION
这里提前两分钟切换配置，如果未勾选强制定时启动，是否可以豁免重启？

并且增加校验，如果没有切换到目标配置，跳过启动。