### PR TITLE
feat: 重构 TaskData

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -620,6 +620,13 @@
         "Doc": "右滑五次，然后检测关卡并左滑",
         "Doc2": "在一次关卡导航中，仅swipe五次，其余情况进exceededNext",
         "baseTask": "ChapterSwipeToTheRight",
+        "specificRect_Doc": "防止在关卡名展开的情况下无法滑动，调整滑动区域",
+        "specificRect": [
+            600,
+            100,
+            20,
+            20
+        ],
         "exceededNext": [
             "ClickStageName",
             "StageNavigationSlowlySwipeLeft"
@@ -1015,10 +1022,10 @@
         "template": "UsePrtsSuccess.png",
         "action": "DoNothing",
         "roi": [
-            1000,
-            550,
-            280,
-            90
+            985,
+            523,
+            159,
+            165
         ]
     },
     "StageQueue": {

--- a/src/MaaCore/Common/AsstTypes.h
+++ b/src/MaaCore/Common/AsstTypes.h
@@ -335,53 +335,106 @@ namespace asst
         }
         return "Invalid";
     }
+
+    enum class TaskDerivedType
+    {
+        Invalid = -1,
+        Raw,      // 原始任务
+        BaseTask, // BaseTask
+        Implicit, // 隐式 TemplateTask
+        Template, // 显式 TemplateTask
+    };
+
+    inline std::string enum_to_string(TaskDerivedType task_derived_type)
+    {
+        static const std::unordered_map<TaskDerivedType, std::string> task_derived_type_map = {
+            { TaskDerivedType::Raw, "Raw" },
+            { TaskDerivedType::BaseTask, "BaseTask" },
+            { TaskDerivedType::Implicit, "Implicit" },
+            { TaskDerivedType::Template, "Template" },
+        };
+        if (auto it = task_derived_type_map.find(task_derived_type); it != task_derived_type_map.end()) {
+            return it->second;
+        }
+        return "Invalid";
+    }
 } // namespace asst
 
 namespace asst
 {
-    // 任务信息
-    struct TaskInfo
+    using TaskList = std::vector<std::string>;
+
+    // 任务流程信息
+    struct TaskPipelineInfo
     {
-        TaskInfo() = default;
-        virtual ~TaskInfo() = default;
-        TaskInfo(const TaskInfo&) = default;
-        TaskInfo(TaskInfo&&) noexcept = default;
-        TaskInfo& operator=(const TaskInfo&) = default;
-        TaskInfo& operator=(TaskInfo&&) noexcept = default;
-        std::string name;         // 任务名
-        AlgorithmType algorithm = // 图像算法类型
-            AlgorithmType::Invalid;
-        ProcessTaskAction action = // 要进行的操作
-            ProcessTaskAction::Invalid;
-        std::vector<std::string> sub;           // 子任务（列表）
-        bool sub_error_ignored = false;         // 子任务如果失败了，是否继续执行剩下的任务
-        std::vector<std::string> next;          // 下一个可能的任务（列表）
-        int max_times = INT_MAX;                // 任务最多执行多少次
-        std::vector<std::string> exceeded_next; // 达到最多次数了之后，下一个可能的任务（列表）
-        std::vector<std::string> on_error_next; // 任务出错之后要去执行什么
-        std::vector<std::string> reduce_other_times; // 执行了该任务后，需要减少别的任务的执行次数。
-                                                     // 例如执行了吃理智药，则说明上一次点击蓝色开始行动按钮没生效，
-                                                     // 所以蓝色开始行动要-1
-        Rect specific_rect;        // 指定区域，目前仅针对ClickRect任务有用，会点这个区域
-        int pre_delay = 0;         // 执行该任务前的延时
-        int post_delay = 0;        // 执行该任务后的延时
-        int retry_times = INT_MAX; // 未找到图像时的重试次数
-        Rect roi;                  // 要识别的区域，若为0则全图识别
+        constexpr TaskPipelineInfo() = default;
+        constexpr virtual ~TaskPipelineInfo() = default;
+        constexpr TaskPipelineInfo(const TaskPipelineInfo&) = default;
+        constexpr TaskPipelineInfo(TaskPipelineInfo&&) noexcept = default;
+        constexpr TaskPipelineInfo& operator=(const TaskPipelineInfo&) = default;
+        constexpr TaskPipelineInfo& operator=(TaskPipelineInfo&&) noexcept = default;
+        std::string name;       // 任务名
+        TaskList next;          // 下一个可能的任务（列表）
+        TaskList sub;           // 子任务（列表）
+        TaskList on_error_next; // 任务出错之后要去执行什么
+        TaskList exceeded_next; // 达到最多次数了之后，下一个可能的任务（列表）
+        TaskList reduce_other_times; // 执行了该任务后，需要减少别的任务的执行次数。例如执行了吃理智药，
+                                     // 则说明上一次点击蓝色开始行动按钮没生效，所以蓝色开始行动要-1
+    };
+    using TaskPipelinePtr = std::shared_ptr<TaskPipelineInfo>;
+    using TaskPipelineConstPtr = std::shared_ptr<const TaskPipelineInfo>;
+
+    // 任务继承信息
+    struct TaskDerivedInfo : public TaskPipelineInfo
+    {
+        constexpr TaskDerivedInfo() = default;
+        constexpr virtual ~TaskDerivedInfo() = default;
+        constexpr TaskDerivedInfo(const TaskDerivedInfo&) = default;
+        constexpr TaskDerivedInfo(TaskDerivedInfo&&) noexcept = default;
+        constexpr TaskDerivedInfo& operator=(const TaskDerivedInfo&) = default;
+        constexpr TaskDerivedInfo& operator=(TaskDerivedInfo&&) noexcept = default;
+        TaskDerivedType type = TaskDerivedType::Raw; // 任务类型
+        std::string base = "";                       // 继承自哪个任务（Raw 任务不需要）
+        std::string prefix = "";                     // 需要添加的前缀（仅对 TemplateTask 生效）
+    };
+    using TaskDerivedPtr = std::shared_ptr<TaskDerivedInfo>;
+    using TaskDerivedConstPtr = std::shared_ptr<const TaskDerivedInfo>;
+
+    // 任务信息
+    struct TaskInfo : public TaskPipelineInfo
+    {
+        constexpr TaskInfo() = default;
+        constexpr virtual ~TaskInfo() = default;
+        constexpr TaskInfo(const TaskInfo&) = default;
+        constexpr TaskInfo(TaskInfo&&) noexcept = default;
+        constexpr TaskInfo& operator=(const TaskInfo&) = default;
+        constexpr TaskInfo& operator=(TaskInfo&&) noexcept = default;
+        AlgorithmType algorithm = AlgorithmType::Invalid;      // 图像算法类型
+        ProcessTaskAction action = ProcessTaskAction::Invalid; // 要进行的操作
+        bool sub_error_ignored = false; // 子任务如果失败了，是否继续执行剩下的任务
+        int max_times = INT_MAX;        // 任务最多执行多少次
+        Rect specific_rect;             // 指定区域，目前仅针对ClickRect任务有用，会点这个区域
+        int pre_delay = 0;              // 执行该任务前的延时
+        int post_delay = 0;             // 执行该任务后的延时
+        int retry_times = INT_MAX;      // 未找到图像时的重试次数
+        Rect roi;                       // 要识别的区域，若为0则全图识别
         Rect rect_move;     // 识别结果移动：有些结果识别到的，和要点击的不是同一个位置。
                             // 即识别到了res，点击res + result_move的位置
         bool cache = false; // 是否使用缓存区域
         std::vector<int> special_params; // 某些任务会用到的特殊参数
     };
+    using TaskPtr = std::shared_ptr<TaskInfo>;
+    using TaskConstPtr = std::shared_ptr<const TaskInfo>;
 
     // 文字识别任务的信息
     struct OcrTaskInfo : public TaskInfo
     {
-        OcrTaskInfo() = default;
-        virtual ~OcrTaskInfo() override = default;
-        OcrTaskInfo(const OcrTaskInfo&) = default;
-        OcrTaskInfo(OcrTaskInfo&&) noexcept = default;
-        OcrTaskInfo& operator=(const OcrTaskInfo&) = default;
-        OcrTaskInfo& operator=(OcrTaskInfo&&) noexcept = default;
+        constexpr OcrTaskInfo() = default;
+        constexpr virtual ~OcrTaskInfo() override = default;
+        constexpr OcrTaskInfo(const OcrTaskInfo&) = default;
+        constexpr OcrTaskInfo(OcrTaskInfo&&) noexcept = default;
+        constexpr OcrTaskInfo& operator=(const OcrTaskInfo&) = default;
+        constexpr OcrTaskInfo& operator=(OcrTaskInfo&&) noexcept = default;
         std::vector<std::string> text; // 文字的容器，匹配到这里面任一个，就算匹配上了
         bool full_match = false;       // 是否需要全匹配，否则搜索到子串就算匹配上了
         bool is_ascii = false;         // 是否启用字符数字模型
@@ -390,35 +443,41 @@ namespace asst
         std::vector<std::pair<std::string, std::string>>
             replace_map; // 部分文字容易识别错，字符串强制replace之后，再进行匹配
     };
+    using OcrTaskPtr = std::shared_ptr<OcrTaskInfo>;
+    using OcrTaskConstPtr = std::shared_ptr<const OcrTaskInfo>;
 
     // 图片匹配任务的信息
     struct MatchTaskInfo : public TaskInfo
     {
-        MatchTaskInfo() = default;
-        virtual ~MatchTaskInfo() override = default;
-        MatchTaskInfo(const MatchTaskInfo&) = default;
-        MatchTaskInfo(MatchTaskInfo&&) noexcept = default;
-        MatchTaskInfo& operator=(const MatchTaskInfo&) = default;
-        MatchTaskInfo& operator=(MatchTaskInfo&&) noexcept = default;
+        constexpr MatchTaskInfo() = default;
+        constexpr virtual ~MatchTaskInfo() override = default;
+        constexpr MatchTaskInfo(const MatchTaskInfo&) = default;
+        constexpr MatchTaskInfo(MatchTaskInfo&&) noexcept = default;
+        constexpr MatchTaskInfo& operator=(const MatchTaskInfo&) = default;
+        constexpr MatchTaskInfo& operator=(MatchTaskInfo&&) noexcept = default;
         std::vector<std::string> templ_names; // 匹配模板图片文件名
         std::vector<double> templ_thresholds; // 模板匹配阈值
         std::pair<int, int> mask_range;       // 掩码的二值化范围
     };
+    using MatchTaskPtr = std::shared_ptr<MatchTaskInfo>;
+    using MatchTaskConstPtr = std::shared_ptr<const MatchTaskInfo>;
 
     // hash 计算任务的信息
     struct HashTaskInfo : public TaskInfo
     {
-        HashTaskInfo() = default;
-        virtual ~HashTaskInfo() override = default;
-        HashTaskInfo(const HashTaskInfo&) = default;
-        HashTaskInfo(HashTaskInfo&&) noexcept = default;
-        HashTaskInfo& operator=(const HashTaskInfo&) = default;
-        HashTaskInfo& operator=(HashTaskInfo&&) noexcept = default;
+        constexpr HashTaskInfo() = default;
+        constexpr virtual ~HashTaskInfo() override = default;
+        constexpr HashTaskInfo(const HashTaskInfo&) = default;
+        constexpr HashTaskInfo(HashTaskInfo&&) noexcept = default;
+        constexpr HashTaskInfo& operator=(const HashTaskInfo&) = default;
+        constexpr HashTaskInfo& operator=(HashTaskInfo&&) noexcept = default;
         std::vector<std::string> hashes; // 需要多个哈希值
         int dist_threshold = 0;          // 汉明距离阈值
         std::pair<int, int> mask_range;  // 掩码的二值化范围
         bool bound = false;              // 是否裁剪周围黑边
     };
+    using HashTaskPtr = std::shared_ptr<HashTaskInfo>;
+    using HashTaskConstPtr = std::shared_ptr<const HashTaskInfo>;
 
     inline static const std::string UploadDataSource = "MeoAssistant";
 } // namespace asst

