### PR TITLE
feat: 增加公招多选策略

### DIFF
--- a/docs/en-us/3.1-INTEGRATION.md
+++ b/docs/en-us/3.1-INTEGRATION.md
@@ -105,6 +105,10 @@ Supports some of the special stages,Please refer to [autoLocalization example](.
         int,
         ...
     ],
+    "extra_tags_mode": int,     // Select more tags, optional
+                                // 0 - default
+                                // 1 - click 3 tags anyway, even if they are in conflict
+                                // 2 - select more combinations if possible, even if their tags are in conflict
     "times": int,               // The times of recruitment, optional, by default 0. Can be set to 0 for calculation only.
     "set_time": bool,           // Whether to set time to 9 hours, available only when `times` is 0, optional, by default true
     "expedite": bool,           // Whether to use expedited plans, optional, by default false

--- a/docs/ja-jp/3.1-統合ドキュメント.md
+++ b/docs/ja-jp/3.1-統合ドキュメント.md
@@ -97,6 +97,7 @@ TaskId ASSTAPI AsstAppendTask(AsstHandle handle, const char* type, const char* p
         int,
         ...
     ],
+    "extra_tags_mode": int,
     "times": int,               // 採用回数, オプション, デフォルトは 0.  0 にセットすることで計算だけに使用可能.
     "set_time": bool,           // 時刻を9時間に設定するかどうか, `times` が 0 の時のみ設定可能, オプション, デフォルトは true
     "expedite": bool,           // 緊急招集票の使用, オプション, デフォルトは false

--- a/docs/ko-kr/3.1-연동.md
+++ b/docs/ko-kr/3.1-연동.md
@@ -104,6 +104,7 @@ TaskId ASSTAPI AsstAppendTask(AsstHandle handle, const char* type, const char* p
         int,
         ...
     ],
+    "extra_tags_mode": int,
     "times": int,               // 고용 횟수, 선택 사항, 기본값은 0입니다. 계산용으로만 0으로 설정할 수 있습니다.
     "set_time": bool,           // 시간을 9시간으로 설정할지 여부, `times`가 0인 경우에만 사용 가능한 옵션입니다, 선택 사항, 기본값은 true입니다.
     "expedite": bool,           // 즉시 완료 허가증을 사용할지 여부, 선택 사항, 기본값은 false입니다.

--- a/docs/zh-tw/3.1-集成文件.md
+++ b/docs/zh-tw/3.1-集成文件.md
@@ -112,6 +112,10 @@ AsstTaskId ASSTAPI AsstAppendTask(AsstHandle handle, const char* type, const cha
         int,
         ...
     ],
+    "extra_tags_mode": int,     // 選擇更多的 Tags, 可選, 預設為 0
+                                // 0 - 預設行為
+                                // 1 - 選 3 個 Tags, 即使可能衝突
+                                // 2 - 如果可能, 同時選擇更多的高星 Tag 組合, 即使可能衝突
     "times": int,               // 招募多少次，可選，預設 0。若僅公招計算，可設定為 0
     "set_time": bool,           // 是否設定招募時限。僅在 times 為 0 時生效，可選，預設 true
     "expedite": bool,           // 是否使用加急許可，可選，預設 false

--- a/docs/协议文档/集成文档.md
+++ b/docs/协议文档/集成文档.md
@@ -114,6 +114,10 @@ AsstTaskId ASSTAPI AsstAppendTask(AsstHandle handle, const char* type, const cha
         int,
         ...
     ],
+    "extra_tags_mode": int,     // 选择更多的 Tags, 可选, 默认为 0
+                                // 0 - 默认行为
+                                // 1 - 选 3 个 Tags, 即使可能冲突
+                                // 2 - 如果可能, 同时选择更多的高星 Tag 组合, 即使可能冲突
     "times": int,               // 招募多少次，可选，默认 0。若仅公招计算，可设置为 0
     "set_time": bool,           // 是否设置招募时限。仅在 times 为 0 时生效，可选，默认 true
     "expedite": bool,           // 是否使用加急许可，可选，默认 false

--- a/src/MaaCore/Config/Miscellaneous/RecruitConfig.h
+++ b/src/MaaCore/Config/Miscellaneous/RecruitConfig.h
@@ -89,12 +89,12 @@ namespace asst
         }
     };
 
