### PR TITLE
style: VS22 Solution Explorer name change

### DIFF
--- a/src/MaaCore/MaaCore.vcxproj.filters
+++ b/src/MaaCore/MaaCore.vcxproj.filters
@@ -1,1065 +1,1065 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <Filter Include="源文件">
+    <Filter Include="Source">
       <UniqueIdentifier>{e8cc6807-e29a-4a4e-925e-65683b83dc74}</UniqueIdentifier>
     </Filter>
-    <Filter Include="源文件\Common">
+    <Filter Include="Source\Common">
       <UniqueIdentifier>{9f0cbbae-c14d-4522-9289-be74f7493701}</UniqueIdentifier>
     </Filter>
-    <Filter Include="头文件">
+    <Filter Include="Header">
       <UniqueIdentifier>{c3ebc635-47cc-4750-b219-bc7f664ffb75}</UniqueIdentifier>
     </Filter>
-    <Filter Include="资源文件">
+    <Filter Include="Resource">
       <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
       <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
     </Filter>
-    <Filter Include="源文件\Vision">
+    <Filter Include="Source\Vision">
       <UniqueIdentifier>{10d5a343-07ec-424b-a597-8ebc63eaeb23}</UniqueIdentifier>
     </Filter>
-    <Filter Include="源文件\Vision\Infrast">
+    <Filter Include="Source\Vision\Infrast">
       <UniqueIdentifier>{b592f9dc-ba0d-4c64-9ced-5a540383c1d0}</UniqueIdentifier>
     </Filter>
-    <Filter Include="源文件\Vision\Miscellaneous">
+    <Filter Include="Source\Vision\Miscellaneous">
       <UniqueIdentifier>{b00c96ac-e0d6-486c-a74a-51db706c6b2b}</UniqueIdentifier>
     </Filter>
-    <Filter Include="源文件\Vision\Roguelike">
+    <Filter Include="Source\Vision\Roguelike">
       <UniqueIdentifier>{250bc7cb-e99a-42f8-ae3c-66998564fdcf}</UniqueIdentifier>
     </Filter>
-    <Filter Include="源文件\Task">
+    <Filter Include="Source\Task">
       <UniqueIdentifier>{8499a77f-7bcc-457c-97f1-6e950ab68bf4}</UniqueIdentifier>
     </Filter>
-    <Filter Include="源文件\Task\Interface">
+    <Filter Include="Source\Task\Interface">
       <UniqueIdentifier>{f4a94ded-5a4e-42e5-b6f2-5ef163e254a4}</UniqueIdentifier>
     </Filter>
-    <Filter Include="源文件\Utils">
+    <Filter Include="Source\Utils">
       <UniqueIdentifier>{60bed13d-c700-4a51-882f-4629b1bdb4d8}</UniqueIdentifier>
     </Filter>
-    <Filter Include="源文件\Utils\Platform">
+    <Filter Include="Source\Utils\Platform">
       <UniqueIdentifier>{ea6699c6-00e4-4a41-becf-96c02f2bb807}</UniqueIdentifier>
     </Filter>
-    <Filter Include="源文件\Task\Fight">
+    <Filter Include="Source\Task\Fight">
       <UniqueIdentifier>{76f49515-1905-41b4-9e90-cc7015445c70}</UniqueIdentifier>
     </Filter>
-    <Filter Include="源文件\Task\Infrast">
+    <Filter Include="Source\Task\Infrast">
       <UniqueIdentifier>{43280e36-9f08-45c3-be44-ee375dfd3c60}</UniqueIdentifier>
     </Filter>
-    <Filter Include="源文件\Task\Miscellaneous">
+    <Filter Include="Source\Task\Miscellaneous">
       <UniqueIdentifier>{6445de69-cafe-42eb-a3e2-658cf78f414d}</UniqueIdentifier>
     </Filter>
-    <Filter Include="源文件\Task\Roguelike">
+    <Filter Include="Source\Task\Roguelike">
       <UniqueIdentifier>{44446da8-4dcc-4d58-b95c-ae4cc746edf5}</UniqueIdentifier>
     </Filter>
-    <Filter Include="资源文件\txwy">
+    <Filter Include="Resource\txwy">
       <UniqueIdentifier>{1aeaff53-2894-4a37-91fd-ddf8f3d676db}</UniqueIdentifier>
     </Filter>
-    <Filter Include="资源文件\YoStarJP">
+    <Filter Include="Resource\YoStarJP">
       <UniqueIdentifier>{8374296b-a1be-4c3e-852d-d52daa04d513}</UniqueIdentifier>
     </Filter>
-    <Filter Include="资源文件\YoStarEN">
+    <Filter Include="Resource\YoStarEN">
       <UniqueIdentifier>{a023473b-ff4a-4969-af22-9744a326fb32}</UniqueIdentifier>
     </Filter>
-    <Filter Include="资源文件\YoStarKR">
+    <Filter Include="Resource\YoStarKR">
       <UniqueIdentifier>{cf25099a-e97f-417f-ab45-4da8bd351747}</UniqueIdentifier>
     </Filter>
-    <Filter Include="源文件\Task\SSS">
+    <Filter Include="Source\Task\SSS">
       <UniqueIdentifier>{a5775bd2-7a8a-4bcb-9465-75d899ea8ca1}</UniqueIdentifier>
     </Filter>
-    <Filter Include="源文件\Task\Reclamation">
+    <Filter Include="Source\Task\Reclamation">
       <UniqueIdentifier>{97f7690d-5924-405f-a332-831e7dad3f1e}</UniqueIdentifier>
     </Filter>
-    <Filter Include="源文件\Controller">
+    <Filter Include="Source\Controller">
       <UniqueIdentifier>{19fb60c0-726b-4397-80eb-cc888c77cd82}</UniqueIdentifier>
     </Filter>
-    <Filter Include="源文件\Controller\adb-lite">
+    <Filter Include="Source\Controller\adb-lite">
       <UniqueIdentifier>{a61a19a3-e1ba-45f2-9264-acb4102106b9}</UniqueIdentifier>
     </Filter>
-    <Filter Include="源文件\Controller\Platform">
+    <Filter Include="Source\Controller\Platform">
       <UniqueIdentifier>{7be68f84-acf3-41c4-9491-19b635a90d66}</UniqueIdentifier>
     </Filter>
-    <Filter Include="源文件\Resource">
+    <Filter Include="Source\Resource">
       <UniqueIdentifier>{3b2a04b8-fb22-43c3-9444-1b455851d8e2}</UniqueIdentifier>
     </Filter>
-    <Filter Include="源文件\Resource\Roguelike">
+    <Filter Include="Source\Resource\Roguelike">
       <UniqueIdentifier>{de1acbf1-3e7a-4e91-8a62-e966602c6b25}</UniqueIdentifier>
     </Filter>
-    <Filter Include="源文件\Resource\Miscellaneous">
+    <Filter Include="Source\Resource\Miscellaneous">
       <UniqueIdentifier>{64367a8b-0654-47bb-92cc-d451799457a4}</UniqueIdentifier>
     </Filter>
-    <Filter Include="源文件\Vision\Battle">
+    <Filter Include="Source\Vision\Battle">
       <UniqueIdentifier>{28d29141-dd91-4954-96e9-a677be9b2471}</UniqueIdentifier>
     </Filter>
-    <Filter Include="源文件\Task\Experiment">
+    <Filter Include="Source\Task\Experiment">
       <UniqueIdentifier>{987541fc-58f0-40eb-8b93-c0cb38881d92}</UniqueIdentifier>
     </Filter>
-    <Filter Include="源文件\Vision\Config">
+    <Filter Include="Source\Vision\Config">
       <UniqueIdentifier>{bf83678b-e9d7-4cf1-8616-aba2009072b6}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\resource\config.json">
-      <Filter>资源文件</Filter>
+      <Filter>Resource</Filter>
     </None>
     <None Include="..\..\resource\tasks.json">
-      <Filter>资源文件</Filter>
+      <Filter>Resource</Filter>
     </None>
     <None Include="..\..\resource\global\txwy\resource\tasks.json">
-      <Filter>资源文件\txwy</Filter>
+      <Filter>Resource\txwy</Filter>
     </None>
     <None Include="..\..\resource\global\YoStarJP\resource\tasks.json">
-      <Filter>资源文件\YoStarJP</Filter>
+      <Filter>Resource\YoStarJP</Filter>
     </None>
     <None Include="..\..\resource\global\YoStarEN\resource\tasks.json">
-      <Filter>资源文件\YoStarEN</Filter>
+      <Filter>Resource\YoStarEN</Filter>
     </None>
     <None Include="..\..\resource\global\YoStarKR\resource\tasks.json">
-      <Filter>资源文件\YoStarKR</Filter>
+      <Filter>Resource\YoStarKR</Filter>
     </None>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\include\AsstCaller.h">
-      <Filter>头文件</Filter>
+      <Filter>Header</Filter>
     </ClInclude>
     <ClInclude Include="..\..\include\AsstPort.h">
-      <Filter>头文件</Filter>
+      <Filter>Header</Filter>
     </ClInclude>
     <ClInclude Include="Common\AsstBattleDef.h">
-      <Filter>源文件\Common</Filter>
+      <Filter>Source\Common</Filter>
     </ClInclude>
     <ClInclude Include="Common\AsstConf.h">
-      <Filter>源文件\Common</Filter>
+      <Filter>Source\Common</Filter>
     </ClInclude>
     <ClInclude Include="Common\AsstInfrastDef.h">
