### PR TITLE
fix: 修复在部分情况下，刷理智的当前理智识别结果丢失分隔符

### DIFF
--- a/src/MaaCore/Task/Fight/SanityBeforeStagePlugin.cpp
+++ b/src/MaaCore/Task/Fight/SanityBeforeStagePlugin.cpp
@@ -6,8 +6,7 @@
 #include "Controller/Controller.h"
 #include "Utils/ImageIo.hpp"
 #include "Utils/Logger.hpp"
-#include "Vision/OCRer.h"
-#include <Vision/RegionOCRer.h>
+#include "Vision/RegionOCRer.h"
 
 bool asst::SanityBeforeStagePlugin::verify(AsstMsg msg, const json::value& details) const
 {
@@ -50,15 +49,15 @@ void asst::SanityBeforeStagePlugin::get_sanity()
     }
     std::string text = analyzer.get_result().text;
 
-    Log.info(__FUNCTION__, "Current Sanity:" + text);
     if (!text.find('/') && text.length() > 2) {
-        if (text[text.length() - 3] == '1' && text[text.length() - 2] <= '3') {
+        if (text[text.length() - 3] == '1' && text[text.length() - 2] >= '0' && text[text.length() - 2] <= '3') {
             text = text.substr(0, text.length() - 3) + '/' + text.substr(text.length() - 3);
         }
         else {
             text = text.substr(0, text.length() - 2) + '/' + text.substr(text.length() - 2);
         }
     }
+    Log.info(__FUNCTION__, "Current Sanity:" + text);
 
     json::value sanity_info = basic_info_with_what("SanityBeforeStage");
     sanity_info["details"]["sanity"] = text;

--- a/src/MaaCore/Task/Fight/SanityBeforeStagePlugin.cpp
+++ b/src/MaaCore/Task/Fight/SanityBeforeStagePlugin.cpp
@@ -48,13 +48,14 @@ void asst::SanityBeforeStagePlugin::get_sanity()
         Log.info("__FUNCTION__", "Current Sanity analyze failed");
         return;
     }
-    auto text = analyzer.get_result().front().text;
+    auto result = analyzer.get_result();
+    auto text = std::string("");
+    for (auto it = result.begin(); it != result.end(); it++) {
+        text = text + it->text;
+    }
 
     Log.info("__FUNCTION__", "Current Sanity:" + text);
-    if (!text.find('/')) {
-        if (text.ends_with(' ')) {
-            text = text.substr(0, text.find_last_not_of(' ') + 1);
-        }
+    if (!text.find('/') && text.length() > 3) {
         if (text[text.length() - 3] == '1' && text[text.length() - 2] <= '3') {
             text = text.substr(0, text.length() - 3) + '/' + text.substr(text.length() - 3);
         }

--- a/src/MaaCore/Task/Fight/SanityBeforeStagePlugin.cpp
+++ b/src/MaaCore/Task/Fight/SanityBeforeStagePlugin.cpp
@@ -7,6 +7,7 @@
 #include "Utils/ImageIo.hpp"
 #include "Utils/Logger.hpp"
 #include "Vision/OCRer.h"
+#include <Vision/RegionOCRer.h>
 
 bool asst::SanityBeforeStagePlugin::verify(AsstMsg msg, const json::value& details) const
 {
@@ -40,22 +41,17 @@ void asst::SanityBeforeStagePlugin::get_sanity()
 {
     LogTraceFunction;
 
-    // 直接摘抄博朗台部分，DrGrandetTaskPlugin
-    OCRer analyzer(ctrler()->get_image());
+    RegionOCRer analyzer(ctrler()->get_image());
     analyzer.set_task_info("SanityMatch");
 
     if (!analyzer.analyze()) {
-        Log.info("__FUNCTION__", "Current Sanity analyze failed");
+        Log.info(__FUNCTION__, "Current Sanity analyze failed");
         return;
     }
-    auto result = analyzer.get_result();
-    auto text = std::string("");
-    for (auto it = result.begin(); it != result.end(); it++) {
-        text = text + it->text;
-    }
+    std::string text = analyzer.get_result().text;
 
-    Log.info("__FUNCTION__", "Current Sanity:" + text);
-    if (!text.find('/') && text.length() > 3) {
+    Log.info(__FUNCTION__, "Current Sanity:" + text);
+    if (!text.find('/') && text.length() > 2) {
         if (text[text.length() - 3] == '1' && text[text.length() - 2] <= '3') {
             text = text.substr(0, text.length() - 3) + '/' + text.substr(text.length() - 3);
         }


### PR DESCRIPTION
![C1WT`{R)Z2T$IP52%{P44A1](https://github.com/MaaAssistantArknights/MaaAssistantArknights/assets/102887808/5ed7bae3-b8f9-41fa-b3f0-5ba53eda630c)
