### PR TITLE
fix: update UnlockClues for EN

### DIFF
--- a/resource/global/YoStarEN/resource/tasks.json
+++ b/resource/global/YoStarEN/resource/tasks.json
@@ -2497,6 +2497,9 @@
             "Unable to receive new Clues"
         ]
     },
+    "UnlockClues": {
+        "templThreshold": 0.85
+    },
     "BattleStageName": {
         "Doc": "该任务的 ocrReplace 被所有涉及Rouge-like的English识别任务复用",
         "ocrReplace": [


### PR DESCRIPTION
The OCR currently fails for the `UnlockClues` task at higher resolutions, so I lowered the threshold a bit for EN (from default `0.90` to `0.85`).

Logs for `1600x900` client:

```
match_templ | UnlockClues.png score: 0.871378 rect: [ 554, 619, 256, 62 ] roi: [ 200, 600, 700, 120 ]
```