### PR TITLE
refactor: 重构肉鸽数据存储，迁移肉鸽主题

### DIFF
--- a/src/MaaCore/MaaCore.vcxproj
+++ b/src/MaaCore/MaaCore.vcxproj
@@ -89,6 +89,7 @@
     <ClInclude Include="Task\BattleHelper.h" />
     <ClInclude Include="Task\Interface\SingleStepTask.h" />
     <ClInclude Include="Task\Interface\SSSCopilotTask.h" />
+    <ClInclude Include="Task\Roguelike\AbstractRoguelikeTaskPlugin.h" />
     <ClInclude Include="Task\Roguelike\RoguelikeFoldartalGainTaskPlugin.h" />
     <ClInclude Include="Task\Roguelike\RoguelikeFoldartalUseTaskPlugin.h" />
     <ClInclude Include="Task\Roguelike\RoguelikeConfig.h" />
@@ -260,6 +261,7 @@
     <ClCompile Include="Task\BattleHelper.cpp" />
     <ClCompile Include="Task\Interface\SingleStepTask.cpp" />
     <ClCompile Include="Task\Interface\SSSCopilotTask.cpp" />
+    <ClCompile Include="Task\Roguelike\AbstractRoguelikeTaskPlugin.cpp" />
     <ClCompile Include="Task\Roguelike\RoguelikeFoldartalGainTaskPlugin.cpp" />
     <ClCompile Include="Task\Roguelike\RoguelikeFoldartalUseTaskPlugin.cpp" />
     <ClCompile Include="Task\Roguelike\RoguelikeConfig.cpp" />

--- a/src/MaaCore/MaaCore.vcxproj.filters
+++ b/src/MaaCore/MaaCore.vcxproj.filters
@@ -558,9 +558,6 @@
     <ClInclude Include="Controller\ControlScaleProxy.h">
       <Filter>Source\Controller</Filter>
     </ClInclude>
-    <ClInclude Include="Controller\MaaThriftController.h">
-      <Filter>Source\Controller</Filter>
-    </ClInclude>
     <ClInclude Include="Controller\MaatouchController.h">
       <Filter>Source\Controller</Filter>
     </ClInclude>
@@ -672,6 +669,7 @@
     <ClInclude Include="Task\Miscellaneous\ScreenshotTaskPlugin.h">
       <Filter>Source\Task\Miscellaneous</Filter>
     </ClInclude>
+    <ClInclude Include="Task\Roguelike\AbstractRoguelikeTaskPlugin.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Vision\VisionHelper.cpp">
@@ -1118,5 +1116,7 @@
     <ClCompile Include="Task\Fight\MedicineCounterPlugin.cpp">
       <Filter>Source\Task\Fight</Filter>
     </ClCompile>
+    <ClCompile Include="Controller\MaaThriftController.h" />
+    <ClCompile Include="Task\Roguelike\AbstractRoguelikeTaskPlugin.cpp" />
   </ItemGroup>
 </Project>

--- a/src/MaaCore/Task/Interface/RoguelikeTask.cpp
+++ b/src/MaaCore/Task/Interface/RoguelikeTask.cpp
@@ -89,7 +89,7 @@ bool asst::RoguelikeTask::set_params(const json::value& params)
         return false;
     }
 
-    m_roguelike_config_ptr->set_roguelike_theme(theme);
+    m_roguelike_config_ptr->set_theme(theme);
     m_roguelike_task_ptr->set_tasks({ theme + "@Roguelike@Begin" });
 
     // 0 - 刷经验，尽可能稳定地打更多层数，不期而遇采用激进策略

--- a/src/MaaCore/Task/Interface/RoguelikeTask.h
+++ b/src/MaaCore/Task/Interface/RoguelikeTask.h
@@ -5,6 +5,7 @@ namespace asst
 {
     class ProcessTask;
     class ScreenshotTaskPlugin;
+    class RoguelikeConfig;
     class RoguelikeBattleTaskPlugin;
     class RoguelikeControlTaskPlugin;
     class RoguelikeCustomStartTaskPlugin;
@@ -35,6 +36,7 @@ namespace asst
     private:
         std::shared_ptr<ProcessTask> m_roguelike_task_ptr = nullptr;
         std::shared_ptr<ScreenshotTaskPlugin> m_screenshot_plugin_ptr = nullptr;
+        std::shared_ptr<RoguelikeConfig> m_roguelike_config_ptr = nullptr;
         std::shared_ptr<RoguelikeControlTaskPlugin> m_control_plugin_ptr = nullptr;
         std::shared_ptr<RoguelikeRecruitTaskPlugin> m_recruit_plugin_ptr = nullptr;
         std::shared_ptr<RoguelikeSkillSelectionTaskPlugin> m_skill_plugin_ptr = nullptr;

--- a/src/MaaCore/Task/Roguelike/AbstractRoguelikeTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/AbstractRoguelikeTaskPlugin.cpp
@@ -2,6 +2,6 @@
 
 asst::AbstractRoguelikeTaskPlugin::AbstractRoguelikeTaskPlugin(const AsstCallback& callback, Assistant* inst,
                                                                std::string_view task_chain,
-                                                               std::shared_ptr<RoguelikeConfig> roguelike_config)
-    : AbstractTaskPlugin(callback, inst, task_chain), m_roguelike_config(roguelike_config)
+                                                               std::shared_ptr<RoguelikeConfig> config)
+    : AbstractTaskPlugin(callback, inst, task_chain), m_config(config)
 {}

--- a/src/MaaCore/Task/Roguelike/AbstractRoguelikeTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/AbstractRoguelikeTaskPlugin.cpp
@@ -1,0 +1,7 @@
+#include "AbstractRoguelikeTaskPlugin.h"
+
+asst::AbstractRoguelikeTaskPlugin::AbstractRoguelikeTaskPlugin(const AsstCallback& callback, Assistant* inst,
+                                                               std::string_view task_chain,
+                                                               std::shared_ptr<RoguelikeConfig> roguelike_config)
+    : AbstractTaskPlugin(callback, inst, task_chain), m_roguelike_config(roguelike_config)
+{}

--- a/src/MaaCore/Task/Roguelike/AbstractRoguelikeTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/AbstractRoguelikeTaskPlugin.h
@@ -11,9 +11,9 @@ namespace asst
     {
     public:
         AbstractRoguelikeTaskPlugin(const AsstCallback& callback, Assistant* inst, std::string_view task_chain,
-                                    std::shared_ptr<RoguelikeConfig> roguelike_data);
+                                    std::shared_ptr<RoguelikeConfig> data);
 
     protected:
-        std::shared_ptr<RoguelikeConfig> m_roguelike_config;
+        std::shared_ptr<RoguelikeConfig> m_config;
     };
 }

--- a/src/MaaCore/Task/Roguelike/AbstractRoguelikeTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/AbstractRoguelikeTaskPlugin.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <memory>
+
+#include "Task/AbstractTaskPlugin.h"
+#include "Task/Roguelike/RoguelikeConfig.h"
+
+namespace asst
+{
+    class AbstractRoguelikeTaskPlugin : public AbstractTaskPlugin
+    {
+    public:
+        AbstractRoguelikeTaskPlugin(const AsstCallback& callback, Assistant* inst, std::string_view task_chain,
+                                    std::shared_ptr<RoguelikeConfig> roguelike_data);
+
+    protected:
+        std::shared_ptr<RoguelikeConfig> m_roguelike_config;
+    };
+}

--- a/src/MaaCore/Task/Roguelike/RoguelikeBattleTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeBattleTaskPlugin.cpp
@@ -24,8 +24,9 @@ using namespace asst::battle;
 using namespace asst::battle::roguelike;
 
 asst::RoguelikeBattleTaskPlugin::RoguelikeBattleTaskPlugin(const AsstCallback& callback, Assistant* inst,
-                                                           std::string_view task_chain)
-    : AbstractTaskPlugin(callback, inst, task_chain), BattleHelper(inst)
+                                                           std::string_view task_chain,
+                                                           std::shared_ptr<RoguelikeConfig> roguelike_config_ptr)
+    : AbstractRoguelikeTaskPlugin(callback, inst, task_chain, roguelike_config_ptr), BattleHelper(inst)
 {}
 
 bool asst::RoguelikeBattleTaskPlugin::verify(AsstMsg msg, const json::value& details) const
@@ -34,11 +35,11 @@ bool asst::RoguelikeBattleTaskPlugin::verify(AsstMsg msg, const json::value& det
         return false;
     }
 
