### PR TITLE
fix: 修复 POSIX 平台上在罕见情况下子进程不结束而使 MAA 永久性挂起的问题

### DIFF
--- a/src/MaaCore/Controller/Platform/PosixIO.cpp
+++ b/src/MaaCore/Controller/Platform/PosixIO.cpp
@@ -101,6 +101,17 @@ std::optional<int> asst::PosixIO::call_command(const std::string& cmd, const boo
             }
             ::shutdown(client_socket, SHUT_RDWR);
             ::close(client_socket);
+
+            // wait until the child has died or time is out
+            do {
+                if (::waitpid(m_child, &exit_ret, WNOHANG) != 0) {
+                    child_exited = true;
+                    break;
+                }
+                if (check_timeout()) {
+                    break;
+                }
+            } while (true);
         }
         else {
             do {


### PR DESCRIPTION
在一些特殊情况下，执行 ADB 命令的子进程可能无法响应退出。尤其是负责在 Screen Capture 时传输数据的 `nc` 进程，一旦 `shutdown` 发送的 `FIN` 数据包被丢失，就会一直卡住，导致 MAA 在 `waitpid` 时也永久性挂起。

Fix #6688.

~~Caveat: Kill 的进行可能有些过于攻击性。是否需要设置一个 timeout 再 kill？~~