### PR TITLE
fix: 优化设置引导界面的视觉效果，并给 UI Theme 添加翻译

### DIFF
--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -20,6 +20,7 @@
     <system:String x:Key="StartupSettings">Startup</system:String>
     <system:String x:Key="ScheduleSettings">Schedule</system:String>
     <system:String x:Key="UiSettings">GUI</system:String>
+    <system:String x:Key="UiTheme">UI Theme</system:String>
     <system:String x:Key="HotKeySettings">HotKeys</system:String>
     <system:String x:Key="UpdateSettings">Update</system:String>
     <system:String x:Key="AboutUs">About us</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -20,6 +20,7 @@
     <system:String x:Key="StartupSettings">起動設定</system:String>
     <system:String x:Key="ScheduleSettings">スケジュール実行設定</system:String>
     <system:String x:Key="UiSettings">UI設定</system:String>
+    <system:String x:Key="UiTheme">UI主題</system:String>
     <system:String x:Key="HotKeySettings">ホットキー設定</system:String>
     <system:String x:Key="UpdateSettings">アップデート設定</system:String>
     <system:String x:Key="AboutUs">About</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -20,6 +20,7 @@
     <system:String x:Key="StartupSettings">시작 설정</system:String>
     <system:String x:Key="ScheduleSettings">예약 설정</system:String>
     <system:String x:Key="UiSettings">UI 설정</system:String>
+    <system:String x:Key="UiTheme">UI 테마</system:String>
     <system:String x:Key="HotKeySettings">단축키 설정</system:String>
     <system:String x:Key="UpdateSettings">업데이트</system:String>
     <system:String x:Key="AboutUs">정보</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -20,6 +20,7 @@
     <system:String x:Key="StartupSettings">启动设置</system:String>
     <system:String x:Key="ScheduleSettings">定时执行</system:String>
     <system:String x:Key="UiSettings">界面设置</system:String>
+    <system:String x:Key="UiTheme">界面主题</system:String>
     <system:String x:Key="HotKeySettings">热键设置</system:String>
     <system:String x:Key="UpdateSettings">软件更新</system:String>
     <system:String x:Key="AboutUs">关于我们</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -20,6 +20,7 @@
     <system:String x:Key="StartupSettings">啟動設定</system:String>
     <system:String x:Key="ScheduleSettings">定時執行</system:String>
     <system:String x:Key="UiSettings">介面設定</system:String>
+    <system:String x:Key="UiTheme">介面主題</system:String>
     <system:String x:Key="HotKeySettings">熱鍵設定</system:String>
     <system:String x:Key="UpdateSettings">軟體更新</system:String>
     <system:String x:Key="AboutUs">關於我們</system:String>

--- a/src/MaaWpfGui/Views/UserControl/GUISettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/GUISettingsUserControl.xaml
@@ -71,7 +71,7 @@
                 HorizontalAlignment="Right"
                 VerticalAlignment="Center"
                 Block.TextAlignment="Center"
-                Text="UI Theme"
+                Text="{DynamicResource UiTheme}"
                 TextWrapping="Wrap" />
             <controls:TextBlock
                 Margin="10"

--- a/src/MaaWpfGui/Views/UserControl/GuideUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/GuideUserControl.xaml
@@ -104,7 +104,7 @@
                                     Style="{StaticResource ComboBoxExtend}" />
                                 <ComboBox
                                     hc:InfoElement.HorizontalAlignment="Center"
-                                    hc:InfoElement.Title="UI Theme"
+                                    hc:InfoElement.Title="{DynamicResource UiTheme}"
                                     hc:InfoElement.TitlePlacement="Left"
                                     hc:InfoElement.TitleWidth="110"
                                     DisplayMemberPath="Display"

--- a/src/MaaWpfGui/Views/UserControl/GuideUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/GuideUserControl.xaml
@@ -83,162 +83,169 @@
                         Visibility="{c:Binding 'GuideStepIndex > 2'}" />
                 </StackPanel>
 
-                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                <ScrollViewer
+                    VerticalScrollBarVisibility="Auto"
+                    Margin="10,20,10,20">
                     <hc:SimplePanel HorizontalAlignment="Center" VerticalAlignment="Center">