-    // 选择更多 Tags 的模式
-    enum struct ExtraTagsMode : int
+    // 选择额外 Tags 的模式
+    enum class ExtraTagsMode
     {
-        default_noextra_mode,             // 0 - 默认行为
-        select_extra_mode,                // 1 - 选 3 个 Tags, 即使可能冲突
-        select_extra_onlyrare_mode,       // 2 - 如果可能, 同时选择更多的高星 Tag 组合, 即使可能冲突
+        NoExtra,              // 0 - 默认行为
+        Extra,                // 1 - 选 3 个 Tags, 即使可能冲突
+        ExtraOnlyRare,        // 2 - 如果可能, 同时选择更多的高星 Tag 组合, 即使可能冲突
     };
 
     class RecruitConfig final : public SingletonHolder<RecruitConfig>, public AbstractConfig
@@ -105,8 +105,7 @@ namespace asst
     public:
         static constexpr bool is_valid_extra_tags_mode(ExtraTagsMode mode)
         {
-            return mode == ExtraTagsMode::default_noextra_mode || mode == ExtraTagsMode::select_extra_mode ||
-                   mode == ExtraTagsMode::select_extra_onlyrare_mode;
+            return mode == ExtraTagsMode::NoExtra || mode == ExtraTagsMode::Extra || mode == ExtraTagsMode::ExtraOnlyRare;
         }
 
     public:

--- a/src/MaaCore/Config/Miscellaneous/RecruitConfig.h
+++ b/src/MaaCore/Config/Miscellaneous/RecruitConfig.h
@@ -89,10 +89,25 @@ namespace asst
         }
     };
 
+    // 选择更多 Tags 的模式
+    enum struct ExtraTagsMode : int
+    {
+        default_noextra_mode,             // 0 - 默认行为
+        select_extra_mode,                // 1 - 选 3 个 Tags, 即使可能冲突
+        select_extra_onlyrare_mode,       // 2 - 如果可能, 同时选择更多的高星 Tag 组合, 即使可能冲突
+    };
+
     class RecruitConfig final : public SingletonHolder<RecruitConfig>, public AbstractConfig
     {
     public:
         using TagId = std::string;
+    
+    public:
+        static constexpr bool is_valid_extra_tags_mode(ExtraTagsMode mode)
+        {
+            return mode == ExtraTagsMode::default_noextra_mode || mode == ExtraTagsMode::select_extra_mode ||
+                   mode == ExtraTagsMode::select_extra_onlyrare_mode;
+        }
 
     public:
         virtual ~RecruitConfig() override = default;

--- a/src/MaaCore/Task/Interface/RecruitTask.cpp
+++ b/src/MaaCore/Task/Interface/RecruitTask.cpp
@@ -44,7 +44,7 @@ bool asst::RecruitTask::set_params(const json::value& params)
     bool force_refresh = params.get("force_refresh", true);
     int times = params.get("times", 0);
     bool expedite = params.get("expedite", false);
-    bool extra_tags = params.get("extra_tags", false);
+    int extra_tags_mode = params.get("extra_tags_mode", 0);
     [[maybe_unused]] int expedite_times = params.get("expedite_times", 0);
     bool skip_robot = params.get("skip_robot", true);
 
@@ -65,7 +65,7 @@ bool asst::RecruitTask::set_params(const json::value& params)
     m_auto_recruit_task_ptr->set_max_times(times)
         .set_need_refresh(refresh)
         .set_use_expedited(expedite)
-        .set_select_extra_tags(extra_tags)
+        .set_select_extra_tags(extra_tags_mode)
         .set_select_level(std::move(select))
         .set_confirm_level(std::move(confirm))
         .set_skip_robot(skip_robot)

--- a/src/MaaCore/Task/Interface/RecruitTask.cpp
+++ b/src/MaaCore/Task/Interface/RecruitTask.cpp
@@ -39,12 +39,17 @@ bool asst::RecruitTask::set_params(const json::value& params)
         confirm.emplace_back(confirm_num_json.as_integer());
     }
 
+    ExtraTagsMode extra_tags_mode = static_cast<ExtraTagsMode>(params.get("extra_tags_mode", 0));
+    // 若出现未知 extra_tags_mod ， 将 extra_tags_mod 置为 default 。
+    if (!RecruitConfig::is_valid_extra_tags_mode(extra_tags_mode)) {
+        extra_tags_mode = ExtraTagsMode::default_noextra_mode;
+    }
+
     bool refresh = params.get("refresh", false);
     bool set_time = params.get("set_time", true);
     bool force_refresh = params.get("force_refresh", true);
     int times = params.get("times", 0);
     bool expedite = params.get("expedite", false);
-    int extra_tags_mode = params.get("extra_tags_mode", 0);
     [[maybe_unused]] int expedite_times = params.get("expedite_times", 0);
     bool skip_robot = params.get("skip_robot", true);
 

