### PR TITLE
feat: 完成后选项 模拟器返回桌面

### DIFF
--- a/include/AsstCaller.h
+++ b/include/AsstCaller.h
@@ -46,6 +46,7 @@ extern "C"
     AsstBool ASSTAPI AsstStop(AsstHandle handle);
     AsstBool ASSTAPI AsstRunning(AsstHandle handle);
     AsstBool ASSTAPI AsstConnected(AsstHandle handle);
+    AsstBool ASSTAPI AsstBackToHome(AsstHandle handle);
 
     /* Async with AsstMsg::AsyncCallInfo Callback*/
     AsstAsyncCallId ASSTAPI AsstAsyncConnect(AsstHandle handle, const char* adb_path, const char* address,

--- a/resource/config.json
+++ b/resource/config.json
@@ -87,7 +87,8 @@
             "pushMinitouch": "[Adb] -s [AdbSerial] push \"[minitouchLocalPath]\" \"/data/local/tmp/[minitouchWorkingFile]\"",
             "chmodMinitouch": "[Adb] -s [AdbSerial] shell chmod 700 \"/data/local/tmp/[minitouchWorkingFile]\"",
             "callMinitouch": "[Adb] -s [AdbSerial] shell \"/data/local/tmp/[minitouchWorkingFile]\" -i",
-            "callMaatouch": "[Adb] -s [AdbSerial] shell \"export CLASSPATH=/data/local/tmp/[minitouchWorkingFile]; app_process /data/local/tmp com.shxyke.MaaTouch.App\""
+            "callMaatouch": "[Adb] -s [AdbSerial] shell \"export CLASSPATH=/data/local/tmp/[minitouchWorkingFile]; app_process /data/local/tmp com.shxyke.MaaTouch.App\"",
+            "back_to_home": "[Adb] -s [AdbSerial] shell input keyevent HOME"
         },
         {
             "configName": "CapWithShell",

--- a/src/MaaCore/Assistant.cpp
+++ b/src/MaaCore/Assistant.cpp
@@ -631,3 +631,8 @@ bool asst::Assistant::inited() const noexcept
 {
     return m_ctrler && m_ctrler->inited();
 }
+
+bool asst::Assistant::back_to_home() const
+{
+    return m_ctrler->back_to_home();
+}

--- a/src/MaaCore/Assistant.h
+++ b/src/MaaCore/Assistant.h
@@ -56,6 +56,8 @@ public:
     virtual std::string get_uuid() const = 0;
     // 获取任务列表
     virtual std::vector<TaskId> get_tasks_list() const = 0;
+
+    virtual bool back_to_home() const = 0;
 };
 
 namespace asst
@@ -91,6 +93,8 @@ namespace asst
         virtual std::vector<unsigned char> get_image() const override;
         virtual std::string get_uuid() const override;
         virtual std::vector<TaskId> get_tasks_list() const override;
+
+        virtual bool back_to_home() const override;
 
     public:
         std::shared_ptr<Controller> ctrler() const { return m_ctrler; }

--- a/src/MaaCore/AsstCaller.cpp
+++ b/src/MaaCore/AsstCaller.cpp
@@ -154,6 +154,15 @@ AsstBool AsstConnected(AsstHandle handle)
     return handle->connected() ? AsstTrue : AsstFalse;
 }
 
+AsstBool ASSTAPI AsstBackToHome(AsstHandle handle)
+{
+    if (!inited() || handle == nullptr) {
+        return AsstFalse;
+    }
+
+    return handle->back_to_home() ? AsstTrue : AsstFalse;
+}
+
 AsstAsyncCallId AsstAsyncConnect(AsstHandle handle, const char* adb_path, const char* address, const char* config,
                                  AsstBool block)
 {

--- a/src/MaaCore/Config/GeneralConfig.cpp
+++ b/src/MaaCore/Config/GeneralConfig.cpp
@@ -86,6 +86,7 @@ bool asst::GeneralConfig::parse(const json::value& json)
         adb.chmod_minitouch = cfg_json.get("chmodMinitouch", base_cfg.chmod_minitouch);
         adb.call_minitouch = cfg_json.get("callMinitouch", base_cfg.call_minitouch);
         adb.call_maatouch = cfg_json.get("callMaatouch", base_cfg.call_maatouch);
+        adb.back_to_home = cfg_json.get("back_to_home", base_cfg.back_to_home);
 
         m_adb_cfg[cfg_json.at("configName").as_string()] = std::move(adb);
     }

