### PR TITLE
feat: 添加了淬羽赫墨与多萝西的基建技能联动

### DIFF
--- a/resource/infrast.json
+++ b/resource/infrast.json
@@ -1490,6 +1490,18 @@
                 ],
                 "optional": [
                     {
+                        "desc": "莱茵科技·γ",
+                        "efficient": {
+                            "all": 35
+                        },
+                        "filter": [
+                            "淬羽赫默"
+                        ],
+                        "skills": [
+                            "bskill_man_spd3"
+                        ]
+                    },
+                    {
                         "desc": "莱茵科技·β",
                         "efficient": {
                             "all": 30
@@ -1533,6 +1545,18 @@
                     }
                 ],
                 "optional": [
+                    {
+                        "desc": "莱茵科技·γ",
+                        "efficient": {
+                            "all": 35
+                        },
+                        "filter": [
+                            "淬羽赫默"
+                        ],
+                        "skills": [
+                            "bskill_man_spd3"
+                        ]
+                    },
                     {
                         "desc": "莱茵科技·β",
                         "efficient": {


### PR DESCRIPTION
如题
我寻思水月组能正常识别多萝西组怎么不行，翻了下issues全是建议使用自定义基建的