### PR TITLE
fix: 尝试修复#6552导致的死循环

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -8675,10 +8675,10 @@
             119
         ],
         "next": [
-            "Roguelike@Back"
+            "Roguelike@ReturnToMap"
         ]
     },
-    "Roguelike@Back": {
+    "Roguelike@ReturnToMap": {
         "Doc": "这两步专门用来消除技能框出现白边闪烁，导致识别干员名出错的问题",
         "template": "Return.png",
         "templThreshold": 0.7,
@@ -8690,24 +8690,23 @@
             180,
             80
         ],
-        "preDelay": 500,
-        "postDelay": 1000,
         "next": [
-            "Roguelike@StageCambatEnterAgain"
+            "Roguelike@StageEnterBattleAgain"
         ]
     },
-    "Roguelike@StageCambatEnterAgain": {
+    "Roguelike@StageEnterBattleAgain": {
         "Doc": "这两步专门用来消除技能框出现白边闪烁，导致识别干员名出错的问题",
         "algorithm": "JustReturn",
         "action": "ClickRect",
         "specificRect": [
-            1100,
-            504,
-            133,
-            94
+            1208,
+            442,
+            45,
+            62
         ],
         "next": [
-            "Roguelike@StartAction"
+            "Roguelike@StartAction",
+            "Roguelike@StageEnterBattleAgain"
         ]
     },
     "Roguelike@FromIntegratedStrategies": {
@@ -9338,7 +9337,7 @@
     },
     "Roguelike@RecruitWithoutButton": {
         "algorithm": "JustReturn",
-        "action": "ClickRect",        
+        "action": "ClickRect",
         "specificRect": [
             1180,
             15,
@@ -10458,7 +10457,7 @@
     "Phantom@Roguelike@RecruitOther": {
         "template": "Phantom@Roguelike@Recruit.png"
     },
-    "Phantom@Roguelike@RecruitWithoutButton": {        
+    "Phantom@Roguelike@RecruitWithoutButton": {
         "next": [
             "Phantom@Roguelike@RecruitOther",
             "Phantom@Roguelike@EnterAfterRecruit",


### PR DESCRIPTION
#6552 重命名任务，缩小了点击范围（只测了下萨米的，其他的不知道位置变化大不大），逻辑改成直到进入肉鸽开始战斗界面前一直点