-      <Filter>源文件\Common</Filter>
+      <Filter>Source\Common</Filter>
     </ClInclude>
     <ClInclude Include="Common\AsstMsg.h">
-      <Filter>源文件\Common</Filter>
+      <Filter>Source\Common</Filter>
     </ClInclude>
     <ClInclude Include="Common\AsstTypes.h">
-      <Filter>源文件\Common</Filter>
+      <Filter>Source\Common</Filter>
     </ClInclude>
     <ClInclude Include="Common\AsstVersion.h">
-      <Filter>源文件\Common</Filter>
+      <Filter>Source\Common</Filter>
     </ClInclude>
     <ClInclude Include="Vision\VisionHelper.h">
-      <Filter>源文件\Vision</Filter>
+      <Filter>Source\Vision</Filter>
     </ClInclude>
     <ClInclude Include="Vision\Hasher.h">
-      <Filter>源文件\Vision</Filter>
+      <Filter>Source\Vision</Filter>
     </ClInclude>
     <ClInclude Include="Vision\Matcher.h">
-      <Filter>源文件\Vision</Filter>
+      <Filter>Source\Vision</Filter>
     </ClInclude>
     <ClInclude Include="Vision\MultiMatcher.h">
-      <Filter>源文件\Vision</Filter>
+      <Filter>Source\Vision</Filter>
     </ClInclude>
     <ClInclude Include="Vision\OCRer.h">
-      <Filter>源文件\Vision</Filter>
+      <Filter>Source\Vision</Filter>
     </ClInclude>
     <ClInclude Include="Vision\TemplDetOCRer.h">
-      <Filter>源文件\Vision</Filter>
+      <Filter>Source\Vision</Filter>
     </ClInclude>
     <ClInclude Include="Vision\RegionOCRer.h">
-      <Filter>源文件\Vision</Filter>
+      <Filter>Source\Vision</Filter>
     </ClInclude>
     <ClInclude Include="Vision\Infrast\InfrastClueVacancyImageAnalyzer.h">
-      <Filter>源文件\Vision\Infrast</Filter>
+      <Filter>Source\Vision\Infrast</Filter>
     </ClInclude>
     <ClInclude Include="Vision\Infrast\InfrastFacilityImageAnalyzer.h">
-      <Filter>源文件\Vision\Infrast</Filter>
+      <Filter>Source\Vision\Infrast</Filter>
     </ClInclude>
     <ClInclude Include="Vision\Infrast\InfrastOperImageAnalyzer.h">
-      <Filter>源文件\Vision\Infrast</Filter>
+      <Filter>Source\Vision\Infrast</Filter>
     </ClInclude>
     <ClInclude Include="Vision\Infrast\InfrastSmileyImageAnalyzer.h">
-      <Filter>源文件\Vision\Infrast</Filter>
+      <Filter>Source\Vision\Infrast</Filter>
     </ClInclude>
     <ClInclude Include="Vision\Miscellaneous\CreditShopImageAnalyzer.h">
-      <Filter>源文件\Vision\Miscellaneous</Filter>
+      <Filter>Source\Vision\Miscellaneous</Filter>
     </ClInclude>
     <ClInclude Include="Vision\Miscellaneous\DepotImageAnalyzer.h">
-      <Filter>源文件\Vision\Miscellaneous</Filter>
+      <Filter>Source\Vision\Miscellaneous</Filter>
     </ClInclude>
     <ClInclude Include="Vision\Miscellaneous\PipelineAnalyzer.h">
-      <Filter>源文件\Vision\Miscellaneous</Filter>
+      <Filter>Source\Vision\Miscellaneous</Filter>
     </ClInclude>
     <ClInclude Include="Vision\Miscellaneous\RecruitImageAnalyzer.h">
-      <Filter>源文件\Vision\Miscellaneous</Filter>
+      <Filter>Source\Vision\Miscellaneous</Filter>
     </ClInclude>
     <ClInclude Include="Vision\Roguelike\RoguelikeFormationImageAnalyzer.h">
-      <Filter>源文件\Vision\Roguelike</Filter>
+      <Filter>Source\Vision\Roguelike</Filter>
     </ClInclude>
     <ClInclude Include="Vision\Roguelike\RoguelikeRecruitImageAnalyzer.h">
-      <Filter>源文件\Vision\Roguelike</Filter>
+      <Filter>Source\Vision\Roguelike</Filter>
     </ClInclude>
     <ClInclude Include="Vision\Roguelike\RoguelikeSkillSelectionImageAnalyzer.h">
-      <Filter>源文件\Vision\Roguelike</Filter>
+      <Filter>Source\Vision\Roguelike</Filter>
     </ClInclude>
     <ClInclude Include="Vision\Roguelike\RoguelikeRecruitSupportAnalyzer.h">
-      <Filter>源文件\Vision\Roguelike</Filter>
+      <Filter>Source\Vision\Roguelike</Filter>
     </ClInclude>
     <ClInclude Include="Config\AbstractConfig.h">
-      <Filter>源文件\Resource</Filter>
+      <Filter>Source\Resource</Filter>
     </ClInclude>
     <ClInclude Include="Config\AbstractConfigWithTempl.h">
-      <Filter>源文件\Resource</Filter>
+      <Filter>Source\Resource</Filter>
     </ClInclude>
     <ClInclude Include="Config\AbstractResource.h">
-      <Filter>源文件\Resource</Filter>
+      <Filter>Source\Resource</Filter>
     </ClInclude>
     <ClInclude Include="Config\ResourceLoader.h">
-      <Filter>源文件\Resource</Filter>
+      <Filter>Source\Resource</Filter>
     </ClInclude>
     <ClInclude Include="Config\TaskData.h">
-      <Filter>源文件\Resource</Filter>
+      <Filter>Source\Resource</Filter>
     </ClInclude>
     <ClInclude Include="Config\TemplResource.h">
-      <Filter>源文件\Resource</Filter>
+      <Filter>Source\Resource</Filter>
     </ClInclude>
     <ClInclude Include="Config\Roguelike\RoguelikeCopilotConfig.h">
-      <Filter>源文件\Resource\Roguelike</Filter>
+      <Filter>Source\Resource\Roguelike</Filter>
     </ClInclude>
     <ClInclude Include="Config\Roguelike\RoguelikeRecruitConfig.h">
-      <Filter>源文件\Resource\Roguelike</Filter>
+      <Filter>Source\Resource\Roguelike</Filter>
     </ClInclude>
     <ClInclude Include="Config\Roguelike\RoguelikeShoppingConfig.h">
-      <Filter>源文件\Resource\Roguelike</Filter>
+      <Filter>Source\Resource\Roguelike</Filter>
     </ClInclude>
     <ClInclude Include="Config\Roguelike\RoguelikeStageEncounterConfig.h">
-      <Filter>源文件\Resource\Roguelike</Filter>
+      <Filter>Source\Resource\Roguelike</Filter>
     </ClInclude>
     <ClInclude Include="Config\Miscellaneous\BattleDataConfig.h">
-      <Filter>源文件\Resource\Miscellaneous</Filter>
+      <Filter>Source\Resource\Miscellaneous</Filter>
     </ClInclude>
     <ClInclude Include="Config\Miscellaneous\CopilotConfig.h">
-      <Filter>源文件\Resource\Miscellaneous</Filter>
+      <Filter>Source\Resource\Miscellaneous</Filter>
     </ClInclude>
     <ClInclude Include="Config\Miscellaneous\InfrastConfig.h">
-      <Filter>源文件\Resource\Miscellaneous</Filter>
+      <Filter>Source\Resource\Miscellaneous</Filter>
     </ClInclude>
     <ClInclude Include="Config\Miscellaneous\ItemConfig.h">
-      <Filter>源文件\Resource\Miscellaneous</Filter>
+      <Filter>Source\Resource\Miscellaneous</Filter>
     </ClInclude>
     <ClInclude Include="Config\Miscellaneous\RecruitConfig.h">
-      <Filter>源文件\Resource\Miscellaneous</Filter>
+      <Filter>Source\Resource\Miscellaneous</Filter>
     </ClInclude>
     <ClInclude Include="Config\Miscellaneous\StageDropsConfig.h">
-      <Filter>源文件\Resource\Miscellaneous</Filter>
+      <Filter>Source\Resource\Miscellaneous</Filter>
     </ClInclude>
     <ClInclude Include="Config\Miscellaneous\TilePack.h">
-      <Filter>源文件\Resource\Miscellaneous</Filter>
+      <Filter>Source\Resource\Miscellaneous</Filter>
     </ClInclude>
     <ClInclude Include="Task\AbstractTask.h">
-      <Filter>源文件\Task</Filter>
+      <Filter>Source\Task</Filter>
     </ClInclude>
     <ClInclude Include="Task\AbstractTaskPlugin.h">
-      <Filter>源文件\Task</Filter>
+      <Filter>Source\Task</Filter>
     </ClInclude>
     <ClInclude Include="Task\InterfaceTask.h">
-      <Filter>源文件\Task</Filter>
+      <Filter>Source\Task</Filter>
     </ClInclude>
     <ClInclude Include="Task\PackageTask.h">
-      <Filter>源文件\Task</Filter>
+      <Filter>Source\Task</Filter>
     </ClInclude>
     <ClInclude Include="Task\ProcessTask.h">
-      <Filter>源文件\Task</Filter>
+      <Filter>Source\Task</Filter>
     </ClInclude>
     <ClInclude Include="Task\ReportDataTask.h">
-      <Filter>源文件\Task</Filter>
+      <Filter>Source\Task</Filter>
     </ClInclude>
     <ClInclude Include="Task\Interface\AwardTask.h">