--- a/src/MaaCore/Task/Interface/RecruitTask.cpp
+++ b/src/MaaCore/Task/Interface/RecruitTask.cpp
@@ -40,9 +40,9 @@ bool asst::RecruitTask::set_params(const json::value& params)
     }
 
     ExtraTagsMode extra_tags_mode = static_cast<ExtraTagsMode>(params.get("extra_tags_mode", 0));
-    // 若出现未知 extra_tags_mod ， 将 extra_tags_mod 置为 default 。
+    // 若出现未知 extra_tags_mode ， 将 extra_tags_mod 置为默认的 NoExtra 。
     if (!RecruitConfig::is_valid_extra_tags_mode(extra_tags_mode)) {
-        extra_tags_mode = ExtraTagsMode::default_noextra_mode;
+        extra_tags_mode = ExtraTagsMode::NoExtra;
     }
 
     bool refresh = params.get("refresh", false);

--- a/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.cpp
@@ -142,24 +142,8 @@ asst::AutoRecruitTask& asst::AutoRecruitTask::set_use_expedited(bool use_or_not)
 
 asst::AutoRecruitTask& asst::AutoRecruitTask::set_select_extra_tags(int select_extra_tags_mode) noexcept
 {
-    switch (select_extra_tags_mode) {
-    case 0:
-        m_select_extra_tags = false;
-        m_select_extra_onlyrare_tags = false;
-        break;
-    case 1:
-        m_select_extra_tags = true;
-        m_select_extra_onlyrare_tags = false;
-        break;
-    case 2:
-        m_select_extra_tags = false;
-        m_select_extra_onlyrare_tags = true;
-        break;
-    default:
-        m_select_extra_tags = false;
-        m_select_extra_onlyrare_tags = false;
-        break;
-    }
+    m_select_extra_tags = (select_extra_tags_mode == 1);
+    m_select_extra_onlyrare_tags = (select_extra_tags_mode == 2);
     return *this;
 }
 
@@ -595,7 +579,8 @@ asst::AutoRecruitTask::calc_task_result_type asst::AutoRecruitTask::recruit_calc
             return result;
         }
 
-        auto final_select = m_select_extra_tags||m_select_extra_onlyrare_tags ? get_select_tags(result_vec) : final_combination.tags;
+        auto final_select =
+            m_select_extra_tags || m_select_extra_onlyrare_tags ? get_select_tags(result_vec) : final_combination.tags;
 
         // select tags
         for (const std::string& final_tag_name : final_select) {
@@ -743,11 +728,11 @@ std::vector<std::string> asst::AutoRecruitTask::get_select_tags(const std::vecto
         }
     }
     else if (m_select_extra_onlyrare_tags) {
-        //only select rare tags ( > 3 rank) and select as much as possible.
-        
-        //when exist higher rank tags, won't select lower rank tags.
-        int min_level = conbinations.front().min_level; 
-        //tag combo will be either full selected,or abandoned. 
+        // only select rare tags ( > 3 rank) and select as many as possible.
+
+        // do not select lower rank tags when higher rank tags exist.
+        int min_level = conbinations.front().min_level;
+        // tag combo will be either full selected, or abandoned.
         int emplace_back_count = 0;
         if (min_level == 3) return select;
         for (const asst::RecruitCombs& comb : conbinations) {

--- a/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.cpp
@@ -140,9 +140,26 @@ asst::AutoRecruitTask& asst::AutoRecruitTask::set_use_expedited(bool use_or_not)
     return *this;
 }
 
-asst::AutoRecruitTask& asst::AutoRecruitTask::set_select_extra_tags(bool select_extra_tags) noexcept
+asst::AutoRecruitTask& asst::AutoRecruitTask::set_select_extra_tags(int select_extra_tags_mode) noexcept
 {
-    m_select_extra_tags = select_extra_tags;
+    switch (select_extra_tags_mode) {
+    case 0:
+        m_select_extra_tags = false;
+        m_select_extra_onlyrare_tags = false;
+        break;
+    case 1:
+        m_select_extra_tags = true;
+        m_select_extra_onlyrare_tags = false;
+        break;
+    case 2:
+        m_select_extra_tags = false;
+        m_select_extra_onlyrare_tags = true;
+        break;
+    default:
+        m_select_extra_tags = false;
+        m_select_extra_onlyrare_tags = false;
+        break;
+    }
     return *this;
 }
 

--- a/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.cpp
@@ -140,10 +140,9 @@ asst::AutoRecruitTask& asst::AutoRecruitTask::set_use_expedited(bool use_or_not)
     return *this;
 }
 
