### PR TITLE
fix: 修复战斗列表中跳过剧情确认识别问题

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -7510,6 +7510,7 @@
     },
     "SkipThePreBattlePlotConfirm": {
         "action": "ClickSelf",
+        "cache": false,
         "roi": [
             721,
             290,


### PR DESCRIPTION
教学关和普通关的位置不一样不能cache：true