### PR TITLE
perf: tasks.json 大修改

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -5321,8 +5321,8 @@
         "action": "DoNothing",
         "next": [
             "Infrast",
-            "InfrastEnteredFlag",
             "InfrastNotification",
+            "InfrastEnteredFlag",
             "Infrast@ReturnButtons#next",
             "Infrast@CloseAnnos#next",
             "Infrast@OfflineConfirm"
@@ -5337,45 +5337,27 @@
     "Infrast@BlackReturn": {
         "template": "Return.png",
         "next": [
-            "Infrast",
-            "InfrastNotification",
-            "InfrastEnteredFlag",
-            "Infrast@(BlackReturn#next)",
-            "Infrast@OfflineConfirm"
+            "InfrastBegin#next",
+            "Infrast@(BlackReturn#next)"
         ]
     },
     "Infrast@ReturnConfirm": {
         "template": "PopupConfirm.png",
         "next": [
-            "Infrast",
-            "InfrastNotification",
-            "InfrastEnteredFlag",
-            "Infrast@ReturnButtons#next",
-            "Infrast@CloseAnnos#next",
-            "Infrast@ReturnConfirm",
-            "Infrast@OfflineConfirm"
+            "InfrastBegin#next",
+            "Infrast@ReturnConfirm"
         ]
     },
     "Infrast@CloseAnno": {
         "template": "CloseAnno.png",
         "next": [
-            "Infrast",
-            "InfrastNotification",
-            "InfrastEnteredFlag",
-            "Infrast@ReturnButtons#next",
-            "Infrast@CloseAnnos#next",
-            "Infrast@OfflineConfirm"
+            "InfrastBegin#next"
         ]
     },
     "Infrast@CloseAnnoTexas": {
         "template": "CloseAnnoTexas.png",
         "next": [
-            "Infrast",
-            "InfrastNotification",
-            "InfrastEnteredFlag",
-            "Infrast@ReturnButtons#next",
-            "Infrast@CloseAnnos#next",
-            "Infrast@OfflineConfirm"
+            "InfrastBegin#next"
         ]
     },
     "Return": {

--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -565,7 +565,7 @@
             "FullStageNavigation"
         ],
         "exceededNext": [
-            "Home@ReturnTo"
+            "Home@ReturnButtons#next"
         ],
         "maxTimes": 20
     },
@@ -2944,7 +2944,7 @@
             "LoginOther#next",
             "SwitchAccount@StartUpThemes#next",
             "SwitchAccount@LoadingIcon",
-            "SwitchAccount@ReturnTo",
+            "SwitchAccount@ReturnButtons#next",
             "Settings"
         ]
     },
@@ -3204,7 +3204,6 @@
             "StartUpConnectingFlag",
             "#back",
             "CloseAnnos#next",
-            "TodaysSupplies",
             "OfflineConfirm"
         ]
     },
@@ -3214,10 +3213,8 @@
         "next": [
             "StartUp@StartUpThemes#next",
             "StartUpBegin@LoadingIcon",
-            "StartUp@ReturnTo",
-            "StartUp@EndOfAction",
-            "StartUp@FromStageSN",
-            "StartUp@Return-White"
+            "StartUp@ReturnButtons#next",
+            "StartUp@EndOfAction"
         ]
     },
     "GameStart": {
@@ -3316,7 +3313,7 @@
         "next": [
             "StartUp",
             "StartUp@LoadingText",
-            "CloseAnnos#next"
+            "StartUp@CloseAnnos#next"
         ]
     },
     "CloseAnnos": {
@@ -3421,9 +3418,18 @@
             "#back"
         ]
     },
