### PR TITLE
refactor: 修改肉鸽开始行动和商店投资达到上限时退出的实现方式

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -9929,7 +9929,7 @@
         ],
         "postDelay": 500,
         "exceededNext": [
-            "RoguelikeControlTaskPlugin-ExitThenAbandon"
+            "RoguelikeControlTaskPlugin-ExitThenStop"
         ],
         "next": [
             "Roguelike@StageTraderInvestSystemError",
@@ -10093,7 +10093,7 @@
             289
         ],
         "exceededNext": [
-            "RoguelikeControlTaskPlugin-ExitThenAbandon"
+            "RoguelikeControlTaskPlugin-ExitThenStop"
         ],
         "next": [
             "Roguelike@StageTraderInvestCancel"
@@ -12192,7 +12192,7 @@
         "Doc": "本任务注册了插件 RoguelikeControlTaskPlugin",
         "algorithm": "JustReturn"
     },
-    "RoguelikeControlTaskPlugin-ExitThenAbandon": {
+    "RoguelikeControlTaskPlugin-ExitThenStop": {
         "Doc": "本任务注册了插件 RoguelikeControlTaskPlugin",
         "algorithm": "JustReturn"
     },

--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -9928,6 +9928,9 @@
             144
         ],
         "postDelay": 500,
+        "exceededNext": [
+            "RoguelikeControlTaskPlugin-ExitThenAbandon"
+        ],
         "next": [
             "Roguelike@StageTraderInvestSystemError",
             "Roguelike@StageTraderInvestSystemFull",
@@ -10089,6 +10092,9 @@
             298,
             289
         ],
+        "exceededNext": [
+            "RoguelikeControlTaskPlugin-ExitThenAbandon"
+        ],
         "next": [
             "Roguelike@StageTraderInvestCancel"
         ]
@@ -10182,6 +10188,9 @@
             248
         ],
         "postDelay": 2000,
+        "exceededNext": [
+            "RoguelikeControlTaskPlugin-Stop"
+        ],
         "next": [
             "Roguelike@SquadDefault",
             "Roguelike@InitalDrop",
@@ -12178,6 +12187,14 @@
         "next": [
             "Sami@Roguelike@WaitForStartButtonClicked"
         ]
+    },
+    "RoguelikeControlTaskPlugin-Stop": {
+        "Doc": "本任务注册了插件 RoguelikeControlTaskPlugin",
+        "algorithm": "JustReturn"
+    },
+    "RoguelikeControlTaskPlugin-ExitThenAbandon": {
+        "Doc": "本任务注册了插件 RoguelikeControlTaskPlugin",
+        "algorithm": "JustReturn"
     },
     "RoguelikeBattleAbandon": {
         "action": "ClickSelf",

--- a/src/MaaCore/Task/Roguelike/RoguelikeControlTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeControlTaskPlugin.cpp
@@ -22,30 +22,31 @@ bool asst::RoguelikeControlTaskPlugin::verify(AsstMsg msg, const json::value& de
         task_view.remove_prefix(roguelike_name.length());
     }
     if (task_view == "Roguelik@ControlTaskPlugin-Stop") {
-        m_need_exit_and_abandon = false;
+        m_need_exit_then_stop = false;
         return true;
     }
-    if (task_view == "RoguelikeControlTaskPlugin-ExitThenAbandon") {
-        m_need_exit_and_abandon = true;
+    if (task_view == "RoguelikeControlTaskPlugin-ExitThenStop") {
+        m_need_exit_then_stop = true;
         return true;
     }
 
     return false;
 }
 
-void asst::RoguelikeControlTaskPlugin::exit_and_abandon()
+void asst::RoguelikeControlTaskPlugin::exit_then_stop()
 {
     std::string theme = status()->get_properties(Status::RoguelikeTheme).value();
     ProcessTask(*this, { theme + "@Roguelike@ExitThenAbandon" })
         .set_times_limit("Roguelike@StartExplore", 0)
+        .set_times_limit("Roguelike@Abandon", 0)
         .run();
 }
 
 bool asst::RoguelikeControlTaskPlugin::_run()
 {
-    if (m_need_exit_and_abandon) {
-        exit_and_abandon();
-        m_need_exit_and_abandon = false;
+    if (m_need_exit_then_stop) {
+        exit_then_stop();
+        m_need_exit_then_stop = false;
     }
     m_task_ptr->set_enable(false);
     return true;

--- a/src/MaaCore/Task/Roguelike/RoguelikeControlTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeControlTaskPlugin.cpp
@@ -6,11 +6,7 @@
 
 bool asst::RoguelikeControlTaskPlugin::verify(AsstMsg msg, const json::value& details) const
 {
-    if (msg != AsstMsg::SubTaskExtraInfo || details.get("subtask", std::string()) != "ProcessTask") {
-        return false;
-    }
-    const std::string what = details.get("what", std::string());
-    if (what != "ExceededLimit") {
+    if (msg != AsstMsg::SubTaskStart || details.get("subtask", std::string()) != "ProcessTask") {
         return false;
     }
 
@@ -25,11 +21,11 @@ bool asst::RoguelikeControlTaskPlugin::verify(AsstMsg msg, const json::value& de
     if (task_view.starts_with(roguelike_name)) {
         task_view.remove_prefix(roguelike_name.length());
     }
-    if (task_view == "Roguelike@StartExplore") {
+    if (task_view == "Roguelik@ControlTaskPlugin-Stop") {
         m_need_exit_and_abandon = false;
         return true;
     }
-    if (task_view == "Roguelike@StageTraderInvestConfirm" || task_view == "Roguelike@StageTraderInvestSystemFull") {
+    if (task_view == "RoguelikeControlTaskPlugin-ExitThenAbandon") {
         m_need_exit_and_abandon = true;
         return true;
     }

--- a/src/MaaCore/Task/Roguelike/RoguelikeControlTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/RoguelikeControlTaskPlugin.h
@@ -14,9 +14,9 @@ namespace asst
 
     protected:
         virtual bool _run() override;
-        void exit_and_abandon();
+        void exit_then_stop();
 
     private:
-        mutable bool m_need_exit_and_abandon = false;
+        mutable bool m_need_exit_then_stop = false;
     };
 }


### PR DESCRIPTION
这样就可以在配置文件中控制是否直接退出肉鸽任务链，不用 改插件 或者 set_enable(false) 了