-      <Filter>源文件\Task\Interface</Filter>
+      <Filter>Source\Task\Interface</Filter>
     </ClInclude>
     <ClInclude Include="Task\Interface\CloseDownTask.h">
-      <Filter>源文件\Task\Interface</Filter>
+      <Filter>Source\Task\Interface</Filter>
     </ClInclude>
     <ClInclude Include="Task\Interface\CopilotTask.h">
-      <Filter>源文件\Task\Interface</Filter>
+      <Filter>Source\Task\Interface</Filter>
     </ClInclude>
     <ClInclude Include="Task\Interface\DebugTask.h">
-      <Filter>源文件\Task\Interface</Filter>
+      <Filter>Source\Task\Interface</Filter>
     </ClInclude>
     <ClInclude Include="Task\Interface\DepotTask.h">
-      <Filter>源文件\Task\Interface</Filter>
+      <Filter>Source\Task\Interface</Filter>
     </ClInclude>
     <ClInclude Include="Task\Interface\FightTask.h">
-      <Filter>源文件\Task\Interface</Filter>
+      <Filter>Source\Task\Interface</Filter>
     </ClInclude>
     <ClInclude Include="Task\Interface\InfrastTask.h">
-      <Filter>源文件\Task\Interface</Filter>
+      <Filter>Source\Task\Interface</Filter>
     </ClInclude>
     <ClInclude Include="Task\Interface\MallTask.h">
-      <Filter>源文件\Task\Interface</Filter>
+      <Filter>Source\Task\Interface</Filter>
     </ClInclude>
     <ClInclude Include="Task\Interface\RecruitTask.h">
-      <Filter>源文件\Task\Interface</Filter>
+      <Filter>Source\Task\Interface</Filter>
     </ClInclude>
     <ClInclude Include="Task\Interface\RoguelikeTask.h">
-      <Filter>源文件\Task\Interface</Filter>
+      <Filter>Source\Task\Interface</Filter>
     </ClInclude>
     <ClInclude Include="Task\Interface\StartUpTask.h">
-      <Filter>源文件\Task\Interface</Filter>
+      <Filter>Source\Task\Interface</Filter>
     </ClInclude>
     <ClInclude Include="Utils\Demangle.hpp">
-      <Filter>源文件\Utils</Filter>
+      <Filter>Source\Utils</Filter>
     </ClInclude>
     <ClInclude Include="Utils\Http.hpp">
-      <Filter>源文件\Utils</Filter>
+      <Filter>Source\Utils</Filter>
     </ClInclude>
     <ClInclude Include="Utils\ImageIo.hpp">
-      <Filter>源文件\Utils</Filter>
+      <Filter>Source\Utils</Filter>
     </ClInclude>
     <ClInclude Include="Utils\Locale.hpp">
-      <Filter>源文件\Utils</Filter>
+      <Filter>Source\Utils</Filter>
     </ClInclude>
     <ClInclude Include="Utils\Logger.hpp">
-      <Filter>源文件\Utils</Filter>
+      <Filter>Source\Utils</Filter>
     </ClInclude>
     <ClInclude Include="Utils\Meta.hpp">
-      <Filter>源文件\Utils</Filter>
+      <Filter>Source\Utils</Filter>
     </ClInclude>
     <ClInclude Include="Utils\NoWarningCV.h">
-      <Filter>源文件\Utils</Filter>
+      <Filter>Source\Utils</Filter>
     </ClInclude>
     <ClInclude Include="Utils\NoWarningCVMat.h">
-      <Filter>源文件\Utils</Filter>
+      <Filter>Source\Utils</Filter>
     </ClInclude>
     <ClInclude Include="Utils\NoWarningCPR.h">
-      <Filter>源文件\Utils</Filter>
+      <Filter>Source\Utils</Filter>
     </ClInclude>
     <ClInclude Include="Utils\Platform.hpp">
-      <Filter>源文件\Utils</Filter>
+      <Filter>Source\Utils</Filter>
     </ClInclude>
     <ClInclude Include="Utils\Ranges.hpp">
-      <Filter>源文件\Utils</Filter>
+      <Filter>Source\Utils</Filter>
     </ClInclude>
     <ClInclude Include="Utils\SingletonHolder.hpp">
-      <Filter>源文件\Utils</Filter>
+      <Filter>Source\Utils</Filter>
     </ClInclude>
     <ClInclude Include="Utils\StringMisc.hpp">
-      <Filter>源文件\Utils</Filter>
+      <Filter>Source\Utils</Filter>
     </ClInclude>
     <ClInclude Include="Utils\Time.hpp">
-      <Filter>源文件\Utils</Filter>
+      <Filter>Source\Utils</Filter>
     </ClInclude>
     <ClInclude Include="Utils\WorkingDir.hpp">
-      <Filter>源文件\Utils</Filter>
+      <Filter>Source\Utils</Filter>
     </ClInclude>
     <ClInclude Include="Utils\Platform\Platform.h">
-      <Filter>源文件\Utils\Platform</Filter>
+      <Filter>Source\Utils\Platform</Filter>
     </ClInclude>
     <ClInclude Include="Utils\Platform\PlatformPosix.h">
-      <Filter>源文件\Utils\Platform</Filter>
+      <Filter>Source\Utils\Platform</Filter>
     </ClInclude>
     <ClInclude Include="Utils\Platform\PlatformWin32.h">
-      <Filter>源文件\Utils\Platform</Filter>
+      <Filter>Source\Utils\Platform</Filter>
     </ClInclude>
     <ClInclude Include="Utils\Platform\SafeWindows.h">
-      <Filter>源文件\Utils\Platform</Filter>
+      <Filter>Source\Utils\Platform</Filter>
     </ClInclude>
     <ClInclude Include="Assistant.h">
-      <Filter>源文件</Filter>
+      <Filter>Source</Filter>
     </ClInclude>
     <ClInclude Include="Status.h">
-      <Filter>源文件</Filter>
+      <Filter>Source</Filter>
     </ClInclude>
     <ClInclude Include="Config\GeneralConfig.h">
-      <Filter>源文件\Resource</Filter>
+      <Filter>Source\Resource</Filter>
     </ClInclude>
     <ClInclude Include="Config\Miscellaneous\OcrPack.h">
-      <Filter>源文件\Resource\Miscellaneous</Filter>
+      <Filter>Source\Resource\Miscellaneous</Filter>
     </ClInclude>
     <ClInclude Include="Task\Fight\DrGrandetTaskPlugin.h">
-      <Filter>源文件\Task\Fight</Filter>
+      <Filter>Source\Task\Fight</Filter>
     </ClInclude>
     <ClInclude Include="Task\Fight\StageDropsTaskPlugin.h">
-      <Filter>源文件\Task\Fight</Filter>
+      <Filter>Source\Task\Fight</Filter>
     </ClInclude>
     <ClInclude Include="Task\Fight\StageNavigationTask.h">
-      <Filter>源文件\Task\Fight</Filter>
+      <Filter>Source\Task\Fight</Filter>
     </ClInclude>
     <ClInclude Include="Task\Infrast\DronesForShamareTaskPlugin.h">
-      <Filter>源文件\Task\Infrast</Filter>
+      <Filter>Source\Task\Infrast</Filter>
     </ClInclude>
     <ClInclude Include="Task\Infrast\InfrastAbstractTask.h">
-      <Filter>源文件\Task\Infrast</Filter>
+      <Filter>Source\Task\Infrast</Filter>
     </ClInclude>
     <ClInclude Include="Task\Infrast\InfrastControlTask.h">
-      <Filter>源文件\Task\Infrast</Filter>
+      <Filter>Source\Task\Infrast</Filter>
     </ClInclude>
     <ClInclude Include="Task\Infrast\InfrastDormTask.h">
-      <Filter>源文件\Task\Infrast</Filter>
+      <Filter>Source\Task\Infrast</Filter>
     </ClInclude>
     <ClInclude Include="Task\Infrast\InfrastInfoTask.h">
-      <Filter>源文件\Task\Infrast</Filter>
+      <Filter>Source\Task\Infrast</Filter>
     </ClInclude>
     <ClInclude Include="Task\Infrast\InfrastMfgTask.h">
-      <Filter>源文件\Task\Infrast</Filter>
+      <Filter>Source\Task\Infrast</Filter>
     </ClInclude>
     <ClInclude Include="Task\Infrast\InfrastOfficeTask.h">
-      <Filter>源文件\Task\Infrast</Filter>
+      <Filter>Source\Task\Infrast</Filter>
     </ClInclude>
     <ClInclude Include="Task\Infrast\InfrastPowerTask.h">
-      <Filter>源文件\Task\Infrast</Filter>
+      <Filter>Source\Task\Infrast</Filter>
     </ClInclude>
     <ClInclude Include="Task\Infrast\InfrastProductionTask.h">
-      <Filter>源文件\Task\Infrast</Filter>
+      <Filter>Source\Task\Infrast</Filter>
     </ClInclude>
     <ClInclude Include="Task\Infrast\InfrastReceptionTask.h">
-      <Filter>源文件\Task\Infrast</Filter>
+      <Filter>Source\Task\Infrast</Filter>
     </ClInclude>
     <ClInclude Include="Task\Infrast\InfrastTradeTask.h">
-      <Filter>源文件\Task\Infrast</Filter>
+      <Filter>Source\Task\Infrast</Filter>
     </ClInclude>
     <ClInclude Include="Task\Infrast\ReplenishOriginiumShardTaskPlugin.h">