--- a/src/MaaCore/Config/TaskData.cpp
+++ b/src/MaaCore/Config/TaskData.cpp
@@ -195,7 +195,7 @@ bool asst::TaskData::parse(const json::value& json)
 
     // 本来重构之后完全支持惰性加载，但是发现模板图片不支持（
     for (std::string_view name : m_json_all_tasks_info | views::keys) {
-        generate_raw_task_and_base(name, true);
+        generate_task_info(name);
     }
 
     return true;

--- a/src/MaaCore/Config/TaskData.cpp
+++ b/src/MaaCore/Config/TaskData.cpp
@@ -385,14 +385,14 @@ asst::TaskPtr asst::TaskData::generate_task_info(std::string_view name)
     }
 
 #define ASST_TASKDATA_GET_VALUE_OR(key, value) utils::get_value_or(name, json, key, task->value, base->value)
-#define ASST_TASKDATA_GET_VALUE_OR_LAZY(key, value, m)                                          \
-    utils::get_value_or(name, json, key, task->value, raw->value);                              \
-    if (auto opt = compile_tasklist(task->value, name, m); !opt) [[unlikely]] {                 \
-        Log.error("Generate task_list", std::string(name) + "->"##key, "failed.", opt.error()); \
-        return nullptr;                                                                         \
-    }                                                                                           \
-    else {                                                                                      \
-        task->value = std::move((*opt).tasks);                                                  \
+#define ASST_TASKDATA_GET_VALUE_OR_LAZY(key, value, m)                                         \
+    utils::get_value_or(name, json, key, task->value, raw->value);                             \
+    if (auto opt = compile_tasklist(task->value, name, m); !opt) [[unlikely]] {                \
+        Log.error("Generate task_list", std::string(name) + "->" key, "failed.", opt.error()); \
+        return nullptr;                                                                        \
+    }                                                                                          \
+    else {                                                                                     \
+        task->value = std::move((*opt).tasks);                                                 \
     }
 
     ASST_TASKDATA_GET_VALUE_OR("action", action);

--- a/src/MaaCore/Config/TaskData.h
+++ b/src/MaaCore/Config/TaskData.h
@@ -2,8 +2,6 @@
 
 #include "AbstractConfigWithTempl.h"
 
-#include <memory>
-#include <optional>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -12,166 +10,75 @@
 
 namespace asst
 {
-    struct TaskInfo;
-
     class TaskData final : public SingletonHolder<TaskData>, public AbstractConfigWithTempl
     {
-    public:
-        using tasklist_t = std::vector<std::string>;
-        using tasklistptr_t = std::shared_ptr<tasklist_t>;
-        using taskptr_t = std::shared_ptr<TaskInfo>;
-
     private:
-        static std::shared_ptr<MatchTaskInfo> _default_match_task_info();
-        static std::shared_ptr<OcrTaskInfo> _default_ocr_task_info();
-        static std::shared_ptr<HashTaskInfo> _default_hash_task_info();
-        static taskptr_t _default_task_info();
+        static MatchTaskConstPtr _default_match_task_info();
+        static OcrTaskConstPtr _default_ocr_task_info();
+        static HashTaskConstPtr _default_hash_task_info();
+        static TaskConstPtr _default_task_info();
 
         // 从模板任务生成
-        static inline const std::shared_ptr<MatchTaskInfo> default_match_task_info_ptr = _default_match_task_info();
-        static inline const std::shared_ptr<OcrTaskInfo> default_ocr_task_info_ptr = _default_ocr_task_info();
-        static inline const std::shared_ptr<HashTaskInfo> default_hash_task_info_ptr = _default_hash_task_info();
-        static inline const taskptr_t default_task_info_ptr = _default_task_info();
+        static inline const MatchTaskConstPtr default_match_task_info_ptr = _default_match_task_info();
+        static inline const OcrTaskConstPtr default_ocr_task_info_ptr = _default_ocr_task_info();
+        static inline const HashTaskConstPtr default_hash_task_info_ptr = _default_hash_task_info();
+        static inline const TaskConstPtr default_task_info_ptr = _default_task_info();
 
-        // 这是下面几个函数的封装
-        taskptr_t generate_task_info(std::string_view name, const json::value&, taskptr_t default_ptr,
-                                     std::string_view task_prefix = "");
+        static std::string append_prefix(std::string_view task_name, std::string_view task_prefix);
+        static TaskList append_prefix(const TaskList& base_task_list, std::string_view task_prefix);
 
-        taskptr_t generate_match_task_info(std::string_view name, const json::value&,
-                                           std::shared_ptr<MatchTaskInfo> default_ptr);
-        taskptr_t generate_ocr_task_info(std::string_view name, const json::value&,
-                                         std::shared_ptr<OcrTaskInfo> default_ptr);
-        taskptr_t generate_hash_task_info(std::string_view name, const json::value&,
-                                          std::shared_ptr<HashTaskInfo> default_ptr);
-        // TaskInfo 的基础成员
-        bool append_base_task_info(taskptr_t task_info_ptr, std::string_view name, const json::value& task_json,
-                                   taskptr_t default_ptr, std::string_view task_prefix = "");
-        static std::string append_prefix(std::string_view task_name, std::string_view task_prefix)
-        {
-            if (task_prefix.ends_with('@')) [[unlikely]] {
-                task_prefix.remove_suffix(1);
-            }
-            if (task_prefix.empty()) [[unlikely]] {
-                return std::string(task_name);
-            }
-            if (task_name.empty()) {
-                return std::string(task_prefix);
-            }
-            if (task_name.starts_with('#')) {
-                return std::string(task_prefix) + std::string(task_name);
-            }
-            return std::string(task_prefix) + '@' + std::string(task_name);
-        }
-        static tasklist_t append_prefix(const tasklist_t& base_task_list, std::string_view task_prefix)
-        {
-            if (task_prefix.ends_with('@')) [[unlikely]] {
-                task_prefix.remove_suffix(1);
-            }
-            if (task_prefix.empty()) {
-                return base_task_list;
-            }
-            tasklist_t task_list = {};
-            for (const std::string& base : base_task_list) {
-                std::string_view base_view = base;
-                size_t l = 0;
-                bool has_same_prefix = false;
-                // base 任务里已经存在相同前缀，则不加前缀
-                // https://github.com/MaaAssistantArknights/MaaAssistantArknights/pull/2116#issuecomment-1270115238
-                for (size_t r = base_view.find('@'); r != std::string_view::npos; r = base_view.find('@', l)) {
-                    if (task_prefix == base_view.substr(l, r - l)) [[unlikely]] {
-                        has_same_prefix = true;
-                        break;
-                    }
-                    l = r + 1;
-                }
-                task_list.emplace_back(has_same_prefix ? base : append_prefix(base_view, task_prefix));
-            }
-            return task_list;
-        };
-
-        // 运行时动态生成任务
-        static taskptr_t _generate_task_info(const taskptr_t& base_ptr)
-        {
-            if (!base_ptr) [[unlikely]] {
-                return nullptr;
-            }
-            switch (base_ptr->algorithm) {
-            case AlgorithmType::MatchTemplate:
-                return std::make_shared<MatchTaskInfo>(*std::dynamic_pointer_cast<MatchTaskInfo>(base_ptr));
-            case AlgorithmType::OcrDetect:
-                return std::make_shared<OcrTaskInfo>(*std::dynamic_pointer_cast<OcrTaskInfo>(base_ptr));
-            case AlgorithmType::Hash:
-                return std::make_shared<HashTaskInfo>(*std::dynamic_pointer_cast<HashTaskInfo>(base_ptr));
-            default:
-                return std::make_shared<TaskInfo>(*base_ptr);
-            }
-        }
-        static taskptr_t _generate_task_info(const taskptr_t& base_ptr, std::string_view task_prefix)
-        {
-            taskptr_t task_info_ptr = _generate_task_info(base_ptr);
-            if (!task_prefix.empty()) {
-                task_info_ptr->name = append_prefix(base_ptr->name, task_prefix);
-                task_info_ptr->sub = append_prefix(base_ptr->sub, task_prefix);
-                task_info_ptr->next = append_prefix(base_ptr->next, task_prefix);
-                task_info_ptr->exceeded_next = append_prefix(base_ptr->exceeded_next, task_prefix);
-                task_info_ptr->on_error_next = append_prefix(base_ptr->on_error_next, task_prefix);
-                task_info_ptr->reduce_other_times = append_prefix(base_ptr->reduce_other_times, task_prefix);
-            }
-            return task_info_ptr;
-        }
         template <ranges::forward_range ListType>
         requires(!std::same_as<ranges::range_value_t<ListType>, std::string> &&
                  requires { std::declval<ranges::range_value_t<ListType>>().as_string(); })
-        static tasklist_t to_string_list(const ListType& other_string_list)
+        static TaskList to_string_list(const ListType& other_string_list)
         {
-            tasklist_t task_list = {};
+            TaskList task_list = {};
             task_list.reserve(other_string_list.size());
             ranges::copy(other_string_list | views::transform(&ranges::range_value_t<ListType>::as_string),
                          std::back_inserter(task_list));
             return task_list;
         }
 
-        static std::string_view task_name_view(std::string_view task_name)
-        {
-            return *m_task_names.emplace(task_name).first;
-        }
-        decltype(auto) insert_or_assign_raw_task(std::string_view task_name, taskptr_t task_info_ptr)
-        {
-            return m_raw_all_tasks_info.insert_or_assign(task_name_view(task_name), task_info_ptr);
-        }
-        decltype(auto) insert_or_assign_task(std::string_view task_name, taskptr_t task_info_ptr)
-        {
-            return m_all_tasks_info.insert_or_assign(task_name_view(task_name), task_info_ptr);
-        }
+        static inline std::unordered_set<std::string> m_task_names {};
+        static const std::string& task_name_view(std::string_view name) { return *m_task_names.emplace(name).first; }
 
         struct RawCompileResult
         {
             bool task_changed;
             TaskDataSymbol::Symbols symbols;
         };
-        static ResultOrError<RawCompileResult> compile_raw_tasklist(const tasklist_t& raw_tasks,
-                                                                    std::string_view self_name,
-                                                                    std::function<taskptr_t(std::string_view)> get_raw,
-                                                                    bool allow_duplicate);
+        static ResultOrError<RawCompileResult> compile_raw_tasklist(
+            const TaskList& raw_tasks, std::string_view self_name,
+            std::function<TaskDerivedConstPtr(std::string_view)> get_raw, bool allow_duplicate);
+
+    private:
+        TaskPtr generate_task_info(std::string_view name);
+        TaskPtr generate_match_task_info(std::string_view name, const json::value&, MatchTaskConstPtr default_ptr,
+                                         TaskDerivedType derived_type);
+        TaskPtr generate_ocr_task_info(std::string_view name, const json::value&, OcrTaskConstPtr default_ptr);
+        TaskPtr generate_hash_task_info(std::string_view name, const json::value&, HashTaskConstPtr default_ptr);
+        decltype(auto) insert_or_assign_raw_task(std::string_view task_name, TaskDerivedPtr task_info_ptr)
+        {
+            return m_raw_all_tasks_info.insert_or_assign(task_name_view(task_name), task_info_ptr);
+        }
+        decltype(auto) insert_or_assign_task(std::string_view task_name, TaskPtr task_info_ptr)
+        {
+            return m_all_tasks_info.insert_or_assign(task_name_view(task_name), task_info_ptr);
+        }
         struct CompileResult
         {
             bool task_changed;
-            tasklist_t tasks;
+            TaskList tasks;
         };
-        ResultOrError<CompileResult> compile_tasklist(const tasklist_t& raw_tasks, std::string_view self_name,
+        ResultOrError<CompileResult> compile_tasklist(const TaskList& raw_tasks, std::string_view self_name,
                                                       bool allow_duplicate);
-        bool generate_task_and_its_base(std::string_view name, bool must_true);
+        bool generate_raw_task_info(std::string_view name, std::string_view prefix, std::string_view base_name,
+                                    const json::value& task_json, TaskDerivedType type);
+        bool generate_raw_task_and_base(std::string_view name, bool must_true);
 #ifdef ASST_DEBUG
         bool syntax_check(std::string_view task_name, const json::value& task_json);
 #endif
-        taskptr_t get_raw(std::string_view name);
-        template <typename TargetTaskInfoType>
-        requires(std::derived_from<TargetTaskInfoType, TaskInfo> &&
-                 !std::same_as<TargetTaskInfoType, TaskInfo>) // Parameter must be a TaskInfo
-        std::shared_ptr<TargetTaskInfoType> get_raw(std::string_view name)
-        {
-            return std::dynamic_pointer_cast<TargetTaskInfoType>(get_raw(name));
-        }
+        TaskDerivedConstPtr get_raw(std::string_view name);
 
     public:
         virtual ~TaskData() override = default;
@@ -180,20 +87,14 @@ namespace asst
         void set_task_base(const std::string_view task_name, std::string base_task_name);
         bool lazy_parse(const json::value& json);
 
-        taskptr_t get(std::string_view name);
+        TaskPtr get(std::string_view name);
         template <typename TargetTaskInfoType>
         requires(std::derived_from<TargetTaskInfoType, TaskInfo> &&
                  !std::same_as<TargetTaskInfoType, TaskInfo>) // Parameter must be a TaskInfo
         std::shared_ptr<TargetTaskInfoType> get(std::string_view name)
         {
+            // TODO: should be const
             return std::dynamic_pointer_cast<TargetTaskInfoType>(get(name));
-        }
-        std::optional<json::object> get_json(std::string_view name) const
-        {
-            if (m_json_all_tasks_info.find(name) != m_json_all_tasks_info.cend())
-                return m_json_all_tasks_info.at(name);
-            else
-                return std::nullopt;
         }
 
     protected:
@@ -207,12 +108,11 @@ namespace asst
 
         virtual bool parse(const json::value& json) override;
 
-        static inline std::unordered_set<std::string> m_task_names;
         std::unordered_set<std::string> m_templ_required;
         std::unordered_map<std::string_view, TaskStatus> m_task_status;
-        std::unordered_map<std::string_view, json::object> m_json_all_tasks_info; // 原始的 json 信息
-        std::unordered_map<std::string_view, taskptr_t> m_raw_all_tasks_info;     // 未展开虚任务的任务信息
-        std::unordered_map<std::string_view, taskptr_t> m_all_tasks_info;         // 已展开虚任务的任务信息
+        std::unordered_map<std::string_view, json::object> m_json_all_tasks_info;  // 原始的 json 信息
+        std::unordered_map<std::string_view, TaskDerivedPtr> m_raw_all_tasks_info; // 未展开虚任务的任务信息
+        std::unordered_map<std::string_view, TaskPtr> m_all_tasks_info;            // 已展开虚任务的任务信息
     };
 
     inline static auto& Task = TaskData::get_instance();

--- a/src/MaaCore/Config/TaskData.h
+++ b/src/MaaCore/Config/TaskData.h
@@ -74,7 +74,7 @@ namespace asst
                                                       bool allow_duplicate);
         bool generate_raw_task_info(std::string_view name, std::string_view prefix, std::string_view base_name,
                                     const json::value& task_json, TaskDerivedType type);
-        bool generate_raw_task_and_base(std::string_view name, bool must_true);
+        bool generate_raw_task_and_base(std::string_view name, bool must_true, bool allow_implicit = true);
 #ifdef ASST_DEBUG
         bool syntax_check(std::string_view task_name, const json::value& task_json);
 #endif

--- a/src/MaaCore/Config/TaskData.h
+++ b/src/MaaCore/Config/TaskData.h
@@ -94,6 +94,12 @@ namespace asst
         std::shared_ptr<TargetTaskInfoType> get(std::string_view name)
         {
             // TODO: should be const
+            // any `Task.get(name)->x = y` could be transformed to
+            // ```
+            // json::object json = {};
+            // json[name][x] = y;
+            // Task.lazy_parse(json);
+            // ```
             return std::dynamic_pointer_cast<TargetTaskInfoType>(get(name));
         }
 

--- a/src/MaaCore/Config/TaskData/TaskDataSymbol.cpp
+++ b/src/MaaCore/Config/TaskData/TaskDataSymbol.cpp
@@ -2,11 +2,10 @@
 
 asst::TaskDataSymbol::SymbolsOrError asst::TaskDataSymbol::append_prefix(
     const TaskDataSymbol& symbol, const TaskDataSymbol& prefix, std::string_view self_name,
-    std::function<std::shared_ptr<TaskInfo>(std::string_view)> get_raw,
-    std::function<SymbolsOrError(const std::vector<std::string>&)> compile_tasklist)
+    std::function<TaskDerivedConstPtr(std::string_view)> get_raw,
+    std::function<SymbolsOrError(const TaskList&)> compile_tasklist)
 {
-    // !!!注意：
-    // A@#self 是 A 而不是 A@self_name, #self@A 是 selfname@A 而不是 A
+    // 注意：A@#self 是 A 而不是 A@self_name, #self@A 是 self_name@A 而不是 A
     std::string_view prefix_name;
     if (prefix == SharpSelf) {
         prefix_name = self_name;

--- a/src/MaaCore/Config/TaskData/TaskDataSymbol.cpp
+++ b/src/MaaCore/Config/TaskData/TaskDataSymbol.cpp
@@ -1,0 +1,56 @@
+#include "TaskDataSymbol.h"
+
+asst::TaskDataSymbol::SymbolsOrError asst::TaskDataSymbol::append_prefix(
+    const TaskDataSymbol& symbol, const TaskDataSymbol& prefix, std::string_view self_name,
+    std::function<std::shared_ptr<TaskInfo>(std::string_view)> get_raw,
+    std::function<SymbolsOrError(const std::vector<std::string>&)> compile_tasklist)
+{
+    // !!!注意：
+    // A@#self 是 A 而不是 A@self_name, #self@A 是 selfname@A 而不是 A
+    std::string_view prefix_name;
+    if (prefix == SharpSelf) {
+        prefix_name = self_name;
+    }
+    else if (prefix.is_name()) {
+        prefix_name = prefix.name();
+    }
+    else [[unlikely]] {
+        return { std::nullopt, "prefix " + prefix.name() + " is not name or self" };
+    }
+    if (prefix_name.empty()) {
+        return std::vector { symbol };
+    }
+    if (symbol == SharpNone) {
+        return std::vector { symbol };
+    }
+    if (symbol == SharpSelf) {
+        return std::vector { symbol };
+    }
+    if (symbol.is_name()) {
+        if (symbol.name().empty()) {
+            return { std::nullopt, "name is empty" };
+        }
+        return std::vector { TaskDataSymbol(std::string(prefix_name) + '@' + symbol.name()) };
+    }
+    if (symbol == SharpBack) {
+        return std::vector { TaskDataSymbol(prefix_name) };
+    }
+    auto other_task_info_ptr = get_raw(prefix_name);
+#define ASST_TASKDATA_PERFORM_OP_IF_BRANCH(t, s, m)                \
+    if (symbol == s) {                                             \
+        if (auto opt = compile_tasklist(other_task_info_ptr->t)) { \
+            return opt.value();                                    \
+        }                                                          \
+        return { std::nullopt, "failed to compile tasklist" };     \
+    }
+    if (other_task_info_ptr == nullptr) [[unlikely]] {
+        return { std::nullopt, "task not found" };
+    }
+    ASST_TASKDATA_PERFORM_OP_IF_BRANCH(next, SharpNext, false)
+    ASST_TASKDATA_PERFORM_OP_IF_BRANCH(sub, SharpSub, true)
+    ASST_TASKDATA_PERFORM_OP_IF_BRANCH(on_error_next, SharpOnErrorNext, false)
+    ASST_TASKDATA_PERFORM_OP_IF_BRANCH(exceeded_next, SharpExceededNext, false)
+    ASST_TASKDATA_PERFORM_OP_IF_BRANCH(reduce_other_times, SharpReduceOtherTimes, true)
+#undef ASST_TASKDATA_PERFORM_OP_IF_BRANCH
+    return { std::nullopt, "unknown symbol" };
+}

--- a/src/MaaCore/Config/TaskData/TaskDataSymbol.h
+++ b/src/MaaCore/Config/TaskData/TaskDataSymbol.h
@@ -1,0 +1,136 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <variant>
+
+#include "TaskDataTypes.hpp"
+
+#include "Common/AsstTypes.h"
+#include "Utils/Logger.hpp"
+
+namespace asst
+{
+    class TaskDataSymbol final
+    {
+    public:
+        using Symbols = std::vector<TaskDataSymbol>;
+        using SymbolsOrError = ResultOrError<Symbols>;
+
+        enum Type
+        {
+            End,
+            LambdaTaskSep,
+            LParen,
+            RParen,
+            LBrace,
+            RBrace,
+            At,
+            Sharp,
+            Mul,
+            Add,
+            Sub,
+            SharpSub,
+            SharpNext,
+            SharpOnErrorNext,
+            SharpExceededNext,
+            SharpReduceOtherTimes,
+            SharpSelf,
+            SharpBack,
+            SharpNone,
+            Name,
+        };
+
+        static const inline std::unordered_map<std::string_view, Type> symbol_repr_to_type = {
+            { "__END__", End },
+            { ",", LambdaTaskSep },
+            { "(", LParen },
+            { ")", RParen },
+            { "{", LBrace },
+            { "}", RBrace },
+            { "@", At },
+            { "#", Sharp },
+            { "*", Mul },
+            { "+", Add },
+            { "^", Sub },
+            { "sub", SharpSub },
+            { "next", SharpNext },
+            { "on_error_next", SharpOnErrorNext },
+            { "exceeded_next", SharpExceededNext },
+            { "reduce_other_times", SharpReduceOtherTimes },
+            { "self", SharpSelf },
+            { "back", SharpBack },
+            { "none", SharpNone },
+            { "__name__", Name },
+        };
+        static const inline std::unordered_map<Type, std::string> symbol_type_to_repr = {
+            { End, "__END__" },
+            { LambdaTaskSep, "," },
+            { LParen, "(" },
+            { RParen, ")" },
+            { LBrace, "{" },
+            { RBrace, "}" },
+            { At, "@" },
+            { Sharp, "#" },
+            { Mul, "*" },
+            { Add, "+" },
+            { Sub, "^" },
+            { SharpSub, "sub" },
+            { SharpNext, "next" },
+            { SharpOnErrorNext, "on_error_next" },
+            { SharpExceededNext, "exceeded_next" },
+            { SharpReduceOtherTimes, "reduce_other_times" },
+            { SharpSelf, "self" },
+            { SharpBack, "back" },
+            { SharpNone, "none" },
+            { Name, "__name__" },
+        };
+
+        Type m_symbol;
+        std::string m_name;
+
+    public:
+        bool operator==(Type other) const noexcept { return m_symbol == other; }
+        bool operator==(std::string_view other) const noexcept { return m_symbol == Name && m_name == other; }
+        bool operator==(const TaskDataSymbol& other) const noexcept
+        {
+            return m_symbol == other.m_symbol && (m_symbol != Name || m_name == other.m_name);
+        }
+        TaskDataSymbol(Type symbol) : m_symbol(symbol) {}
+        template <typename StringT>
+        requires(std::constructible_from<std::string, StringT>)
+        TaskDataSymbol(StringT&& name) : m_symbol(Name), m_name(std::forward<StringT>(name))
+        {}
+
+        static bool is_sharp_type(Type type) noexcept
+        {
+            static std::unordered_set<Type> sharp_types = {
+                SharpSub,  SharpNext, SharpOnErrorNext, SharpExceededNext, SharpReduceOtherTimes,
+                SharpSelf, SharpBack, SharpNone,
+            };
+            return sharp_types.contains(type);
+        }
+        static const std::string& repr(Type type)
+        {
+            const auto pos = symbol_type_to_repr.find(type);
+            return pos == symbol_type_to_repr.end() ? symbol_type_to_repr.at(Name) : pos->second;
+        }
+        static Type type(std::string_view repr)
+        {
+            const auto pos = symbol_repr_to_type.find(repr);
+            return pos == symbol_repr_to_type.end() ? Name : pos->second;
+        }
+
+        static SymbolsOrError append_prefix(
+            const TaskDataSymbol& symbol, const TaskDataSymbol& prefix, std::string_view self_name,
+            std::function<std::shared_ptr<TaskInfo>(std::string_view)> get_raw,
+            std::function<SymbolsOrError(const std::vector<std::string>&)> compile_tasklist);
+
+        bool is_name() const noexcept { return m_symbol == Name; }
+        bool is_sharp_type() const noexcept { return is_sharp_type(m_symbol); }
+        Type type() const noexcept { return m_symbol; }
+        // const std::string& repr() const& noexcept { return repr(m_symbol); }
+        const std::string& name() const& noexcept { return is_name() ? m_name : repr(m_symbol); }
+    };
+} // namespace asst

--- a/src/MaaCore/Config/TaskData/TaskDataSymbol.h
+++ b/src/MaaCore/Config/TaskData/TaskDataSymbol.h
@@ -5,9 +5,8 @@
 #include <unordered_map>
 #include <variant>
 
-#include "TaskDataTypes.hpp"
-
 #include "Common/AsstTypes.h"
+#include "TaskDataTypes.h"
 #include "Utils/Logger.hpp"
 
 namespace asst
@@ -122,10 +121,10 @@ namespace asst
             return pos == symbol_repr_to_type.end() ? Name : pos->second;
         }
 
-        static SymbolsOrError append_prefix(
-            const TaskDataSymbol& symbol, const TaskDataSymbol& prefix, std::string_view self_name,
-            std::function<std::shared_ptr<TaskInfo>(std::string_view)> get_raw,
-            std::function<SymbolsOrError(const std::vector<std::string>&)> compile_tasklist);
+        static SymbolsOrError append_prefix(const TaskDataSymbol& symbol, const TaskDataSymbol& prefix,
+                                            std::string_view self_name,
+                                            std::function<TaskDerivedConstPtr(std::string_view)> get_raw,
+                                            std::function<SymbolsOrError(const TaskList&)> compile_tasklist);
 
         bool is_name() const noexcept { return m_symbol == Name; }
         bool is_sharp_type() const noexcept { return is_sharp_type(m_symbol); }

--- a/src/MaaCore/Config/TaskData/TaskDataSymbolStream.cpp
+++ b/src/MaaCore/Config/TaskData/TaskDataSymbolStream.cpp
@@ -149,12 +149,11 @@ asst::TaskDataSymbolStream::SymbolsOrError asst::TaskDataSymbolStream::decode(Ap
                 // self_name + #self ^ #self = #none
                 // self_name + #self ^ self_name = #self
                 if (ranges::any_of(y, [&](const auto& sy) { return sy == Symbol::SharpSelf; })) {
-                    auto remove_ret = ranges::remove(x, self_name);
-                    x.erase(remove_ret.begin(), remove_ret.end());
+                    std::erase(x, self_name);
                 }
-                auto remove_ret = ranges::remove_if(
-                    x, [&](const auto& sx) { return ranges::any_of(y, [&](const auto& sy) { return sx == sy; }); });
-                x.erase(remove_ret.begin(), remove_ret.end());
+                std::erase_if(x, [&](const auto& sx) {
+                    return ranges::any_of(y, [&](const auto& sy) { return sx == sy; });
+                });
             }
         }
         return x;
@@ -224,7 +223,7 @@ asst::TaskDataSymbolStream::SymbolsOrError asst::TaskDataSymbolStream::decode(Ap
                     auto opt = append_prefix(sy, sx);
                     if (!opt) {
                         return { std::nullopt,
-                                 "decode_vtasks: failed while " + sx.name() + " @ " + sy.name() + ", " + opt.what() };
+                                 "decode_vtasks: failed while " + sx.name() + " @ " + sy.name() + ", " + opt.error() };
                     }
                     ranges::copy(*opt, std::back_inserter(x));
                 }

--- a/src/MaaCore/Config/TaskData/TaskDataSymbolStream.cpp
+++ b/src/MaaCore/Config/TaskData/TaskDataSymbolStream.cpp
@@ -1,0 +1,266 @@
+#include "TaskDataSymbolStream.h"
+
+asst::ResultOrError<bool> asst::TaskDataSymbolStream::parse(std::string_view task_expr)
+{
+    bool task_changed = false;
+    auto emplace_symbol_if_not_empty = [&](const auto l, const auto r) {
+        if (l < r) {
+            auto symbol = std::string_view(l, r);
+            auto symbol_type = Symbol::type(symbol);
+            if (Symbol::is_sharp_type(symbol_type)) {
+                if (!m_symbolstream.empty() && m_symbolstream.back() == Symbol::Sharp) {
+                    m_symbolstream.pop_back();
+                    if (!m_symbolstream.empty() &&
+                        (m_symbolstream.back().is_name() || m_symbolstream.back().is_sharp_type() ||
+                         m_symbolstream.back() == Symbol::RParen)) {
+                        m_symbolstream.emplace_back(Symbol::At);
+                    }
+                    m_symbolstream.emplace_back(symbol_type);
+                }
+                else {
+                    m_symbolstream.emplace_back(symbol);
+                }
+            }
+            else if (symbol_type != Symbol::Name) {
+                m_symbolstream.emplace_back(symbol_type);
+            }
+            else {
+                m_symbolstream.emplace_back(symbol);
+            }
+        }
+    };
+
+    // 记号流分析
+    auto y_begin = task_expr.cbegin();
+    for (auto p = task_expr.cbegin(); p != task_expr.cend(); ++p) {
+        switch (*p) {
+        case ' ':
+        case '\t':
+        case '\r':
+        case '\n':
+            task_changed = true;
+            emplace_symbol_if_not_empty(y_begin, p);
+            y_begin = p + 1;
+            break;
+        case ',':
+        case '(':
+        case ')':
+        case '{':
+        case '}':
+        case '#':
+        case '*':
+        case '+':
+        case '^':
+            task_changed = true;
+            [[fallthrough]];
+        case '@': {
+            emplace_symbol_if_not_empty(y_begin, p);
+            y_begin = p + 1;
+            auto symbol = TaskDataSymbol::type(std::string_view { std::addressof(*p), 1 });
+            if (symbol == TaskDataSymbol::Name) [[unlikely]] {
+                // should not happen
+                return { std::nullopt, std::string("Error when decode symbol ") + *p + " at " +
+                                           std::to_string(p - task_expr.cbegin()) + " in " += task_expr };
+            }
+            m_symbolstream.emplace_back(symbol);
+            break;
+        }
+        default:
+            break;
+        }
+    }
+    emplace_symbol_if_not_empty(y_begin, task_expr.cend());
+    m_symbolstream.emplace_back(TaskDataSymbol::End); // 结束符
+
+    return task_changed;
+}
+
+asst::TaskDataSymbolStream::SymbolsOrError asst::TaskDataSymbolStream::decode(AppendPrefixFunc append_prefix,
+                                                                              std::string_view self_name) const
+{
+    /*
+    $name         = 至少一位的任务名
+    $numbers      = 至少一位的数字
+
+    $subtask_type = # sub
+                    | # next
+                    | # on_error_next
+                    | # exceeded_next
+                    | # reduce_other_times
+
+    $sharp_type   = $subtask_type
+                    | # self
+                    | # back
+                    | # none
+
+    $subtask      = $subtask_type ( $tasks )
+
+    $lambda_task  = { $subtask , ... }           // 暂未实现
+                    | { $tasks }                 // 暂未实现；不写 subtask_type 默认为 sub
+
+    $parens       = $sharp_type
+                    | $name
+                    | $name $lambda_task         // 暂未实现
+                    | ( $tasks )
+
+    $top_tasks    = $top_tasks @ $parens
+                    | $parens
+
+    $mul_tasks    = $top_tasks * $numbers
+                    | $top_tasks
+
+    $tasks        = $mul_tasks + $tasks
+                    | $mul_tasks ^ $tasks         // 删除 $mul_tasks 中所有在 $tasks 中的任务
+                    | $mul_tasks
+    */
+    using decode_func_t = std::function<SymbolsOrError()>;
+
+    auto cur = m_symbolstream.cbegin();
+    decode_func_t decode_name_or_vtask, decode_tasks, decode_multasks, decode_vtasks, decode_parens;
+    decode_name_or_vtask = [&]() -> SymbolsOrError {
+        if (cur->is_name() || cur->is_sharp_type()) {
+            return Symbols { *(cur++) };
+        }
+        return { std::nullopt, "expect name or sharp type, got " + cur->name() };
+    };
+    decode_tasks = [&]() -> SymbolsOrError {
+        Symbols x = {}, y = {};
+        if (auto opt = decode_multasks(); !opt) {
+            return opt;
+        }
+        else {
+            x = *opt;
+        }
+        while (*cur == Symbol::Add || *cur == Symbol::Sub) {
+            Symbol op = *(cur++);
+            if (auto opt = decode_multasks(); !opt) {
+                return opt;
+            }
+            else {
+                y = *opt;
+            }
+            if (op == Symbol::Add) {
+                // x = x + y
+                ranges::move(y, std::back_inserter(x));
+            }
+            else {
+                // x = x - y
+                // WARNING:
+                // self_name + #self ^ #self = #none
+                // self_name + #self ^ self_name = #self
+                if (ranges::any_of(y, [&](const auto& sy) { return sy == Symbol::SharpSelf; })) {
+                    auto remove_ret = ranges::remove(x, self_name);
+                    x.erase(remove_ret.begin(), remove_ret.end());
+                }
+                auto remove_ret = ranges::remove_if(
+                    x, [&](const auto& sx) { return ranges::any_of(y, [&](const auto& sy) { return sx == sy; }); });
+                x.erase(remove_ret.begin(), remove_ret.end());
+            }
+        }
+        return x;
+    };
+    decode_multasks = [&]() -> SymbolsOrError {
+        Symbols x = {}, y = {};
+        if (auto opt = decode_vtasks(); !opt) {
+            return opt;
+        }
+        else {
+            x = *opt;
+        }
+        while (*cur == Symbol::Mul) {
+            Symbol op = *(cur++);
+            if (auto opt = decode_name_or_vtask(); !opt) {
+                return opt;
+            }
+            else {
+                y = *opt;
+            }
+            if (y.size() != 1) {
+                return { std::nullopt, "too many y" };
+            }
+            int times = 0;
+            if (const auto s = y.front(); !s.is_name() || !utils::chars_to_number<int, true>(s.name(), times)) {
+                return { std::nullopt, "y is not number" };
+            }
+            if (times < 0) {
+                return { std::nullopt, "y is negative" };
+            }
+            if (times == 0) {
+                x = {};
+                Log.warn("y:", times, "is zero");
+                continue;
+            }
+            if (times == 1) {
+                continue;
+            }
+            Symbols x_copy = x;
+            for (int i = 0; i < times - 1; ++i) {
+                ranges::copy(x_copy, std::back_inserter(x));
+            }
+        }
+        return x;
+    };
+    decode_vtasks = [&]() -> SymbolsOrError {
+        Symbols x = {}, y = {};
+        if (auto opt = decode_parens(); !opt) {
+            return opt;
+        }
+        else {
+            x = *opt;
+        }
+        while (*cur == Symbol::At) {
+            Symbol op = *(cur++);
+            if (auto opt = decode_parens(); !opt) {
+                return opt;
+            }
+            else {
+                y = *opt;
+            }
+            // (A+B)@(C+D) = A@C + A@D + B@C + B@D
+            Symbols x_copy = x;
+            x.clear();
+            for (const auto& sx : x_copy) {
+                for (const auto& sy : y) {
+                    auto opt = append_prefix(sy, sx);
+                    if (!opt) {
+                        return { std::nullopt,
+                                 "decode_vtasks: failed while " + sx.name() + " @ " + sy.name() + ", " + opt.what() };
+                    }
+                    ranges::copy(*opt, std::back_inserter(x));
+                }
+            }
+        }
+        return x;
+    };
+    decode_parens = [&]() -> SymbolsOrError {
+        if (*cur == Symbol::LParen) {
+            ++cur;
+            Symbols x = {};
+            if (auto opt = decode_tasks(); !opt) {
+                return opt;
+            }
+            else {
+                x = *opt;
+            }
+            if (*cur != Symbol::RParen) [[unlikely]] {
+                return { std::nullopt, "decode_parens: expected ')', got " + cur->name() };
+            }
+            ++cur;
+            return x;
+        }
+        if (cur->is_name() || cur->is_sharp_type()) {
+            return decode_name_or_vtask();
+        }
+        return { std::nullopt, "decode_parens: unexpected symbol " + cur->name() };
+    };
+
+    auto opt = decode_tasks();
+    if (!opt) {
+        return opt;
+    }
+    if (cur != m_symbolstream.cend() && *cur != TaskDataSymbol::End) {
+        return { std::nullopt, "decode: did not reach end, got " + cur->name() };
+    }
+
+    return opt;
+}

--- a/src/MaaCore/Config/TaskData/TaskDataSymbolStream.h
+++ b/src/MaaCore/Config/TaskData/TaskDataSymbolStream.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <optional>
+#include <vector>
+
+#include "Config/TaskData.h"
+#include "TaskDataSymbol.h"
+#include "TaskDataTypes.hpp"
+
+namespace asst
+{
+    class TaskDataSymbolStream final
+    {
+    public:
+        using Symbol = TaskDataSymbol;
+        using Symbols = TaskDataSymbol::Symbols;
+        using SymbolsOrError = TaskDataSymbol::SymbolsOrError;
+        using AppendPrefixFunc = std::function<SymbolsOrError(const Symbol&, const Symbol&)>;
+
+    private:
+        Symbols m_symbolstream;
+
+    public:
+        ResultOrError<bool> parse(std::string_view task_expr);
+        SymbolsOrError decode(AppendPrefixFunc append_prefix, std::string_view self_name) const;
+    };
+} // namespace asst

--- a/src/MaaCore/Config/TaskData/TaskDataSymbolStream.h
+++ b/src/MaaCore/Config/TaskData/TaskDataSymbolStream.h
@@ -5,7 +5,7 @@
 
 #include "Config/TaskData.h"
 #include "TaskDataSymbol.h"
-#include "TaskDataTypes.hpp"
+#include "TaskDataTypes.h"
 
 namespace asst
 {

--- a/src/MaaCore/Config/TaskData/TaskDataTypes.h
+++ b/src/MaaCore/Config/TaskData/TaskDataTypes.h
@@ -37,9 +37,9 @@ namespace asst
         constexpr ResultT&& value() && { return std::move(std::get<0>(m_result_or_error)); }
         constexpr const ResultT&& value() const&& { return std::move(std::get<0>(m_result_or_error)); }
 
-        constexpr std::string& what() & { return std::get<1>(m_result_or_error); }
-        constexpr const std::string& what() const& { return std::get<1>(m_result_or_error); }
-        constexpr std::string&& what() && { return std::move(std::get<1>(m_result_or_error)); }
-        constexpr const std::string&& what() const&& { return std::move(std::get<1>(m_result_or_error)); }
+        constexpr std::string& error() & { return std::get<1>(m_result_or_error); }
+        constexpr const std::string& error() const& { return std::get<1>(m_result_or_error); }
+        constexpr std::string&& error() && { return std::move(std::get<1>(m_result_or_error)); }
+        constexpr const std::string&& error() const&& { return std::move(std::get<1>(m_result_or_error)); }
     };
 } // namespace asst

