### PR TITLE
ci: 规范化ci文件格式及命名，优化pr-checker的触发逻辑及表现形式

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,42 +3,44 @@ name: ci
 on:
   push:
     tags:
-      - 'v*'
+      - "v*"
     branches-ignore:
-      - 'master'
+      - "master"
     paths:
-      - '3rdparty/include/**'
-      - 'include/**'
-      - 'src/**'
-      - 'cmake/**'
-      - 'CMakeLists.txt'
-      - 'MAA.sln'
-      - '.github/workflows/ci.yml'
-      - '!**/*.md'
+      - "3rdparty/include/**"
+      - "include/**"
+      - "src/**"
+      - "cmake/**"
+      - "CMakeLists.txt"
+      - "MAA.sln"
+      - ".github/workflows/ci.yml"
+      - "!**/*.md"
   pull_request:
     branches:
-      - 'dev'
+      - "dev"
     paths:
-      - '3rdparty/include/**'
-      - 'include/**'
-      - 'src/**'
-      - 'cmake/**'
-      - 'CMakeLists.txt'
-      - 'MAA.sln'
-      - '!**/*.md'
+      - "3rdparty/include/**"
+      - "include/**"
+      - "src/**"
+      - "cmake/**"
+      - "CMakeLists.txt"
+      - "MAA.sln"
+      - "!**/*.md"
   workflow_dispatch:
 
 jobs:
-
   meta:
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.set_tag.outputs.tag }}
       prerelease: ${{ steps.set_pre.outputs.prerelease }}
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v4
         with:
           path: temp
+          show-progress: false
+
       - name: Fetch history
         if: ${{ !startsWith(github.ref, 'refs/pull/') }}
         run: |
@@ -50,13 +52,15 @@ jobs:
           git reset --hard origin/$(git branch --show-current) || true
           git checkout ${{ github.ref_name }}
 
-      - id: set_tag
+      - name: Set tag
+        id: set_tag
         run: |
           ${{ startsWith(github.ref, 'refs/pull/') && 'cd temp' || '' }}
           echo tag=$(git describe --tags --match "v*" ${{ github.ref }} || git rev-parse --short HEAD) | tee -a $GITHUB_OUTPUT
           exit ${PIPESTATUS[0]}
 
