### PR TITLE
fix: 将基建换班编组匹配的可用干员缓存移动至Status，以免多实例时发生冲突

### DIFF
--- a/src/MaaCore/Status.h
+++ b/src/MaaCore/Status.h
@@ -37,6 +37,8 @@ namespace asst
         Status& operator=(Status&& rhs) noexcept = delete;
 
     public:
+        static inline const std::string InfrastAvailableOpersForGroup = "InfrastAvailableOpersForGroup";
+
         static inline const std::string RoguelikeCharElitePrefix = "RoguelikeElite-";
         static inline const std::string RoguelikeCharLevelPrefix = "RoguelikeLevel-";
         static inline const std::string RoguelikeCharRarityPrefix = "RoguelikeRarity-";

--- a/src/MaaCore/Task/Infrast/InfrastAbstractTask.h
+++ b/src/MaaCore/Task/Infrast/InfrastAbstractTask.h
@@ -20,8 +20,6 @@ namespace asst
 
         void set_custom_config(infrast::CustomFacilityConfig config) noexcept;
         void clear_custom_config() noexcept;
-        // 清空编组匹配用的可用干员列表
-        static void clear_opers_for_group();
 
         static constexpr int OperSelectRetryTimes = 3;
         static constexpr int TaskRetryTimes = 3;
@@ -45,6 +43,10 @@ namespace asst
         infrast::CustomRoomConfig& current_room_config();
         // 将定义的干员编组解释为具体干员，每次基建换班任务的第一次调用时缓存可用干员列表
         bool match_operator_groups();
+        // 编组匹配用的可用干员列表，每次基建换班任务清空
+        std::set<std::string> get_available_oper_for_group();
+        void set_available_oper_for_group(std::set<std::string> opers);
+
         bool swipe_and_select_custom_opers(bool is_dorm_order = false);
         bool select_custom_opers(std::vector<std::string>& partial_result);
         // 扫描当前页满足心情条件的所有干员名
@@ -75,7 +77,5 @@ namespace asst
         int m_cur_facility_index = 0;
         bool m_is_custom = false;
         infrast::CustomFacilityConfig m_custom_config;
-        // 编组匹配用的可用干员列表，每次基建换班前清空。按照第一次调用match_operator_groups()时设置的心情阈值进行缓存
-        inline static std::set<std::string> m_opers_for_groups;
     };
 } // namespace asst

--- a/src/MaaCore/Task/Interface/InfrastTask.cpp
+++ b/src/MaaCore/Task/Interface/InfrastTask.cpp
@@ -29,7 +29,6 @@ asst::InfrastTask::InfrastTask(const AsstCallback& callback, Assistant* inst)
       m_dorm_task_ptr(std::make_shared<InfrastDormTask>(callback, inst, TaskType))
 {
     LogTraceFunction;
-    clear_opers_for_group();
 
     m_infrast_begin_task_ptr->set_tasks({ "InfrastBegin" }).set_ignore_error(true);
     m_replenish_task_ptr = m_mfg_task_ptr->register_plugin<ReplenishOriginiumShardTaskPlugin>();


### PR DESCRIPTION
修复#6376