-                    <hc:TransitioningContentControl
-                        Width="200"
-                        TransitionMode="{Binding GuideTransitionMode}"
-                        Visibility="{c:Binding 'GuideStepIndex less= 0'}">
-                        <hc:UniformSpacingPanel Orientation="Vertical" Spacing="40">
-                            <ComboBox
-                                hc:InfoElement.HorizontalAlignment="Center"
-                                hc:InfoElement.Title="{Binding LanguageInfo, Mode=OneTime}"
-                                hc:InfoElement.TitlePlacement="Left"
-                                hc:InfoElement.TitleWidth="110"
-                                DisplayMemberPath="Display"
-                                ItemsSource="{Binding LanguageList}"
-                                SelectedValue="{Binding Language}"
-                                SelectedValuePath="Value"
-                                Style="{StaticResource ComboBoxExtend}" />
-                            <ComboBox
-                                hc:InfoElement.HorizontalAlignment="Center"
-                                hc:InfoElement.Title="UI Theme"
-                                hc:InfoElement.TitlePlacement="Left"
-                                hc:InfoElement.TitleWidth="110"
-                                DisplayMemberPath="Display"
-                                ItemsSource="{Binding DarkModeList}"
-                                SelectedValue="{Binding DarkMode}"
-                                SelectedValuePath="Value"
-                                Style="{StaticResource ComboBoxExtend}" />
-                        </hc:UniformSpacingPanel>
-                    </hc:TransitioningContentControl>
+                        <hc:TransitioningContentControl
+                            Width="240"
+                            TransitionMode="{Binding GuideTransitionMode}"
+                            Visibility="{c:Binding 'GuideStepIndex less= 0'}">
+                            <hc:UniformSpacingPanel Orientation="Vertical" Spacing="40">
+                                <ComboBox
+                                    hc:InfoElement.HorizontalAlignment="Center"
+                                    hc:InfoElement.Title="{Binding LanguageInfo, Mode=OneTime}"
+                                    hc:InfoElement.TitlePlacement="Left"
+                                    hc:InfoElement.TitleWidth="110"
+                                    DisplayMemberPath="Display"
+                                    ItemsSource="{Binding LanguageList}"
+                                    SelectedValue="{Binding Language}"
+                                    SelectedValuePath="Value"
+                                    Style="{StaticResource ComboBoxExtend}" />
+                                <ComboBox
+                                    hc:InfoElement.HorizontalAlignment="Center"
+                                    hc:InfoElement.Title="UI Theme"
+                                    hc:InfoElement.TitlePlacement="Left"
+                                    hc:InfoElement.TitleWidth="110"
+                                    DisplayMemberPath="Display"
+                                    ItemsSource="{Binding DarkModeList}"
+                                    SelectedValue="{Binding DarkMode}"
+                                    SelectedValuePath="Value"
+                                    Style="{StaticResource ComboBoxExtend}" />
+                            </hc:UniformSpacingPanel>
+                        </hc:TransitioningContentControl>
 
-                    <hc:TransitioningContentControl TransitionMode="{Binding GuideTransitionMode}" Visibility="{c:Binding 'GuideStepIndex == 1'}">
-                        <userControl:GameClientUserControl />
-                    </hc:TransitioningContentControl>
+                        <hc:TransitioningContentControl
+                            TransitionMode="{Binding GuideTransitionMode}"
+                            Visibility="{c:Binding 'GuideStepIndex == 1'}">
+                            <userControl:GameClientUserControl />
+                        </hc:TransitioningContentControl>
 
-                    <hc:TransitioningContentControl
-                        Width="200"
-                        TransitionMode="{Binding GuideTransitionMode}"
-                        Visibility="{c:Binding 'GuideStepIndex == 2'}">
-                        <userControl:ConnectSettingsOnWakeUpUserControl />
-                    </hc:TransitioningContentControl>
+                        <hc:TransitioningContentControl
+                            Width="240"
+                            TransitionMode="{Binding GuideTransitionMode}"
+                            Visibility="{c:Binding 'GuideStepIndex == 2'}">
+                            <userControl:ConnectSettingsOnWakeUpUserControl />
+                        </hc:TransitioningContentControl>
 
