### PR TITLE
feat: 支持识别长于一页的掉落列表

### DIFF
--- a/src/MaaCore/Vision/Miscellaneous/StageDropsImageAnalyzer.cpp
+++ b/src/MaaCore/Vision/Miscellaneous/StageDropsImageAnalyzer.cpp
@@ -3,7 +3,6 @@
 #include <numbers>
 #include <regex>
 
-#include "Common/AsstTypes.h"
 #include "Utils/Ranges.hpp"
 
 #include "Utils/NoWarningCV.h"
@@ -227,7 +226,7 @@ bool asst::StageDropsImageAnalyzer::analyze_drops()
 {
     LogTraceFunction;
 
-    if (Point p {}; !analyze_baseline(p) && p == Point {}) {
+    if (!analyze_baseline()) {
         return false;
     }
 
@@ -362,7 +361,7 @@ bool asst::StageDropsImageAnalyzer::analyze_drops_for_12()
     return !flag_analyzer.analyze();
 }
 
-bool asst::StageDropsImageAnalyzer::analyze_baseline(Point& cropped_out)
+bool asst::StageDropsImageAnalyzer::analyze_baseline()
 {
     LogTraceFunction;
 
@@ -463,11 +462,8 @@ bool asst::StageDropsImageAnalyzer::analyze_baseline(Point& cropped_out)
     }
 
     if (m_image.cols - (x_offset + bounding_rect.width) < 30 + max_spacing) {
-        cropped_out.x = x_offset + bounding_rect.width;
-        cropped_out.y = task_ptr->roi.y;
-        Log.trace("bounding_rect.right=", cropped_out.x, ", more materials to reveal?");
-        return false;
-    }
+        Log.trace("bounding_rect.right=", x_offset + bounding_rect.width, ", more materials to reveal?");
+    } // TODO: else tell caller to prevent unnecessary swipe
 
     return !m_baseline.empty();
 }

--- a/src/MaaCore/Vision/Miscellaneous/StageDropsImageAnalyzer.h
+++ b/src/MaaCore/Vision/Miscellaneous/StageDropsImageAnalyzer.h
@@ -23,12 +23,13 @@ namespace asst
         // <drop_type, <item_id, quantity>>
         const auto& get_drops() const noexcept { return m_drops; }
 
+        bool analyze_baseline(Point& cropped_out);
+
     protected:
         bool analyze_stage_code();
         bool analyze_times();
         bool analyze_stars();
         bool analyze_difficulty();
-        bool analyze_baseline();
         bool analyze_drops();
         // 落叶殇火 活动（异格夜刀）, act24side, 2023-03
         bool analyze_drops_for_CF();

--- a/src/MaaCore/Vision/Miscellaneous/StageDropsImageAnalyzer.h
+++ b/src/MaaCore/Vision/Miscellaneous/StageDropsImageAnalyzer.h
@@ -23,13 +23,12 @@ namespace asst
         // <drop_type, <item_id, quantity>>
         const auto& get_drops() const noexcept { return m_drops; }
 
-        bool analyze_baseline(Point& cropped_out);
-
     protected:
         bool analyze_stage_code();
         bool analyze_times();
         bool analyze_stars();
         bool analyze_difficulty();
+        bool analyze_baseline();
         bool analyze_drops();
         // 落叶殇火 活动（异格夜刀）, act24side, 2023-03
         bool analyze_drops_for_CF();

--- a/src/MaaCore/Vision/Miscellaneous/StageDropsImageAnalyzer.h
+++ b/src/MaaCore/Vision/Miscellaneous/StageDropsImageAnalyzer.h
@@ -23,6 +23,11 @@ namespace asst
         // <drop_type, <item_id, quantity>>
         const auto& get_drops() const noexcept { return m_drops; }
 
+        // merge a new image with a different material position into m_image
+        // might resize m_image.
+        // return offset in pixels
+        std::optional<int> merge_image(const cv::Mat& new_img);
+
     protected:
         bool analyze_stage_code();
         bool analyze_times();


### PR DESCRIPTION
基本就是先想办法边划动边截图先把所有材料都拼接到一整张长图片里面, 然后按原来的方法识别.
- 里面硬编码了一些 ROI 和划动参数是我瞎凑的, 应该可以继续优化

![image](https://github.com/MaaAssistantArknights/MaaAssistantArknights/assets/107091537/abdb6bd9-27a0-4874-bed8-b9674b54e652)

fix #7176
fix #7193
fix #7194 