--- a/src/MaaCore/Config/TaskData/TaskDataTypes.hpp
+++ b/src/MaaCore/Config/TaskData/TaskDataTypes.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <variant>
+
+namespace asst
+{
+    template <typename ResultT>
+    class ResultOrError
+    {
+        using _variant_t = std::variant<ResultT, std::string>;
+        bool m_success;
+        _variant_t m_result_or_error;
+
+    public:
+        template <typename... Args>
+        requires std::constructible_from<ResultT, Args...>
+        constexpr ResultOrError(Args&&... args)
+            : m_success(true), m_result_or_error(std::in_place_index<0>, std::forward<Args>(args)...)
+        {}
+
+        constexpr ResultOrError([[maybe_unused]] std::nullopt_t nullopt, std::string result)
+            : m_success(false), m_result_or_error(std::in_place_index<1>, std::move(result))
+        {}
+
+        constexpr operator bool() const noexcept { return m_success; }
+        constexpr bool has_value() const noexcept { return m_success; }
+
+        constexpr ResultT& operator*() & { return std::get<0>(m_result_or_error); }
+        constexpr const ResultT& operator*() const& { return std::get<0>(m_result_or_error); }
+        constexpr ResultT&& operator*() && { return std::move(std::get<0>(m_result_or_error)); }
+        constexpr const ResultT&& operator*() const&& { return std::move(std::get<0>(m_result_or_error)); }
+
+        constexpr ResultT& value() & { return std::get<0>(m_result_or_error); }
+        constexpr const ResultT& value() const& { return std::get<0>(m_result_or_error); }
+        constexpr ResultT&& value() && { return std::move(std::get<0>(m_result_or_error)); }
+        constexpr const ResultT&& value() const&& { return std::move(std::get<0>(m_result_or_error)); }
+
+        constexpr std::string& what() & { return std::get<1>(m_result_or_error); }
+        constexpr const std::string& what() const& { return std::get<1>(m_result_or_error); }
+        constexpr std::string&& what() && { return std::move(std::get<1>(m_result_or_error)); }
+        constexpr const std::string&& what() const&& { return std::move(std::get<1>(m_result_or_error)); }
+    };
+} // namespace asst