-      <Filter>源文件\Task\Infrast</Filter>
+      <Filter>Source\Task\Infrast</Filter>
     </ClInclude>
     <ClInclude Include="Task\Miscellaneous\AutoRecruitTask.h">
-      <Filter>源文件\Task\Miscellaneous</Filter>
+      <Filter>Source\Task\Miscellaneous</Filter>
     </ClInclude>
     <ClInclude Include="Task\Miscellaneous\BattleFormationTask.h">
-      <Filter>源文件\Task\Miscellaneous</Filter>
+      <Filter>Source\Task\Miscellaneous</Filter>
     </ClInclude>
     <ClInclude Include="Task\Miscellaneous\BattleProcessTask.h">
-      <Filter>源文件\Task\Miscellaneous</Filter>
+      <Filter>Source\Task\Miscellaneous</Filter>
     </ClInclude>
     <ClInclude Include="Task\Miscellaneous\CreditFightTask.h">
-      <Filter>源文件\Task\Miscellaneous</Filter>
+      <Filter>Source\Task\Miscellaneous</Filter>
     </ClInclude>
     <ClInclude Include="Task\Miscellaneous\CreditShoppingTask.h">
-      <Filter>源文件\Task\Miscellaneous</Filter>
+      <Filter>Source\Task\Miscellaneous</Filter>
     </ClInclude>
     <ClInclude Include="Task\Miscellaneous\DepotRecognitionTask.h">
-      <Filter>源文件\Task\Miscellaneous</Filter>
+      <Filter>Source\Task\Miscellaneous</Filter>
     </ClInclude>
     <ClInclude Include="Task\Miscellaneous\StartGameTaskPlugin.h">
-      <Filter>源文件\Task\Miscellaneous</Filter>
+      <Filter>Source\Task\Miscellaneous</Filter>
     </ClInclude>
     <ClInclude Include="Task\Roguelike\RoguelikeBattleTaskPlugin.h">
-      <Filter>源文件\Task\Roguelike</Filter>
+      <Filter>Source\Task\Roguelike</Filter>
     </ClInclude>
     <ClInclude Include="Task\Roguelike\RoguelikeControlTaskPlugin.h">
-      <Filter>源文件\Task\Roguelike</Filter>
+      <Filter>Source\Task\Roguelike</Filter>
     </ClInclude>
     <ClInclude Include="Task\Roguelike\RoguelikeCustomStartTaskPlugin.h">
-      <Filter>源文件\Task\Roguelike</Filter>
+      <Filter>Source\Task\Roguelike</Filter>
     </ClInclude>
     <ClInclude Include="Task\Roguelike\RoguelikeDebugTaskPlugin.h">
-      <Filter>源文件\Task\Roguelike</Filter>
+      <Filter>Source\Task\Roguelike</Filter>
     </ClInclude>
     <ClInclude Include="Task\Roguelike\RoguelikeFormationTaskPlugin.h">
-      <Filter>源文件\Task\Roguelike</Filter>
+      <Filter>Source\Task\Roguelike</Filter>
     </ClInclude>
     <ClInclude Include="Task\Roguelike\RoguelikeRecruitTaskPlugin.h">
-      <Filter>源文件\Task\Roguelike</Filter>
+      <Filter>Source\Task\Roguelike</Filter>
     </ClInclude>
     <ClInclude Include="Task\Roguelike\RoguelikeResetTaskPlugin.h">
-      <Filter>源文件\Task\Roguelike</Filter>
+      <Filter>Source\Task\Roguelike</Filter>
     </ClInclude>
     <ClInclude Include="Task\Roguelike\RoguelikeShoppingTaskPlugin.h">
-      <Filter>源文件\Task\Roguelike</Filter>
+      <Filter>Source\Task\Roguelike</Filter>
     </ClInclude>
     <ClInclude Include="Task\Roguelike\RoguelikeSkillSelectionTaskPlugin.h">
-      <Filter>源文件\Task\Roguelike</Filter>
+      <Filter>Source\Task\Roguelike</Filter>
     </ClInclude>
     <ClInclude Include="Task\Roguelike\RoguelikeStageEncounterTaskPlugin.h">
-      <Filter>源文件\Task\Roguelike</Filter>
+      <Filter>Source\Task\Roguelike</Filter>
     </ClInclude>
     <ClInclude Include="InstHelper.h">
-      <Filter>源文件</Filter>
+      <Filter>Source</Filter>
     </ClInclude>
     <ClInclude Include="Vision\Miscellaneous\StageDropsImageAnalyzer.h">
-      <Filter>源文件\Vision\Miscellaneous</Filter>
+      <Filter>Source\Vision\Miscellaneous</Filter>
     </ClInclude>
     <ClInclude Include="Task\BattleHelper.h">
-      <Filter>源文件\Task</Filter>
+      <Filter>Source\Task</Filter>
     </ClInclude>
     <ClInclude Include="Config\Miscellaneous\SSSCopilotConfig.h">
-      <Filter>源文件\Resource\Miscellaneous</Filter>
+      <Filter>Source\Resource\Miscellaneous</Filter>
     </ClInclude>
     <ClInclude Include="Task\Interface\SSSCopilotTask.h">
-      <Filter>源文件\Task\Interface</Filter>
+      <Filter>Source\Task\Interface</Filter>
     </ClInclude>
     <ClInclude Include="Config\Miscellaneous\AvatarCacheManager.h">
-      <Filter>源文件\Resource\Miscellaneous</Filter>
+      <Filter>Source\Resource\Miscellaneous</Filter>
     </ClInclude>
     <ClInclude Include="Task\SSS\SSSBattleProcessTask.h">
-      <Filter>源文件\Task\SSS</Filter>
+      <Filter>Source\Task\SSS</Filter>
     </ClInclude>
     <ClInclude Include="Task\SSS\SSSStageManagerTask.h">
-      <Filter>源文件\Task\SSS</Filter>
+      <Filter>Source\Task\SSS</Filter>
     </ClInclude>
     <ClInclude Include="Task\SSS\SSSDropRewardsTaskPlugin.h">
-      <Filter>源文件\Task\SSS</Filter>
+      <Filter>Source\Task\SSS</Filter>
     </ClInclude>
     <ClInclude Include="Task\Miscellaneous\StopGameTaskPlugin.h">
-      <Filter>源文件\Task\Miscellaneous</Filter>
+      <Filter>Source\Task\Miscellaneous</Filter>
     </ClInclude>
     <ClInclude Include="Vision\BestMatcher.h">
-      <Filter>源文件\Vision</Filter>
+      <Filter>Source\Vision</Filter>
     </ClInclude>
     <ClInclude Include="Task\Interface\SingleStepTask.h">
-      <Filter>源文件\Task\Interface</Filter>
+      <Filter>Source\Task\Interface</Filter>
     </ClInclude>
     <ClInclude Include="Task\Interface\ReclamationTask.h">
-      <Filter>源文件\Task\Interface</Filter>
+      <Filter>Source\Task\Interface</Filter>
     </ClInclude>
     <ClInclude Include="Task\Reclamation\ReclamationBattlePlugin.h">
-      <Filter>源文件\Task\Reclamation</Filter>
+      <Filter>Source\Task\Reclamation</Filter>
     </ClInclude>
     <ClInclude Include="Task\Reclamation\ReclamationConclusionReportPlugin.h">
-      <Filter>源文件\Task\Reclamation</Filter>
+      <Filter>Source\Task\Reclamation</Filter>
     </ClInclude>
     <ClInclude Include="Task\Reclamation\ReclamationControlTask.h">
-      <Filter>源文件\Task\Reclamation</Filter>
+      <Filter>Source\Task\Reclamation</Filter>
     </ClInclude>
     <ClInclude Include="Utils\File.hpp">
-      <Filter>源文件\Utils</Filter>
+      <Filter>Source\Utils</Filter>
     </ClInclude>
     <ClInclude Include="Controller\Controller.h">
-      <Filter>源文件\Controller</Filter>
+      <Filter>Source\Controller</Filter>
     </ClInclude>
     <ClInclude Include="Controller\adb-lite\client.hpp">
-      <Filter>源文件\Controller\adb-lite</Filter>
+      <Filter>Source\Controller\adb-lite</Filter>
     </ClInclude>
     <ClInclude Include="Controller\adb-lite\protocol.hpp">
-      <Filter>源文件\Controller\adb-lite</Filter>
+      <Filter>Source\Controller\adb-lite</Filter>
     </ClInclude>
     <ClInclude Include="Controller\ControllerAPI.h">
-      <Filter>源文件\Controller</Filter>
+      <Filter>Source\Controller</Filter>
     </ClInclude>
     <ClInclude Include="Controller\ControllerFactory.h">
-      <Filter>源文件\Controller</Filter>
+      <Filter>Source\Controller</Filter>
     </ClInclude>
     <ClInclude Include="Controller\ControlScaleProxy.h">
-      <Filter>源文件\Controller</Filter>
+      <Filter>Source\Controller</Filter>
     </ClInclude>
     <ClInclude Include="Controller\MaatouchController.h">
-      <Filter>源文件\Controller</Filter>
+      <Filter>Source\Controller</Filter>
     </ClInclude>
     <ClInclude Include="Controller\MinitouchController.h">
-      <Filter>源文件\Controller</Filter>
+      <Filter>Source\Controller</Filter>
     </ClInclude>
     <ClInclude Include="Controller\AdbController.h">
-      <Filter>源文件\Controller</Filter>
+      <Filter>Source\Controller</Filter>
     </ClInclude>
     <ClInclude Include="Controller\Platform\AdbLiteIO.h">
