### PR TITLE
feat: WpfGui新增 肉鸽设置-中止行为等待至本次战斗结束后

### DIFF
--- a/src/MaaCore/Task/Roguelike/RoguelikeBattleTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeBattleTaskPlugin.cpp
@@ -407,13 +407,11 @@ bool asst::RoguelikeBattleTaskPlugin::do_once()
 {
     check_drone_tiles();
 
-    cv::Mat image = ctrler()->get_image(false);
+    cv::Mat image = ctrler()->get_image();
     if (!m_first_deploy && use_all_ready_skill(image)) {
         return true;
     }
-    if (need_exit()) {
-        Log.info("exit");
-    }
+
     std::unordered_set<std::string> pre_cooling;
     for (const auto& [name, oper] : m_cur_deployment_opers) {
         if (oper.cooling) {

--- a/src/MaaCore/Task/Roguelike/RoguelikeBattleTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeBattleTaskPlugin.cpp
@@ -86,7 +86,9 @@ bool asst::RoguelikeBattleTaskPlugin::_run()
             break;
         }
     }
-
+    // 通知战斗结束，无论成功与否
+    auto info = basic_info_with_what("RoguelikeCombatEnd");
+    callback(AsstMsg::SubTaskExtraInfo, info);
     return true;
 }
 
@@ -812,7 +814,6 @@ asst::battle::AttackRange asst::RoguelikeBattleTaskPlugin::get_attack_range(cons
     if (m_oper_elite.contains(oper.name)) {
         elite = m_oper_elite.at(oper.name);
     }
-    // int64_t elite = status()->get_number(Status::RoguelikeCharElitePrefix + oper.name).value_or(0);
     battle::AttackRange right_attack_range = BattleData.get_range(oper_name_in_config(oper), elite);
 
     if (right_attack_range == BattleDataConfig::EmptyRange) {

--- a/src/MaaWpfGui/Constants/ConfigurationKeys.cs
+++ b/src/MaaWpfGui/Constants/ConfigurationKeys.cs
@@ -99,6 +99,7 @@ namespace MaaWpfGui.Constants
         public const string RoguelikeStartWithEliteTwo = "Roguelike.RoguelikeStartWithEliteTwo";
         public const string RoguelikeUseSupportUnit = "Roguelike.RoguelikeUseSupportUnit";
         public const string RoguelikeEnableNonfriendSupport = "Roguelike.RoguelikeEnableNonfriendSupport";
+        public const string RoguelikeDelayAbortUntilCombatComplete = "Roguelike.RoguelikeDelayAbortUntilCombatComplete";
         public const string RoguelikeStartsCount = "Roguelike.StartsCount";
         public const string RoguelikeInvestmentEnabled = "Roguelike.InvestmentEnabled";
         public const string RoguelikeInvestmentEnterSecondFloor = "Roguelike.InvestmentEnterSecondFloor";

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -1060,6 +1060,10 @@ namespace MaaWpfGui.Main
                 case "StageInfo":
                     {
                         Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("StartCombat") + subTaskDetails["name"]);
+                        if (Instances.SettingsViewModel.RoguelikeDelayAbortUntilCombatComplete)
+                        {
+                            Instances.TaskQueueViewModel.RoguelikeInCombatAndShowWait = true;
+                        }
                     }
 
                     break;
@@ -1069,6 +1073,10 @@ namespace MaaWpfGui.Main
                         Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("StageInfoError"), UiLogColor.Error);
                     }
 
+                    break;
+                case "RoguelikeCombatEnd":
+                    // 肉鸽战斗结束，无论成功与否
+                    Instances.TaskQueueViewModel.RoguelikeInCombatAndShowWait = false;
                     break;
 
                 case "PenguinId":

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -110,6 +110,7 @@
     <system:String x:Key="RoguelikeStartWithEliteTwo">Repeat for「Starting Operator」Elite 2</system:String>
     <system:String x:Key="RoguelikeUseSupportUnit">Select 「Starting Operator」 from support unit list</system:String>
     <system:String x:Key="RoguelikeUseNonFriendSupport">Enable non-friend support</system:String>