--- a/src/MaaCore/Config/GeneralConfig.h
+++ b/src/MaaCore/Config/GeneralConfig.h
@@ -80,6 +80,7 @@ namespace asst
         std::string chmod_minitouch;
         std::string call_minitouch;
         std::string call_maatouch;
+        std::string back_to_home;
     };
 
     class GeneralConfig final : public SingletonHolder<GeneralConfig>, public AbstractConfig

--- a/src/MaaCore/Controller/AdbController.cpp
+++ b/src/MaaCore/Controller/AdbController.cpp
@@ -694,6 +694,7 @@ bool asst::AdbController::connect(const std::string& adb_path, const std::string
     m_adb.screencap_encode = cmd_replace(adb_cfg.screencap_encode);
     m_adb.start = cmd_replace(adb_cfg.start);
     m_adb.stop = cmd_replace(adb_cfg.stop);
+    m_adb.back_to_home = cmd_replace(adb_cfg.back_to_home);
 
     if (m_support_socket && !m_server_started) {
         std::string bind_address;
@@ -739,4 +740,10 @@ void asst::AdbController::set_kill_adb_on_exit(bool enable) noexcept
 void asst::AdbController::clear_lf_info()
 {
     m_adb.screencap_end_of_line = AdbProperty::ScreencapEndOfLine::UnknownYet;
+}
+
+void asst::AdbController::back_to_home() noexcept
+{
+    call_command(m_adb.back_to_home);
+    return;
 }

--- a/src/MaaCore/Controller/AdbController.h
+++ b/src/MaaCore/Controller/AdbController.h
@@ -48,6 +48,8 @@ namespace asst
         AdbController& operator=(const AdbController&) = delete;
         AdbController& operator=(AdbController&&) = delete;
 
+        virtual void back_to_home() noexcept override;
+
     protected:
         std::optional<std::string> call_command(const std::string& cmd, int64_t timeout = 20000,
                                                 bool allow_reconnect = true, bool recv_by_socket = false);
@@ -96,6 +98,8 @@ namespace asst
 
             std::string start;
             std::string stop;
+
+            std::string back_to_home;
 
             /* properties */
             enum class ScreencapEndOfLine

--- a/src/MaaCore/Controller/Controller.cpp
+++ b/src/MaaCore/Controller/Controller.cpp
@@ -70,6 +70,12 @@ void asst::Controller::sync_params()
     m_controller->set_kill_adb_on_exit(m_kill_adb_on_exit);
 }
 
+bool asst::Controller::back_to_home()
+{
+    m_controller->back_to_home();
+    return true;
+}
+
 cv::Mat asst::Controller::get_resized_image_cache() const
 {
     const static cv::Size d_size(m_scale_size.first, m_scale_size.second);

--- a/src/MaaCore/Controller/Controller.h
+++ b/src/MaaCore/Controller/Controller.h
@@ -71,6 +71,8 @@ namespace asst
         Controller& operator=(const Controller&) = delete;
         Controller& operator=(Controller&&) = delete;
 
+        bool back_to_home();
+
     private:
         cv::Mat get_resized_image_cache() const;
 

--- a/src/MaaCore/Controller/ControllerAPI.h
+++ b/src/MaaCore/Controller/ControllerAPI.h
@@ -49,6 +49,8 @@ namespace asst
 
         ControllerAPI& operator=(const ControllerAPI&) = delete;
         ControllerAPI& operator=(ControllerAPI&&) = delete;
+
+        virtual void back_to_home() noexcept {}
     };
 
     struct InputEvent

--- a/src/MaaCore/Controller/MaaThriftController.cpp
+++ b/src/MaaCore/Controller/MaaThriftController.cpp
@@ -484,6 +484,8 @@ std::pair<int, int> asst::MaaThriftController::get_screen_res() const noexcept
     return m_screen_size;
 }
 
