### PR TITLE
typo: DerpLearning -> DeepLearning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,7 +320,7 @@ jobs:
         working-directory: build
         run: |
           xcodebuild -create-xcframework -library libMaaCore.dylib -headers ../include -output MaaCore.xcframework
-          xcodebuild -create-xcframework -library libMaaDerpLearning.dylib -output MaaDerpLearning.xcframework
+          xcodebuild -create-xcframework -library libMaaDeepLearning.dylib -output MaaDeepLearning.xcframework
           xcodebuild -create-xcframework -library libonnxruntime.*.dylib -output ONNXRuntime.xcframework
           xcodebuild -create-xcframework -library libopencv*.dylib -output OpenCV.xcframework
       - name: Setup GUI Version

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ endif (BUILD_TEST)
 
 find_package(OpenCV REQUIRED COMPONENTS core imgproc imgcodecs videoio)
 find_package(ZLIB REQUIRED)
-find_package(MaaDerpLearning REQUIRED)
+find_package(MaaDeepLearning REQUIRED)
 find_package(asio REQUIRED)
 find_package(ONNXRuntime)
 find_package(cpr CONFIG REQUIRED)
@@ -85,7 +85,7 @@ if(WITH_THRIFT)
     find_package(Thrift CONFIG REQUIRED)
 endif(WITH_THRIFT)
 
-target_link_libraries(MaaCore ${OpenCV_LIBS} MaaDerpLearning asio::asio ZLIB::ZLIB ONNXRuntime::ONNXRuntime cpr::cpr header_only_libraries)
+target_link_libraries(MaaCore ${OpenCV_LIBS} MaaDeepLearning asio::asio ZLIB::ZLIB ONNXRuntime::ONNXRuntime cpr::cpr header_only_libraries)
 
 if(WITH_THRIFT)
     add_subdirectory(src/MaaThriftController)

--- a/cmake/macos.cmake
+++ b/cmake/macos.cmake
@@ -15,13 +15,13 @@ if (BUILD_XCFRAMEWORK)
         COMMAND xcodebuild -create-xcframework -library "${PROJECT_SOURCE_DIR}/MaaDeps/runtime/${MAADEPS_TRIPLET}/libonnxruntime.1.14.1.dylib" -output ONNXRuntime.xcframework
     )
 