+    <system:String x:Key="RoguelikeDelayAbortUntilCombatComplete">Stops after clearing the combat</system:String>
     <system:String x:Key="DeploymentWithPause" xml:space="preserve">Deployment with Pause (Pause-Trick) (Works for IS, Copilot and SSS) (Beta function, Not recommended yet)</system:String>
     <system:String x:Key="AdbLiteEnabled">Use ADB Lite (Experimental)</system:String>
     <system:String x:Key="KillAdbOnExit">Kill ADB On Exit</system:String>
@@ -330,6 +331,7 @@ Other client types are not supported</system:String>
     <system:String x:Key="ExitSelfIfOtherMaaElseShutdown">Exit MAA and Emulator, then Shutdown if no other running MAA</system:String>
     <system:String x:Key="LinkStart">Link Start!</system:String>
     <system:String x:Key="Stop">Stop</system:String>
+    <system:String x:Key="WaitAndStop">Wait &amp; Stop</system:String>
     <!--  FightSettings  -->
     <system:String x:Key="UseSanityPotion">Use Sanity Potion</system:String>
     <system:String x:Key="UseOriginitePrime">Use Originium*</system:String>
@@ -383,6 +385,7 @@ Other client types are not supported</system:String>
     <system:String x:Key="UnselectedTask">Unselected task</system:String>
     <system:String x:Key="Running">Running……</system:String>
     <system:String x:Key="AdbReplacementTips">If nothing happens or it gets stuck, please go to Settings → Connection → ADB path and change the ADB.exe, or turn on ADB Input (Deprecated).</system:String>
+    <system:String x:Key="Waiting">Waiting for the combat to end……</system:String>
     <system:String x:Key="Stopping">Stopping……</system:String>
     <system:String x:Key="Stopped">Has stopped</system:String>
     <system:String x:Key="UnknownErrorOccurs">Unknown error occurred</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -110,6 +110,7 @@
     <system:String x:Key="RoguelikeStartWithEliteTwo">「最初のオペレーター」直接昇進</system:String>
     <system:String x:Key="RoguelikeUseSupportUnit">「最初のオペレーター」をサポートから選択</system:String>
     <system:String x:Key="RoguelikeUseNonFriendSupport">フレンド以外のサポートの使用を許可</system:String>
+    <system:String x:Key="RoguelikeDelayAbortUntilCombatComplete">戦闘クリアで止まる</system:String>
     <system:String x:Key="DeploymentWithPause">統合戦略/保全駐在でポーズトリックを使用します（ベータ機能のため非推奨です）</system:String>
     <system:String x:Key="AdbLiteEnabled">軽量ADBを使用(実験機能)</system:String>
     <system:String x:Key="KillAdbOnExit">終了時にADBを終了する</system:String>
@@ -330,6 +331,7 @@ Bilibili: ログイン インターフェイスに表示されるアカウント
     <system:String x:Key="ExitSelfIfOtherMaaElseShutdown">MAAを終了し、他のMAAがない場合はシャットダウン</system:String>
     <system:String x:Key="LinkStart">Link Start!</system:String>
     <system:String x:Key="Stop">止める</system:String>
+    <system:String x:Key="WaitAndStop">待って &amp; 止める</system:String>
     <!--  戦闘設定  -->
     <system:String x:Key="UseSanityPotion">理性剤使用数</system:String>
     <system:String x:Key="UseOriginitePrime">割る源石の数*</system:String>
@@ -383,6 +385,7 @@ Bilibili: ログイン インターフェイスに表示されるアカウント
     <system:String x:Key="UnselectedTask">タスクが選択されていません</system:String>
     <system:String x:Key="Running">動作中……</system:String>
     <system:String x:Key="AdbReplacementTips">タスクが応答なしになる場合は、設定 - 接続設定 - ADBの強制置き換え、もしくは ADB Input タッチモード をチェックしてください（お勧めしない）。</system:String>
