### PR TITLE
fix: 修复在点击停止后下一次开始任务时可能操作延时很高的问题

### DIFF
--- a/src/MaaCore/Controller/Platform/Win32IO.cpp
+++ b/src/MaaCore/Controller/Platform/Win32IO.cpp
@@ -215,7 +215,16 @@ std::optional<int> asst::Win32IO::call_command(const std::string& cmd, bool recv
     CloseHandle(pipe_parent_read);
     CloseHandle(pipeov.hEvent);
     if (recv_by_socket) {
-        if (!socket_eof) closesocket(client_socket);
+        if (accept_pending) {
+            Log.warn("cancel AcceptEx");
+            CancelIoEx(reinterpret_cast<HANDLE>(m_server_sock), &sockov);
+            closesocket(client_socket);
+        }
+        else if (!socket_eof) {
+            Log.warn("cancel ReadFile");
+            CancelIoEx(reinterpret_cast<HANDLE>(client_socket), &sockov);
+            closesocket(client_socket);
+        }
         CloseHandle(sockov.hEvent);
     }
 

--- a/src/MaaCore/Controller/Platform/Win32IO.cpp
+++ b/src/MaaCore/Controller/Platform/Win32IO.cpp
@@ -104,9 +104,8 @@ std::optional<int> asst::Win32IO::call_command(const std::string& cmd, bool recv
         if (wait_handles.empty()) break;
         auto elapsed = steady_clock::now() - start_time;
         // TODO: 这里目前是隔 5000ms 判断一次，应该可以加一个 wait_handle 来判断外部中断（need_exit）
-        auto wait_time =
-            (std::min)(timeout - duration_cast<milliseconds>(elapsed).count(), process_running ? 5LL * 1000 : 0LL);
-        if (wait_time < 0) break;
+        auto wait_time = (std::min)(timeout - duration_cast<milliseconds>(elapsed).count(), 5LL * 1000);
+        if (wait_time < 0 || !process_running) wait_time = 0;
         auto wait_result =
             WaitForMultipleObjectsEx((DWORD)wait_handles.size(), wait_handles.data(), FALSE, (DWORD)wait_time, TRUE);
         HANDLE signaled_object = INVALID_HANDLE_VALUE;

--- a/src/MaaCore/Controller/Platform/Win32IO.cpp
+++ b/src/MaaCore/Controller/Platform/Win32IO.cpp
@@ -208,12 +208,6 @@ std::optional<int> asst::Win32IO::call_command(const std::string& cmd, bool recv
         }
     }
 
-    DWORD exit_ret = 0;
-    GetExitCodeProcess(process_info.hProcess, &exit_ret);
-    CloseHandle(process_info.hProcess);
-    CloseHandle(process_info.hThread);
-    CloseHandle(pipe_parent_read);
-    CloseHandle(pipeov.hEvent);
     if (recv_by_socket) {
         if (accept_pending) {
             Log.warn("cancel AcceptEx");
@@ -228,6 +222,16 @@ std::optional<int> asst::Win32IO::call_command(const std::string& cmd, bool recv
         CloseHandle(sockov.hEvent);
     }
 
+    if (process_running) {
+        TerminateProcess(process_info.hProcess, 0);
+    }
+
+    DWORD exit_ret = 0;
+    GetExitCodeProcess(process_info.hProcess, &exit_ret);
+    CloseHandle(process_info.hProcess);
+    CloseHandle(process_info.hThread);
+    CloseHandle(pipe_parent_read);
+    CloseHandle(pipeov.hEvent);
     return static_cast<int>(exit_ret);
 }
 


### PR DESCRIPTION
[asst.zip](https://github.com/MaaAssistantArknights/MaaAssistantArknights/files/13072914/asst.zip)

```bash
[2023-10-23 17:01:35.431][INF][Px6798][Tx66c4] Call ` C:\Program Files\BlueStacks_nxt_cn\.\HD-Adb.exe -s emulator-5554 exec-out "screencap | nc -w 3 10.0.2.3 1853" ` ret 0 , cost 835 ms , stdout size: 0 , socket size: 8294412
[2023-10-23 17:01:35.456][TRC][Px6798][Tx66c4] asst::BattlefieldMatcher::pause_button_analyze count 0 threshold 200
[2023-10-23 17:01:35.493][TRC][Px6798][Tx16f0] asst::Assistant::stop | enter
[2023-10-23 17:01:35.493][INF][Px6798][Tx16f0] Stop | block
[2023-10-23 17:01:35.493][TRC][Px6798][Tx16f0] asst::Assistant::stop | leave, 0 ms
[2023-10-23 17:01:35.526][INF][Px6798][Tx66c4] Call ` C:\Program Files\BlueStacks_nxt_cn\.\HD-Adb.exe -s emulator-5554 exec-out "screencap | nc -w 3 10.0.2.3 1853" ` ret 259 , cost 54 ms , stdout size: 0 , socket size: 0
...
[2023-10-23 17:01:36.860][TRC][Px6798][Tx2f7c] asst::Assistant::start | enter
[2023-10-23 17:01:36.860][INF][Px6798][Tx2f7c] Start | block
[2023-10-23 17:01:36.860][TRC][Px6798][Tx2f7c] asst::Assistant::start | leave, 0 ms
[2023-10-23 17:01:36.860][INF][Px6798][Tx66c4] Assistant::append_callback | TaskChainStart {"taskchain":"StartUp","taskid":12,"uuid":"2944826a77f8f39c"}
[2023-10-23 17:01:36.860][INF][Px6798][Tx66c4] Assistant::append_callback | SubTaskStart {"class":"asst::StartGameTaskPlugin","details":{},"subtask":"StartGameTask","taskchain":"StartUp","taskid":12,"uuid":"2944826a77f8f39c"}
[2023-10-23 17:01:37.610][INF][Px6798][Tx66c4] Call ` C:\Program Files\BlueStacks_nxt_cn\.\HD-Adb.exe -s emulator-5554 shell am start -n com.hypergryph.arknights/com.u8.sdk.U8UnityContext ` ret 0 , cost 749 ms , stdout size: 156 , socket size: 0
...
[2023-10-23 17:01:38.111][TRC][Px6798][Tx66c4] asst::ProcessTask::_run | enter
[2023-10-23 17:01:38.111][INF][Px6798][Tx66c4] {"class":"asst::ProcessTask","details":{"cur_retry":0,"retry_times":30,"to_be_recognized":["StartAtHome","StartWithSanity","StartUpBegin"]},"first":["StartAtHome","StartWithSanity","StartUpBegin"],"pre_task":"","subtask":"ProcessTask","taskchain":"StartUp","taskid":12}
[2023-10-23 17:01:58.112][WRN][Px6798][Tx66c4] Wait handles: [process_info.hProcess, pipeov.hEvent] timeout.
[2023-10-23 17:01:58.112][INF][Px6798][Tx66c4] Call ` C:\Program Files\BlueStacks_nxt_cn\.\HD-Adb.exe -s emulator-5554 exec-out "screencap | nc -w 3 10.0.2.3 1853" ` ret 0 , cost 20000 ms , stdout size: 0 , socket size: 8294412
```