-    "Return-White": {
+    "ReturnButtons": {
+        "algorithm": "JustReturn",
+        "next": [
+            "BlackReturn",
+            "WhiteReturn",
+            "FromStageSN"
+        ]
+    },
+    "WhiteReturn": {
+        "template": "Return-White.png",
         "templThreshold": 0.8,
-        "baseTask": "ReturnTo",
+        "baseTask": "BlackReturn",
         "roi": [
             0,
             0,
@@ -3431,7 +3437,7 @@
             150
         ]
     },
-    "ReturnTo": {
+    "BlackReturn": {
         "template": "Return.png",
         "templThreshold": 0.7,
         "action": "ClickSelf",
@@ -3444,16 +3450,34 @@
         ],
         "next": [
             "#back",
-            "ReturnTo",
-            "ReturnToConfirm",
-            "ReturnTo@LoadingIcon",
-            "CloseAnnos#next",
-            "FromStageSN",
-            "TodaysSupplies",
-            "Return-White"
+            "ReturnButtons#next",
+            "ReturnConfirm",
+            "ReturnButtons@LoadingIcon",
+            "ReturnButtons@LoadingText",
+            "CloseAnnos#next"
         ]
     },
-    "ReturnToConfirm": {
+    "FromStageSN": {
+        "template": "StageSNReturnFlag.png",
+        "action": "ClickRect",
+        "cache": false,
+        "roi": [
+            284,
+            509,
+            242,
+            141
+        ],
+        "specificRect": [
+            20,
+            20,
+            135,
+            35
+        ],
+        "next": [
+            "BlackReturn"
+        ]
+    },
+    "ReturnConfirm": {
         "template": "PopupConfirm.png",
         "action": "ClickSelf",
         "roi": [
@@ -3463,13 +3487,11 @@
             160
         ],
         "next": [
-            "ReturnTo",
+            "ReturnButtons#next",
             "#back",
-            "ReturnToConfirm@LoadingIcon",
+            "ReturnConfirm@LoadingIcon",
             "CloseAnnos#next",
-            "FromStageSN",
-            "TodaysSupplies",
-            "ReturnToConfirm"
+            "ReturnConfirm"
         ]
     },
     "OfflineConfirm": {
@@ -3502,38 +3524,15 @@
         "next": [
             "CloseAnnos#next",
             "OfflineConfirmImpl",
-            "StartUpThemes#next",
-            "TodaysSupplies"
+            "StartUpThemes#next"
         ]
     },
     "StartUp@ClickCorner": {
         "next": [
-            "StartUp@ReturnTo",
+            "StartUp@ReturnButtons#next",
             "StartUp",
             "StartUp@CloseAnnos#next",
-            "StartUp@FromStageSN",
-            "StartUp@TodaysSupplies",
             "StartUp@OfflineConfirm"
-        ]
-    },
-    "FromStageSN": {
-        "template": "StageSNReturnFlag.png",
-        "action": "ClickRect",
-        "cache": false,
-        "roi": [
-            284,
-            509,
-            242,
-            141
-        ],
-        "specificRect": [
-            20,
-            20,
-            135,
-            35
-        ],
-        "next": [
-            "ReturnTo"
         ]
     },
     "Annihilation": {
@@ -3557,11 +3556,9 @@
         "algorithm": "JustReturn",
         "action": "DoNothing",
         "next": [
-            "Fight@ReturnTo",
+            "Fight@ReturnButtons#next",
             "Fight",
-            "Fight@CloseAnnos#next",
-            "Fight@FromStageSN",
-            "Fight@TodaysSupplies"
+            "Fight@CloseAnnos#next"
         ]
     },
     "FightBegin": {
@@ -3585,11 +3582,9 @@
             "Fight@StartButton1",
             "Fight@UsePrts",
             "Fight@UsePrts-StageSN",
-            "Fight@ReturnTo",
+            "Fight@ReturnButtons#next",
             "Fight",
             "Fight@CloseAnnos#next",
-            "Fight@FromStageSN",
-            "Fight@TodaysSupplies",
             "Fight@PRTS#next",
             "Fight@EndOfAction"
         ]
@@ -4291,8 +4286,7 @@
         "next": [
             "StartUpThemes#next",
             "RestartGameAndContinue@LoadingIcon",
-            "ReturnTo",
-            "FromStageSN"
+            "ReturnButtons#next"
         ]
     },
     "Fight": {
@@ -4313,7 +4307,6 @@
             "Fight@GoLastBattle",
             "Fight",
             "Fight@CloseAnnos#next",
-            "Fight@TodaysSupplies",
             "Stop"
         ],
         "postDelay": 3000
@@ -4344,10 +4337,8 @@
         "next": [
             "RecruitFlag",
             "Recruit",
-            "Recruit@ReturnTo",
+            "Recruit@ReturnButtons#next",
             "Recruit@CloseAnnos#next",
-            "Recruit@FromStageSN",
-            "Recruit@TodaysSupplies",
             "Recruit@OfflineConfirm"
         ]
     },