-      <Filter>源文件\Controller\Platform</Filter>
+      <Filter>Source\Controller\Platform</Filter>
     </ClInclude>
     <ClInclude Include="Controller\Platform\PosixIO.h">
-      <Filter>源文件\Controller\Platform</Filter>
+      <Filter>Source\Controller\Platform</Filter>
     </ClInclude>
     <ClInclude Include="Controller\Platform\Win32IO.h">
-      <Filter>源文件\Controller\Platform</Filter>
+      <Filter>Source\Controller\Platform</Filter>
     </ClInclude>
     <ClInclude Include="Controller\Platform\PlatformFactory.h">
-      <Filter>源文件\Controller\Platform</Filter>
+      <Filter>Source\Controller\Platform</Filter>
     </ClInclude>
     <ClInclude Include="Controller\Platform\PlatformIO.h">
-      <Filter>源文件\Controller\Platform</Filter>
+      <Filter>Source\Controller\Platform</Filter>
     </ClInclude>
     <ClInclude Include="Config\Miscellaneous\OcrConfig.h">
-      <Filter>源文件\Resource\Miscellaneous</Filter>
+      <Filter>Source\Resource\Miscellaneous</Filter>
     </ClInclude>
     <ClInclude Include="Task\Interface\CustomTask.h">
-      <Filter>源文件\Task\Interface</Filter>
+      <Filter>Source\Task\Interface</Filter>
     </ClInclude>
     <ClInclude Include="Task\Interface\VideoRecognitionTask.h">
-      <Filter>源文件\Task\Interface</Filter>
+      <Filter>Source\Task\Interface</Filter>
     </ClInclude>
     <ClInclude Include="Vision\Battle\BattleFormationAnalyzer.h">
-      <Filter>源文件\Vision\Battle</Filter>
+      <Filter>Source\Vision\Battle</Filter>
     </ClInclude>
     <ClInclude Include="Vision\Battle\BattlefieldMatcher.h">
-      <Filter>源文件\Vision\Battle</Filter>
+      <Filter>Source\Vision\Battle</Filter>
     </ClInclude>
     <ClInclude Include="Vision\Battle\BattlefieldClassifier.h">
-      <Filter>源文件\Vision\Battle</Filter>
+      <Filter>Source\Vision\Battle</Filter>
     </ClInclude>
     <ClInclude Include="Vision\Battle\BattlefieldDetector.h">
-      <Filter>源文件\Vision\Battle</Filter>
+      <Filter>Source\Vision\Battle</Filter>
     </ClInclude>
     <ClInclude Include="Config\OnnxSessions.h">
-      <Filter>源文件\Resource\Miscellaneous</Filter>
+      <Filter>Source\Resource\Miscellaneous</Filter>
     </ClInclude>
     <ClInclude Include="Utils\Algorithm.hpp">
-      <Filter>源文件\Utils</Filter>
+      <Filter>Source\Utils</Filter>
     </ClInclude>
     <ClInclude Include="Vision\OnnxHelper.h">
-      <Filter>源文件\Vision</Filter>
+      <Filter>Source\Vision</Filter>
     </ClInclude>
     <ClInclude Include="Task\Experiment\CombatRecordRecognitionTask.h">
-      <Filter>源文件\Task\Experiment</Filter>
+      <Filter>Source\Task\Experiment</Filter>
     </ClInclude>
     <ClInclude Include="Task\Experiment\SingleStepBattleProcessTask.h">
-      <Filter>源文件\Task\Experiment</Filter>
+      <Filter>Source\Task\Experiment</Filter>
     </ClInclude>
     <ClInclude Include="Controller\PlayToolsController.h">
-      <Filter>源文件\Controller</Filter>
+      <Filter>Source\Controller</Filter>
     </ClInclude>
     <ClInclude Include="Task\Interface\OperBoxTask.h">
-      <Filter>源文件\Task\Interface</Filter>
+      <Filter>Source\Task\Interface</Filter>
     </ClInclude>
     <ClInclude Include="Task\Miscellaneous\OperBoxRecognitionTask.h">
-      <Filter>源文件\Task\Miscellaneous</Filter>
+      <Filter>Source\Task\Miscellaneous</Filter>
     </ClInclude>
     <ClInclude Include="Vision\Miscellaneous\OperBoxImageAnalyzer.h">
-      <Filter>源文件\Vision\Miscellaneous</Filter>
+      <Filter>Source\Vision\Miscellaneous</Filter>
     </ClInclude>
     <ClInclude Include="Vision\Config\MatcherConfig.h">
-      <Filter>源文件\Vision\Config</Filter>
+      <Filter>Source\Vision\Config</Filter>
     </ClInclude>
     <ClInclude Include="Vision\Config\OCRerConfig.h">
-      <Filter>源文件\Vision\Config</Filter>
+      <Filter>Source\Vision\Config</Filter>
     </ClInclude>
     <ClInclude Include="Task\Roguelike\RoguelikeDifficultySelectionTaskPlugin.h">
-      <Filter>源文件\Task\Roguelike</Filter>
+      <Filter>Source\Task\Roguelike</Filter>
     </ClInclude>
     <ClInclude Include="Task\Roguelike\RoguelikeLastRewardTaskPlugin.h">
-      <Filter>源文件\Task\Roguelike</Filter>
+      <Filter>Source\Task\Roguelike</Filter>
     </ClInclude>
     <ClInclude Include="Task\Fight\SanityBeforeStagePlugin.h">
-      <Filter>源文件\Task\Fight</Filter>
+      <Filter>Source\Task\Fight</Filter>
     </ClInclude>
     <ClInclude Include="Task\Fight\SideStoryReopenTask.h">
-      <Filter>源文件\Task\Fight</Filter>
+      <Filter>Source\Task\Fight</Filter>
     </ClInclude>
     <ClInclude Include="Task\Fight\StageQueueMissionCompletedPlugin.h">
-      <Filter>源文件\Task\Fight</Filter>
+      <Filter>Source\Task\Fight</Filter>
     </ClInclude>
     <ClInclude Include="Task\Miscellaneous\AccountSwitchTask.h">
-      <Filter>源文件\Task\Miscellaneous</Filter>
+      <Filter>Source\Task\Miscellaneous</Filter>
     </ClInclude>
     <ClInclude Include="Task\Infrast\InfrastProcessingTask.h">
-      <Filter>源文件\Task\Infrast</Filter>
+      <Filter>Source\Task\Infrast</Filter>
     </ClInclude>
     <ClInclude Include="Task\Miscellaneous\CopilotListNotificationPlugin.h">
-      <Filter>源文件\Task\Miscellaneous</Filter>
+      <Filter>Source\Task\Miscellaneous</Filter>
     </ClInclude>
     <ClInclude Include="Task\Miscellaneous\TaskFileReloadTask.h">
-      <Filter>源文件\Task\Miscellaneous</Filter>
+      <Filter>Source\Task\Miscellaneous</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Vision\VisionHelper.cpp">
-      <Filter>源文件\Vision</Filter>
+      <Filter>Source\Vision</Filter>
     </ClCompile>
     <ClCompile Include="Vision\Hasher.cpp">
-      <Filter>源文件\Vision</Filter>
+      <Filter>Source\Vision</Filter>
     </ClCompile>
     <ClCompile Include="Vision\Matcher.cpp">
-      <Filter>源文件\Vision</Filter>
+      <Filter>Source\Vision</Filter>
     </ClCompile>
     <ClCompile Include="Vision\MultiMatcher.cpp">
-      <Filter>源文件\Vision</Filter>
+      <Filter>Source\Vision</Filter>
     </ClCompile>
     <ClCompile Include="Vision\OCRer.cpp">
-      <Filter>源文件\Vision</Filter>
+      <Filter>Source\Vision</Filter>
     </ClCompile>
     <ClCompile Include="Vision\TemplDetOCRer.cpp">
-      <Filter>源文件\Vision</Filter>
+      <Filter>Source\Vision</Filter>
     </ClCompile>
     <ClCompile Include="Vision\RegionOCRer.cpp">
-      <Filter>源文件\Vision</Filter>
+      <Filter>Source\Vision</Filter>
     </ClCompile>
     <ClCompile Include="Vision\Infrast\InfrastClueVacancyImageAnalyzer.cpp">
-      <Filter>源文件\Vision\Infrast</Filter>
+      <Filter>Source\Vision\Infrast</Filter>
     </ClCompile>
     <ClCompile Include="Vision\Infrast\InfrastFacilityImageAnalyzer.cpp">
-      <Filter>源文件\Vision\Infrast</Filter>
+      <Filter>Source\Vision\Infrast</Filter>
     </ClCompile>
     <ClCompile Include="Vision\Infrast\InfrastOperImageAnalyzer.cpp">
-      <Filter>源文件\Vision\Infrast</Filter>
+      <Filter>Source\Vision\Infrast</Filter>
     </ClCompile>
     <ClCompile Include="Vision\Infrast\InfrastSmileyImageAnalyzer.cpp">
-      <Filter>源文件\Vision\Infrast</Filter>
+      <Filter>Source\Vision\Infrast</Filter>
     </ClCompile>
     <ClCompile Include="Vision\Miscellaneous\CreditShopImageAnalyzer.cpp">
-      <Filter>源文件\Vision\Miscellaneous</Filter>
+      <Filter>Source\Vision\Miscellaneous</Filter>
     </ClCompile>
     <ClCompile Include="Vision\Miscellaneous\DepotImageAnalyzer.cpp">
-      <Filter>源文件\Vision\Miscellaneous</Filter>
+      <Filter>Source\Vision\Miscellaneous</Filter>
     </ClCompile>
     <ClCompile Include="Vision\Miscellaneous\PipelineAnalyzer.cpp">
