### PR TITLE
fix: update InfrastReward task (Max Trust base notification) for EN

### DIFF
--- a/resource/global/YoStarEN/resource/tasks.json
+++ b/resource/global/YoStarEN/resource/tasks.json
@@ -2420,7 +2420,7 @@
         "text": [
             "Collectable",
             "Orders Acquired",
-            "Trust"
+            "Max Trust"
         ]
     },
     "ShamareThumbnail1": {


### PR DESCRIPTION
Currently the `InfrastReward` task in EN looks for the string `"Trust"`. However, the OCR actually parses the text on screen as `"Max Trust"` so the task is unable to progress.

Logs for `1600x900` client:

```
asst::WordOcr [{ Backlog: [ 49, 83, 68, 26 ], score: 0.995247 }, { Max Trust: [ 218, 79, 55, 15 ], score: 0.964198 }, { MAX: [ 169, 92, 37, 16 ], score: 0.994455 }, { reached: [ 219, 99, 44, 13 ], score: 0.998339 }] by OCR Pipeline , cost 276 ms
```

<details>
<summary>Screenshot containing icon on EN client</summary>

[Source](https://www.reddit.com/r/arknights/comments/wzhuju/theres_a_max_trust_notification_for_base/)
![image](https://github.com/MaaAssistantArknights/MaaAssistantArknights/assets/3837473/62f93230-62d8-43c1-a6f6-1982ecc32c94)
</details>