+void asst::MaaThriftController::back_to_home() noexcept {}
+
 void asst::MaaThriftController::clear_info() noexcept
 {
     m_inited = false;

--- a/src/MaaCore/Controller/MaaThriftController.h
+++ b/src/MaaCore/Controller/MaaThriftController.h
@@ -54,6 +54,8 @@ namespace asst
         MaaThriftController& operator=(const MaaThriftController&) = delete;
         MaaThriftController& operator=(MaaThriftController&&) = delete;
 
+        virtual void back_to_home() noexcept override;
+
     protected:
         virtual void clear_info() noexcept;
         void callback(AsstMsg msg, const json::value& details);

--- a/src/MaaCore/Controller/MinitouchController.cpp
+++ b/src/MaaCore/Controller/MinitouchController.cpp
@@ -374,3 +374,9 @@ bool asst::MinitouchController::connect(const std::string& adb_path, const std::
 
     return true;
 }
+
+void asst::MinitouchController::back_to_home() noexcept
+{
+    AdbController::back_to_home();
+    return;
+}

--- a/src/MaaCore/Controller/MinitouchController.h
+++ b/src/MaaCore/Controller/MinitouchController.h
@@ -35,6 +35,8 @@ namespace asst
         MinitouchController& operator=(const MinitouchController&) = delete;
         MinitouchController& operator=(MinitouchController&&) = delete;
 
+        virtual void back_to_home() noexcept override;
+
     protected:
         virtual std::optional<std::string> reconnect(const std::string& cmd, int64_t timeout,
                                                      bool recv_by_socket) override;

--- a/src/MaaCore/Controller/PlayToolsController.cpp
+++ b/src/MaaCore/Controller/PlayToolsController.cpp
@@ -166,6 +166,12 @@ std::pair<int, int> asst::PlayToolsController::get_screen_res() const noexcept
     return m_screen_size;
 }
 
+void asst::PlayToolsController::back_to_home() noexcept
+{
+    Log.info("HOME is not supported on iOS");
+    return;
+}
+
 bool asst::PlayToolsController::toucher_down(const Point& p, const int delay)
 {
     return toucher_commit(TouchPhase::Began, p, delay);

--- a/src/MaaCore/Controller/PlayToolsController.h
+++ b/src/MaaCore/Controller/PlayToolsController.h
@@ -47,6 +47,8 @@ namespace asst
         PlayToolsController& operator=(const PlayToolsController&) = delete;
         PlayToolsController& operator=(PlayToolsController&&) = delete;
 
+        virtual void back_to_home() noexcept override;
+
     protected:
         AsstCallback m_callback;
 

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -1677,6 +1677,11 @@ namespace MaaWpfGui.Main
             return AsstAppendCloseDown() && AsstStart();
         }
 
+        public bool AsstBackToHome()
+        {
+            return MaaService.AsstBackToHome(_handle);
+        }
+
         /// <summary>
         /// 领取信用及商店购物。
         /// </summary>

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -332,6 +332,8 @@ Other client types are not supported</system:String>
     <system:String x:Key="ShutdownWithoutPersist">Shutdown (only once)</system:String>
     <system:String x:Key="ExitEmulatorAndSelfIfOtherMaaElseExitEmulatorAndSelfAndHibernate">Exit MAA and Emulator, then Hibernate if no other running MAA</system:String>
     <system:String x:Key="ExitSelfIfOtherMaaElseShutdown">Exit MAA and Emulator, then Shutdown if no other running MAA</system:String>
+    <system:String x:Key="BackToDesktop">Back to Desktop</system:String>
+    <system:String x:Key="BackToAndroidHome">Move Arknights into background</system:String>
     <system:String x:Key="LinkStart">Link Start!</system:String>
     <system:String x:Key="Stop">Stop</system:String>
     <system:String x:Key="WaitAndStop">Wait &amp; Stop</system:String>

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -332,8 +332,7 @@ Other client types are not supported</system:String>
     <system:String x:Key="ShutdownWithoutPersist">Shutdown (only once)</system:String>
     <system:String x:Key="ExitEmulatorAndSelfIfOtherMaaElseExitEmulatorAndSelfAndHibernate">Exit MAA and Emulator, then Hibernate if no other running MAA</system:String>
     <system:String x:Key="ExitSelfIfOtherMaaElseShutdown">Exit MAA and Emulator, then Shutdown if no other running MAA</system:String>