-      <Filter>源文件\Vision\Miscellaneous</Filter>
+      <Filter>Source\Vision\Miscellaneous</Filter>
     </ClCompile>
     <ClCompile Include="Vision\Miscellaneous\RecruitImageAnalyzer.cpp">
-      <Filter>源文件\Vision\Miscellaneous</Filter>
+      <Filter>Source\Vision\Miscellaneous</Filter>
     </ClCompile>
     <ClCompile Include="Vision\Roguelike\RoguelikeFormationImageAnalyzer.cpp">
-      <Filter>源文件\Vision\Roguelike</Filter>
+      <Filter>Source\Vision\Roguelike</Filter>
     </ClCompile>
     <ClCompile Include="Vision\Roguelike\RoguelikeRecruitImageAnalyzer.cpp">
-      <Filter>源文件\Vision\Roguelike</Filter>
+      <Filter>Source\Vision\Roguelike</Filter>
     </ClCompile>
     <ClCompile Include="Vision\Roguelike\RoguelikeSkillSelectionImageAnalyzer.cpp">
-      <Filter>源文件\Vision\Roguelike</Filter>
+      <Filter>Source\Vision\Roguelike</Filter>
     </ClCompile>
     <ClCompile Include="Vision\Roguelike\RoguelikeRecruitSupportAnalyzer.cpp">
-      <Filter>源文件\Vision\Roguelike</Filter>
+      <Filter>Source\Vision\Roguelike</Filter>
     </ClCompile>
     <ClCompile Include="Config\AbstractConfig.cpp">
-      <Filter>源文件\Resource</Filter>
+      <Filter>Source\Resource</Filter>
     </ClCompile>
     <ClCompile Include="Config\ResourceLoader.cpp">
-      <Filter>源文件\Resource</Filter>
+      <Filter>Source\Resource</Filter>
     </ClCompile>
     <ClCompile Include="Config\TaskData.cpp">
-      <Filter>源文件\Resource</Filter>
+      <Filter>Source\Resource</Filter>
     </ClCompile>
     <ClCompile Include="Config\TemplResource.cpp">
-      <Filter>源文件\Resource</Filter>
+      <Filter>Source\Resource</Filter>
     </ClCompile>
     <ClCompile Include="Config\Roguelike\RoguelikeCopilotConfig.cpp">
-      <Filter>源文件\Resource\Roguelike</Filter>
+      <Filter>Source\Resource\Roguelike</Filter>
     </ClCompile>
     <ClCompile Include="Config\Roguelike\RoguelikeRecruitConfig.cpp">
-      <Filter>源文件\Resource\Roguelike</Filter>
+      <Filter>Source\Resource\Roguelike</Filter>
     </ClCompile>
     <ClCompile Include="Config\Roguelike\RoguelikeShoppingConfig.cpp">
-      <Filter>源文件\Resource\Roguelike</Filter>
+      <Filter>Source\Resource\Roguelike</Filter>
     </ClCompile>
     <ClCompile Include="Config\Roguelike\RoguelikeStageEncounterConfig.cpp">
-      <Filter>源文件\Resource\Roguelike</Filter>
+      <Filter>Source\Resource\Roguelike</Filter>
     </ClCompile>
     <ClCompile Include="Config\Miscellaneous\BattleDataConfig.cpp">
-      <Filter>源文件\Resource\Miscellaneous</Filter>
+      <Filter>Source\Resource\Miscellaneous</Filter>
     </ClCompile>
     <ClCompile Include="Config\Miscellaneous\CopilotConfig.cpp">
-      <Filter>源文件\Resource\Miscellaneous</Filter>
+      <Filter>Source\Resource\Miscellaneous</Filter>
     </ClCompile>
     <ClCompile Include="Config\Miscellaneous\InfrastConfig.cpp">
-      <Filter>源文件\Resource\Miscellaneous</Filter>
+      <Filter>Source\Resource\Miscellaneous</Filter>
     </ClCompile>
     <ClCompile Include="Config\Miscellaneous\ItemConfig.cpp">
-      <Filter>源文件\Resource\Miscellaneous</Filter>
+      <Filter>Source\Resource\Miscellaneous</Filter>
     </ClCompile>
     <ClCompile Include="Config\Miscellaneous\RecruitConfig.cpp">
-      <Filter>源文件\Resource\Miscellaneous</Filter>
+      <Filter>Source\Resource\Miscellaneous</Filter>
     </ClCompile>
     <ClCompile Include="Config\Miscellaneous\StageDropsConfig.cpp">
-      <Filter>源文件\Resource\Miscellaneous</Filter>
+      <Filter>Source\Resource\Miscellaneous</Filter>
     </ClCompile>
     <ClCompile Include="Config\Miscellaneous\TilePack.cpp">
-      <Filter>源文件\Resource\Miscellaneous</Filter>
+      <Filter>Source\Resource\Miscellaneous</Filter>
     </ClCompile>
     <ClCompile Include="Task\AbstractTask.cpp">
-      <Filter>源文件\Task</Filter>
+      <Filter>Source\Task</Filter>
     </ClCompile>
     <ClCompile Include="Task\AbstractTaskPlugin.cpp">
-      <Filter>源文件\Task</Filter>
+      <Filter>Source\Task</Filter>
     </ClCompile>
     <ClCompile Include="Task\PackageTask.cpp">
-      <Filter>源文件\Task</Filter>
+      <Filter>Source\Task</Filter>
     </ClCompile>
     <ClCompile Include="Task\ProcessTask.cpp">
-      <Filter>源文件\Task</Filter>
+      <Filter>Source\Task</Filter>
     </ClCompile>
     <ClCompile Include="Task\ReportDataTask.cpp">
-      <Filter>源文件\Task</Filter>
+      <Filter>Source\Task</Filter>
     </ClCompile>
     <ClCompile Include="Task\Interface\AwardTask.cpp">
-      <Filter>源文件\Task\Interface</Filter>
+      <Filter>Source\Task\Interface</Filter>
     </ClCompile>
     <ClCompile Include="Task\Interface\CloseDownTask.cpp">
-      <Filter>源文件\Task\Interface</Filter>
+      <Filter>Source\Task\Interface</Filter>
     </ClCompile>
     <ClCompile Include="Task\Interface\CopilotTask.cpp">
-      <Filter>源文件\Task\Interface</Filter>
+      <Filter>Source\Task\Interface</Filter>
     </ClCompile>
     <ClCompile Include="Task\Interface\DebugTask.cpp">
-      <Filter>源文件\Task\Interface</Filter>
+      <Filter>Source\Task\Interface</Filter>
     </ClCompile>
     <ClCompile Include="Task\Interface\DepotTask.cpp">
-      <Filter>源文件\Task\Interface</Filter>
+      <Filter>Source\Task\Interface</Filter>
     </ClCompile>
     <ClCompile Include="Task\Interface\FightTask.cpp">
-      <Filter>源文件\Task\Interface</Filter>
+      <Filter>Source\Task\Interface</Filter>
     </ClCompile>
     <ClCompile Include="Task\Interface\InfrastTask.cpp">
-      <Filter>源文件\Task\Interface</Filter>
+      <Filter>Source\Task\Interface</Filter>
     </ClCompile>
     <ClCompile Include="Task\Interface\MallTask.cpp">
-      <Filter>源文件\Task\Interface</Filter>
+      <Filter>Source\Task\Interface</Filter>
     </ClCompile>
     <ClCompile Include="Task\Interface\RecruitTask.cpp">
-      <Filter>源文件\Task\Interface</Filter>
+      <Filter>Source\Task\Interface</Filter>
     </ClCompile>
     <ClCompile Include="Task\Interface\RoguelikeTask.cpp">
-      <Filter>源文件\Task\Interface</Filter>
+      <Filter>Source\Task\Interface</Filter>
     </ClCompile>
     <ClCompile Include="Task\Interface\StartUpTask.cpp">
-      <Filter>源文件\Task\Interface</Filter>
+      <Filter>Source\Task\Interface</Filter>
     </ClCompile>
     <ClCompile Include="Utils\Platform\PlatformPosix.cpp">
-      <Filter>源文件\Utils\Platform</Filter>
+      <Filter>Source\Utils\Platform</Filter>
     </ClCompile>
     <ClCompile Include="Utils\Platform\PlatformWin32.cpp">
-      <Filter>源文件\Utils\Platform</Filter>
+      <Filter>Source\Utils\Platform</Filter>
     </ClCompile>
     <ClCompile Include="Assistant.cpp">
-      <Filter>源文件</Filter>
+      <Filter>Source</Filter>
     </ClCompile>
     <ClCompile Include="AsstCaller.cpp">
-      <Filter>源文件</Filter>
+      <Filter>Source</Filter>
     </ClCompile>
     <ClCompile Include="Status.cpp">
-      <Filter>源文件</Filter>
+      <Filter>Source</Filter>
     </ClCompile>
     <ClCompile Include="Config\GeneralConfig.cpp">
-      <Filter>源文件\Resource</Filter>
+      <Filter>Source\Resource</Filter>
     </ClCompile>
     <ClCompile Include="Config\Miscellaneous\OcrPack.cpp">
-      <Filter>源文件\Resource\Miscellaneous</Filter>
+      <Filter>Source\Resource\Miscellaneous</Filter>
     </ClCompile>
     <ClCompile Include="Task\Fight\DrGrandetTaskPlugin.cpp">
