### PR TITLE
fix: all operators are marked as new for overseas clients (Toolbox-Recruitment)

### DIFF
--- a/src/MaaCore/Config/Miscellaneous/RecruitConfig.cpp
+++ b/src/MaaCore/Config/Miscellaneous/RecruitConfig.cpp
@@ -24,6 +24,7 @@ bool asst::RecruitConfig::parse(const json::value& json)
     for (const json::value& oper : json.at("operators").as_array()) {
         Recruitment oper_temp;
         oper_temp.name = oper.at("name").as_string();
+        oper_temp.id = oper.at("id").as_string();
 
         oper_temp.level = oper.at("rarity").as_integer();
         for (const json::value& tag_value : oper.at("tags").as_array()) {

--- a/src/MaaCore/Config/Miscellaneous/RecruitConfig.h
+++ b/src/MaaCore/Config/Miscellaneous/RecruitConfig.h
@@ -17,6 +17,7 @@ namespace asst
     struct Recruitment
     {
         std::string name;
+        std::string id;
         int level = 0;
         std::unordered_set<std::string> tags;
 
@@ -39,7 +40,7 @@ namespace asst
 
         friend bool operator==(const Recruitment& lhs, const Recruitment& rhs)
         {
-            return lhs.name == rhs.name && lhs.level == rhs.level;
+            return lhs.id == rhs.id && lhs.level == rhs.level;
         }
     };
 

--- a/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.cpp
@@ -439,6 +439,7 @@ asst::AutoRecruitTask::calc_task_result_type asst::AutoRecruitTask::recruit_calc
                 for (const Recruitment& oper_info : ranges::reverse_view(comb.opers)) { // print reversely
                     json::value oper_json;
                     oper_json["name"] = oper_info.name;
+                    oper_json["id"] = oper_info.id;
                     oper_json["level"] = oper_info.level;
                     opers_json_vector.emplace_back(std::move(oper_json));
                 }

--- a/src/MaaWpfGui/ViewModels/UI/RecognizerViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/RecognizerViewModel.cs
@@ -297,15 +297,16 @@ namespace MaaWpfGui.ViewModels.UI
                             foreach (var oper in (JArray)combs["opers"])
                             {
                                 int oper_level = (int)oper["level"];
+                                string oper_id = oper["id"].ToString();
                                 string oper_name = oper["name"].ToString();
 
                                 string potential = string.Empty;
 
                                 if (RecruitmentShowPotential && OperBoxPotential != null && (tag_level >= 4 || oper_level == 1))
                                 {
-                                    if (OperBoxPotential.ContainsKey(oper_name))
+                                    if (OperBoxPotential.ContainsKey(oper_id))
                                     {
-                                        potential = " ( " + OperBoxPotential[oper_name] + " )";
+                                        potential = " ( " + OperBoxPotential[oper_id] + " )";
                                     }
                                     else
                                     {
@@ -533,7 +534,7 @@ namespace MaaWpfGui.ViewModels.UI
                     _operBoxPotential = new Dictionary<string, int>();
                     foreach (JObject operBoxData in OperBoxDataArray.Cast<JObject>())
                     {
-                        _operBoxPotential.Add((string)operBoxData["name"], (int)operBoxData["potential"]);
+                        _operBoxPotential.Add((string)operBoxData["id"], (int)operBoxData["potential"]);
                     }
                 }
 


### PR DESCRIPTION
Makes Maa use IDs for recruitment instead of names, so it can properly show potential data for overseas clients.

<details><summary>Screenshot (Before)</summary>

![image](https://github.com/MaaAssistantArknights/MaaAssistantArknights/assets/61264540/cbc2e701-3e47-4a79-ad16-265841ad09d5)
</details>

<details><summary>Screenshot (After)</summary>

![image](https://github.com/MaaAssistantArknights/MaaAssistantArknights/assets/61264540/a64cc223-de78-4e12-a694-442242571c87)
</details>