### PR TITLE
roguelike: 适配刷源石锭模式不期而遇选择策略

### DIFF
--- a/resource/roguelike/Mizuki/encounter.json
+++ b/resource/roguelike/Mizuki/encounter.json
@@ -87,6 +87,12 @@
             "choose": 1
         },
         {
+            "name": "梦中之会",
+            "note": "多次选择",
+            "option_num": 4,
+            "choose": 4
+        },
+        {
             "name": "噬尘扩散",
             "option_num": 1,
             "choose": 1
@@ -103,31 +109,37 @@
         },
         {
             "name": "孤行的老者",
+            "note": "存在多次选择",
             "option_num": 2,
             "choose": 1
         },
         {
             "name": "为了生存",
+            "note": "存在多次选择",
             "option_num": 2,
             "choose": 1
         },
         {
             "name": "苦路",
+            "note": "存在多次选择",
             "option_num": 2,
             "choose": 2
         },
         {
             "name": "设身处地",
+            "note": "存在多次选择",
             "option_num": 2,
             "choose": 1
         },
         {
             "name": "信念",
             "option_num": 2,
-            "choose": 1
+            "note": "存在多次选择",
+            "choose": 2
         },
         {
             "name": "是非黑白",
+            "note": "存在多次选择",
             "option_num": 2,
             "choose": 1
         },
@@ -138,6 +150,7 @@
         },
         {
             "name": "诸王不再",
+            "note": "存在多次选择",
             "option_num": 2,
             "choose": 2
         },
@@ -187,7 +200,7 @@
             "choose": 2
         },
         {
-            "name": "商业帝国",
+            "name": "商业帝国?",
             "option_num": 2,
             "choose": 2
         },