-                    <hc:TransitioningContentControl
-                        Width="230"
-                        Height="270"
-                        TransitionMode="{Binding GuideTransitionMode}"
-                        Visibility="{c:Binding 'GuideStepIndex == 3'}">
-                        <hc:RelativePanel>
-                            <TextBlock
-                                Name="ToolTipGuide"
-                                Margin="0,10"
-                                Text="{DynamicResource ToolTipGuide}" />
-                            <Border
-                                Name="PerformBattlesGuide"
-                                Margin="5"
-                                Padding="5"
-                                hc:RelativePanel.RightOf="{Binding ElementName=ToolTipGuide}"
-                                BorderBrush="{DynamicResource BorderBrush}"
-                                BorderThickness="1"
-                                CornerRadius="4">
-                                <TextBlock Text="{DynamicResource PerformBattles}" ToolTip="{DynamicResource CheckBoxesNotSaved}" />
-                            </Border>
-                            <Border
-                                Name="Task"
-                                Padding="5,0,0,0"
-                                hc:RelativePanel.Below="{Binding ElementName=ToolTipGuide}"
-                                BorderBrush="{DynamicResource BorderBrush}"
-                                BorderThickness="1"
-                                CornerRadius="4">
-                                <StackPanel Orientation="Horizontal">
-                                    <!--<maa:TextBlock  Text="{Binding ID}" />
+                        <hc:TransitioningContentControl
+                            Width="240"
+                            Height="270"
+                            TransitionMode="{Binding GuideTransitionMode}"
+                            Visibility="{c:Binding 'GuideStepIndex == 3'}">
+                            <hc:RelativePanel>
+                                <TextBlock
+                                    Name="ToolTipGuide"
+                                    Margin="0,10"
+                                    Text="{DynamicResource ToolTipGuide}" />
+                                <Border
+                                    Name="PerformBattlesGuide"
+                                    Margin="5"
+                                    Padding="5"
+                                    hc:RelativePanel.RightOf="{Binding ElementName=ToolTipGuide}"
+                                    BorderBrush="{DynamicResource BorderBrush}"
+                                    BorderThickness="1"
+                                    CornerRadius="4">
+                                    <TextBlock Text="{DynamicResource PerformBattles}"
+                                        ToolTip="{DynamicResource CheckBoxesNotSaved}" />
+                                </Border>
+                                <Border
+                                    Name="Task"
+                                    Padding="5,0,0,0"
+                                    hc:RelativePanel.Below="{Binding ElementName=ToolTipGuide}"
+                                    BorderBrush="{DynamicResource BorderBrush}"
+                                    BorderThickness="1"
+                                    CornerRadius="4">
+                                    <StackPanel Orientation="Horizontal">
+                                        <!--<maa:TextBlock
+                                        Text="{Binding ID}" />
                             <maa:TextBlock  Text=". " />-->
