### PR TITLE
fix: 修复水月肉鸽卡在藏品

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -10539,7 +10539,16 @@
             "Mizuki@Roguelike@ChooseOperFlag"
         ]
     },
-    "Mizuki@Roguelike@CloseEvent": {},
+    "Mizuki@Roguelike@CloseEvent": {
+        "action": "ClickRect",
+        "specificRect": [
+            619,
+            615,
+            41,
+            17
+        ],
+        "postDelay": 1000
+    },
     "Mizuki@Roguelike@CommissionedMissionCompleted": {
         "action": "ClickRect",
         "specificRect": [


### PR DESCRIPTION
当藏品超过5个时，点击Mizuki@Roguelike@CloseEvent会有概率点到藏品导致展开藏品界面并卡主
fix #5892 
fix #6148 
fix #6090 
fix #5530 
fix #6452 
fix #6366 
fix #5831 
fix #5709 
fix #5041 
fix #4759 
fix #4499 
fix #4175