-    <system:String x:Key="BackToDesktop">Back to Desktop</system:String>
-    <system:String x:Key="BackToAndroidHome">Move Arknights into background</system:String>
+    <system:String x:Key="BackToAndroidHome">Emulator returns to home screen</system:String>
     <system:String x:Key="LinkStart">Link Start!</system:String>
     <system:String x:Key="Stop">Stop</system:String>
     <system:String x:Key="WaitAndStop">Wait &amp; Stop</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -332,8 +332,7 @@ Bilibili: ログイン インターフェイスに表示されるアカウント
     <system:String x:Key="ShutdownWithoutPersist">シャットダウン（1回のみ）</system:String>
     <system:String x:Key="ExitEmulatorAndSelfIfOtherMaaElseExitEmulatorAndSelfAndHibernate">MAAとエミューレータを終了し、他のMAAがない場合はPCを休止状態になる</system:String>
     <system:String x:Key="ExitSelfIfOtherMaaElseShutdown">MAAを終了し、他のMAAがない場合はシャットダウン</system:String>
-    <system:String x:Key="BackToDesktop">デスクトップに戻る</system:String>
-    <system:String x:Key="BackToAndroidHome">アークナイツをバックグラウンドに移動する</system:String>
+    <system:String x:Key="BackToAndroidHome">エミュレータをホーム画面に戻る</system:String>
     <system:String x:Key="LinkStart">Link Start!</system:String>
     <system:String x:Key="Stop">止める</system:String>
     <system:String x:Key="WaitAndStop">待って &amp; 止める</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -332,6 +332,8 @@ Bilibili: ログイン インターフェイスに表示されるアカウント
     <system:String x:Key="ShutdownWithoutPersist">シャットダウン（1回のみ）</system:String>
     <system:String x:Key="ExitEmulatorAndSelfIfOtherMaaElseExitEmulatorAndSelfAndHibernate">MAAとエミューレータを終了し、他のMAAがない場合はPCを休止状態になる</system:String>
     <system:String x:Key="ExitSelfIfOtherMaaElseShutdown">MAAを終了し、他のMAAがない場合はシャットダウン</system:String>
+    <system:String x:Key="BackToDesktop">デスクトップに戻る</system:String>
+    <system:String x:Key="BackToAndroidHome">アークナイツをバックグラウンドに移動する</system:String>
     <system:String x:Key="LinkStart">Link Start!</system:String>
     <system:String x:Key="Stop">止める</system:String>
     <system:String x:Key="WaitAndStop">待って &amp; 止める</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -332,8 +332,7 @@ Bilibili: 로그인 인터페이스에 표시되는 계정 이름(예: 장산)�
     <system:String x:Key="ShutdownWithoutPersist">시스템 종료(한 번만)</system:String>
     <system:String x:Key="ExitEmulatorAndSelfIfOtherMaaElseExitEmulatorAndSelfAndHibernate">MAA와 에뮬레이터를 종료, 다른 MAA가 없으면 절전 모드</system:String>
     <system:String x:Key="ExitSelfIfOtherMaaElseShutdown">MAA를 종료, 다른 MAA가 없으면 시스템 종료</system:String>
-    <system:String x:Key="BackToDesktop">데스크톱으로 돌아가기 </system:String>
-    <system:String x:Key="BackToAndroidHome">명일방주 를 배경으로 이동</system:String>
+    <system:String x:Key="BackToAndroidHome">에뮬레이터가 홈 화면으로 돌아갑니다</system:String>
     <system:String x:Key="LinkStart">Link Start!</system:String>
     <system:String x:Key="Stop">중지</system:String>
     <system:String x:Key="WaitAndStop">기다리다 &amp; 중지</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -332,6 +332,8 @@ Bilibili: 로그인 인터페이스에 표시되는 계정 이름(예: 장산)�
     <system:String x:Key="ShutdownWithoutPersist">시스템 종료(한 번만)</system:String>
     <system:String x:Key="ExitEmulatorAndSelfIfOtherMaaElseExitEmulatorAndSelfAndHibernate">MAA와 에뮬레이터를 종료, 다른 MAA가 없으면 절전 모드</system:String>
     <system:String x:Key="ExitSelfIfOtherMaaElseShutdown">MAA를 종료, 다른 MAA가 없으면 시스템 종료</system:String>
