### PR TITLE
style: hidden "Manual switch" button

### DIFF
--- a/src/MaaWpfGui/Views/UserControl/ConnectSettingsOnWakeUpUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/ConnectSettingsOnWakeUpUserControl.xaml
@@ -14,7 +14,9 @@
     d:DesignWidth="220"
     mc:Ignorable="d">
     <StackPanel>
-        <Grid Margin="0,5">
+        <Grid
+            Margin="0,5"
+            Visibility="{c:Binding '(ClientType == &quot;Official&quot;) or (ClientType == &quot;Bilibili&quot;) or (ClientType == &quot;&quot;)'}" >
             <Grid.ColumnDefinitions>
                 <ColumnDefinition />
                 <ColumnDefinition Width="Auto" />
@@ -24,9 +26,7 @@
                 IsReadOnly="{c:Binding !Idle}"
                 Style="{StaticResource TextBoxExtend}"
                 Text="{Binding AccountName, UpdateSourceTrigger=PropertyChanged}"
-                ToolTip="{DynamicResource AccountSwitchTip}"
-                Visibility="{c:Binding '(ClientType == &quot;Official&quot;) or (ClientType == &quot;Bilibili&quot;) or (ClientType == &quot;&quot;)'}" />
-
+                ToolTip="{DynamicResource AccountSwitchTip}"/>
             <Button
                 Grid.Column="1"
                 Padding="12,1,12,1"
@@ -35,7 +35,7 @@
                 hc:BorderElement.CornerRadius="0,4,4,0"
                 BorderThickness="0,1,1,1"
                 Command="{s:Action AccountSwitchManualRun}"
-                Content="{DynamicResource AccountSwitchManualRun}" />
+                Content="{DynamicResource AccountSwitchManualRun}"/>
         </Grid>
 
         <CheckBox


### PR DESCRIPTION
YostarEN does not allow multi-accounting (I'm pretty sure it's the same for JP and KR as they are all under Yostar) the "Manual Switch" button is not really needed.
With this PR I'm completely hiding the Grid.