-      <Filter>源文件\Task\Fight</Filter>
+      <Filter>Source\Task\Fight</Filter>
     </ClCompile>
     <ClCompile Include="Task\Fight\StageDropsTaskPlugin.cpp">
-      <Filter>源文件\Task\Fight</Filter>
+      <Filter>Source\Task\Fight</Filter>
     </ClCompile>
     <ClCompile Include="Task\Fight\StageNavigationTask.cpp">
-      <Filter>源文件\Task\Fight</Filter>
+      <Filter>Source\Task\Fight</Filter>
     </ClCompile>
     <ClCompile Include="Task\Infrast\DronesForShamareTaskPlugin.cpp">
-      <Filter>源文件\Task\Infrast</Filter>
+      <Filter>Source\Task\Infrast</Filter>
     </ClCompile>
     <ClCompile Include="Task\Infrast\InfrastAbstractTask.cpp">
-      <Filter>源文件\Task\Infrast</Filter>
+      <Filter>Source\Task\Infrast</Filter>
     </ClCompile>
     <ClCompile Include="Task\Infrast\InfrastControlTask.cpp">
-      <Filter>源文件\Task\Infrast</Filter>
+      <Filter>Source\Task\Infrast</Filter>
     </ClCompile>
     <ClCompile Include="Task\Infrast\InfrastDormTask.cpp">
-      <Filter>源文件\Task\Infrast</Filter>
+      <Filter>Source\Task\Infrast</Filter>
     </ClCompile>
     <ClCompile Include="Task\Infrast\InfrastInfoTask.cpp">
-      <Filter>源文件\Task\Infrast</Filter>
+      <Filter>Source\Task\Infrast</Filter>
     </ClCompile>
     <ClCompile Include="Task\Infrast\InfrastMfgTask.cpp">
-      <Filter>源文件\Task\Infrast</Filter>
+      <Filter>Source\Task\Infrast</Filter>
     </ClCompile>
     <ClCompile Include="Task\Infrast\InfrastOfficeTask.cpp">
-      <Filter>源文件\Task\Infrast</Filter>
+      <Filter>Source\Task\Infrast</Filter>
     </ClCompile>
     <ClCompile Include="Task\Infrast\InfrastPowerTask.cpp">
-      <Filter>源文件\Task\Infrast</Filter>
+      <Filter>Source\Task\Infrast</Filter>
     </ClCompile>
     <ClCompile Include="Task\Infrast\InfrastProductionTask.cpp">
-      <Filter>源文件\Task\Infrast</Filter>
+      <Filter>Source\Task\Infrast</Filter>
     </ClCompile>
     <ClCompile Include="Task\Infrast\InfrastReceptionTask.cpp">
-      <Filter>源文件\Task\Infrast</Filter>
+      <Filter>Source\Task\Infrast</Filter>
     </ClCompile>
     <ClCompile Include="Task\Infrast\InfrastTradeTask.cpp">
-      <Filter>源文件\Task\Infrast</Filter>
+      <Filter>Source\Task\Infrast</Filter>
     </ClCompile>
     <ClCompile Include="Task\Infrast\ReplenishOriginiumShardTaskPlugin.cpp">
-      <Filter>源文件\Task\Infrast</Filter>
+      <Filter>Source\Task\Infrast</Filter>
     </ClCompile>
     <ClCompile Include="Task\Miscellaneous\AutoRecruitTask.cpp">
-      <Filter>源文件\Task\Miscellaneous</Filter>
+      <Filter>Source\Task\Miscellaneous</Filter>
     </ClCompile>
     <ClCompile Include="Task\Miscellaneous\BattleFormationTask.cpp">
-      <Filter>源文件\Task\Miscellaneous</Filter>
+      <Filter>Source\Task\Miscellaneous</Filter>
     </ClCompile>
     <ClCompile Include="Task\Miscellaneous\BattleProcessTask.cpp">
-      <Filter>源文件\Task\Miscellaneous</Filter>
+      <Filter>Source\Task\Miscellaneous</Filter>
     </ClCompile>
     <ClCompile Include="Task\Miscellaneous\CreditFightTask.cpp">
-      <Filter>源文件\Task\Miscellaneous</Filter>
+      <Filter>Source\Task\Miscellaneous</Filter>
     </ClCompile>
     <ClCompile Include="Task\Miscellaneous\CreditShoppingTask.cpp">
-      <Filter>源文件\Task\Miscellaneous</Filter>
+      <Filter>Source\Task\Miscellaneous</Filter>
     </ClCompile>
     <ClCompile Include="Task\Miscellaneous\DepotRecognitionTask.cpp">
-      <Filter>源文件\Task\Miscellaneous</Filter>
+      <Filter>Source\Task\Miscellaneous</Filter>
     </ClCompile>
     <ClCompile Include="Task\Miscellaneous\StartGameTaskPlugin.cpp">
-      <Filter>源文件\Task\Miscellaneous</Filter>
+      <Filter>Source\Task\Miscellaneous</Filter>
     </ClCompile>
     <ClCompile Include="Task\Miscellaneous\StopGameTaskPlugin.cpp">
-      <Filter>源文件\Task\Miscellaneous</Filter>
+      <Filter>Source\Task\Miscellaneous</Filter>
     </ClCompile>
     <ClCompile Include="Task\Roguelike\RoguelikeBattleTaskPlugin.cpp">
-      <Filter>源文件\Task\Roguelike</Filter>
+      <Filter>Source\Task\Roguelike</Filter>
     </ClCompile>
     <ClCompile Include="Task\Roguelike\RoguelikeControlTaskPlugin.cpp">
-      <Filter>源文件\Task\Roguelike</Filter>
+      <Filter>Source\Task\Roguelike</Filter>
     </ClCompile>
     <ClCompile Include="Task\Roguelike\RoguelikeCustomStartTaskPlugin.cpp">
-      <Filter>源文件\Task\Roguelike</Filter>
+      <Filter>Source\Task\Roguelike</Filter>
     </ClCompile>
     <ClCompile Include="Task\Roguelike\RoguelikeDebugTaskPlugin.cpp">
-      <Filter>源文件\Task\Roguelike</Filter>
+      <Filter>Source\Task\Roguelike</Filter>
     </ClCompile>
     <ClCompile Include="Task\Roguelike\RoguelikeFormationTaskPlugin.cpp">
-      <Filter>源文件\Task\Roguelike</Filter>
+      <Filter>Source\Task\Roguelike</Filter>
     </ClCompile>
     <ClCompile Include="Task\Roguelike\RoguelikeRecruitTaskPlugin.cpp">
-      <Filter>源文件\Task\Roguelike</Filter>
+      <Filter>Source\Task\Roguelike</Filter>
     </ClCompile>
     <ClCompile Include="Task\Roguelike\RoguelikeResetTaskPlugin.cpp">
-      <Filter>源文件\Task\Roguelike</Filter>
+      <Filter>Source\Task\Roguelike</Filter>
     </ClCompile>
     <ClCompile Include="Task\Roguelike\RoguelikeShoppingTaskPlugin.cpp">
-      <Filter>源文件\Task\Roguelike</Filter>
+      <Filter>Source\Task\Roguelike</Filter>
     </ClCompile>
     <ClCompile Include="Task\Roguelike\RoguelikeSkillSelectionTaskPlugin.cpp">
-      <Filter>源文件\Task\Roguelike</Filter>
+      <Filter>Source\Task\Roguelike</Filter>
     </ClCompile>
     <ClCompile Include="Task\Roguelike\RoguelikeStageEncounterTaskPlugin.cpp">
-      <Filter>源文件\Task\Roguelike</Filter>
+      <Filter>Source\Task\Roguelike</Filter>
     </ClCompile>
     <ClCompile Include="InstHelper.cpp">
-      <Filter>源文件</Filter>
+      <Filter>Source</Filter>
     </ClCompile>
     <ClCompile Include="Vision\Miscellaneous\StageDropsImageAnalyzer.cpp">
-      <Filter>源文件\Vision\Miscellaneous</Filter>
+      <Filter>Source\Vision\Miscellaneous</Filter>
     </ClCompile>
     <ClCompile Include="Task\BattleHelper.cpp">
-      <Filter>源文件\Task</Filter>
+      <Filter>Source\Task</Filter>
     </ClCompile>
     <ClCompile Include="Config\Miscellaneous\SSSCopilotConfig.cpp">
-      <Filter>源文件\Resource\Miscellaneous</Filter>
+      <Filter>Source\Resource\Miscellaneous</Filter>
     </ClCompile>
     <ClCompile Include="Task\Interface\SSSCopilotTask.cpp">
-      <Filter>源文件\Task\Interface</Filter>
+      <Filter>Source\Task\Interface</Filter>
     </ClCompile>
     <ClCompile Include="Config\Miscellaneous\AvatarCacheManager.cpp">
-      <Filter>源文件\Resource\Miscellaneous</Filter>
+      <Filter>Source\Resource\Miscellaneous</Filter>
     </ClCompile>
     <ClCompile Include="Task\SSS\SSSBattleProcessTask.cpp">
-      <Filter>源文件\Task\SSS</Filter>
+      <Filter>Source\Task\SSS</Filter>
     </ClCompile>
     <ClCompile Include="Task\SSS\SSSStageManagerTask.cpp">
-      <Filter>源文件\Task\SSS</Filter>
+      <Filter>Source\Task\SSS</Filter>
     </ClCompile>
     <ClCompile Include="Task\SSS\SSSDropRewardsTaskPlugin.cpp">
-      <Filter>源文件\Task\SSS</Filter>
+      <Filter>Source\Task\SSS</Filter>
     </ClCompile>
     <ClCompile Include="Vision\BestMatcher.cpp">