-      - id: set_pre
+      - name: Judge pre-release
+        id: set_pre
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         run: |
           if [[ '${{ steps.set_tag.outputs.tag }}' =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
@@ -64,7 +68,9 @@ jobs:
           else
             echo prerelease=true | tee -a $GITHUB_OUTPUT
           fi
-      - if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+
+      - name: Generate changelog
+        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         run: |
           this_tag=${{ steps.set_tag.outputs.tag }}
           if [[ '${{ steps.set_pre.outputs.prerelease }}' != 'false' ]]; then
@@ -74,7 +80,9 @@ jobs:
           fi
           echo >> CHANGELOG.md
           echo "**Full Changelog**: [$last_tag -> $this_tag](https://github.com/MaaAssistantArknights/MaaAssistantArknights/compare/${last_tag}...${this_tag})" >> CHANGELOG.md
-      - uses: actions/upload-artifact@v3
+
+      - name: Upload changelog to Github
+        uses: actions/upload-artifact@v3
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         with:
           name: changelog
@@ -94,7 +102,10 @@ jobs:
     runs-on: windows-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          show-progress: false
 
       - name: Cache .nuke/temp, ~/.nuget/packages
         uses: actions/cache@v3
@@ -113,10 +124,12 @@ jobs:
       - name: Create fake event file
         shell: bash
         run: cp -v "$GITHUB_EVENT_PATH" ./event.json
-      - if: startsWith(github.ref, 'refs/tags/v')
+
+      - name: Merge Event Data with Inputs
+        if: startsWith(github.ref, 'refs/tags/v')
         shell: bash
         run: |
-          cat "$GITHUB_EVENT_PATH" | jq '. + { "inputs": {"ReleaseSimulation": "${{ needs.meta.outputs.tag }}"} }' | tee ./event.json	
+          cat "$GITHUB_EVENT_PATH" | jq '. + { "inputs": {"ReleaseSimulation": "${{ needs.meta.outputs.tag }}"} }' | tee ./event.json
 
       - name: Taggify Version
         run: |
@@ -147,10 +160,14 @@ jobs:
           ./build.cmd DevBuild
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: |
+
+      - name: Cleanup checksum file
+        run: |
           rm -vf ./artifacts/checksum.json
         shell: bash
-      - uses: actions/upload-artifact@v3
+
+      - name: Upload MAA to Github
+        uses: actions/upload-artifact@v3
         with:
           name: MAA-win-${{ matrix.lowercase_target }}
           path: artifacts
@@ -162,8 +179,10 @@ jobs:
       matrix:
         arch: [aarch64, x86_64]
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v4
         with:
+          show-progress: false
           submodules: recursive
 
       - name: Install cross compile toolchains
@@ -184,9 +203,6 @@ jobs:
           python3 maadeps-download.py ${{ matrix.arch == 'x86_64' && 'x64' || 'arm64' }}-linux
 
       - name: Build MAA
-        env:
-          CC: ${{ matrix.arch == 'x86_64' && 'ccache gcc-12' || 'ccache aarch64-linux-gnu-gcc-12' }}
-          CXX: ${{ matrix.arch == 'x86_64' && 'ccache g++-12' || 'ccache aarch64-linux-gnu-g++-12' }}
         run: |
           mkdir -p build
           cmake -B build \
@@ -199,6 +215,9 @@ jobs:
 
           mkdir -p install
           cmake --install build --prefix install
+        env:
+          CC: ${{ matrix.arch == 'x86_64' && 'ccache gcc-12' || 'ccache aarch64-linux-gnu-gcc-12' }}
+          CXX: ${{ matrix.arch == 'x86_64' && 'ccache g++-12' || 'ccache aarch64-linux-gnu-g++-12' }}
 
       - name: Install cross compile tool (CLI)
         if: ${{ matrix.arch != 'x86_64' }}
@@ -207,13 +226,13 @@ jobs:
           tool: cross
 
       - name: Build CLI
-        working-directory: src/maa-cli
-        env:
-          CARGO_CMD: ${{ matrix.arch == 'x86_64' && 'cargo' || 'cross' }}
-          CARGO_BUILD_TARGET: ${{ matrix.arch }}-unknown-linux-gnu
         run: |
           $CARGO_CMD build --release --locked --package maa-cli
           cp -v target/$CARGO_BUILD_TARGET/release/maa $GITHUB_WORKSPACE/install/maa
+        env:
+          CARGO_CMD: ${{ matrix.arch == 'x86_64' && 'cargo' || 'cross' }}
+          CARGO_BUILD_TARGET: ${{ matrix.arch }}-unknown-linux-gnu
+        working-directory: src/maa-cli
 
       - name: Build Appimage
         run: |
@@ -227,7 +246,7 @@ jobs:
           mkdir -pv Maa.AppDir/usr/share/icons/hicolor/512x512/apps/
           cp -v Maa.AppDir/maa.png Maa.AppDir/usr/share/icons/hicolor/512x512/apps/
           chmod a+x Maa.AppDir/usr/share/maa/maa
-          
+
           cat > Maa.AppDir/maa.desktop <<EOF
           [Desktop Entry]
           Type=Application
@@ -238,7 +257,7 @@ jobs:
           Categories=Game;StrategyGame;
           Comment=An Arknights assistant
           EOF
-          
+
           ln -sv usr/share/maa/maa Maa.AppDir/AppRun
           mkdir -pv Maa.AppDir/usr/share/metainfo/
           cp -v tools/AppImage/io.github.maaassistantarknights.maaassistantarknights.metainfo.xml Maa.AppDir/usr/share/metainfo/
@@ -248,13 +267,14 @@ jobs:
           chmod a+x MaaAssistantArknights-${{ matrix.arch }}.AppImage
           mv -v MaaAssistantArknights-${{ matrix.arch }}.AppImage $GITHUB_WORKSPACE/release/MAA-${{ needs.meta.outputs.tag }}-linux-${{ matrix.arch }}.AppImage
 
-      - name: tar files
+      - name: Tar files
         run: |
           mkdir -p release
           cd install
           tar czvf $GITHUB_WORKSPACE/release/MAA-${{ needs.meta.outputs.tag }}-linux-${{ matrix.arch }}.tar.gz .
-      
-      - uses: actions/upload-artifact@v3
+
+      - name: Upload MAA to Github
+        uses: actions/upload-artifact@v3
         with:
           name: MAA-linux-${{ matrix.arch }}
           path: |
@@ -268,90 +288,117 @@ jobs:
       matrix:
         arch: [arm64, x86_64]
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          show-progress: false
+
       - name: Install Dependencies
-        run: brew install ninja
+        run: |
+          brew install ninja
+
       - name: Bootstrap MaaDeps
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           [[ ${{ matrix.arch }} = "arm64" ]] && triplet="arm64-osx" || triplet="x64-osx"
           python3 maadeps-download.py ${triplet}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Configure MaaCore
         run: |
           cmake -B build -GNinja -DCMAKE_BUILD_TYPE=Release -DCMAKE_OSX_ARCHITECTURES='${{ matrix.arch }}' -DMAA_VERSION='${{ needs.meta.outputs.tag }}'
+
       - name: Build MaaCore
         run: |
           cmake --build build
           cmake --install build --prefix install
-      - uses: actions/upload-artifact@v3
+
+      - name: Upload MAA to Github
+        uses: actions/upload-artifact@v3
         with:
           name: MAACore-macos-${{ matrix.arch }}
-          path: 'install/*.dylib'
+          path: "install/*.dylib"
 
   macOS-GUI:
     needs: [meta, macOS-Core]
     runs-on: macos-13
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v4
         with:
+          show-progress: false
           submodules: recursive
-      - uses: actions/download-artifact@v3
+
+      - name: Download Arm64 MAA from Github
+        uses: actions/download-artifact@v3
         with:
           name: MAACore-macos-arm64
           path: install-arm64
-      - uses: actions/download-artifact@v3
+
+      - name: Download x64 MAA from Github
+        uses: actions/download-artifact@v3
         with:
           name: MAACore-macos-x86_64
           path: install-x86_64
+
       - name: Install Developer ID Certificate
         if: startsWith(github.ref, 'refs/tags/v')
         uses: ssrobins/import-codesign-certs@v2
         with:
           p12-file-base64: ${{ secrets.HGUANDL_SIGN_CERT_P12 }}
           p12-password: ${{ secrets.HGUANDL_SIGN_CERT_PASSWD }}
+
       - name: Build Universal Binaries
         run: |
           mkdir build
           for LIB_NAME in $(ls install-arm64); do
             lipo -create install-arm64/$LIB_NAME install-x86_64/$LIB_NAME -output build/$LIB_NAME
           done
+
       - name: Build XCFramework
-        working-directory: build
         run: |
           xcodebuild -create-xcframework -library libMaaCore.dylib -headers ../include -output MaaCore.xcframework
           xcodebuild -create-xcframework -library libMaaDerpLearning.dylib -output MaaDerpLearning.xcframework
           xcodebuild -create-xcframework -library libonnxruntime.*.dylib -output ONNXRuntime.xcframework
           xcodebuild -create-xcframework -library libopencv*.dylib -output OpenCV.xcframework
+        working-directory: build
+
       - name: Setup GUI Version
         run: |
           RELEASE_COUNT=$(git ls-remote --tags origin | grep refs/tags/v | awk 'END{print NR}')
           echo 'MARKETING_VERSION = ${{ needs.meta.outputs.tag }}' | tee src/MaaMacGui/Version.xcconfig
           echo 'CURRENT_PROJECT_VERSION = '"${RELEASE_COUNT}" | tee -a src/MaaMacGui/Version.xcconfig
+
       - name: Build MAA
-        working-directory: src/MaaMacGui
         run: |
           if ${{ startsWith(github.ref, 'refs/tags/v') }}; then
             xcodebuild -project MeoAsstMac.xcodeproj -scheme MAA archive -archivePath MAA.xcarchive -configuration Release
           else
             xcodebuild CODE_SIGN_IDENTITY="-" DEVELOPMENT_TEAM="-" ONLY_ACTIVE_ARCH=NO -project MeoAsstMac.xcodeproj -scheme MAA archive -archivePath MAA.xcarchive -configuration Debug
           fi
+        working-directory: src/MaaMacGui
+
       - name: Export MAA
         if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          xcodebuild -exportArchive -archivePath MAA.xcarchive -exportOptionsPlist ExportOptions.plist -exportPath Export
         working-directory: src/MaaMacGui
-        run: xcodebuild -exportArchive -archivePath MAA.xcarchive -exportOptionsPlist ExportOptions.plist -exportPath Export
+
       - name: Create Disk Image
         if: startsWith(github.ref, 'refs/tags/v')
-        working-directory: src/MaaMacGui
         run: |
           mkdir Image
           mv Export/MAA.app Image/
           ln -s /Applications Image/
           hdiutil create -volname MAA -srcfolder Image -ov -fs APFS -format ULMO MAA.dmg
+        working-directory: src/MaaMacGui
+
       - name: Archive Debug Symbols
         if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          ditto -c -k --keepParent MAA.app.dSYM MAA.app.dSYM.zip
         working-directory: src/MaaMacGui/MAA.xcarchive/dSYMs
-        run: ditto -c -k --keepParent MAA.app.dSYM MAA.app.dSYM.zip
+
       - name: Place Packages
         if: startsWith(github.ref, 'refs/tags/v')
         run: |
@@ -361,20 +408,23 @@ jobs:
           mkdir -p release
           mv src/MaaMacGui/MAA.dmg release/${APP_DMG}
           mv src/MaaMacGui/MAA.xcarchive/dSYMs/MAA.app.dSYM.zip release/${APP_SYM}
+
       - name: Notarize Image
         if: startsWith(github.ref, 'refs/tags/v')
-        env:
-          NOTARY_USER: ${{ secrets.HGUANDL_NOTARY_AAPL_ID }}
-          NOTARY_PASSWD: ${{ secrets.HGUANDL_NOTARY_PASSWD }}
-          NOTARY_TEAM: ${{ secrets.HGUANDL_SIGN_IDENTITY }}
-        working-directory: release
         run: |
           find . -name "*.dmg" | while read dmg; do
             codesign -s "$NOTARY_TEAM" --timestamp ${dmg}
             xcrun notarytool submit --apple-id "$NOTARY_USER" --password "$NOTARY_PASSWD" --team-id "$NOTARY_TEAM" --wait ${dmg}
             xcrun stapler staple ${dmg}
           done
-      - uses: actions/upload-artifact@v3
+        env:
+          NOTARY_USER: ${{ secrets.HGUANDL_NOTARY_AAPL_ID }}
+          NOTARY_PASSWD: ${{ secrets.HGUANDL_NOTARY_PASSWD }}
+          NOTARY_TEAM: ${{ secrets.HGUANDL_SIGN_IDENTITY }}
+        working-directory: release
+
+      - name: Upload MAA to Github
+        uses: actions/upload-artifact@v3
         with:
           name: MAA-macos-universal
           path: ${{ startsWith(github.ref, 'refs/tags/v') && 'release/MAA*' || 'src/MaaMacGui/MAA.xcarchive/**' }}
@@ -384,23 +434,29 @@ jobs:
     needs: [meta, windows, ubuntu, macOS-GUI]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v3
+      - name: Download MAA from Github
+        uses: actions/download-artifact@v3
         with:
           path: assets
-      - run: |
+
+      - name: Cleanup files
+        run: |
           mv -vf assets/changelog/* .
           rm -rf assets/MAACore-macos-*
           cd assets
           # find . -type f | xargs mv -fvt .
           find . -type f | while read f; do mv -fvt . $f; done
-      - uses: softprops/action-gh-release@v1
+
+      - name: Release to Github
+        uses: softprops/action-gh-release@v1
         with:
           body_path: CHANGELOG.md
           files: |
             assets/*
           prerelease: ${{ needs.meta.outputs.prerelease != 'false' }}
+
       - name: Trigger secondary workflows # ref: https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow
         run: |
           gh workflow run --repo $GITHUB_REPOSITORY release-ota
         env:
-            GH_TOKEN: ${{ secrets.MISTEOWORKFLOW }}
+          GH_TOKEN: ${{ secrets.MISTEOWORKFLOW }}

--- a/.github/workflows/docs-build-test.yml
+++ b/.github/workflows/docs-build-test.yml
@@ -1,18 +1,18 @@
 name: Build Test for docs
 
 on:
-    push:
-      branches-ignore:
-        - 'master'
-      paths:
-        - 'docs/**'
-    pull_request:
-      branches:
-        - 'dev'
-      paths:
-        - 'docs/**'
-    workflow_dispatch:
-  
+  push:
+    branches-ignore:
+      - "master"
+    paths:
+      - "docs/**"
+  pull_request:
+    branches:
+      - "dev"
+    paths:
+      - "docs/**"
+  workflow_dispatch:
+
 jobs:
   build-test:
     timeout-minutes: 20
@@ -28,23 +28,23 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'npm'
-          cache-dependency-path: './docs/package-lock.json'
+          cache: "npm"
+          cache-dependency-path: "./docs/package-lock.json"
 
       - name: Install dependencies
         run: npm ci
-        working-directory: './docs'
+        working-directory: "./docs"
 
       - name: Cleanup files
         run: rm tsconfig.json
-        working-directory: './docs'
+        working-directory: "./docs"
 
       - name: Build
         run: npm run build
-        working-directory: './docs'
+        working-directory: "./docs"
 
       - name: Upload artifact to GitHub
         uses: actions/upload-artifact@v3
         with:
           name: docs
-          path: './docs/.vuepress/dist'
+          path: "./docs/.vuepress/dist"

--- a/.github/workflows/gen-changelog.yml
+++ b/.github/workflows/gen-changelog.yml
@@ -10,16 +10,18 @@ jobs:
     if: github.event.pull_request.draft == false && (startsWith(github.event.pull_request.title, 'Release v') || startsWith(github.event.pull_request.title, 'release v'))
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          show-progress: false
 
       - name: Extract tag name
         id: extract_tag
         run: |
           tag_name=$(echo "${{ github.event.pull_request.title }}" | sed -E 's/(Release|release)//' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
           echo "tag_name=$tag_name" >> $GITHUB_OUTPUT
-          
+
           pr_title="docs: Auto Update Changelogs of "$tag_name
           echo "pr_title=$pr_title" >> $GITHUB_OUTPUT
 
@@ -39,16 +41,16 @@ jobs:
           cat $GITHUB_OUTPUT
 
       - name: Generate Changelog
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git switch dev
           python3 tools/ChangelogGenerator/changelog_generator.py --tag "${{ steps.extract_tag.outputs.tag_name }}" --latest "${{ steps.extract_tag.outputs.latest }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Add files to git
         run: |
           git status
-          
+
           git config user.name "$GITHUB_ACTOR"
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
           git add .
@@ -62,6 +64,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           title: ${{ steps.extract_tag.outputs.pr_title }}
           body: ${{ github.event.pull_request.html_url }}
-          base: 'dev'
-          branch: 'changelog'
+          base: "dev"
+          branch: "changelog"
           delete-branch: true

--- a/.github/workflows/issue-checker.yml
+++ b/.github/workflows/issue-checker.yml
@@ -16,9 +16,9 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: zzyyyl/issue-checker@v1.7
-      with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        configuration-path: .github/issue-checker.yml
-        not-before: 2022-08-05T00:00:00Z
-        include-title: 1
+      - uses: zzyyyl/issue-checker@v1.7
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          configuration-path: .github/issue-checker.yml
+          not-before: 2022-08-05T00:00:00Z
+          include-title: 1

--- a/.github/workflows/pr-auto-tag.yml
+++ b/.github/workflows/pr-auto-tag.yml
@@ -18,10 +18,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout code
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.MAARELEASE_RELEASE }}
+
       - name: Git config
         run: |
           git config user.name "$GITHUB_ACTOR"

--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -36,7 +36,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.payload.pull_request.number,
-                body: `Invalid commit(s) found:\n\n${invalidCommitInfoList}`
+                body: `Invalid commit(s) found:\n\n${invalidCommitInfoList}\nPlease follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format.`
               });
 
               core.setFailed(`Invalid commit(s) found: ${invalidCommitNames.join(", ")}`);

--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -20,12 +20,12 @@ jobs:
               repo: context.repo.repo,
               pull_number: context.payload.pull_request.number
             });
-            
+
             const regex = /^((build|chore|ci|docs?|feat|fix|perf|refactor|rft|style|test|i18n)[\:\.\(\,]|[Rr]evert|[Rr]elease)/;
             const invalidCommits = commits.filter(commit => !regex.test(commit.commit.message) || commit.parents.length > 1);
-            
+
             console.log(`check ${commits.length} commit(s)`);
-            
+
             if (invalidCommits.length > 0) {
               const invalidCommitNames = invalidCommits.map(commit => commit.commit.message);
               core.setFailed(`Invalid commit found: ${invalidCommitNames.join(", ")}`);

--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   check_commit_name_in_pr:
-    if: github.head_ref != 'dev'
+    if: ${{ !github.event.pull_request.merged }}
     runs-on: ubuntu-latest
     steps:
       - name: Check Commits

--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -4,11 +4,13 @@ on:
   pull_request:
     types: [opened, edited, ready_for_review, reopened, synchronize]
 
+permissions:
+  pull-requests: write
+
 jobs:
   check_commit_name_in_pr:
     if: github.head_ref != 'dev'
     runs-on: ubuntu-latest
-
     steps:
       - name: Check Commits
         uses: actions/github-script@v7
@@ -21,12 +23,21 @@ jobs:
               pull_number: context.payload.pull_request.number
             });
 
-            const regex = /^((build|chore|ci|docs?|feat|fix|perf|refactor|rft|style|test|i18n)[\:\.\(\,]|[Rr]evert|[Rr]elease)/;
+            const regex = /^((build|chore|ci|docs?|feat|fix|perf|refactor|rft|style|test|i18n|typo)[\:\.\(\,]|[Rr]evert|[Rr]elease)/;
             const invalidCommits = commits.filter(commit => !regex.test(commit.commit.message) || commit.parents.length > 1);
 
-            console.log(`check ${commits.length} commit(s)`);
+            console.log(`Check ${commits.length} commit(s)`);
 
             if (invalidCommits.length > 0) {
               const invalidCommitNames = invalidCommits.map(commit => commit.commit.message);
-              core.setFailed(`Invalid commit found: ${invalidCommitNames.join(", ")}`);
+              const invalidCommitInfoList = invalidCommits.map(commit => `- ${commit.commit.message} [\`${commit.sha.substring(0, 7)}\`](${commit.html_url})`).join("\n");
+
+              github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body: `Invalid commit(s) found:\n\n${invalidCommitInfoList}`
+              });
+
+              core.setFailed(`Invalid commit(s) found: ${invalidCommitNames.join(", ")}`);
             }

--- a/.github/workflows/qodana.yml
+++ b/.github/workflows/qodana.yml
@@ -4,20 +4,20 @@ on:
   workflow_dispatch:
   pull_request: # 在 PR 更新的场合进行扫描
     paths:
-      - '.github/workflows/qodana.yml'
-      - 'src/MaaWpfGui/*'
-      - 'qodana.yaml'
-      - 'src/MaaWpfGui/**'
-      - 'MAA.sln'
-  push:  # 在主分支推送代码的场合进行扫描
+      - ".github/workflows/qodana.yml"
+      - "src/MaaWpfGui/*"
+      - "qodana.yaml"
+      - "src/MaaWpfGui/**"
+      - "MAA.sln"
+  push: # 在主分支推送代码的场合进行扫描
     branches:
       - master
-      - 'releases/*'
+      - "releases/*"
       - dev
     paths:
-      - '.github/workflows/qodana.yml'
-      - 'src/MaaWpfGui/**'
-      - 'qodana.yaml'
+      - ".github/workflows/qodana.yml"
+      - "src/MaaWpfGui/**"
+      - "qodana.yaml"
 
 permissions:
   contents: write
@@ -31,8 +31,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}  # to check out the actual pull request commit, not the merge commit
-          fetch-depth: 0  # a full history is required for pull request analysis
+          ref: ${{ github.event.pull_request.head.sha }} # to check out the actual pull request commit, not the merge commit
+          fetch-depth: 0 # a full history is required for pull request analysis
           show-progress: false
 
       - name: Qodana Scan

--- a/.github/workflows/release-nightly-ota.yml
+++ b/.github/workflows/release-nightly-ota.yml
@@ -4,26 +4,25 @@ on:
   workflow_dispatch:
     inputs:
       release_body:
-        description: 'Release note'
+        description: "Release note"
         type: string
         required: false
       ref:
-        description: 'Commit to build (git checkout)'
+        description: "Commit to build (git checkout)"
         type: string
         required: false
       limit:
-        description: 'Number of releases to fetch from MaaAssistantArknights'
+        description: "Number of releases to fetch from MaaAssistantArknights"
         required: true
         default: 30
         type: number
       limit_2:
-        description: 'Number of releases to fetch from MaaRelease'
+        description: "Number of releases to fetch from MaaRelease"
         required: true
         default: 30
         type: number
 
 jobs:
-
   build-win-nightly:
     runs-on: windows-latest
     strategy:
@@ -39,19 +38,23 @@ jobs:
       pre_version: ${{ steps.set_tag.outputs.pre_version }}
       main_tag_name: ${{ steps.push_main_tag.outputs.main_tag_name }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # repository: 'MaaAssistantArknights/MaaAssistantArknights'
           submodules: recursive
           #ref: ${{ inputs.ref }}
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
+          show-progress: false
+
       - name: Checkout ref
         run: |
           if ("${{ inputs.ref }}" -ne "") {
             git checkout --progress --recurse-submodules ${{ inputs.ref || 'dev' }}
           }
-      - run: |
+
+      - name: Install semver
+        run: |
           npm install --global --progress semver
 
       - name: Set tag
@@ -81,7 +84,7 @@ jobs:
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
-          
+
           $main_tag_name=$(echo "alpha/${{ steps.set_tag.outputs.tag }}")
           git tag $main_tag_name -f
           git push --tags origin HEAD:refs/tags/$main_tag_name -f
@@ -94,11 +97,13 @@ jobs:
             .nuke/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj') }}
+
       - name: Bootstrap MaaDeps
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           python3 maadeps-download.py ${{ matrix.lowercase_target }}-windows
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Run './build.cmd DevBuild'
         run: |
           $env:GITHUB_WORKFLOW = 'dev-build-win' # pretend this is a dev-build-win workflow
@@ -107,24 +112,27 @@ jobs:
 
           ./build.cmd DevBuild
         env:
-          Reason: 'Build nightly version'
+          Reason: "Build nightly version"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/upload-artifact@v3
+
+      - name: Upload MAA to Github
+        uses: actions/upload-artifact@v3
         with:
           name: MAA-win-${{ matrix.lowercase_target }}
           path: artifacts
-
 
   push-tag:
     needs: build-win-nightly
     runs-on: ubuntu-latest
     steps:
       - name: Fetch MaaRelease
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ format('{0}/{1}', github.repository_owner, 'MaaRelease') }}
           fetch-depth: 0
           token: ${{ secrets.MAARELEASE_RELEASE }}
+          show-progress: false
+
       - name: Commit and setup tag
         run: |
           git config user.name 'github-actions[bot]'
@@ -142,21 +150,26 @@ jobs:
         target: [x64]
     runs-on: ubuntu-latest
     steps:
-      - run: echo ${{ needs.build-win-nightly.outputs.tag }}
-      - uses: actions/checkout@v3
+      - name: Echo tag version
+        run: |
+          echo ${{ needs.build-win-nightly.outputs.tag }}
+
+      - name: Checkout code
+        uses: actions/checkout@v4
         with:
           path: MaaAssistantArknights
           token: ${{ secrets.MAARELEASE_RELEASE }}
-      - uses: actions/download-artifact@v3
+          show-progress: false
+
+      - name: Download MAA from Github
+        uses: actions/download-artifact@v3
         with:
           name: MAA-win-${{ matrix.target }}
           path: ${{ format('{0}/{1}', 'build-ota', needs.build-win-nightly.outputs.tag) }}
+
       - name: Fetch release info
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           mkdir -pv build-ota && cd build-ota
-
 
           gh release list --repo 'MaaAssistantArknights/MaaAssistantArknights' --limit ${{ inputs.limit || 30 }} | tee ./release_maa.txt
           gh release list --repo "${{ github.repository_owner }}/MaaRelease" --limit ${{ inputs.limit_2 || 30 }} | tee ./release_mr.txt
@@ -171,9 +184,10 @@ jobs:
           cat ./config
 
           echo "release_tag=$(head -n 1 ./config)" >> $GITHUB_ENV
-      - name: Build OTA
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build OTA
         run: |
           cd build-ota
 
@@ -184,6 +198,8 @@ jobs:
 
           $GITHUB_WORKSPACE/MaaAssistantArknights/tools/OTAPacker/build.sh 'MaaAssistantArknights/MaaAssistantArknights' ./config ${{ matrix.target }} "${{ github.repository_owner }}/MaaRelease"
           mv -v ${{ needs.build-win-nightly.outputs.tag }}/*.zip ./MAA-${{ env.release_tag }}-win-${{ matrix.target }}.zip
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Make release body
         id: make_release_body
@@ -193,7 +209,7 @@ jobs:
           cur_version=${{ needs.build-win-nightly.outputs.main_tag_name }}
           echo -e "${{ inputs.release_body || '' }}\n\n**Full Changelog**: [$pre_version -> $cur_version](https://github.com/$GITHUB_REPOSITORY/compare/$pre_version...$cur_version)" > alpha_changelog.md
           export r=$(cat alpha_changelog.md)
-          
+
           # https://github.com/svenstaro/upload-release-action
           r="${r//'%'/'%25'}"                               # Multiline escape sequences for %
           r="${r//$'\n'/'%0A'}"                             # Multiline escape sequences for '\n'
@@ -215,6 +231,6 @@ jobs:
 
       - name: Setup release mirror
         run: |
-            gh workflow --repo MaaAssistantArknights/MaaRelease run release-mirrors.yml
+          gh workflow --repo MaaAssistantArknights/MaaRelease run release-mirrors.yml
         env:
-            GH_TOKEN: ${{ secrets.MISTEOWORKFLOW }}
+          GH_TOKEN: ${{ secrets.MISTEOWORKFLOW }}

--- a/.github/workflows/release-ota.yml
+++ b/.github/workflows/release-ota.yml
@@ -2,7 +2,7 @@ name: release-ota
 
 on:
   release:
-    types: 
+    types:
       - published
   workflow_dispatch:
     inputs:
@@ -31,6 +31,7 @@ jobs:
           path: MaaRelease
           fetch-depth: 0
           token: ${{ secrets.MAARELEASE_RELEASE }}
+
       - name: Fetch release info
         id: fetchReleaseInfo
         run: |
@@ -49,6 +50,7 @@ jobs:
 
           echo "prerelease=$([ $(head -n 1 release_maa.txt | awk '{ print $2}') = 'Pre-release' ] && echo true || echo false)" >> $GITHUB_OUTPUT
           echo "release_tag=$(head -n 1 ./config)" >> $GITHUB_OUTPUT
+
       - name: Commit and setup tag
         run: |
           cd MaaRelease
@@ -61,10 +63,13 @@ jobs:
           git push --tags
         env:
           PUSH_REMOTE: https://github-actions[bot]:${{ secrets.MAARELEASE_RELEASE }}@github.com/${{ github.repository_owner }}/MaaRelease
-      - uses: actions/upload-artifact@v3
+
+      - name: Upload release config to GitHub
+        uses: actions/upload-artifact@v3
         with:
           name: MaaReleaseConfig
           path: ./build-ota/config
+
     outputs:
       prerelease: ${{ steps.fetchReleaseInfo.outputs.prerelease }}
       release_tag: ${{ steps.fetchReleaseInfo.outputs.release_tag }}
@@ -73,11 +78,13 @@ jobs:
     needs: create-tag
     runs-on: ubuntu-latest
     strategy:
-      matrix: 
-        target: 
+      matrix:
+        target:
           - x64
     steps:
-      - uses: actions/download-artifact@v3
+      - name: Download release config
+        uses: actions/download-artifact@v3
+
       - name: Fetch MaaRelease
         uses: actions/checkout@v3
         with:
@@ -85,19 +92,24 @@ jobs:
           path: MaaRelease
           fetch-depth: 0
           token: ${{ secrets.MAARELEASE_RELEASE }}
-      - uses: actions/checkout@v3
+
+      - name: Checkout code
+        uses: actions/checkout@v3
         with:
           path: MaaAssistantArknights
+
       - name: Download latest version for server
         run: |
           mkdir -pv build-ota/${{ needs.create-tag.outputs.release_tag }}
           cd build-ota/${{ needs.create-tag.outputs.release_tag }}
           gh release download ${{ needs.create-tag.outputs.release_tag }} --repo 'MaaAssistantArknights/MaaAssistantArknights' --pattern "MAA-${{ needs.create-tag.outputs.release_tag }}-win-${{ matrix.target }}.zip" --clobber
           cp *.zip ..
+
       - name: Build OTA
         run: |
           cd build-ota
           $GITHUB_WORKSPACE/MaaAssistantArknights/tools/OTAPacker/build.sh 'MaaAssistantArknights/MaaAssistantArknights' ../MaaReleaseConfig/config ${{ matrix.target }} 'MaaAssistantArknights/MaaRelease'
+
       - name: Upload to MaaRelease
         uses: svenstaro/upload-release-action@v2
         with:
@@ -115,6 +127,7 @@ jobs:
     steps:
       - name: Fetch release info
         run: gh release list --repo 'MaaAssistantArknights/MaaAssistantArknights' --limit ${{ inputs.limit || 31 }} | tee ./release_maa.txt
+
       - name: Download release packages
         run: |
           cat ./release_maa.txt | awk '{ print $1 }' | while read tag; do
@@ -123,8 +136,11 @@ jobs:
             gh api /markdown -f text="$RELEASE_NOTES" | tee ./packages/MAA-"$tag"-macos-universal.html
           done
           curl -fsSL -o packages/appcast.xml https://maa-release.hguandl.com/macos/appcast.xml
+
       - name: Setup Sparkle
-        run: gh release download --repo 'sparkle-project/Sparkle' --clobber -O - -p 'Sparkle-*.tar.xz' | tar xf -
+        run: |
+          gh release download --repo 'sparkle-project/Sparkle' --clobber -O - -p 'Sparkle-*.tar.xz' | tar xf -
+
       - name: Generate Update Packages
         run: |
           if [ $(head -n 1 release_maa.txt | awk '{ print $2 }') = 'Pre-release' ]; then
@@ -132,8 +148,11 @@ jobs:
           else
             echo ${{ secrets.SPARKLE_PRIV_KEY }} | ./bin/generate_appcast --ed-key-file - ./packages
           fi
+
       - name: Cleanup files
-        run: find ./packages -type f ! \( -name 'MAA-${{ needs.create-tag.outputs.release_tag }}-macos-universal.dmg' -o -name '*.delta' -o -name '*.xml' \) -print -delete
+        run: |
+          find ./packages -type f ! \( -name 'MAA-${{ needs.create-tag.outputs.release_tag }}-macos-universal.dmg' -o -name '*.delta' -o -name '*.xml' \) -print -delete
+
       - name: Unpack the .dmg files for .dylib
         run: |
           cd ${{ runner.temp }}
@@ -158,6 +177,7 @@ jobs:
           echo ::group::Detaching release package...
           hdiutil detach /Volumes/MAA
           echo ::endgroup::
+
       - name: Upload to MaaRelease
         uses: svenstaro/upload-release-action@v2
         with:
@@ -170,7 +190,7 @@ jobs:
           overwrite: true
 
   release:
-    needs: 
+    needs:
       - make-ota
       - make-ota-mac
     runs-on: ubuntu-latest
@@ -180,6 +200,7 @@ jobs:
       - name: Setup release mirror
         run: |
           gh workflow --repo MaaAssistantArknights/MaaRelease run release-mirrors.yml
+
       - name: Deploy docs
         run: |
           mkdir -p ${{ runner.temp }}/new

--- a/.github/workflows/res-update-game.yml
+++ b/.github/workflows/res-update-game.yml
@@ -17,21 +17,25 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.MISTEOWORKFLOW }}
     steps:
-      - uses: actions/checkout@v4
-        name: Checkout MAA
+      - name: Checkout MAA
+        uses: actions/checkout@v4
         with:
           show-progress: false
           token: ${{ secrets.MISTEOWORKFLOW }}
+
       - name: Bootstrap MaaDeps
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           python3 maadeps-download.py x64-windows
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1
+
       - name: Build Resource Updater
         run: |
           MSBUILD tools/ResourceUpdater/ResourceUpdater.vcxproj /t:rebuild /p:Configuration="Release" /p:Platform="x64" /p:BuildProjectReferences=false /m
+
       - name: Clone ArknightsGameResource for Official
         uses: actions/checkout@v4
         with:
@@ -44,6 +48,7 @@ jobs:
             item
             building_skill
             gamedata/excel
+
       - name: Clone ArknightsGameResource_Yostar for Overseas
         uses: actions/checkout@v4
         with:
@@ -55,6 +60,7 @@ jobs:
             en_US/gamedata/excel
             ja_JP/gamedata/excel
             ko_kr/gamedata/excel
+
       - name: Clone arknights-toolbox-update for Taiwan
         uses: actions/checkout@v4
         with:
@@ -63,12 +69,15 @@ jobs:
           ref: data-tw
           path: .\tools\ResourceUpdater\x64\Release\Overseas\zh_TW\gamedata\excel
           token: ${{ secrets.ARKNTOOLS_MAA_RESOURCE_UPDATER}}
+
       - name: Run Resource Updater
         run: |
           .\tools\ResourceUpdater\x64\Release\ResourceUpdater.exe
+
       - name: Overseas Tasks Ordering
         run: |
           python3 tools/TaskSorter/TaskSorter.py
+
       - name: Check if only sorted
         id: check_only_sorted
         run: |

--- a/.github/workflows/smoke-testing.yml
+++ b/.github/workflows/smoke-testing.yml
@@ -3,46 +3,52 @@ name: test
 on:
   push:
     paths:
-      - '3rdparty/include/**'
-      - 'include/**'
-      - 'src/**'
-      - 'cmake/**'
-      - 'CMakeLists.txt'
-      - 'MAA.sln'
-      - 'resource/**'
-      - 'MaaDeps/**'
-      - '!**/*.md'
+      - "3rdparty/include/**"
+      - "include/**"
+      - "src/**"
+      - "cmake/**"
+      - "CMakeLists.txt"
+      - "MAA.sln"
+      - "resource/**"
+      - "MaaDeps/**"
+      - "!**/*.md"
   pull_request:
     paths:
-      - '3rdparty/include/**'
-      - 'include/**'
-      - 'src/**'
-      - 'cmake/**'
-      - 'CMakeLists.txt'
-      - 'MAA.sln'
-      - 'resource/**'
-      - 'MaaDeps/**'
-      - '!**/*.md'
+      - "3rdparty/include/**"
+      - "include/**"
+      - "src/**"
+      - "cmake/**"
+      - "CMakeLists.txt"
+      - "MAA.sln"
+      - "resource/**"
+      - "MaaDeps/**"
+      - "!**/*.md"
   workflow_dispatch:
 
 jobs:
   smoke-testing:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v3
-      
-      - uses: NuGet/setup-nuget@v1.2.0
-      - run: |
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          show-progress: false
+
+      - name: Setup NuGet
+        uses: NuGet/setup-nuget@v1.2.0
+
+      - name: Restore NuGet packages
+        run: |
           nuget restore MAA.sln
           if ($LASTEXITCODE) { nuget restore MAA.sln }
           if ($LASTEXITCODE) { nuget restore MAA.sln }
-      
+
       - name: Bootstrap MaaDeps
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           python3 maadeps-download.py x64-windows
-          
+
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1
       - name: Build MaaSample

--- a/.github/workflows/sync-resource.yml
+++ b/.github/workflows/sync-resource.yml
@@ -6,27 +6,33 @@ on:
     branches:
       - dev
     paths:
-      - 'resource/**'
-      - '.github/workflows/sync-resource.yml'
+      - "resource/**"
+      - ".github/workflows/sync-resource.yml"
 
 jobs:
   sync-reource:
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout MaaAssistantArknights
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
+        with:
+          show-progress: false
+
       - name: Setup Git
         run: |
           git config --global user.name "$GITHUB_ACTOR"
           git config --global user.email "$GITHUB_ACTOR@users.noreply.github.com"
           git show -s
+
       - name: Checkout MaaResource
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
         with:
           repository: MaaAssistantArknights/MaaResource
+          show-progress: false
           ssh-key: ${{secrets.MAA_RESOURCE_DEPLOY}}
           path: MaaResource
+
       - name: Update MaaResource
         run: |
           export commit_msg=$(git show -s --format=%s)
@@ -37,11 +43,12 @@ jobs:
           rm -rf !(".gitignore")
           cp -rf ../../resource/* .
           cd ..
-          
+
           git add .
           git status
           git commit -m "$commit_msg" || exit 0
           git push
+
       - name: Setup resource update
         env:
           GH_TOKEN: ${{ secrets.MISTEOWORKFLOW }}


### PR DESCRIPTION
+ 给所有 ci 文件的每一个 step 都添加了名字，并且做了格式化
+ 现在 pr-checker 的触发机制应该是正常的了
先前不正常的原因是：PR被合并后会触发synchronize事件，此时获取的comimits是merge后分支内的commit，加一个检查就可以跳过这种情况了
+ 给 pr-checker 添加了 issue 评论，现在不合规的 commit 将会由 github-action bot 做出评论
大致效果：
<img width="696" alt="image" src="https://github.com/MaaAssistantArknights/MaaAssistantArknights/assets/57581480/dbe3aba2-a3d8-422c-92cf-17627604849d">

