### PR TITLE
perf: RegionOCRer增加识别前图像归一化处理

### DIFF
--- a/src/MaaCore/Vision/RegionOCRer.cpp
+++ b/src/MaaCore/Vision/RegionOCRer.cpp
@@ -36,7 +36,15 @@ RegionOCRer::ResultOpt RegionOCRer::analyze() const
     cv::rectangle(m_image_draw, make_rect<cv::Rect>(new_roi), cv::Scalar(0, 0, 255), 1);
 #endif // ASST_DEBUG
 
-    OCRer ocr_analyzer(m_image, new_roi);
+    OCRer ocr_analyzer;
+    if (m_normalize) {
+        ocr_analyzer.set_roi(new_roi);
+    }
+    else {
+        auto new_image = make_roi(m_image, new_roi);
+        cv::normalize(new_image, m_image, 255.0, 0.0, cv::NormTypes::NORM_MINMAX);
+    }
+    ocr_analyzer.set_image(m_image);
     auto config = m_params;
     config.without_det = true;
     ocr_analyzer.set_params(std::move(config));

--- a/src/MaaCore/Vision/RegionOCRer.cpp
+++ b/src/MaaCore/Vision/RegionOCRer.cpp
@@ -38,13 +38,14 @@ RegionOCRer::ResultOpt RegionOCRer::analyze() const
 
     OCRer ocr_analyzer;
     if (m_normalize) {
-        ocr_analyzer.set_roi(new_roi);
+        auto new_image = make_roi(m_image, new_roi);
+        cv::normalize(new_image, new_image, 255.0, 0.0, cv::NormTypes::NORM_MINMAX);
+        ocr_analyzer.set_image(new_image);
     }
     else {
-        auto new_image = make_roi(m_image, new_roi);
-        cv::normalize(new_image, m_image, 255.0, 0.0, cv::NormTypes::NORM_MINMAX);
+        ocr_analyzer.set_roi(new_roi);
+        ocr_analyzer.set_image(m_image);
     }
-    ocr_analyzer.set_image(m_image);
     auto config = m_params;
     config.without_det = true;
     ocr_analyzer.set_params(std::move(config));

--- a/src/MaaCore/Vision/RegionOCRer.cpp
+++ b/src/MaaCore/Vision/RegionOCRer.cpp
@@ -43,8 +43,8 @@ RegionOCRer::ResultOpt RegionOCRer::analyze() const
         ocr_analyzer.set_image(new_image);
     }
     else {
-        ocr_analyzer.set_roi(new_roi);
         ocr_analyzer.set_image(m_image);
+        ocr_analyzer.set_roi(new_roi);
     }
     auto config = m_params;
     config.without_det = true;

--- a/src/MaaCore/Vision/RegionOCRer.h
+++ b/src/MaaCore/Vision/RegionOCRer.h
@@ -16,7 +16,8 @@ namespace asst
         ResultOpt analyze() const;
         // FIXME: 老接口太难重构了，先弄个这玩意兼容下，后续慢慢全删掉
         const auto& get_result() const noexcept { return m_result; }
-
+        
+        void set_normalize(bool normalize) { m_normalize = normalize; }
     protected:
         using OCRerConfig::set_without_det;
         virtual void _set_roi(const Rect& roi) override { set_roi(roi); }
@@ -27,5 +28,6 @@ namespace asst
     private:
         // FIXME: 老接口太难重构了，先弄个这玩意兼容下，后续慢慢全删掉
         mutable Result m_result;
+        bool m_normalize = false;
     };
 }


### PR DESCRIPTION
用来处理过滤后/过暗（比如理智识别）的图片

归一化要提取对应区域，不能全图做。但是处理完又会导致m_image、m_image_draw、new_image不一致，除非拼回去（拼回去好怪哦