--- a/src/MaaCore/MaaCore.vcxproj
+++ b/src/MaaCore/MaaCore.vcxproj
@@ -48,6 +48,9 @@
     <ClInclude Include="Config\Miscellaneous\OcrConfig.h" />
     <ClInclude Include="Config\Miscellaneous\SSSCopilotConfig.h" />
     <ClInclude Include="Config\OnnxSessions.h" />
+    <ClInclude Include="Config\TaskData\TaskDataSymbol.h" />
+    <ClInclude Include="Config\TaskData\TaskDataSymbolStream.h" />
+    <ClInclude Include="Config\TaskData\TaskDataTypes.hpp" />
     <ClInclude Include="Controller\adb-lite\client.hpp" />
     <ClInclude Include="Controller\adb-lite\protocol.hpp" />
     <ClInclude Include="Controller\Controller.h" />
@@ -229,6 +232,8 @@
     <ClCompile Include="Config\Miscellaneous\OcrConfig.cpp" />
     <ClCompile Include="Config\Miscellaneous\SSSCopilotConfig.cpp" />
     <ClCompile Include="Config\OnnxSessions.cpp" />
+    <ClCompile Include="Config\TaskData\TaskDataSymbol.cpp" />
+    <ClCompile Include="Config\TaskData\TaskDataSymbolStream.cpp" />
     <ClCompile Include="Controller\adb-lite\client.cpp" />
     <ClCompile Include="Controller\adb-lite\protocol.cpp" />
     <ClCompile Include="Controller\Controller.cpp" />