+    <system:String x:Key="Waiting">戦闘が終わるのを待っています……</system:String>
     <system:String x:Key="Stopping">動作停止中……</system:String>
     <system:String x:Key="Stopped">動作停止</system:String>
     <system:String x:Key="UnknownErrorOccurs">不明なエラーが発生しました</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -110,6 +110,7 @@
     <system:String x:Key="RoguelikeStartWithEliteTwo">시초 에 간부 가 직진 하다</system:String>
     <system:String x:Key="RoguelikeUseSupportUnit">시작 오퍼레이터로 지원 유닛 사용</system:String>
     <system:String x:Key="RoguelikeUseNonFriendSupport">친구가 아니어도 지원 유닛 사용</system:String>
+    <system:String x:Key="RoguelikeDelayAbortUntilCombatComplete">전투 클리어 후 정지</system:String>
     <system:String x:Key="DeploymentWithPause" xml:space="preserve">일시정지 상태로 배치하기 - 통합전략, 자동 작전, 보안 파견에 적용 (베타 기능, 현재 비권장)</system:String>
     <system:String x:Key="AdbLiteEnabled">ADB Lite 사용 (실험적)</system:String>
     <system:String x:Key="KillAdbOnExit">종료 시 ADB도 종료</system:String>
@@ -330,6 +331,7 @@ Bilibili: 로그인 인터페이스에 표시되는 계정 이름(예: 장산)�
     <system:String x:Key="ExitSelfIfOtherMaaElseShutdown">MAA를 종료, 다른 MAA가 없으면 시스템 종료</system:String>
     <system:String x:Key="LinkStart">Link Start!</system:String>
     <system:String x:Key="Stop">중지</system:String>
+    <system:String x:Key="WaitAndStop">기다리다 &amp; 중지</system:String>
     <!--  작전 설정  -->
     <system:String x:Key="UseSanityPotion">이성 회복제 사용</system:String>
     <system:String x:Key="UseOriginitePrime">순오리지늄 사용*</system:String>
@@ -383,6 +385,7 @@ Bilibili: 로그인 인터페이스에 표시되는 계정 이름(예: 장산)�
     <system:String x:Key="UnselectedTask">선택된 작업이 없습니다</system:String>
     <system:String x:Key="Running">실행 중……</system:String>
     <system:String x:Key="AdbReplacementTips">작업이 완전히 응답하지 않는 경우 설정-연결 설정-ADB 강제 교체를 시행하거나 터치 모드에서 ADB Input(추천하지 않음)을 선택하세요.</system:String>
+    <system:String x:Key="Waiting">전투가 끝나기를 기다리며……</system:String>
     <system:String x:Key="Stopping">중지 중……</system:String>
     <system:String x:Key="Stopped">중지됨</system:String>
     <system:String x:Key="UnknownErrorOccurs">예상치 못한 오류가 발생했습니다</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -110,6 +110,7 @@
     <system:String x:Key="RoguelikeStartWithEliteTwo">凹「开局干员」直升精二</system:String>
     <system:String x:Key="RoguelikeUseSupportUnit">「开局干员」使用助战</system:String>
     <system:String x:Key="RoguelikeUseNonFriendSupport">可以使用非好友助战</system:String>
+    <system:String x:Key="RoguelikeDelayAbortUntilCombatComplete">中止行为等待至当前战斗结束后</system:String>
     <system:String x:Key="DeploymentWithPause">暂停下干员（同时影响肉鸽、自动战斗、保全）（不稳定，暂不推荐开启）</system:String>
     <system:String x:Key="AdbLiteEnabled">使用 ADB Lite（实验性功能）</system:String>
     <system:String x:Key="KillAdbOnExit">退出时释放 ADB</system:String>
@@ -330,6 +331,7 @@
     <system:String x:Key="ExitSelfIfOtherMaaElseShutdown">退出 MAA，如无其他 MAA 进程则关机</system:String>
     <system:String x:Key="LinkStart">Link Start!</system:String>
     <system:String x:Key="Stop">停止</system:String>
+    <system:String x:Key="WaitAndStop">等待 &amp; 停止</system:String>
     <!--  战斗设置  -->
     <system:String x:Key="UseSanityPotion">吃理智药</system:String>
     <system:String x:Key="UseOriginitePrime">吃源石*</system:String>
