### PR TITLE
feat: 添加CLI支持

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,6 @@ on:
       - 'cmake/**'
       - 'CMakeLists.txt'
       - 'MAA.sln'
-      - '.github/workflows/ci.yml'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ on:
       - 'cmake/**'
       - 'CMakeLists.txt'
       - 'MAA.sln'
+      - '.github/workflows/ci.yml'
   workflow_dispatch:
 
 jobs:
@@ -177,11 +178,14 @@ jobs:
       - name: Download CLI Release
         uses: robinraju/release-downloader@v1.8
         with:
-          repo: MaaAssistantArknights/maa-cli
-          lastest: true
+          repository: MaaAssistantArknights/maa-cli
+          latest: true
           fileName: maa_cli-v*-${{ matrix.arch }}-unknown-linux-gnu.tar.gz
-          extract: true
-          out-file-path: install
+
+      - name: Extract CLI
+        run: |
+          maa=$(tar xzvf maa_cli-v*-${{ matrix.arch }}-unknown-linux-gnu.tar.gz)
+          cp -v $maa install/maa
 
       - name: tar files
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,15 @@ jobs:
           mkdir -p install
           cmake --install build --prefix install
 
+      - name: Download CLI Release
+        uses: robinraju/release-downloader@v1.8
+        with:
+          repo: MaaAssistantArknights/maa-cli
+          lastest: true
+          fileName: maa_cli-v*-${{ matrix.arch }}-unknown-linux-gnu.tar.gz
+          extract: true
+          out-file-path: install
+
       - name: tar files
         run: |
           mkdir -p release

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ MAA 的意思是 MAA Assistant Arknights
 
 ### 外服支持
 
