### PR TITLE
ci: 使用 token 下载 CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ on:
       - 'cmake/**'
       - 'CMakeLists.txt'
       - 'MAA.sln'
+      - '.github/workflows/ci.yml'
   pull_request:
     branches:
       - 'dev'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,6 +178,7 @@ jobs:
         uses: robinraju/release-downloader@v1.8
         with:
           repository: MaaAssistantArknights/maa-cli
+          token: ${{ secrets.MISTEOWORKFLOW }}
           latest: true
           fileName: maa_cli-v*-${{ matrix.arch }}-unknown-linux-gnu.tar.gz
 


### PR DESCRIPTION
尝试解决下载 403 的问题：https://github.com/MaaAssistantArknights/MaaAssistantArknights/actions/runs/6522057109/job/17711276716。

但是这个可能不一定解决了这个问题，因为下载速率限制可能可以通过使用 `GITHUB_TOKEN` 来解决。这已经是 `release-downloader` 的[默认值](https://github.com/robinraju/release-downloader/blob/0ef9efab81fa2487942697c8f438cdd179f82529/action.yml#L39)了，我不确定再换一个 token 是否真的可以解决这个问题。如果之后还是出现这种情况，我就在 clone 过来再编译。

BTW, 我还改了 CI 的触发条件，因为即使是主仓库的分支，任何只对 CI 的修改也没办法触发 CI，如果这个不需要，我就 revert。