### PR TITLE
ci: 移除 qodana 的插件来恢复工作流

### DIFF
--- a/qodana.yaml
+++ b/qodana.yaml
@@ -1,5 +1,5 @@
 version: "1.0"
-linter: jetbrains/qodana-dotnet:2023.2-eap
+linter: jetbrains/qodana-dotnet:2023.2
 bootstrap: echo 123
 plugins:
   - id: com.intellij.grazie.pro

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -1,5 +1,5 @@
 version: "1.0"
-linter: jetbrains/qodana-dotnet:2023.2
+linter: jetbrains/qodana-dotnet:2023.2-eap
 bootstrap: echo 123
 profile:
   name: qodana.recommended

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -1,8 +1,6 @@
 version: "1.0"
 linter: jetbrains/qodana-dotnet:2023.2
 bootstrap: echo 123
-plugins:
-  - id: com.intellij.grazie.pro
 profile:
   name: qodana.recommended
 dotnet:


### PR DESCRIPTION
EAP 满 30 天的有效时间，过期了，只能等 Jetbrains 解决那个问题了。目前先换回正式版的镜像，在 QODANA-TOKEN 有效的情况下，依然可以使用。

https://youtrack.jetbrains.com/issue/QD-6711

只能说不知道 Jetbrains 还要摆多久了，这个问题也两个多月了（sad