### PR TITLE
fix: credit fight task retry after error

### DIFF
--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -52,7 +52,8 @@ bool asst::BattleFormationTask::_run()
     }
 
     if (!enter_selection_page()) {
-        return false;
+        if (!enter_selection_page()) 
+            return false;
     }
 
     for (auto& [role, oper_groups] : m_formation) {


### PR DESCRIPTION
Since I can't seem to build a NON-DEBUG version of MAA to "test" (yeah I need a non-debug to debug, it's strange).
I'm creating this PR in the hope to quickly merge and release a nightly.
The code SHOULD NOT change absolutely anything (logically speaking)
But in the case of a SubTaskError like in #6584 it should try again.
attemp to fix #6584
[skip ci]