### PR TITLE
feat: OCR manipulation params for QuickFormation

### DIFF
--- a/resource/global/YoStarEN/resource/tasks.json
+++ b/resource/global/YoStarEN/resource/tasks.json
@@ -3242,6 +3242,12 @@
             231,
             116,
             22
+        ],
+        "specialParams": [
+            160,
+            4,
+            7,
+            0
         ]
     },
     "BattleStartPre": {

--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -7354,11 +7354,11 @@
             20
         ],
         "postDelay": 200,
-        "specialParams_Doc": "Used in BattleFormationTask.cpp for OCR manipulation",
+        "specialParams_Doc": "USED FOR YOSTAREN. Used in BattleFormationTask.cpp for OCR manipulation. For CN: OCRerConfig.h default values are used.",
         "specialParams": [
-            160,
-            4,
-            4,
+            140,
+            2,
+            0,
             0
         ]
     },

--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -7353,7 +7353,14 @@
             107,
             20
         ],
-        "postDelay": 200
+        "postDelay": 200,
+        "specialParams_Doc": "Used in BattleFormationTask.cpp for OCR manipulation",
+        "specialParams": [
+            160,
+            4,
+            4,
+            0
+        ]
     },
     "BattleQuickFormationSkill1": {
         "algorithm": "JustReturn",

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -240,8 +240,13 @@ std::vector<asst::TextRect> asst::BattleFormationTask::analyzer_opers()
     for (int i = 0; i < 8; ++i) {
         std::string task_name = "BattleQuickFormation-OperNameFlag" + std::to_string(i);
 
+        const auto& params = Task.get("BattleQuickFormationOCR")->special_params;
         TemplDetOCRer name_analyzer(image);
+
         name_analyzer.set_task_info(task_name, "BattleQuickFormationOCR");
+        name_analyzer.set_bin_threshold(params[0]);
+        name_analyzer.set_bin_expansion(params[1]);
+        name_analyzer.set_bin_trim_threshold(params[2], params[3]);
         name_analyzer.set_replace(ocr_replace->replace_map, ocr_replace->replace_full);
         auto cur_opt = name_analyzer.analyze();
         if (!cur_opt) {


### PR DESCRIPTION
I still haven't fully tested on the CN, but it has the same specialParams as `OperBoxNameOCR` so it shouldn't create problems.
Closes #6680