+    <system:String x:Key="BackToDesktop">Back to Desktop</system:String>
+    <system:String x:Key="BackToAndroidHome">Move Arknights into background</system:String>
     <system:String x:Key="LinkStart">Link Start!</system:String>
     <system:String x:Key="Stop">중지</system:String>
     <system:String x:Key="WaitAndStop">기다리다 &amp; 중지</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -332,8 +332,8 @@ Bilibili: 로그인 인터페이스에 표시되는 계정 이름(예: 장산)�
     <system:String x:Key="ShutdownWithoutPersist">시스템 종료(한 번만)</system:String>
     <system:String x:Key="ExitEmulatorAndSelfIfOtherMaaElseExitEmulatorAndSelfAndHibernate">MAA와 에뮬레이터를 종료, 다른 MAA가 없으면 절전 모드</system:String>
     <system:String x:Key="ExitSelfIfOtherMaaElseShutdown">MAA를 종료, 다른 MAA가 없으면 시스템 종료</system:String>
-    <system:String x:Key="BackToDesktop">Back to Desktop</system:String>
-    <system:String x:Key="BackToAndroidHome">Move Arknights into background</system:String>
+    <system:String x:Key="BackToDesktop">데스크톱으로 돌아가기 </system:String>
+    <system:String x:Key="BackToAndroidHome">명일방주 를 배경으로 이동</system:String>
     <system:String x:Key="LinkStart">Link Start!</system:String>
     <system:String x:Key="Stop">중지</system:String>
     <system:String x:Key="WaitAndStop">기다리다 &amp; 중지</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -332,6 +332,8 @@
     <system:String x:Key="ShutdownWithoutPersist">关机（仅一次）</system:String>
     <system:String x:Key="ExitEmulatorAndSelfIfOtherMaaElseExitEmulatorAndSelfAndHibernate">退出 MAA 和 模拟器，如无其他 MAA 进程则休眠</system:String>
     <system:String x:Key="ExitSelfIfOtherMaaElseShutdown">退出 MAA，如无其他 MAA 进程则关机</system:String>
+    <system:String x:Key="BackToDesktop">返回桌面</system:String>
+    <system:String x:Key="BackToAndroidHome">将 明日方舟 切入后台</system:String>
     <system:String x:Key="LinkStart">Link Start!</system:String>
     <system:String x:Key="Stop">停止</system:String>
     <system:String x:Key="WaitAndStop">等待 &amp; 停止</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -332,8 +332,7 @@
     <system:String x:Key="ShutdownWithoutPersist">关机（仅一次）</system:String>
     <system:String x:Key="ExitEmulatorAndSelfIfOtherMaaElseExitEmulatorAndSelfAndHibernate">退出 MAA 和 模拟器，如无其他 MAA 进程则休眠</system:String>
     <system:String x:Key="ExitSelfIfOtherMaaElseShutdown">退出 MAA，如无其他 MAA 进程则关机</system:String>
-    <system:String x:Key="BackToDesktop">返回桌面</system:String>
-    <system:String x:Key="BackToAndroidHome">将 明日方舟 切入后台</system:String>
+    <system:String x:Key="BackToAndroidHome">模拟器 返回主屏幕</system:String>
     <system:String x:Key="LinkStart">Link Start!</system:String>
     <system:String x:Key="Stop">停止</system:String>
     <system:String x:Key="WaitAndStop">等待 &amp; 停止</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -332,8 +332,7 @@
     <system:String x:Key="ShutdownWithoutPersist">關機（僅一次）</system:String>
     <system:String x:Key="ExitEmulatorAndSelfIfOtherMaaElseExitEmulatorAndSelfAndHibernate">退出 MAA 和 模擬器，如無其他 MAA 程式則休眠</system:String>
     <system:String x:Key="ExitSelfIfOtherMaaElseShutdown">退出 MAA，如無其他 MAA 程式則關機</system:String>