-    if (m_roguelike_theme.empty()) {
+    if (m_roguelike_config->get_theme().empty()) {
         Log.error("Roguelike name doesn't exist!");
         return false;
     }
-    const std::string roguelike_name = m_roguelike_theme + "@";
+    const std::string roguelike_name = m_roguelike_config->get_theme() + "@";
     const std::string& task = details.get("details", "task", "");
     std::string_view task_view = task;
     if (task_view.starts_with(roguelike_name)) {
@@ -94,7 +95,7 @@ bool asst::RoguelikeBattleTaskPlugin::_run()
 
 void asst::RoguelikeBattleTaskPlugin::wait_until_start_button_clicked()
 {
-    ProcessTask(*this, { m_roguelike_theme + "@Roguelike@WaitForStartButtonClicked" })
+    ProcessTask(*this, { m_roguelike_config->get_theme() + "@Roguelike@WaitForStartButtonClicked" })
         .set_task_delay(0)
         .set_retry_times(0)
         .run();
@@ -330,7 +331,7 @@ bool asst::RoguelikeBattleTaskPlugin::do_best_deploy()
     // 构造当前地图的部署指令列表
     std::vector<DeployPlanInfo> deploy_plan_list;
     // 获取当前肉鸽的分组信息[干员组1名称,干员组2名称,...]
-    const auto& groups = RoguelikeRecruit.get_group_info(m_roguelike_theme);
+    const auto& groups = RoguelikeRecruit.get_group_info(m_roguelike_config->get_theme());
     // 获取当前肉鸽的分组内排名信息
     // const auto& group_rank = RoguelikeRecruit.get_group_rank(rogue_theme);
     for (const auto& [name, oper] : m_cur_deployment_opers) {
@@ -342,9 +343,9 @@ bool asst::RoguelikeBattleTaskPlugin::do_best_deploy()
 
         const std::string& oper_name = oper_name_in_config(oper);
         // 获取招募信息
-        const auto& recruit_info = RoguelikeRecruit.get_oper_info(m_roguelike_theme, oper_name);
+        const auto& recruit_info = RoguelikeRecruit.get_oper_info(m_roguelike_config->get_theme(), oper_name);
         // 获取会用到该干员的干员组[干员组1序号,干员组2序号,...]
-        std::vector<int> group_ids = RoguelikeRecruit.get_group_id(m_roguelike_theme, oper_name);
+        std::vector<int> group_ids = RoguelikeRecruit.get_group_id(m_roguelike_config->get_theme(), oper_name);
 
         for (const auto& group_id : group_ids) {
             // 当前干员组名,string类型
@@ -393,7 +394,8 @@ bool asst::RoguelikeBattleTaskPlugin::do_best_deploy()
             auto deployed_time = std::chrono::steady_clock::now();
             m_deployed_time.insert_or_assign(deploy_plan.oper_name, deployed_time);
             // 获取技能用法和使用次数
-            const auto& oper_info = RoguelikeRecruit.get_oper_info(m_roguelike_theme, deploy_plan.oper_name);
+            const auto& oper_info =
+                RoguelikeRecruit.get_oper_info(m_roguelike_config->get_theme(), deploy_plan.oper_name);
             m_skill_usage[deploy_plan.oper_name] = oper_info.skill_usage;
             m_skill_times[deploy_plan.oper_name] = oper_info.skill_times;
             Log.trace("    best deploy is", deploy_plan.oper_name, "with rank", deploy_plan.rank);
@@ -422,7 +424,7 @@ bool asst::RoguelikeBattleTaskPlugin::do_once()
 
     auto pre_battlefield = m_battlefield_opers;
     for (const auto& [name, loc] : pre_battlefield) {
-        const auto& oper_info = RoguelikeRecruit.get_oper_info(m_roguelike_theme, name);
+        const auto& oper_info = RoguelikeRecruit.get_oper_info(m_roguelike_config->get_theme(), name);
         auto iter = m_deployed_time.find(name);
         if (iter != m_deployed_time.end() && oper_info.auto_retreat > 0) {
             if (std::chrono::steady_clock::now() - m_deployed_time.at(name) >=
@@ -518,7 +520,7 @@ bool asst::RoguelikeBattleTaskPlugin::do_once()
         auto deployed_time = std::chrono::steady_clock::now();
         m_deployed_time.insert_or_assign(best_oper.name, deployed_time);
         // 获取技能用法和使用次数
-        const auto& oper_info = RoguelikeRecruit.get_oper_info(m_roguelike_theme, best_oper.name);
+        const auto& oper_info = RoguelikeRecruit.get_oper_info(m_roguelike_config->get_theme(), best_oper.name);
         m_skill_usage[best_oper.name] = oper_info.skill_usage;
         m_skill_times[best_oper.name] = oper_info.skill_times;
 

--- a/src/MaaCore/Task/Roguelike/RoguelikeBattleTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeBattleTaskPlugin.cpp
@@ -35,11 +35,11 @@ bool asst::RoguelikeBattleTaskPlugin::verify(AsstMsg msg, const json::value& det
         return false;
     }
 
-    if (m_roguelike_config->get_theme().empty()) {
+    if (m_config->get_theme().empty()) {
         Log.error("Roguelike name doesn't exist!");
         return false;
     }
-    const std::string roguelike_name = m_roguelike_config->get_theme() + "@";
+    const std::string roguelike_name = m_config->get_theme() + "@";
     const std::string& task = details.get("details", "task", "");
     std::string_view task_view = task;
     if (task_view.starts_with(roguelike_name)) {
@@ -95,7 +95,7 @@ bool asst::RoguelikeBattleTaskPlugin::_run()
 
 void asst::RoguelikeBattleTaskPlugin::wait_until_start_button_clicked()
 {
-    ProcessTask(*this, { m_roguelike_config->get_theme() + "@Roguelike@WaitForStartButtonClicked" })
+    ProcessTask(*this, { m_config->get_theme() + "@Roguelike@WaitForStartButtonClicked" })
         .set_task_delay(0)
         .set_retry_times(0)
         .run();
@@ -331,7 +331,7 @@ bool asst::RoguelikeBattleTaskPlugin::do_best_deploy()
     // 构造当前地图的部署指令列表
     std::vector<DeployPlanInfo> deploy_plan_list;
     // 获取当前肉鸽的分组信息[干员组1名称,干员组2名称,...]
-    const auto& groups = RoguelikeRecruit.get_group_info(m_roguelike_config->get_theme());
+    const auto& groups = RoguelikeRecruit.get_group_info(m_config->get_theme());
     // 获取当前肉鸽的分组内排名信息
     // const auto& group_rank = RoguelikeRecruit.get_group_rank(rogue_theme);
     for (const auto& [name, oper] : m_cur_deployment_opers) {
@@ -343,9 +343,9 @@ bool asst::RoguelikeBattleTaskPlugin::do_best_deploy()
 
         const std::string& oper_name = oper_name_in_config(oper);
         // 获取招募信息
-        const auto& recruit_info = RoguelikeRecruit.get_oper_info(m_roguelike_config->get_theme(), oper_name);
+        const auto& recruit_info = RoguelikeRecruit.get_oper_info(m_config->get_theme(), oper_name);
         // 获取会用到该干员的干员组[干员组1序号,干员组2序号,...]
-        std::vector<int> group_ids = RoguelikeRecruit.get_group_id(m_roguelike_config->get_theme(), oper_name);
+        std::vector<int> group_ids = RoguelikeRecruit.get_group_id(m_config->get_theme(), oper_name);
 
         for (const auto& group_id : group_ids) {
             // 当前干员组名,string类型
@@ -395,7 +395,7 @@ bool asst::RoguelikeBattleTaskPlugin::do_best_deploy()
             m_deployed_time.insert_or_assign(deploy_plan.oper_name, deployed_time);
             // 获取技能用法和使用次数
             const auto& oper_info =
-                RoguelikeRecruit.get_oper_info(m_roguelike_config->get_theme(), deploy_plan.oper_name);
+                RoguelikeRecruit.get_oper_info(m_config->get_theme(), deploy_plan.oper_name);
             m_skill_usage[deploy_plan.oper_name] = oper_info.skill_usage;
             m_skill_times[deploy_plan.oper_name] = oper_info.skill_times;
             Log.trace("    best deploy is", deploy_plan.oper_name, "with rank", deploy_plan.rank);
@@ -424,7 +424,7 @@ bool asst::RoguelikeBattleTaskPlugin::do_once()
 
     auto pre_battlefield = m_battlefield_opers;
     for (const auto& [name, loc] : pre_battlefield) {
-        const auto& oper_info = RoguelikeRecruit.get_oper_info(m_roguelike_config->get_theme(), name);
+        const auto& oper_info = RoguelikeRecruit.get_oper_info(m_config->get_theme(), name);
         auto iter = m_deployed_time.find(name);
         if (iter != m_deployed_time.end() && oper_info.auto_retreat > 0) {
             if (std::chrono::steady_clock::now() - m_deployed_time.at(name) >=
@@ -520,7 +520,7 @@ bool asst::RoguelikeBattleTaskPlugin::do_once()
         auto deployed_time = std::chrono::steady_clock::now();
         m_deployed_time.insert_or_assign(best_oper.name, deployed_time);
         // 获取技能用法和使用次数
-        const auto& oper_info = RoguelikeRecruit.get_oper_info(m_roguelike_config->get_theme(), best_oper.name);
+        const auto& oper_info = RoguelikeRecruit.get_oper_info(m_config->get_theme(), best_oper.name);
         m_skill_usage[best_oper.name] = oper_info.skill_usage;
         m_skill_times[best_oper.name] = oper_info.skill_times;
 

--- a/src/MaaCore/Task/Roguelike/RoguelikeBattleTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/RoguelikeBattleTaskPlugin.h
@@ -3,23 +3,22 @@
 #include <queue>
 #include <stack>
 
+#include "AbstractRoguelikeTaskPlugin.h"
 #include "Common/AsstBattleDef.h"
 #include "Common/AsstTypes.h"
 #include "Config/Miscellaneous/TilePack.h"
-#include "Task/AbstractTaskPlugin.h"
 #include "Task/BattleHelper.h"
-#include "Task/Roguelike/RoguelikeConfig.h"
 
 namespace asst
 {
-    class RoguelikeBattleTaskPlugin : public AbstractTaskPlugin, private BattleHelper, public RoguelikeConfig
+    class RoguelikeBattleTaskPlugin : public AbstractRoguelikeTaskPlugin, private BattleHelper
     {
         using Time_Point = std::chrono::time_point<std::chrono::system_clock>;
 
         inline static const std::unordered_set<std::string> DiceSet = { "骰子", "8面骰子", "12面骰子" };
 
     public:
-        RoguelikeBattleTaskPlugin(const AsstCallback& callback, Assistant* inst, std::string_view task_chain);
+        RoguelikeBattleTaskPlugin(const AsstCallback& callback, Assistant* inst, std::string_view task_chain, std::shared_ptr<RoguelikeConfig>roguelike_config_ptr);
         virtual ~RoguelikeBattleTaskPlugin() override = default;
 
         virtual bool verify(AsstMsg msg, const json::value& details) const override;

--- a/src/MaaCore/Task/Roguelike/RoguelikeConfig.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeConfig.cpp
@@ -1,6 +1,3 @@
 #include "RoguelikeConfig.h"
 
-void asst::RoguelikeConfig::clear() {
-
-
-}
+void asst::RoguelikeConfig::clear() {}

--- a/src/MaaCore/Task/Roguelike/RoguelikeConfig.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeConfig.cpp
@@ -1,6 +1,6 @@
 #include "RoguelikeConfig.h"
 
-void asst::RoguelikeConfig::set_roguelike_theme(std::string roguelike_theme)
-{
-    m_roguelike_theme = std::move(roguelike_theme);
+void asst::RoguelikeConfig::clear() {
+
+
 }

--- a/src/MaaCore/Task/Roguelike/RoguelikeConfig.h
+++ b/src/MaaCore/Task/Roguelike/RoguelikeConfig.h
@@ -9,11 +9,11 @@ namespace asst
         void clear();
 
     public:
-        void set_roguelike_theme(std::string roguelike_theme) { m_roguelike_config->get_theme() = std::move(roguelike_theme); }
-        std::string get_theme() { return m_roguelike_config->get_theme(); }
+        void set_roguelike_theme(std::string roguelike_theme) { m_roguelike_theme = std::move(roguelike_theme); }
+        std::string get_theme() { return m_roguelike_theme; }
 
     protected:
         // 肉鸽主题
-        std::string m_roguelike_config->get_theme();
+        std::string m_roguelike_theme;
     };
 }

--- a/src/MaaCore/Task/Roguelike/RoguelikeConfig.h
+++ b/src/MaaCore/Task/Roguelike/RoguelikeConfig.h
@@ -6,10 +6,14 @@ namespace asst
     class RoguelikeConfig
     {
     public:
-        void set_roguelike_theme(std::string roguelike_theme);
+        void clear();
+
+    public:
+        void set_roguelike_theme(std::string roguelike_theme) { m_roguelike_config->get_theme() = std::move(roguelike_theme); }
+        std::string get_theme() { return m_roguelike_config->get_theme(); }
 
     protected:
         // 肉鸽主题
-        std::string m_roguelike_theme;
+        std::string m_roguelike_config->get_theme();
     };
 }

--- a/src/MaaCore/Task/Roguelike/RoguelikeConfig.h
+++ b/src/MaaCore/Task/Roguelike/RoguelikeConfig.h
@@ -9,11 +9,11 @@ namespace asst
         void clear();
 
     public:
-        void set_roguelike_theme(std::string roguelike_theme) { m_roguelike_theme = std::move(roguelike_theme); }
-        std::string get_theme() { return m_roguelike_theme; }
+        void set_theme(std::string roguelike_theme) { m_theme = std::move(roguelike_theme); }
+        std::string get_theme() { return m_theme; }
 
     protected:
         // 肉鸽主题
-        std::string m_roguelike_theme;
+        std::string m_theme;
     };
 }

--- a/src/MaaCore/Task/Roguelike/RoguelikeControlTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeControlTaskPlugin.cpp
@@ -10,11 +10,11 @@ bool asst::RoguelikeControlTaskPlugin::verify(AsstMsg msg, const json::value& de
         return false;
     }
 
-    if (m_roguelike_config->get_theme().empty()) {
+    if (m_config->get_theme().empty()) {
         Log.error("Roguelike name doesn't exist!");
         return false;
     }
-    const std::string roguelike_name = m_roguelike_config->get_theme() + "@";
+    const std::string roguelike_name = m_config->get_theme() + "@";
     const std::string& task = details.get("details", "task", "");
     std::string_view task_view = task;
     if (task_view.starts_with(roguelike_name)) {
@@ -34,7 +34,7 @@ bool asst::RoguelikeControlTaskPlugin::verify(AsstMsg msg, const json::value& de
 
 void asst::RoguelikeControlTaskPlugin::exit_then_stop()
 {
-    ProcessTask(*this, { m_roguelike_config->get_theme() + "@Roguelike@ExitThenAbandon" })
+    ProcessTask(*this, { m_config->get_theme() + "@Roguelike@ExitThenAbandon" })
         .set_times_limit("Roguelike@StartExplore", 0)
         .set_times_limit("Roguelike@Abandon", 0)
         .run();

--- a/src/MaaCore/Task/Roguelike/RoguelikeControlTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeControlTaskPlugin.cpp
@@ -10,11 +10,11 @@ bool asst::RoguelikeControlTaskPlugin::verify(AsstMsg msg, const json::value& de
         return false;
     }
 
-    if (m_roguelike_theme.empty()) {
+    if (m_roguelike_config->get_theme().empty()) {
         Log.error("Roguelike name doesn't exist!");
         return false;
     }
-    const std::string roguelike_name = m_roguelike_theme + "@";
+    const std::string roguelike_name = m_roguelike_config->get_theme() + "@";
     const std::string& task = details.get("details", "task", "");
     std::string_view task_view = task;
     if (task_view.starts_with(roguelike_name)) {
@@ -34,7 +34,7 @@ bool asst::RoguelikeControlTaskPlugin::verify(AsstMsg msg, const json::value& de
 
 void asst::RoguelikeControlTaskPlugin::exit_then_stop()
 {
-    ProcessTask(*this, { m_roguelike_theme + "@Roguelike@ExitThenAbandon" })
+    ProcessTask(*this, { m_roguelike_config->get_theme() + "@Roguelike@ExitThenAbandon" })
         .set_times_limit("Roguelike@StartExplore", 0)
         .set_times_limit("Roguelike@Abandon", 0)
         .run();

--- a/src/MaaCore/Task/Roguelike/RoguelikeControlTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/RoguelikeControlTaskPlugin.h
@@ -1,13 +1,12 @@
 #pragma once
-#include "Task/AbstractTaskPlugin.h"
-#include "Task/Roguelike/RoguelikeConfig.h"
+#include "AbstractRoguelikeTaskPlugin.h"
 
 namespace asst
 {
-    class RoguelikeControlTaskPlugin : public AbstractTaskPlugin, public RoguelikeConfig
+    class RoguelikeControlTaskPlugin : public AbstractRoguelikeTaskPlugin
     {
     public:
-        using AbstractTaskPlugin::AbstractTaskPlugin;
+        using AbstractRoguelikeTaskPlugin::AbstractRoguelikeTaskPlugin;
         virtual ~RoguelikeControlTaskPlugin() override = default;
 
     public:

--- a/src/MaaCore/Task/Roguelike/RoguelikeCustomStartTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeCustomStartTaskPlugin.cpp
@@ -14,11 +14,11 @@ bool asst::RoguelikeCustomStartTaskPlugin::verify(AsstMsg msg, const json::value
         return false;
     }
 
-    if (m_roguelike_theme.empty()) {
+    if (m_roguelike_config->get_theme().empty()) {
         Log.error("Roguelike name doesn't exist!");
         return false;
     }
-    const std::string roguelike_name = m_roguelike_theme + "@";
+    const std::string roguelike_name = m_roguelike_config->get_theme() + "@";
     const std::string& task = details.get("details", "task", "");
     std::string_view task_view = task;
     if (task_view.starts_with(roguelike_name)) {

--- a/src/MaaCore/Task/Roguelike/RoguelikeCustomStartTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeCustomStartTaskPlugin.cpp
@@ -14,11 +14,11 @@ bool asst::RoguelikeCustomStartTaskPlugin::verify(AsstMsg msg, const json::value
         return false;
     }
 
-    if (m_roguelike_config->get_theme().empty()) {
+    if (m_config->get_theme().empty()) {
         Log.error("Roguelike name doesn't exist!");
         return false;
     }
-    const std::string roguelike_name = m_roguelike_config->get_theme() + "@";
+    const std::string roguelike_name = m_config->get_theme() + "@";
     const std::string& task = details.get("details", "task", "");
     std::string_view task_view = task;
     if (task_view.starts_with(roguelike_name)) {

--- a/src/MaaCore/Task/Roguelike/RoguelikeCustomStartTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/RoguelikeCustomStartTaskPlugin.h
@@ -1,6 +1,5 @@
 #pragma once
-#include "Task/AbstractTaskPlugin.h"
-#include "Task/Roguelike/RoguelikeConfig.h"
+#include "AbstractRoguelikeTaskPlugin.h"
 
 namespace asst
 {
@@ -15,10 +14,10 @@ namespace asst
         // CoCoreChar,  // 次选干员， 干员名
     };
 
-    class RoguelikeCustomStartTaskPlugin : public AbstractTaskPlugin, public RoguelikeConfig
+    class RoguelikeCustomStartTaskPlugin : public AbstractRoguelikeTaskPlugin
     {
     public:
-        using AbstractTaskPlugin::AbstractTaskPlugin;
+        using AbstractRoguelikeTaskPlugin::AbstractRoguelikeTaskPlugin;
         virtual ~RoguelikeCustomStartTaskPlugin() override = default;
 
     public:

--- a/src/MaaCore/Task/Roguelike/RoguelikeDebugTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeDebugTaskPlugin.cpp
@@ -14,11 +14,11 @@ bool asst::RoguelikeDebugTaskPlugin::verify(AsstMsg msg, const json::value& deta
         return true;
     }
 
-    if (m_roguelike_config->get_theme().empty()) {
+    if (m_config->get_theme().empty()) {
         Log.error("Roguelike name doesn't exist!");
         return false;
     }
-    const std::string roguelike_name = m_roguelike_config->get_theme() + "@";
+    const std::string roguelike_name = m_config->get_theme() + "@";
     const std::string& task = details.get("details", "task", "");
     std::string_view task_view = task;
     if (task_view.starts_with(roguelike_name)) {

--- a/src/MaaCore/Task/Roguelike/RoguelikeDebugTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeDebugTaskPlugin.cpp
@@ -14,11 +14,11 @@ bool asst::RoguelikeDebugTaskPlugin::verify(AsstMsg msg, const json::value& deta
         return true;
     }
 
-    if (m_roguelike_theme.empty()) {
+    if (m_roguelike_config->get_theme().empty()) {
         Log.error("Roguelike name doesn't exist!");
         return false;
     }
-    const std::string roguelike_name = m_roguelike_theme + "@";
+    const std::string roguelike_name = m_roguelike_config->get_theme() + "@";
     const std::string& task = details.get("details", "task", "");
     std::string_view task_view = task;
     if (task_view.starts_with(roguelike_name)) {

--- a/src/MaaCore/Task/Roguelike/RoguelikeDebugTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/RoguelikeDebugTaskPlugin.h
@@ -1,13 +1,12 @@
 #pragma once
-#include "Task/AbstractTaskPlugin.h"
-#include "Task/Roguelike/RoguelikeConfig.h"
+#include "AbstractRoguelikeTaskPlugin.h"
 
 namespace asst
 {
-    class RoguelikeDebugTaskPlugin : public AbstractTaskPlugin, public RoguelikeConfig
+    class RoguelikeDebugTaskPlugin : public AbstractRoguelikeTaskPlugin
     {
     public:
-        using AbstractTaskPlugin::AbstractTaskPlugin;
+        using AbstractRoguelikeTaskPlugin::AbstractRoguelikeTaskPlugin;
         virtual ~RoguelikeDebugTaskPlugin() override = default;
 
     public:

--- a/src/MaaCore/Task/Roguelike/RoguelikeDifficultySelectionTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeDifficultySelectionTaskPlugin.cpp
@@ -10,11 +10,11 @@ bool asst::RoguelikeDifficultySelectionTaskPlugin::verify(AsstMsg msg, const jso
         return false;
     }
 
-    if (m_roguelike_config->get_theme().empty()) {
+    if (m_config->get_theme().empty()) {
         Log.error("Roguelike name doesn't exist!");
         return false;
     }
-    const std::string roguelike_name = m_roguelike_config->get_theme() + "@";
+    const std::string roguelike_name = m_config->get_theme() + "@";
     const std::string& task = details.get("details", "task", "");
     std::string_view task_view = task;
     if (task_view.starts_with(roguelike_name)) {
@@ -37,14 +37,14 @@ bool asst::RoguelikeDifficultySelectionTaskPlugin::_run()
 
     // 当前难度
     std::string difficulty = status()->get_properties(Status::RoguelikeDifficulty).value();
-    if (m_roguelike_config->get_theme() != "Phantom" && mode == "4") {
+    if (m_config->get_theme() != "Phantom" && mode == "4") {
         if (difficulty == "max") {
-            ProcessTask(*this, { m_roguelike_config->get_theme() + "@Roguelike@ChooseDifficulty_Hardest" }).run();
+            ProcessTask(*this, { m_config->get_theme() + "@Roguelike@ChooseDifficulty_Hardest" }).run();
         }
         else {
-            ProcessTask(*this, { m_roguelike_config->get_theme() + "@Roguelike@ChooseDifficulty_Easiest" }).run();
+            ProcessTask(*this, { m_config->get_theme() + "@Roguelike@ChooseDifficulty_Easiest" }).run();
         }
-        ProcessTask(*this, { m_roguelike_config->get_theme() + "@Roguelike@ChooseDifficultyConfirm" }).run();
+        ProcessTask(*this, { m_config->get_theme() + "@Roguelike@ChooseDifficultyConfirm" }).run();
     }
 
     return true;

--- a/src/MaaCore/Task/Roguelike/RoguelikeDifficultySelectionTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeDifficultySelectionTaskPlugin.cpp
@@ -10,11 +10,11 @@ bool asst::RoguelikeDifficultySelectionTaskPlugin::verify(AsstMsg msg, const jso
         return false;
     }
 
-    if (m_roguelike_theme.empty()) {
+    if (m_roguelike_config->get_theme().empty()) {
         Log.error("Roguelike name doesn't exist!");
         return false;
     }
-    const std::string roguelike_name = m_roguelike_theme + "@";
+    const std::string roguelike_name = m_roguelike_config->get_theme() + "@";
     const std::string& task = details.get("details", "task", "");
     std::string_view task_view = task;
     if (task_view.starts_with(roguelike_name)) {
@@ -37,14 +37,14 @@ bool asst::RoguelikeDifficultySelectionTaskPlugin::_run()
 
     // 当前难度
     std::string difficulty = status()->get_properties(Status::RoguelikeDifficulty).value();
-    if (m_roguelike_theme != "Phantom" && mode == "4") {
+    if (m_roguelike_config->get_theme() != "Phantom" && mode == "4") {
         if (difficulty == "max") {
-            ProcessTask(*this, { m_roguelike_theme + "@Roguelike@ChooseDifficulty_Hardest" }).run();
+            ProcessTask(*this, { m_roguelike_config->get_theme() + "@Roguelike@ChooseDifficulty_Hardest" }).run();
         }
         else {
-            ProcessTask(*this, { m_roguelike_theme + "@Roguelike@ChooseDifficulty_Easiest" }).run();
+            ProcessTask(*this, { m_roguelike_config->get_theme() + "@Roguelike@ChooseDifficulty_Easiest" }).run();
         }
-        ProcessTask(*this, { m_roguelike_theme + "@Roguelike@ChooseDifficultyConfirm" }).run();
+        ProcessTask(*this, { m_roguelike_config->get_theme() + "@Roguelike@ChooseDifficultyConfirm" }).run();
     }
 
     return true;

--- a/src/MaaCore/Task/Roguelike/RoguelikeDifficultySelectionTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/RoguelikeDifficultySelectionTaskPlugin.h
@@ -1,13 +1,12 @@
 #pragma once
-#include "Task/AbstractTaskPlugin.h"
-#include "Task/Roguelike/RoguelikeConfig.h"
+#include "AbstractRoguelikeTaskPlugin.h"
 
 namespace asst
 {
-    class RoguelikeDifficultySelectionTaskPlugin : public AbstractTaskPlugin, public RoguelikeConfig
+    class RoguelikeDifficultySelectionTaskPlugin : public AbstractRoguelikeTaskPlugin
     {
     public:
-        using AbstractTaskPlugin::AbstractTaskPlugin;
+        using AbstractRoguelikeTaskPlugin::AbstractRoguelikeTaskPlugin;
         virtual ~RoguelikeDifficultySelectionTaskPlugin() override = default;
 
     public:

--- a/src/MaaCore/Task/Roguelike/RoguelikeFoldartalGainTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeFoldartalGainTaskPlugin.cpp
@@ -11,14 +11,14 @@ bool asst::RoguelikeFoldartalGainTaskPlugin::verify(AsstMsg msg, const json::val
         return false;
     }
 
-    if (m_roguelike_config->get_theme().empty()) {
+    if (m_config->get_theme().empty()) {
         Log.error("Roguelike name doesn't exist!");
         return false;
     }
-    if (m_roguelike_config->get_theme() != "Sami") {
+    if (m_config->get_theme() != "Sami") {
         return false;
     }
-    const std::string roguelike_name = m_roguelike_config->get_theme() + "@";
+    const std::string roguelike_name = m_config->get_theme() + "@";
     const std::string& task = details.get("details", "task", "");
     std::string_view task_view = task;
 
@@ -56,7 +56,7 @@ bool asst::RoguelikeFoldartalGainTaskPlugin::_run()
 {
     LogTraceFunction;
 
-    std::string theme = m_roguelike_config->get_theme();
+    std::string theme = m_config->get_theme();
     std::string mode = status()->get_properties(Status::RoguelikeMode).value();
 
     auto image = ctrler()->get_image();

--- a/src/MaaCore/Task/Roguelike/RoguelikeFoldartalGainTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeFoldartalGainTaskPlugin.cpp
@@ -11,14 +11,14 @@ bool asst::RoguelikeFoldartalGainTaskPlugin::verify(AsstMsg msg, const json::val
         return false;
     }
 
-    if (m_roguelike_theme.empty()) {
+    if (m_roguelike_config->get_theme().empty()) {
         Log.error("Roguelike name doesn't exist!");
         return false;
     }
-    if (m_roguelike_theme != "Sami") {
+    if (m_roguelike_config->get_theme() != "Sami") {
         return false;
     }
-    const std::string roguelike_name = m_roguelike_theme + "@";
+    const std::string roguelike_name = m_roguelike_config->get_theme() + "@";
     const std::string& task = details.get("details", "task", "");
     std::string_view task_view = task;
 
@@ -56,7 +56,7 @@ bool asst::RoguelikeFoldartalGainTaskPlugin::_run()
 {
     LogTraceFunction;
 
-    std::string theme = m_roguelike_theme;
+    std::string theme = m_roguelike_config->get_theme();
     std::string mode = status()->get_properties(Status::RoguelikeMode).value();
 
     auto image = ctrler()->get_image();

--- a/src/MaaCore/Task/Roguelike/RoguelikeFoldartalGainTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/RoguelikeFoldartalGainTaskPlugin.h
@@ -1,13 +1,12 @@
 #pragma once
-#include "RoguelikeConfig.h"
-#include "Task/AbstractTaskPlugin.h"
+#include "AbstractRoguelikeTaskPlugin.h"
 
 namespace asst
 {
-    class RoguelikeFoldartalGainTaskPlugin : public AbstractTaskPlugin, public RoguelikeConfig
+    class RoguelikeFoldartalGainTaskPlugin : public AbstractRoguelikeTaskPlugin
     {
     public:
-        using AbstractTaskPlugin::AbstractTaskPlugin;
+        using AbstractRoguelikeTaskPlugin::AbstractRoguelikeTaskPlugin;
         virtual ~RoguelikeFoldartalGainTaskPlugin() override = default;
 
     public:

--- a/src/MaaCore/Task/Roguelike/RoguelikeFoldartalUseTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeFoldartalUseTaskPlugin.cpp
@@ -14,15 +14,15 @@ bool asst::RoguelikeFoldartalUseTaskPlugin::verify(AsstMsg msg, const json::valu
         return false;
     }
 
-    if (m_roguelike_config->get_theme().empty()) {
+    if (m_config->get_theme().empty()) {
         Log.error("Roguelike name doesn't exist!");
         return false;
     }
-    if (m_roguelike_config->get_theme() != "Sami") {
+    if (m_config->get_theme() != "Sami") {
         return false;
     }
     std::string mode = status()->get_properties(Status::RoguelikeMode).value();
-    std::string task_name_pre = m_roguelike_config->get_theme() + "@Roguelike@Stage";
+    std::string task_name_pre = m_config->get_theme() + "@Roguelike@Stage";
     const std::string& task = details.get("details", "task", "");
     std::string_view task_view = task;
 
@@ -73,9 +73,9 @@ bool asst::RoguelikeFoldartalUseTaskPlugin::_run()
 {
     LogTraceFunction;
 
-    std::string theme = m_roguelike_config->get_theme();
+    std::string theme = m_config->get_theme();
 
-    std::vector<RoguelikeFoldartalCombination> combination = RoguelikeFoldartal.get_combination(m_roguelike_config->get_theme());
+    std::vector<RoguelikeFoldartalCombination> combination = RoguelikeFoldartal.get_combination(m_config->get_theme());
 
     std::string overview_str =
         status()->get_str(Status::RoguelikeFoldartalOverview).value_or(json::value().to_string());
@@ -139,16 +139,16 @@ bool asst::RoguelikeFoldartalUseTaskPlugin::use_board(const std::string& up_boar
 {
     Log.trace("Try to use the board pair", up_board, down_board);
 
-    if (ProcessTask(*this, { m_roguelike_config->get_theme() + "@Roguelike@Foldartal" }).run()) {
+    if (ProcessTask(*this, { m_config->get_theme() + "@Roguelike@Foldartal" }).run()) {
         swipe_to_top();
         // todo:插入一个滑动时顺便更新密文板overview,因为有的板子可以用两次
         if (search_and_click_board(up_board) && search_and_click_board(down_board)) {
             search_and_click_stage();
-            if (ProcessTask(*this, { m_roguelike_config->get_theme() + "@Roguelike@FoldartalUseConfirm" }).run()) {
+            if (ProcessTask(*this, { m_config->get_theme() + "@Roguelike@FoldartalUseConfirm" }).run()) {
                 return true;
             }
         }
-        ProcessTask(*this, { m_roguelike_config->get_theme() + "@Roguelike@FoldartalBack" }).run();
+        ProcessTask(*this, { m_config->get_theme() + "@Roguelike@FoldartalBack" }).run();
     }
     return false;
 }
@@ -161,7 +161,7 @@ bool asst::RoguelikeFoldartalUseTaskPlugin::search_and_click_board(const std::st
     int try_time = 0;
     while (try_time < max_retry && !need_exit()) {
         OCRer analyzer(ctrler()->get_image());
-        std::string task_name = m_roguelike_config->get_theme() + "@Roguelike@FoldartalUseOcr";
+        std::string task_name = m_config->get_theme() + "@Roguelike@FoldartalUseOcr";
         analyzer.set_task_info(task_name);
         analyzer.set_required({ board });
         if (!analyzer.analyze()) {
@@ -187,13 +187,13 @@ bool asst::RoguelikeFoldartalUseTaskPlugin::search_and_click_stage()
     sleep(1000);
 
     // 节点会闪烁，所以这里不用单次Match
-    if (ProcessTask(*this, { m_roguelike_config->get_theme() + "@Roguelike@FoldartalUseOnStage" }).run()) {
+    if (ProcessTask(*this, { m_config->get_theme() + "@Roguelike@FoldartalUseOnStage" }).run()) {
         return true;
     }
     // 滑到最右边，萨米的地图只有两页，暂时先这么糊着，出现识别不到再写循环
     ProcessTask(*this, { "SwipeToTheRight" }).run();
     sleep(1000);
-    if (ProcessTask(*this, { m_roguelike_config->get_theme() + "@Roguelike@FoldartalUseOnStage" }).run()) {
+    if (ProcessTask(*this, { m_config->get_theme() + "@Roguelike@FoldartalUseOnStage" }).run()) {
         return true;
     }
     return false;
@@ -209,7 +209,7 @@ void asst::RoguelikeFoldartalUseTaskPlugin::swipe_to_top()
     while (try_time < max_retry && !need_exit()) {
         while (try_time < max_retry && !need_exit()) {
             OCRer analyzer(ctrler()->get_image());
-            analyzer.set_task_info(m_roguelike_config->get_theme() + "@Roguelike@FoldartalUseOcr");
+            analyzer.set_task_info(m_config->get_theme() + "@Roguelike@FoldartalUseOcr");
             if (analyzer.analyze()) {
                 return;
             }

--- a/src/MaaCore/Task/Roguelike/RoguelikeFoldartalUseTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeFoldartalUseTaskPlugin.cpp
@@ -14,15 +14,15 @@ bool asst::RoguelikeFoldartalUseTaskPlugin::verify(AsstMsg msg, const json::valu
         return false;
     }
 
-    if (m_roguelike_theme.empty()) {
+    if (m_roguelike_config->get_theme().empty()) {
         Log.error("Roguelike name doesn't exist!");
         return false;
     }
-    if (m_roguelike_theme != "Sami") {
+    if (m_roguelike_config->get_theme() != "Sami") {
         return false;
     }
     std::string mode = status()->get_properties(Status::RoguelikeMode).value();
-    std::string task_name_pre = m_roguelike_theme + "@Roguelike@Stage";
+    std::string task_name_pre = m_roguelike_config->get_theme() + "@Roguelike@Stage";
     const std::string& task = details.get("details", "task", "");
     std::string_view task_view = task;
 
@@ -73,9 +73,9 @@ bool asst::RoguelikeFoldartalUseTaskPlugin::_run()
 {
     LogTraceFunction;
 
-    std::string theme = m_roguelike_theme;
+    std::string theme = m_roguelike_config->get_theme();
 
-    std::vector<RoguelikeFoldartalCombination> combination = RoguelikeFoldartal.get_combination(m_roguelike_theme);
+    std::vector<RoguelikeFoldartalCombination> combination = RoguelikeFoldartal.get_combination(m_roguelike_config->get_theme());
 
     std::string overview_str =
         status()->get_str(Status::RoguelikeFoldartalOverview).value_or(json::value().to_string());
@@ -139,16 +139,16 @@ bool asst::RoguelikeFoldartalUseTaskPlugin::use_board(const std::string& up_boar
 {
     Log.trace("Try to use the board pair", up_board, down_board);
 
-    if (ProcessTask(*this, { m_roguelike_theme + "@Roguelike@Foldartal" }).run()) {
+    if (ProcessTask(*this, { m_roguelike_config->get_theme() + "@Roguelike@Foldartal" }).run()) {
         swipe_to_top();
         // todo:插入一个滑动时顺便更新密文板overview,因为有的板子可以用两次
         if (search_and_click_board(up_board) && search_and_click_board(down_board)) {
             search_and_click_stage();
-            if (ProcessTask(*this, { m_roguelike_theme + "@Roguelike@FoldartalUseConfirm" }).run()) {
+            if (ProcessTask(*this, { m_roguelike_config->get_theme() + "@Roguelike@FoldartalUseConfirm" }).run()) {
                 return true;
             }
         }
-        ProcessTask(*this, { m_roguelike_theme + "@Roguelike@FoldartalBack" }).run();
+        ProcessTask(*this, { m_roguelike_config->get_theme() + "@Roguelike@FoldartalBack" }).run();
     }
     return false;
 }
@@ -161,7 +161,7 @@ bool asst::RoguelikeFoldartalUseTaskPlugin::search_and_click_board(const std::st
     int try_time = 0;
     while (try_time < max_retry && !need_exit()) {
         OCRer analyzer(ctrler()->get_image());
-        std::string task_name = m_roguelike_theme + "@Roguelike@FoldartalUseOcr";
+        std::string task_name = m_roguelike_config->get_theme() + "@Roguelike@FoldartalUseOcr";
         analyzer.set_task_info(task_name);
         analyzer.set_required({ board });
         if (!analyzer.analyze()) {
@@ -187,13 +187,13 @@ bool asst::RoguelikeFoldartalUseTaskPlugin::search_and_click_stage()
     sleep(1000);
 
     // 节点会闪烁，所以这里不用单次Match
-    if (ProcessTask(*this, { m_roguelike_theme + "@Roguelike@FoldartalUseOnStage" }).run()) {
+    if (ProcessTask(*this, { m_roguelike_config->get_theme() + "@Roguelike@FoldartalUseOnStage" }).run()) {
         return true;
     }
     // 滑到最右边，萨米的地图只有两页，暂时先这么糊着，出现识别不到再写循环
     ProcessTask(*this, { "SwipeToTheRight" }).run();
     sleep(1000);
-    if (ProcessTask(*this, { m_roguelike_theme + "@Roguelike@FoldartalUseOnStage" }).run()) {
+    if (ProcessTask(*this, { m_roguelike_config->get_theme() + "@Roguelike@FoldartalUseOnStage" }).run()) {
         return true;
     }
     return false;
@@ -209,7 +209,7 @@ void asst::RoguelikeFoldartalUseTaskPlugin::swipe_to_top()
     while (try_time < max_retry && !need_exit()) {
         while (try_time < max_retry && !need_exit()) {
             OCRer analyzer(ctrler()->get_image());
-            analyzer.set_task_info(m_roguelike_theme + "@Roguelike@FoldartalUseOcr");
+            analyzer.set_task_info(m_roguelike_config->get_theme() + "@Roguelike@FoldartalUseOcr");
             if (analyzer.analyze()) {
                 return;
             }

--- a/src/MaaCore/Task/Roguelike/RoguelikeFoldartalUseTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/RoguelikeFoldartalUseTaskPlugin.h
@@ -1,13 +1,12 @@
 #pragma once
-#include "RoguelikeConfig.h"
-#include "Task/AbstractTaskPlugin.h"
+#include "AbstractRoguelikeTaskPlugin.h"
 
 namespace asst
 {
-    class RoguelikeFoldartalUseTaskPlugin : public AbstractTaskPlugin, public RoguelikeConfig
+    class RoguelikeFoldartalUseTaskPlugin : public AbstractRoguelikeTaskPlugin
     {
     public:
-        using AbstractTaskPlugin::AbstractTaskPlugin;
+        using AbstractRoguelikeTaskPlugin::AbstractRoguelikeTaskPlugin;
         virtual ~RoguelikeFoldartalUseTaskPlugin() override = default;
 
     public:

--- a/src/MaaCore/Task/Roguelike/RoguelikeFormationTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeFormationTaskPlugin.cpp
@@ -15,11 +15,11 @@ bool asst::RoguelikeFormationTaskPlugin::verify(AsstMsg msg, const json::value& 
         return false;
     }
 
-    if (m_roguelike_config->get_theme().empty()) {
+    if (m_config->get_theme().empty()) {
         Log.error("Roguelike name doesn't exist!");
         return false;
     }
-    const std::string roguelike_name = m_roguelike_config->get_theme() + "@";
+    const std::string roguelike_name = m_config->get_theme() + "@";
     const std::string& task = details.get("details", "task", "");
     std::string_view task_view = task;
     if (task_view.starts_with(roguelike_name)) {
@@ -102,14 +102,14 @@ void asst::RoguelikeFormationTaskPlugin::clear_and_reselect()
     Log.info(__FUNCTION__, "max_page: ", max_page, " oper_count: ", oper_list.size());
 
     std::vector<asst::RoguelikeFormationImageAnalyzer::FormationOper> sorted_oper_list;
-    const auto& team_complete_condition = RoguelikeRecruit.get_team_complete_info(m_roguelike_config->get_theme());
-    const auto& group_list = RoguelikeRecruit.get_group_info(m_roguelike_config->get_theme());
+    const auto& team_complete_condition = RoguelikeRecruit.get_team_complete_info(m_config->get_theme());
+    const auto& group_list = RoguelikeRecruit.get_group_info(m_config->get_theme());
     for (const auto& condition : team_complete_condition) { // 优先选择阵容核心干员
         int count = 0;
         int require = condition.threshold;
         for (const std::string& group_name : condition.groups) {
             for (const auto& oper : oper_list) {
-                std::vector<int> group_ids = RoguelikeRecruit.get_group_id(m_roguelike_config->get_theme(), oper.name);
+                std::vector<int> group_ids = RoguelikeRecruit.get_group_id(m_config->get_theme(), oper.name);
                 for (const auto& group_id : group_ids) {
                     std::string oper_group = group_list[group_id];
                     if (oper_group == group_name) {

--- a/src/MaaCore/Task/Roguelike/RoguelikeFormationTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeFormationTaskPlugin.cpp
@@ -15,11 +15,11 @@ bool asst::RoguelikeFormationTaskPlugin::verify(AsstMsg msg, const json::value& 
         return false;
     }
 
-    if (m_roguelike_theme.empty()) {
+    if (m_roguelike_config->get_theme().empty()) {
         Log.error("Roguelike name doesn't exist!");
         return false;
     }
-    const std::string roguelike_name = m_roguelike_theme + "@";
+    const std::string roguelike_name = m_roguelike_config->get_theme() + "@";
     const std::string& task = details.get("details", "task", "");
     std::string_view task_view = task;
     if (task_view.starts_with(roguelike_name)) {
@@ -102,14 +102,14 @@ void asst::RoguelikeFormationTaskPlugin::clear_and_reselect()
     Log.info(__FUNCTION__, "max_page: ", max_page, " oper_count: ", oper_list.size());
 
     std::vector<asst::RoguelikeFormationImageAnalyzer::FormationOper> sorted_oper_list;
-    const auto& team_complete_condition = RoguelikeRecruit.get_team_complete_info(m_roguelike_theme);
-    const auto& group_list = RoguelikeRecruit.get_group_info(m_roguelike_theme);
+    const auto& team_complete_condition = RoguelikeRecruit.get_team_complete_info(m_roguelike_config->get_theme());
+    const auto& group_list = RoguelikeRecruit.get_group_info(m_roguelike_config->get_theme());
     for (const auto& condition : team_complete_condition) { // 优先选择阵容核心干员
         int count = 0;
         int require = condition.threshold;
         for (const std::string& group_name : condition.groups) {
             for (const auto& oper : oper_list) {
-                std::vector<int> group_ids = RoguelikeRecruit.get_group_id(m_roguelike_theme, oper.name);
+                std::vector<int> group_ids = RoguelikeRecruit.get_group_id(m_roguelike_config->get_theme(), oper.name);
                 for (const auto& group_id : group_ids) {
                     std::string oper_group = group_list[group_id];
                     if (oper_group == group_name) {

--- a/src/MaaCore/Task/Roguelike/RoguelikeFormationTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/RoguelikeFormationTaskPlugin.h
@@ -1,18 +1,18 @@
 #pragma once
-#include "Task/AbstractTaskPlugin.h"
-#include "Task/Roguelike/RoguelikeConfig.h"
+
+#include "AbstractRoguelikeTaskPlugin.h"
 #include "Vision/Roguelike/RoguelikeFormationImageAnalyzer.h"
 
 namespace asst
 {
     // 集成战略模式快捷编队任务
-    class RoguelikeFormationTaskPlugin : public AbstractTaskPlugin, public RoguelikeConfig
+    class RoguelikeFormationTaskPlugin : public AbstractRoguelikeTaskPlugin
     {
     public:
         static constexpr size_t MaxNumOfOperPerPage = 8;
 
     public:
-        using AbstractTaskPlugin::AbstractTaskPlugin;
+        using AbstractRoguelikeTaskPlugin::AbstractRoguelikeTaskPlugin;
         virtual ~RoguelikeFormationTaskPlugin() override = default;
 
         virtual bool verify(AsstMsg msg, const json::value& details) const override;

--- a/src/MaaCore/Task/Roguelike/RoguelikeLastRewardTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeLastRewardTaskPlugin.cpp
@@ -11,11 +11,11 @@ bool asst::RoguelikeLastRewardTaskPlugin::verify(AsstMsg msg, const json::value&
         return false;
     }
 
-    if (m_roguelike_config->get_theme().empty()) {
+    if (m_config->get_theme().empty()) {
         Log.error("Roguelike name doesn't exist!");
         return false;
     }
-    const std::string roguelike_name = m_roguelike_config->get_theme() + "@";
+    const std::string roguelike_name = m_config->get_theme() + "@";
     const std::string& task = details.get("details", "task", "");
     std::string_view task_view = task;
     if (task_view.starts_with(roguelike_name)) {
@@ -45,7 +45,7 @@ bool asst::RoguelikeLastRewardTaskPlugin::_run()
     LogTraceFunction;
 
     std::string mode = status()->get_properties(Status::RoguelikeMode).value();
-    std::string stages_task_name = m_roguelike_config->get_theme() + "@Roguelike@Stages";
+    std::string stages_task_name = m_config->get_theme() + "@Roguelike@Stages";
     std::string strategy_task_name = stages_task_name + "_default";
 
     if (Task.get(strategy_task_name) == nullptr) {
@@ -59,7 +59,7 @@ bool asst::RoguelikeLastRewardTaskPlugin::_run()
     // 需要开局凹直升
     bool start_with_elite_two =
         status()->get_properties(Status::RoguelikeStartWithEliteTwo).value() == std::to_string(true);
-    if (m_roguelike_config->get_theme() != "Phantom" && mode == "4") {
+    if (m_config->get_theme() != "Phantom" && mode == "4") {
         if (m_is_next_hardest) {
             status()->set_properties(Status::RoguelikeDifficulty, "max");
             // 获得热水壶和演讲时停止肉鸽（凹直升则继续），获得其他奖励时重开

--- a/src/MaaCore/Task/Roguelike/RoguelikeLastRewardTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeLastRewardTaskPlugin.cpp
@@ -11,11 +11,11 @@ bool asst::RoguelikeLastRewardTaskPlugin::verify(AsstMsg msg, const json::value&
         return false;
     }
 
-    if (m_roguelike_theme.empty()) {
+    if (m_roguelike_config->get_theme().empty()) {
         Log.error("Roguelike name doesn't exist!");
         return false;
     }
-    const std::string roguelike_name = m_roguelike_theme + "@";
+    const std::string roguelike_name = m_roguelike_config->get_theme() + "@";
     const std::string& task = details.get("details", "task", "");
     std::string_view task_view = task;
     if (task_view.starts_with(roguelike_name)) {
@@ -45,7 +45,7 @@ bool asst::RoguelikeLastRewardTaskPlugin::_run()
     LogTraceFunction;
 
     std::string mode = status()->get_properties(Status::RoguelikeMode).value();
-    std::string stages_task_name = m_roguelike_theme + "@Roguelike@Stages";
+    std::string stages_task_name = m_roguelike_config->get_theme() + "@Roguelike@Stages";
     std::string strategy_task_name = stages_task_name + "_default";
 
     if (Task.get(strategy_task_name) == nullptr) {
@@ -59,7 +59,7 @@ bool asst::RoguelikeLastRewardTaskPlugin::_run()
     // 需要开局凹直升
     bool start_with_elite_two =
         status()->get_properties(Status::RoguelikeStartWithEliteTwo).value() == std::to_string(true);
-    if (m_roguelike_theme != "Phantom" && mode == "4") {
+    if (m_roguelike_config->get_theme() != "Phantom" && mode == "4") {
         if (m_is_next_hardest) {
             status()->set_properties(Status::RoguelikeDifficulty, "max");
             // 获得热水壶和演讲时停止肉鸽（凹直升则继续），获得其他奖励时重开

--- a/src/MaaCore/Task/Roguelike/RoguelikeLastRewardTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/RoguelikeLastRewardTaskPlugin.h
@@ -1,13 +1,12 @@
 #pragma once
-#include "Task/AbstractTaskPlugin.h"
-#include "Task/Roguelike/RoguelikeConfig.h"
+#include "AbstractRoguelikeTaskPlugin.h"
 
 namespace asst
 {
-    class RoguelikeLastRewardTaskPlugin : public AbstractTaskPlugin, public RoguelikeConfig
+    class RoguelikeLastRewardTaskPlugin : public AbstractRoguelikeTaskPlugin
     {
     public:
-        using AbstractTaskPlugin::AbstractTaskPlugin;
+        using AbstractRoguelikeTaskPlugin::AbstractRoguelikeTaskPlugin;
         virtual ~RoguelikeLastRewardTaskPlugin() override = default;
 
     public:

--- a/src/MaaCore/Task/Roguelike/RoguelikeRecruitTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeRecruitTaskPlugin.cpp
@@ -21,11 +21,11 @@ bool asst::RoguelikeRecruitTaskPlugin::verify(AsstMsg msg, const json::value& de
         return false;
     }
 
-    if (m_roguelike_config->get_theme().empty()) {
+    if (m_config->get_theme().empty()) {
         Log.error("Roguelike name doesn't exist!");
         return false;
     }
-    const std::string roguelike_name = m_roguelike_config->get_theme() + "@";
+    const std::string roguelike_name = m_config->get_theme() + "@";
     const std::string& task = details.get("details", "task", "");
     std::string_view task_view = task;
     if (task_view.starts_with(roguelike_name)) {
@@ -99,9 +99,9 @@ bool asst::RoguelikeRecruitTaskPlugin::_run()
     // __________________will-be-removed-end__________________
 
     std::unordered_map<std::string, int> group_count;
-    const auto& group_list = RoguelikeRecruit.get_group_info(m_roguelike_config->get_theme());
+    const auto& group_list = RoguelikeRecruit.get_group_info(m_config->get_theme());
     for (const auto& oper : chars_map) {
-        std::vector<int> group_ids = RoguelikeRecruit.get_group_id(m_roguelike_config->get_theme(), oper.first);
+        std::vector<int> group_ids = RoguelikeRecruit.get_group_id(m_config->get_theme(), oper.first);
         for (const auto& group_id : group_ids) {
             const std::string& group_name = group_list[group_id];
             group_count[group_name]++;
@@ -110,7 +110,7 @@ bool asst::RoguelikeRecruitTaskPlugin::_run()
 
     if (!start_complete) {
         for (const auto& oper : chars_map) {
-            auto& recruit_info = RoguelikeRecruit.get_oper_info(m_roguelike_config->get_theme(), oper.first);
+            auto& recruit_info = RoguelikeRecruit.get_oper_info(m_config->get_theme(), oper.first);
             if (recruit_info.is_start) start_complete = true;
         }
     }
@@ -119,7 +119,7 @@ bool asst::RoguelikeRecruitTaskPlugin::_run()
         bool complete = true;
         int complete_count = 0;
         int complete_require = 0;
-        const auto& team_complete_condition = RoguelikeRecruit.get_team_complete_info(m_roguelike_config->get_theme());
+        const auto& team_complete_condition = RoguelikeRecruit.get_team_complete_info(m_config->get_theme());
         for (const auto& condition : team_complete_condition) {
             int count = 0;
             complete_require += condition.threshold;
@@ -217,7 +217,7 @@ bool asst::RoguelikeRecruitTaskPlugin::_run()
             }
 
             // 查询招募配置
-            auto& recruit_info = RoguelikeRecruit.get_oper_info(m_roguelike_config->get_theme(), oper_info.name);
+            auto& recruit_info = RoguelikeRecruit.get_oper_info(m_config->get_theme(), oper_info.name);
             int priority = 0;
 
             // 查询编队是否已持有该干员
@@ -468,7 +468,7 @@ bool asst::RoguelikeRecruitTaskPlugin::recruit_appointed_char(const std::string&
                     else {
                         // 重置难度并放弃
                         status()->set_properties(Status::RoguelikeDifficulty, "0");
-                        ProcessTask(*this, { m_roguelike_config->get_theme() + "@Roguelike@ExitThenAbandon" })
+                        ProcessTask(*this, { m_config->get_theme() + "@Roguelike@ExitThenAbandon" })
                             .set_times_limit("Roguelike@Abandon", 0)
                             .run();
                     }

--- a/src/MaaCore/Task/Roguelike/RoguelikeRecruitTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeRecruitTaskPlugin.cpp
@@ -21,11 +21,11 @@ bool asst::RoguelikeRecruitTaskPlugin::verify(AsstMsg msg, const json::value& de
         return false;
     }
 
-    if (m_roguelike_theme.empty()) {
+    if (m_roguelike_config->get_theme().empty()) {
         Log.error("Roguelike name doesn't exist!");
         return false;
     }
-    const std::string roguelike_name = m_roguelike_theme + "@";
+    const std::string roguelike_name = m_roguelike_config->get_theme() + "@";
     const std::string& task = details.get("details", "task", "");
     std::string_view task_view = task;
     if (task_view.starts_with(roguelike_name)) {
@@ -99,9 +99,9 @@ bool asst::RoguelikeRecruitTaskPlugin::_run()
     // __________________will-be-removed-end__________________
 
     std::unordered_map<std::string, int> group_count;
-    const auto& group_list = RoguelikeRecruit.get_group_info(m_roguelike_theme);
+    const auto& group_list = RoguelikeRecruit.get_group_info(m_roguelike_config->get_theme());
     for (const auto& oper : chars_map) {
-        std::vector<int> group_ids = RoguelikeRecruit.get_group_id(m_roguelike_theme, oper.first);
+        std::vector<int> group_ids = RoguelikeRecruit.get_group_id(m_roguelike_config->get_theme(), oper.first);
         for (const auto& group_id : group_ids) {
             const std::string& group_name = group_list[group_id];
             group_count[group_name]++;
@@ -110,7 +110,7 @@ bool asst::RoguelikeRecruitTaskPlugin::_run()
 
     if (!start_complete) {
         for (const auto& oper : chars_map) {
-            auto& recruit_info = RoguelikeRecruit.get_oper_info(m_roguelike_theme, oper.first);
+            auto& recruit_info = RoguelikeRecruit.get_oper_info(m_roguelike_config->get_theme(), oper.first);
             if (recruit_info.is_start) start_complete = true;
         }
     }
@@ -119,7 +119,7 @@ bool asst::RoguelikeRecruitTaskPlugin::_run()
         bool complete = true;
         int complete_count = 0;
         int complete_require = 0;
-        const auto& team_complete_condition = RoguelikeRecruit.get_team_complete_info(m_roguelike_theme);
+        const auto& team_complete_condition = RoguelikeRecruit.get_team_complete_info(m_roguelike_config->get_theme());
         for (const auto& condition : team_complete_condition) {
             int count = 0;
             complete_require += condition.threshold;
@@ -217,7 +217,7 @@ bool asst::RoguelikeRecruitTaskPlugin::_run()
             }
 
             // 查询招募配置
-            auto& recruit_info = RoguelikeRecruit.get_oper_info(m_roguelike_theme, oper_info.name);
+            auto& recruit_info = RoguelikeRecruit.get_oper_info(m_roguelike_config->get_theme(), oper_info.name);
             int priority = 0;
 
             // 查询编队是否已持有该干员
@@ -468,7 +468,7 @@ bool asst::RoguelikeRecruitTaskPlugin::recruit_appointed_char(const std::string&
                     else {
                         // 重置难度并放弃
                         status()->set_properties(Status::RoguelikeDifficulty, "0");
-                        ProcessTask(*this, { m_roguelike_theme + "@Roguelike@ExitThenAbandon" })
+                        ProcessTask(*this, { m_roguelike_config->get_theme() + "@Roguelike@ExitThenAbandon" })
                             .set_times_limit("Roguelike@Abandon", 0)
                             .run();
                     }

--- a/src/MaaCore/Task/Roguelike/RoguelikeRecruitTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/RoguelikeRecruitTaskPlugin.h
@@ -1,7 +1,6 @@
 #pragma once
 #include "Common/AsstBattleDef.h"
-#include "Task/AbstractTaskPlugin.h"
-#include "Task/Roguelike/RoguelikeConfig.h"
+#include "AbstractRoguelikeTaskPlugin.h"
 
 namespace asst
 {
@@ -13,10 +12,10 @@ namespace asst
         int page_index = 0;        // 所在页码 (用于判断翻页方向)
         bool is_alternate = false; // 是否后备干员 (允许重复招募、划到后备干员时不再往右划动)
     };
-    class RoguelikeRecruitTaskPlugin : public AbstractTaskPlugin, public RoguelikeConfig
+    class RoguelikeRecruitTaskPlugin : public AbstractRoguelikeTaskPlugin
     {
     public:
-        using AbstractTaskPlugin::AbstractTaskPlugin;
+        using AbstractRoguelikeTaskPlugin::AbstractRoguelikeTaskPlugin;
         virtual ~RoguelikeRecruitTaskPlugin() override = default;
 
         virtual bool verify(AsstMsg msg, const json::value& details) const override;

--- a/src/MaaCore/Task/Roguelike/RoguelikeResetTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeResetTaskPlugin.cpp
@@ -9,11 +9,11 @@ bool asst::RoguelikeResetTaskPlugin::verify(AsstMsg msg, const json::value& deta
         return false;
     }
 
-    if (m_roguelike_config->get_theme().empty()) {
+    if (m_config->get_theme().empty()) {
         Log.error("Roguelike name doesn't exist!");
         return false;
     }
-    const std::string roguelike_name = m_roguelike_config->get_theme() + "@";
+    const std::string roguelike_name = m_config->get_theme() + "@";
     const std::string& task = details.get("details", "task", "");
     std::string_view task_view = task;
     if (task_view.starts_with(roguelike_name)) {
@@ -34,6 +34,6 @@ bool asst::RoguelikeResetTaskPlugin::_run()
     status()->clear_number();
     status()->clear_str();
 
-    m_roguelike_config->clear();
+    m_config->clear();
     return true;
 }

--- a/src/MaaCore/Task/Roguelike/RoguelikeResetTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeResetTaskPlugin.cpp
@@ -9,11 +9,11 @@ bool asst::RoguelikeResetTaskPlugin::verify(AsstMsg msg, const json::value& deta
         return false;
     }
 
-    if (m_roguelike_theme.empty()) {
+    if (m_roguelike_config->get_theme().empty()) {
         Log.error("Roguelike name doesn't exist!");
         return false;
     }
-    const std::string roguelike_name = m_roguelike_theme + "@";
+    const std::string roguelike_name = m_roguelike_config->get_theme() + "@";
     const std::string& task = details.get("details", "task", "");
     std::string_view task_view = task;
     if (task_view.starts_with(roguelike_name)) {
@@ -29,8 +29,11 @@ bool asst::RoguelikeResetTaskPlugin::verify(AsstMsg msg, const json::value& deta
 
 bool asst::RoguelikeResetTaskPlugin::_run()
 {
+    // 改完全部肉鸽数据之后一起删掉！
     // 简单粗暴，后面如果多任务间有联动可能要改改
     status()->clear_number();
     status()->clear_str();
+
+    m_roguelike_config->clear();
     return true;
 }

--- a/src/MaaCore/Task/Roguelike/RoguelikeResetTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/RoguelikeResetTaskPlugin.h
@@ -1,13 +1,12 @@
 #pragma once
-#include "Task/AbstractTaskPlugin.h"
-#include "Task/Roguelike/RoguelikeConfig.h"
+#include "AbstractRoguelikeTaskPlugin.h"
 
 namespace asst
 {
-    class RoguelikeResetTaskPlugin : public AbstractTaskPlugin, public RoguelikeConfig
+    class RoguelikeResetTaskPlugin : public AbstractRoguelikeTaskPlugin
     {
     public:
-        using AbstractTaskPlugin::AbstractTaskPlugin;
+        using AbstractRoguelikeTaskPlugin::AbstractRoguelikeTaskPlugin;
         virtual ~RoguelikeResetTaskPlugin() = default;
 
         virtual bool verify(AsstMsg msg, const json::value& details) const override;

--- a/src/MaaCore/Task/Roguelike/RoguelikeShoppingTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeShoppingTaskPlugin.cpp
@@ -16,11 +16,11 @@ bool asst::RoguelikeShoppingTaskPlugin::verify(AsstMsg msg, const json::value& d
         return false;
     }
 
-    if (m_roguelike_config->get_theme().empty()) {
+    if (m_config->get_theme().empty()) {
         Log.error("Roguelike name doesn't exist!");
         return false;
     }
-    const std::string roguelike_name = m_roguelike_config->get_theme() + "@";
+    const std::string roguelike_name = m_config->get_theme() + "@";
     const std::string& task = details.get("details", "task", "");
     std::string_view task_view = task;
     if (task_view.starts_with(roguelike_name)) {
@@ -104,8 +104,8 @@ bool asst::RoguelikeShoppingTaskPlugin::_run()
     }
 
     bool bought = false;
-    auto& all_goods = RoguelikeShopping.get_goods(m_roguelike_config->get_theme());
-    std::vector<std::string> all_foldartal = m_roguelike_config->get_theme() == "Sami"
+    auto& all_goods = RoguelikeShopping.get_goods(m_config->get_theme());
+    std::vector<std::string> all_foldartal = m_config->get_theme() == "Sami"
                                                  ? Task.get<OcrTaskInfo>("Sami@Roguelike@FoldartalGainOcr")->text
                                                  : std::vector<std::string>();
     for (const auto& goods : all_goods) {
@@ -170,7 +170,7 @@ bool asst::RoguelikeShoppingTaskPlugin::_run()
         Log.info("Ready to buy", goods.name);
         ctrler()->click(find_it->rect);
         bought = true;
-        if (m_roguelike_config->get_theme() == "Sami") {
+        if (m_config->get_theme() == "Sami") {
 
             auto iter = std::find(all_foldartal.begin(), all_foldartal.end(), goods.name);
             if (iter != all_foldartal.end()) {

--- a/src/MaaCore/Task/Roguelike/RoguelikeShoppingTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeShoppingTaskPlugin.cpp
@@ -16,11 +16,11 @@ bool asst::RoguelikeShoppingTaskPlugin::verify(AsstMsg msg, const json::value& d
         return false;
     }
 
-    if (m_roguelike_theme.empty()) {
+    if (m_roguelike_config->get_theme().empty()) {
         Log.error("Roguelike name doesn't exist!");
         return false;
     }
-    const std::string roguelike_name = m_roguelike_theme + "@";
+    const std::string roguelike_name = m_roguelike_config->get_theme() + "@";
     const std::string& task = details.get("details", "task", "");
     std::string_view task_view = task;
     if (task_view.starts_with(roguelike_name)) {
@@ -104,8 +104,8 @@ bool asst::RoguelikeShoppingTaskPlugin::_run()
     }
 
     bool bought = false;
-    auto& all_goods = RoguelikeShopping.get_goods(m_roguelike_theme);
-    std::vector<std::string> all_foldartal = m_roguelike_theme == "Sami"
+    auto& all_goods = RoguelikeShopping.get_goods(m_roguelike_config->get_theme());
+    std::vector<std::string> all_foldartal = m_roguelike_config->get_theme() == "Sami"
                                                  ? Task.get<OcrTaskInfo>("Sami@Roguelike@FoldartalGainOcr")->text
                                                  : std::vector<std::string>();
     for (const auto& goods : all_goods) {
@@ -170,7 +170,7 @@ bool asst::RoguelikeShoppingTaskPlugin::_run()
         Log.info("Ready to buy", goods.name);
         ctrler()->click(find_it->rect);
         bought = true;
-        if (m_roguelike_theme == "Sami") {
+        if (m_roguelike_config->get_theme() == "Sami") {
 
             auto iter = std::find(all_foldartal.begin(), all_foldartal.end(), goods.name);
             if (iter != all_foldartal.end()) {

--- a/src/MaaCore/Task/Roguelike/RoguelikeShoppingTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/RoguelikeShoppingTaskPlugin.h
@@ -1,13 +1,12 @@
 #pragma once
-#include "Task/AbstractTaskPlugin.h"
-#include "Task/Roguelike/RoguelikeConfig.h"
+#include "AbstractRoguelikeTaskPlugin.h"
 
 namespace asst
 {
-    class RoguelikeShoppingTaskPlugin : public AbstractTaskPlugin, public RoguelikeConfig
+    class RoguelikeShoppingTaskPlugin : public AbstractRoguelikeTaskPlugin
     {
     public:
-        using AbstractTaskPlugin::AbstractTaskPlugin;
+        using AbstractRoguelikeTaskPlugin::AbstractRoguelikeTaskPlugin;
         virtual ~RoguelikeShoppingTaskPlugin() override = default;
 
         virtual bool verify(AsstMsg msg, const json::value& details) const override;

--- a/src/MaaCore/Task/Roguelike/RoguelikeSkillSelectionTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeSkillSelectionTaskPlugin.cpp
@@ -13,11 +13,11 @@ bool asst::RoguelikeSkillSelectionTaskPlugin::verify(AsstMsg msg, const json::va
         return false;
     }
 
-    if (m_roguelike_config->get_theme().empty()) {
+    if (m_config->get_theme().empty()) {
         Log.error("Roguelike name doesn't exist!");
         return false;
     }
-    const std::string roguelike_name = m_roguelike_config->get_theme() + "@";
+    const std::string roguelike_name = m_config->get_theme() + "@";
     const std::string& task = details.get("details", "task", "");
     std::string_view task_view = task;
     if (task_view.starts_with(roguelike_name)) {
@@ -45,7 +45,7 @@ bool asst::RoguelikeSkillSelectionTaskPlugin::_run()
     int delay = Task.get("RoguelikeSkillSelectionMove1")->post_delay;
     bool has_rookie = false;
     for (const auto& [name, skill_vec] : analyzer.get_result()) {
-        const auto& oper_info = RoguelikeRecruit.get_oper_info(m_roguelike_config->get_theme(), name);
+        const auto& oper_info = RoguelikeRecruit.get_oper_info(m_config->get_theme(), name);
         if (oper_info.name.empty()) {
             Log.warn("Unknown oper", name);
             continue;

--- a/src/MaaCore/Task/Roguelike/RoguelikeSkillSelectionTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeSkillSelectionTaskPlugin.cpp
@@ -13,11 +13,11 @@ bool asst::RoguelikeSkillSelectionTaskPlugin::verify(AsstMsg msg, const json::va
         return false;
     }
 
-    if (m_roguelike_theme.empty()) {
+    if (m_roguelike_config->get_theme().empty()) {
         Log.error("Roguelike name doesn't exist!");
         return false;
     }
-    const std::string roguelike_name = m_roguelike_theme + "@";
+    const std::string roguelike_name = m_roguelike_config->get_theme() + "@";
     const std::string& task = details.get("details", "task", "");
     std::string_view task_view = task;
     if (task_view.starts_with(roguelike_name)) {
@@ -45,7 +45,7 @@ bool asst::RoguelikeSkillSelectionTaskPlugin::_run()
     int delay = Task.get("RoguelikeSkillSelectionMove1")->post_delay;
     bool has_rookie = false;
     for (const auto& [name, skill_vec] : analyzer.get_result()) {
-        const auto& oper_info = RoguelikeRecruit.get_oper_info(m_roguelike_theme, name);
+        const auto& oper_info = RoguelikeRecruit.get_oper_info(m_roguelike_config->get_theme(), name);
         if (oper_info.name.empty()) {
             Log.warn("Unknown oper", name);
             continue;

--- a/src/MaaCore/Task/Roguelike/RoguelikeSkillSelectionTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/RoguelikeSkillSelectionTaskPlugin.h
@@ -1,15 +1,15 @@
 #pragma once
-#include "Task/AbstractTaskPlugin.h"
-#include "Task/Roguelike/RoguelikeConfig.h"
 
 #include <unordered_map>
 
+#include "AbstractRoguelikeTaskPlugin.h"
+
 namespace asst
 {
-    class RoguelikeSkillSelectionTaskPlugin final : public AbstractTaskPlugin, public RoguelikeConfig
+    class RoguelikeSkillSelectionTaskPlugin final : public AbstractRoguelikeTaskPlugin
     {
     public:
-        using AbstractTaskPlugin::AbstractTaskPlugin;
+        using AbstractRoguelikeTaskPlugin::AbstractRoguelikeTaskPlugin;
         virtual ~RoguelikeSkillSelectionTaskPlugin() override = default;
 
         virtual bool verify(AsstMsg msg, const json::value& details) const override;

--- a/src/MaaCore/Task/Roguelike/RoguelikeStageEncounterTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeStageEncounterTaskPlugin.cpp
@@ -16,11 +16,11 @@ bool asst::RoguelikeStageEncounterTaskPlugin::verify(AsstMsg msg, const json::va
         return false;
     }
 
-    if (m_roguelike_theme.empty()) {
+    if (m_roguelike_config->get_theme().empty()) {
         Log.error("Roguelike name doesn't exist!");
         return false;
     }
-    const std::string roguelike_name = m_roguelike_theme + "@";
+    const std::string roguelike_name = m_roguelike_config->get_theme() + "@";
     const std::string& task = details.get("details", "task", "");
     std::string_view task_view = task;
     if (task_view.starts_with(roguelike_name)) {
@@ -39,10 +39,10 @@ bool asst::RoguelikeStageEncounterTaskPlugin::_run()
     LogTraceFunction;
 
     std::string rogue_mode = status()->get_properties(Status::RoguelikeMode).value();
-    std::vector<RoguelikeEvent> events = RoguelikeStageEncounter.get_events(m_roguelike_theme);
+    std::vector<RoguelikeEvent> events = RoguelikeStageEncounter.get_events(m_roguelike_config->get_theme());
     // 刷源石锭模式和烧水模式
     if (rogue_mode == "1" || rogue_mode == "4") {
-        events = RoguelikeStageEncounter.get_events(m_roguelike_theme + "_deposit");
+        events = RoguelikeStageEncounter.get_events(m_roguelike_config->get_theme() + "_deposit");
     }
     std::vector<std::string> event_names;
     std::unordered_map<std::string, RoguelikeEvent> event_map;
@@ -79,7 +79,7 @@ bool asst::RoguelikeStageEncounterTaskPlugin::_run()
     info["details"]["default_choose"] = event.default_choose;
     callback(AsstMsg::SubTaskExtraInfo, info);
     for (int j = 0; j < 2; ++j) {
-        ProcessTask(*this, { m_roguelike_theme + "@Roguelike@OptionChoose" + std::to_string(event.option_num) + "-" +
+        ProcessTask(*this, { m_roguelike_config->get_theme() + "@Roguelike@OptionChoose" + std::to_string(event.option_num) + "-" +
                              std::to_string(event.default_choose) })
             .run();
         sleep(300);

--- a/src/MaaCore/Task/Roguelike/RoguelikeStageEncounterTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeStageEncounterTaskPlugin.cpp
@@ -16,11 +16,11 @@ bool asst::RoguelikeStageEncounterTaskPlugin::verify(AsstMsg msg, const json::va
         return false;
     }
 
-    if (m_roguelike_config->get_theme().empty()) {
+    if (m_config->get_theme().empty()) {
         Log.error("Roguelike name doesn't exist!");
         return false;
     }
-    const std::string roguelike_name = m_roguelike_config->get_theme() + "@";
+    const std::string roguelike_name = m_config->get_theme() + "@";
     const std::string& task = details.get("details", "task", "");
     std::string_view task_view = task;
     if (task_view.starts_with(roguelike_name)) {
@@ -39,10 +39,10 @@ bool asst::RoguelikeStageEncounterTaskPlugin::_run()
     LogTraceFunction;
 
     std::string rogue_mode = status()->get_properties(Status::RoguelikeMode).value();
-    std::vector<RoguelikeEvent> events = RoguelikeStageEncounter.get_events(m_roguelike_config->get_theme());
+    std::vector<RoguelikeEvent> events = RoguelikeStageEncounter.get_events(m_config->get_theme());
     // 刷源石锭模式和烧水模式
     if (rogue_mode == "1" || rogue_mode == "4") {
-        events = RoguelikeStageEncounter.get_events(m_roguelike_config->get_theme() + "_deposit");
+        events = RoguelikeStageEncounter.get_events(m_config->get_theme() + "_deposit");
     }
     std::vector<std::string> event_names;
     std::unordered_map<std::string, RoguelikeEvent> event_map;
@@ -79,7 +79,7 @@ bool asst::RoguelikeStageEncounterTaskPlugin::_run()
     info["details"]["default_choose"] = event.default_choose;
     callback(AsstMsg::SubTaskExtraInfo, info);
     for (int j = 0; j < 2; ++j) {
-        ProcessTask(*this, { m_roguelike_config->get_theme() + "@Roguelike@OptionChoose" + std::to_string(event.option_num) + "-" +
+        ProcessTask(*this, { m_config->get_theme() + "@Roguelike@OptionChoose" + std::to_string(event.option_num) + "-" +
                              std::to_string(event.default_choose) })
             .run();
         sleep(300);

--- a/src/MaaCore/Task/Roguelike/RoguelikeStageEncounterTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/RoguelikeStageEncounterTaskPlugin.h
@@ -1,13 +1,12 @@
 #pragma once
-#include "Task/AbstractTaskPlugin.h"
-#include "Task/Roguelike/RoguelikeConfig.h"
+#include "AbstractRoguelikeTaskPlugin.h"
 
 namespace asst
 {
-    class RoguelikeStageEncounterTaskPlugin : public AbstractTaskPlugin, public RoguelikeConfig
+    class RoguelikeStageEncounterTaskPlugin : public AbstractRoguelikeTaskPlugin
     {
     public:
-        using AbstractTaskPlugin::AbstractTaskPlugin;
+        using AbstractRoguelikeTaskPlugin::AbstractRoguelikeTaskPlugin;
         virtual ~RoguelikeStageEncounterTaskPlugin() override = default;
 
     public:

--- a/src/MaaCore/Task/Roguelike/RoguelikeStrategyChangeTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeStrategyChangeTaskPlugin.cpp
@@ -13,11 +13,11 @@ bool asst::RoguelikeStrategyChangeTaskPlugin::verify(AsstMsg msg, const json::va
         return false;
     }
 
-    if (m_roguelike_config->get_theme().empty()) {
+    if (m_config->get_theme().empty()) {
         Log.error("Roguelike name doesn't exist!");
         return false;
     }
-    const std::string roguelike_name = m_roguelike_config->get_theme() + "@";
+    const std::string roguelike_name = m_config->get_theme() + "@";
     const std::string& task = details.get("details", "task", "");
     std::string_view task_view = task;
     if (task_view.starts_with(roguelike_name)) {
@@ -35,7 +35,7 @@ bool asst::RoguelikeStrategyChangeTaskPlugin::_run()
 {
     LogTraceFunction;
 
-    std::string theme = m_roguelike_config->get_theme();
+    std::string theme = m_config->get_theme();
     std::string mode = status()->get_properties(Status::RoguelikeMode).value();
 
     // TODO: 这段识别有点冗余，要是 plugin 能获取识别结果就好了

--- a/src/MaaCore/Task/Roguelike/RoguelikeStrategyChangeTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeStrategyChangeTaskPlugin.cpp
@@ -13,11 +13,11 @@ bool asst::RoguelikeStrategyChangeTaskPlugin::verify(AsstMsg msg, const json::va
         return false;
     }
 
-    if (m_roguelike_theme.empty()) {
+    if (m_roguelike_config->get_theme().empty()) {
         Log.error("Roguelike name doesn't exist!");
         return false;
     }
-    const std::string roguelike_name = m_roguelike_theme + "@";
+    const std::string roguelike_name = m_roguelike_config->get_theme() + "@";
     const std::string& task = details.get("details", "task", "");
     std::string_view task_view = task;
     if (task_view.starts_with(roguelike_name)) {
@@ -35,7 +35,7 @@ bool asst::RoguelikeStrategyChangeTaskPlugin::_run()
 {
     LogTraceFunction;
 
-    std::string theme = m_roguelike_theme;
+    std::string theme = m_roguelike_config->get_theme();
     std::string mode = status()->get_properties(Status::RoguelikeMode).value();
 
     // TODO: 这段识别有点冗余，要是 plugin 能获取识别结果就好了

--- a/src/MaaCore/Task/Roguelike/RoguelikeStrategyChangeTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/RoguelikeStrategyChangeTaskPlugin.h
@@ -1,13 +1,12 @@
 #pragma once
-#include "RoguelikeConfig.h"
-#include "Task/AbstractTaskPlugin.h"
+#include "AbstractRoguelikeTaskPlugin.h"
 
 namespace asst
 {
-    class RoguelikeStrategyChangeTaskPlugin : public AbstractTaskPlugin, public RoguelikeConfig
+    class RoguelikeStrategyChangeTaskPlugin : public AbstractRoguelikeTaskPlugin
     {
     public:
-        using AbstractTaskPlugin::AbstractTaskPlugin;
+        using AbstractRoguelikeTaskPlugin::AbstractRoguelikeTaskPlugin;
         virtual ~RoguelikeStrategyChangeTaskPlugin() override = default;
 
     public:


### PR DESCRIPTION
不再继承RoguelikeConfig，改为继承AbstractRoguelikeTaskPlugin。通过RoguelikeConfig共享数据，不再走Status（下个pr的部分

- 参考 #7137 