### PR TITLE
feat: 给MAA添加对于WSA的原生支持

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,27 +1,160 @@
-## v4.23.0-beta.2
+## v4.23.0
 
 ### 新增
 
 - 支持带参数启动切换配置 @ABA2396
+- 新增新保全关卡内置作业 @AnnoyingFlowers @junyihan233
+- 增加烧开水功能，优化萨米肉鸽策略 (#6053) @Lancarus
+- 抄作业新增 "skill_times" 字段 (#6007) @AnnoyingFlowers
+- 肉鸽开局干员支持点选 is_start 中的干员 @ABA2396
+- 增加关卡数据获取成功提示 @ABA2396
+- add config `CompatPOSIXShell` (#5945) @wangl-cc
+- 关卡导航 - SideStory「理想城：长夏狂欢季」复刻 @ABA2396
+- 繁中服風雪過境復刻導航 (#6130) @momomochi987
 
 ### 改进
 
+- 修复 PlayCover 下识别差异问题 @MistEO @hguandl
+- 修复肉鸽中干员 山 2 技能反复释放的问题 (#6033) @AnnoyingFlowers
+- 尝试修复日志被占用的问题 @MistEO
+- 修复干员识别错误 (#6022) @Black1312
+- 尝试修复mac上阈值差异 @MistEO
+- 修复自动编队部分干员文字识别错误 (#6020) @cenfusheng
+- 重写自动战斗编队干员检测 @MistEO
+- all operators are marked as new for overseas clients (Toolbox-Recruitment) (#6009) @178619
+- 修复SSS技能用法判断错误的问题 @MistEO
+- 修复编队时“全部”识别错误 @MistEO
+- 仓库识别界面未在最左侧时，识别不全的问题 (#6000) @H1MSK
+- Prevents possible forced retreat (Amiya S3) @178619
+- 修复一些文字识别问题（txwy） (#5993) @cenfusheng
+- 紧急修复 dlx 算法工具类的越界问题 @lhhxxxxx
+- Mizuki IS DropBox recog. and Shopping regex @Constrat
+- SL event navigation @Constrat
+- 定时执行逻辑错误 @ABA2396
+- "Gummy" with skin undetected with new ROI @Constrat
+- increased ROI in fight task @Constrat
+- changed award ROI and template  EN @Constrat
+- 修复关卡“干酪封锁”与装置““甜蜜狂搅””的识别 (#5975) @cenfusheng
+- link in mac-runtime release (#5954) @wangl-cc
+- 肉鸽在招募逻辑内可以将同一干员纳入多个群组,修复由于拆分文件造成的bug (#5946) @Lancarus
+- 新版萨米肉鸽商店文件&水月肉鸽商店文件提交 (#5936) @Yumi0606
+- 错误的类型转换 @ABA2396
+- 修复模拟器关闭逻辑错误，增加模拟器退出错误日志 @ABA2396
+- `CloseDown` not works on macOS (#5920) @wangl-cc
+- 关闭模拟器时索引超出了数组界限 @ABA2396
+- 添加繁中服对于鸿雪的OCR等价规则 #5931 #5933 @Constrat
+- 肉鸽打折商品识别错误 @ABA2396
+- 修复特别关注干员的识别问题 (#5924) @cenfusheng
+- wrong template for reception room detection @Constrat
+- 修复添加了具有相同键的项 @MistEO
+- 添加刷理智任务报错提示 @ABA2396
+- [Roguelike] 优化刷源石锭模式的逻辑 (#5987) @lassnuttun
+- 优化萨米肉鸽策略 (#5990) @Lancarus
+- 优化了萨米肉鸽第三层的部分关卡打法,更新了肉鸽文档 (#5986) @Lancarus @ABA2396
+- 优化萨米肉鸽招募逻辑，优化前两层作战逻辑 (#5966) @Lancarus
+- optimized ROI for EPISODE navigation @Constrat
+- 更新简中OCR识别模型 | Re-training OCR rec model of CN client (#5895) @Plumess
+- 更新游戏资源 @yuanyan3060 @MistEO
+- 拆分所有肉鸽资源文件 (#5856) @MistEO @Lancarus
+- 优化萨米肉鸽不期而遇 (#5890) @cenfusheng
+- 傀影肉鸽适配更多干员 (#5817) @cenfusheng
+- 适配萨米肉鸽关卡“豪华车队” (#5798) @cenfusheng
+- 肉鸽开局助战or自选干员后不再要求选用start属性干员 (#5824) @LingXii
+- 增加强制替换adb的信息提示，增加异常处理 (#5838) @ABA2396
 - 优化烧开水逻辑，现在能在低难度烧水，高难度开始 (#6094) @Lancarus
-- 更新保全阿尔斯特甜品制造平台，不兼容应急 (#6088) @AnnoyingFlowers
-   - 更新保全阿尔斯特甜品制造平台，不兼容应急 @AnnoyingFlowers
 - 更新3.4任务流程协议文档 @ABA2396
 
 ### 修复
 
-- try to fix #6006 @MistEO
+- 强制替换adb报错 @ABA2396
+- 修复纯烬艾雅法拉识别 (#5791) @Black1312
+- 修复了傀影肉鸽的一些错误 (#5859) @Lancarus
+- 修正 zh-cn.xaml 文本错误 (#5861) @javilak
 - 尝试修复TN-4地图view错误 (#6097) @status102
 - txwy stage navigation, similar to 4c2c644 @Constrat
 
 ### 其他
 
+- 更新文档内容 (#5901) (#5885) @SherkeyXD @AnnAngela
+- Events and Banners displayed according to timetable (#6050) @Constrat
+- 添加用户词典，减少拼写错误提示 @ABA2396
+- merge and re-structure stage.json (#5944) @MistEO
+- golang 接口从io/ioutil包更新为os包 (#5988) @javilak
+- 重构 TaskQueueViewModel (#5753) @ABA2396
+- 重构 CopilotViewModel.cs (#6003) @ABA2396
+- 重构 RecognizerViewModel.cs @ABA2396
+- 重构 CopilotViewModel.cs @ABA2396
+- tweaked english tasks json schema @Constrat
+- 3.1-Integration.md (#6039) @NtskwK
+- Update 3.1-集成文档.md (#6036) @hzxjy1
+- 修正偶尔OCR错误造成的吃48小时理智药失效问题 (#6004) @bigqiao
+- gui.log 启动时记录目录 @ABA2396
+- ML translation @Constrat
+- tools: global content update @Constrat
+- ormatting + output log cleanup / clearup @Constrat
+- Feat: Auto Update now orders Global tasks.json like Official @Constrat
+- localization update @178619
+- 调整肉鸽商品识别roi范围 @ABA2396
+- Useless png in roguelike JP @Constrat
+- tools: added impossible to translate task @Constrat
+- 为文档添加docsearch和sitemap支持 (#5785) @SherkeyXD
+- CI-在静态分析中增加基线 (#5757)(#5867) @hxdnshx
+- 修改了部分肉鸽文档 (#5873) @Lancarus
+- typo of 1.3-模拟器支持.md (#5802) @BlueandwhiteXD
+- fix rpath for macos @horror-proton
 - add log for #6006 @MistEO
 - roguelike: 适配刷源石锭模式不期而遇选择策略 (#6102) @Yumi0606
 - 启动时检测是否为管理员启动 @ABA2396
 - 添加报错信息 #6089 @ABA2396
 - 修改格式为适配更多启动参数 @ABA2396
 - 合并关闭+重启方法 @ABA2396
+
+### For overseas
+
+#### txwy
+
+- 更新繁中服肉鴿不期而遇 ocrReplace (#5882) @momomochi987
+- 修正繁中服水月肉鴿會卡在 "緊急運輸" 的問題 (#5790) @momomochi987
+- 繁中服 快捷編隊 部署費用 (#6131) @vonnoq
+- 適配繁中服保全派駐 (#5926) @momomochi987
+- remake StageSK & StagePR-C picture for txwy (#5999) (#6018) @momomochi987
+- 添加繁中服对于鸿雪的OCR等价规则 #5931 (#5933) @Roland125 @Constrat @MistEO
+
+#### YostarEN
+
+- d0dc294 auto update version issue @Constrat
+- more long names regex for OperBox @Constrat
+- ROI for BattleStartOCR, new IMG+ROI for Oper @Constrat
+- OperBox regex, BattleMatcher regex, longname and IS @Constrat
+- modified text for EX stages (WB event) @Constrat
+- SSS Identification issue with NON-1080 emulators @Constrat
+- DepotAllTab for EN from 1126db9 @Constrat
+- Adapted EN regex for new AutoSquad algorithm (#6028) @Constrat
+- tweaked SSS copilot descriptions for EN @Constrat
+- PRTS3 and LevelOFDifficulty i18n EN @Constrat
+- Senior Operator tag EN @Constrat
+- Infrast Task stuck Max Trust notification EN @Constrat
+- Reception sends clue when full in YostarEN @Constrat
+- battlequickformationocr modified roi for EN @Constrat
+- optimized: regex for I.S. trader shopping in EN @Constrat
+- Invitation to Wine rerun implementation for EN @Constrat
+- Oper Regex Tweaked for EN (BattleMatcher) @Constrat
+- Adapted EndOfActionAnnihilation for EN @Constrat
+- Paradox Simulation for YostarEN + BattleMatcher regex @Constrat
+
+#### YostarKR
+
+- add templates for YoStarKR @178619
+- SSS copilot support for YostarKR @178619
+- make the option to not recruit selectable in SSS for YoStarKR @178619
+- Goldenglow(澄闪) & Surtr(史尔特尔) ocrReplace (#5852) @Large-Japchae
+- nbsp character from OCR (YoStarKR) @178619
+- ocr replace for YostarJP (#6093) @jie17
+
+#### YostarJP
+
+- Invitation to Wine rerun implemen. for JP @Constrat
+- add roguelike encounter ocrReplace for JP and EN (#5903) @momomochi987
+- [JP] Docs Update (#6070) @wallsman
+- add ocr replace for YostarJP (#5977) @jie17
+- Removed useless .png from JP I.S. @Constrat

--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -8581,6 +8581,7 @@
         "next": [
             "Roguelike@FormationConfirm"
         ],
+        "preDelay": 500,
         "postDelay": 2000
     },
     "Roguelike@RecruitCloseGuide": {

--- a/src/MaaCore/Assistant.cpp
+++ b/src/MaaCore/Assistant.cpp
@@ -105,6 +105,10 @@ bool asst::Assistant::set_instance_option(InstanceOptionKey key, const std::stri
             m_ctrler->set_touch_mode(TouchMode::MacPlayTools);
             return true;
         }
+        else if (constexpr std::string_view WSA = "wsa"; value == WSA) {
+            m_ctrler->set_touch_mode(TouchMode::WSA);
+            return true;
+        }
         break;
     case InstanceOptionKey::DeploymentWithPause:
         if (constexpr std::string_view Enable = "1"; value == Enable) {
@@ -133,6 +137,26 @@ bool asst::Assistant::set_instance_option(InstanceOptionKey key, const std::stri
         }
         else if (constexpr std::string_view Disable = "0"; value == Disable) {
             m_ctrler->set_kill_adb_on_exit(false);
+            return true;
+        }
+        break;
+    case InstanceOptionKey::GoldenBorder:
+        if (constexpr std::string_view Enable = "1"; value == Enable) {
+            m_ctrler->set_golden_border(true);
+            return true;
+        }
+        else if (constexpr std::string_view Disable = "0"; value == Disable) {
+            m_ctrler->set_golden_border(false);
+            return true;
+        }
+        break;
+    case InstanceOptionKey::ResizeWindow:
+        if (constexpr std::string_view Enable = "1"; value == Enable) {
+            m_ctrler->set_resize_window(true);
+            return true;
+        }
+        else if (constexpr std::string_view Disable = "0"; value == Disable) {
+            m_ctrler->set_resize_window(false);
             return true;
         }
         break;

--- a/src/MaaCore/Common/AsstTypes.h
+++ b/src/MaaCore/Common/AsstTypes.h
@@ -37,6 +37,8 @@ namespace asst
         DeploymentWithPause = 3, // 自动战斗、肉鸽、保全 是否使用 暂停下干员， "0" | "1"
         AdbLiteEnabled = 4,      // 是否使用 AdbLite， "0" | "1"
         KillAdbOnExit = 5,       // 退出时是否杀掉 Adb 进程， "0" | "1"
+        GoldenBorder = 6,        // 是否给明日方舟添加金边框
+        ResizeWindow = 7,        // 是否直接把明日方舟缩放为1280x720
     };
 
     enum class TouchMode
@@ -45,6 +47,7 @@ namespace asst
         Minitouch = 1,
         Maatouch = 2,
         MacPlayTools = 3,
+        WSA = 4,
     };
 
     namespace ControlFeat

--- a/src/MaaCore/Controller/Controller.cpp
+++ b/src/MaaCore/Controller/Controller.cpp
@@ -68,6 +68,8 @@ void asst::Controller::sync_params()
     CHECK_EXIST(m_controller, );
     m_controller->set_swipe_with_pause(m_swipe_with_pause);
     m_controller->set_kill_adb_on_exit(m_kill_adb_on_exit);
+    m_controller->set_resize_window(m_resize_window);
+    m_controller->set_golden_border(m_golden_border);
 }
 
 cv::Mat asst::Controller::get_resized_image_cache() const
@@ -149,7 +151,7 @@ bool asst::Controller::connect(const std::string& adb_path, const std::string& a
     clear_info();
 
     m_controller =
-        m_controller_factory->create_controller(m_controller_type, adb_path, address, config, m_platform_type);
+        m_controller_factory->create_controller(m_controller_type, m_platform_type);
 
     if (!m_controller) {
         Log.error("connect failed");
@@ -157,6 +159,11 @@ bool asst::Controller::connect(const std::string& adb_path, const std::string& a
     }
 
     sync_params();
+
+    if (!m_controller->connect(adb_path, address, config)) {
+        m_controller.reset();
+        return false;
+    }
 
     m_uuid = m_controller->get_uuid();
 
@@ -224,6 +231,9 @@ void asst::Controller::set_touch_mode(const TouchMode& mode) noexcept
     case TouchMode::MacPlayTools:
         m_controller_type = ControllerType::MacPlayTools;
         break;
+    case TouchMode::WSA:
+        m_controller_type = ControllerType::WSA;
+        break;
     default:
         m_controller_type = ControllerType::Minitouch;
     }
@@ -243,6 +253,18 @@ void asst::Controller::set_adb_lite_enabled(bool enable) noexcept
 void asst::Controller::set_kill_adb_on_exit(bool enable) noexcept
 {
     m_kill_adb_on_exit = enable;
+    sync_params();
+}
+
+void asst::Controller::set_golden_border(bool enable) noexcept
+{
+    m_golden_border = enable;
+    sync_params();
+}
+
+void asst::Controller::set_resize_window(bool enable) noexcept
+{
+    m_resize_window = enable;
     sync_params();
 }
 

--- a/src/MaaCore/Controller/Controller.h
+++ b/src/MaaCore/Controller/Controller.h
@@ -44,6 +44,8 @@ namespace asst
         void set_swipe_with_pause(bool enable) noexcept;
         void set_adb_lite_enabled(bool enable) noexcept;
         void set_kill_adb_on_exit(bool enable) noexcept;
+        void set_golden_border(bool enable) noexcept;
+        void set_resize_window(bool enable) noexcept;
 
         const std::string& get_uuid() const;
         cv::Mat get_image(bool raw = false);

--- a/src/MaaCore/Controller/Controller.h
+++ b/src/MaaCore/Controller/Controller.h
@@ -98,6 +98,8 @@ namespace asst
 
         bool m_swipe_with_pause = false;
         bool m_kill_adb_on_exit = false;
+        bool m_resize_window = false;
+        bool m_golden_border = false;
 
         mutable std::shared_mutex m_image_mutex;
         cv::Mat m_cache_image;

--- a/src/MaaCore/Controller/ControllerAPI.h
+++ b/src/MaaCore/Controller/ControllerAPI.h
@@ -15,6 +15,7 @@ namespace asst
         Minitouch,
         Maatouch,
         MacPlayTools,
+        WSA,
     };
 
     class ControllerAPI
@@ -26,6 +27,8 @@ namespace asst
         virtual bool inited() const noexcept = 0;
         virtual void set_swipe_with_pause([[maybe_unused]] bool enable) noexcept {}
         virtual void set_kill_adb_on_exit([[maybe_unused]] bool enable) noexcept {}
+        virtual void set_resize_window([[maybe_unused]] bool enable) noexcept {};
+        virtual void set_golden_border([[maybe_unused]] bool enable) noexcept {};
 
         virtual const std::string& get_uuid() const = 0;
 

--- a/src/MaaCore/Controller/ControllerFactory.h
+++ b/src/MaaCore/Controller/ControllerFactory.h
@@ -5,6 +5,7 @@
 #include "MaatouchController.h"
 #include "MinitouchController.h"
 #include "PlayToolsController.h"
+#include "WSAController.h"
 
 namespace asst
 {
@@ -33,6 +34,8 @@ namespace asst
                 case ControllerType::MacPlayTools:
                     controller = std::make_shared<PlayToolsController>(m_callback, m_inst, platform_type);
                     break;
+                case ControllerType::WSA:
+                    controller = std::make_shared<WSAController>(m_callback, m_inst, platform_type);
                 default:
                     return nullptr;
                 }

--- a/src/MaaCore/Controller/ControllerFactory.h
+++ b/src/MaaCore/Controller/ControllerFactory.h
@@ -15,9 +15,7 @@ namespace asst
         ControllerFactory(const AsstCallback& callback, Assistant* inst) : m_callback(callback), m_inst(inst) {}
         ~ControllerFactory() = default;
 
-        std::shared_ptr<ControllerAPI> create_controller(ControllerType type, const std::string& adb_path,
-                                                         const std::string& address, const std::string& config,
-                                                         PlatformType platform_type)
+        std::shared_ptr<ControllerAPI> create_controller(ControllerType type, PlatformType platform_type)
         {
             std::shared_ptr<ControllerAPI> controller;
             try {
@@ -36,6 +34,7 @@ namespace asst
                     break;
                 case ControllerType::WSA:
                     controller = std::make_shared<WSAController>(m_callback, m_inst, platform_type);
+                    break;
                 default:
                     return nullptr;
                 }
@@ -44,10 +43,7 @@ namespace asst
                 Log.error("Cannot create controller: {}", e.what());
                 return nullptr;
             }
-            if (controller->connect(adb_path, address, config)) {
-                return controller;
-            }
-            return nullptr;
+            return controller;
         }
 
     private:

--- a/src/MaaCore/Controller/WSAController.cpp
+++ b/src/MaaCore/Controller/WSAController.cpp
@@ -1,0 +1,582 @@
+
+#include "WSAController.h"
+
+#if defined(_WIN32)
+
+asst::WSAController::WSAController(const AsstCallback& callback, Assistant* inst, PlatformType type)
+    : InstHelper(inst), m_callback(callback), m_wgc(m_last_error), m_uuid("什么是UUID？")
+{
+    LogTraceFunction;
+
+    if (!winrt::Windows::Graphics::Capture::GraphicsCaptureSession::IsSupported()) {
+        json::value create_device_error = json::object {
+            { "uuid", m_uuid },
+            { "what", "NotSupported" },
+            { "why", "Require higher windows version" },
+            { "details",
+              json::object {
+                  { "Minium version supported: win10 1903", m_last_error },
+              } },
+        };
+        this->callback(AsstMsg::InternalError, create_device_error);
+    }
+
+    if (m_last_error != 0) {
+        json::value create_device_error = json::object {
+            { "uuid", m_uuid },
+            { "what", "DeviceFailed" },
+            { "why", "Cannot create D3D11 device." },
+            { "details",
+              json::object {
+                  { "GetLastError() = ", m_last_error },
+              } },
+        };
+        this->callback(AsstMsg::InternalError, create_device_error);
+    }
+
+    m_platform_io = PlatformFactory::create_platform(inst, type);
+
+    if (!m_platform_io) {
+        Log.error("platform not supported");
+        throw std::runtime_error("platform not supported");
+    }
+
+    m_inited = true;
+}
+
+asst::WSAController::~WSAController()
+{
+    LogTraceFunction;
+
+    m_inited = false;
+}
+
+bool asst::WSAController::connect([[maybe_unused]] const std::string& adb_path,
+                                  [[maybe_unused]] const std::string& address,
+                                  [[maybe_unused]] const std::string& config)
+{
+    LogTraceFunction;
+
+    bool result = m_wgc.prepare(m_resize_window, m_golden_border);
+
+    if (!result) {
+        json::value error = json::object { { "uuid", m_uuid },
+                                           { "what", "ConnectionFailed" },
+                                           { "detail", "cannot prepare for connection" } };
+        callback(AsstMsg::ConnectionInfo, error);
+        return false;
+    }
+
+    if (need_exit()) {
+        return false;
+    }
+
+    if (!m_wgc.start_capture()) {
+
+        json::value error = json::object { { "uuid", m_uuid },
+                                           { "what", "ConnectionFailed" },
+                                           { "detail", "capture failed" } };
+        callback(AsstMsg::ConnectionInfo, error);
+        return false;
+    }
+
+    m_touch.init(m_wgc.pub_wndwsa, m_wgc.pub_caption_height);
+
+    return true;
+}
+
+ void asst::WSAController::set_resize_window(bool enable) noexcept {
+     m_resize_window = enable;
+ }
+ 
+ void asst::WSAController::set_golden_border(bool enable) noexcept {
+     m_golden_border = enable;
+ }
+
+asst::WSAController::FrameBuffer::FrameBuffer(OUT DWORD& last_error)
+    : m_frame_pool(nullptr), m_session(nullptr), m_item(nullptr)
+{
+    LogTraceFunction;
+
+    HRESULT result = S_OK;
+    last_error = 0;
+
+    result = D3D11CreateDevice(nullptr, D3D_DRIVER_TYPE_HARDWARE, NULL, D3D11_CREATE_DEVICE_VIDEO_SUPPORT, nullptr, 0,
+                               D3D11_SDK_VERSION, m_native_device.put(), nullptr, m_context.put());
+    if (FAILED(result)) {
+        last_error = GetLastError();
+        return;
+    }
+}
+
+asst::WSAController::FrameBuffer::~FrameBuffer() {
+    LogTraceFunction;
+
+    end_capture();
+    m_frame_pool = nullptr;
+    m_item = nullptr;
+    m_device = nullptr;
+    m_staging_texture->Release();
+    m_context->Release();
+    m_native_device->Release();
+}
+
+bool asst::WSAController::FrameBuffer::prepare(bool resize_window, bool golden_border)
+{
+    LogTraceFunction;
+
+    m_golden_border = golden_border;
+
+    auto fill_error = [](std::string fn_name) {
+        Log.error(std::format("prepare() FAILED  function name [{}], GetLastError() = {}", fn_name, GetLastError()));
+    };
+
+    pub_wndwsa = FindWindow(arknights_classname.c_str(), nullptr);
+    if (pub_wndwsa == NULL) {
+        fill_error("FindWindow");
+        return false;
+    }
+
+    if (IsIconic(pub_wndwsa)) {
+        Log.trace("WSA window is iconic. Try to show WSA window.");
+        if (!ShowWindow(pub_wndwsa, SW_SHOW)) return false;
+    }
+    
+    SetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+    auto wndStyle = GetWindowLong(pub_wndwsa, GWL_STYLE);
+    auto wndExStyle = GetWindowLong(pub_wndwsa, GWL_EXSTYLE);
+    auto dpi = GetDpiForWindow(pub_wndwsa);
+
+    RECT wantedSize = { .left = 0, .top = 0, .right = WindowWidthDefault, .bottom = WindowHeightDefault };
+    RECT wantedWindow = wantedSize, wantedClient = wantedSize;
+    if (resize_window) {
+        AdjustWindowRectExForDpi(&wantedWindow, wndStyle, false, wndExStyle, dpi);
+        wantedWindow.right -= wantedWindow.left;
+        wantedWindow.bottom -= wantedWindow.top;
+        wantedWindow.top = wantedWindow.left = 0;
+        SetWindowPos(pub_wndwsa, NULL, 0, 0, wantedWindow.right, wantedWindow.bottom, SWP_NOMOVE);
+
+        GetClientRect(pub_wndwsa, &wantedClient);
+        pub_caption_height = wantedClient.bottom - wantedClient.top - WindowHeightDefault;
+    }
+    else {
+        GetClientRect(pub_wndwsa, &wantedClient);
+        GetWindowRect(pub_wndwsa, &wantedWindow);
+        wantedWindow.bottom -= wantedWindow.top;
+        wantedWindow.right -= wantedWindow.left;
+        wantedWindow.left = wantedWindow.top = 0;
+        RECT testCaption = { 0, 0, 100, 100 };
+        AdjustWindowRectExForDpi(&testCaption, wndStyle, false, wndExStyle, dpi);
+
+        pub_caption_height = wantedClient.bottom - wantedClient.top - 720;
+        wantedSize.right = wantedClient.right;
+        wantedSize.bottom = wantedClient.bottom - pub_caption_height;
+    }
+    m_arknights_roi = cv::Rect { 0, pub_caption_height, wantedSize.right, wantedSize.bottom };
+
+    HRESULT result = S_OK;
+    auto factory = winrt::get_activation_factory<winrt::Windows::Graphics::Capture::GraphicsCaptureItem,
+                                                 IGraphicsCaptureItemInterop>();
+    result = factory->CreateForWindow(
+        pub_wndwsa, winrt::guid_of<winrt::Windows::Graphics::Capture::GraphicsCaptureItem>(), winrt::put_abi(m_item));
+    if (FAILED(result)) {
+        fill_error("IGraphicsCaptureItem::CreateForWindow");
+        return false;
+    }
+
+    auto dxgiDevice = m_native_device.as<IDXGIDevice>();
+    result = CreateDirect3D11DeviceFromDXGIDevice(dxgiDevice.get(),
+                                                  reinterpret_cast<IInspectable**>(winrt::put_abi(m_device)));
+    if (FAILED(result)) {
+        fill_error("CreateDirect3D11DeviceFromDXGIDevice");
+        return false;
+    }
+    
+    m_size = m_item.Size();
+    pub_size.first = wantedSize.right;
+    pub_size.second = wantedSize.bottom;
+    m_pitch = m_size.Width * 3ull;
+
+    m_front.create(m_size.Height, m_size.Width, CV_8UC3);
+    m_back.create(m_size.Height, m_size.Width, CV_8UC3);
+
+    {
+        D3D11_TEXTURE2D_DESC desc = { .Width = WindowWidthDefault,
+                                      .Height = WindowHeightDefault,
+                                      .MipLevels = 1,
+                                      .ArraySize = 1,
+                                      .Format = DXGI_FORMAT_B8G8R8A8_UNORM,
+                                      .SampleDesc = { .Count = 1, .Quality = 0 },
+                                      .Usage = D3D11_USAGE_STAGING,
+                                      .CPUAccessFlags = D3D11_CPU_ACCESS_READ | D3D11_CPU_ACCESS_WRITE,
+                                      .MiscFlags = 0 };
+        result = m_native_device->CreateTexture2D(&desc, nullptr, m_staging_texture.put());
+    }
+    if (FAILED(result)) {
+        fill_error("ID3D11Device::CreateTexture2D");
+        return false;
+    }
+
+    m_frame_pool = winrt::Windows::Graphics::Capture::Direct3D11CaptureFramePool::CreateFreeThreaded(
+        m_device, winrt::Windows::Graphics::DirectX::DirectXPixelFormat::B8G8R8A8UIntNormalized, 1, m_size);
+    if (m_frame_pool == nullptr) {
+        fill_error("winrt::Windows::Graphics::Capture::Direct3D11CaptureFramePool::CreateFreeThreaded");
+        return false;
+    }
+
+    m_session = m_frame_pool.CreateCaptureSession(m_item);
+    if (m_session == nullptr) {
+        fill_error("winrt::Windows::Graphics::Capture::Direct3D11CaptureFramePool::CreateCaptureSession");
+        return false;
+    }
+    m_session.IsBorderRequired(m_golden_border);
+    m_session.IsCursorCaptureEnabled(false);
+
+    return SUCCEEDED(result);
+}
+
+bool asst::WSAController::FrameBuffer::start_capture()
+{
+    LogTraceFunction;
+
+    if (end_capture()) return false;
+    m_frame_arrived = m_frame_pool.FrameArrived({ this, &FrameBuffer::process_frame });
+    m_session = m_frame_pool.CreateCaptureSession(m_item);
+    m_session.IsBorderRequired(m_golden_border);
+    m_session.IsCursorCaptureEnabled(false);
+    m_session.StartCapture();
+
+    return true;
+}
+
+bool asst::WSAController::FrameBuffer::end_capture()
+{
+    LogTraceFunction;
+
+    if (m_session) {
+        m_locker.lock();
+        m_session = nullptr;
+        m_frame_pool.FrameArrived(m_frame_arrived);
+        m_locker.unlock();
+        return true;
+    }
+
+    return false;
+}
+
+bool asst::WSAController::FrameBuffer::restart_capture()
+{
+    LogTraceFunction;
+
+    end_capture();
+
+    m_frame_pool.Recreate(m_device, winrt::Windows::Graphics::DirectX::DirectXPixelFormat::B8G8R8A8UIntNormalized, 1,
+                          m_size);
+
+    start_capture();
+
+    return true;
+}
+
+bool asst::WSAController::FrameBuffer::get_once(cv::Mat payload)
+{
+    m_locker.lock();
+    payload = m_front(m_arknights_roi).clone();
+    m_locker.unlock();
+
+    return true;
+}
+
+void asst::WSAController::FrameBuffer::process_frame(
+    winrt::Windows::Graphics::Capture::Direct3D11CaptureFramePool const& framePool,
+    [[maybe_unused]] winrt::Windows::Foundation::IInspectable const& object)
+{
+    m_locker.lock();
+    if (!m_session) {
+        m_locker.unlock();
+        return;
+    }
+    m_locker.unlock();
+
+    winrt::Windows::Graphics::Capture::Direct3D11CaptureFrame frame = framePool.TryGetNextFrame();
+    auto size = frame.ContentSize();
+
+    if (size != m_size) {
+        frame = nullptr;
+        restart_capture();
+        return;
+    }
+
+    winrt::com_ptr<Windows::Graphics::DirectX::Direct3D11::IDirect3DDxgiInterfaceAccess> dxgiAccess = {
+        frame.Surface().as<Windows::Graphics::DirectX::Direct3D11::IDirect3DDxgiInterfaceAccess>()
+    };
+    winrt::com_ptr<::ID3D11Resource> resource;
+    winrt::check_hresult(dxgiAccess->GetInterface(__uuidof(resource), resource.put_void()));
+    
+    m_context->CopyResource(m_staging_texture.get(), resource.get());
+
+    D3D11_MAPPED_SUBRESOURCE field;
+    UINT subresource = D3D11CalcSubresource(0, 0, 0);
+    m_context->Map(m_staging_texture.get(), subresource, D3D11_MAP_READ, 0, &field);
+
+    uchar* data = m_back.ptr();
+    uchar* source = (uchar*)field.pData;
+    for (size_t i = 0; i < m_size.Height; i++) {
+        for (size_t j = 0; j < m_size.Width; j++) {
+            data[i * m_pitch + j * 3] = source[i * field.RowPitch + j * 4 + 2];
+            data[i * m_pitch + j * 3 + 1] = source[i * field.RowPitch + j * 4 + 1];
+            data[i * m_pitch + j * 3 + 2] = source[i * field.RowPitch + j * 4];
+        }
+    }
+
+    m_locker.lock();
+    std::swap(m_front, m_back);
+    m_locker.unlock();
+    m_context->Unmap(m_staging_texture.get(), subresource);
+}
+
+void asst::WSAController::callback(AsstMsg msg, const json::value& details)
+{
+    if (m_callback) {
+        m_callback(msg, details, m_inst);
+    }
+}
+
+bool asst::WSAController::screencap(cv::Mat& image_payload, [[maybe_unused]] bool allow_reconnect)
+{
+    return m_wgc.get_once(image_payload);
+}
+
+bool asst::WSAController::start_game([[maybe_unused]] const std::string& client_type)
+{
+    LogTraceFunction;
+
+    platform::os_string env = GetEnvironmentStrings();
+    auto path_pos = env.find(platform::to_osstring("APPDATA"));
+    std::wostringstream wiss;
+    wiss << env.substr(path_pos + 7);
+    std::filesystem::path appdata_path = wiss.str();
+
+    auto whole_path = appdata_path / m_wsapath;
+    system(whole_path.string().c_str());
+
+    return false;
+}
+
+bool asst::WSAController::click(const Point& p)
+{
+    return  m_touch.click(p.x, p.y);
+}
+
+bool asst::WSAController::swipe(const Point& p1, const Point& p2, int duration, [[maybe_unused]] bool extra_swipe,
+                                [[maybe_unused]] double slope_in, [[maybe_unused]] double slope_out,
+                                [[maybe_unused]] bool with_pause)
+{
+    if (with_pause) {
+        return m_touch.swipe_with_pause(p1.x, p1.y, p2.x, p2.y, duration);
+    }
+    else {
+        return m_touch.swipe(p1.x, p1.y, p2.x, p2.y, duration);
+    }
+}
+
+bool asst::WSAController::press_esc()
+{
+    m_touch.press(VK_ESCAPE);
+    return true;
+}
+
+asst::WSAController::Toucher::~Toucher()
+{
+    m_running.store(false);
+    if (m_thread.joinable()) m_thread.join();
+}
+
+void asst::WSAController::Toucher::init(HWND hwnd, int caption_height)
+{
+    m_wnd = hwnd;
+    m_caption_height = caption_height;
+
+    m_running.store(true);
+    m_thread = std::thread([this]() { this->run(); });
+
+    std::mt19937_64 random_engine { std::random_device {}() };
+    std::uniform_real_distribution<double> dist(-5, 5);
+    for (int i = 0; i < 10; i++)
+        random_end.push_back(dist(random_engine));
+}
+
+bool asst::WSAController::Toucher::click(int x, int y)
+{
+    if (!m_inited) return false;
+
+    m_locker.lock();
+
+    if (m_msgs.size() > max_queue_length) {
+        m_locker.unlock();
+        return false;
+    }
+
+    m_msgs.push({ 0, x, y });
+
+    m_locker.unlock();
+
+    return true;
+}
+
+bool asst::WSAController::Toucher::swipe(double sx, double sy, double ex, double ey, int dur)
+{
+    if (!m_inited) return false;
+
+    if (dur < 40) {
+        return false;
+    }
+
+    m_locker.lock();
+
+    if (m_msgs.size() > max_queue_length) {
+        m_locker.unlock();
+        return false;
+    }
+
+    constexpr int nslices = 6;
+    auto dx = (ex - sx) / nslices, dy = (ey - sy) / nslices;
+    auto dur_slice = dur / nslices;
+
+    m_msgs.push({ 100, 0, 0 });
+    for (int i = 0; i < 5; i++)
+        m_msgs.push({ 1, (int)sx, (int)sy });
+    linear_interpolate(sx, sy, dx, dy, 0, dur_slice, nslices);
+
+    m_msgs.push({ 2, (int)sx, (int)sy });
+    m_locker.unlock();
+
+    return true;
+}
+
+bool asst::WSAController::Toucher::swipe_with_pause(double sx, double sy, double ex, double ey, int dur)
+{
+    if (!m_inited) return false;
+
+    if (dur < 40) {
+        return false;
+    }
+
+    m_locker.lock();
+
+    if (m_msgs.size() > max_queue_length) {
+        m_locker.unlock();
+        return false;
+    }
+
+    constexpr int nslices = 6;
+    constexpr int neslices = 6;
+    constexpr int extra_slice_size = 3;
+    ex += extra_slice_size, ey += extra_slice_size;
+    constexpr double slide_time_ratio = 3. / 5.;
+
+    auto dx = (ex - sx) / nslices, dy = (ey - sy) / nslices;
+    auto ux = std::abs(dx) / dx, uy = std::abs(dy) / dy;
+
+    auto dur_slice = dur * slide_time_ratio / nslices;
+
+    m_msgs.push({ 100, 0, 0 });
+    for (int i = 0; i < 5; i++)
+        m_msgs.push({ 1, (int)sx, (int)sy });
+    auto time_stamp = linear_interpolate(sx, sy, dx, dy, 0, dur_slice, nslices);
+
+    dx = -ux * extra_slice_size / neslices, dy = -uy * extra_slice_size / neslices;
+    time_stamp = linear_interpolate(sx, sy, dx, dy, time_stamp, dur_slice, neslices);
+    linear_interpolate(sx, sy, 0, 0, time_stamp, 0, 10);
+
+    m_msgs.push({ 2, (int)sx, (int)sy });
+    m_locker.unlock();
+
+    return true;
+}
+
+void asst::WSAController::Toucher::press(int key)
+{
+    m_msgs.push({ -1, key, 0 });
+}
+
+void asst::WSAController::Toucher::wait()
+{
+    while (!m_msgs.empty())
+        ;
+}
+
+void asst::WSAController::Toucher::run()
+{
+    SetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+
+    using namespace std::chrono;
+    time_point<high_resolution_clock, milliseconds> tic;
+    time_point<high_resolution_clock, milliseconds> toc;
+
+    while (m_running.load()) {
+        if (m_msgs.empty()) {
+            Sleep(50);
+            continue;
+        }
+
+        m_locker.lock();
+
+        auto command = m_msgs.front();
+        LRESULT res = 0;
+        command.y += m_caption_height;
+        LPARAM coord = MAKELPARAM(command.x, command.y);
+
+        switch (command.type) {
+        case -1:
+            res = SendMessage(m_wnd, WM_KEYDOWN, command.x, 0);
+            Sleep(20);
+            res = SendMessage(m_wnd, WM_KEYUP, command.x, 0);
+            Sleep(20);
+            break;
+        case 0:
+            res = SendMessage(m_wnd, WM_LBUTTONDOWN, 0, coord);
+            Sleep(20);
+            res &= SendMessage(m_wnd, WM_LBUTTONUP, 0, coord);
+            Sleep(20);
+            break;
+        case 100:
+            tic = time_point_cast<milliseconds>(high_resolution_clock::now());
+            res = TRUE;
+            break;
+        case 200:
+            toc = time_point_cast<milliseconds>(high_resolution_clock::now());
+            while (toc - tic <= milliseconds { command.x }) {
+                toc = time_point_cast<milliseconds>(high_resolution_clock::now());
+            }
+            res = TRUE;
+            break;
+        case 1:
+            res = SendMessage(m_wnd, WM_LBUTTONDOWN, 0, coord);
+            break;
+        case 2:
+            res = SendMessage(m_wnd, WM_LBUTTONUP, 0, coord);
+            break;
+        case 3:
+            res = SendMessage(m_wnd, WM_MOUSEMOVE, 0, coord);
+            break;
+        }
+
+        m_msgs.pop();
+        m_locker.unlock();
+    }
+}
+
+double asst::WSAController::Toucher::linear_interpolate(double& sx, double& sy, double dx, double dy, double time_stamp,
+                                                      double dur_slice, double n)
+{
+    for (int i = 1; i <= n; i++) {
+        sx += dx, sy += dy;
+        m_msgs.push({ 200, (int)time_stamp, 0 });
+        m_msgs.push({ 3, (int)sx, (int)sy });
+        time_stamp += dur_slice;
+    }
+    return time_stamp;
+}
+
+#endif // _WIN32

--- a/src/MaaCore/Controller/WSAController.cpp
+++ b/src/MaaCore/Controller/WSAController.cpp
@@ -152,6 +152,8 @@ asst::WSAController::WSAController(const AsstCallback& callback, Assistant* inst
               } },
         };
         this->callback(AsstMsg::InternalError, create_device_error);
+        Log.error("platform not supported");
+        throw std::runtime_error("platform not supported");
     }
 
     if (m_last_error != 0) {
@@ -165,6 +167,8 @@ asst::WSAController::WSAController(const AsstCallback& callback, Assistant* inst
               } },
         };
         this->callback(AsstMsg::InternalError, create_device_error);
+        Log.error("failed to createdevice");
+        throw std::runtime_error("failed to createdevice");
     }
 
     m_platform_io = PlatformFactory::create_platform(inst, type);
@@ -277,7 +281,7 @@ bool asst::WSAController::FrameBuffer::prepare(bool resize_window, bool golden_b
     }
 
     if (IsIconic(pub_wndwsa)) {
-        Log.trace("WSA window is iconic. Try to show WSA window.");
+        Log.warn("WSA window is iconic. Try to show WSA window.");
         if (!ShowWindow(pub_wndwsa, SW_SHOW)) return false;
     }
     

--- a/src/MaaCore/Controller/WSAController.cpp
+++ b/src/MaaCore/Controller/WSAController.cpp
@@ -4,7 +4,7 @@
 #if defined(_WIN32)
 
 asst::WSAController::WSAController(const AsstCallback& callback, Assistant* inst, PlatformType type)
-    : InstHelper(inst), m_callback(callback), m_wgc(m_last_error), m_uuid("什么是UUID？")
+    : InstHelper(inst), m_callback(callback), m_wgc(m_last_error), m_uuid("111111")
 {
     LogTraceFunction;
 
@@ -116,9 +116,9 @@ asst::WSAController::FrameBuffer::~FrameBuffer() {
     m_frame_pool = nullptr;
     m_item = nullptr;
     m_device = nullptr;
-    m_staging_texture->Release();
-    m_context->Release();
-    m_native_device->Release();
+    if (m_staging_texture) m_staging_texture->Release();
+    if (m_context) m_context->Release();
+    if (m_native_device) m_native_device->Release();
 }
 
 bool asst::WSAController::FrameBuffer::prepare(bool resize_window, bool golden_border)
@@ -168,7 +168,7 @@ bool asst::WSAController::FrameBuffer::prepare(bool resize_window, bool golden_b
         RECT testCaption = { 0, 0, 100, 100 };
         AdjustWindowRectExForDpi(&testCaption, wndStyle, false, wndExStyle, dpi);
 
-        pub_caption_height = wantedClient.bottom - wantedClient.top - 720;
+        pub_caption_height = testCaption.bottom - testCaption.top - 100;
         wantedSize.right = wantedClient.right;
         wantedSize.bottom = wantedClient.bottom - pub_caption_height;
     }
@@ -223,14 +223,6 @@ bool asst::WSAController::FrameBuffer::prepare(bool resize_window, bool golden_b
         fill_error("winrt::Windows::Graphics::Capture::Direct3D11CaptureFramePool::CreateFreeThreaded");
         return false;
     }
-
-    m_session = m_frame_pool.CreateCaptureSession(m_item);
-    if (m_session == nullptr) {
-        fill_error("winrt::Windows::Graphics::Capture::Direct3D11CaptureFramePool::CreateCaptureSession");
-        return false;
-    }
-    m_session.IsBorderRequired(m_golden_border);
-    m_session.IsCursorCaptureEnabled(false);
 
     return SUCCEEDED(result);
 }

--- a/src/MaaCore/Controller/WSAController.cpp
+++ b/src/MaaCore/Controller/WSAController.cpp
@@ -676,6 +676,14 @@ bool asst::WSAController::Toucher::VirtualMouse::inject()
     *(ULONGLONG*)&(m_newcode[13]) = ((ULONGLONG)remote_func_addr);
 
     if (injection_count == 0) memcpy(m_oldcode, m_remote.lpGetKeyState, code_size);
+    {
+        std::ostringstream str_codes;
+        str_codes << std::hex;
+        for (auto i : m_oldcode) {
+            str_codes << "\\x" << (int)i;
+        }
+        Log.info("Old codes: ", str_codes.str());
+    }
     memcpy((char*)m_remote.oldcode, (char*)m_oldcode, code_size);
     memcpy((char*)m_remote.newcode, (char*)m_newcode, code_size);
     m_remote.func_addr = remote_func_addr;

--- a/src/MaaCore/Controller/WSAController.cpp
+++ b/src/MaaCore/Controller/WSAController.cpp
@@ -33,6 +33,73 @@ namespace asst
             "\x55\xd0\x4c\x8b\x45\xd8\x48\x89\xc1\x48\x8b\x45\xe0\x41\xb9\x20\x00\x00\x00\x45\x31\xd2\x48\xc7"
             "\x44\x24\x20\x00\x00\x00\x00\xff\xd0\x8b\x45\xf2\x48\x81\xc4\x80\x00\x00\x00\x5a\x5f\x5e\x5b\x5d"
             "\xc3";
+        /*
+void FunctionCodeCompiledFromBelow()
+{
+	__asm {
+		pop rax
+		push rbp
+		push rbx
+		push rsi
+		push rdi
+		push rdx
+		sub rsp, 128
+		lea rbp, 128[rsp]
+	}
+	RemoteParam* pRP;
+	INT vKey;
+	__asm {
+		mov[vKey], rcx
+		mov[pRP], rax
+	}
+
+	if (vKey == VK_LBUTTON) {
+		if (pRP->lpFlag == 1ull) {
+			__asm {
+				add rsp, 128
+				pop rdx
+				pop rdi
+				pop rsi
+				pop rbx
+				pop rbp
+				mov eax, 8001h
+				ret
+			}
+		}
+		{
+			__asm {
+				add rsp, 128
+				pop rdx
+				pop rdi
+				pop rsi
+				pop rbx
+				pop rbp
+				xor eax, eax
+				ret
+			}
+		}
+	}
+	((PFN_WRITEPROCESSMEMORY)pRP->lpWriteProcessMemory)(
+		((PFN_GETCURRENTPROCESS)pRP->lpGetCurrentProcess)(),
+		pRP->lpGetKeyState, pRP->szOldCode, code_size, NULL
+		);
+	SHORT get = ((PFN_GetKeyState)pRP->lpGetKeyState)(vKey);
+	((PFN_WRITEPROCESSMEMORY)pRP->lpWriteProcessMemory)(
+		((PFN_GETCURRENTPROCESS)pRP->lpGetCurrentProcess)(),
+		pRP->lpGetKeyState, pRP->szNewCode, code_size, NULL
+		);
+	__asm {
+		mov eax, [get]
+		add rsp, 128
+		pop rdx
+		pop rdi
+		pop rsi
+		pop rbx
+		pop rbp
+		ret
+	}
+}
+        */
 
         struct
         {

--- a/src/MaaCore/Controller/WSAController.cpp
+++ b/src/MaaCore/Controller/WSAController.cpp
@@ -642,17 +642,18 @@ void asst::WSAController::Toucher::run()
         switch (command.type) {
         case -1:
             res = SendMessage(m_wnd, WM_KEYDOWN, command.x, 0);
-            Sleep(40);
+            Sleep(80);
             res = SendMessage(m_wnd, WM_KEYUP, command.x, 0);
-            Sleep(20);
+            Sleep(40);
             break;
         case 0:
             s_vm.down();
-            res = SendMessage(m_wnd, WM_LBUTTONDOWN, 0, coord);
-            res = SendMessage(m_wnd, WM_LBUTTONDOWN, 0, coord);
-            Sleep(40);
+            for (int i = 0; i < 2; i++) {
+                res = SendMessage(m_wnd, WM_LBUTTONDOWN, 0, coord);
+            }
+            Sleep(80);
             res &= SendMessage(m_wnd, WM_LBUTTONUP, 0, coord);
-            Sleep(20);
+            Sleep(40);
             s_vm.up();
             break;
         case 100:

--- a/src/MaaCore/Controller/WSAController.cpp
+++ b/src/MaaCore/Controller/WSAController.cpp
@@ -172,7 +172,8 @@ bool asst::WSAController::FrameBuffer::prepare(bool resize_window, bool golden_b
         RECT testCaption = { 0, 0, 100, 100 };
         AdjustWindowRectExForDpi(&testCaption, wndStyle, false, wndExStyle, dpi);
 
-        pub_caption_height = testCaption.bottom - testCaption.top - 100;
+        auto black = wantedWindow.right - wantedClient.right;
+        pub_caption_height = testCaption.bottom - testCaption.top - 100 - black;
         wantedSize.right = wantedClient.right;
         wantedSize.bottom = wantedClient.bottom - pub_caption_height;
     }
@@ -520,6 +521,7 @@ void asst::WSAController::Toucher::run()
             break;
         case 0:
             m_vm.down();
+            res = SendMessage(m_wnd, WM_LBUTTONDOWN, 0, coord);
             res = SendMessage(m_wnd, WM_LBUTTONDOWN, 0, coord);
             Sleep(40);
             res &= SendMessage(m_wnd, WM_LBUTTONUP, 0, coord);

--- a/src/MaaCore/Controller/WSAController.cpp
+++ b/src/MaaCore/Controller/WSAController.cpp
@@ -360,12 +360,12 @@ bool asst::WSAController::click(const Point& p)
     return  m_touch.click(p.x, p.y);
 }
 
-bool asst::WSAController::swipe(const Point& p1, const Point& p2, int duration, [[maybe_unused]] bool extra_swipe,
+bool asst::WSAController::swipe(const Point& p1, const Point& p2, int duration, bool extra_swipe,
                                 [[maybe_unused]] double slope_in, [[maybe_unused]] double slope_out,
-                                [[maybe_unused]] bool with_pause)
+                                bool with_pause)
 {
-    if (with_pause) {
-        return m_touch.swipe_with_pause(p1.x, p1.y, p2.x, p2.y, duration);
+    if (extra_swipe) {
+        return m_touch.swipe_precisely(p1.x, p1.y, p2.x, p2.y, duration, with_pause);
     }
     else {
         return m_touch.swipe(p1.x, p1.y, p2.x, p2.y, duration);
@@ -446,7 +446,7 @@ bool asst::WSAController::Toucher::swipe(double sx, double sy, double ex, double
     return true;
 }
 
-bool asst::WSAController::Toucher::swipe_with_pause(double sx, double sy, double ex, double ey, int dur)
+bool asst::WSAController::Toucher::swipe_precisely(double sx, double sy, double ex, double ey, int dur, bool pause)
 {
     if (!m_inited) return false;
 
@@ -475,6 +475,7 @@ bool asst::WSAController::Toucher::swipe_with_pause(double sx, double sy, double
     m_msgs.push({ 100, 0, 0 });
     for (int i = 0; i < 5; i++)
         m_msgs.push({ 1, (int)sx, (int)sy });
+    if (pause) press(VK_ESCAPE);
     auto time_stamp = linear_interpolate(sx, sy, dx, dy, 0, dur_slice, nslices);
 
     dx = -ux * extra_slice_size / neslices, dy = -uy * extra_slice_size / neslices;

--- a/src/MaaCore/Controller/WSAController.h
+++ b/src/MaaCore/Controller/WSAController.h
@@ -163,6 +163,8 @@ namespace asst
                 }
             };
 
+            int m_caption_height;
+
             double linear_interpolate(double& sx, double& sy, double dx, double dy, double time_stamp, double dur_slice,
                                       double n);
 
@@ -170,7 +172,6 @@ namespace asst
             bool m_inited = false;
 
             HWND m_wnd = NULL;
-            int m_caption_height = 45;
 
             std::thread m_thread;
             std::atomic_bool m_running;

--- a/src/MaaCore/Controller/WSAController.h
+++ b/src/MaaCore/Controller/WSAController.h
@@ -38,6 +38,7 @@ namespace asst
         virtual bool connect([[maybe_unused]] const std::string& adb_path, [[maybe_unused]] const std::string& address,
                              [[maybe_unused]] const std::string& config) override;
 
+        const std::string& get_uuid() const override { return m_uuid; }
         virtual void set_resize_window(bool enable) noexcept override;
         virtual void set_golden_border(bool enable) noexcept override;
 
@@ -58,8 +59,7 @@ namespace asst
         virtual bool press_esc() override;
         virtual ControlFeat::Feat support_features() const noexcept override
         {
-            // return ControlFeat::SWIPE_WITH_PAUSE | ControlFeat::PRECISE_SWIPE;
-            return ControlFeat::NONE;
+            return ControlFeat::SWIPE_WITH_PAUSE | ControlFeat::PRECISE_SWIPE;
         }
 
         virtual std::pair<int, int> get_screen_res() const noexcept override { return m_screen_size; }
@@ -101,8 +101,8 @@ namespace asst
 
         public:
             std::pair<int, int> pub_size; // 输出大小
-            HWND pub_wndwsa;
-            int pub_caption_height;
+            HWND pub_wndwsa = NULL;
+            int pub_caption_height = 0;
 
         private:
             void process_frame(winrt::Windows::Graphics::Capture::Direct3D11CaptureFramePool const& framePool,
@@ -126,9 +126,9 @@ namespace asst
             std::mutex m_locker;
             cv::Mat m_front, m_back;
             winrt::event_token m_frame_arrived;
-            size_t m_pitch;
+            size_t m_pitch = 0;
             cv::Rect m_arknights_roi;
-            bool m_golden_border;
+            bool m_golden_border = false;
 
         } m_wgc; // Windows Graphics Capture member class;
         DWORD m_last_error;

--- a/src/MaaCore/Controller/WSAController.h
+++ b/src/MaaCore/Controller/WSAController.h
@@ -1,0 +1,188 @@
+#pragma once
+
+#if defined(_WIN32)
+
+#include "ControllerAPI.h"
+
+#include <queue>
+#include <random>
+
+#include "Platform/PlatformFactory.h"
+
+#include <Windows.h>
+#include <d3d11.h>
+
+#include <Windows.Graphics.Capture.Interop.h>
+#include <windows.graphics.capture.h>
+#include <windows.graphics.directx.direct3d11.h>
+#include <windows.graphics.directx.direct3d11.interop.h>
+
+#include <winrt/windows.foundation.h>
+#include <winrt/windows.graphics.capture.h>
+#include <winrt/windows.graphics.directx.direct3d11.h>
+#include <winrt/windows.system.h>
+
+#include "Common/AsstMsg.h"
+#include "InstHelper.h"
+
+namespace asst
+{
+    class WSAController : public ControllerAPI, protected InstHelper
+    {
+    public:
+        WSAController(const AsstCallback& callback, Assistant* inst, PlatformType type);
+        WSAController(const WSAController&) = delete;
+        WSAController(WSAController&&) = delete;
+        virtual ~WSAController();
+
+        virtual bool connect([[maybe_unused]] const std::string& adb_path, [[maybe_unused]] const std::string& address,
+                             [[maybe_unused]] const std::string& config) override;
+
+        virtual void set_resize_window(bool enable) noexcept override;
+        virtual void set_golden_border(bool enable) noexcept override;
+
+        virtual bool inited() const noexcept override { return m_inited; }
+
+        virtual bool screencap(cv::Mat& image_payload, [[maybe_unused]] bool allow_reconnect = false) override;
+
+        virtual bool start_game([[maybe_unused]] const std::string& client_type) override;
+        virtual bool stop_game() override { return false; }
+
+        virtual bool click(const Point& p) override;
+
+        virtual bool swipe(const Point& p1, const Point& p2, int duration = 0, bool extra_swipe = false,
+                           double slope_in = 1, double slope_out = 1, bool with_pause = false) override;
+
+        virtual bool inject_input_event([[maybe_unused]] const InputEvent& event) override { return false; }
+
+        virtual bool press_esc() override;
+        virtual ControlFeat::Feat support_features() const noexcept override
+        {
+            // return ControlFeat::SWIPE_WITH_PAUSE | ControlFeat::PRECISE_SWIPE;
+            return ControlFeat::NONE;
+        }
+
+        virtual std::pair<int, int> get_screen_res() const noexcept override { return m_screen_size; }
+
+        WSAController& operator=(const WSAController&) = delete;
+        WSAController& operator=(WSAController&&) = delete;
+
+    protected:
+        void callback(AsstMsg msg, const json::value& details);
+
+        AsstCallback m_callback;
+
+        std::shared_ptr<asst::PlatformIO> m_platform_io = nullptr;
+
+        std::string m_uuid;
+        std::pair<int, int> m_screen_size = { 0, 0 };
+        int m_width = 0;
+        int m_height = 0;
+        bool m_server_started = false;
+        bool m_inited = false;
+        bool m_resize_window = false;
+        bool m_golden_border = false;
+
+        const std::filesystem::path m_wsapath =
+            R"(..\Local\Microsoft\WindowsApps\WsaClient.exe /launch wsa://com.hypergryph.arknights)";
+
+        class FrameBuffer
+        {
+        public:
+            FrameBuffer() = delete;
+            FrameBuffer(OUT DWORD& last_error);
+            ~FrameBuffer();
+
+            bool prepare(bool resize_window, bool golden_border);
+            bool start_capture();
+            bool end_capture();
+            bool restart_capture();
+            bool get_once(cv::Mat payload);
+
+        public:
+            std::pair<int, int> pub_size; // 输出大小
+            HWND pub_wndwsa;
+            int pub_caption_height;
+
+        private:
+            void process_frame(winrt::Windows::Graphics::Capture::Direct3D11CaptureFramePool const& framePool,
+                               [[maybe_unused]] winrt::Windows::Foundation::IInspectable const& object);
+
+        private:
+            winrt::Windows::Graphics::Capture::Direct3D11CaptureFramePool m_frame_pool;
+            winrt::Windows::Graphics::Capture::GraphicsCaptureSession m_session;
+            winrt::Windows::Graphics::Capture::GraphicsCaptureItem m_item;
+
+            winrt::com_ptr<ID3D11Device> m_native_device;
+            winrt::com_ptr<ID3D11DeviceContext> m_context;
+            winrt::com_ptr<ID3D11Texture2D> m_staging_texture;
+            winrt::Windows::Graphics::DirectX::Direct3D11::IDirect3DDevice m_device;
+
+            winrt::Windows::Graphics::SizeInt32 m_size; // 输入大小
+
+            const platform::os_string arknights_classname =
+                platform::to_osstring(std::string("com.hypergryph.arknights"));
+
+            std::mutex m_locker;
+            cv::Mat m_front, m_back;
+            winrt::event_token m_frame_arrived;
+            size_t m_pitch;
+            cv::Rect m_arknights_roi;
+            bool m_golden_border;
+
+        } m_wgc; // Windows Graphics Capture member class;
+        DWORD m_last_error;
+
+        class Toucher
+        {
+        public:
+            ~Toucher();
+
+            void init(HWND, int caption_height);
+
+            bool click(int x, int y);
+            bool swipe(double sx, double sy, double ex, double ey, int dur);
+            bool swipe_with_pause(double sx, double sy, double ex, double ey, int dur);
+            void press(int key);
+            void wait();
+
+            void run();
+
+        private:
+            struct MsgUnit
+            {
+                int type;
+                int x, y;
+                MsgUnit(std::initializer_list<int> list)
+                {
+                    auto beg = list.begin();
+                    type = *beg++;
+                    x = *beg++;
+                    y = *beg++;
+                }
+            };
+
+            double linear_interpolate(double& sx, double& sy, double dx, double dy, double time_stamp, double dur_slice,
+                                      double n);
+
+        private:
+            bool m_inited = false;
+
+            HWND m_wnd;
+            int m_caption_height;
+
+            std::thread m_thread;
+            std::mutex m_locker;
+            std::atomic_bool m_running;
+            std::queue<MsgUnit> m_msgs;
+            std::vector<double> random_end;
+
+            std::unique_ptr<IOHandler> m_shell;
+
+            const size_t max_queue_length = 1024;
+
+        } m_touch;
+    };
+} // namespace asst
+
+#endif // _WIN32

--- a/src/MaaCore/Controller/WSAController.h
+++ b/src/MaaCore/Controller/WSAController.h
@@ -181,6 +181,66 @@ namespace asst
 
             const size_t max_queue_length = 1024;
 
+            class VirtualMouse
+            {
+            public:
+                ~VirtualMouse();
+                bool inject();
+                bool down();
+                bool up();
+
+            private:
+                void restore();
+
+                static const size_t code_size = 32;
+                const unsigned char func_code[1024] =
+                    "\x58\x55\x53\x56\x57\x52\x48\x81\xec\x80\x00\x00\x00\x48\x8d\xac\x24\x80\x00\x00\x00\x48\x89\x4d"
+                    "\xf4\x48\x89\x45\xf8\x83\x7d\xf4\x01\x75\x2c\x48\x8b\x45\xf8\x48\x83\x78\x60\x01\x75\x12\x48\x81"
+                    "\xc4\x80\x00\x00\x00\x5a\x5f\x5e\x5b\x5d\xb8\x01\x80\x00\x00\xc3\x48\x81\xc4\x80\x00\x00\x00\x5a"
+                    "\x5f\x5e\x5b\x5d\x31\xc0\xc3\x48\x8b\x45\xf8\x48\x8b\x40\x10\x48\x89\x45\xc8\x48\x8b\x45\xf8\x48"
+                    "\x83\xc0\x18\x48\x89\x45\xc0\x48\x8b\x45\xf8\x48\x8b\x00\x48\x89\x45\xb8\x48\x8b\x45\xf8\xff\x50"
+                    "\x08\x48\x8b\x55\xb8\x4c\x8b\x45\xc0\x48\x89\xc1\x48\x8b\x45\xc8\x41\xb9\x20\x00\x00\x00\x45\x31"
+                    "\xd2\x48\xc7\x44\x24\x20\x00\x00\x00\x00\xff\xd0\x48\x8b\x45\xf8\x48\x8b\x00\x8b\x4d\xf4\xff\xd0"
+                    "\x66\x89\x45\xf2\x48\x8b\x45\xf8\x48\x8b\x40\x10\x48\x89\x45\xe0\x48\x8b\x45\xf8\x48\x83\xc0\x38"
+                    "\x48\x89\x45\xd8\x48\x8b\x45\xf8\x48\x8b\x00\x48\x89\x45\xd0\x48\x8b\x45\xf8\xff\x50\x08\x48\x8b"
+                    "\x55\xd0\x4c\x8b\x45\xd8\x48\x89\xc1\x48\x8b\x45\xe0\x41\xb9\x20\x00\x00\x00\x45\x31\xd2\x48\xc7"
+                    "\x44\x24\x20\x00\x00\x00\x00\xff\xd0\x8b\x45\xf2\x48\x81\xc4\x80\x00\x00\x00\x5a\x5f\x5e\x5b\x5d"
+                    "\xc3";
+
+                struct
+                {
+                    LPVOID lpGetKeyState;
+                    LPVOID lpGetCurrentProcess;
+                    LPVOID lpWriteProcessMemory;
+                    unsigned char oldcode[code_size];
+                    unsigned char newcode[code_size];
+                    LPVOID func_addr;
+                    ULONGLONG flag;
+                } m_remote;
+                const ULONGLONG m_flag_offset = (ULONGLONG)&m_remote.flag - (ULONGLONG)&m_remote;
+                unsigned char m_oldcode[code_size];
+                unsigned char m_newcode[code_size] =
+                    "\x48\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x50\x48\xb8\x00\x00\x00\x00\x00\x00\x00\x00\xff\xe0";
+
+                typedef HANDLE(__stdcall* PFN_CREATEFILE)(LPCWSTR, DWORD, DWORD, LPSECURITY_ATTRIBUTES, DWORD, DWORD,
+                                                          HANDLE);
+                typedef int(__stdcall* PFN_MESSAGEBOX)(HWND, LPCWSTR, LPCWSTR, DWORD);
+                typedef BOOL(__stdcall* PFN_WRITEPROCESSMEMORY)(HANDLE, LPVOID, LPCVOID, SIZE_T, SIZE_T*);
+                typedef HANDLE(__stdcall* PFN_GETCURRENTPROCESS)(void);
+                typedef SHORT(__stdcall* PFN_GetKeyState)(INT);
+                typedef VOID(__stdcall* PFN_COPYMEMORY)(LPVOID, LPVOID, SIZE_T);
+
+                HANDLE m_target_process = NULL;
+                HMODULE m_kernel32 = NULL;
+                HMODULE m_user32 = NULL;
+
+                LPVOID remote_func_addr = nullptr;
+                LPVOID remote_para_addr = nullptr;
+                LPVOID remote_flag_addr = nullptr;
+
+                bool m_good = false;
+            } m_vm;
+
         } m_touch;
     };
 } // namespace asst

--- a/src/MaaCore/Controller/WSAController.h
+++ b/src/MaaCore/Controller/WSAController.h
@@ -124,6 +124,7 @@ namespace asst
                 platform::to_osstring(std::string("com.hypergryph.arknights"));
 
             std::mutex m_locker;
+            std::atomic_bool m_need_update = false;
             cv::Mat m_front, m_back;
             winrt::event_token m_frame_arrived;
             size_t m_pitch = 0;
@@ -168,11 +169,10 @@ namespace asst
         private:
             bool m_inited = false;
 
-            HWND m_wnd;
-            int m_caption_height;
+            HWND m_wnd = NULL;
+            int m_caption_height = 45;
 
             std::thread m_thread;
-            std::mutex m_locker;
             std::atomic_bool m_running;
             std::queue<MsgUnit> m_msgs;
             std::vector<double> random_end;

--- a/src/MaaCore/Controller/WSAController.h
+++ b/src/MaaCore/Controller/WSAController.h
@@ -41,6 +41,7 @@ namespace asst
         const std::string& get_uuid() const override { return m_uuid; }
         virtual void set_resize_window(bool enable) noexcept override;
         virtual void set_golden_border(bool enable) noexcept override;
+        virtual void set_swipe_with_pause(bool enable) noexcept override;
 
         virtual bool inited() const noexcept override { return m_inited; }
 
@@ -59,7 +60,7 @@ namespace asst
         virtual bool press_esc() override;
         virtual ControlFeat::Feat support_features() const noexcept override
         {
-            return ControlFeat::SWIPE_WITH_PAUSE | ControlFeat::PRECISE_SWIPE;
+            return /*ControlFeat::SWIPE_WITH_PAUSE |*/ ControlFeat::PRECISE_SWIPE;
         }
 
         virtual std::pair<int, int> get_screen_res() const noexcept override { return m_screen_size; }
@@ -82,6 +83,7 @@ namespace asst
         bool m_inited = false;
         bool m_resize_window = false;
         bool m_golden_border = false;
+        bool m_use_swipe_with_pause = false;
 
         const std::filesystem::path m_wsapath =
             R"(..\Local\Microsoft\WindowsApps\WsaClient.exe /launch wsa://com.hypergryph.arknights)";
@@ -97,7 +99,8 @@ namespace asst
             bool start_capture();
             bool end_capture();
             bool restart_capture();
-            bool get_once(cv::Mat& payload);
+            bool peek(cv::Mat& payload);
+            bool get(cv::Mat& payload);
 
         public:
             std::pair<int, int> pub_size; // 输出大小
@@ -129,6 +132,8 @@ namespace asst
             size_t m_pitch = 0;
             cv::Rect m_arknights_roi;
             bool m_golden_border = false;
+
+            std::atomic_bool m_recieved = true;
 
         } m_wgc; // Windows Graphics Capture member class;
         DWORD m_last_error;

--- a/src/MaaCore/Controller/WSAController.h
+++ b/src/MaaCore/Controller/WSAController.h
@@ -141,7 +141,7 @@ namespace asst
             bool init(HWND, int caption_height);
 
             bool click(int x, int y);
-            bool swipe(double sx, double sy, double ex, double ey, int dur);
+            bool swipe(double sx, double sy, double ex, double ey, int dur, bool pause);
             bool swipe_precisely(double sx, double sy, double ex, double ey, int dur, bool pause);
             void press(int key);
             void wait();

--- a/src/MaaCore/Controller/WSAController.h
+++ b/src/MaaCore/Controller/WSAController.h
@@ -175,7 +175,7 @@ namespace asst
             std::thread m_thread;
             std::atomic_bool m_running;
             std::queue<MsgUnit> m_msgs;
-            std::vector<double> random_end;
+            std::vector<double> m_rands;
 
             const size_t max_queue_length = 1024;
 

--- a/src/MaaCore/Controller/WSAController.h
+++ b/src/MaaCore/Controller/WSAController.h
@@ -124,8 +124,7 @@ namespace asst
                 platform::to_osstring(std::string("com.hypergryph.arknights"));
 
             std::mutex m_locker;
-            std::atomic_bool m_need_update = false;
-            cv::Mat m_front, m_back;
+            cv::Mat m_cache;
             winrt::event_token m_frame_arrived;
             size_t m_pitch = 0;
             cv::Rect m_arknights_roi;

--- a/src/MaaCore/Controller/WSAController.h
+++ b/src/MaaCore/Controller/WSAController.h
@@ -163,7 +163,7 @@ namespace asst
                 }
             };
 
-            int m_caption_height;
+            int m_caption_height = 45;
 
             double linear_interpolate(double& sx, double& sy, double dx, double dy, double time_stamp, double dur_slice,
                                       double n);
@@ -179,66 +179,6 @@ namespace asst
             std::vector<double> random_end;
 
             const size_t max_queue_length = 1024;
-
-            class VirtualMouse
-            {
-            public:
-                ~VirtualMouse();
-                bool inject();
-                bool down();
-                bool up();
-
-            private:
-                void restore();
-
-                static const size_t code_size = 32;
-                const unsigned char func_code[1024] =
-                    "\x58\x55\x53\x56\x57\x52\x48\x81\xec\x80\x00\x00\x00\x48\x8d\xac\x24\x80\x00\x00\x00\x48\x89\x4d"
-                    "\xf4\x48\x89\x45\xf8\x83\x7d\xf4\x01\x75\x2c\x48\x8b\x45\xf8\x48\x83\x78\x60\x01\x75\x12\x48\x81"
-                    "\xc4\x80\x00\x00\x00\x5a\x5f\x5e\x5b\x5d\xb8\x01\x80\x00\x00\xc3\x48\x81\xc4\x80\x00\x00\x00\x5a"
-                    "\x5f\x5e\x5b\x5d\x31\xc0\xc3\x48\x8b\x45\xf8\x48\x8b\x40\x10\x48\x89\x45\xc8\x48\x8b\x45\xf8\x48"
-                    "\x83\xc0\x18\x48\x89\x45\xc0\x48\x8b\x45\xf8\x48\x8b\x00\x48\x89\x45\xb8\x48\x8b\x45\xf8\xff\x50"
-                    "\x08\x48\x8b\x55\xb8\x4c\x8b\x45\xc0\x48\x89\xc1\x48\x8b\x45\xc8\x41\xb9\x20\x00\x00\x00\x45\x31"
-                    "\xd2\x48\xc7\x44\x24\x20\x00\x00\x00\x00\xff\xd0\x48\x8b\x45\xf8\x48\x8b\x00\x8b\x4d\xf4\xff\xd0"
-                    "\x66\x89\x45\xf2\x48\x8b\x45\xf8\x48\x8b\x40\x10\x48\x89\x45\xe0\x48\x8b\x45\xf8\x48\x83\xc0\x38"
-                    "\x48\x89\x45\xd8\x48\x8b\x45\xf8\x48\x8b\x00\x48\x89\x45\xd0\x48\x8b\x45\xf8\xff\x50\x08\x48\x8b"
-                    "\x55\xd0\x4c\x8b\x45\xd8\x48\x89\xc1\x48\x8b\x45\xe0\x41\xb9\x20\x00\x00\x00\x45\x31\xd2\x48\xc7"
-                    "\x44\x24\x20\x00\x00\x00\x00\xff\xd0\x8b\x45\xf2\x48\x81\xc4\x80\x00\x00\x00\x5a\x5f\x5e\x5b\x5d"
-                    "\xc3";
-
-                struct
-                {
-                    LPVOID lpGetKeyState;
-                    LPVOID lpGetCurrentProcess;
-                    LPVOID lpWriteProcessMemory;
-                    unsigned char oldcode[code_size];
-                    unsigned char newcode[code_size];
-                    LPVOID func_addr;
-                    ULONGLONG flag;
-                } m_remote;
-                const ULONGLONG m_flag_offset = (ULONGLONG)&m_remote.flag - (ULONGLONG)&m_remote;
-                unsigned char m_oldcode[code_size];
-                unsigned char m_newcode[code_size] =
-                    "\x48\xb8\x00\x00\x00\x00\x00\x00\x00\x00\x50\x48\xb8\x00\x00\x00\x00\x00\x00\x00\x00\xff\xe0";
-
-                typedef HANDLE(__stdcall* PFN_CREATEFILE)(LPCWSTR, DWORD, DWORD, LPSECURITY_ATTRIBUTES, DWORD, DWORD,
-                                                          HANDLE);
-                typedef int(__stdcall* PFN_MESSAGEBOX)(HWND, LPCWSTR, LPCWSTR, DWORD);
-                typedef BOOL(__stdcall* PFN_WRITEPROCESSMEMORY)(HANDLE, LPVOID, LPCVOID, SIZE_T, SIZE_T*);
-                typedef HANDLE(__stdcall* PFN_GETCURRENTPROCESS)(void);
-                typedef SHORT(__stdcall* PFN_GetKeyState)(INT);
-                typedef VOID(__stdcall* PFN_COPYMEMORY)(LPVOID, LPVOID, SIZE_T);
-
-                HANDLE m_target_process = NULL;
-                HMODULE m_kernel32 = NULL;
-                HMODULE m_user32 = NULL;
-
-                LPVOID remote_func_addr = nullptr;
-                LPVOID remote_para_addr = nullptr;
-                LPVOID remote_flag_addr = nullptr;
-
-                bool m_good = false;
-            } m_vm;
 
         } m_touch;
     };

--- a/src/MaaCore/Controller/WSAController.h
+++ b/src/MaaCore/Controller/WSAController.h
@@ -97,7 +97,7 @@ namespace asst
             bool start_capture();
             bool end_capture();
             bool restart_capture();
-            bool get_once(cv::Mat payload);
+            bool get_once(cv::Mat& payload);
 
         public:
             std::pair<int, int> pub_size; // 输出大小
@@ -118,7 +118,7 @@ namespace asst
             winrt::com_ptr<ID3D11Texture2D> m_staging_texture;
             winrt::Windows::Graphics::DirectX::Direct3D11::IDirect3DDevice m_device;
 
-            winrt::Windows::Graphics::SizeInt32 m_size; // 输入大小
+            winrt::Windows::Graphics::SizeInt32 m_size = { 0, 0 }; // 输入大小
 
             const platform::os_string arknights_classname =
                 platform::to_osstring(std::string("com.hypergryph.arknights"));

--- a/src/MaaCore/Controller/WSAController.h
+++ b/src/MaaCore/Controller/WSAController.h
@@ -142,7 +142,7 @@ namespace asst
 
             bool click(int x, int y);
             bool swipe(double sx, double sy, double ex, double ey, int dur);
-            bool swipe_with_pause(double sx, double sy, double ex, double ey, int dur);
+            bool swipe_precisely(double sx, double sy, double ex, double ey, int dur, bool pause);
             void press(int key);
             void wait();
 

--- a/src/MaaCore/Controller/WSAController.h
+++ b/src/MaaCore/Controller/WSAController.h
@@ -139,7 +139,7 @@ namespace asst
         public:
             ~Toucher();
 
-            void init(HWND, int caption_height);
+            bool init(HWND, int caption_height);
 
             bool click(int x, int y);
             bool swipe(double sx, double sy, double ex, double ey, int dur);
@@ -176,8 +176,6 @@ namespace asst
             std::atomic_bool m_running;
             std::queue<MsgUnit> m_msgs;
             std::vector<double> random_end;
-
-            std::unique_ptr<IOHandler> m_shell;
 
             const size_t max_queue_length = 1024;
 

--- a/src/MaaCore/MaaCore.vcxproj
+++ b/src/MaaCore/MaaCore.vcxproj
@@ -63,6 +63,7 @@
     <ClInclude Include="Controller\Platform\Win32IO.h" />
     <ClInclude Include="Controller\Platform\PlatformIO.h" />
     <ClInclude Include="Controller\Platform\PlatformFactory.h" />
+    <ClInclude Include="Controller\WSAController.h" />
     <ClInclude Include="InstHelper.h" />
     <ClInclude Include="Task\Experiment\CombatRecordRecognitionTask.h" />
     <ClInclude Include="Task\Experiment\SingleStepBattleProcessTask.h" />
@@ -220,6 +221,7 @@
     <ClCompile Include="Controller\Platform\AdbLiteIO.cpp" />
     <ClCompile Include="Controller\Platform\PosixIO.cpp" />
     <ClCompile Include="Controller\Platform\Win32IO.cpp" />
+    <ClCompile Include="Controller\WSAController.cpp" />
     <ClCompile Include="InstHelper.cpp" />
     <ClCompile Include="Task\Experiment\CombatRecordRecognitionTask.cpp" />
     <ClCompile Include="Task\Experiment\SingleStepBattleProcessTask.cpp" />
@@ -472,7 +474,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>MaaDerpLearning.lib;opencv_world4.lib;zlib.lib;ws2_32.lib;onnxruntime.lib;cpr.lib;libcurl.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>MaaDerpLearning.lib;d3d11.lib;opencv_world4.lib;zlib.lib;ws2_32.lib;onnxruntime.lib;cpr.lib;libcurl.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <UACExecutionLevel>RequireAdministrator</UACExecutionLevel>
       <Profile>true</Profile>
       <AdditionalOptions>/ignore:4286 %(AdditionalOptions)</AdditionalOptions>
@@ -570,7 +572,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>MaaDerpLearning.lib;opencv_world4.lib;zlib.lib;ws2_32.lib;onnxruntime.lib;cpr.lib;libcurl.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>MaaDerpLearning.lib;d3d11.lib;opencv_world4.lib;zlib.lib;ws2_32.lib;onnxruntime.lib;cpr.lib;libcurl.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <UACExecutionLevel>RequireAdministrator</UACExecutionLevel>
       <Profile>true</Profile>
       <AdditionalOptions>/ignore:4286 %(AdditionalOptions)</AdditionalOptions>
@@ -624,7 +626,7 @@
       <OptimizeReferences>
       </OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>MaaDerpLearning.lib;opencv_world4d.lib;zlibd.lib;ws2_32.lib;onnxruntime.lib;cpr.lib;libcurl-d.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>MaaDerpLearning.lib;d3d11.lib;opencv_world4d.lib;zlibd.lib;ws2_32.lib;onnxruntime.lib;cpr.lib;libcurl-d.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <UACExecutionLevel>RequireAdministrator</UACExecutionLevel>
       <Profile>
       </Profile>

--- a/src/MaaCore/MaaCore.vcxproj.filters
+++ b/src/MaaCore/MaaCore.vcxproj.filters
@@ -618,6 +618,9 @@
     <ClInclude Include="Task\Roguelike\RoguelikeLastRewardTaskPlugin.h">
       <Filter>源文件\Task\Roguelike</Filter>
     </ClInclude>
+    <ClInclude Include="Controller\WSAController.h">
+      <Filter>源文件\Controller</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Vision\VisionHelper.cpp">
@@ -1018,6 +1021,9 @@
     </ClCompile>
     <ClCompile Include="Task\Roguelike\RoguelikeLastRewardTaskPlugin.cpp">
       <Filter>源文件\Task\Roguelike</Filter>
+    </ClCompile>
+    <ClCompile Include="Controller\WSAController.cpp">
+      <Filter>源文件\Controller</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/src/MaaCore/Task/Roguelike/RoguelikeBattleTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeBattleTaskPlugin.cpp
@@ -125,10 +125,15 @@ bool asst::RoguelikeBattleTaskPlugin::calc_stage_info()
         RegionOCRer name_analyzer(ctrler()->get_image());
         name_analyzer.set_task_info(stage_name_task_ptr);
         if (!name_analyzer.analyze()) {
+            // 电脑性能过高时会得到100张近似黑屏的图片
+            // 为了防止过快得消耗重试次数，同时不给其他非高性能电脑增加负担
+            // 计算图像的熵，如果小于0.5说明画面几乎没有任何信息，需要继续获取有用的画面
+            if (name_analyzer.get_image_entropy() < .5) i--;
             continue;
         }
         const std::string& text = name_analyzer.get_result().text;
         if (text.empty()) {
+            if (name_analyzer.get_image_entropy() < .5) i--;
             continue;
         }
 

--- a/src/MaaCore/Vision/VisionHelper.cpp
+++ b/src/MaaCore/Vision/VisionHelper.cpp
@@ -39,6 +39,26 @@ void VisionHelper::set_log_tracing(bool enable)
     m_log_tracing = enable;
 }
 
+double asst::VisionHelper::get_image_entropy()
+{
+    // < 5ms
+    cv::Mat grayed, hist;
+    cv::cvtColor(m_image, grayed, cv::COLOR_BGR2GRAY);
+    constexpr int channels[1] = { 0 };
+    constexpr int histSize[1] = { 256 };
+    constexpr float pranges[2] = { 0, 256 };
+    const float* ranges[1] = { pranges };
+    cv::calcHist(&grayed, 1, channels, cv::Mat(), hist, 1, histSize, ranges);
+    const double total = grayed.size().area();
+    hist /= total;
+    double entropy = 0;
+    const float* hist_data = hist.ptr<float>(0);
+    for (int i = 0; i < 256; i++)
+        if (hist_data[i] != 0)
+            entropy += -cv::log(hist_data[i]) * hist_data[i];
+    return entropy;
+}
+
 Rect VisionHelper::correct_rect(const Rect& rect, const cv::Mat& image)
 {
     if (image.empty()) {

--- a/src/MaaCore/Vision/VisionHelper.h
+++ b/src/MaaCore/Vision/VisionHelper.h
@@ -30,6 +30,8 @@ namespace asst
         virtual void set_roi(const Rect& roi);
         virtual void set_log_tracing(bool enable);
 
+        virtual double get_image_entropy();
+
         bool save_img(const std::filesystem::path& relative_dir = utils::path("debug"));
 
 #ifdef ASST_DEBUG

--- a/src/MaaWpfGui/Constants/ConfigurationKeys.cs
+++ b/src/MaaWpfGui/Constants/ConfigurationKeys.cs
@@ -62,6 +62,8 @@ namespace MaaWpfGui.Constants
         public const string KillAdbOnExit = "Connect.KillAdbOnExit";
         public const string TouchMode = "Connect.TouchMode";
         public const string AdbReplaced = "Connect.AdbReplaced";
+        public const string ResizeWindow = "Connect.ResizeWindow";
+        public const string GoldenBorder = "Connect.GoldenBorder";
 
         public const string ClientType = "Start.ClientType";
         public const string RunDirectly = "Start.RunDirectly";

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -296,6 +296,8 @@ namespace MaaWpfGui.Main
             this.AsstSetInstanceOption(InstanceOptionKey.TouchMode, Instances.SettingsViewModel.TouchMode);
             this.AsstSetInstanceOption(InstanceOptionKey.DeploymentWithPause, Instances.SettingsViewModel.DeploymentWithPause ? "1" : "0");
             this.AsstSetInstanceOption(InstanceOptionKey.AdbLiteEnabled, Instances.SettingsViewModel.AdbLiteEnabled ? "1" : "0");
+            this.AsstSetInstanceOption(InstanceOptionKey.GoldenBorder, Instances.SettingsViewModel.GoldenBorder ? "1" : "0");
+            this.AsstSetInstanceOption(InstanceOptionKey.ResizeWindow, Instances.SettingsViewModel.ResizeWindow ? "1" : "0");
             Execute.OnUIThread(async () =>
             {
                 if (Instances.SettingsViewModel.RunDirectly)
@@ -372,6 +374,7 @@ namespace MaaWpfGui.Main
             switch (msg)
             {
                 case AsstMsg.InternalError:
+                    ProcInternalError(details);
                     break;
 
                 case AsstMsg.InitFailed:
@@ -415,6 +418,22 @@ namespace MaaWpfGui.Main
 
         private string connectedAdb;
         private string connectedAddress;
+
+        private void ProcInternalError(JObject details)
+        {
+            var what = details["what"].ToString();
+            switch (what)
+            {
+                case "NotSupported":
+                    Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("FeatureNotSupported"), UiLogColor.Error);
+                    Instances.TaskQueueViewModel.SetNotSupported();
+                    break;
+                case "DeviceFailed":
+                    Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("CreateDeviceFailed"), UiLogColor.Error);
+                    Instances.TaskQueueViewModel.SetNotSupported();
+                    break;
+            }
+        }
 
         private void ProcConnectInfo(JObject details)
         {
@@ -1137,7 +1156,8 @@ namespace MaaWpfGui.Main
         /// <returns>是否成功。</returns>
         public bool AsstConnect(ref string error)
         {
-            if (Instances.SettingsViewModel.AutoDetectConnection)
+            if (Instances.SettingsViewModel.AutoDetectConnection &&
+                !Instances.SettingsViewModel.IsWSATouchMode())
             {
                 string bsHvAddress = Instances.SettingsViewModel.TryToSetBlueStacksHyperVAddress();
                 if (bsHvAddress != null)
@@ -1878,5 +1898,15 @@ namespace MaaWpfGui.Main
         /// Indicates whether the ADB server process should be killed when the instance is exited.
         /// </summary>
         KillAdbOnExit = 5,
+
+        /// <summary>
+        /// Indicates whether to give WSA window a golden border.
+        /// </summary>
+        GoldenBorder = 6,
+
+        /// <summary>
+        /// Indicates whether to resize WSA window to 1280x720.
+        /// </summary>
+        ResizeWindow = 7,
     }
 }

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -203,9 +203,13 @@
     <system:String x:Key="MiniTouchMode">Minitouch (Default)</system:String>
     <system:String x:Key="MaaTouchMode">MaaTouch (Experimental)</system:String>
     <system:String x:Key="AdbTouchMode">ADB Input (Deprecated)</system:String>
+    <system:String x:Key="WSATouchMode">WSATouch (Recommended for WSA)</system:String>
     <system:String x:Key="AdditionCommand">Additional command arguments</system:String>
     <system:String x:Key="StartsWithScript">Starts with Script</system:String>
     <system:String x:Key="EndsWithScript">Ends with Script</system:String>
+    <system:String x:Key="WGCWarn">Note: Using this mode will automatically show the WSA window</system:String>
+    <system:String x:Key="ResizeWindow">Set the WSA window to 1280x720</system:String>
+    <system:String x:Key="GoldenBorder">Gilded Edge</system:String>
     <system:String x:Key="RoguelikeTheme">I.S. Theme</system:String>
     <system:String x:Key="RoguelikeThemePhantom">Phantom</system:String>
     <system:String x:Key="RoguelikeThemeMizuki">Mizuki</system:String>
@@ -475,6 +479,8 @@ The video aspect ratio needs to be 16:9 without interference factors such as bla
     <system:String x:Key="FailedToReplaceAdbAndUseLocal">Falied to replace ADB file</system:String>
     <system:String x:Key="FailedToReplaceAdbAndUseLocalDesc">Temporarily connected using local ADB.</system:String>
     <system:String x:Key="InitializationError">Initialization error!</system:String>
+    <system:String x:Key="FeatureNotSupported">WSATouch requires windows version higher than build 1903</system:String>
+    <system:String x:Key="CreateDeviceFailed">Failed to create D3D device. Please check if your GPU supports Direct3D11</system:String>
     <system:String x:Key="ResolutionNotSupported">Emulator resolution not supported, please set a resolution of at least 1280x720 with a 16:9 aspect ratio</system:String>
     <system:String x:Key="ResolutionAcquisitionFailure">Failed to obtain emulator resolution. It is recommended to restart the emulator and ADB, or restart the computer, or consider switching to another emulator</system:String>
     <system:String x:Key="TryToReconnect">Emulator disconnected, trying to reconnect</system:String>

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -207,7 +207,7 @@
     <system:String x:Key="AdditionCommand">Additional command arguments</system:String>
     <system:String x:Key="StartsWithScript">Starts with Script</system:String>
     <system:String x:Key="EndsWithScript">Ends with Script</system:String>
-    <system:String x:Key="WGCWarn">Note: Using this mode will automatically show the WSA window</system:String>
+    <system:String x:Key="WGCWarn">Note: Using this mode will automatically show the WSA window, but if you find that WSA window is auto-fronted, please go to wsa settings->advanced settings->window focus and select "standalone".</system:String>
     <system:String x:Key="ResizeWindow">Set the WSA window to 1280x720</system:String>
     <system:String x:Key="GoldenBorder">Gilded Edge</system:String>
     <system:String x:Key="RoguelikeTheme">I.S. Theme</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -207,6 +207,7 @@
     <system:String x:Key="AdditionCommand">追加コマンド</system:String>
     <system:String x:Key="StartsWithScript">スクリプトを使用して始めます</system:String>
     <system:String x:Key="EndsWithScript">終了時にスクリプトを使用します</system:String>
+    <system:String x:Key="WGCWarn">注：このモードを使用すると、アークナイツ ウィンドウは自動的に最小化されません。ただし、WSAのウィンドウが自動的に前面に表示される場合は、WSAの設定->詳細設定->ウィンドウのフォーカスで、"スタンドアロン "オプションを選択してください。</system:String>
     <system:String x:Key="RoguelikeTheme">主題</system:String>
     <system:String x:Key="RoguelikeThemePhantom">ファントム</system:String>
     <system:String x:Key="RoguelikeThemeMizuki">ミヅキ</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -203,6 +203,7 @@
     <system:String x:Key="MiniTouchMode">Minitouch (標準)</system:String>
     <system:String x:Key="MaaTouchMode">MaaTouch (実験機能)</system:String>
     <system:String x:Key="AdbTouchMode">ADB Input (非推奨)</system:String>
+    <system:String x:Key="WSATouchMode">WSATouch (WSA専用)</system:String>
     <system:String x:Key="AdditionCommand">追加コマンド</system:String>
     <system:String x:Key="StartsWithScript">スクリプトを使用して始めます</system:String>
     <system:String x:Key="EndsWithScript">終了時にスクリプトを使用します</system:String>
@@ -473,6 +474,8 @@
     <system:String x:Key="FailedToReplaceAdbAndUseLocal">ADBファイルの置換に失敗しました</system:String>
     <system:String x:Key="FailedToReplaceAdbAndUseLocalDesc">一時的にローカルADBを使用して接続されました。</system:String>
     <system:String x:Key="InitializationError">初期化エラー！</system:String>
+    <system:String x:Key="FeatureNotSupported">WSATouchは、ビルド1903より高いWindowsバージョンを必要とします</system:String>
+    <system:String x:Key="CreateDeviceFailed">D3D11デバイスを作成できません。お使いのグラフィックスカードがDirect3D11をサポートしているか確認してください</system:String>
     <system:String x:Key="ResolutionNotSupported">エミュレータの解像度はサポートされていません。アスペクト比16: 9で、720p以上に設定してください</system:String>
     <system:String x:Key="ResolutionAcquisitionFailure">エミュレータの解像度を取得できませんでした。エミュレータとADBを再起動するか、コンピュータを再起動することをお勧めします、エミュレータを変更してから再試行することをお勧めします</system:String>
     <system:String x:Key="TryToReconnect">エミュレータが切断、再接続を行います</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -207,6 +207,7 @@
     <system:String x:Key="MiniTouchMode">Minitouch (기본값)</system:String>
     <system:String x:Key="MaaTouchMode">MaaTouch (실험적)</system:String>
     <system:String x:Key="AdbTouchMode">ADB Input (권장하지 않음)</system:String>
+    <system:String x:Key="WSATouchMode">WSATouch (WSA전용)</system:String>
     <system:String x:Key="AdditionCommand">추가 변수</system:String>
     <system:String x:Key="StartsWithScript">시작 시 추가 스크립트</system:String>
     <system:String x:Key="EndsWithScript">종료 시 추가 스크립트</system:String>
@@ -479,6 +480,8 @@ OF-1을 해금하지 않았다면 선택하지 말아 주세요.</system:String>
     <system:String x:Key="FailedToReplaceAdbAndUseLocal">ADB 교체 실패</system:String>
     <system:String x:Key="FailedToReplaceAdbAndUseLocalDesc">로컬 ADB 파일로 임시적으로 연결했습니다.</system:String>
     <system:String x:Key="InitializationError">초기화 오류!</system:String>
+    <system:String x:Key="FeatureNotSupported">WSATouch에는 빌드 1903 이상의 Windows 버전이 필요합니다.</system:String>
+    <system:String x:Key="CreateDeviceFailed">D3D 장치를 생성하지 못했습니다. 사용 중인 GPU가 Direct3D11을 지원하는지 확인하세요</system:String>
     <system:String x:Key="ResolutionNotSupported">에뮬레이터 해상도가 지원되지 않습니다. 16:9 비율로 설정하시고 해상도를 720p 이상으로 설정해주세요</system:String>
     <system:String x:Key="ResolutionAcquisitionFailure">에뮬레이터 해상도를 가져올 수 없습니다. 시뮬레이터와 ADB를 재시작하거나 컴퓨터를 재부팅하거나 시뮬레이터를 교체한 후 다시 시도하십시오</system:String>
     <system:String x:Key="TryToReconnect">에뮬레이터가 연결 해제되었습니다. 재연결을 시도합니다</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -207,9 +207,13 @@
     <system:String x:Key="MiniTouchMode">Minitouch（默认）</system:String>
     <system:String x:Key="MaaTouchMode">MaaTouch（实验功能）</system:String>
     <system:String x:Key="AdbTouchMode">ADB Input（不推荐使用）</system:String>
+    <system:String x:Key="WSATouchMode">WSATouch（WSA专用）</system:String>
     <system:String x:Key="AdditionCommand">附加命令</system:String>
     <system:String x:Key="StartsWithScript">开始前脚本</system:String>
     <system:String x:Key="EndsWithScript">结束后脚本</system:String>
+    <system:String x:Key="WGCWarn">注意：使用该模式会自动将WSA明日方舟窗口非最小化</system:String>
+    <system:String x:Key="ResizeWindow">设置WSA明日方舟窗口为最优分辨率（1280x720）</system:String>
+    <system:String x:Key="GoldenBorder">镶金边（字面意思）</system:String>
     <system:String x:Key="RoguelikeTheme">肉鸽主题</system:String>
     <system:String x:Key="RoguelikeThemePhantom">傀影</system:String>
     <system:String x:Key="RoguelikeThemeMizuki">水月</system:String>
@@ -479,6 +483,8 @@
     <system:String x:Key="FailedToReplaceAdbAndUseLocal">替换 ADB 失败</system:String>
     <system:String x:Key="FailedToReplaceAdbAndUseLocalDesc">已临时使用本地 ADB 进行连接。</system:String>
     <system:String x:Key="InitializationError">初始化错误！</system:String>
+    <system:String x:Key="FeatureNotSupported">Windows版本过低，使用WSACapture需要win10 build 1903以上的版本</system:String>
+    <system:String x:Key="CreateDeviceFailed">无法创建D3D11设备，请检查显卡是否支持Direct3D11</system:String>
     <system:String x:Key="ResolutionNotSupported">模拟器分辨率不支持，请设置为 720p 或更高，且为 16:9 比例</system:String>
     <system:String x:Key="ResolutionAcquisitionFailure">模拟器分辨率获取失败，建议重启模拟器与 ADB 或重启电脑，或更换模拟器后再次尝试</system:String>
     <system:String x:Key="TryToReconnect">模拟器断开，正在尝试重连</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -211,7 +211,7 @@
     <system:String x:Key="AdditionCommand">附加命令</system:String>
     <system:String x:Key="StartsWithScript">开始前脚本</system:String>
     <system:String x:Key="EndsWithScript">结束后脚本</system:String>
-    <system:String x:Key="WGCWarn">注意：使用该模式会自动将WSA明日方舟窗口非最小化</system:String>
+    <system:String x:Key="WGCWarn">注意：使用该模式会自动将WSA明日方舟窗口非最小化。但如果发现WSA窗口自动前置的现象，请前往wsa设置->高级设置->窗口焦点，选择“独立”选项。</system:String>
     <system:String x:Key="ResizeWindow">设置WSA明日方舟窗口为最优分辨率（1280x720）</system:String>
     <system:String x:Key="GoldenBorder">镶金边（字面意思）</system:String>
     <system:String x:Key="RoguelikeTheme">肉鸽主题</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -207,7 +207,7 @@
     <system:String x:Key="AdditionCommand">附加命令</system:String>
     <system:String x:Key="StartsWithScript">開始前腳本</system:String>
     <system:String x:Key="EndsWithScript">結束後腳本</system:String>
-    <system:String x:Key="WGCWarn">注意：使用該模式會自動將WSA明日方舟視窗非最小化</system:String>
+    <system:String x:Key="WGCWarn">注意：使用該模式會自動將WSA明日方舟視窗非最小化。但如果發現WSA視窗自動前置的現象，請前往wsa設定->高級設定->視窗焦點，選擇“獨立”選項。</system:String>
     <system:String x:Key="ResizeWindow">設定WSA明日方舟視窗為最優分辯率（1280x720）</system:String>
     <system:String x:Key="GoldenBorder">鑲金邊（字面意思）</system:String>
     <system:String x:Key="RoguelikeTheme">肉鴿主題</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -203,9 +203,13 @@
     <system:String x:Key="MiniTouchMode">Minitouch（預設）</system:String>
     <system:String x:Key="MaaTouchMode">MaaTouch（實驗功能）</system:String>
     <system:String x:Key="AdbTouchMode">ADB Input（不推薦使用）</system:String>
+    <system:String x:Key="WSATouchMode">WSATouch（WSA專用）</system:String>
     <system:String x:Key="AdditionCommand">附加命令</system:String>
     <system:String x:Key="StartsWithScript">開始前腳本</system:String>
     <system:String x:Key="EndsWithScript">結束後腳本</system:String>
+    <system:String x:Key="WGCWarn">注意：使用該模式會自動將WSA明日方舟視窗非最小化</system:String>
+    <system:String x:Key="ResizeWindow">設定WSA明日方舟視窗為最優分辯率（1280x720）</system:String>
+    <system:String x:Key="GoldenBorder">鑲金邊（字面意思）</system:String>
     <system:String x:Key="RoguelikeTheme">肉鴿主題</system:String>
     <system:String x:Key="RoguelikeThemePhantom">傀影</system:String>
     <system:String x:Key="RoguelikeThemeMizuki">水月</system:String>
@@ -474,6 +478,8 @@
     <system:String x:Key="FailedToReplaceAdbAndUseLocal">替換 ADB 失敗</system:String>
     <system:String x:Key="FailedToReplaceAdbAndUseLocalDesc">已臨時使用本地 ADB 進行連接。</system:String>
     <system:String x:Key="InitializationError">初始化錯誤！</system:String>
+    <system:String x:Key="FeatureNotSupported">Windows版本過低，使用WSACapture需要win10 build 1903以上的版本</system:String>
+    <system:String x:Key="CreateDeviceFailed">無法創建D3D11設備，請檢查顯卡是否支持Direct3D11</system:String>
     <system:String x:Key="ResolutionNotSupported">模擬器解析度不支持，請設定為 720p 或更高，且為 16:9 比例</system:String>
     <system:String x:Key="ResolutionAcquisitionFailure">模擬器解析度獲取失敗，建議重啟模擬器與 ADB 或重啟電腦，或更換模擬器後再次嘗試</system:String>
     <system:String x:Key="TryToReconnect">模擬器斷開，正在嘗試重連</system:String>

--- a/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
@@ -2455,6 +2455,7 @@ namespace MaaWpfGui.ViewModels.UI
             {
                 SetAndNotify(ref _resizeWindow, value);
                 ConfigurationHelper.SetValue(ConfigurationKeys.ResizeWindow, value.ToString());
+                UpdateInstanceSettings();
             }
         }
 
@@ -2467,6 +2468,7 @@ namespace MaaWpfGui.ViewModels.UI
             {
                 SetAndNotify(ref _goldenBorder, value);
                 ConfigurationHelper.SetValue(ConfigurationKeys.GoldenBorder, value.ToString());
+                UpdateInstanceSettings();
             }
         }
 

--- a/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
@@ -27,6 +27,7 @@ using System.Runtime.InteropServices.ComTypes;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Controls;
 using HandyControl.Controls;
 using HandyControl.Data;
 using MaaWpfGui.Constants;
@@ -232,6 +233,7 @@ namespace MaaWpfGui.ViewModels.UI
                 new CombinedData { Display = LocalizationHelper.GetString("MiniTouchMode"), Value = "minitouch" },
                 new CombinedData { Display = LocalizationHelper.GetString("MaaTouchMode"), Value = "maatouch" },
                 new CombinedData { Display = LocalizationHelper.GetString("AdbTouchMode"), Value = "adb" },
+                new CombinedData { Display = LocalizationHelper.GetString("WSATouchMode"), Value = "wsa" },
             };
 
             _dormThresholdLabel = LocalizationHelper.GetString("DormThreshold") + ": " + _dormThreshold + "%";
@@ -2444,6 +2446,30 @@ namespace MaaWpfGui.ViewModels.UI
             }
         }
 
+        private bool _resizeWindow = bool.Parse(ConfigurationHelper.GetValue(ConfigurationKeys.ResizeWindow, false.ToString()));
+
+        public bool ResizeWindow
+        {
+            get => _resizeWindow;
+            set
+            {
+                SetAndNotify(ref _resizeWindow, value);
+                ConfigurationHelper.SetValue(ConfigurationKeys.ResizeWindow, value.ToString());
+            }
+        }
+
+        private bool _goldenBorder = bool.Parse(ConfigurationHelper.GetValue(ConfigurationKeys.GoldenBorder, false.ToString()));
+
+        public bool GoldenBorder
+        {
+            get => _goldenBorder;
+            set
+            {
+                SetAndNotify(ref _goldenBorder, value);
+                ConfigurationHelper.SetValue(ConfigurationKeys.GoldenBorder, value.ToString());
+            }
+        }
+
         /// <summary>
         /// Gets the default addresses.
         /// </summary>
@@ -2656,6 +2682,10 @@ namespace MaaWpfGui.ViewModels.UI
         {
             return TouchMode == "adb";
         }
+        public bool IsWSATouchMode()
+        {
+            return TouchMode == "wsa";
+        }
 
         private string _touchMode = ConfigurationHelper.GetValue(ConfigurationKeys.TouchMode, "minitouch");
 
@@ -2676,6 +2706,8 @@ namespace MaaWpfGui.ViewModels.UI
             Instances.AsstProxy.AsstSetInstanceOption(InstanceOptionKey.DeploymentWithPause, DeploymentWithPause ? "1" : "0");
             Instances.AsstProxy.AsstSetInstanceOption(InstanceOptionKey.AdbLiteEnabled, AdbLiteEnabled ? "1" : "0");
             Instances.AsstProxy.AsstSetInstanceOption(InstanceOptionKey.KillAdbOnExit, KillAdbOnExit ? "1" : "0");
+            Instances.AsstProxy.AsstSetInstanceOption(InstanceOptionKey.GoldenBorder, GoldenBorder ? "1" : "0");
+            Instances.AsstProxy.AsstSetInstanceOption(InstanceOptionKey.ResizeWindow, ResizeWindow ? "1" : "0");
         }
 
         private static readonly string GoogleAdbDownloadUrl = "https://dl.google.com/android/repository/platform-tools-latest-windows.zip";

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -1866,6 +1866,20 @@ namespace MaaWpfGui.ViewModels.UI
         }
 
         /// <summary>
+        /// Gets a value indicating whether WGC feature is not supported.
+        /// </summary>
+        public bool NotSupported { get; private set; }
+
+        /// <summary>
+        /// Sets it initialized.
+        /// </summary>
+        public void SetNotSupported()
+        {
+            NotSupported = true;
+            NotifyOfPropertyChange(nameof(NotSupported));
+        }
+
+        /// <summary>
         /// Gets a value indicating whether it is initialized.
         /// </summary>
         public bool Inited { get; private set; }

--- a/src/MaaWpfGui/Views/UI/TaskQueueView.xaml
+++ b/src/MaaWpfGui/Views/UI/TaskQueueView.xaml
@@ -171,7 +171,7 @@
                     Margin="5"
                     Command="{s:Action LinkStart}"
                     Content="{DynamicResource LinkStart}"
-                    IsEnabled="{Binding Inited}"
+                    IsEnabled="{c:Binding Path='Inited and !NotSupported'}"
                     Visibility="{c:Binding Path='(Idle and !Stopping) or !Inited'}" />
                 <Button
                     Width="100"

--- a/src/MaaWpfGui/Views/UserControl/ConnectSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/ConnectSettingsUserControl.xaml
@@ -13,7 +13,7 @@
     xmlns:viewModels="clr-namespace:MaaWpfGui.ViewModels"
     xmlns:vm="clr-namespace:MaaWpfGui"
     d:DataContext="{d:DesignInstance {x:Type ui:SettingsViewModel}}"
-    d:DesignHeight="300"
+    d:DesignHeight="330"
     d:DesignWidth="550"
     mc:Ignorable="d">
     <Grid>
@@ -23,16 +23,17 @@
             <ColumnDefinition Width="150" />
         </Grid.ColumnDefinitions>
         <Grid.RowDefinitions>
+            <RowDefinition MaxHeight="{c:Binding '(TouchMode == &quot;wsa&quot;) ? 0 : 1024'}" />
+            <RowDefinition MaxHeight="{c:Binding '(TouchMode == &quot;wsa&quot;) ? 0 : 1024'}" />
+            <RowDefinition MaxHeight="{c:Binding '(TouchMode == &quot;wsa&quot;) ? 0 : 1024'}" />
+            <RowDefinition MaxHeight="{c:Binding '(TouchMode == &quot;wsa&quot;) ? 0 : 1024'}" />
+            <RowDefinition MaxHeight="{c:Binding '(TouchMode == &quot;wsa&quot;) ? 0 : 1024'}" />
             <RowDefinition />
-            <RowDefinition />
-            <RowDefinition />
-            <RowDefinition />
-            <RowDefinition />
-            <RowDefinition />
-            <RowDefinition />
-            <RowDefinition />
-            <RowDefinition />
-            <RowDefinition />
+            <RowDefinition MaxHeight="{c:Binding '(TouchMode == &quot;wsa&quot;) ? 0 : 1024'}" />
+            <RowDefinition MaxHeight="{c:Binding '(TouchMode == &quot;wsa&quot;) ? 0 : 1024'}" />
+            <RowDefinition MaxHeight="{c:Binding '(TouchMode == &quot;wsa&quot;) ? 0 : 1024'}" />
+            <RowDefinition MaxHeight="{c:Binding '(TouchMode == &quot;wsa&quot;) ? 0 : 1024'}" />
+            <RowDefinition MaxHeight="{c:Binding '(TouchMode == &quot;wsa&quot;) ? 1024 : 0'}" />
         </Grid.RowDefinitions>
         <StackPanel
             Grid.Row="0"
@@ -253,5 +254,25 @@
             Drop="EndsWithScript_Drop"
             PreviewDragOver="TextBox_PreviewDragOver"
             Text="{Binding EndsWithScript}" />
+        <WrapPanel
+	        Grid.Row="10"
+	        Grid.Column="0"
+	        Grid.ColumnSpan="3"
+	        HorizontalAlignment="Center"
+	        VerticalAlignment="Center" >
+            <controls:TextBlock
+				Margin="10"
+				TextWrapping="Wrap"
+				TextAlignment="Center"
+				Text="{DynamicResource WGCWarn}"/>
+            <CheckBox
+				Margin="20,10"
+				Content="{DynamicResource ResizeWindow}"
+				IsChecked="{Binding ResizeWindow}" />
+            <CheckBox
+				Margin="20,10"
+				Content="{DynamicResource GoldenBorder}"
+				IsChecked="{Binding GoldenBorder}" />
+        </WrapPanel>
     </Grid>
 </UserControl>


### PR DESCRIPTION
1、新增WSAController，增加其子类FrameBuffer和Toucher，增加static类VirtualMouse用于全程的鼠标兼容。
2、给RoguelikeFormationTask夹了preDelay，防止点击太快。
3、修改了ConnectSettingsUserControl，增加WSAController控制器，并给Grid的其他行增加MaxHeight属性绑定控制是否显示。
4、修改VisionHelper类，增加计算图片信息熵的get_entropy方法。
5、修改RoguelikeBattleTaskPlugin，使calc_stage_info函数在获取图片信息熵较小时不算在重试次数内。
6、增加WSAController的中文、英文本地化。
7、其他适配MAA的小修改。