### PR TITLE
fix: ocr replace for YostarJP

### DIFF
--- a/resource/global/YoStarJP/resource/tasks.json
+++ b/resource/global/YoStarJP/resource/tasks.json
@@ -2214,14 +2214,8 @@
         ]
     },
     "Mall": {
-        "ocrReplace": [
-            [
-                "買瑠",
-                "買部"
-            ]
-        ],
         "text": [
-            "買部"
+            "購買"
         ]
     },
     "CreditStoreOcr": {


### PR DESCRIPTION
OCR识别结果好像不稳定

```
[2023-08-27 11:56:48.010][TRC][Px20e2c][Tx16724] asst::WordOcr [{ 購買照: [ 37, 28, 115, 53 ], score: 0.724399 }] by OCR Pipeline , cost 22 ms
```

```
[2023-08-27 11:47:23.769][TRC][Px2b2c8][Tx158a4] asst::WordOcr [{ 購買瑠拠: [ 38, 29, 114, 51 ], score: 0.650200 }] by OCR Pipeline , cost 19 ms
```