### PR TITLE
fix: 修复理智预测时间格式

### DIFF
--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -646,7 +646,7 @@ namespace MaaWpfGui.Main
                             .Replace("{Preset}", configurationPreset);
                         if (isSanityForecastSucc)
                         {
-                            sanityReport = sanityReport.Replace("{DateTime}", reportTime.ToString("yyyy-MM-dd HH:mm")).Replace("{TimeDiff}", timeDiff.ToString(@"h\ \h\ m\ \m"));
+                            sanityReport = sanityReport.Replace("{DateTime}", reportTime.ToString("yyyy-MM-dd HH:mm")).Replace("{TimeDiff}", timeDiff.ToString(@"h\h\ m\m"));
 
                             Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("AllTasksComplete") + Environment.NewLine + sanityReport);
                             ExternalNotificationService.Send(allTaskCompleteTitle, allTaskCompleteMessage + Environment.NewLine + sanityReport);

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -646,7 +646,7 @@ namespace MaaWpfGui.Main
                             .Replace("{Preset}", configurationPreset);
                         if (isSanityForecastSucc)
                         {
-                            sanityReport = sanityReport.Replace("{DateTime}", reportTime.ToString("T")).Replace("{TimeDiffH}", timeDiff.Hours.ToString()).Replace("{TimeDiffM}", timeDiff.Minutes.ToString());
+                            sanityReport = sanityReport.Replace("{DateTime}", reportTime.ToString("yyyy-MM-dd HH:mm")).Replace("{TimeDiff}", timeDiff.ToString(@"h\ \h\ m\ \m"));
 
                             Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("AllTasksComplete") + Environment.NewLine + sanityReport);
                             ExternalNotificationService.Send(allTaskCompleteTitle, allTaskCompleteMessage + Environment.NewLine + sanityReport);

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -544,7 +544,7 @@ The video aspect ratio needs to be 16:9 without interference factors such as bla
     <system:String x:Key="StartCombat" xml:space="preserve">Start combat: </system:String>
     <system:String x:Key="CompleteCombat">Complete combat</system:String>
     <system:String x:Key="AllTasksComplete">All task(s) completed!</system:String>
-    <system:String x:Key="SanityReport">Sanity will be full at {DateTime} ({TimeDiffH} hours {TimeDiffM} minutes later).</system:String>
+    <system:String x:Key="SanityReport">Sanity will be full at {DateTime}.({TimeDiff} later)</system:String>
     <system:String x:Key="AllTaskCompleteContent">MAA has completed all tasks under the {Preset} configuration in {DateTime}.</system:String>
     <system:String x:Key="BackgroundLinkStarted">Tasks started</system:String>
     <system:String x:Key="BackgroundLinkStopped">Tasks stopped</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -544,7 +544,7 @@ Bilibili: ログイン インターフェイスに表示されるアカウント
     <system:String x:Key="StartCombat" xml:space="preserve">戦闘開始: </system:String>
     <system:String x:Key="CompleteCombat">戦闘完了</system:String>
     <system:String x:Key="AllTasksComplete">すべてのタスクが完了しました！</system:String>
-    <system:String x:Key="SanityReport">理性は {DateTime} に満杯になります ({TimeDiffH}時間{TimeDiffM}分後)。</system:String>
+    <system:String x:Key="SanityReport">理性は {DateTime} に満杯になります。({TimeDiff} 後)</system:String>
     <system:String x:Key="AllTaskCompleteContent">MAA は、{DateTime} の {Preset} 構成の下にあるすべてのプリセット タスクを完了しました。</system:String>
     <system:String x:Key="BackgroundLinkStarted">Tasks started</system:String>
     <system:String x:Key="BackgroundLinkStopped">Tasks stopped</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -544,7 +544,7 @@ Bilibili: 로그인 인터페이스에 표시되는 계정 이름(예: Zhang San
     <system:String x:Key="StartCombat" xml:space="preserve">작전 시작: </system:String>
     <system:String x:Key="CompleteCombat">작전 완료</system:String>
     <system:String x:Key="AllTasksComplete">모든 작업이 완료되었습니다!</system:String>
-    <system:String x:Key="SanityReport">{DateTime}({TimeDiffH}시간 {TimeDiffM}분 후이후)에 정신 상태가 가득 차게 됩니다.</system:String>
+    <system:String x:Key="SanityReport">{DateTime}에 정신 상태가 가득 차게 됩니다.({TimeDiff} 이후)</system:String>
     <system:String x:Key="AllTaskCompleteContent">MAA는 {DateTime}의 {Preset} 구성에서 모든 사전 설정 작업을 완료했습니다.</system:String>
     <system:String x:Key="BackgroundLinkStarted">작업 시작됨</system:String>
     <system:String x:Key="BackgroundLinkStopped">작업 중지됨</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -544,7 +544,7 @@
     <system:String x:Key="StartCombat" xml:space="preserve">开始战斗: </system:String>
     <system:String x:Key="CompleteCombat">完成战斗</system:String>
     <system:String x:Key="AllTasksComplete">任务已全部完成！</system:String>
-    <system:String x:Key="SanityReport">理智将在 {DateTime} ({TimeDiffH}时{TimeDiffM}分后) 回满。</system:String>
+    <system:String x:Key="SanityReport">理智将在 {DateTime} 回满。({TimeDiff} 后)</system:String>
     <system:String x:Key="AllTaskCompleteContent">MAA 已在 {DateTime} 完成了 {Preset} 配置下所有预设的任务。</system:String>
     <system:String x:Key="BackgroundLinkStarted">开始执行任务</system:String>
     <system:String x:Key="BackgroundLinkStopped">任务终止</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -544,7 +544,7 @@
     <system:String x:Key="StartCombat" xml:space="preserve">開始戰鬥: </system:String>
     <system:String x:Key="CompleteCombat">完成戰鬥</system:String>
     <system:String x:Key="AllTasksComplete">任務已全部完成！</system:String>
-    <system:String x:Key="SanityReport">理智會在 {DateTime} ({TimeDiffH}时{TimeDiffM}分後) 回滿。</system:String>
+    <system:String x:Key="SanityReport">理智會在 {DateTime}回滿。({TimeDiff} 後)</system:String>
     <system:String x:Key="AllTaskCompleteContent">MAA 已在 {DateTime} 完成了 {Preset} 配置下所有預設的任務。</system:String>
     <system:String x:Key="BackgroundLinkStarted">開始執行任務</system:String>
     <system:String x:Key="BackgroundLinkStopped">任務終止</system:String>


### PR DESCRIPTION
修了一下格式问题（日期丢失，导致难以判断第一个时间是具体时间）
设计格式：
![image](https://github.com/MaaAssistantArknights/MaaAssistantArknights/assets/102887808/1ab78272-4257-4d50-9ac9-ae8f63468860)
当前格式：
![image](https://github.com/MaaAssistantArknights/MaaAssistantArknights/assets/102887808/b94e10c3-6af3-45dd-b1ab-90fba71eb428)

顺带修改了一下时间间隔的格式

- close #6506