### PR TITLE
[JP] readme Update test / Japanese font readability

### DIFF
--- a/docs/ja-jp/readme.md
+++ b/docs/ja-jp/readme.md
@@ -1,4 +1,4 @@
-//Not Chinese Base font use Japanese(Better readability)
+<!-- 中華フォント優先のため、日本語フォント指定 / Not Chinese Base font use Japanese(Better readability) -->
 <font face="Helvetica Neue,Arial,Hiragino Kaku Gothic ProN,Hiragino Sans,Meiryo,sans-serif">
     
 <div align="center">

--- a/docs/ja-jp/readme.md
+++ b/docs/ja-jp/readme.md
@@ -1,3 +1,6 @@
+//Not Chinese Base font use Japanese(Better readability)
+<font face="Helvetica Neue,Arial,Hiragino Kaku Gothic ProN,Hiragino Sans,Meiryo,sans-serif">
+    
 <div align="center">
 
 <img alt="LOGO" src="https://cdn.jsdelivr.net/gh/MaaAssistantArknights/design@main/logo/maa-logo_512x512.png" width="256" height="256" />
@@ -182,3 +185,5 @@ MAAをより良くするために開発・テストに貢献してくれたす�
 開発者グループ：[QQグループ](https://jq.qq.com/?_wv=1027&k=JM9oCk3C)<br>
 
 ソフトウェアが役立つと思うなら、Star（ページの右上隅にある星）をクリックしてください。私たちにとって最高のサポートです！
+
+</font>


### PR DESCRIPTION
The current default font specified is a Chinese-based font, which is very difficult to read, so a Japanese-based font was mandatorily specified.

現在デフォルトで指定されているフォントが中国語ベースのフォントで非常に読みづらくなっているので、日本語ベースフォントを強制指定した。