### PR TITLE
fix#根据反馈调整Qodana 忽略特定的警告

### DIFF
--- a/qodana.yaml
+++ b/qodana.yaml
@@ -27,3 +27,4 @@ exclude:
   - name: CppUnreachableCode
   - name: CppUnusedIncludeDirective
   - name: Xaml.RedundantNamespaceAlias
+  - name: ArrangeTrailingCommaInMultilineLists

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -28,3 +28,4 @@ exclude:
   - name: CppUnusedIncludeDirective
   - name: Xaml.RedundantNamespaceAlias
   - name: ArrangeTrailingCommaInMultilineLists
+  - name: ArrangeTrailingCommaInSinglelineLists


### PR DESCRIPTION
忽略的警告类型是额外的逗号，如下：
```csharp
              "zh-tw" => new[] { "zh-cn", _culture, },
                "en-us" => new[] { "zh-cn", _culture, },
                _ => new[] { "zh-cn", "en-us", _culture, }, //<- 尾部的逗号
            };
```

```csharp
           { "en-us", "YoStarEN" },
            { "ja-jp", "YoStarJP" },
            { "ko-kr", "YoStarKR" }, // <- 尾部的逗号
        };
```