### PR TITLE
fix: 日服水月Rogue选择难度功能

### DIFF
--- a/resource/global/YoStarJP/resource/tasks.json
+++ b/resource/global/YoStarJP/resource/tasks.json
@@ -3563,6 +3563,11 @@
     "Phantom@Roguelike@StageEncounterOptionUnknown": {
         "templThreshold": 0.95
     },
+    "Mizuki@Roguelike@ChooseDifficultyConfirm": {
+        "text": [
+            "選択"
+        ]
+    },
     "Mizuki@Roguelike@MissionFailedFlag2": {
         "roi": [
             400,


### PR DESCRIPTION
https://github.com/MaaAssistantArknights/MaaAssistantArknights/pull/6947
此处难度选择可能不依赖图片模板，而是依赖文字OCR。已添加文字OCR所需任务，并初步测试能够正常选择“风平浪静”难度。