### PR TITLE
fix: 修复因部分皮肤造成的关卡难度识别问题

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -7759,7 +7759,7 @@
             220
         ],
         "specialParams": [
-            500
+            100
         ],
         "specialParams_Doc": "red count threshold"
     },

--- a/src/MaaCore/Vision/Miscellaneous/StageDropsImageAnalyzer.cpp
+++ b/src/MaaCore/Vision/Miscellaneous/StageDropsImageAnalyzer.cpp
@@ -145,9 +145,9 @@ bool asst::StageDropsImageAnalyzer::analyze_difficulty()
     cv::cvtColor(image_roi, hsv, cv::COLOR_BGR2HSV);
 
     cv::Mat bin1;
-    cv::inRange(hsv, cv::Scalar(0, 150, 0), cv::Scalar(2, 255, 255), bin1);
+    cv::inRange(hsv, cv::Scalar(0, 150, 100), cv::Scalar(2, 255, 255), bin1);
     cv::Mat bin2;
-    cv::inRange(hsv, cv::Scalar(177, 150, 0), cv::Scalar(179, 255, 255), bin2);
+    cv::inRange(hsv, cv::Scalar(177, 150, 100), cv::Scalar(179, 255, 255), bin2);
     cv::Mat bin = bin1 + bin2;
     int count = cv::countNonZero(bin);
 


### PR DESCRIPTION
fix #5837 #6306 
已知出问题的老鲤皮、纯艾精二皮都是暗红色的背景，把明度阈值提高点就完事了
Refer to https://github.com/MaaAssistantArknights/MaaAssistantArknights/pull/6308#issuecomment-1713173208

测测？