### PR TITLE
fix: 修复 刷理智-指定材料 选项取消无效的问题

### DIFF
--- a/src/MaaCore/Task/Interface/FightTask.cpp
+++ b/src/MaaCore/Task/Interface/FightTask.cpp
@@ -82,6 +82,9 @@ bool asst::FightTask::set_params(const json::value& params)
         }
         m_stage_drops_plugin_ptr->set_specify_quantity(drops);
     }
+    else {
+        m_stage_drops_plugin_ptr->set_specify_quantity({});
+    }
 
     if (!m_running) {
         if (stage.empty()) {


### PR DESCRIPTION
fix #7302