--- a/src/MaaCore/MaaCore.vcxproj
+++ b/src/MaaCore/MaaCore.vcxproj
@@ -50,7 +50,7 @@
     <ClInclude Include="Config\OnnxSessions.h" />
     <ClInclude Include="Config\TaskData\TaskDataSymbol.h" />
     <ClInclude Include="Config\TaskData\TaskDataSymbolStream.h" />
-    <ClInclude Include="Config\TaskData\TaskDataTypes.hpp" />
+    <ClInclude Include="Config\TaskData\TaskDataTypes.h" />
     <ClInclude Include="Controller\adb-lite\client.hpp" />
     <ClInclude Include="Controller\adb-lite\protocol.hpp" />
     <ClInclude Include="Controller\Controller.h" />

--- a/src/MaaCore/MaaCore.vcxproj.filters
+++ b/src/MaaCore/MaaCore.vcxproj.filters
@@ -690,7 +690,7 @@
     <ClInclude Include="Config\TaskData\TaskDataSymbolStream.h">
       <Filter>Source\Resource\TaskData</Filter>
     </ClInclude>
-    <ClInclude Include="Config\TaskData\TaskDataTypes.hpp">
+    <ClInclude Include="Config\TaskData\TaskDataTypes.h">
       <Filter>Source\Resource\TaskData</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/MaaCore/MaaCore.vcxproj.filters