-    <system:String x:Key="BackToDesktop">返回桌面</system:String>
-    <system:String x:Key="BackToAndroidHome">將 明日方舟 轉入後臺</system:String>
+    <system:String x:Key="BackToAndroidHome">模擬器 返回主荧幕</system:String>
     <system:String x:Key="LinkStart">Link Start!</system:String>
     <system:String x:Key="Stop">停止</system:String>
     <system:String x:Key="WaitAndStop">等待 &amp; 停止</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -332,6 +332,8 @@
     <system:String x:Key="ShutdownWithoutPersist">關機（僅一次）</system:String>
     <system:String x:Key="ExitEmulatorAndSelfIfOtherMaaElseExitEmulatorAndSelfAndHibernate">退出 MAA 和 模擬器，如無其他 MAA 程式則休眠</system:String>
     <system:String x:Key="ExitSelfIfOtherMaaElseShutdown">退出 MAA，如無其他 MAA 程式則關機</system:String>
+    <system:String x:Key="BackToDesktop">返回桌面</system:String>
+    <system:String x:Key="BackToAndroidHome">將 明日方舟 轉入後臺</system:String>
     <system:String x:Key="LinkStart">Link Start!</system:String>
     <system:String x:Key="Stop">停止</system:String>
     <system:String x:Key="WaitAndStop">等待 &amp; 停止</system:String>

--- a/src/MaaWpfGui/Services/MaaService.cs
+++ b/src/MaaWpfGui/Services/MaaService.cs
@@ -65,5 +65,8 @@ namespace MaaWpfGui.Services
 
         [DllImport("MaaCore.dll")]
         public static extern IntPtr AsstGetVersion();
+
+        [DllImport("MaaCore.dll")]
+        public static extern bool AsstBackToHome(AsstHandle handle);
     }
 }

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -380,8 +380,6 @@ namespace MaaWpfGui.ViewModels.UI
 
                 new GenericCombinedData<ActionType> { Display = LocalizationHelper.GetString("ExitEmulatorAndSelfIfOtherMaaElseExitEmulatorAndSelfAndHibernate"), Value = ActionType.ExitEmulatorAndSelfIfOtherMaaElseExitEmulatorAndSelfAndHibernate },
                 new GenericCombinedData<ActionType> { Display = LocalizationHelper.GetString("ExitSelfIfOtherMaaElseShutdown"), Value = ActionType.ExitSelfIfOtherMaaElseShutdown },
-
-                new GenericCombinedData<ActionType> { Display = LocalizationHelper.GetString("BackToDesktop"), Value = ActionType.BackToDesktop },
             };
             var tempOrderList = new List<DragItemViewModel>(new DragItemViewModel[taskList.Count]);
             var nonOrderList = new List<DragItemViewModel>();
@@ -1943,12 +1941,7 @@ namespace MaaWpfGui.ViewModels.UI
             ExitSelfIfOtherMaaElseShutdown,
 
             /// <summary>
-            /// Do nothing, just back to desktop.
-            /// </summary>
-            BackToDesktop,
-
-            /// <summary>
-            /// Switch the game to background without kill it.
+            /// Switch the game to background without killing it.
             /// </summary>
             BackToAndroidHome,
         }
@@ -2069,12 +2062,6 @@ namespace MaaWpfGui.ViewModels.UI
                     {
                         goto case ActionType.Shutdown;
                     }