-asst::AutoRecruitTask& asst::AutoRecruitTask::set_select_extra_tags(int select_extra_tags_mode) noexcept
+asst::AutoRecruitTask& asst::AutoRecruitTask::set_select_extra_tags(ExtraTagsMode select_extra_tags_mode) noexcept
 {
-    m_select_extra_tags = (select_extra_tags_mode == 1);
-    m_select_extra_onlyrare_tags = (select_extra_tags_mode == 2);
+    m_select_extra_tags_mode = select_extra_tags_mode;
     return *this;
 }
 
@@ -579,8 +578,8 @@ asst::AutoRecruitTask::calc_task_result_type asst::AutoRecruitTask::recruit_calc
             return result;
         }
 
-        auto final_select =
-            m_select_extra_tags || m_select_extra_onlyrare_tags ? get_select_tags(result_vec) : final_combination.tags;
+        auto final_select = 
+            (m_select_extra_tags_mode != ExtraTagsMode::default_noextra_mode) ? get_select_tags(result_vec) : final_combination.tags;
 
         // select tags
         for (const std::string& final_tag_name : final_select) {
@@ -709,15 +708,15 @@ std::vector<std::string> asst::AutoRecruitTask::get_tag_names(const std::vector<
     return names;
 }
 
-std::vector<std::string> asst::AutoRecruitTask::get_select_tags(const std::vector<RecruitCombs>& conbinations)
+std::vector<std::string> asst::AutoRecruitTask::get_select_tags(const std::vector<RecruitCombs>& combinations)
 {
     LogTraceFunction;
     std::unordered_set<std::string> unique_tags;
     std::vector<std::string> select;
 
-    if (m_select_extra_tags) {
+    if (m_select_extra_tags_mode == ExtraTagsMode::select_extra_mode) {
         while (select.size() < 3) {
-            for (const asst::RecruitCombs& comb : conbinations)
+            for (const asst::RecruitCombs& comb : combinations)
                 for (const std::string& tag : comb.tags) {
                     if (unique_tags.find(tag) == unique_tags.cend()) {
                         unique_tags.insert(tag);
@@ -727,15 +726,15 @@ std::vector<std::string> asst::AutoRecruitTask::get_select_tags(const std::vecto
                 }
         }
     }
-    else if (m_select_extra_onlyrare_tags) {
+    else if (m_select_extra_tags_mode == ExtraTagsMode::select_extra_onlyrare_mode) {
         // only select rare tags ( > 3 rank) and select as many as possible.
 
         // do not select lower rank tags when higher rank tags exist.
-        int min_level = conbinations.front().min_level;
+        int min_level = combinations.front().min_level;
         // tag combo will be either full selected, or abandoned.
         int emplace_back_count = 0;
         if (min_level == 3) return select;
-        for (const asst::RecruitCombs& comb : conbinations) {
+        for (const asst::RecruitCombs& comb : combinations) {
             if (comb.min_level < min_level) return select;
             emplace_back_count = 0;
             for (const std::string& tag : comb.tags) {

--- a/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.cpp
@@ -579,7 +579,7 @@ asst::AutoRecruitTask::calc_task_result_type asst::AutoRecruitTask::recruit_calc
         }
 
         auto final_select = 
-            (m_select_extra_tags_mode != ExtraTagsMode::default_noextra_mode) ? get_select_tags(result_vec) : final_combination.tags;
+            (m_select_extra_tags_mode != ExtraTagsMode::NoExtra) ? get_select_tags(result_vec) : final_combination.tags;
 
         // select tags
         for (const std::string& final_tag_name : final_select) {
@@ -714,7 +714,7 @@ std::vector<std::string> asst::AutoRecruitTask::get_select_tags(const std::vecto
     std::unordered_set<std::string> unique_tags;
     std::vector<std::string> select;
 
-    if (m_select_extra_tags_mode == ExtraTagsMode::select_extra_mode) {
+    if (m_select_extra_tags_mode == ExtraTagsMode::Extra) {
         while (select.size() < 3) {
             for (const asst::RecruitCombs& comb : combinations)
                 for (const std::string& tag : comb.tags) {
@@ -726,7 +726,7 @@ std::vector<std::string> asst::AutoRecruitTask::get_select_tags(const std::vecto
                 }
         }
     }
-    else if (m_select_extra_tags_mode == ExtraTagsMode::select_extra_onlyrare_mode) {
+    else if (m_select_extra_tags_mode == ExtraTagsMode::ExtraOnlyRare) {
         // only select rare tags ( > 3 rank) and select as many as possible.
 
         // do not select lower rank tags when higher rank tags exist.

--- a/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.h
+++ b/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.h
@@ -23,7 +23,7 @@ namespace asst
         AutoRecruitTask& set_need_refresh(bool need_refresh) noexcept;
         AutoRecruitTask& set_max_times(int max_times) noexcept;
         AutoRecruitTask& set_use_expedited(bool use_or_not) noexcept;
-        AutoRecruitTask& set_select_extra_tags(int select_extra_tags_mode) noexcept;
+        AutoRecruitTask& set_select_extra_tags(ExtraTagsMode select_extra_tags_mode) noexcept;
         AutoRecruitTask& set_skip_robot(bool skip_robot) noexcept;
         AutoRecruitTask& set_set_time(bool set_time) noexcept;
         AutoRecruitTask& set_force_refresh(bool force_refrest) noexcept;
@@ -76,8 +76,7 @@ namespace asst
         std::vector<int> m_confirm_level;
         bool m_need_refresh = false;
         bool m_use_expedited = false;
-        bool m_select_extra_tags = false;
-        bool m_select_extra_onlyrare_tags = false;
+        ExtraTagsMode m_select_extra_tags_mode = ExtraTagsMode::default_noextra_mode;
         int m_max_times = 0;
         bool m_has_permit = true;
         bool m_has_refresh = true;

--- a/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.h
+++ b/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.h
@@ -76,7 +76,7 @@ namespace asst
         std::vector<int> m_confirm_level;
         bool m_need_refresh = false;
         bool m_use_expedited = false;
-        ExtraTagsMode m_select_extra_tags_mode = ExtraTagsMode::default_noextra_mode;
+        ExtraTagsMode m_select_extra_tags_mode = ExtraTagsMode::NoExtra;
         int m_max_times = 0;
         bool m_has_permit = true;
         bool m_has_refresh = true;

--- a/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.h
+++ b/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.h
@@ -23,7 +23,7 @@ namespace asst
         AutoRecruitTask& set_need_refresh(bool need_refresh) noexcept;
         AutoRecruitTask& set_max_times(int max_times) noexcept;
         AutoRecruitTask& set_use_expedited(bool use_or_not) noexcept;
-        AutoRecruitTask& set_select_extra_tags(bool select_extra_tags) noexcept;
+        AutoRecruitTask& set_select_extra_tags(int select_extra_tags_mode) noexcept;
         AutoRecruitTask& set_skip_robot(bool skip_robot) noexcept;
         AutoRecruitTask& set_set_time(bool set_time) noexcept;
         AutoRecruitTask& set_force_refresh(bool force_refrest) noexcept;

--- a/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.h
+++ b/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.h
@@ -77,6 +77,7 @@ namespace asst
         bool m_need_refresh = false;
         bool m_use_expedited = false;
         bool m_select_extra_tags = false;
+        bool m_select_extra_onlyrare_tags = false;
         int m_max_times = 0;
         bool m_has_permit = true;
         bool m_has_refresh = true;

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -1764,13 +1764,29 @@ namespace MaaWpfGui.Main
         /// <param name="needRefresh">是否刷新三星 Tags。</param>
         /// <param name="needForceRefresh">无招募许可时是否继续尝试刷新 Tags。</param>
         /// <param name="useExpedited">是否使用加急许可。</param>
-        /// <param name="selectExtraTags">选择 Tags 时是否总是选择三个 Tag</param>
+        /// <param name="selectExtraTagsMode">
+        /// 公招选择额外tag的模式。可用值包括：
+        /// <list type="bullet">
+        ///     <item>
+        ///         <term><c>0</c></term>
+        ///         <description>默认不选择额外tag。</description>
+        ///     </item>
+        ///     <item>
+        ///         <term><c>1</c></term>
+        ///         <description>选满至3个tag。</description>
+        ///     </item>
+        ///     <item>
+        ///         <term><c>2</c></term>
+        ///         <description>尽可能多选且只选四星以上的tag。</description>
+        ///     </item>
+        /// </list>
+        /// </param>
         /// <param name="skipRobot">是否在识别到小车词条时跳过。</param>
         /// <param name="isLevel3UseShortTime">三星Tag是否使用短时间（7:40）</param>
         /// <param name="isLevel3UseShortTime2">三星Tag是否使用短时间（1:00）</param>
         /// <returns>是否成功。</returns>
         public bool AsstAppendRecruit(int maxTimes, int[] selectLevel, int[] confirmLevel, bool needRefresh, bool needForceRefresh, bool useExpedited,
-            bool selectExtraTags, bool skipRobot, bool isLevel3UseShortTime, bool isLevel3UseShortTime2 = false)
+            int selectExtraTagsMode, bool skipRobot, bool isLevel3UseShortTime, bool isLevel3UseShortTime2 = false)
         {
             var taskParams = new JObject
             {
@@ -1781,7 +1797,7 @@ namespace MaaWpfGui.Main
                 ["times"] = maxTimes,
                 ["set_time"] = true,
                 ["expedite"] = useExpedited,
-                ["extra_tags"] = selectExtraTags,
+                ["extra_tags_mode"] = selectExtraTagsMode,
                 ["expedite_times"] = maxTimes,
                 ["skip_robot"] = skipRobot,
             };

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -634,7 +634,10 @@ The video aspect ratio needs to be 16:9 without interference factors such as bla
     <system:String x:Key="Refreshed">Refreshed</system:String>
     <system:String x:Key="ContinueRefresh">No recruitment permit, trying to refresh Tags</system:String>
     <system:String x:Key="NoRecruitmentPermit">No recruitment permit, returned</system:String>
+    <system:String x:Key="AutoRecruitSelectStrategy">strategy for whether choose additional Tags</system:String>
+    <system:String x:Key="DefaultNoExtraTags">default: no additional Tags</system:String>
     <system:String x:Key="SelectExtraTags">When selecting Tags always select three Tags</system:String>
+    <system:String x:Key="SelectExtraOnlyRareTags">select only rare Tags as many as possible</system:String>
     <system:String x:Key="NotEnoughStaff">Insufficient operators</system:String>
     <system:String x:Key="StageInfoError">Stage recognition error</system:String>
     <system:String x:Key="UseFormation">Use formation</system:String>

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -634,10 +634,10 @@ The video aspect ratio needs to be 16:9 without interference factors such as bla
     <system:String x:Key="Refreshed">Refreshed</system:String>
     <system:String x:Key="ContinueRefresh">No recruitment permit, trying to refresh Tags</system:String>
     <system:String x:Key="NoRecruitmentPermit">No recruitment permit, returned</system:String>
-    <system:String x:Key="AutoRecruitSelectStrategy">strategy for whether choose additional Tags</system:String>
-    <system:String x:Key="DefaultNoExtraTags">default: no additional Tags</system:String>
+    <system:String x:Key="AutoRecruitSelectStrategy">Strategies for Additional Tags</system:String>
+    <system:String x:Key="DefaultNoExtraTags">Additional Tags are not selected by default</system:String>
     <system:String x:Key="SelectExtraTags">When selecting Tags always select three Tags</system:String>
-    <system:String x:Key="SelectExtraOnlyRareTags">select only rare Tags as many as possible</system:String>
+    <system:String x:Key="SelectExtraOnlyRareTags">Pick as many high-star Tags as possible</system:String>
     <system:String x:Key="NotEnoughStaff">Insufficient operators</system:String>
     <system:String x:Key="StageInfoError">Stage recognition error</system:String>
     <system:String x:Key="UseFormation">Use formation</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -634,7 +634,10 @@ Bilibili: ログイン インターフェイスに表示されるアカウント
     <system:String x:Key="Refreshed">現在のタグが更新されました</system:String>
     <system:String x:Key="ContinueRefresh">採用許可がないため、タグを更新しようとしています</system:String>
     <system:String x:Key="NoRecruitmentPermit">採用許可がないため返却されました</system:String>
+    <system:String x:Key="AutoRecruitSelectStrategy">公募の複数のタグを選択する戦略</system:String>
+    <system:String x:Key="DefaultNoExtraTags">デフォルトでは、追加のタグを選択しない</system:String>
     <system:String x:Key="SelectExtraTags">タグを選択すると、常に 3 つのタグが選択されます</system:String>
+    <system:String x:Key="SelectExtraOnlyRareTags">可能な限り多くのタグを選択し、高い星のタグのみを選択する</system:String>
     <system:String x:Key="NotEnoughStaff">利用可能なオペレーターが不足しています</system:String>
     <system:String x:Key="StageInfoError">ステージ認識エラー</system:String>
     <system:String x:Key="UseFormation">使用編成</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -634,7 +634,10 @@ Bilibili: 로그인 인터페이스에 표시되는 계정 이름(예: 장산)�
     <system:String x:Key="Refreshed">새로고침됨</system:String>
     <system:String x:Key="ContinueRefresh">채용 허가 없음, 새로 고치려고 태그</system:String>
     <system:String x:Key="NoRecruitmentPermit">채용허가증이 없어 반환함</system:String>
+    <system:String x:Key="AutoRecruitSelectStrategy">공개 채용에서 다중 태그 선택 전략</system:String>
+    <system:String x:Key="DefaultNoExtraTags">기본값:추가 태그 없습니다</system:String>
     <system:String x:Key="SelectExtraTags">태그를 선택할 때 항상 태그 3개를 선택하세요.</system:String>
+    <system:String x:Key="SelectExtraOnlyRareTags">가능한 한 많은 태그를 선택하고 높은 등급의 태그만 선택합니다</system:String>
     <system:String x:Key="NotEnoughStaff">오퍼레이터 부족</system:String>
     <system:String x:Key="StageInfoError">스테이지 인식 오류</system:String>
     <system:String x:Key="UseFormation">사용 형성</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -634,7 +634,10 @@
     <system:String x:Key="Refreshed">当前槽位已刷新</system:String>
     <system:String x:Key="ContinueRefresh">无招聘许可，继续尝试刷新 Tags</system:String>
     <system:String x:Key="NoRecruitmentPermit">无招聘许可，已返回</system:String>
+    <system:String x:Key="AutoRecruitSelectStrategy">公招多选 Tag 的策略</system:String>
+    <system:String x:Key="DefaultNoExtraTags">默认不选择额外 Tag</system:String>
     <system:String x:Key="SelectExtraTags">总是选择三个 Tag</system:String>
+    <system:String x:Key="SelectExtraOnlyRareTags">尽可能多地选且只选高星 Tag</system:String>
     <system:String x:Key="NotEnoughStaff">可用干员不足</system:String>
     <system:String x:Key="StageInfoError">关卡识别错误</system:String>
     <system:String x:Key="UseFormation">使用编队</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -635,7 +635,10 @@
     <system:String x:Key="ContinueRefresh">無招聘許可，繼續嘗試刷新 Tags</system:String>
     <system:String x:Key="NoRecruitmentPermit">無招聘許可，已返回</system:String>
     <system:String x:Key="NotEnoughStaff">可用幹員不足</system:String>
+    <system:String x:Key="AutoRecruitSelectStrategy">公招多選 Tags 的策略</system:String>
+    <system:String x:Key="DefaultNoExtraTags">默認不選擇額外的 Tags</system:String>
     <system:String x:Key="SelectExtraTags">選擇 Tags 時總是選擇三個 Tag</system:String>
+    <system:String x:Key="SelectExtraOnlyRareTags">盡可能多地選且只選高星 Tags</system:String>
     <system:String x:Key="StageInfoError">關卡辨識錯誤</system:String>
     <system:String x:Key="UseFormation">使用編隊</system:String>
     <system:String x:Key="Current">當前</system:String>

--- a/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
@@ -1320,6 +1320,11 @@ namespace MaaWpfGui.ViewModels.UI
         // public List<CombData> RoguelikeCoreCharList { get; set; }
 
         /// <summary>
+        /// Gets or sets the list of auto recruit selecting extra tags.
+        /// </summary>
+        public List<CombinedData> AutoRecruitSelectExtraTagsList { get; set; }
+
+        /// <summary>
         /// Gets or sets the list of the client types.
         /// </summary>
         public List<CombinedData> ClientTypeList { get; set; }
@@ -2458,18 +2463,18 @@ namespace MaaWpfGui.ViewModels.UI
             set => SetAndNotify(ref _useExpedited, value);
         }
 
-        private bool _selectExtraTags = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.SelectExtraTags, bool.FalseString));
+        private string _selectExtraTags = ConfigurationHelper.GetValue(ConfigurationKeys.SelectExtraTags, "0");
 
         /// <summary>
-        /// Gets or sets a value indicating whether three tags are alway selected when selecting tags.
+        /// Gets or sets a value indicating three tags are alway selected or select only rare tags as many as possible .
         /// </summary>
-        public bool SelectExtraTags
+        public string SelectExtraTags
         {
             get => _selectExtraTags;
             set
             {
                 SetAndNotify(ref _selectExtraTags, value);
-                ConfigurationHelper.SetValue(ConfigurationKeys.SelectExtraTags, value.ToString());
+                ConfigurationHelper.SetValue(ConfigurationKeys.SelectExtraTags, value);
             }
         }
 

--- a/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
@@ -169,6 +169,7 @@ namespace MaaWpfGui.ViewModels.UI
             InitTitleBar();
             InitInfrast();
             InitRoguelike();
+            InitAutoRecruit();
             InitConfiguration();
             InitUiSettings();
             InitUpdate();
@@ -277,6 +278,16 @@ namespace MaaWpfGui.ViewModels.UI
                 new CombinedData { Display = LocalizationHelper.GetString("SlowAndSteadyWinsTheRace"), Value = "稳扎稳打" },
                 new CombinedData { Display = LocalizationHelper.GetString("OvercomingYourWeaknesses"), Value = "取长补短" },
                 new CombinedData { Display = LocalizationHelper.GetString("AsYourHeartDesires"), Value = "随心所欲" },
+            };
+        }
+
+        private void InitAutoRecruit()
+        {
+            AutoRecruitSelectExtraTagsList = new List<CombinedData>
+            {
+            new CombinedData { Display = LocalizationHelper.GetString("DefaultNoExtraTags"), Value = "0" },
+            new CombinedData { Display = LocalizationHelper.GetString("SelectExtraTags"), Value = "1" },
+            new CombinedData { Display = LocalizationHelper.GetString("SelectExtraOnlyRareTags"), Value = "2" },
             };
         }
 

--- a/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
@@ -2470,7 +2470,24 @@ namespace MaaWpfGui.ViewModels.UI
         /// </summary>
         public string SelectExtraTags
         {
-            get => _selectExtraTags;
+            get
+            {
+                if (int.TryParse(_selectExtraTags, out _))
+                {
+                    return _selectExtraTags;
+                }
+
+                var value = "0";
+                if (bool.TryParse(_selectExtraTags, out bool boolValue))
+                {
+                    value = boolValue ? "1" : "0";
+                }
+
+                SetAndNotify(ref _selectExtraTags, value);
+                ConfigurationHelper.SetValue(ConfigurationKeys.SelectExtraTags, value);
+                return value;
+            }
+
             set
             {
                 SetAndNotify(ref _selectExtraTags, value);

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -1300,9 +1300,11 @@ namespace MaaWpfGui.ViewModels.UI
                 cfmList.Add(5);
             }
 
+            int.TryParse(Instances.SettingsViewModel.SelectExtraTags, out var selectExtra);
+
             return Instances.AsstProxy.AsstAppendRecruit(
                 maxTimes, reqList.ToArray(), cfmList.ToArray(), Instances.SettingsViewModel.RefreshLevel3, Instances.SettingsViewModel.ForceRefresh, Instances.SettingsViewModel.UseExpedited,
-                Instances.SettingsViewModel.SelectExtraTags, Instances.SettingsViewModel.NotChooseLevel1, Instances.SettingsViewModel.IsLevel3UseShortTime, Instances.SettingsViewModel.IsLevel3UseShortTime2);
+                selectExtra, Instances.SettingsViewModel.NotChooseLevel1, Instances.SettingsViewModel.IsLevel3UseShortTime, Instances.SettingsViewModel.IsLevel3UseShortTime2);
         }
 
         private static bool AppendRoguelike()

--- a/src/MaaWpfGui/Views/UserControl/AutoRecruitSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/AutoRecruitSettingsUserControl.xaml
@@ -33,15 +33,19 @@
         </StackPanel>
 
         <StackPanel Visibility="{c:Binding TaskSettingVisibilities.EnableAdvancedSettings}">
+            <ComboBox
+                Margin="0,5"
+                hc:InfoElement.Title="{DynamicResource AutoRecruitSelectStrategy}"
+                DisplayMemberPath="Display"
+                IsHitTestVisible="{Binding Path=Idle}"
+                ItemsSource="{Binding AutoRecruitSelectExtraTagsList}"
+                SelectedValue="{Binding SelectExtraTags}"
+                SelectedValuePath="Value" 
+                Style="{StaticResource ComboBoxExtend}" />
             <CheckBox
                 Margin="0,10"
                 Content="{DynamicResource AutoRefresh}"
                 IsChecked="{Binding RefreshLevel3}" />
-            <CheckBox
-                Margin="0,10"
-                Content="{DynamicResource SelectExtraTags}"
-                IsChecked="{Binding SelectExtraTags}"
-                IsEnabled="True" />
             <CheckBox
                 Margin="0,10"
                 Content="{DynamicResource ForceRefresh}"


### PR DESCRIPTION
* fix #7452   

按照 #7452 的想法，在 #6900  的基础上增加了只选尽可能多选且只选高星tag的功能选项，并将选项策略合并
默认策略：只选一个高星tag组合
#6900 策略：选满三个tag为止
新增策略：尽可能多选高星tag，且额外的tag组合要么完整选入，要么舍弃；且若当前出现更高星tag组合，则不会考虑较低星，只会尽可能选高星tag组合（例如出现五星tag时，将尽力多选五星tag，不会考虑四星tag）
(result_vec的排序规则暂时未更改)
在GUI中增加了选择公招策略的功能，如图：

<details>

![image](https://github.com/MaaAssistantArknights/MaaAssistantArknights/assets/113409320/4b0d4f7d-5156-4144-b411-b96b604e49c7)
![image](https://github.com/MaaAssistantArknights/MaaAssistantArknights/assets/113409320/18167d72-741a-4bcd-95c8-6f916dec008d)

</details>

最后用模拟器在自己账号上进行了一些自动公招测试。