### PR TITLE
fix: 修复 POSIX 平台上在一些情况下子进程不结束而使 MAA 永久性挂起的问题 

### DIFF
--- a/src/MaaCore/Controller/Platform/PosixIO.cpp
+++ b/src/MaaCore/Controller/Platform/PosixIO.cpp
@@ -101,17 +101,35 @@ std::optional<int> asst::PosixIO::call_command(const std::string& cmd, const boo
             ::shutdown(client_socket, SHUT_RDWR);
             ::close(client_socket);
         }
-        else {
-            do {
-                ssize_t read_num = ::read(m_pipe_out[PIPE_READ], pipe_buffer.get(), pipe_buffer.size());
-                while (read_num > 0) {
+
+
+        // has the child exited in the loop?
+        bool child_exited = false;
+
+        // whether we recv_by_socket or not, we have to
+        // drain the output pipe so that it doesn't block I/O.
+        do {
+            ssize_t read_num = ::read(m_pipe_out[PIPE_READ], pipe_buffer.get(), pipe_buffer.size());
+            while (read_num > 0) {
+                if (!recv_by_socket) {
                     pipe_data.insert(pipe_data.end(), pipe_buffer.get(), pipe_buffer.get() + read_num);
-                    read_num = ::read(m_pipe_out[PIPE_READ], pipe_buffer.get(), pipe_buffer.size());
                 }
-            } while (::waitpid(m_child, &exit_ret, WNOHANG) == 0 && !check_timeout());
+                read_num = ::read(m_pipe_out[PIPE_READ], pipe_buffer.get(), pipe_buffer.size());
+            }
+            if (::waitpid(m_child, &exit_ret, WNOHANG) != 0) {
+                child_exited = true;
+                break;
+            }
+            if (check_timeout()) {
+                Log.warn("timeout when reading the output, will kill the child: ", m_child);
+                break;
+            }
+        } while (true);
+
+        if (!child_exited) {
+            ::kill(m_child, SIGKILL);
+            ::waitpid(m_child, &exit_ret, 0);
         }
-        ::waitpid(m_child, &exit_ret, 0); // if ::waitpid(m_child, &exit_ret, WNOHANG) == 0, repeat it will cause
-        // ECHILD, so not check the return value
     }
     else {
         // failed to create child process


### PR DESCRIPTION
在满足 `recv_by_socket = true` 时的一些特殊情况下，POSIX 平台上执行 ADB 命令的子进程可能无法及时退出：

1. **子进程在 `nc` 后未退出。**[这篇博文](https://billauer.co.il/blog/2018/07/netcat-nc-stop-quit-disconnect/)提及 FreeBSD、GNU 和其他 Netcat 实现，在以下情况是否会退出**是未定义的**：
    1. gets an EOF on its standard input;
    2. receives a FIN packet.
   
    如果模拟器的 `nc` 是一个不良的实现，可能会在不传递 `-q` 参数时完全不退出，在 MAA 对不同截屏命令进行测速时卡死；
2. **子进程有任何标准输出或错误输出。** 因为未将 `m_pipe_out[PIPE_WRITE]` 设置 `O_NONBLOCKING`，也未读取管道内容，子进程将在管道缓冲区满时挂起。

该 PR 对于第一种情况添加了超时 Killing，对第二种情况排空了管道。

Fix #6688.