### PR TITLE
feat: 最快截图耗时超出阈值后，输出额外提示文本

### DIFF
--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -479,6 +479,7 @@ namespace MaaWpfGui.Main
 
                     fastestScreencapStringBuilder.Insert(0, string.Format(LocalizationHelper.GetString("FastestWayToScreencap"), method, costString));
                     Instances.TaskQueueViewModel.AddLog(fastestScreencapStringBuilder.ToString(), color);
+                    Instances.CopilotViewModel.AddLog(fastestScreencapStringBuilder.ToString());
                     break;
             }
         }

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -457,10 +457,10 @@ namespace MaaWpfGui.Main
                     break;
 
                 case "FastestWayToScreencap":
-                    var detailsObj = details["details"];
-                    string costString = detailsObj?["cost"]?.ToString() ?? "???";
-                    string method = detailsObj?["method"]?.ToString() ?? "???";
+                    string costString = details["details"]?["cost"]?.ToString() ?? "???";
+                    string method = details["details"]?["method"]?.ToString() ?? "???";
 
+                    StringBuilder fastestScreencapStringBuilder = new StringBuilder();
                     string color = UiLogColor.Trace;
                     if (!int.TryParse(costString, out var timeCost))
                     {
@@ -469,14 +469,16 @@ namespace MaaWpfGui.Main
                     else if (timeCost > 800)
                     {
                         color = UiLogColor.Error;
+                        fastestScreencapStringBuilder.AppendLine().Append(LocalizationHelper.GetString("FastestWayToScreencapErrorTip"));
                     }
                     else if (timeCost > 400)
                     {
                         color = UiLogColor.Warning;
+                        fastestScreencapStringBuilder.AppendLine().Append(LocalizationHelper.GetString("FastestWayToScreencapWarningTip"));
                     }
 
-                    string logMessage = string.Format(LocalizationHelper.GetString("FastestWayToScreencap"), method, costString);
-                    Instances.TaskQueueViewModel.AddLog(logMessage, color);
+                    fastestScreencapStringBuilder.Insert(0, string.Format(LocalizationHelper.GetString("FastestWayToScreencap"), method, costString));
+                    Instances.TaskQueueViewModel.AddLog(fastestScreencapStringBuilder.ToString(), color);
                     break;
             }
         }

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -558,6 +558,8 @@ The video aspect ratio needs to be 16:9 without interference factors such as bla
     <system:String x:Key="TouchModeNotAvailable">Touch mode is not available, please go to 「Settings - Connection Settings」 to switch to a different touch mode.</system:String>
     <system:String x:Key="ScreencapFailed">Screencap failed. If it happens repeatedly, try to restart or change the emulator!</system:String>
     <system:String x:Key="FastestWayToScreencap">Fastest screenshot method: {0} ({1:#,#}ms)</system:String>
+    <system:String x:Key="FastestWayToScreencapWarningTip">Screencap takes a long time which may cause some abnormal behaviors using automatic combat functions (e.g. Auto I. S.).</system:String>
+    <system:String x:Key="FastestWayToScreencapErrorTip">Screencap takes too long, so automatic combat functions (e.g. Auto I. S.) may not run properly. It is recommended to try restarting or changing the simulator!</system:String>
     <system:String x:Key="IdentifyTheMistakes">Recognition error</system:String>
     <system:String x:Key="TaskError" xml:space="preserve">Task error: </system:String>
     <system:String x:Key="CombatError">Combat error</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -558,6 +558,8 @@ Bilibili: ログイン インターフェイスに表示されるアカウント
     <system:String x:Key="TouchModeNotAvailable">タッチモードは利用できません。設定-接続設定に入って、他のタッチモードに変更してください。</system:String>
     <system:String x:Key="ScreencapFailed">スクリーンキャプチャに失敗しました。繰り返し発生する場合は、エミュレータの再起動または変更をお試しください！</system:String>
     <system:String x:Key="FastestWayToScreencap">最速のスクリーンショット方法: {0} ({1:#,#}ms)</system:String>
+    <system:String x:Key="FastestWayToScreencapWarningTip">スクリーンキャップには時間がかかるため、自動戦闘機能 (Auto I.S. など) を使用すると異常な動作が発生する可能性があります。</system:String>
+    <system:String x:Key="FastestWayToScreencapErrorTip">スクリーンキャップに時間がかかりすぎるため、自動戦闘機能 (Auto I.S. など) が適切に動作しない可能性があります。 シミュレーターを再起動または変更してみることをお勧めします。</system:String>
     <system:String x:Key="IdentifyTheMistakes">認識エラー</system:String>
     <system:String x:Key="TaskError" xml:space="preserve">タスクエラー: </system:String>
     <system:String x:Key="CombatError">戦闘エラー</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -558,6 +558,8 @@ Bilibili: 로그인 인터페이스에 표시되는 계정 이름(예: 장산)�
     <system:String x:Key="TouchModeNotAvailable">터치 수행 방식이 사용 불가능합니다. 설정 - 연결 설정에서 다른 방식으로 변경해 주세요.</system:String>
     <system:String x:Key="ScreencapFailed">스크린샷 캡처에 실패했습니다. 반복적으로 발생 시 에뮬레이터를 다시 시작하거나 변경해 보세요!</system:String>
     <system:String x:Key="FastestWayToScreencap">가장 빠른 스크린샷 방법: {0} ({1:#,#}ms)</system:String>
+    <system:String x:Key="FastestWayToScreencapWarningTip">스크린샷을 찍는 데 시간이 오래 걸리므로 자동 전투 기능(예: Auto I. S.)을 사용하면 비정상적인 동작이 발생할 수 있습니다.</system:String>
+    <system:String x:Key="FastestWayToScreencapErrorTip">스크린캡쳐 시간이 너무 길어 자동 전투 기능(예: Auto I.S.)이 제대로 실행되지 않을 수 있습니다. 시뮬레이터를 다시 시작하거나 변경해 보는 것이 좋습니다!</system:String>
     <system:String x:Key="IdentifyTheMistakes">인식 오류</system:String>
     <system:String x:Key="TaskError" xml:space="preserve">작업 오류: </system:String>
     <system:String x:Key="CombatError">작전 오류</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -558,6 +558,8 @@
     <system:String x:Key="TouchModeNotAvailable">触控模式不可用。请进入 设置 - 连接设置 切换其他触控模式。</system:String>
     <system:String x:Key="ScreencapFailed">截图失败，如反复出现请尝试重启或更换模拟器！</system:String>
     <system:String x:Key="FastestWayToScreencap">最快截图: {0} ({1:#,#}ms)</system:String>
+    <system:String x:Key="FastestWayToScreencapWarningTip">截图用时较长，使用自动战斗类功能（如自动肉鸽）时，可能出现部分异常表现</system:String>
+    <system:String x:Key="FastestWayToScreencapErrorTip">截图用时过长，自动战斗类功能（如自动肉鸽）很可能无法正常运行，建议尝试重启或更换模拟器</system:String>
     <system:String x:Key="IdentifyTheMistakes">识别错误</system:String>
     <system:String x:Key="TaskError" xml:space="preserve">任务出错: </system:String>
     <system:String x:Key="CombatError">战斗出错</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -558,6 +558,8 @@
     <system:String x:Key="TouchModeNotAvailable">觸控模式不可用。請進入 設定 - 連接設定 切換其他觸控模式。</system:String>
     <system:String x:Key="ScreencapFailed">截圖失敗，如反覆出現請嘗試重開或更換模擬器！</system:String>
     <system:String x:Key="FastestWayToScreencap">最快截圖: {0} ({1:#,#}ms)</system:String>
+    <system:String x:Key="FastestWayToScreencapWarningTip">截圖用時較長，使用自動戰鬥類功能（如自動肉鴿）時，可能會出現部分異常表現</system:String>
+    <system:String x:Key="FastestWayToScreencapErrorTip">截圖用時過長，自動戰鬥類功能（如自動肉鴿）很可能無法正常運行，建議嘗試重新啟動或更換模擬器</system:String>
     <system:String x:Key="IdentifyTheMistakes">辨識錯誤</system:String>
     <system:String x:Key="TaskError" xml:space="preserve">任務出錯: </system:String>
     <system:String x:Key="CombatError">戰鬥出錯</system:String>


### PR DESCRIPTION
- link to #7441

进一步拓展提示，但是单独copilot的时候还不会输出到对应的那边去
GrowlInfo试了下如果MAA不在前台就显示不了，Global信息又会报错（而且位置也不是期望值，给到屏幕右上角去了

![image](https://github.com/MaaAssistantArknights/MaaAssistantArknights/assets/102887808/2d732de1-afc0-4625-b9e6-6ad3d9a8a2c9)
