### PR TITLE
fix: 修复肉鸽烧水逻辑错误、肉鸽卡在第三层 boss 等策略相关问题

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -3791,13 +3791,6 @@
             "MainThemes#next"
         ]
     },
-    "NextOnce": {
-        "algorithm": "JustReturn",
-        "next": [
-            "#next",
-            "Stop"
-        ]
-    },
     "LoadingText": {
         "algorithm": "OcrDetect",
         "action": "DoNothing",
@@ -9108,8 +9101,7 @@
         "Doc_2": "需要在任务 Task 开始时截图时，将 Task 加入到此任务的 next 列表。",
         "algorithm": "JustReturn",
         "next": [
-            "Roguelike@StageEncounterOptionUnknown",
-            "StrategyChanges@Stop"
+            "Roguelike@StageEncounterOptionUnknown"
         ]
     },
     "ScreenshotTaskPlugin-Config-Debug": {
@@ -11755,8 +11747,9 @@
             245,
             144
         ],
+        "postDelay": 1000,
         "sub": [
-            "Roguelike@StrategyChanges@NextOnce"
+            "Roguelike@StrategyChange"
         ],
         "next": [
             "Roguelike@Stages#next"
@@ -12744,16 +12737,8 @@
         ]
     },
     "Roguelike@StrategyChange": {
-        "baseTask": "Roguelike@StrategyChange_default"
-    },
-    "Roguelike@StrategyChangeAtNextLevel": {
-        "baseTask": "Roguelike@StrategyChange",
-        "roi": [
-            522,
-            431,
-            245,
-            144
-        ]
+        "baseTask": "Roguelike@StrategyChange_default",
+        "Doc": "占位任务，实际用到的是带 theme 前缀的任务"
     },
     "Roguelike@StrategyChange_default": {
         "algorithm": "OcrDetect",
@@ -12776,13 +12761,6 @@
     },
     "Roguelike@StrategyChange_mode4": {
         "baseTask": "Roguelike@StrategyChange_default"
-    },
-    "Roguelike@StrategyChanges": {
-        "algorithm": "JustReturn",
-        "next": [
-            "Roguelike@StrategyChangeAtNextLevel",
-            "Roguelike@StrategyChange"
-        ]
     },
     "Roguelike@TempRecruitFlag": {
         "action": "DoNothing",
@@ -13423,20 +13401,26 @@
         ],
         "templThreshold": 0.95,
         "postDelay": 1000,
-        "sub": [
-            "Mizuki@Roguelike@StrategyChanges@NextOnce"
-        ],
         "next": [
             "Mizuki@Roguelike@StageEncounterEnter",
             "Mizuki@Roguelike@Stages#next",
             "Mizuki@Roguelike@ClickToDrops"
         ]
     },
+    "Mizuki@Roguelike@DiceConfirmAfterNextLevel": {
+        "baseTask": "Mizuki@Roguelike@DiceConfirm",
+        "template": "Mizuki@Roguelike@DiceConfirm.png",
+        "sub": [
+            "Mizuki@Roguelike@StrategyChange"
+        ],
+        "next": [
+            "Mizuki@Roguelike@Stages#next"
+        ]
+    },
     "Mizuki@Roguelike@DiceConfirmThenAbandon": {
         "baseTask": "Mizuki@Roguelike@DiceConfirm",
         "template": "Mizuki@Roguelike@DiceConfirm.png",
         "postDelay": 0,
-        "sub": [],
         "next": [
             "Mizuki@Roguelike@ExitThenAbandon"
         ]
@@ -13607,6 +13591,9 @@
             "失尘岩洞",
             "幽海丛林",
             "绀碧摇篮"
+        ],
+        "next": [
+            "Mizuki@Roguelike@DiceConfirmAfterNextLevel"
         ]
     },
     "Mizuki@Roguelike@RecruitMain": {

--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -11748,11 +11748,8 @@
             144
         ],
         "postDelay": 1000,