@@ -4680,14 +4671,12 @@
         "algorithm": "JustReturn",
         "action": "DoNothing",
         "next": [
-            "Award@ReturnTo",
+            "Award@ReturnButtons#next",
             "Award",
             "ReceiveAward",
             "DailyTask",
             "WeeklyTask",
-            "Award@CloseAnnos#next",
-            "Award@FromStageSN",
-            "Award@TodaysSupplies"
+            "Award@CloseAnnos#next"
         ]
     },
     "Award": {
@@ -4705,8 +4694,7 @@
             "DailyTask",
             "WeeklyTask",
             "Award",
-            "Award@CloseAnnos#next",
-            "Award@TodaysSupplies"
+            "Award@CloseAnnos#next"
         ]
     },
     "ReceiveAward": {
@@ -4797,7 +4785,7 @@
         "algorithm": "JustReturn",
         "action": "DoNothing",
         "next": [
-            "MailReturnToHome@ReturnTo",
+            "MailReturnToHome@ReturnButtons#next",
             "MailReturnToHome",
             "ReceiveMail"
         ]
@@ -4863,7 +4851,7 @@
     "CloseTaskMailDouble": {
         "baseTask": "CloseTaskAwardDouble",
         "next": [
-            "Return-White",
+            "WhiteReturn",
             "CloseTaskMailDouble"
         ]
     },
@@ -4876,10 +4864,8 @@
             "StartToVisit",
             "VisitNext",
             "VisitNextBlack",
-            "Visit@ReturnTo",
-            "Visit@CloseAnnos#next",
-            "Visit@FromStageSN",
-            "Visit@TodaysSupplies"
+            "Visit@ReturnButtons#next",
+            "Visit@CloseAnnos#next"
         ]
     },
     "Visit": {
@@ -4895,8 +4881,7 @@
         "next": [
             "FriendsList",
             "Visit",
-            "Visit@CloseAnnos#next",
-            "Visit@TodaysSupplies"
+            "Visit@CloseAnnos#next"
         ]
     },
     "FriendsList": {
@@ -4925,7 +4910,7 @@
         ],
         "action": "DoNothing",
         "next": [
-            "Home@ReturnTo"
+            "Home@ReturnButtons#next"
         ]
     },
     "StartToVisit": {
@@ -4984,11 +4969,9 @@
         "algorithm": "JustReturn",
         "action": "DoNothing",
         "next": [
-            "Mall@ReturnTo",
+            "Mall@ReturnButtons#next",
             "Mall",
-            "Mall@CloseAnnos#next",
-            "Mall@FromStageSN",
-            "Mall@TodaysSupplies"
+            "Mall@CloseAnnos#next"
         ]
     },
     "Mall": {
@@ -5007,8 +4990,7 @@
         "next": [
             "CreditStoreOcr",
             "Mall",
-            "Mall@CloseAnnos#next",
-            "Mall@TodaysSupplies"
+            "Mall@CloseAnnos#next"
         ]
     },
     "CreditStoreOcr": {
@@ -5098,7 +5080,7 @@
             140
         ],
         "next": [
-            "Home@ReturnTo"
+            "Home@ReturnButtons#next"
         ]
     },
     "VisitNextBlack": {
@@ -5110,7 +5092,7 @@
             130
         ],
         "next": [
-            "Home@ReturnTo"
+            "Home@ReturnButtons#next"
         ]
     },
     "Home": {
@@ -5341,38 +5323,36 @@
             "Infrast",
             "InfrastEnteredFlag",
             "InfrastNotification",
-            "Infrast@ReturnTo",
+            "Infrast@ReturnButtons#next",
             "Infrast@CloseAnnos#next",
-            "Infrast@FromStageSN",
-            "Infrast@TodaysSupplies",
             "Infrast@OfflineConfirm"
         ]
     },
