### PR TITLE
fix: 修复Wpf无法复制版本号至剪贴板

### DIFF
--- a/src/MaaWpfGui/Views/UserControl/VersionUpdateSettingsUserControl.xaml.cs
+++ b/src/MaaWpfGui/Views/UserControl/VersionUpdateSettingsUserControl.xaml.cs
@@ -74,7 +74,7 @@ namespace MaaWpfGui.Views.UserControl
                 {
                     try
                     {
-                        Clipboard.SetDataObject(text);
+                        Clipboard.SetData(DataFormats.Text, text);
                     }
                     catch (Exception e)
                     {


### PR DESCRIPTION
内测版的UI Version显示为`DEBUG VERSION`，不知道是不是bug