### PR TITLE
feat: Event Activity and Gacha Banner are displayed according to current time

### DIFF
--- a/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
@@ -2575,10 +2575,23 @@ namespace MaaWpfGui.ViewModels.UI
             if (File.Exists(jsonPath))
             {
                 JObject versionJson = (JObject)JsonConvert.DeserializeObject(File.ReadAllText(jsonPath));
+                var currentTime = (ulong)DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).TotalSeconds;
                 var poolTime = (ulong)versionJson?["gacha"]["time"];
                 var activityTime = (ulong)versionJson?["activity"]["time"];
 
-                if (poolTime > activityTime)
+                if ((currentTime < poolTime) && (currentTime < activityTime))
+                {
+                    versionName = string.Empty;
+                }
+                else if ((currentTime >= poolTime) && (currentTime < activityTime))
+                {
+                    versionName = versionJson?["gacha"]?["pool"]?.ToString() ?? string.Empty;
+                }
+                else if ((currentTime < poolTime) && (currentTime >= activityTime))
+                {
+                    versionName = versionJson?["activity"]?["name"]?.ToString() ?? string.Empty;
+                }
+                else if (poolTime > activityTime)
                 {
                     versionName = versionJson?["gacha"]?["pool"]?.ToString() ?? string.Empty;
                 }

--- a/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
@@ -2575,7 +2575,7 @@ namespace MaaWpfGui.ViewModels.UI
             if (File.Exists(jsonPath))
             {
                 JObject versionJson = (JObject)JsonConvert.DeserializeObject(File.ReadAllText(jsonPath));
-                var currentTime = (ulong)DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).TotalSeconds;
+                var currentTime = (ulong)DateTimeOffset.UtcNow.ToUnixTimeSeconds();
                 var poolTime = (ulong)versionJson?["gacha"]["time"];
                 var activityTime = (ulong)versionJson?["activity"]["time"];
 


### PR DESCRIPTION
Nested if logic can potentially be optimized (?)
With [3fa182d](https://github.com/MaaAssistantArknights/MaaAssistantArknights/pull/6050/commits/3fa182d735bb55b6e2eb8580076de76308c0e0f5) 
```
{
    "activity": {
        "name": "引航者试炼",
        "time": 1692345600
    },
    "gacha": {
        "pool": "云间清醒梦",
        "time": 1690862400
    }
}
```
`time` is used and compared to the current (UTC, NOT local) time of the machine to choose what event / gacha pool to display