-    add_custom_command(OUTPUT MaaDerpLearning.xcframework
-        COMMAND rm -rf MaaDerpLearning.xcframework
-        COMMAND xcodebuild -create-xcframework -library "${PROJECT_SOURCE_DIR}/MaaDeps/runtime/${MAADEPS_TRIPLET}/libMaaDerpLearning.dylib" -output MaaDerpLearning.xcframework
+    add_custom_command(OUTPUT MaaDeepLearning.xcframework
+        COMMAND rm -rf MaaDeepLearning.xcframework
+        COMMAND xcodebuild -create-xcframework -library "${PROJECT_SOURCE_DIR}/MaaDeps/runtime/${MAADEPS_TRIPLET}/libMaaDeepLearning.dylib" -output MaaDeepLearning.xcframework
     )
 
     add_custom_target(MaaXCFramework ALL
-        DEPENDS MaaCore MaaCore.xcframework OpenCV.xcframework ONNXRuntime.xcframework MaaDerpLearning.xcframework
+        DEPENDS MaaCore MaaCore.xcframework OpenCV.xcframework ONNXRuntime.xcframework MaaDeepLearning.xcframework
     )
 endif (BUILD_XCFRAMEWORK)
 

--- a/src/MaaCore/MaaCore.vcxproj
+++ b/src/MaaCore/MaaCore.vcxproj
@@ -514,7 +514,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>MaaDerpLearning.lib;opencv_world4.lib;zlib.lib;ws2_32.lib;onnxruntime.lib;cpr.lib;libcurl.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>MaaDeepLearning.lib;opencv_world4.lib;zlib.lib;ws2_32.lib;onnxruntime.lib;cpr.lib;libcurl.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <UACExecutionLevel>RequireAdministrator</UACExecutionLevel>
       <Profile>true</Profile>
       <AdditionalOptions>/ignore:4286 %(AdditionalOptions)</AdditionalOptions>
@@ -561,7 +561,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>MaaDerpLearning.lib;opencv_world4.lib;zlib.lib;ws2_32.lib;onnxruntime.lib;cpr.lib;libcurl.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>MaaDeepLearning.lib;opencv_world4.lib;zlib.lib;ws2_32.lib;onnxruntime.lib;cpr.lib;libcurl.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <UACExecutionLevel>RequireAdministrator</UACExecutionLevel>
       <Profile>true</Profile>
       <AdditionalOptions>/ignore:4286 %(AdditionalOptions)</AdditionalOptions>
@@ -612,7 +612,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>MaaDerpLearning.lib;opencv_world4.lib;zlib.lib;ws2_32.lib;onnxruntime.lib;cpr.lib;libcurl.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>MaaDeepLearning.lib;opencv_world4.lib;zlib.lib;ws2_32.lib;onnxruntime.lib;cpr.lib;libcurl.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <UACExecutionLevel>RequireAdministrator</UACExecutionLevel>
       <Profile>true</Profile>
       <AdditionalOptions>/ignore:4286 %(AdditionalOptions)</AdditionalOptions>
@@ -666,7 +666,7 @@
       <OptimizeReferences>
       </OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>MaaDerpLearning.lib;opencv_world4d.lib;zlibd.lib;ws2_32.lib;onnxruntime.lib;cpr.lib;libcurl-d.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>MaaDeepLearning.lib;opencv_world4d.lib;zlibd.lib;ws2_32.lib;onnxruntime.lib;cpr.lib;libcurl-d.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <UACExecutionLevel>RequireAdministrator</UACExecutionLevel>
       <Profile>
       </Profile>
@@ -717,7 +717,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>MaaDerpLearning.lib;opencv_world4.lib;zlib.lib;ws2_32.lib;onnxruntime.lib;cpr.lib;libcurl.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>MaaDeepLearning.lib;opencv_world4.lib;zlib.lib;ws2_32.lib;onnxruntime.lib;cpr.lib;libcurl.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <UACExecutionLevel>RequireAdministrator</UACExecutionLevel>
       <Profile>true</Profile>
       <AdditionalOptions>/ignore:4286 %(AdditionalOptions)</AdditionalOptions>
@@ -770,7 +770,7 @@
       <OptimizeReferences>
       </OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>MaaDerpLearning.lib;opencv_world4.lib;zlib.lib;ws2_32.lib;onnxruntime.lib;cpr.lib;libcurl.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>MaaDeepLearning.lib;opencv_world4.lib;zlib.lib;ws2_32.lib;onnxruntime.lib;cpr.lib;libcurl.lib;crypt32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <UACExecutionLevel>RequireAdministrator</UACExecutionLevel>
       <Profile>
       </Profile>

--- a/tools/build_macos_universal.zsh
+++ b/tools/build_macos_universal.zsh
@@ -23,7 +23,7 @@ done
 
 pushd build
 xcodebuild -create-xcframework -library libMaaCore.dylib -headers ../include -output MaaCore.xcframework
-xcodebuild -create-xcframework -library libMaaDerpLearning.dylib -output MaaDerpLearning.xcframework
+xcodebuild -create-xcframework -library libMaaDeepLearning.dylib -output MaaDeepLearning.xcframework
 xcodebuild -create-xcframework -library libonnxruntime.*.dylib -output ONNXRuntime.xcframework
 xcodebuild -create-xcframework -library libopencv*.dylib -output OpenCV.xcframework
 rm -rf *.dylib


### PR DESCRIPTION
Opening this PR to let everyone know that DerpLearning is actually a "meme" and not really professional.

I've spent the entire afternoon trying to find how to change from MaaDeps these files but from what I could find (couldn't find actually) they have been "overwritten" somewhere in the commit history. Nothing bad has happened yet because to build the entire MAA project we are using `TARGET_TAG = "2023-04-24-3"`, but this is not really a solution.

The files are (most of these are already "compiled", as they have been extracted from the tar.xz 2023-04-24-3)
`MaaAssistantArknights\MaaDeps\runtime\maa-x64-windows\MaaDerpLearning.dll`
`MaaAssistantArknights\MaaDeps\runtime\maa-x64-windows\msvc-debug\MaaDerpLearning.dll`
`MaaAssistantArknights\MaaDeps\vcpkg\installed\maa-x64-windows\bin\MaaDerpLearning.dll`
`MaaAssistantArknights\MaaDeps\vcpkg\installed\maa-x64-windows\lib\MaaDerpLearning.lib`
`MaaAssistantArknights\MaaDeps\vcpkg\installed\maa-x64-windows\debug\bin\MaaDerpLearning.dll`
`MaaAssistantArknights\MaaDeps\vcpkg\installed\maa-x64-windows\debug\lib\MaaDerpLearning.lib`
`MaaAssistantArknights\MaaDeps\vcpkg\installed\maa-x64-windows\share\MaaDerpLearning`
`MaaAssistantArknights\MaaDeps\vcpkg\installed\maa-x64-windows\share\MaaDerpLearning\MaaDerpLearningConfig.cmake`
`MaaAssistantArknights\MaaDeps\vcpkg\installed\maa-x64-windows\share\MaaDerpLearning\MaaDerpLearningConfig-release.cmake`

_I'm sorry if I'm like this, it's probably my OCD? I don't know, but ever since I tried MAA (in January 2023) this made me laugh a lot, but also made me think that it needed to be changed, after entering the rabbit hole I'm in a bit of a pickle now, as there doesn't seem to be any way to change this file, unless I can create a new `tar.xz` to be used as a replacement_