-
-                case ActionType.BackToDesktop:
-                    Type shellType = Type.GetTypeFromProgID("Shell.Application");
-                    object shellObject = System.Activator.CreateInstance(shellType);
-                    shellType.InvokeMember("ToggleDesktop", System.Reflection.BindingFlags.InvokeMethod, null, shellObject, null);
-                    break;
 
                 case ActionType.BackToAndroidHome:
                     Instances.AsstProxy.AsstBackToHome();

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -363,6 +363,8 @@ namespace MaaWpfGui.ViewModels.UI
             {
                 new GenericCombinedData<ActionType> { Display = LocalizationHelper.GetString("DoNothing"), Value = ActionType.DoNothing },
                 new GenericCombinedData<ActionType> { Display = LocalizationHelper.GetString("ExitArknights"), Value = ActionType.StopGame },
+                new GenericCombinedData<ActionType> { Display = LocalizationHelper.GetString("BackToAndroidHome"), Value = ActionType.BackToAndroidHome },
+
                 new GenericCombinedData<ActionType> { Display = LocalizationHelper.GetString("ExitEmulator"), Value = ActionType.ExitEmulator },
                 new GenericCombinedData<ActionType> { Display = LocalizationHelper.GetString("ExitSelf"), Value = ActionType.ExitSelf },
                 new GenericCombinedData<ActionType> { Display = LocalizationHelper.GetString("ExitEmulatorAndSelf"), Value = ActionType.ExitEmulatorAndSelf },
@@ -378,6 +380,8 @@ namespace MaaWpfGui.ViewModels.UI
 
                 new GenericCombinedData<ActionType> { Display = LocalizationHelper.GetString("ExitEmulatorAndSelfIfOtherMaaElseExitEmulatorAndSelfAndHibernate"), Value = ActionType.ExitEmulatorAndSelfIfOtherMaaElseExitEmulatorAndSelfAndHibernate },
                 new GenericCombinedData<ActionType> { Display = LocalizationHelper.GetString("ExitSelfIfOtherMaaElseShutdown"), Value = ActionType.ExitSelfIfOtherMaaElseShutdown },
+
+                new GenericCombinedData<ActionType> { Display = LocalizationHelper.GetString("BackToDesktop"), Value = ActionType.BackToDesktop },
             };
             var tempOrderList = new List<DragItemViewModel>(new DragItemViewModel[taskList.Count]);
             var nonOrderList = new List<DragItemViewModel>();
@@ -1937,6 +1941,16 @@ namespace MaaWpfGui.ViewModels.UI
             /// Exits MAA and, if no other processes of MAA are running, computer shutdown.
             /// </summary>
             ExitSelfIfOtherMaaElseShutdown,
+
+            /// <summary>
+            /// Do nothing, just back to desktop.
+            /// </summary>
+            BackToDesktop,
+
+            /// <summary>
+            /// Switch the game to background without kill it.
+            /// </summary>
+            BackToAndroidHome,
         }
 
         /// <summary>
@@ -2055,6 +2069,16 @@ namespace MaaWpfGui.ViewModels.UI
                     {
                         goto case ActionType.Shutdown;
                     }
+
+                case ActionType.BackToDesktop:
+                    Type shellType = Type.GetTypeFromProgID("Shell.Application");
+                    object shellObject = System.Activator.CreateInstance(shellType);
+                    shellType.InvokeMember("ToggleDesktop", System.Reflection.BindingFlags.InvokeMethod, null, shellObject, null);
+                    break;
+
+                case ActionType.BackToAndroidHome:
+                    Instances.AsstProxy.AsstBackToHome();
+                    break;
 
                 default:
                     Execute.OnUIThread(() =>


### PR DESCRIPTION
https://github.com/MaaAssistantArknights/MaaAssistantArknights/issues/7132
<img width="600" alt="2023110301" src="https://github.com/MaaAssistantArknights/MaaAssistantArknights/assets/63437036/d5753a69-f9a3-4c03-b8a2-9bd9a78d6504">

添加完成后选项 返回桌面（windows返回桌面） 和 将明日方舟切入后台（模拟器返回桌面）。
返回桌面 没什么用，而且应该是一段windows only的代码，是否保留可能需要讨论一下。
模拟器返回桌面 是根据 issues 7132 的建议写的，使用```adb shell input keyevent HOME```使模拟器返回桌面，在模拟器内保留游戏进程方便下次唤起。经测试可以释放大约80%的CPU占用和一部分GPU占用，但似乎不会释放内存占用。以这种方式结束任务后，游戏会停留在任务结束时的界面，下次启动时需要勾选“开始唤醒”任务才能唤起游戏进程。
已知问题：
1. 不清楚模拟器会不会、什么时候会杀后台。
2. WSA能接收这个指令，也会把游戏切后台省CPU资源，表现为音乐停止，画面保留最后的图像不动。现阶段要用WSA需要把它全屏，此时需要把它手动退出全屏。或许可以把两个功能合并出第三个。
待改进：
1. 没有韩语翻译，这个我真不会。
2. 测试更多模拟器，可能有些模拟器不会响应这个keyevent。