### PR TITLE
feat: add config `CompatPOSIXShell`

### DIFF
--- a/resource/config.json
+++ b/resource/config.json
@@ -146,6 +146,11 @@
             "screencapRawWithGzip": ""
         },
         {
+            "configName": "CompatPOSIXShell",
+            "baseConfig": "General",
+            "stop": "[Adb] -s [AdbSerial] shell 'PACKAGE_NAME=$(dumpsys activity activities 2>/dev/null | grep -E \"(packageName|Activities)=[^\\n]+arknights\" 2>/dev/null | grep -i -o -E \"[^= ]*arknights[^ /\\n]*\" | head -n 1); if [ -n \"$PACKAGE_NAME\" ]; then echo \"Closing $PACKAGE_NAME\"; am force-stop $PACKAGE_NAME; else echo \"app not running or arknights package name not found\"; fi'"
+        },
+        {
             "configName": "GeneralWithoutScreencapErr",
             "baseConfig": "General",
             "screencapRawWithGzip": "[Adb] -s [AdbSerial] exec-out \"screencap 2>/tmp/maa-assistant-arknights.log | gzip -1\"",


### PR DESCRIPTION
在POSIX shell中，双引号内的`$`内的内容将被提前展开，导致`CloseDown`任务失效。所以这里添加了一个配置`CompatPOSIXShell`，将`Stop`字段相应的双引号换成单引号。

另见： #5920，因为那个PR已经合并了，所以我新提了一个PR。