### PR TITLE
fix: 修复重岳等干员带三技能时点错的问题

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -7838,6 +7838,28 @@
             10
         ]
     },
+    "BattleQuickFormationSkill-SwipeToTheDown": {
+        "algorithm": "JustReturn",
+        "action": "Swipe",
+        "specificRect": [
+            15,
+            710,
+            80,
+            10
+        ],
+        "rectMove": [
+            15,
+            385,
+            80,
+            100
+        ],
+        "specialParams": [
+            150,
+            0,
+            1,
+            1
+        ]
+    },
     "BattleQuickFormationConfirm": {
         "action": "ClickSelf",
         "roi": [

--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -7833,14 +7833,15 @@
         "action": "ClickRect",
         "specificRect": [
             15,
-            710,
+            650,
             80,
-            10
+            30
         ]
     },
     "BattleQuickFormationSkill-SwipeToTheDown": {
         "algorithm": "JustReturn",
         "action": "Swipe",
+        "postDelay": 100,
         "specificRect": [
             15,
             710,

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -340,6 +340,9 @@ bool asst::BattleFormationTask::select_opers_in_cur_page(std::vector<OperGroup>&
         ctrler()->click(res.rect);
         sleep(delay);
         if (1 <= skill && skill <= 3) {
+            if (skill == 3) {
+                ProcessTask(*this, { "BattleQuickFormationSkill-SwipeToTheDown" }).run();
+            }
             ctrler()->click(SkillRectArray.at(skill - 1ULL));
             sleep(delay);
         }


### PR DESCRIPTION
选择三技能前先进行一次滑动

- close #4977 
- fix #7349 