@@ -203,13 +216,18 @@
         },
         {
             "name": "开端",
-            "option_num": 2,
+            "option_num": 3,
             "choose": 2
         },
         {
             "name": "深蓝之心",
             "option_num": 4,
             "choose": 4
+        },
+        {
+            "name": "赞歌",
+            "option_num": 1,
+            "choose": 1
         },
         {
             "name": "深蓝仪式",
@@ -219,11 +237,6 @@
         {
             "name": "升华",
             "option_num": 3,
-            "choose": 1
-        },
-        {
-            "name": "赞歌",
-            "option_num": 1,
             "choose": 1
         },
         {
@@ -237,12 +250,12 @@
             "choose": 1
         },
         {
-            "name": "守望相助",
+            "name": "消失的习俗",
             "option_num": 2,
             "choose": 2
         },
         {
-            "name": "消失的习俗",
+            "name": "守望相助",
             "option_num": 2,
             "choose": 2
         },

--- a/resource/roguelike/Mizuki/encounter.json
+++ b/resource/roguelike/Mizuki/encounter.json
@@ -135,7 +135,7 @@
             "name": "信念",
             "option_num": 2,
             "note": "存在多次选择",
-            "choose": 2
+            "choose": 1
         },
         {
             "name": "是非黑白",

--- a/resource/roguelike/Mizuki/encounter_for_deposit.json
+++ b/resource/roguelike/Mizuki/encounter_for_deposit.json
@@ -14,7 +14,7 @@
         {
             "name": "重返家园",
             "option_num": 3,
-            "choose": 1
+            "choose": 3
         },
         {
             "name": "引火之木",
@@ -39,12 +39,12 @@
         {
             "name": "海边的歌者",
             "option_num": 2,
-            "choose": 1
+            "choose": 2
         },
         {
             "name": "远销海外",
             "option_num": 2,
-            "choose": 1
+            "choose": 2
         },
         {
             "name": "传统技术",
@@ -59,12 +59,12 @@
         {
             "name": "变卖身家",
             "option_num": 3,
-            "choose": 1
+            "choose": 3
         },
         {
             "name": "无知是福",
             "option_num": 2,
-            "choose": 1
+            "choose": 2
         },
         {
             "name": "点滴星火",
@@ -87,6 +87,12 @@
             "choose": 1
         },
         {
+            "name": "梦中之会",
+            "note": "存在多次选择",
+            "option_num": 4,
+            "choose": 4
+        },
+        {
             "name": "噬尘扩散",
             "option_num": 1,
             "choose": 1
@@ -103,31 +109,37 @@
         },
         {
             "name": "孤行的老者",
+            "note": "存在多次选择",
             "option_num": 2,
             "choose": 1
         },
         {
             "name": "为了生存",
+            "note": "存在多次选择",
             "option_num": 2,
             "choose": 1
         },
         {
             "name": "苦路",
+            "note": "存在多次选择",
             "option_num": 2,
             "choose": 2
         },
         {
             "name": "设身处地",
+            "note": "存在多次选择",
             "option_num": 2,
-            "choose": 1
+            "choose": 2
         },
         {
             "name": "信念",
             "option_num": 2,
-            "choose": 1
+            "note": "存在多次选择",
+            "choose": 2
         },
         {
             "name": "是非黑白",
+            "note": "存在多次选择",
             "option_num": 2,
             "choose": 1
         },
@@ -138,6 +150,7 @@
         },
         {
             "name": "诸王不再",
+            "note": "存在多次选择",
             "option_num": 2,
             "choose": 2
         },
@@ -159,7 +172,7 @@
         {
             "name": "藏宝港湾",
             "option_num": 2,
-            "choose": 1
+            "choose": 2
         },
         {
             "name": "宝箱之舞",
@@ -169,7 +182,7 @@
         {
             "name": "狗眼婆娑",
             "option_num": 2,
-            "choose": 1
+            "choose": 2
         },
         {
             "name": "鸭力测试",
@@ -187,14 +200,14 @@
             "choose": 2
         },
         {
-            "name": "商业帝国",
+            "name": "商业帝国?",
             "option_num": 2,
             "choose": 2
         },
         {
             "name": "狂徒妄念",
             "option_num": 3,
-            "choose": 2
+            "choose": 3
         },
         {
             "name": "骑士仍在",
@@ -203,13 +216,18 @@
         },
         {
             "name": "开端",
-            "option_num": 2,
+            "option_num": 3,
             "choose": 2
         },
         {
             "name": "深蓝之心",
             "option_num": 4,
             "choose": 4
+        },
+        {
+            "name": "赞歌",
+            "option_num": 1,
+            "choose": 1
         },
         {
             "name": "深蓝仪式",
@@ -222,11 +240,6 @@
             "choose": 1
         },
         {
-            "name": "赞歌",
-            "option_num": 1,
-            "choose": 1
-        },
-        {
             "name": "安全屋",
             "option_num": 4,
             "choose": 2
@@ -234,15 +247,15 @@
         {
             "name": "现买现印",
             "option_num": 2,
-            "choose": 1
-        },
-        {
-            "name": "守望相助",
-            "option_num": 2,
             "choose": 2
         },
         {
             "name": "消失的习俗",
+            "option_num": 2,
+            "choose": 2
+        },
+        {
+            "name": "守望相助",
             "option_num": 2,
             "choose": 2
         },

--- a/resource/roguelike/Phantom/encounter.json
+++ b/resource/roguelike/Phantom/encounter.json
@@ -157,13 +157,18 @@
             "choose": 1
         },
         {
-            "name": "解脱",
+            "name": "解脱?",
             "option_num": 2,
             "choose": 2
         },
         {
             "name": "疯狂玩偶",
             "option_num": 2,
+            "choose": 1
+        },
+        {
+            "name": "解脱",
+            "option_num": 1,
             "choose": 1
         },
         {
@@ -203,12 +208,12 @@
         },
         {
             "name": "暴殄天物",
-            "option_num": 2,
-            "choose": 2
+            "option_num": 4,
+            "choose": 4
         },
         {
             "name": "鼠胆神偷",
-            "option_num": 2,
+            "option_num": 3,
             "choose": 1
         },
         {

--- a/resource/roguelike/Phantom/encounter_for_deposit.json
+++ b/resource/roguelike/Phantom/encounter_for_deposit.json
@@ -19,7 +19,7 @@
         {
             "name": "委托冒险者",
             "option_num": 3,
-            "choose": 1
+            "choose": 3
         },
         {
             "name": "皇家争执",
@@ -44,7 +44,7 @@
         {
             "name": "哥伦比亚酒商",
             "option_num": 2,
-            "choose": 1
+            "choose": 2
         },
         {
             "name": "锡人",
@@ -54,7 +54,7 @@
         {
             "name": "猩红舞会",
             "option_num": 4,
-            "choose": 1
+            "choose": 4
         },
         {
             "name": "剧目需求",
@@ -64,17 +64,17 @@
         {
             "name": "狂舞之人",
             "option_num": 2,
-            "choose": 1
+            "choose": 2
         },
         {
             "name": "音乐挑战",
             "option_num": 2,
-            "choose": 1
+            "choose": 2
         },
         {
             "name": "石中剑",
             "option_num": 3,
-            "choose": 1
+            "choose": 3
         },
         {
             "name": "被困的人",
@@ -84,32 +84,32 @@
         {
             "name": "佝偻怪客",
             "option_num": 2,
-            "choose": 1
+            "choose": 2
         },
         {
             "name": "沉睡石像",
             "option_num": 2,
-            "choose": 1
+            "choose": 2
         },
         {
             "name": "受缚之血",
             "option_num": 2,
-            "choose": 1
+            "choose": 2
         },
         {
             "name": "幽影狂言",
             "option_num": 2,
-            "choose": 1
+            "choose": 2
         },
         {
             "name": "艺术与疯狂",
             "option_num": 2,
-            "choose": 1
+            "choose": 2
         },
         {
             "name": "鸭爵主演",
             "option_num": 2,
-            "choose": 1
+            "choose": 2
         },
         {
             "name": "鸭爵的宴会",
@@ -129,12 +129,12 @@
         {
             "name": "邪恶之棺",
             "option_num": 2,
-            "choose": 1
+            "choose": 2
         },
         {
             "name": "以血还血",
             "option_num": 3,
-            "choose": 2
+            "choose": 3
         },
         {
             "name": "暗门",
@@ -149,21 +149,26 @@
         {
             "name": "废品地摊",
             "option_num": 3,
-            "choose": 2
+            "choose": 3
         },
         {
             "name": "鉴赏家",
             "option_num": 4,
-            "choose": 1
+            "choose": 3
         },
         {
-            "name": "解脱",
+            "name": "解脱?",
             "option_num": 2,
             "choose": 2
         },
         {
             "name": "疯狂玩偶",
             "option_num": 2,
+            "choose": 1
+        },
+        {
+            "name": "解脱",
+            "option_num": 1,
             "choose": 1
         },
         {
@@ -179,12 +184,12 @@
         {
             "name": "别打扰他们",
             "option_num": 2,
-            "choose": 1
+            "choose": 2
         },
         {
             "name": "复仇剧",
             "option_num": 2,
-            "choose": 1
+            "choose": 2
         },
         {
             "name": "安全的角落",
@@ -203,12 +208,12 @@
         },
         {
             "name": "暴殄天物",
-            "option_num": 2,
-            "choose": 2
+            "option_num": 4,
+            "choose": 1
         },
         {
             "name": "鼠胆神偷",
-            "option_num": 2,
+            "option_num": 3,
             "choose": 1
         },
         {

--- a/resource/roguelike/Sami/encounter.json
+++ b/resource/roguelike/Sami/encounter.json
@@ -359,7 +359,16 @@
         {
             "name": "科考站",
             "option_num": 3,
-            "choose": 1
+            "choose": 1,
+            "choice_require": [
+                {
+                    "name": "无人机好像有新发现",
+                    "Vision": {
+                        "value": "1",
+                        "type": ">"
+                    }
+                }
+            ]
         },
         {
             "name": "北地巫师竞技",
@@ -424,7 +433,6 @@
                 }
             ]
         },
-        
         {
             "name": "低地市集",
             "option_num": 3,
@@ -519,7 +527,7 @@
         {
             "name": "探寻前路",
             "option_num": 3,
-            "choose": 2            
+            "choose": 3
         },
         {
             "name": "前行的林地",

--- a/resource/roguelike/Sami/encounter_for_deposit.json
+++ b/resource/roguelike/Sami/encounter_for_deposit.json
@@ -1,160 +1,7 @@
 {
     "theme": "Sami_deposit",
     "stage": [
-        {
-            "name": "低地市集",
-            "option_num": 3,
-            "choose": 3,
-            "choice_require": [
-                {
-                    "name": "选择碎草药",
-                    "ChaosLevel": {
-                        "value": "3",
-                        "type": ">"
-                    }
-                },
-                {
-                    "name": "选择好看的织物",
-                    "ChaosLevel": {
-                        "value": "3",
-                        "type": ">"
-                    }
-                },
-                {
-                    "name": "选择湿膏药",
-                    "ChaosLevel": {
-                        "value": "3",
-                        "type": ">"
-                    }
-                },
-                {
-                    "name": "选择好看的木刻",
-                    "ChaosLevel": {
-                        "value": "3",
-                        "type": ">"
-                    }
-                },
-                {
-                    "name": "选择纯霜露",
-                    "ChaosLevel": {
-                        "value": "3",
-                        "type": ">"
-                    }
-                },
-                {
-                    "name": "选择琥珀核",
-                    "ChaosLevel": {
-                        "value": "3",
-                        "type": ">"
-                    }
-                }
-            ]
-        },
-        {
-            "name": "雪与木的笆篱",
-            "option_num": 3,
-            "choose": 3,
-            "choice_require": [
-                {
-                    "name": "“活力”",
-                    "ChaosLevel": {
-                        "value": "3",
-                        "type": ">"
-                    }
-                },
-                {
-                    "name": "“金钱”",
-                    "ChaosLevel": {
-                        "value": "3",
-                        "type": ">"
-                    }
-                }
-            ]
-        },
-        {
-            "name": "安玛塔卢",
-            "option_num": 3,
-            "choose": 3,
-            "choice_require": [
-                {
-                    "name": "寻求希望",
-                    "ChaosLevel": {
-                        "value": "3",
-                        "type": ">"
-                    }
-                },
-                {
-                    "name": "寻求护佑",
-                    "ChaosLevel": {
-                        "value": "3",
-                        "type": ">"
-                    }
-                }
-            ]
-        },
-        {
-            "name": "北地巫师竞技",
-            "option_num": 2,
-            "choose": 2,
-            "choice_require": [
-                {
-                    "name": "接过名册木板，是该选择了！",
-                    "OriginiumIngot": {
-                        "value": "3",
-                        "type": ">"
-                    }
-                },
-                {
-                    "name": "没来过萨米的人一定没见过！",
-                    "OriginiumIngot": {
-                        "value": "3",
-                        "type": ">"
-                    }
-                }
-            ]
-        },
-        {
-            "name": "最好的朋友",
-            "option_num": 2,
-            "choose": 2,
-            "choice_require": [
-                {
-                    "name": "仓皇离开",
-                    "Shield": {
-                        "value": "1",
-                        "type": ">"
-                    }
-                },
-                {
-                    "name": "留下",
-                    "LivePointCap": {
-                        "value": "1",
-                        "type": ">"
-                    }
-                },
-                {
-                    "name": "再喝一口",
-                    "LivePoint": {
-                        "value": "3",
-                        "type": ">"
-                    }
-                }
-            ]
-        },
-        {
-            "name": "深渊入口",
-            "option_num": 2,
-            "choose": 2,
-            "choice_require": [
-                {
-                    "name": "再试试看吧",
-                    "Vision": {
-                        "value": "1",
-                        "type": ">"
-                    }
-                }
-            ]
-        },
+        
         {
             "name": "吉兆",
             "option_num": 2,
@@ -347,56 +194,6 @@
             "choose": 1
         },
         {
-            "name": "鲍勃杂货店",
-            "option_num": 3,
-            "choose": 1,
-            "choice_require": [
-                {
-                    "name": "选择他脚边的货品",
-                    "Vision": {
-                        "value": "1",
-                        "type": ">"
-                    }
-                },
-                {
-                    "name": "选择仓库深处的货品",
-                    "Vision": {
-                        "value": "3",
-                        "type": ">"
-                    }
-                }
-            ]
-        },
-        {
-            "name": "科考站",
-            "option_num": 3,
-            "choose": 1
-        },
-        {
-            "name": "走过萨米的臂膀",
-            "option_num": 2,
-            "choose": 1,
-            "choice_require": [
-                {
-                    "name": "戴上头盔",
-                    "Relic": {
-                        "value": "树痕之盔",
-                        "type": "have"
-                    }
-                }
-            ]
-        },
-        {
-            "name": "木裂前兆",
-            "option_num": 2,
-            "choose": 1
-        },
-        {
-            "name": "悲观者囚笼",
-            "option_num": 2,
-            "choose": 1
-        },
-        {
             "name": "沼泽里的抽泣声",
             "option_num": 3,
             "choose": 3
@@ -436,7 +233,16 @@
         {
             "name": "邪恶计划鸭",
             "option_num": 2,
-            "choose": 2
+            "choose": 2,
+            "choice_require": [
+                {
+                    "name": "你在做什么?",
+                    "LivePoint": {
+                        "value": "3",
+                        "type": ">"
+                    }
+                }
+            ]
         },
         {
             "name": "百里连营",
@@ -496,6 +302,224 @@
                     }
                 }
             ]
+        },
+        {
+            "name": "走过萨米的臂膀",
+            "option_num": 2,
+            "choose": 1,
+            "choice_require": [
+                {
+                    "name": "戴上头盔",
+                    "Relic": {
+                        "value": "树痕之盔",
+                        "type": "have"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "木裂前兆",
+            "option_num": 2,
+            "choose": 1
+        },
+        {
+            "name": "悲观者囚笼",
+            "option_num": 2,
+            "choose": 1
+        },
+        {
+            "name": "鲍勃杂货店",
+            "option_num": 3,
+            "choose": 1,
+            "choice_require": [
+                {
+                    "name": "选择他脚边的货品",
+                    "Vision": {
+                        "value": "1",
+                        "type": ">"
+                    }
+                },
+                {
+                    "name": "选择仓库深处的货品",
+                    "Vision": {
+                        "value": "3",
+                        "type": ">"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "科考站",
+            "option_num": 3,
+            "choose": 1,
+            "choice_require": [
+                {
+                    "name": "无人机好像有新发现",
+                    "Vision": {
+                        "value": "1",
+                        "type": ">"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "北地巫师竞技",
+            "option_num": 2,
+            "choose": 2,
+            "choice_require": [
+                {
+                    "name": "接过名册木板，是该选择了！",
+                    "OriginiumIngot": {
+                        "value": "3",
+                        "type": ">"
+                    }
+                },
+                {
+                    "name": "没来过萨米的人一定没见过！",
+                    "OriginiumIngot": {
+                        "value": "3",
+                        "type": ">"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "最好的朋友",
+            "option_num": 2,
+            "choose": 2,
+            "choice_require": [
+                {
+                    "name": "仓皇离开",
+                    "Shield": {
+                        "value": "1",
+                        "type": ">"
+                    }
+                },
+                {
+                    "name": "留下",
+                    "LivePointCap": {
+                        "value": "1",
+                        "type": ">"
+                    }
+                },
+                {
+                    "name": "再喝一口",
+                    "LivePoint": {
+                        "value": "3",
+                        "type": ">"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "深渊入口",
+            "option_num": 2,
+            "choose": 2,
+            "choice_require": [
+                {
+                    "name": "再试试看吧",
+                    "Vision": {
+                        "value": "1",
+                        "type": ">"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "低地市集",
+            "option_num": 3,
+            "choose": 3,
+            "choice_require": [
+                {
+                    "name": "选择碎草药",
+                    "ChaosLevel": {
+                        "value": "3",
+                        "type": ">"
+                    }
+                },
+                {
+                    "name": "选择好看的织物",
+                    "ChaosLevel": {
+                        "value": "3",
+                        "type": ">"
+                    }
+                },
+                {
+                    "name": "选择湿膏药",
+                    "ChaosLevel": {
+                        "value": "3",
+                        "type": ">"
+                    }
+                },
+                {
+                    "name": "选择好看的木刻",
+                    "ChaosLevel": {
+                        "value": "3",
+                        "type": ">"
+                    }
+                },
+                {
+                    "name": "选择纯霜露",
+                    "ChaosLevel": {
+                        "value": "3",
+                        "type": ">"
+                    }
+                },
+                {
+                    "name": "选择琥珀核",
+                    "ChaosLevel": {
+                        "value": "3",
+                        "type": ">"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "雪与木的笆篱",
+            "option_num": 3,
+            "choose": 3,
+            "choice_require": [
+                {
+                    "name": "“活力”",
+                    "ChaosLevel": {
+                        "value": "3",
+                        "type": ">"
+                    }
+                },
+                {
+                    "name": "“金钱”",
+                    "ChaosLevel": {
+                        "value": "3",
+                        "type": ">"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "安玛塔卢",
+            "option_num": 3,
+            "choose": 3,
+            "choice_require": [
+                {
+                    "name": "寻求希望",
+                    "ChaosLevel": {
+                        "value": "3",
+                        "type": ">"
+                    }
+                },
+                {
+                    "name": "寻求护佑",
+                    "ChaosLevel": {
+                        "value": "3",
+                        "type": ">"
+                    }
+                }
+            ]
+        },
+        {
+            "name": "探寻前路",
+            "option_num": 3,
+            "choose": 2
         },
         {
             "name": "前行的林地",


### PR DESCRIPTION
水月和傀影的文件都是小小改动,只调数字,萨米的顺便修复了顺序使其与wiki顺序保持一致,而且使encounter_for_deposit与encounter同项对齐,方便对比