+++ b/src/MaaCore/MaaCore.vcxproj.filters
@@ -95,6 +95,9 @@
     <Filter Include="Source\Vision\Config">
       <UniqueIdentifier>{bf83678b-e9d7-4cf1-8616-aba2009072b6}</UniqueIdentifier>
     </Filter>
+    <Filter Include="Source\Resource\TaskData">
+      <UniqueIdentifier>{8d436f0b-8dad-42b2-9549-f9073b808104}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\resource\config.json">
@@ -681,6 +684,15 @@
     <ClInclude Include="Task\Roguelike\AbstractRoguelikeTaskPlugin.h">
       <Filter>Source\Task\Roguelike</Filter>
     </ClInclude>
+    <ClInclude Include="Config\TaskData\TaskDataSymbol.h">
+      <Filter>Source\Resource\TaskData</Filter>
+    </ClInclude>
+    <ClInclude Include="Config\TaskData\TaskDataSymbolStream.h">
+      <Filter>Source\Resource\TaskData</Filter>
+    </ClInclude>
+    <ClInclude Include="Config\TaskData\TaskDataTypes.hpp">
+      <Filter>Source\Resource\TaskData</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="Vision\VisionHelper.cpp">
@@ -1135,6 +1147,12 @@
     </ClCompile>
     <ClCompile Include="Task\Roguelike\AbstractRoguelikeTaskPlugin.cpp">
       <Filter>Source\Task\Roguelike</Filter>