@@ -383,6 +385,7 @@
     <system:String x:Key="UnselectedTask">未选择任务</system:String>
     <system:String x:Key="Running">正在运行中……</system:String>
     <system:String x:Key="AdbReplacementTips">如果任务完全没有反应，请使用 设置 - 连接设置 - 强制替换 ADB，或触控模式选择 ADB Input（不推荐）。</system:String>
+    <system:String x:Key="Waiting">正在等待战斗结束……</system:String>
     <system:String x:Key="Stopping">正在停止……</system:String>
     <system:String x:Key="Stopped">已停止</system:String>
     <system:String x:Key="UnknownErrorOccurs">出现未知错误</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -110,6 +110,7 @@
     <system:String x:Key="RoguelikeStartWithEliteTwo">凹「開局幹員」直升精二</system:String>
     <system:String x:Key="RoguelikeUseSupportUnit">「開局幹員」使用助戰</system:String>
     <system:String x:Key="RoguelikeUseNonFriendSupport">可以使用非好友助戰</system:String>
+    <system:String x:Key="RoguelikeDelayAbortUntilCombatComplete">中止行為等待至當前戰鬥結束後</system:String>
     <system:String x:Key="DeploymentWithPause">暫停下幹員（同時影響肉鴿、自動戰鬥、保全）（不穩定，暫不推薦開啟）</system:String>
     <system:String x:Key="AdbLiteEnabled">使用 ADB Lite（實驗性功能）</system:String>
     <system:String x:Key="KillAdbOnExit">退出時釋放 ADB</system:String>
@@ -330,6 +331,7 @@
     <system:String x:Key="ExitSelfIfOtherMaaElseShutdown">退出 MAA，如無其他 MAA 程式則關機</system:String>
     <system:String x:Key="LinkStart">Link Start!</system:String>
     <system:String x:Key="Stop">停止</system:String>
+    <system:String x:Key="WaitAndStop">等待 &amp; 停止</system:String>
     <!--  戰鬥設定  -->
     <system:String x:Key="UseSanityPotion">吃理智藥</system:String>
     <system:String x:Key="UseOriginitePrime">吃源石*</system:String>
@@ -383,6 +385,7 @@
     <system:String x:Key="UnselectedTask">未選擇任務</system:String>
     <system:String x:Key="Running">正在運行中……</system:String>
     <system:String x:Key="AdbReplacementTips">如果任務完全沒有反應，請使用 設定 - 連接設定 - 強制替換 ADB，或觸控模式選擇 ADB Input（不推薦）。</system:String>
+    <system:String x:Key="Waiting">正在等待戰鬥結束……</system:String>
     <system:String x:Key="Stopping">正在停止……</system:String>
     <system:String x:Key="Stopped">已停止</system:String>
     <system:String x:Key="UnknownErrorOccurs">出現未知錯誤</system:String>

--- a/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
@@ -1722,6 +1722,21 @@ namespace MaaWpfGui.ViewModels.UI
             }
         }
 
+        private bool _roguelikeDelayAbortUntilCombatComplete = bool.Parse(ConfigurationHelper.GetValue(ConfigurationKeys.RoguelikeDelayAbortUntilCombatComplete, false.ToString()));
+
+        /// <summary>
+        /// Gets or sets a value indicating whether delay abort until battle complete
+        /// </summary>
+        public bool RoguelikeDelayAbortUntilCombatComplete
+        {
+            get => _roguelikeDelayAbortUntilCombatComplete;
+            set
+            {
+                SetAndNotify(ref _roguelikeDelayAbortUntilCombatComplete, value);
+                ConfigurationHelper.SetValue(ConfigurationKeys.RoguelikeDelayAbortUntilCombatComplete, value.ToString());
+            }
+        }
+
         private string _roguelikeStartsCount = ConfigurationHelper.GetValue(ConfigurationKeys.RoguelikeStartsCount, "9999999");
 
         /// <summary>

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -947,6 +947,44 @@ namespace MaaWpfGui.ViewModels.UI
             }
         }
 
