### PR TITLE
refactor: removing useless EndOfActionAnnihilation task

### DIFF
--- a/resource/global/txwy/resource/tasks.json
+++ b/resource/global/txwy/resource/tasks.json
@@ -1542,11 +1542,6 @@
             "實驗基地"
         ]
     },
-    "EndOfActionAnnihilation": {
-        "text": [
-            "行動結束"
-        ]
-    },
     "EnterChapterDifficultyHard": {
         "text": [
             "進入",

--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -3190,7 +3190,6 @@
             136
         ],
         "next": [
-            "EndOfActionAnnihilation",
             "EndOfAction"
         ]
     },
@@ -3408,23 +3407,6 @@
         "preDelay": 5000,
         "next": [
             "EndOfActionThenStop"
-        ]
-    },
-    "EndOfActionAnnihilation": {
-        "algorithm": "OcrDetect",
-        "Doc": "本任务注册了插件 StageDropsTaskPlugin",
-        "text": [
-            "行动结束"
-        ],
-        "roi": [
-            0,
-            118,
-            409,
-            194
-        ],
-        "action": "DoNothing",
-        "next": [
-            "ClickCorner"
         ]
     },
     "StageDrops": {


### PR DESCRIPTION
From my understanding: this part of json is useless, after @zzyyyl implemented the new EndOfAction.png it works in annihilation.