-      <Filter>源文件\Vision</Filter>
+      <Filter>Source\Vision</Filter>
     </ClCompile>
     <ClCompile Include="Task\Interface\SingleStepTask.cpp">
-      <Filter>源文件\Task\Interface</Filter>
+      <Filter>Source\Task\Interface</Filter>
     </ClCompile>
     <ClCompile Include="Task\Interface\ReclamationTask.cpp">
-      <Filter>源文件\Task\Interface</Filter>
+      <Filter>Source\Task\Interface</Filter>
     </ClCompile>
     <ClCompile Include="Task\Reclamation\ReclamationBattlePlugin.cpp">
-      <Filter>源文件\Task\Reclamation</Filter>
+      <Filter>Source\Task\Reclamation</Filter>
     </ClCompile>
     <ClCompile Include="Task\Reclamation\ReclamationConclusionReportPlugin.cpp">
-      <Filter>源文件\Task\Reclamation</Filter>
+      <Filter>Source\Task\Reclamation</Filter>
     </ClCompile>
     <ClCompile Include="Task\Reclamation\ReclamationControlTask.cpp">
-      <Filter>源文件\Task\Reclamation</Filter>
+      <Filter>Source\Task\Reclamation</Filter>
     </ClCompile>
     <ClCompile Include="Controller\Controller.cpp">
-      <Filter>源文件\Controller</Filter>
+      <Filter>Source\Controller</Filter>
     </ClCompile>
     <ClCompile Include="Controller\adb-lite\client.cpp">
-      <Filter>源文件\Controller\adb-lite</Filter>
+      <Filter>Source\Controller\adb-lite</Filter>
     </ClCompile>
     <ClCompile Include="Controller\adb-lite\protocol.cpp">
-      <Filter>源文件\Controller\adb-lite</Filter>
+      <Filter>Source\Controller\adb-lite</Filter>
     </ClCompile>
     <ClCompile Include="Controller\MinitouchController.cpp">
-      <Filter>源文件\Controller</Filter>
+      <Filter>Source\Controller</Filter>
     </ClCompile>
     <ClCompile Include="Controller\AdbController.cpp">
-      <Filter>源文件\Controller</Filter>
+      <Filter>Source\Controller</Filter>
     </ClCompile>
     <ClCompile Include="Controller\ControlScaleProxy.cpp">
-      <Filter>源文件\Controller</Filter>
+      <Filter>Source\Controller</Filter>
     </ClCompile>
     <ClCompile Include="Controller\Platform\AdbLiteIO.cpp">
-      <Filter>源文件\Controller\Platform</Filter>
+      <Filter>Source\Controller\Platform</Filter>
     </ClCompile>
     <ClCompile Include="Controller\Platform\PosixIO.cpp">
-      <Filter>源文件\Controller\Platform</Filter>
+      <Filter>Source\Controller\Platform</Filter>
     </ClCompile>
     <ClCompile Include="Controller\Platform\Win32IO.cpp">
-      <Filter>源文件\Controller\Platform</Filter>
+      <Filter>Source\Controller\Platform</Filter>
     </ClCompile>
     <ClCompile Include="Config\Miscellaneous\OcrConfig.cpp">
-      <Filter>源文件\Resource\Miscellaneous</Filter>
+      <Filter>Source\Resource\Miscellaneous</Filter>
     </ClCompile>
     <ClCompile Include="Task\Interface\CustomTask.cpp">
-      <Filter>源文件\Task\Interface</Filter>
+      <Filter>Source\Task\Interface</Filter>
     </ClCompile>
     <ClCompile Include="Task\Interface\VideoRecognitionTask.cpp">
-      <Filter>源文件\Task\Interface</Filter>
+      <Filter>Source\Task\Interface</Filter>
     </ClCompile>
     <ClCompile Include="Vision\Battle\BattleFormationAnalyzer.cpp">
-      <Filter>源文件\Vision\Battle</Filter>
+      <Filter>Source\Vision\Battle</Filter>
     </ClCompile>
     <ClCompile Include="Vision\Battle\BattlefieldMatcher.cpp">
-      <Filter>源文件\Vision\Battle</Filter>
+      <Filter>Source\Vision\Battle</Filter>
     </ClCompile>
     <ClCompile Include="Vision\Battle\BattlefieldClassifier.cpp">
-      <Filter>源文件\Vision\Battle</Filter>
+      <Filter>Source\Vision\Battle</Filter>
     </ClCompile>
     <ClCompile Include="Vision\Battle\BattlefieldDetector.cpp">
-      <Filter>源文件\Vision\Battle</Filter>
+      <Filter>Source\Vision\Battle</Filter>
     </ClCompile>
     <ClCompile Include="Config\OnnxSessions.cpp">
-      <Filter>源文件\Resource\Miscellaneous</Filter>
+      <Filter>Source\Resource\Miscellaneous</Filter>
     </ClCompile>
     <ClCompile Include="Vision\OnnxHelper.cpp">
-      <Filter>源文件\Vision</Filter>
+      <Filter>Source\Vision</Filter>
     </ClCompile>
     <ClCompile Include="Task\Experiment\CombatRecordRecognitionTask.cpp">
-      <Filter>源文件\Task\Experiment</Filter>
+      <Filter>Source\Task\Experiment</Filter>
     </ClCompile>
     <ClCompile Include="Task\Experiment\SingleStepBattleProcessTask.cpp">
-      <Filter>源文件\Task\Experiment</Filter>
+      <Filter>Source\Task\Experiment</Filter>
     </ClCompile>
     <ClCompile Include="Controller\PlayToolsController.cpp">
-      <Filter>源文件\Controller</Filter>
+      <Filter>Source\Controller</Filter>
     </ClCompile>
     <ClCompile Include="Task\Interface\OperBoxTask.cpp">
-      <Filter>源文件\Task\Interface</Filter>
+      <Filter>Source\Task\Interface</Filter>
     </ClCompile>
     <ClCompile Include="Task\Miscellaneous\OperBoxRecognitionTask.cpp">
-      <Filter>源文件\Task\Miscellaneous</Filter>
+      <Filter>Source\Task\Miscellaneous</Filter>
     </ClCompile>
     <ClCompile Include="Vision\Miscellaneous\OperBoxImageAnalyzer.cpp">
-      <Filter>源文件\Vision\Miscellaneous</Filter>
+      <Filter>Source\Vision\Miscellaneous</Filter>
     </ClCompile>
     <ClCompile Include="Vision\Config\MatcherConfig.cpp">
-      <Filter>源文件\Vision\Config</Filter>
+      <Filter>Source\Vision\Config</Filter>
     </ClCompile>
     <ClCompile Include="Vision\Config\OCRerConfig.cpp">
-      <Filter>源文件\Vision\Config</Filter>
+      <Filter>Source\Vision\Config</Filter>
     </ClCompile>
     <ClCompile Include="Task\Roguelike\RoguelikeDifficultySelectionTaskPlugin.cpp">
-      <Filter>源文件\Task\Roguelike</Filter>
+      <Filter>Source\Task\Roguelike</Filter>
     </ClCompile>
     <ClCompile Include="Task\Roguelike\RoguelikeLastRewardTaskPlugin.cpp">
-      <Filter>源文件\Task\Roguelike</Filter>
+      <Filter>Source\Task\Roguelike</Filter>
     </ClCompile>
     <ClCompile Include="Task\Fight\SanityBeforeStagePlugin.cpp">
-      <Filter>源文件\Task\Fight</Filter>
+      <Filter>Source\Task\Fight</Filter>
     </ClCompile>
     <ClCompile Include="Task\Fight\SideStoryReopenTask.cpp">
-      <Filter>源文件\Task\Fight</Filter>
+      <Filter>Source\Task\Fight</Filter>
     </ClCompile>
     <ClCompile Include="Task\Fight\StageQueueMissionCompletedPlugin.cpp">
-      <Filter>源文件\Task\Fight</Filter>
+      <Filter>Source\Task\Fight</Filter>
     </ClCompile>
     <ClCompile Include="Task\Miscellaneous\AccountSwitchTask.cpp">
-      <Filter>源文件\Task\Miscellaneous</Filter>
+      <Filter>Source\Task\Miscellaneous</Filter>
     </ClCompile>
     <ClCompile Include="Task\Infrast\InfrastProcessingTask.cpp">
-      <Filter>源文件\Task\Infrast</Filter>
+      <Filter>Source\Task\Infrast</Filter>
     </ClCompile>
     <ClCompile Include="Task\Miscellaneous\CopilotListNotificationPlugin.cpp">
-      <Filter>源文件\Task\Miscellaneous</Filter>
+      <Filter>Source\Task\Miscellaneous</Filter>
     </ClCompile>
     <ClCompile Include="Task\Miscellaneous\TaskFileReloadTask.cpp">
-      <Filter>源文件\Task\Miscellaneous</Filter>
+      <Filter>Source\Task\Miscellaneous</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
I understand that most of the MAA developers use Chinese as main language but I feel like this little change will not impact the developers, as the new nomenclature is basic programming knowledge (needed for VS22) but will definitely help all of the developers that don't understand Chinese.
This change will not impact the VSCode default environment where no programming knowledge is needed.

![image](https://github.com/MaaAssistantArknights/MaaAssistantArknights/assets/56174894/fbc5a4ee-b7a7-4fdc-aece-12e7b3812d04)

![image](https://github.com/MaaAssistantArknights/MaaAssistantArknights/assets/56174894/37e19566-6e4b-4fcf-8795-04568bd3057d)