+        // UI 绑定的方法
+        // ReSharper disable once UnusedMember.Global
+        public async void WaitAndStop()
+        {
+            Waiting = true;
+            AddLog(LocalizationHelper.GetString("Waiting"));
+            if (Instances.SettingsViewModel.RoguelikeDelayAbortUntilCombatComplete)
+            {
+                await WaitUntilRoguelikeCombatComplete();
+            }
+
+            if (!Stopping)
+            {
+                await Stop();
+            }
+        }
+
+        /// <summary>
+        /// 等待肉鸽战斗结束，10分钟强制退出
+        /// </summary>
+        private async Task WaitUntilRoguelikeCombatComplete()
+        {
+            int time = 0;
+            while (Instances.SettingsViewModel.RoguelikeDelayAbortUntilCombatComplete && RoguelikeInCombatAndShowWait && time < 600 && !Stopping)
+            {
+                await Task.Delay(1000);
+                ++time;
+            }
+        }
+
+        private bool _roguelikeInCombatAndShowWait = false;
+
+        public bool RoguelikeInCombatAndShowWait
+        {
+            get => _roguelikeInCombatAndShowWait;
+            set => SetAndNotify(ref _roguelikeInCombatAndShowWait, value);
+        }
+
         public void SetStopped()
         {
             if (!_runningState.GetIdle() || Stopping)
@@ -954,6 +992,7 @@ namespace MaaWpfGui.ViewModels.UI
                 AddLog(LocalizationHelper.GetString("Stopped"));
             }
 
+            Waiting = false;
             Stopping = false;
             _runningState.SetIdle(true);
         }
@@ -2057,6 +2096,17 @@ namespace MaaWpfGui.ViewModels.UI
         {
             get => _stopping;
             private set => SetAndNotify(ref _stopping, value);
+        }
+
+        private bool _waiting;
+
+        /// <summary>
+        /// Gets a value indicating whether waiting for roguelike combat complete.
+        /// </summary>
+        public bool Waiting
+        {
+            get => _waiting;
+            private set => SetAndNotify(ref _waiting, value);
         }
 
         private bool _fightTaskRunning;

--- a/src/MaaWpfGui/Views/UI/TaskQueueView.xaml
+++ b/src/MaaWpfGui/Views/UI/TaskQueueView.xaml
@@ -181,6 +181,14 @@
                     Content="{DynamicResource Stop}"
                     IsEnabled="{c:Binding Path='!Stopping'}"
                     Visibility="{c:Binding Path='(!Idle or Stopping) and Inited'}" />
+                <Button
+                    Width="100"
+                    Height="50"
+                    Margin="5"
+                    Command="{s:Action WaitAndStop}"
+                    Content="{DynamicResource WaitAndStop}"
+                    Visibility="{c:Binding Path='RoguelikeInCombatAndShowWait and !Waiting and Inited and !Idle'}"
+                     />
             </Grid>
 
             <!--<StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment ="Center" >-->

--- a/src/MaaWpfGui/Views/UserControl/RoguelikeSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/RoguelikeSettingsUserControl.xaml
@@ -145,6 +145,15 @@
                     Text="{DynamicResource RoguelikeUseNonFriendSupport}"
                     TextWrapping="Wrap" />
             </CheckBox>
+            <CheckBox
+                Margin="0,10"
+                IsEnabled="{Binding Idle}"
+                IsChecked="{Binding RoguelikeDelayAbortUntilCombatComplete}">
+                <TextBlock
+                    Block.TextAlignment="Left"
+                    Text="{DynamicResource RoguelikeDelayAbortUntilCombatComplete}"
+                    TextWrapping="Wrap" />
+            </CheckBox>
         </StackPanel>
     </StackPanel>
 </UserControl>


### PR DESCRIPTION
- close #1961

~~顺带移除了肉鸽battle里面从status()读数据的部分~~
~~顺带移除了status()的肉鸽主题数据，以及在肉鸽battle的缓存了一下精英数据(?)~~
- ↑移动至 #6646

![image](https://github.com/MaaAssistantArknights/MaaAssistantArknights/assets/102887808/805837d8-12e7-4cdc-9284-e6ce8c93499f)

![image](https://github.com/MaaAssistantArknights/MaaAssistantArknights/assets/102887808/4e3d66e8-f2c2-42e7-98ab-bea3bab7a255)