-目前国际服（美服）、日服、韩服、繁中服的绝大部分功能均已支持。但由于外服用户较少及项目人手不足，很多功能并没有进行全面的测试，所以请自行体验。
+目前国际服（美服）、日服、韩服、繁中服的绝大部分功能均已支持。但由于外服用户较少及项目人手不足，很多功能并没有进行全面的测试，所以请自行体验。  
 若您遇到了 Bug，或对某个功能有强需求，欢迎在 [Issues](https://github.com/MaaAssistantArknights/MaaAssistantArknights/issues) 和 [讨论区](https://github.com/MaaAssistantArknights/MaaAssistantArknights/discussions) 催更；或加入我们一起建设 MAA！请参考 [外服适配教程](#外服适配)
 
 ### CLI支持

--- a/README.md
+++ b/README.md
@@ -75,12 +75,12 @@ MAA 的意思是 MAA Assistant Arknights
 
 ### 外服支持
 
-目前国际服（美服）、日服、韩服、繁中服的绝大部分功能均已支持。但由于外服用户较少及项目人手不足，很多功能并没有进行全面的测试，所以请自行体验。  
+目前国际服（美服）、日服、韩服、繁中服的绝大部分功能均已支持。但由于外服用户较少及项目人手不足，很多功能并没有进行全面的测试，所以请自行体验。
 若您遇到了 Bug，或对某个功能有强需求，欢迎在 [Issues](https://github.com/MaaAssistantArknights/MaaAssistantArknights/issues) 和 [讨论区](https://github.com/MaaAssistantArknights/MaaAssistantArknights/discussions) 催更；或加入我们一起建设 MAA！请参考 [外服适配教程](#外服适配)
 
 ### CLI支持
 
-MAA支持命令行界面（CLI）操作，支持Linux和macOS，可用于自动化脚本或在无图形界面的服务器上使用。请参考 [CLI 使用指南](https://maa.plus/docs/1.6-CLI使用指南.html)
+MAA支持命令行界面（CLI）操作，支持 Linux 和 macOS，可用于自动化脚本或在无图形界面的服务器上使用。请参考 [CLI 使用指南](https://maa.plus/docs/1.6-CLI使用指南.html)
 
 ## 加入我们
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ MAA 的意思是 MAA Assistant Arknights
 
 ### CLI支持
 
-MAA支持命令行界面（CLI）操作，支持 Linux 和 macOS，可用于自动化脚本或在无图形界面的服务器上使用。请参考 [CLI 使用指南](https://maa.plus/docs/1.6-CLI使用指南.html)
+MAA 支持命令行界面（CLI）操作，支持 Linux 和 macOS，可用于自动化脚本或在无图形界面的服务器上使用。请参考 [CLI 使用指南](https://maa.plus/docs/1.6-CLI使用指南.html)
 
 ## 加入我们
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ MAA 的意思是 MAA Assistant Arknights
 目前国际服（美服）、日服、韩服、繁中服的绝大部分功能均已支持。但由于外服用户较少及项目人手不足，很多功能并没有进行全面的测试，所以请自行体验。  
 若您遇到了 Bug，或对某个功能有强需求，欢迎在 [Issues](https://github.com/MaaAssistantArknights/MaaAssistantArknights/issues) 和 [讨论区](https://github.com/MaaAssistantArknights/MaaAssistantArknights/discussions) 催更；或加入我们一起建设 MAA！请参考 [外服适配教程](#外服适配)
 
+### CLI支持
+
+MAA支持命令行界面（CLI）操作，支持Linux和macOS，可用于自动化脚本或在无图形界面的服务器上使用。请参考 [CLI 使用指南](https://maa.plus/docs/1.6-CLI使用指南.html)
+
 ## 加入我们
 
 ### 主要关联项目

--- a/docs/1.6-CLI使用指南.md
+++ b/docs/1.6-CLI使用指南.md
@@ -2,21 +2,38 @@
 
 ## 功能介绍
 
-- 通过TOML，JSON，YAML格式的配置文件，定义MAA任务流程，并通过`maa run <task>`命令执行任务。
+- 通过TOML，JSON，YAML格式的配置文件定义MAA任务流程，并通过`maa run <task>`命令执行任务。
 - 通过`maa list`命令列出所有可用任务。
 - 通过`maa install` 和 `maa update`命令安装和更新MAA共享库和资源。
+- 通过`maa self update`命令更新CLI自身。
 
 ## 安装
 
 ### Linux
 
-对于最新版本的MAA，CLI已经打包在MAA的安装包中，无需额外安装。
+对于最新版本的MAA，CLI已经打包在MAA压缩包中，如果你下载了最新版MAA，解压后就可以使用CLI，无需额外安装。
+**注意**: 请不要将库文件和资源文件随便移动到其他位置，否则CLI将无法找到它们。
+如果你想将它们移动到其他位置，你可以通过以下命令：
+```bash
+# 请确保你当前的工作目录是解压后的MAA目录
+lib_dir="$(./maa dir lib)"
+resource_dir="$(./maa dir resource)"
+mv lib* "$lib_dir"
+mv resource "$resource_dir"
+```
+
+如果你当前使用的是旧版本的MAA或者希望单独安装CLI，
+你可以前往[CLI Release页面](https://github.com/MaaAssistantArknights/maa-cli/releases/latest)
+根据你的架构下载对应的预编译的CLI二进制文件，
+（对于x86_64架构，你可以下载以`x86_64-unknown-linux-gnu.tar.gz`结尾的文件，
+对于aarch64架构，你可以下载以`aarch64-unknown-linux-gnu.tar.gz`结尾的文件），
+解压后将`maa`文件移动到你任何在`PATH`环境变量中的目录下, 然后使用`maa install`命令安装MAA共享库和资源。
 
 ### macOS
 
-macOS请前往[Release页面](https://github.com/MaaAssistantArknights/maa-cli/releases/latest)
-下载预编译的CLI二进制文件， 解压后将`maa`文件移动到你任何在`PATH`环境变量中的目录下,
-然后使用`maa install`命令安装MAA共享库和资源。
+macOS用户和Linux用户一样，可以在[CLI Release页面](https://github.com/MaaAssistantArknights/maa-cli/releases/latest)
+下载对应的预编译的CLI二进制文件（macOS提供通用的二进制文件，以`universal-apple-darwin.tar.gz`结尾），
+解压后将`maa`文件移动到你任何在`PATH`环境变量中的目录下，然后使用`maa install`命令安装MAA共享库和资源。
 
 ### Windows
 
@@ -28,8 +45,8 @@ CLI目前尚不支持Windows。
 
 你的配置文件（选项，任务等）位于配置目录中，你可以通过`maa dir config`获取配置目录,
 并通过`mkdir -p "$(maa dir config)"`创建它。
-以下配置目录的将被称为`$MAA_CONFIG_DIR`，且以下所有配置文件的格式可以是TOML，JSON或YAML。
-
+在以下的介绍中，配置目录的将被称为`$MAA_CONFIG_DIR`。
+此外尽管所有的例子都是针对TOML格式的，但是以下所有配置文件的格式可以是TOML，JSON或YAML。
 
 ### MAA选项
 

--- a/docs/1.6-CLI使用指南.md
+++ b/docs/1.6-CLI使用指南.md
@@ -11,20 +11,17 @@
 
 ### Linux
 
-对于最新版本的 MAA，CLI 已经打包在 MAA 压缩包中，如果你下载了最新版 MAA，解压后就可以使用 CLI，无需额外安装。
-**注意**: 请不要将库文件和资源文件随便移动到其他位置，否则CLI将无法找到它们。
-如果你想将它们移动到其他位置，你可以通过以下命令：
+对于最新版本的 MAA，CLI 已经打包在 MAA 压缩包中，如果你下载了最新版 MAA，解压后就可以使用 CLI，无需额外安装。 **注意**: 请不要将库文件和资源文件随便移动到其他位置，否则CLI将无法找到它们。 如果你想将它们移动到其他位置，你可以通过以下命令：
 
 ```bash
 # 请确保你当前的工作目录是解压后的MAA目录
-lib_dir="$(./maa dir lib)"
-resource_dir="$(./maa dir resource)"
+lib_dir="$(./maa dir data)/lib"
+resource_dir="$(./maa dir data)/resource"
 mv lib* "$lib_dir"
 mv resource "$resource_dir"
 ```
 
-如果你当前使用的是旧版本的MAA或者希望单独安装CLI，你可以前往[CLI Release页面](https://github.com/MaaAssistantArknights/maa-cli/releases/latest)
-根据你的架构下载对应的预编译的LCI二进制文件（对于x86_64架构，你可以下载以 `x86_64-unknown-linux-gnu.tar.gz` 结尾的文件，对于aarch64架构，你可以下载以 `aarch64-unknown-linux-gnu.tar.gz` 结尾的文件），解压后将 `maa` 文件移动到你任何在 `PATH` 环境变量中的目录下, 然后使用 `maa install` 命令安装MAA共享库和资源。
+如果你当前使用的是旧版本的MAA或者希望单独安装CLI，你可以前往[CLI Release页面](https://github.com/MaaAssistantArknights/maa-cli/releases/latest) 根据你的架构下载对应的预编译的LCI二进制文件（对于x86_64架构，你可以下载以 `x86_64-unknown-linux-gnu.tar.gz` 结尾的文件，对于aarch64架构，你可以下载以 `aarch64-unknown-linux-gnu.tar.gz` 结尾的文件），解压后将 `maa` 文件移动到你任何在 `PATH` 环境变量中的目录下, 然后使用 `maa install` 命令安装MAA共享库和资源。
 
 ### macOS
 
@@ -38,14 +35,11 @@ CLI目前尚不支持Windows。
 
 ### 配置目录
 
-你的配置文件（选项，任务等）位于配置目录中，你可以通过 `maa dir config` 获取配置目录，并通过 `mkdir -p "$(maa dir config)"` 创建它。
-在以下的介绍中，配置目录的将被称为 `$MAA_CONFIG_DIR`。
-此外尽管所有的例子都是针对 TOML 格式的，但是以下所有配置文件的格式可以是 TOML，JSON 或 YAML。
+你的配置文件（选项，任务等）位于配置目录中，你可以通过 `maa dir config` 获取配置目录，并通过 `mkdir -p "$(maa dir config)"` 创建它。在以下的介绍中，配置目录的将被称为 `$MAA_CONFIG_DIR`。此外尽管所有的例子都是针对 TOML 格式的，但是以下所有配置文件的格式可以是 TOML，JSON 或 YAML。
 
 ### MAA选项
 
-针对MAA本身的选项，你可以在 `$MAA_CONFIG_DIR/asst.toml` 中进行配置。
-这里的选项包括三个部分：
+针对MAA本身的选项，你可以在 `$MAA_CONFIG_DIR/asst.toml` 中进行配置。 这里的选项包括三个部分：
 
 - `connection`：MAA连接设置；
 - `instance_options`：MAA实例选项；
@@ -67,8 +61,7 @@ device = "emulator-5554" # 你的android设备的序列号
 config = "General" # maa connect的配置名称，可选，不建议修改
 ```
 
-设备的序列号可以是地址加端口号，也可以是非地址的任意字符串，可以通过 `adb devices` 命令获取。
-更多信息参见模拟器支持文档。
+设备的序列号可以是地址加端口号，也可以是非地址的任意字符串，可以通过 `adb devices` 命令获取。更多信息参见模拟器支持文档。
 
 ##### PlayTools 连接
 
@@ -109,8 +102,7 @@ resources = ["platform_diff/iOS", "global/YoStarEN"]
 
 ### 定义任务
 
-任务文件位于 `$MAA_CONFIG_DIR/tasks` 目录下。
-每一个任务文件都是一个任务列表，每一个子任务是一个 MAA 任务，其中包含任务类型和参数，可用的任务及其参数参见[集成文档](https://maa.plus/docs/3.1-集成文档.html#asstappendtask)。
+任务文件位于 `$MAA_CONFIG_DIR/tasks` 目录下。 每一个任务文件都是一个任务列表，每一个子任务是一个 MAA 任务，其中包含任务类型和参数，可用的任务及其参数参见[集成文档](https://maa.plus/docs/3.1-集成文档.html#asstappendtask)。
 
 一个简单的任务文件示例：
 
@@ -205,14 +197,11 @@ condition = { type = "Time", start = "18:00:00" }
 
 ### 运行任务
 
-当你定义了任务后，你可以通过 `maa run <task>` 命令运行任务，所有可用的任务可以通过 `maa list` 命令列出。
-更多其他可用命令参见 `maa --help`。
+当你定义了任务后，你可以通过 `maa run <task>` 命令运行任务，所有可用的任务可以通过 `maa list` 命令列出。 更多其他可用命令参见 `maa --help`。
 
 #### 日志级别
 
-当运行任务时，CLI 会处理 MAA 的消息。但是不是所有的消息都会输出。
-日志级别用于控制哪些消息会被输出。
-当前有6个日志级别：
+当运行任务时，CLI 会处理 MAA 的消息。但是不是所有的消息都会输出。日志级别用于控制哪些消息会被输出。当前有6个日志级别：
 
 - Error：出现错误，MAA将会停止运行或者无法正常工作；
 - Warning：出现错误，但是MAA仍然可以正常工作；
@@ -221,9 +210,6 @@ condition = { type = "Time", start = "18:00:00" }
 - Debug：关于你的配置的详细信息，例如将要运行任务的类型和参数；
 - Trace：任何没有被CLI正确解析的MAA消息。
 
-默认的日志级别是 `Normal`，你可以通过 `-v` 和 `-q` 选项来控制日志级别：
-`-v`将会提高日志级别以显更多消息，`-q` 将会减少日志级别以显示更少的消息，重复使用 `-v` 和 `-q` 将会提高或降低日志级别，直到达到最高或最低级别。
-比如，`-vv` 将会显示 `Debug` 级别及以上的消息，而 `-qq` 将会显示 `Warning` 级别及以下的消息。
+默认的日志级别是 `Normal`，你可以通过 `-v` 和 `-q` 选项来控制日志级别：`-v`将会提高日志级别以显更多消息，`-q` 将会减少日志级别以显示更少的消息，重复使用 `-v` 和 `-q` 将会提高或降低日志级别，直到达到最高或最低级别。比如，`-vv` 将会显示 `Debug` 级别及以上的消息，而 `-qq` 将会显示 `Warning` 级别及以下的消息。
 
-对于一般使用，建议使用 `maa run -v <task>`，这样你可以看到 MAA 的所有有用的消息。
-当你在调试配置时，你可以使用 `maa run -vv <task>` 来看到更多的调试信息。
+对于一般使用，建议使用 `maa run -v <task>`，这样你可以看到 MAA 的所有有用的消息。 当你在调试配置时，你可以使用 `maa run -vv <task>` 来看到更多的调试信息。

--- a/docs/1.6-CLI使用指南.md
+++ b/docs/1.6-CLI使用指南.md
@@ -1,0 +1,204 @@
+# CLI使用指南
+
+## 功能介绍
+
+- 通过TOML，JSON，YAML格式的配置文件，定义MAA任务流程，并通过`maa run <task>`命令执行任务。
+- 通过`maa list`命令列出所有可用任务。
+- 通过`maa install` 和 `maa update`命令安装和更新MAA共享库和资源。
+
+## 安装
+
+### Linux
+
+对于最新版本的MAA，CLI已经打包在MAA的安装包中，无需额外安装。
+
+### macOS
+
+macOS请前往[Release页面](https://github.com/MaaAssistantArknights/maa-cli/releases/latest)
+下载预编译的CLI二进制文件， 解压后将`maa`文件移动到你任何在`PATH`环境变量中的目录下,
+然后使用`maa install`命令安装MAA共享库和资源。
+
+### Windows
+
+CLI目前尚不支持Windows。
+
+## 使用和配置
+
+### 配置目录
+
+你的配置文件（选项，任务等）位于配置目录中，你可以通过`maa dir config`获取配置目录,
+并通过`mkdir -p "$(maa dir config)"`创建它。
+以下配置目录的将被称为`$MAA_CONFIG_DIR`，且以下所有配置文件的格式可以是TOML，JSON或YAML。
+
+
+### MAA选项
+
+针对MAA本身的选项，你可以在`$MAA_CONFIG_DIR/asst.toml`中进行配置。
+这里的选项包括三个部分：
+- `connection`：MAA连接设置；
+- `instance_options`：MAA实例选项；
+- `resources`: 额外资源地址。
+
+#### `connection`设置
+
+`connection`设置用于配置MAA连接游戏，其包括两种方式：通过ADB连接和通过PlayTools连接。
+
+##### ADB连接
+
+当你使用ADB连接时，你需要提供`adb`的路径和设备的序列号:
+```toml
+[connection]
+type = "ADB"
+adb_path = "adb" # adb可执行文件的路径
+device = "emulator-5554" # 你的android设备的序列号
+config = "General" # maa connect的配置名称，可选，不建议修改
+```
+设备的序列号可以是地址加端口号，也可以是非地址的任意字符串，可以通过`adb devices`命令获取。
+更多信息参见模拟器支持文档。
+
+##### PlayTools连接
+
+当你使用PlayTools连接时，你需要提供在PlayCover中设置的MacTools的地址:
+```toml
+[connection]
+type = "PlayTools"
+client_address = "localhost:1717" # MacTools的地址
+config = "CompatMac" # maa connect的配置，可选，不建议修改
+```
+使用之前请先阅读[Mac模拟器支持](https://maa.plus/docs/1.4-Mac模拟器支持.html#✅-playcover-原生运行最流畅🚀)。
+
+#### `instance_options`设置
+
+`instance_options`部分用于配置MAA实例的选项：
+```toml
+[instance_options]
+touch_mode = "ADB" # 使用的触摸模式，可选值为"ADB", "MiniTouch", "MaaTouch"  或者 "MacPlayTools"（仅适用于PlayTools连接）
+deployment_with_pause = false # 是否在部署时暂停游戏
+adb_lite_enabled = false # 是否使用adb-lite
+kill_adb_on_exit = false # 是否在退出时杀死adb
+```
+注意，如果你使用`PlayTools`连接，`touch_mode`字段将被忽略并被设置为`MacPlayTools`。
+
+#### `resources`设置
+
+`resources`部分用于指定资源的路径，这是一个资源目录列表（如果是相对路径，路径应该相对于MAA仓库的`resource`目录）：
+```toml
+resources = ["platform_diff/iOS", "global/YoStarEN"]
+```
+这对于指定不同平台的资源和使用外服的用户非常有用。
+
+### 定义任务
+
+任务文件位于`$MAA_CONFIG_DIR/tasks`目录下。
+每一个任务文件都是一个任务列表，每一个子任务是一个MAA任务
+其中包含任务类型和参数，可用的任务及其参数参见[集成文档](https://maa.plus/docs/3.1-集成文档.html#asstappendtask)。
+
+一个简单的任务文件示例：
+```toml
+[[tasks]]
+type = "StartUp"
+params = { client_type = "Official", start_game_enabled = true }
+
+[[tasks]]
+type = "CloseDown"
+```
+建议每个任务中都包含`StartUp`并声明参数`client_type`，这个参数用于指定客户端类型，并会在CLI其他部分使用。
+
+如果你想要根据一些条件运行不同参数的任务，你可以定义多个任务的变体：
+```toml
+[[tasks]]
+type = "Infrast"
+
+[tasks.params]
+mode = 10000
+facility = ["Trade", "Reception", "Mfg", "Control", "Power", "Office", "Dorm"]
+dorm_trust_enabled = true
+filename = "normal.json" # 自定义的基建计划的文件名应该位于`$MAA_CONFIG_DIR/infrast`
+
+# 在12:00:00之前使用计划1，在12:00:00到18:00:00之间使用计划2，在18:00:00之后使用计划0
+[[tasks.variants]]
+condition = { type = "Time", end = "12:00:00" } # 如果没有定义start，那么它将会是00:00:00
+params = { plan_index = 1 }
+
+[[tasks.variants]]
+condition = { type = "Time", start = "12:00:00", end = "18:00:00" }
+params = { plan_index = 2 }
+
+[[tasks.variants]]
+condition = { type = "Time", start = "18:00:00" }
+params = { plan_index = 0 }
+```
+这里的`condition`字段用于确定哪一个变体应该被使用， 而匹配的变体的`params`字段将会被合并到主任务的`params`字段中。
+
+**注意**：这个CLI不会读取基建计划文件中的任何内容，包括基建计划文件中定义的时间段，
+所以你必须在`condition`字段中定义时间段来在不同的时间运行不同的基建计划。
+
+除了`Time`条件，还有`DateTime`，`Weakday`和`Combined`（其他条件的组合）条件：
+```toml
+[[tasks]]
+type = "Fight"
+
+# 周一早上刷5次剿灭
+[[tasks.variants]]
+params = { "stage" = "Annihilation", times = 5 }
+[tasks.variants.condition]
+type = "Combined"
+conditions = [
+  { type = "Weekday", weekdays = ["Mon"] },
+  { type = "Time", end = "12:00:00" },
+]
+
+# 在夏活期间，刷SL-8
+[[tasks.variants]]
+params = { stage = "SL-8" }
+condition = { type = "DateTime", start = "2023-08-01T16:00:00", end = "2023-08-21T03:59:59" }
+
+# 在夏活期间以外的周二、周四和周六，刷CE-6
+[[tasks.variants]]
+condition = { type = "Weekday", weekdays = ["Tue", "Thu", "Sat"] }
+params = { stage = "CE-6" }
+
+# 其他时间，刷1-7
+[[tasks.variants]]
+params = { stage = "1-7" }
+```
+如果有多个变体被匹配，第一个将会被使用。如果没有给出条件，那么变体将会总是被匹配，
+所以你可以把没有条件的变体放在最后作为默认的情况。
+
+如果没有变体被匹配，那么任务将不会被执行，这在你想要只在某些条件下运行任务时很有用：
+```toml
+# 只在在18:00:00之后进行信用商店相关的操作
+[[tasks]]
+type = "Mall"
+[tasks.params]
+shopping = true
+credit_fight = true
+buy_first = ["招聘许可", "龙门币"]
+blacklist = ["碳", "家具", "加急许可"]
+[[tasks.variants]]
+condition = { type = "Time", start = "18:00:00" }
+```
+
+### 运行任务
+
+当你定义了任务后，你可以通过`maa run <task>`命令运行任务。
+你可以通过`maa list`命令列出所有可用的任务。
+更多其他可用命令参见`maa --help`。
+
+#### 日志级别
+
+当运行任务时，CLI会处理MAA的消息。但是不是所有的消息都会输出。
+日志级别用于控制哪些消息会被输出。
+当前CLI有6个日志级别：
+- Error：出现错误，MAA将会停止运行或者无法正常工作；
+- Warning：出现错误，但是MAA仍然可以正常工作；
+- Normal：一些简要的信息，例如任务开始和结束；
+- Info：更详细的信息，例如关卡掉落统计，基建自定义换班干员，肉鸽关卡信息等；
+- Debug：关于你的配置的详细信息，例如将要运行任务的类型和参数；
+- Trace：任何没有被CLI正确解析的MAA消息。
+
+默认的日志级别是`Normal`，你可以通过`-v`和`-q`选项来控制日志级别：
+`-v`将会提高日志级别以显更多消息，`-q`将会减少日志级别以显示更少的消息。
+
+对于一般使用，建议使用`maa run -v <task>`，这样你可以看到MAA的所有有用的消息，但是不会看到太多的调试信息。
+当你在调试时，你可以使用`maa run -vv <task>`选项来看到更多的调试信息。

--- a/docs/1.6-CLI使用指南.md
+++ b/docs/1.6-CLI使用指南.md
@@ -2,16 +2,16 @@
 
 ## 功能介绍
 
-- 通过TOML，JSON，YAML格式的配置文件定义MAA任务流程，并通过`maa run <task>`命令执行任务。
-- 通过`maa list`命令列出所有可用任务。
-- 通过`maa install` 和 `maa update`命令安装和更新MAA共享库和资源。
-- 通过`maa self update`命令更新CLI自身。
+- 通过TOML，JSON，YAML格式的配置文件定义MAA任务流程，并通过 `maa run <task>` 命令执行任务。
+- 通过 `maa list` 命令列出所有可用任务。
+- 通过 `maa install` 和 `maa update` 命令安装和更新MAA共享库和资源。
+- 通过 `maa self update` 命令更新CLI自身。
 
 ## 安装
 
 ### Linux
 
-对于最新版本的MAA，CLI已经打包在MAA压缩包中，如果你下载了最新版MAA，解压后就可以使用CLI，无需额外安装。
+对于最新版本的 MAA，CLI 已经打包在 MAA 压缩包中，如果你下载了最新版 MAA，解压后就可以使用 CLI，无需额外安装。
 **注意**: 请不要将库文件和资源文件随便移动到其他位置，否则CLI将无法找到它们。
 如果你想将它们移动到其他位置，你可以通过以下命令：
 ```bash
@@ -25,15 +25,15 @@ mv resource "$resource_dir"
 如果你当前使用的是旧版本的MAA或者希望单独安装CLI，
 你可以前往[CLI Release页面](https://github.com/MaaAssistantArknights/maa-cli/releases/latest)
 根据你的架构下载对应的预编译的CLI二进制文件，
-（对于x86_64架构，你可以下载以`x86_64-unknown-linux-gnu.tar.gz`结尾的文件，
-对于aarch64架构，你可以下载以`aarch64-unknown-linux-gnu.tar.gz`结尾的文件），
-解压后将`maa`文件移动到你任何在`PATH`环境变量中的目录下, 然后使用`maa install`命令安装MAA共享库和资源。
+（对于x86_64架构，你可以下载以 `x86_64-unknown-linux-gnu.tar.gz` 结尾的文件，
+对于aarch64架构，你可以下载以 `aarch64-unknown-linux-gnu.tar.gz` 结尾的文件），
+解压后将 `maa` 文件移动到你任何在 `PATH` 环境变量中的目录下, 然后使用 `maa install` 命令安装MAA共享库和资源。
 
 ### macOS
 
-macOS用户和Linux用户一样，可以在[CLI Release页面](https://github.com/MaaAssistantArknights/maa-cli/releases/latest)
-下载对应的预编译的CLI二进制文件（macOS提供通用的二进制文件，以`universal-apple-darwin.tar.gz`结尾），
-解压后将`maa`文件移动到你任何在`PATH`环境变量中的目录下，然后使用`maa install`命令安装MAA共享库和资源。
+macOS用户和Linux用户一样，可以在[CLI Release 页面](https://github.com/MaaAssistantArknights/maa-cli/releases/latest)
+下载对应的预编译的CLI二进制文件（macOS提供通用的二进制文件，以 `universal-apple-darwin.zip` 结尾），
+解压后将 `maa` 文件移动到你任何在 `PATH` 环境变量中的目录下，然后使用 `maa install` 命令安装MAA共享库和资源。
 
 ### Windows
 
@@ -43,22 +43,22 @@ CLI目前尚不支持Windows。
 
 ### 配置目录
 
-你的配置文件（选项，任务等）位于配置目录中，你可以通过`maa dir config`获取配置目录,
-并通过`mkdir -p "$(maa dir config)"`创建它。
-在以下的介绍中，配置目录的将被称为`$MAA_CONFIG_DIR`。
-此外尽管所有的例子都是针对TOML格式的，但是以下所有配置文件的格式可以是TOML，JSON或YAML。
+你的配置文件（选项，任务等）位于配置目录中，你可以通过 `maa dir config` 获取配置目录,
+并通过 `mkdir -p "$(maa dir config)"` 创建它。
+在以下的介绍中，配置目录的将被称为 `$MAA_CONFIG_DIR`。
+此外尽管所有的例子都是针对 TOML 格式的，但是以下所有配置文件的格式可以是 TOML，JSON 或 YAML。
 
 ### MAA选项
 
-针对MAA本身的选项，你可以在`$MAA_CONFIG_DIR/asst.toml`中进行配置。
+针对MAA本身的选项，你可以在 `$MAA_CONFIG_DIR/asst.toml` 中进行配置。
 这里的选项包括三个部分：
 - `connection`：MAA连接设置；
 - `instance_options`：MAA实例选项；
 - `resources`: 额外资源地址。
 
-#### `connection`设置
+#### `connection` 设置
 
-`connection`设置用于配置MAA连接游戏，其包括两种方式：通过ADB连接和通过PlayTools连接。
+`connection` 设置用于配置MAA连接游戏，其包括两种方式：通过 ADB 连接和通过 PlayTools 连接。
 
 ##### ADB连接
 
@@ -70,35 +70,35 @@ adb_path = "adb" # adb可执行文件的路径
 device = "emulator-5554" # 你的android设备的序列号
 config = "General" # maa connect的配置名称，可选，不建议修改
 ```
-设备的序列号可以是地址加端口号，也可以是非地址的任意字符串，可以通过`adb devices`命令获取。
+设备的序列号可以是地址加端口号，也可以是非地址的任意字符串，可以通过 `adb devices` 命令获取。
 更多信息参见模拟器支持文档。
 
-##### PlayTools连接
+##### PlayTools 连接
 
-当你使用PlayTools连接时，你需要提供在PlayCover中设置的MacTools的地址:
+当你使用 PlayTools 连接时，你需要提供在 PlayCover 中设置的 MacTools 的地址:
 ```toml
 [connection]
 type = "PlayTools"
 client_address = "localhost:1717" # MacTools的地址
 config = "CompatMac" # maa connect的配置，可选，不建议修改
 ```
-使用之前请先阅读[Mac模拟器支持](https://maa.plus/docs/1.4-Mac模拟器支持.html#✅-playcover-原生运行最流畅🚀)。
+使用之前请先阅读 [Mac模拟器支持](https://maa.plus/docs/1.4-Mac模拟器支持.html#✅-playcover-原生运行最流畅🚀)。
 
-#### `instance_options`设置
+#### `instance_options` 设置
 
-`instance_options`部分用于配置MAA实例的选项：
+`instance_options` 部分用于配置MAA实例的选项：
 ```toml
 [instance_options]
-touch_mode = "ADB" # 使用的触摸模式，可选值为"ADB", "MiniTouch", "MaaTouch"  或者 "MacPlayTools"（仅适用于PlayTools连接）
+touch_mode = "ADB" # 使用的触摸模式，可选值为 "ADB", "MiniTouch", "MaaTouch" 或者 "MacPlayTools"（仅适用于PlayTools连接）
 deployment_with_pause = false # 是否在部署时暂停游戏
 adb_lite_enabled = false # 是否使用adb-lite
 kill_adb_on_exit = false # 是否在退出时杀死adb
 ```
-注意，如果你使用`PlayTools`连接，`touch_mode`字段将被忽略并被设置为`MacPlayTools`。
+注意，如果你使用 PlayTools 连接，`touch_mode`字段将被忽略并被设置为`MacPlayTools`。
 
-#### `resources`设置
+#### `resources` 设置
 
-`resources`部分用于指定资源的路径，这是一个资源目录列表（如果是相对路径，路径应该相对于MAA仓库的`resource`目录）：
+`resources` 部分用于指定资源的路径，这是一个资源目录列表（如果是相对路径，路径应该相对于MAA主仓库的`resource` 目录）：
 ```toml
 resources = ["platform_diff/iOS", "global/YoStarEN"]
 ```
@@ -106,8 +106,8 @@ resources = ["platform_diff/iOS", "global/YoStarEN"]
 
 ### 定义任务
 
-任务文件位于`$MAA_CONFIG_DIR/tasks`目录下。
-每一个任务文件都是一个任务列表，每一个子任务是一个MAA任务
+任务文件位于 `$MAA_CONFIG_DIR/tasks` 目录下。
+每一个任务文件都是一个任务列表，每一个子任务是一个 MAA 任务
 其中包含任务类型和参数，可用的任务及其参数参见[集成文档](https://maa.plus/docs/3.1-集成文档.html#asstappendtask)。
 
 一个简单的任务文件示例：
@@ -119,7 +119,7 @@ params = { client_type = "Official", start_game_enabled = true }
 [[tasks]]
 type = "CloseDown"
 ```
-建议每个任务中都包含`StartUp`并声明参数`client_type`，这个参数用于指定客户端类型，并会在CLI其他部分使用。
+建议每个任务中都包含 `StartUp` 并声明参数 `client_type` ，这个参数用于指定客户端类型，并会在 CLI 其他部分使用。
 
 如果你想要根据一些条件运行不同参数的任务，你可以定义多个任务的变体：
 ```toml
@@ -145,12 +145,12 @@ params = { plan_index = 2 }
 condition = { type = "Time", start = "18:00:00" }
 params = { plan_index = 0 }
 ```
-这里的`condition`字段用于确定哪一个变体应该被使用， 而匹配的变体的`params`字段将会被合并到主任务的`params`字段中。
+这里的 `condition` 字段用于确定哪一个变体应该被使用，而匹配的变体的 `params` 字段将会被合并到主任务的 `params` 字段中。
 
 **注意**：这个CLI不会读取基建计划文件中的任何内容，包括基建计划文件中定义的时间段，
-所以你必须在`condition`字段中定义时间段来在不同的时间运行不同的基建计划。
+所以你必须在 `condition` 字段中定义时间段来在不同的时间运行不同的基建计划。
 
-除了`Time`条件，还有`DateTime`，`Weakday`和`Combined`（其他条件的组合）条件：
+除了 `Time` 条件，还有 `DateTime`，`Weakday`和 `Combined`（其他条件的组合）条件：
 ```toml
 [[tasks]]
 type = "Fight"
@@ -198,15 +198,15 @@ condition = { type = "Time", start = "18:00:00" }
 
 ### 运行任务
 
-当你定义了任务后，你可以通过`maa run <task>`命令运行任务。
-你可以通过`maa list`命令列出所有可用的任务。
-更多其他可用命令参见`maa --help`。
+当你定义了任务后，你可以通过 `maa run <task>` 命令运行任务，
+所有可用的任务可以通过 `maa list` 命令列出。
+更多其他可用命令参见 `maa --help`。
 
 #### 日志级别
 
-当运行任务时，CLI会处理MAA的消息。但是不是所有的消息都会输出。
+当运行任务时，CLI 会处理 MAA 的消息。但是不是所有的消息都会输出。
 日志级别用于控制哪些消息会被输出。
-当前CLI有6个日志级别：
+当前有6个日志级别：
 - Error：出现错误，MAA将会停止运行或者无法正常工作；
 - Warning：出现错误，但是MAA仍然可以正常工作；
 - Normal：一些简要的信息，例如任务开始和结束；
@@ -214,8 +214,11 @@ condition = { type = "Time", start = "18:00:00" }
 - Debug：关于你的配置的详细信息，例如将要运行任务的类型和参数；
 - Trace：任何没有被CLI正确解析的MAA消息。
 
-默认的日志级别是`Normal`，你可以通过`-v`和`-q`选项来控制日志级别：
-`-v`将会提高日志级别以显更多消息，`-q`将会减少日志级别以显示更少的消息。
+默认的日志级别是 `Normal`，你可以通过 `-v` 和 `-q` 选项来控制日志级别：
+`-v`将会提高日志级别以显更多消息，`-q` 将会减少日志级别以显示更少的消息，
+重复使用 `-v` 和 `-q` 将会提高或降低日志级别，直到达到最高或最低级别。
+比如，`-vv` 将会显示 `Debug` 级别及以上的消息，
+而 `-qq` 将会显示 `Warning` 级别及以下的消息。
 
-对于一般使用，建议使用`maa run -v <task>`，这样你可以看到MAA的所有有用的消息，但是不会看到太多的调试信息。
-当你在调试时，你可以使用`maa run -vv <task>`选项来看到更多的调试信息。
+对于一般使用，建议使用 `maa run -v <task>`，这样你可以看到 MAA 的所有有用的消息。
+当你在调试配置时，你可以使用 `maa run -vv <task>` 来看到更多的调试信息。

--- a/docs/1.6-CLI使用指南.md
+++ b/docs/1.6-CLI使用指南.md
@@ -21,11 +21,11 @@ mv lib* "$lib_dir"
 mv resource "$resource_dir"
 ```
 
-如果你当前使用的是旧版本的MAA或者希望单独安装CLI，你可以前往[CLI Release页面](https://github.com/MaaAssistantArknights/maa-cli/releases/latest) 根据你的架构下载对应的预编译的LCI二进制文件（对于x86_64架构，你可以下载以 `x86_64-unknown-linux-gnu.tar.gz` 结尾的文件，对于aarch64架构，你可以下载以 `aarch64-unknown-linux-gnu.tar.gz` 结尾的文件），解压后将 `maa` 文件移动到你任何在 `PATH` 环境变量中的目录下, 然后使用 `maa install` 命令安装MAA共享库和资源。
+如果你当前使用的是旧版本的 MAA 或者希望单独安装 CLI，你可以前往 [CLI Release页面](https://github.com/MaaAssistantArknights/maa-cli/releases/latest) 根据你的架构下载对应的预编译的 CLI 二进制文件（对于 x86_64 架构，你可以下载以 `x86_64-unknown-linux-gnu.tar.gz` 结尾的文件，对于 aarch64 架构，你可以下载以 `aarch64-unknown-linux-gnu.tar.gz` 结尾的文件），解压后将 `maa` 文件移动到你任何在 `PATH` 环境变量中的目录下, 然后使用 `maa install` 命令安装 MAA 共享库和资源。
 
 ### macOS
 
-macOS用户和Linux用户一样，可以在 [CLI Release 页面](https://github.com/MaaAssistantArknights/maa-cli/releases/latest)下载对应的预编译的CLI二进制文件（macOS提供通用的二进制文件，以 `universal-apple-darwin.zip` 结尾），解压后将 `maa` 文件移动到你任何在 `PATH` 环境变量中的目录下，然后使用 `maa install` 命令安装MAA共享库和资源。
+macOS用户和Linux用户一样，可以在 [CLI Release 页面](https://github.com/MaaAssistantArknights/maa-cli/releases/latest)下载对应的预编译的CLI二进制文件（macOS提供通用的二进制文件，以 `universal-apple-darwin.zip` 结尾），解压后将 `maa` 文件移动到你任何在 `PATH` 环境变量中的目录下，然后使用 `maa install` 命令安装 MAA 共享库和资源。
 
 ### Windows
 
@@ -39,7 +39,7 @@ CLI目前尚不支持Windows。
 
 ### MAA选项
 
-针对MAA本身的选项，你可以在 `$MAA_CONFIG_DIR/asst.toml` 中进行配置。 这里的选项包括三个部分：
+针对 MAA 本身的选项，你可以在 `$MAA_CONFIG_DIR/asst.toml` 中进行配置。 这里的选项包括三个部分：
 
 - `connection`：MAA连接设置；
 - `instance_options`：MAA实例选项；
@@ -47,11 +47,11 @@ CLI目前尚不支持Windows。
 
 #### `connection` 设置
 
-`connection` 设置用于配置MAA连接游戏，其包括两种方式：通过 ADB 连接和通过 PlayTools 连接。
+`connection` 设置用于配置 MAA 连接游戏，其包括两种方式：通过 ADB 连接和通过 PlayTools 连接。
 
 ##### ADB连接
 
-当你使用ADB连接时，你需要提供`adb`的路径和设备的序列号:
+当你使用 ADB 连接时，你需要提供 `adb` 的路径和设备的序列号:
 
 ```toml
 [connection]
@@ -78,7 +78,7 @@ config = "CompatMac" # maa connect的配置，可选，不建议修改
 
 #### `instance_options` 设置
 
-`instance_options` 部分用于配置MAA实例的选项：
+`instance_options` 部分用于配置 MAA 实例的选项：
 
 ```toml
 [instance_options]
@@ -92,7 +92,7 @@ kill_adb_on_exit = false # 是否在退出时杀死adb
 
 #### `resources` 设置
 
-`resources` 部分用于指定资源的路径，这是一个资源目录列表（如果是相对路径，路径应该相对于MAA主仓库的`resource` 目录）：
+`resources` 部分用于指定资源的路径，这是一个资源目录列表（如果是相对路径，路径应该相对于 MAA 主仓库的 `resource` 目录）：
 
 ```toml
 resources = ["platform_diff/iOS", "global/YoStarEN"]

--- a/docs/1.6-CLI使用指南.md
+++ b/docs/1.6-CLI使用指南.md
@@ -2,7 +2,7 @@
 
 ## 功能介绍
 
-- 通过TOML，JSON，YAML格式的配置文件定义MAA任务流程，并通过 `maa run <task>` 命令执行任务。
+- 通过 TOML，JSON，YAML 格式的配置文件定义 MAA 任务流程，并通过 `maa run <task>` 命令执行任务。
 - 通过 `maa list` 命令列出所有可用任务。
 - 通过 `maa install` 和 `maa update` 命令安装和更新MAA共享库和资源。
 - 通过 `maa self update` 命令更新CLI自身。
@@ -14,6 +14,7 @@
 对于最新版本的 MAA，CLI 已经打包在 MAA 压缩包中，如果你下载了最新版 MAA，解压后就可以使用 CLI，无需额外安装。
 **注意**: 请不要将库文件和资源文件随便移动到其他位置，否则CLI将无法找到它们。
 如果你想将它们移动到其他位置，你可以通过以下命令：
+
 ```bash
 # 请确保你当前的工作目录是解压后的MAA目录
 lib_dir="$(./maa dir lib)"
@@ -22,18 +23,12 @@ mv lib* "$lib_dir"
 mv resource "$resource_dir"
 ```
 
-如果你当前使用的是旧版本的MAA或者希望单独安装CLI，
-你可以前往[CLI Release页面](https://github.com/MaaAssistantArknights/maa-cli/releases/latest)
-根据你的架构下载对应的预编译的CLI二进制文件，
-（对于x86_64架构，你可以下载以 `x86_64-unknown-linux-gnu.tar.gz` 结尾的文件，
-对于aarch64架构，你可以下载以 `aarch64-unknown-linux-gnu.tar.gz` 结尾的文件），
-解压后将 `maa` 文件移动到你任何在 `PATH` 环境变量中的目录下, 然后使用 `maa install` 命令安装MAA共享库和资源。
+如果你当前使用的是旧版本的MAA或者希望单独安装CLI，你可以前往[CLI Release页面](https://github.com/MaaAssistantArknights/maa-cli/releases/latest)
+根据你的架构下载对应的预编译的LCI二进制文件（对于x86_64架构，你可以下载以 `x86_64-unknown-linux-gnu.tar.gz` 结尾的文件，对于aarch64架构，你可以下载以 `aarch64-unknown-linux-gnu.tar.gz` 结尾的文件），解压后将 `maa` 文件移动到你任何在 `PATH` 环境变量中的目录下, 然后使用 `maa install` 命令安装MAA共享库和资源。
 
 ### macOS
 
-macOS用户和Linux用户一样，可以在[CLI Release 页面](https://github.com/MaaAssistantArknights/maa-cli/releases/latest)
-下载对应的预编译的CLI二进制文件（macOS提供通用的二进制文件，以 `universal-apple-darwin.zip` 结尾），
-解压后将 `maa` 文件移动到你任何在 `PATH` 环境变量中的目录下，然后使用 `maa install` 命令安装MAA共享库和资源。
+macOS用户和Linux用户一样，可以在 [CLI Release 页面](https://github.com/MaaAssistantArknights/maa-cli/releases/latest)下载对应的预编译的CLI二进制文件（macOS提供通用的二进制文件，以 `universal-apple-darwin.zip` 结尾），解压后将 `maa` 文件移动到你任何在 `PATH` 环境变量中的目录下，然后使用 `maa install` 命令安装MAA共享库和资源。
 
 ### Windows
 
@@ -43,8 +38,7 @@ CLI目前尚不支持Windows。
 
 ### 配置目录
 
-你的配置文件（选项，任务等）位于配置目录中，你可以通过 `maa dir config` 获取配置目录,
-并通过 `mkdir -p "$(maa dir config)"` 创建它。
+你的配置文件（选项，任务等）位于配置目录中，你可以通过 `maa dir config` 获取配置目录，并通过 `mkdir -p "$(maa dir config)"` 创建它。
 在以下的介绍中，配置目录的将被称为 `$MAA_CONFIG_DIR`。
 此外尽管所有的例子都是针对 TOML 格式的，但是以下所有配置文件的格式可以是 TOML，JSON 或 YAML。
 
@@ -52,6 +46,7 @@ CLI目前尚不支持Windows。
 
 针对MAA本身的选项，你可以在 `$MAA_CONFIG_DIR/asst.toml` 中进行配置。
 这里的选项包括三个部分：
+
 - `connection`：MAA连接设置；
 - `instance_options`：MAA实例选项；
 - `resources`: 额外资源地址。
@@ -63,6 +58,7 @@ CLI目前尚不支持Windows。
 ##### ADB连接
 
 当你使用ADB连接时，你需要提供`adb`的路径和设备的序列号:
+
 ```toml
 [connection]
 type = "ADB"
@@ -70,23 +66,27 @@ adb_path = "adb" # adb可执行文件的路径
 device = "emulator-5554" # 你的android设备的序列号
 config = "General" # maa connect的配置名称，可选，不建议修改
 ```
+
 设备的序列号可以是地址加端口号，也可以是非地址的任意字符串，可以通过 `adb devices` 命令获取。
 更多信息参见模拟器支持文档。
 
 ##### PlayTools 连接
 
 当你使用 PlayTools 连接时，你需要提供在 PlayCover 中设置的 MacTools 的地址:
+
 ```toml
 [connection]
 type = "PlayTools"
 client_address = "localhost:1717" # MacTools的地址
 config = "CompatMac" # maa connect的配置，可选，不建议修改
 ```
+
 使用之前请先阅读 [Mac模拟器支持](https://maa.plus/docs/1.4-Mac模拟器支持.html#✅-playcover-原生运行最流畅🚀)。
 
 #### `instance_options` 设置
 
 `instance_options` 部分用于配置MAA实例的选项：
+
 ```toml
 [instance_options]
 touch_mode = "ADB" # 使用的触摸模式，可选值为 "ADB", "MiniTouch", "MaaTouch" 或者 "MacPlayTools"（仅适用于PlayTools连接）
@@ -94,23 +94,26 @@ deployment_with_pause = false # 是否在部署时暂停游戏
 adb_lite_enabled = false # 是否使用adb-lite
 kill_adb_on_exit = false # 是否在退出时杀死adb
 ```
+
 注意，如果你使用 PlayTools 连接，`touch_mode`字段将被忽略并被设置为`MacPlayTools`。
 
 #### `resources` 设置
 
 `resources` 部分用于指定资源的路径，这是一个资源目录列表（如果是相对路径，路径应该相对于MAA主仓库的`resource` 目录）：
+
 ```toml
 resources = ["platform_diff/iOS", "global/YoStarEN"]
 ```
+
 这对于指定不同平台的资源和使用外服的用户非常有用。
 
 ### 定义任务
 
 任务文件位于 `$MAA_CONFIG_DIR/tasks` 目录下。
-每一个任务文件都是一个任务列表，每一个子任务是一个 MAA 任务
-其中包含任务类型和参数，可用的任务及其参数参见[集成文档](https://maa.plus/docs/3.1-集成文档.html#asstappendtask)。
+每一个任务文件都是一个任务列表，每一个子任务是一个 MAA 任务，其中包含任务类型和参数，可用的任务及其参数参见[集成文档](https://maa.plus/docs/3.1-集成文档.html#asstappendtask)。
 
 一个简单的任务文件示例：
+
 ```toml
 [[tasks]]
 type = "StartUp"
@@ -119,9 +122,11 @@ params = { client_type = "Official", start_game_enabled = true }
 [[tasks]]
 type = "CloseDown"
 ```
+
 建议每个任务中都包含 `StartUp` 并声明参数 `client_type` ，这个参数用于指定客户端类型，并会在 CLI 其他部分使用。
 
 如果你想要根据一些条件运行不同参数的任务，你可以定义多个任务的变体：
+
 ```toml
 [[tasks]]
 type = "Infrast"
@@ -145,12 +150,13 @@ params = { plan_index = 2 }
 condition = { type = "Time", start = "18:00:00" }
 params = { plan_index = 0 }
 ```
+
 这里的 `condition` 字段用于确定哪一个变体应该被使用，而匹配的变体的 `params` 字段将会被合并到主任务的 `params` 字段中。
 
-**注意**：这个CLI不会读取基建计划文件中的任何内容，包括基建计划文件中定义的时间段，
-所以你必须在 `condition` 字段中定义时间段来在不同的时间运行不同的基建计划。
+**注意**：这个CLI不会读取基建计划文件中的任何内容，包括基建计划文件中定义的时间段，所以你必须在 `condition` 字段中定义时间段来在不同的时间运行不同的基建计划。
 
 除了 `Time` 条件，还有 `DateTime`，`Weakday`和 `Combined`（其他条件的组合）条件：
+
 ```toml
 [[tasks]]
 type = "Fight"
@@ -179,10 +185,11 @@ params = { stage = "CE-6" }
 [[tasks.variants]]
 params = { stage = "1-7" }
 ```
-如果有多个变体被匹配，第一个将会被使用。如果没有给出条件，那么变体将会总是被匹配，
-所以你可以把没有条件的变体放在最后作为默认的情况。
 
-如果没有变体被匹配，那么任务将不会被执行，这在你想要只在某些条件下运行任务时很有用：
+如果有多个变体被匹配，第一个将会被使用。如果没有给出条件，那么变体将会总是被匹配，所以你可以把没有条件的变体放在最后作为默认的情况。
+
+如果没有变体被匹配，那么任务将不会被执行，这在你想要任务只在某些条件下运行任务时很有用：
+
 ```toml
 # 只在在18:00:00之后进行信用商店相关的操作
 [[tasks]]
@@ -198,8 +205,7 @@ condition = { type = "Time", start = "18:00:00" }
 
 ### 运行任务
 
-当你定义了任务后，你可以通过 `maa run <task>` 命令运行任务，
-所有可用的任务可以通过 `maa list` 命令列出。
+当你定义了任务后，你可以通过 `maa run <task>` 命令运行任务，所有可用的任务可以通过 `maa list` 命令列出。
 更多其他可用命令参见 `maa --help`。
 
 #### 日志级别
@@ -207,6 +213,7 @@ condition = { type = "Time", start = "18:00:00" }
 当运行任务时，CLI 会处理 MAA 的消息。但是不是所有的消息都会输出。
 日志级别用于控制哪些消息会被输出。
 当前有6个日志级别：
+
 - Error：出现错误，MAA将会停止运行或者无法正常工作；
 - Warning：出现错误，但是MAA仍然可以正常工作；
 - Normal：一些简要的信息，例如任务开始和结束；
@@ -215,10 +222,8 @@ condition = { type = "Time", start = "18:00:00" }
 - Trace：任何没有被CLI正确解析的MAA消息。
 
 默认的日志级别是 `Normal`，你可以通过 `-v` 和 `-q` 选项来控制日志级别：
-`-v`将会提高日志级别以显更多消息，`-q` 将会减少日志级别以显示更少的消息，
-重复使用 `-v` 和 `-q` 将会提高或降低日志级别，直到达到最高或最低级别。
-比如，`-vv` 将会显示 `Debug` 级别及以上的消息，
-而 `-qq` 将会显示 `Warning` 级别及以下的消息。
+`-v`将会提高日志级别以显更多消息，`-q` 将会减少日志级别以显示更少的消息，重复使用 `-v` 和 `-q` 将会提高或降低日志级别，直到达到最高或最低级别。
+比如，`-vv` 将会显示 `Debug` 级别及以上的消息，而 `-qq` 将会显示 `Warning` 级别及以下的消息。
 
 对于一般使用，建议使用 `maa run -v <task>`，这样你可以看到 MAA 的所有有用的消息。
 当你在调试配置时，你可以使用 `maa run -vv <task>` 来看到更多的调试信息。


### PR DESCRIPTION
增加了CLI的文档，并且在Linux的发行版里面打包了一个预编译的CLI。因为现在CLI可以完全独立于Core编译了，所以我就没有把那个库当成子模块加进来。