### PR TITLE
perf: 理智识别模块优化：对识别区域预处理；增加失败后重试；优化log输出

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -4164,8 +4164,7 @@
             20,
             160,
             40
-        ],
-        "preDelay": 300
+        ]
     },
     "UseMedicine": {
         "doc": "绑定MedicineCounter来使用理智药",

--- a/src/MaaCore/Task/Fight/SanityBeforeStagePlugin.cpp
+++ b/src/MaaCore/Task/Fight/SanityBeforeStagePlugin.cpp
@@ -1,6 +1,6 @@
 #include "SanityBeforeStagePlugin.h"
 
-#include <regex>
+#include <meojson/json.hpp>
 
 #include "Config/TaskData.h"
 #include "Controller/Controller.h"

--- a/src/MaaCore/Task/Fight/SanityBeforeStagePlugin.cpp
+++ b/src/MaaCore/Task/Fight/SanityBeforeStagePlugin.cpp
@@ -50,21 +50,9 @@ bool asst::SanityBeforeStagePlugin::get_sanity_before_stage()
 
     const static auto task = Task.get<OcrTaskInfo>("SanityMatch");
     auto img = make_roi(ctrler()->get_image(), task->roi);
+    cv::normalize(img, img, 255.0, 0.0, cv::NormTypes::NORM_MINMAX);
 
-    // 转灰度，取单通道其实也行
-    cv::Mat img_gray;
-    cv::cvtColor(img, img_gray, cv::COLOR_BGR2GRAY);
-    double min_val = 0.0, max_val = 0.0;
-    cv::minMaxLoc(img_gray, &min_val, &max_val);
-
-    cv::Mat img_bin;
-    cv::inRange(img_gray, cv::Scalar { (min_val + max_val) / 2 }, cv::Scalar { 255 }, img_bin);
-
-    const std::vector<cv::Mat> img_bin_vec { img_bin, img_bin, img_bin };
-    cv::Mat img_after;
-    cv::merge(img_bin_vec, img_after);
-
-    RegionOCRer analyzer(img_after);
+    RegionOCRer analyzer(img);
     analyzer.set_replace(task->replace_map);
     auto res_opt = analyzer.analyze();
 

--- a/src/MaaCore/Task/Fight/SanityBeforeStagePlugin.cpp
+++ b/src/MaaCore/Task/Fight/SanityBeforeStagePlugin.cpp
@@ -63,7 +63,7 @@ void asst::SanityBeforeStagePlugin::get_sanity_before_stage()
     do {
         if (!res_opt) [[unlikely]] {
             Log.warn(__FUNCTION__, "Sanity ocr failed");
-            save_img(utils::path("debug") / utils::path("sanity"));
+            analyzer.save_img(utils::path("debug") / utils::path("sanity"));
             break;
         }
 

--- a/src/MaaCore/Task/Fight/SanityBeforeStagePlugin.h
+++ b/src/MaaCore/Task/Fight/SanityBeforeStagePlugin.h
@@ -1,7 +1,5 @@
 #pragma once
 #include "Task/AbstractTaskPlugin.h"
-
-#include <meojson/json.hpp>
 namespace asst
 {
     class SanityBeforeStagePlugin final : public AbstractTaskPlugin

--- a/src/MaaCore/Task/Fight/SanityBeforeStagePlugin.h
+++ b/src/MaaCore/Task/Fight/SanityBeforeStagePlugin.h
@@ -14,6 +14,9 @@ namespace asst
     private:
         virtual bool _run() override;
 
-        void get_sanity_before_stage();
+
+        // 获取 当前理智/最大理智
+        // 返回 是否获取成功
+        bool get_sanity_before_stage();
     };
 }


### PR DESCRIPTION
- 对识别区域进行预处理
- 识别失败后重试3次
- 重试识别延迟改为使用taskDelay
- 减少不必要的log
- 增加更多识别失败时的log