### PR TITLE
perf: WpfGui自动战斗解析作业后，提示文本移动至最顶端

### DIFF
--- a/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
@@ -255,8 +255,9 @@ namespace MaaWpfGui.ViewModels.UI
                     return;
                 }
 
-                var doc = (JObject)json["doc"];
+                AddLog(LocalizationHelper.GetString("CopilotTip"));
 
+                var doc = (JObject)json["doc"];
                 string title = string.Empty;
                 if (doc != null && doc.TryGetValue("title", out var titleValue))
                 {
@@ -374,8 +375,6 @@ namespace MaaWpfGui.ViewModels.UI
                     File.Delete(TempCopilotFile);
                     File.WriteAllText(TempCopilotFile, json.ToString());
                 }
-
-                AddLog(LocalizationHelper.GetString("CopilotTip"));
             }
             catch (Exception)
             {


### PR DESCRIPTION
- https://github.com/orgs/MaaAssistantArknights/discussions/6600

![image](https://github.com/MaaAssistantArknights/MaaAssistantArknights/assets/102887808/d681fcdf-939b-44fa-9067-4fece0bbcb45)

现在新版加完战斗列表之后太长了，完全遮挡了作业信息部分。
或许挪到作业信息之前会好一些？