### PR TITLE
chore: 更新Qodana，将 csproj 中的 Xml相关的错误/editorconfig错误 忽略

### DIFF
--- a/qodana.yaml
+++ b/qodana.yaml
@@ -22,8 +22,14 @@ exclude:
       - vsts/QodanaScan
       - src/MaaWpfGui/Views
       - src/MaaCore
+      - .editorconfig
+      - src/MaaWpfGui/MaaWpfGui.csproj
+      - src/MaaWpfGui/app.manifest
+      - src/MaaWpfGui/MeoAsstGui.csproj.DotSettings
   - name: CppUnreachableCode
   - name: CppUnusedIncludeDirective
   - name: Xaml.RedundantNamespaceAlias
   - name: ArrangeTrailingCommaInMultilineLists
   - name: ArrangeTrailingCommaInSinglelineLists
+  - name: EditorConfigKeyCorrectness
+  - name: EditorConfigNoMatchingFiles

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -22,7 +22,6 @@ exclude:
       - vsts/QodanaScan
       - src/MaaWpfGui/Views
       - src/MaaCore
-      - .editorconfig
       - src/MaaWpfGui/MaaWpfGui.csproj
       - src/MaaWpfGui/app.manifest
       - src/MaaWpfGui/MeoAsstGui.csproj.DotSettings


### PR DESCRIPTION
如题

在更新 Qodana 版本后，增加了对于 Xml 和 EditorConfig的检查(详见： https://qodana.cloud/projects/3P0oy/reports/bdXLa )

这些检查是我们暂时不会处理的，于是将其加入基线。