-    "Infrast@ReturnTo": {
+    "Infrast@WhiteReturn": {
+        "template": "Return-White.png",
+        "next": [
+            "Infrast@BlackReturn#next"
+        ]
+    },
+    "Infrast@BlackReturn": {
         "template": "Return.png",
         "next": [
             "Infrast",
             "InfrastNotification",
             "InfrastEnteredFlag",
-            "Infrast@ReturnTo",
-            "Infrast@ReturnToConfirm",
-            "Infrast@CloseAnnos#next",
-            "Infrast@FromStageSN",
-            "Infrast@TodaysSupplies",
+            "Infrast@(BlackReturn#next)",
             "Infrast@OfflineConfirm"
         ]
     },
-    "Infrast@ReturnToConfirm": {
+    "Infrast@ReturnConfirm": {
         "template": "PopupConfirm.png",
         "next": [
             "Infrast",
             "InfrastNotification",
             "InfrastEnteredFlag",
-            "Infrast@ReturnTo",
+            "Infrast@ReturnButtons#next",
             "Infrast@CloseAnnos#next",
-            "Infrast@FromStageSN",
-            "Infrast@TodaysSupplies",
-            "Infrast@ReturnToConfirm",
+            "Infrast@ReturnConfirm",
             "Infrast@OfflineConfirm"
         ]
     },
@@ -5382,10 +5362,8 @@
             "Infrast",
             "InfrastNotification",
             "InfrastEnteredFlag",
-            "Infrast@ReturnTo",
+            "Infrast@ReturnButtons#next",
             "Infrast@CloseAnnos#next",
-            "Infrast@FromStageSN",
-            "Infrast@TodaysSupplies",
             "Infrast@OfflineConfirm"
         ]
     },
@@ -5395,10 +5373,8 @@
             "Infrast",
             "InfrastNotification",
             "InfrastEnteredFlag",
-            "Infrast@ReturnTo",
+            "Infrast@ReturnButtons#next",
             "Infrast@CloseAnnos#next",
-            "Infrast@FromStageSN",
-            "Infrast@TodaysSupplies",
             "Infrast@OfflineConfirm"
         ]
     },
@@ -5427,7 +5403,6 @@
             "InfrastEnteredFlag",
             "Infrast",
             "Infrast@CloseAnnos#next",
-            "Infrast@TodaysSupplies",
             "Infrast@OfflineConfirm"
         ],
         "postDelay": 5000
@@ -8286,7 +8261,7 @@
             "DepotMaterialTab",
             "DepotAllTab",
             "DepotMaterialTabClicked",
-            "DepotEnter@ReturnTo"
+            "DepotEnter@ReturnButtons#next"
         ]
     },
     "DepotEnter": {
@@ -8434,10 +8409,9 @@
             "Roguelike@Abandon",
             "Roguelike@TodoEnter",
             "Roguelike@Continue",
-            "Roguelike@ReturnTo",
-            "Roguelike@ReturnToConfirm",
-            "Roguelike@StartUpThemes#next",
-            "Roguelike@FromStageSN"
+            "Roguelike@ReturnButtons#next",
+            "Roguelike@ReturnConfirm",
+            "Roguelike@StartUpThemes#next"
         ]
     },
     "Roguelike@ChooseDifficulty": {
@@ -8551,8 +8525,8 @@
             "Roguelike@GamePass",
             "Roguelike@TodoEnter",
             "Roguelike@Continue",
-            "Roguelike@ReturnTo",
-            "Roguelike@ReturnToConfirm",
+            "Roguelike@ReturnButtons#next",
+            "Roguelike@ReturnConfirm",
             "Roguelike@StartUpThemes#next",
             "Roguelike@ClickToStartPoint"
         ]
@@ -9346,18 +9320,20 @@
             60
         ]
     },
-    "Roguelike@ReturnTo": {
+    "Roguelike@WhiteReturn": {
+        "template": "Return-White.png",
+        "next": [
+            "Roguelike@BlackReturn#next"
+        ]
+    },
+    "Roguelike@BlackReturn": {
         "template": "Return.png",
         "next": [
             "Roguelike@ChooseDifficulty",
             "Roguelike@StartExplore",
             "Roguelike@ExitThenAbandon",
             "Roguelike@Abandon",
-            "Roguelike",
-            "Roguelike@ReturnTo",
-            "Roguelike@ReturnToConfirm",
-            "Roguelike@CloseAnnos#next",
-            "Roguelike@FromStageSN"
+            "Roguelike@(BlackReturn#next)"
         ]
     },
     "Roguelike@RolesConfirm": {
@@ -10615,7 +10591,7 @@
             "Mizuki@Roguelike@CloseCollectionClose",
             "Mizuki@Roguelike@ChooseOperConfirm",
             "Mizuki@Roguelike@RecruitSkip",
-            "Mizuki@Roguelike@ReturnTo"
+            "Mizuki@Roguelike@ReturnButtons#next"
         ]
     },
     "Mizuki@Roguelike@CloseCollection": {
@@ -11204,7 +11180,7 @@
             "Sami@Roguelike@CloseCollectionClose",
             "Sami@Roguelike@ChooseOperConfirm",
             "Sami@Roguelike@RecruitSkip",
-            "Sami@Roguelike@ReturnTo"
+            "Sami@Roguelike@ReturnButtons#next"
         ]
     },
     "Sami@Roguelike@CloseCollection": {
@@ -12511,7 +12487,7 @@
             "OperBoxEnter",
             "OperBoxRoleTabSelect",
             "OperBoxRoleTab",
-            "OperBoxEnter@ReturnTo"
+            "OperBoxEnter@ReturnButtons#next"
         ]
     },
     "OperBoxEnter": {
@@ -13404,20 +13380,16 @@
             160
         ]
     },