-        "sub": [
-            "Roguelike@StrategyChange"
-        ],
         "next": [
-            "Roguelike@Stages"
+            "Roguelike@StrategyChange"
         ]
     },
     "Roguelike@OptionChoose1-1": {
@@ -12738,7 +12735,9 @@
     },
     "Roguelike@StrategyChange": {
         "baseTask": "Roguelike@StrategyChange_default",
-        "Doc": "占位任务，实际用到的是带 theme 前缀的任务"
+        "next": [
+            "Roguelike@Stages"
+        ]
     },
     "Roguelike@StrategyChange_default": {
         "algorithm": "OcrDetect",
@@ -13410,11 +13409,8 @@
     "Mizuki@Roguelike@DiceConfirmAfterNextLevel": {
         "baseTask": "Mizuki@Roguelike@DiceConfirm",
         "template": "Mizuki@Roguelike@DiceConfirm.png",
-        "sub": [
-            "Mizuki@Roguelike@StrategyChange"
-        ],
         "next": [
-            "Mizuki@Roguelike@Stages"
+            "Mizuki@Roguelike@StrategyChange"
         ]
     },
     "Mizuki@Roguelike@DiceConfirmThenAbandon": {
@@ -13594,7 +13590,8 @@
         ],
         "sub": [],
         "next": [
-            "Mizuki@Roguelike@DiceConfirmAfterNextLevel"
+            "Mizuki@Roguelike@DiceConfirmAfterNextLevel",
+            "Mizuki@Roguelike@StrategyChange"
         ]
     },
     "Mizuki@Roguelike@RecruitMain": {

--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -13592,6 +13592,7 @@
             "幽海丛林",
             "绀碧摇篮"
         ],
+        "sub": [],
         "next": [
             "Mizuki@Roguelike@DiceConfirmAfterNextLevel"
         ]

--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -11752,7 +11752,7 @@
             "Roguelike@StrategyChange"
         ],
         "next": [
-            "Roguelike@Stages#next"
+            "Roguelike@Stages"
         ]
     },
     "Roguelike@OptionChoose1-1": {
@@ -13414,7 +13414,7 @@
             "Mizuki@Roguelike@StrategyChange"
         ],
         "next": [
-            "Mizuki@Roguelike@Stages#next"
+            "Mizuki@Roguelike@Stages"
         ]
     },
     "Mizuki@Roguelike@DiceConfirmThenAbandon": {

--- a/src/MaaCore/Task/Roguelike/RoguelikeStrategyChangeTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeStrategyChangeTaskPlugin.cpp
@@ -23,7 +23,7 @@ bool asst::RoguelikeStrategyChangeTaskPlugin::verify(AsstMsg msg, const json::va
     if (task_view.starts_with(roguelike_name)) {
         task_view.remove_prefix(roguelike_name.length());
     }
-    if (task_view == "Roguelike@StrategyChange" || task_view == "Roguelike@StrategyChangeAtNextLevel") {
+    if (task_view == "Roguelike@StrategyChange") {
         m_result = details.get("details", "result", json::object());
         return true;
     }
@@ -39,9 +39,13 @@ bool asst::RoguelikeStrategyChangeTaskPlugin::_run()
     const std::string theme = m_config->get_theme();
     const std::string stages_task_name = theme + "@Roguelike@Stages";
     const std::string current_strategy = m_result.get("text", "");
+    if (current_strategy.empty() || current_strategy.find("_SKIP_") != std::string::npos) {
+        Log.info("Skip strategy change, current strategy is", current_strategy);
+        return true;
+    }
     const std::string strategy_task_name = stages_task_name + current_strategy;
 
-    if (current_strategy.empty() || Task.get(strategy_task_name) == nullptr) [[unlikely]] {
+    if (Task.get(strategy_task_name) == nullptr) [[unlikely]] {
         Log.error("Strategy task", strategy_task_name, "doesn't exist!");
         return false;
     }


### PR DESCRIPTION
关于 StrategyChange：

这个任务是通过识别肉鸽选关界面正上方的层名来进行策略变更的，之前的处理逻辑会在 NextLevel（进入下一层，画面正下方会出现层名的界面，萨米肉鸽则是”完成本层后将获得“的密文板界面）任务点击后识别层名。

- 最早的处理逻辑，水月肉鸽会在 NextLevel 结束后卡死在 StrategyChange 的识别上，因为这个时候会卡在 DiceConfirm 的界面。
- 之前采用的 TryOnce 方法（仅识别一次，未识别到则忽略）虽然不会卡死，但可能会导致没有识别到层名就继续任务，可能导致包括烧热水在内的许多（策略相关的）任务逻辑出问题。

这个 PR 的逻辑：

- Phantom 和 Sami 的 NextLevel 后有 `next: [ StrategyChange ]`
- Mizuki 的 NextLevel 后有 `next: [ DiceConfirmAfterNextLevel, StrategyChange ]`,
  DiceConfirmAfterNextLevel 后有 `next: [ StrategyChange ]`.
- `StrategyChange->next = [ Stages ]` （而不是 Stages#next）


有其它想法欢迎讨论。

<!-- Skip Labels -->