+    </ClCompile>
+    <ClCompile Include="Config\TaskData\TaskDataSymbol.cpp">
+      <Filter>Source\Resource\TaskData</Filter>
+    </ClCompile>
+    <ClCompile Include="Config\TaskData\TaskDataSymbolStream.cpp">
+      <Filter>Source\Resource\TaskData</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/src/MaaCore/Task/Fight/SideStoryReopenTask.cpp
+++ b/src/MaaCore/Task/Fight/SideStoryReopenTask.cpp
@@ -165,8 +165,6 @@ bool asst::SideStoryReopenTask::select_stage(int stage_index)
 
     Task.get<OcrTaskInfo>(m_stage_code + "@ClickStageName")->text = { m_stage_code };
     Task.get<OcrTaskInfo>(m_stage_code + "@ClickedCorrectStage")->text = { m_stage_code };
-    // 防止在关卡名展开的情况下无法滑动，调整滑动区域
-    Task.get(m_stage_code + "@FullStageNavigation")->specific_rect = Rect(600, 100, 20, 20);
     return ProcessTask(*this, { m_stage_code + "@StageNavigationBegin" }).run();
 }
 /// <summary>
@@ -175,8 +173,6 @@ bool asst::SideStoryReopenTask::select_stage(int stage_index)
 bool asst::SideStoryReopenTask::activate_prts()
 {
     LogTraceFunction;
-    // 复制一下UnableToAgent2的roi
-    Task.get("StageQueue@UsePrtsSuccess")->roi = Task.get("UnableToAgent2")->roi;
     return ProcessTask(*this, { "StageQueue@CheckPrts" }).run();
 }
 

