### PR TITLE
Revert "添加繁中服对于鸿雪的OCR等价规则 #5931"

### DIFF
--- a/resource/global/txwy/ocr_config.json
+++ b/resource/global/txwy/ocr_config.json
@@ -1,9 +1,0 @@
-{
-    "equivalence_classes": [
-        [
-            "鴻",
-            "嗚"
-        ]
-
-    ]
-}


### PR DESCRIPTION
Reverts MaaAssistantArknights/MaaAssistantArknights#5933

@Roland125 @Constrat

请使用 tasks.json 中 ocrReplace 来进行替换，而非 equivalence_classes，这个是全局配置，会导致以后出的所有 `嗚` 均被替换为 `鴻`，而 tasks.json 中可以区分仅为干员名进行替换

equivalence_classes 的设计初衷是针对日语中这类仅靠肉眼都无法有效区分、在任意场合替换都合适的字符。

![image](https://github.com/MaaAssistantArknights/MaaAssistantArknights/assets/18511905/0c3b9dd5-9778-4e11-bfe8-6f140b187b82)
