### PR TITLE
ci: 修复smoke-testing重复加载外服和国服资源导致潜在的非预期TaskData字段问题

### DIFF
--- a/.github/workflows/smoke-testing.yml
+++ b/.github/workflows/smoke-testing.yml
@@ -49,6 +49,10 @@ jobs:
         run: |
           MSBUILD src/Cpp/MaaSample.slnf /t:rebuild /p:Configuration="Debug" /p:Platform="x64" /m
 
+      - name: Run tests - Official #用来判断是不是国服资源出错导致外服全炸
+        run: |
+          .\x64\Debug\Sample.exe
+
       - name: Run tests - YoStarJP
         run: |
           .\x64\Debug\Sample.exe YoStarJP

--- a/.github/workflows/smoke-testing.yml
+++ b/.github/workflows/smoke-testing.yml
@@ -49,9 +49,21 @@ jobs:
         run: |
           MSBUILD src/Cpp/MaaSample.slnf /t:rebuild /p:Configuration="Debug" /p:Platform="x64" /m
 
-      - name: Run tests
+      - name: Run tests - YoStarJP
         run: |
-          .\x64\Debug\Sample.exe
+          .\x64\Debug\Sample.exe YoStarJP
+          
+      - name: Run tests - YoStarEN
+        run: |
+          .\x64\Debug\Sample.exe YoStarEN
+        
+      - name: Run tests - YoStarKR
+        run: |
+          .\x64\Debug\Sample.exe YoStarKR
+        
+      - name: Run tests - txwy
+        run: |
+          .\x64\Debug\Sample.exe txwy
 
       - name: Upload logs
         if: always()

--- a/src/Cpp/main.cpp
+++ b/src/Cpp/main.cpp
@@ -20,7 +20,18 @@ int main([[maybe_unused]] int argc, char** argv)
         return -1;
     }
 
-#ifdef ASST_DEBUG
+#ifdef SMOKE_TESTING
+    if (argc >= 2) {
+        std::string overseas_type(argv[1]); // "YoStarJP", "YoStarEN", "YoStarKR", "txwy"
+        std::cout << "load overseas_type:" << overseas_type << std::endl;
+
+        const auto overseas_path = cur_path / "resource" / "global" / overseas_type;
+        if (!AsstLoadResource(overseas_path.string().c_str())) {
+            std::cerr << "-------- load resource failed: " << overseas_type << " --------" << std::endl;
+            return -1;
+        }
+    }
+#elif defined(ASST_DEBUG)
     bool load_error = false;
     const auto overseas_dir = cur_path / "resource" / "global";
     for (const auto& client : { "YoStarJP", "YoStarEN", "YoStarKR", "txwy" }) {

--- a/src/Cpp/main.cpp
+++ b/src/Cpp/main.cpp
@@ -16,7 +16,7 @@ int main([[maybe_unused]] int argc, char** argv)
     // 这里默认读取的是可执行文件同目录下 resource 文件夹里的资源
     bool loaded = AsstLoadResource(cur_path.string().c_str());
     if (!loaded) {
-        std::cerr << "-------- load resource failed --------" << std::endl;
+        std::cerr << "-------- load resource failed: official --------" << std::endl;
         return -1;
     }
 


### PR DESCRIPTION
修复类似 [0291163](https://github.com/MaaAssistantArknights/MaaAssistantArknights/commit/02911638ce49730d3745fd910c250bc31a9cd44c) 的问题

（本地DEBUG就先扔着了