--- a/src/MaaCore/Task/Interface/CopilotTask.cpp
+++ b/src/MaaCore/Task/Interface/CopilotTask.cpp
@@ -135,12 +135,15 @@ bool asst::CopilotTask::set_params(const json::value& params)
     bool is_adverse = params.get("is_adverse", false);
     m_adverse_select_task_ptr->set_enable(need_navigate && is_adverse);
 
-    // 防止在关卡名展开的情况下无法滑动，调整滑动区域
     std::string m_navigate_name = params.get("navigate_name", std::string());
-    Task.get<OcrTaskInfo>(m_navigate_name + "@Copilot@ClickStageName")->text = { m_navigate_name };
-    Task.get<OcrTaskInfo>(m_navigate_name + "@Copilot@ClickedCorrectStage")->text = { m_navigate_name };
-    Task.get(m_navigate_name + "@Copilot@FullStageNavigation")->specific_rect = Rect(600, 100, 20, 20);
-    m_navigate_task_ptr->set_tasks({ m_navigate_name + "@Copilot@StageNavigationBegin" });
+    if (!m_navigate_name.empty()) {
+        Task.get<OcrTaskInfo>(m_navigate_name + "@Copilot@ClickStageName")->text = { m_navigate_name };
+        Task.get<OcrTaskInfo>(m_navigate_name + "@Copilot@ClickedCorrectStage")->text = { m_navigate_name };
+        m_navigate_task_ptr->set_tasks({ m_navigate_name + "@Copilot@StageNavigationBegin" });
+    }
+    else {
+        m_navigate_task_ptr->set_tasks({});
+    }
     m_navigate_task_ptr->set_enable(need_navigate);
 
     bool with_formation = params.get("formation", false);


### PR DESCRIPTION
#### 主要修改

- 从 TaskData 中分离 TaskDataSymbol, TaskDataSymbolStream
- 优化与 TaskData 的 get_raw 和 get 相关部分
   现在 get_raw 只能获取任务的继承信息，其它详细信息会在 get 的时候解析。

#### 其它修改

- 增加 TaskDerivedType 表示任务的继承类型
- 增加 TaskPipelineInfo 表示任务的流程信息（name + 5 个 TaskList 的任务列表）
- 增加 TaskDerivedInfo 表示任务的继承信息，包含 base & prefix & TaskDerivedType
- 给各个任务类型的 shared_ptr 增加了别名；
- 增加 ResultOrError（是 std::expected 的下位替代，同时又类似于 std::optional）


close #7129 