### PR TITLE
fix: typo in task name

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -9759,10 +9759,10 @@
             427
         ],
         "next": [
-            "ChangeOrderComfirm"
+            "ChangeOrderConfirm"
         ]
     },
-    "ChangeOrderComfirm": {
+    "ChangeOrderConfirm": {
         "algorithm": "JustReturn",
         "action": "ClickRect",
         "specificRect": [
@@ -9772,7 +9772,7 @@
             140
         ],
         "next": [
-            "ChangeOrderComfirm@LoadingText",
+            "ChangeOrderConfirm@LoadingText",
             "Stop"
         ]
     },
@@ -9803,7 +9803,7 @@
             427
         ],
         "next": [
-            "ChangeOrderComfirm"
+            "ChangeOrderConfirm"
         ]
     },
     "ChooseProductList": {
@@ -9824,7 +9824,7 @@
             487
         ]
     },
-    "ComfirmProductChange": {
+    "ConfirmProductChange": {
         "algorithm": "MatchTemplate",
         "action": "ClickSelf",
         "template": "ReplenishToMaxConfirm.png",
@@ -9836,7 +9836,7 @@
             120
         ],
         "next": [
-            "ProductFinalComfirm"
+            "ProductFinalConfirm"
         ]
     },
     "ClickProductMax": {
@@ -9851,7 +9851,7 @@
             60
         ],
         "next": [
-            "ComfirmProductChange"
+            "ConfirmProductChange"
         ]
     },
     "ChooseBattleRecord": {
@@ -9869,7 +9869,7 @@
             "ClickProductMax"
         ]
     },
-    "ProductFinalComfirm": {
+    "ProductFinalConfirm": {
         "algorithm": "MatchTemplate",
         "action": "ClickSelf",
         "template": "SSSSettlementConfirm.png",
@@ -9881,7 +9881,7 @@
             100
         ],
         "next": [
-            "ProductFinalComfirm@LoadingText",
+            "ProductFinalConfirm@LoadingText",
             "Stop"
         ]
     },


### PR DESCRIPTION
This pull request fixes a typo in the task name from 
Changes tasks from "Comfirm" to "Confirm"

I've checked the Core, it doesn't seem like these tasks were used, so there shouldn't be any core changes needed.