-    "Reclamation@PopupConfirm": {
+    "Reclamation@ReturnConfirm": {
         "Doc": "base_task",
         "template": "PopupConfirm.png",
         "templThreshold": 0.7,
-        "action": "ClickSelf",
-        "roi": [
-            630,
-            400,
-            650,
-            160
-        ],
         "next": [
-            "Reclamation@ReturnTo#next",
-            "Reclamation@ReturnToConfirm#next"
+            "Reclamation",
+            "Reclamation@ReturnButtons#next",
+            "Reclamation@ReturnConfirm",
+            "Reclamation@ReturnConfirm@LoadingIcon",
+            "Reclamation@ReturnConfirm@LoadingText"
         ]
     },
     "Reclamation@AtMapFlag": {
@@ -13498,10 +13470,16 @@
         "templThreshold": 0.7,
         "action": "ClickSelf",
         "next": [
-            "Reclamation@ReturnTo#next"
+            "Reclamation@BlackReturn#next"
         ]
     },
-    "Reclamation@ReturnTo": {
+    "Reclamation@WhiteReturn": {
+        "template": "Return-White.png",
+        "next": [
+            "Reclamation@BlackReturn#next"
+        ]
+    },
+    "Reclamation@BlackReturn": {
         "template": "Return.png",
         "next": [
             "Reclamation@AtHomePageFlag",
@@ -13511,10 +13489,7 @@
             "Reclamation@ExitAlgorithm",
             "Reclamation@SmallReturn",
             "Reclamation@ReturnInFocus",
-            "Reclamation",
-            "Reclamation@ReturnTo",
-            "Reclamation@PopupConfirm",
-            "Reclamation@CloseAnnos#next"
+            "Reclamation@(BlackReturn#next)"
         ]
     },
     "Reclamation@ReturnInFocus": {
@@ -13527,7 +13502,7 @@
         "templThreshold": 0.7,
         "action": "ClickSelf",
         "next": [
-            "Reclamation@ReturnTo#next"
+            "Reclamation@BlackReturn#next"
         ]
     },
     "Reclamation@Begin": {
@@ -13536,7 +13511,7 @@
             "Reclamation@GiveupAlgorithm",
             "Reclamation@StartAlgorithm",
             "Reclamation@ConfirmStart#next",
-            "Reclamation@ReturnTo#next",
+            "Reclamation@BlackReturn#next",
             "Reclamation@BattleStart#next",
             "Reclamation@LevelComplete",
             "Reclamation@GiveupReportSkip",
@@ -13573,7 +13548,7 @@
             "Reclamation@EmptyInitUnits",
             "Reclamation@InitSupplyAll",
             "Reclamation@ClickChooseInitUnits",
-            "Reclamation@ReturnTo"
+            "Reclamation@ReturnButtons#next"
         ]
     },
     "Reclamation@EmptyInitUnits": {
@@ -13834,7 +13809,7 @@
     },
     "Reclamation@StartActionPopupConfirm": {
         "template": "PopupConfirm.png",
-        "baseTask": "Reclamation@PopupConfirm",
+        "baseTask": "Reclamation@ReturnConfirm",
         "postDelay": 4000,
         "next": [
             "Reclamation@BattleStart",
@@ -13894,13 +13869,13 @@
         "next": [
             "Reclamation@LevelForceExitConfirm",
             "Reclamation@LevelForceExit",
-            "Reclamation@ReturnTo#next"
+            "Reclamation@BlackReturn#next"
         ]
     },
     "Reclamation@LevelForceExitConfirm": {
         "baseTask": "Reclamation@ExitLevelConfirm",
         "next": [
-            "Reclamation@ReturnTo#next"
+            "Reclamation@BlackReturn#next"
         ]
     },
     "Reclamation@LevelComplete": {
@@ -14001,7 +13976,7 @@
     },
     "Reclamation@GiveupAlgorithmConfirm": {
         "template": "PopupConfirm.png",
-        "baseTask": "Reclamation@PopupConfirm",
+        "baseTask": "Reclamation@ReturnConfirm",
         "next": [
             "Reclamation@GiveupReportSkip",
             "Reclamation@GiveupCrossdomainPageFlag",
@@ -14162,7 +14137,7 @@
     },
     "Reclamation@GiveupTakeNothingConfirm": {
         "template": "PopupConfirm.png",
-        "baseTask": "Reclamation@PopupConfirm",
+        "baseTask": "Reclamation@ReturnConfirm",
         "next": [
             "Reclamation@GiveupTakeNothingConfirm",
             "Reclamation@GiveupReportSkip",
@@ -14394,7 +14369,7 @@
         "algorithm": "JustReturn",
         "next": [
             "NavigateHome@Reclamation@AtHomePageFlag",
-            "NavigateHome@Reclamation@ReturnTo#next",
+            "NavigateHome@Reclamation@BlackReturn#next",
             "NavigateHome@Reclamation@SkipAnnounce",
             "NavigateHome@Reclamation@SkipDailyReport",
             "NavigateHome@Reclamation@LevelComplete",
@@ -14839,7 +14814,7 @@
         "next": [
             "DoGacha",
             "GachaEnter",
-            "GachaEnter@ReturnTo",
+            "GachaEnter@ReturnButtons#next",
             "GachaLastOnceResult",
             "GachaLastTenTimesResult1",
             "GachaLastTenTimesResult2"

--- a/src/MaaCore/Task/Infrast/InfrastAbstractTask.cpp
+++ b/src/MaaCore/Task/Infrast/InfrastAbstractTask.cpp
@@ -550,7 +550,7 @@ void asst::InfrastAbstractTask::order_opers_selection(const std::vector<std::str
 void asst::InfrastAbstractTask::click_return_button()
 {
     LogTraceFunction;
-    ProcessTask(*this, { "Infrast@ReturnTo" }).run();
+    ProcessTask(*this, { "Infrast@BlackReturn" }).run();
 }
 
 bool asst::InfrastAbstractTask::click_bottom_left_tab()

--- a/src/MaaCore/Task/Interface/StartUpTask.cpp
+++ b/src/MaaCore/Task/Interface/StartUpTask.cpp
@@ -17,7 +17,7 @@ asst::StartUpTask::StartUpTask(const AsstCallback& callback, Assistant* inst)
     LogTraceFunction;
 
     m_start_up_task_ptr->set_tasks({ "StartUpBegin" })
-        .set_times_limit("ReturnTo", 0)
+        .set_times_limit("BlackReturn", 0)
         .set_task_delay(Config.get_options().task_delay * 2)
         .set_retry_times(30);
     m_account_switch_task_ptr->set_retry_times(0);


### PR DESCRIPTION
1. 删除已有 `CloseAnnos#next` 时冗余的 `TodaysSupplies`
2. `ReturnTo` -> `BlackReturn`, `Return-White` -> `WhiteReturn`, `ReturnToConfirm` -> `ReturnConfirm`
3. 把 黑返回键 `BlackReturn`、白返回键 `WhiteReturn`、`FromStageSN` 组合成 返回键组 `ReturnButtons`（类似 `CloseAnnos`）
4. 给 黑白返回键 的 _next_ 增加 _Loading_ 套餐（跳过领取奖励时匹配得分低也许是因为这个）
5. 由于 _Infrast_, _Roguelike_, _Reclamation_ 之前特化了 `ReturnTo`，现在重新特化黑白返回键；_Reclamation_ 之前特化了 `PopupConfirm` 作为 `ReturnConfirm` (好奇怪，但我应该没理解错吧)，现在重新特化 `ReturnConfirm`，修改了名称和相关内容