-                                    <CheckBox
-                                        Width="180"
-                                        Content="{DynamicResource Combat}"
-                                        ToolTip="{DynamicResource LabelSequenceTip}" />
-                                    <hc:ButtonGroup>
-                                        <RadioButton
-                                            hc:IconElement.Geometry="{StaticResource ConfigGeometry}"
-                                            hc:VisualElement.HighlightBackground="Transparent"
-                                            hc:VisualElement.HighlightForeground="{DynamicResource PrimaryBrush}"
-                                            Background="Transparent"
-                                            BorderThickness="0"
-                                            Foreground="{DynamicResource SecondaryTextBrush}"
-                                            Style="{DynamicResource RadioGroupItemSingle}"
-                                            ToolTip="{DynamicResource TaskSettings}" />
-                                    </hc:ButtonGroup>
-                                </StackPanel>
-                            </Border>
-                            <TextBlock
-                                Name="TaskGuide"
-                                Margin="10"
-                                hc:RelativePanel.AlignLeftWith="{Binding ElementName=Task}"
-                                hc:RelativePanel.Below="{Binding ElementName=Task}"
-                                FontSize="14"
-                                Text="{DynamicResource TaskGuide}" />
-                            <TextBlock
-                                Name="TaskSettingsGuide1"
-                                Margin="0,5,30,0"
-                                hc:RelativePanel.AlignRightWith="{Binding ElementName=Task}"
-                                hc:RelativePanel.Below="{Binding ElementName=Task}"
-                                FontSize="14"
-                                Text="↗" />
-                            <TextBlock
-                                Name="TaskSettingsGuide2"
-                                Width="90"
-                                Margin="5,5,0,5"
-                                hc:RelativePanel.AlignRightWith="{Binding ElementName=TaskSettingsGuide1}"
-                                hc:RelativePanel.Below="{Binding ElementName=TaskSettingsGuide1}"
-                                FontSize="14"
-                                Text="{DynamicResource TaskSettings}"
-                                TextAlignment="Left" />
-                            <TextBlock
-                                Name="TaskSettingsGuide3"
-                                hc:RelativePanel.AlignLeftWith="{Binding ElementName=TaskSettingsGuide2}"
-                                hc:RelativePanel.Below="{Binding ElementName=TaskSettingsGuide2}"
-                                FontSize="14"
-                                Text="↙" />
-                            <TextBlock
-                                Name="GeneralSettingsGuide"
-                                Margin="5,10"
-                                hc:RelativePanel.AlignLeftWith="{Binding ElementName=TaskGuide}"
-                                hc:RelativePanel.Below="{Binding ElementName=TaskGuide}"
-                                FontSize="14"
-                                Text="{DynamicResource OftenUsedGuide}" />
-                            <hc:ButtonGroup
-                                Name="TaskSettings"
-                                Width="220"
-                                hc:RelativePanel.Below="{Binding ElementName=GeneralSettingsGuide}"
-                                Orientation="Horizontal">
-                                <RadioButton Content="{DynamicResource GeneralSettings}" IsChecked="True" />
-                                <RadioButton Content="{DynamicResource AdvancedSettings}" />
-                            </hc:ButtonGroup>
-                            <TextBlock
-                                Name="AdvancedSettingsGuide"
-                                Margin="5,10"
-                                hc:RelativePanel.AlignRightWith="{Binding ElementName=TaskSettings}"
-                                hc:RelativePanel.Below="{Binding ElementName=TaskSettings}"
-                                FontSize="14"
-                                Text="{DynamicResource SometimesUsedGuide}" />
-                            <Button
-                                Name="LinkStart"
-                                Width="100"
-                                Height="50"
-                                Margin="5"
-                                hc:RelativePanel.Below="{Binding ElementName=AdvancedSettingsGuide}"
-                                Content="{DynamicResource LinkStart}" />
-                            <TextBlock
-                                Name="LinkStartGuide"
-                                Margin="10,20"
-                                hc:RelativePanel.Below="{Binding ElementName=AdvancedSettingsGuide}"
-                                hc:RelativePanel.RightOf="{Binding ElementName=LinkStart}"
-                                FontSize="14"
-                                Text="{DynamicResource LinkStartGuide}" />
-                        </hc:RelativePanel>
-                    </hc:TransitioningContentControl>
-                </hc:SimplePanel>
+                                        <CheckBox
+                                            Width="180"
+                                            Content="{DynamicResource Combat}"
+                                            ToolTip="{DynamicResource LabelSequenceTip}" />
+                                        <hc:ButtonGroup>
+                                            <RadioButton
+                                                hc:IconElement.Geometry="{StaticResource ConfigGeometry}"
+                                                hc:VisualElement.HighlightBackground="Transparent"
+                                                hc:VisualElement.HighlightForeground="{DynamicResource PrimaryBrush}"
+                                                Background="Transparent"
+                                                BorderThickness="0"
+                                                Foreground="{DynamicResource SecondaryTextBrush}"
+                                                Style="{DynamicResource RadioGroupItemSingle}"
+                                                ToolTip="{DynamicResource TaskSettings}" />
+                                        </hc:ButtonGroup>
+                                    </StackPanel>
+                                </Border>
+                                <TextBlock
+                                    Name="TaskGuide"
+                                    Margin="10"
+                                    hc:RelativePanel.AlignLeftWith="{Binding ElementName=Task}"
+                                    hc:RelativePanel.Below="{Binding ElementName=Task}"
+                                    FontSize="14"
+                                    Text="{DynamicResource TaskGuide}" />
+                                <TextBlock
+                                    Name="TaskSettingsGuide1"
+                                    Margin="0,5,30,0"
+                                    hc:RelativePanel.AlignRightWith="{Binding ElementName=Task}"
+                                    hc:RelativePanel.Below="{Binding ElementName=Task}"
+                                    FontSize="14"
+                                    Text="↗" />
+                                <TextBlock
+                                    Name="TaskSettingsGuide2"
+                                    Width="90"
+                                    Margin="5,5,0,5"
+                                    hc:RelativePanel.AlignRightWith="{Binding ElementName=TaskSettingsGuide1}"
+                                    hc:RelativePanel.Below="{Binding ElementName=TaskSettingsGuide1}"
+                                    FontSize="14"
+                                    Text="{DynamicResource TaskSettings}"
+                                    TextAlignment="Left" />
+                                <TextBlock
+                                    Name="TaskSettingsGuide3"
+                                    hc:RelativePanel.AlignLeftWith="{Binding ElementName=TaskSettingsGuide2}"
+                                    hc:RelativePanel.Below="{Binding ElementName=TaskSettingsGuide2}"
+                                    FontSize="14"
+                                    Text="↙" />
+                                <TextBlock
+                                    Name="GeneralSettingsGuide"
+                                    Margin="5,10"
+                                    hc:RelativePanel.AlignLeftWith="{Binding ElementName=TaskGuide}"
+                                    hc:RelativePanel.Below="{Binding ElementName=TaskGuide}"
+                                    FontSize="14"
+                                    Text="{DynamicResource OftenUsedGuide}" />
+                                <hc:ButtonGroup
+                                    Name="TaskSettings"
+                                    Width="220"
+                                    hc:RelativePanel.Below="{Binding ElementName=GeneralSettingsGuide}"
+                                    Orientation="Horizontal">
+                                    <RadioButton Content="{DynamicResource GeneralSettings}"
+                                        IsChecked="True" />
+                                    <RadioButton Content="{DynamicResource AdvancedSettings}" />
+                                </hc:ButtonGroup>
+                                <TextBlock
+                                    Name="AdvancedSettingsGuide"
+                                    Margin="5,10"
+                                    hc:RelativePanel.AlignRightWith="{Binding ElementName=TaskSettings}"
+                                    hc:RelativePanel.Below="{Binding ElementName=TaskSettings}"
+                                    FontSize="14"
+                                    Text="{DynamicResource SometimesUsedGuide}" />
+                                <Button
+                                    Name="LinkStart"
+                                    Width="100"
+                                    Height="50"
+                                    Margin="5"
+                                    hc:RelativePanel.Below="{Binding ElementName=AdvancedSettingsGuide}"
+                                    Content="{DynamicResource LinkStart}" />
+                                <TextBlock
+                                    Name="LinkStartGuide"
+                                    Margin="10,20"
+                                    hc:RelativePanel.Below="{Binding ElementName=AdvancedSettingsGuide}"
+                                    hc:RelativePanel.RightOf="{Binding ElementName=LinkStart}"
+                                    FontSize="14"
+                                    Text="{DynamicResource LinkStartGuide}" />
+                            </hc:RelativePanel>
+                        </hc:TransitioningContentControl>
+                    </hc:SimplePanel>
                 </ScrollViewer>
             </DockPanel>
         </GroupBox>


### PR DESCRIPTION
如题，先前的宽度设置会导致 `UI Theme` 显示不全

<img width="211" alt="8b6d8402827a61c9c118b59f04a9e452" src="https://github.com/MaaAssistantArknights/MaaAssistantArknights/assets/57581480/bfa49f8e-8726-48b9-b9af-083eaba1ed79">

顺便做了个style（
