### PR TITLE
fix: 修复Wpf自动战斗-战斗列表-批量导入时，缓存文件夹未存在导致报错的bug；调整关卡名匹配规则

### DIFF
--- a/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
@@ -492,21 +492,30 @@ namespace MaaWpfGui.ViewModels.UI
                 }
             }
 
-            foreach (var pair in taskPairs)
+            try
             {
-                var jsonPath = $"{CopilotJsonDir}/{pair.Key}.json";
-                if (new FileInfo(jsonPath).FullName != pair.Value)
+                Directory.CreateDirectory(CopilotJsonDir);
+            }
+            catch (Exception)
+            {
+                // ignored
+            }
+
+            foreach (var taskPair in taskPairs)
+            {
+                var jsonPath = $"{CopilotJsonDir}/{taskPair.Key}.json";
+                if (new FileInfo(jsonPath).FullName != taskPair.Value)
                 {
                     // 相同路径跳拷贝
-                    File.Copy(pair.Value, jsonPath, true);
+                    File.Copy(taskPair.Value, jsonPath, true);
                 }
 
-                var item = new CopilotItemViewModel(pair.Key, jsonPath)
+                var item = new CopilotItemViewModel(taskPair.Key, jsonPath)
                 {
                     Index = CopilotItemViewModels.Count,
                 };
                 CopilotItemViewModels.Add(item);
-                AddLog("append task: " + pair.Key);
+                AddLog("append task: " + taskPair.Key);
             }
 
             SaveCopilotTask();
@@ -703,7 +712,7 @@ namespace MaaWpfGui.ViewModels.UI
             {
                 Directory.CreateDirectory(CopilotJsonDir);
             }
-            catch (Exception)
+            catch
             {
                 // ignored
             }

--- a/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
@@ -466,11 +466,17 @@ namespace MaaWpfGui.ViewModels.UI
                     var json = (JObject)JsonConvert.DeserializeObject(jsonStr);
                     if (json is null || !json.ContainsKey("stage_name") || !json.ContainsKey("actions"))
                     {
-                        AddLog($"{filename} corrupted", UiLogColor.Error);
+                        AddLog($"{filename} is broken", UiLogColor.Error);
                         return;
                     }
 
-                    taskPairs.Add(fileInfo.Name.Substring(0, fileInfo.Name.Length - fileInfo.Extension.Length).Replace("突袭", "-Adverse"), filename);
+                    var stageName = FindStageName(fileInfo.Name.Substring(0, fileInfo.Name.Length - fileInfo.Extension.Length));
+                    if (fileInfo.Name.Contains("突袭") || fileInfo.Name.Contains("-Adverse"))
+                    {
+                        stageName += "-Adverse";
+                    }
+
+                    taskPairs.Add(stageName, filename);
                 }
                 catch (Exception)
                 {

--- a/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
@@ -464,13 +464,6 @@ namespace MaaWpfGui.ViewModels.UI
                     return;
                 }
 
-                bool isJsonFile = filename.ToLower().EndsWith(".json") || fileInfo.Length < 4 * 1024 * 1024;
-                if (!isJsonFile)
-                {
-                    _isVideoTask = true;
-                    return;
-                }
-
                 try
                 {
                     using var reader = new StreamReader(File.OpenRead(filename));

--- a/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
@@ -254,7 +254,8 @@ namespace MaaWpfGui.ViewModels.UI
         /// <returns>关卡名 or string.Empty</returns>
         private static string FindStageName(params string[] names)
         {
-            if ((names = names.Where(str => !str.IsNullOrEmpty()).ToArray()).Length == 0)
+            names = names.Where(str => !str.IsNullOrEmpty()).ToArray();
+            if (names.Length == 0)
             {
                 return string.Empty;
             }

--- a/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
@@ -254,7 +254,7 @@ namespace MaaWpfGui.ViewModels.UI
         /// <returns>关卡名 or string.Empty</returns>
         private static string FindStageName(params string[] names)
         {
-            if (names.Length == 0)
+            if (((names = names.Where(str => !str.IsNullOrEmpty()).ToArray())?.Length ?? 0) == 0)
             {
                 return string.Empty;
             }

--- a/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
@@ -245,6 +245,19 @@ namespace MaaWpfGui.ViewModels.UI
 
         private const string TempCopilotFile = "cache/_temp_copilot.json";
         private string _taskType = "General";
+        private const string StageNameRegex = @"([a-z]{0,3})(\d{0,2})-(EX-)?(\d{1,2})";
+
+        // 为自动战斗列表匹配名字
+        private static string FindStageName(params string[] name)
+        {
+            if (name.Length == 0)
+            {
+                return string.Empty;
+            }
+
+            var regex = new Regex(StageNameRegex, RegexOptions.Compiled | RegexOptions.IgnoreCase);
+            return name.Select(str => regex.Match(str)).FirstOrDefault(result => result.Success)?.Value ?? string.Empty;
+        }
 
         private void ParseJsonAndShowInfo(string jsonStr)
         {
@@ -270,26 +283,7 @@ namespace MaaWpfGui.ViewModels.UI
                 {
                     title = titleValue.ToString();
 
-                    do
-                    {
-                        // 为自动作战列表匹配名字
-                        var stageNameParser = new Regex(@"([a-z]{0,3})(\d{0,2})-(EX-)?(\d{1,2})", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-                        var stageNameResult = stageNameParser.Matches(title);
-                        if (stageNameResult.Count > 0)
-                        {
-                            CopilotTaskName = stageNameResult[0].Value;
-                            break;
-                        }
-
-                        if (!IsDataFromWeb && (stageNameResult = stageNameParser.Matches(_filename)).Count > 0)
-                        {
-                            CopilotTaskName = stageNameResult[0].Value;
-                            break;
-                        }
-
-                        CopilotTaskName = string.Empty;
-                    }
-                    while (false);
+                    CopilotTaskName = FindStageName(title, _filename);
                 }
 
                 if (title.Length != 0)

--- a/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
@@ -254,7 +254,7 @@ namespace MaaWpfGui.ViewModels.UI
         /// <returns>关卡名 or string.Empty</returns>
         private static string FindStageName(params string[] names)
         {
-            if (((names = names.Where(str => !str.IsNullOrEmpty()).ToArray())?.Length ?? 0) == 0)
+            if ((names = names.Where(str => !str.IsNullOrEmpty()).ToArray()).Length == 0)
             {
                 return string.Empty;
             }


### PR DESCRIPTION
关卡名匹配规则为：
    1. 如果由[a-z0-9\-]*组成，则直接使用
    2. 匹配正则：[a-z]{0,3}-(([A-D]|EX)-)?\d+

匹配顺序：
    1. 作业[doc][title]（仅单文件添加时启用）
    2. 文件名

- close #6978 