### PR TITLE
feat: 增加雷电模拟器 nc 截图方式

### DIFF
--- a/resource/config.json
+++ b/resource/config.json
@@ -110,7 +110,8 @@
         },
         {
             "configName": "LDPlayer",
-            "baseConfig": "CapWithShell"
+            "baseConfig": "CapWithShell",
+            "screencapRawByNC": "[Adb] -s [AdbSerial] shell \"screencap | busybox nc -w 3 [NcAddress] [NcPort]\""
         },
         {
             "configName": "Nox",


### PR DESCRIPTION
使用 `busybox nc`

用户可能需要在模拟器中开启 adb 远程调试