### PR TITLE
feat: 肉鸽开局干员支持输入任意客户端对应名称

### DIFF
--- a/src/MaaWpfGui/Helper/DataHelper.cs
+++ b/src/MaaWpfGui/Helper/DataHelper.cs
@@ -1,0 +1,110 @@
+// <copyright file="DataHelper.cs" company="MaaAssistantArknights">
+// MaaWpfGui - A part of the MaaCoreArknights project
+// Copyright (C) 2021 MistEO and Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace MaaWpfGui.Helper
+{
+    public static class DataHelper
+    {
+        // 储存角色信息的字典
+        public static Dictionary<string, CharacterInfo> Characters { get; }
+
+        static DataHelper()
+        {
+            Characters = new Dictionary<string, CharacterInfo>();
+
+            const string FilePath = "resource/battle_data.json";
+            if (!File.Exists(FilePath))
+            {
+                return;
+            }
+
+            string jsonText = File.ReadAllText(FilePath);
+            var characterData = JsonConvert.DeserializeObject<Dictionary<string, CharacterInfo>>(JObject.Parse(jsonText)["chars"]?.ToString() ?? string.Empty);
+
+            foreach (var pair in characterData)
+            {
+                Characters.Add(pair.Key, pair.Value);
+            }
+        }
+
+        public static CharacterInfo GetCharacterByNameOrAlias(string characterName)
+        {
+            return Characters.Values.FirstOrDefault(
+                character =>
+                    new[]
+                    {
+                        character?.Name,
+                        character?.NameEn,
+                        character?.NameJp,
+                        character?.NameKr,
+                        character?.NameTw,
+                    }.Any(name => name.Equals(characterName, StringComparison.OrdinalIgnoreCase)));
+        }
+
+        public static string GetLocalizedCharacterName(string characterName, string language)
+        {
+            var characterInfo = GetCharacterByNameOrAlias(characterName);
+            if (characterInfo?.Name == null)
+            {
+                return null;
+            }
+
+            return language switch
+            {
+                "zh-cn" => characterInfo.Name,
+                "zh-tw" => characterInfo.NameTw ?? characterInfo.Name,
+                "en-us" => characterInfo.NameEn ?? characterInfo.Name,
+                "ja-jp" => characterInfo.NameJp ?? characterInfo.Name,
+                "ko-kr" => characterInfo.NameKr ?? characterInfo.Name,
+                _ => characterInfo.Name,
+            };
+        }
+
+        public class CharacterInfo
+        {
+            [JsonProperty("name")]
+            public string Name { get; set; }
+
+            [JsonProperty("name_en")]
+            public string NameEn { get; set; }
+
+            [JsonProperty("name_jp")]
+            public string NameJp { get; set; }
+
+            [JsonProperty("name_kr")]
+            public string NameKr { get; set; }
+
+            [JsonProperty("name_tw")]
+            public string NameTw { get; set; }
+
+            [JsonProperty("position")]
+            public string Position { get; set; }
+
+            [JsonProperty("profession")]
+            public string Profession { get; set; }
+
+            [JsonProperty("rangeId")]
+            public List<string> RangeId { get; set; }
+
+            [JsonProperty("rarity")]
+            public int Rarity { get; set; }
+        }
+    }
+}

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -106,7 +106,7 @@
     <system:String x:Key="StartingSquad">Starting Squad</system:String>
     <system:String x:Key="StartingRoles">Starting Roles</system:String>
     <system:String x:Key="StartingCoreChar">Starting Operator (single)</system:String>
-    <system:String x:Key="StartingCoreCharTip">Default if not filled.</system:String>
+    <system:String x:Key="StartingCoreCharTip">If not filled out, the default policy will be used.</system:String>
     <system:String x:Key="RoguelikeStartingCoreCharNotFound">The agent entered「{0}」is not in battle_data. Check that the name entered is correct, or check the maa resource version.</system:String>
     <system:String x:Key="RoguelikeStartWithEliteTwo">Repeat for「Starting Operator」Elite 2</system:String>
     <system:String x:Key="RoguelikeOnlyStartWithEliteTwo">Only Repeat for「Starting Operator」Elite 2, No Battle</system:String>

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -105,8 +105,9 @@
     <system:String x:Key="RoguelikeLastReward">Fight to obtain starting rewards, reach the third floor then exit</system:String>
     <system:String x:Key="StartingSquad">Starting Squad</system:String>
     <system:String x:Key="StartingRoles">Starting Roles</system:String>
-    <system:String x:Key="StartingCoreChar">Starting Operator (CN name only)</system:String>
-    <system:String x:Key="StartingCoreCharTip">Only supports the CN name of a single operator, default if not filled.</system:String>
+    <system:String x:Key="StartingCoreChar">Starting Operator (single)</system:String>
+    <system:String x:Key="StartingCoreCharTip">Default if not filled.</system:String>
+    <system:String x:Key="RoguelikeStartingCoreCharNotFound">The agent entered「{0}」is not in battle_data. Check that the name entered is correct, or check the maa resource version.</system:String>
     <system:String x:Key="RoguelikeStartWithEliteTwo">Repeat for「Starting Operator」Elite 2</system:String>
     <system:String x:Key="RoguelikeOnlyStartWithEliteTwo">Only Repeat for「Starting Operator」Elite 2, No Battle</system:String>
     <system:String x:Key="RoguelikeUseSupportUnit">Select 「Starting Operator」 from support unit list</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -106,7 +106,7 @@
     <system:String x:Key="StartingSquad">最初の分隊</system:String>
     <system:String x:Key="StartingRoles">最初の職業</system:String>
     <system:String x:Key="StartingCoreChar">最初のオペレーター（一人だけ）</system:String>
-    <system:String x:Key="StartingCoreCharTip">入力されていない場合はデフォルトになります。</system:String>
+    <system:String x:Key="StartingCoreCharTip">記入がない場合はデフォルトの方針を使用します。</system:String>
     <system:String x:Key="RoguelikeStartingCoreCharNotFound">入力のスタッフ「{0}」がbattle_dataにありません。入力の名前が正しいか、maaリソースのバージョンをチェックしてください。</system:String>
     <system:String x:Key="RoguelikeStartWithEliteTwo">「最初のオペレーター」直接昇進</system:String>
     <system:String x:Key="RoguelikeOnlyStartWithEliteTwo">指定オペレーターの昇進招集までリセマラし、戦闘を行わない</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -105,8 +105,9 @@
     <system:String x:Key="RoguelikeLastReward">序盤の報酬を得るために戦い、3階到着後終了</system:String>
     <system:String x:Key="StartingSquad">最初の分隊</system:String>
     <system:String x:Key="StartingRoles">最初の職業</system:String>
-    <system:String x:Key="StartingCoreChar">最初のオペレーター（一人だけ、中国名のみを入力可能）</system:String>
-    <system:String x:Key="StartingCoreCharTip">一人のオペレーターの中国名のみをサポートします。入力されていない場合はデフォルトになります。</system:String>
+    <system:String x:Key="StartingCoreChar">最初のオペレーター（一人だけ）</system:String>
+    <system:String x:Key="StartingCoreCharTip">入力されていない場合はデフォルトになります。</system:String>
+    <system:String x:Key="RoguelikeStartingCoreCharNotFound">入力のスタッフ「{0}」がbattle_dataにありません。入力の名前が正しいか、maaリソースのバージョンをチェックしてください。</system:String>
     <system:String x:Key="RoguelikeStartWithEliteTwo">「最初のオペレーター」直接昇進</system:String>
     <system:String x:Key="RoguelikeOnlyStartWithEliteTwo">指定オペレーターの昇進招集までリセマラし、戦闘を行わない</system:String>
     <system:String x:Key="RoguelikeUseSupportUnit">「最初のオペレーター」をサポートから選択</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -106,7 +106,7 @@
     <system:String x:Key="StartingSquad">시작 분대</system:String>
     <system:String x:Key="StartingRoles">모집 조합</system:String>
     <system:String x:Key="StartingCoreChar">시작 오퍼레이터 (1명)</system:String>
-    <system:String x:Key="StartingCoreCharTip">입력하지 않으면 기본값이 선택됩니다.</system:String>
+    <system:String x:Key="StartingCoreCharTip">작성하지 않으면 기본 정책이 사용됩니다.</system:String>
     <system:String x:Key="RoguelikeStartingCoreCharNotFound">입력한 하프「{0}」는 battle_data에 없습니다. 입력한 이름이 올바른지 확인하거나 maa 리소스 버전을 확인하십시오.</system:String>
     <system:String x:Key="RoguelikeStartWithEliteTwo">시초 에 간부 가 직진 하다</system:String>
     <system:String x:Key="RoguelikeOnlyStartWithEliteTwo">시작 오퍼레이터 2정예화까지 반복(전투 X)</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -106,8 +106,9 @@
     <system:String x:Key="StartingSquad">시작 분대</system:String>
     <system:String x:Key="StartingRoles">모집 조합</system:String>
     <system:String x:Key="StartingCoreChar">시작 오퍼레이터 (1명)</system:String>
-    <system:String x:Key="StartingCoreCharTip">단일 오퍼레이터의 중국어 이름만 지원하며, 입력하지 않으면 기본값이 선택됩니다.</system:String>
-    <system:String x:Key="RoguelikeStartWithEliteTwo">시작 오퍼레이터 2정예화까지 반복</system:String>
+    <system:String x:Key="StartingCoreCharTip">입력하지 않으면 기본값이 선택됩니다.</system:String>
+    <system:String x:Key="RoguelikeStartingCoreCharNotFound">입력한 하프「{0}」는 battle_data에 없습니다. 입력한 이름이 올바른지 확인하거나 maa 리소스 버전을 확인하십시오.</system:String>
+    <system:String x:Key="RoguelikeStartWithEliteTwo">시초 에 간부 가 직진 하다</system:String>
     <system:String x:Key="RoguelikeOnlyStartWithEliteTwo">시작 오퍼레이터 2정예화까지 반복(전투 X)</system:String>
     <system:String x:Key="RoguelikeUseSupportUnit">시작 오퍼레이터로 지원 유닛 사용</system:String>
     <system:String x:Key="RoguelikeUseNonFriendSupport">친구가 아니어도 지원 유닛 사용</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -106,7 +106,8 @@
     <system:String x:Key="StartingSquad">开局分队</system:String>
     <system:String x:Key="StartingRoles">开局职业组</system:String>
     <system:String x:Key="StartingCoreChar">开局干员 (单个)</system:String>
-    <system:String x:Key="StartingCoreCharTip">仅支持单个干员中文名，不填写则默认选择。</system:String>
+    <system:String x:Key="StartingCoreCharTip">不填写则默认选择。</system:String>
+    <system:String x:Key="RoguelikeStartingCoreCharNotFound">输入的干员「{0}」未在 battle_data 中，请检查输入的名称是否正确，或检查 maa 资源版本。</system:String>
     <system:String x:Key="RoguelikeStartWithEliteTwo">凹「开局干员」直升精二</system:String>
     <system:String x:Key="RoguelikeOnlyStartWithEliteTwo">只凹「开局干员」直升精二，不进行作战</system:String>
     <system:String x:Key="RoguelikeUseSupportUnit">「开局干员」使用助战</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -106,7 +106,7 @@
     <system:String x:Key="StartingSquad">开局分队</system:String>
     <system:String x:Key="StartingRoles">开局职业组</system:String>
     <system:String x:Key="StartingCoreChar">开局干员 (单个)</system:String>
-    <system:String x:Key="StartingCoreCharTip">不填写则默认选择。</system:String>
+    <system:String x:Key="StartingCoreCharTip">不填写则使用默认策略。</system:String>
     <system:String x:Key="RoguelikeStartingCoreCharNotFound">输入的干员「{0}」未在 battle_data 中，请检查输入的名称是否正确，或检查 maa 资源版本。</system:String>
     <system:String x:Key="RoguelikeStartWithEliteTwo">凹「开局干员」直升精二</system:String>
     <system:String x:Key="RoguelikeOnlyStartWithEliteTwo">只凹「开局干员」直升精二，不进行作战</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -106,7 +106,8 @@
     <system:String x:Key="StartingSquad">開局分隊</system:String>
     <system:String x:Key="StartingRoles">開局職業組</system:String>
     <system:String x:Key="StartingCoreChar">開局幹員（單個）</system:String>
-    <system:String x:Key="StartingCoreCharTip">僅支持單個幹員中文名，不填寫則預設選擇。</system:String>
+    <system:String x:Key="StartingCoreCharTip">不填寫則預設選擇。</system:String>
+    <system:String x:Key="RoguelikeStartingCoreCharNotFound">輸入的幹員「{0}」未在 battle_data 中，請檢查輸入的名稱是否正確，或檢查 maa 資源版本。</system:String>
     <system:String x:Key="RoguelikeStartWithEliteTwo">凹「開局幹員」直升精二</system:String>
     <system:String x:Key="RoguelikeOnlyStartWithEliteTwo">只凹「開局幹員」直升精二，不進行作戰</system:String>
     <system:String x:Key="RoguelikeUseSupportUnit">「開局幹員」使用助戰</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -106,7 +106,7 @@
     <system:String x:Key="StartingSquad">開局分隊</system:String>
     <system:String x:Key="StartingRoles">開局職業組</system:String>
     <system:String x:Key="StartingCoreChar">開局幹員（單個）</system:String>
-    <system:String x:Key="StartingCoreCharTip">不填寫則預設選擇。</system:String>
+    <system:String x:Key="StartingCoreCharTip">不填寫則使用預設策略。</system:String>
     <system:String x:Key="RoguelikeStartingCoreCharNotFound">輸入的幹員「{0}」未在 battle_data 中，請檢查輸入的名稱是否正確，或檢查 maa 資源版本。</system:String>
     <system:String x:Key="RoguelikeStartWithEliteTwo">凹「開局幹員」直升精二</system:String>
     <system:String x:Key="RoguelikeOnlyStartWithEliteTwo">只凹「開局幹員」直升精二，不進行作戰</system:String>

--- a/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
@@ -3977,7 +3977,7 @@ namespace MaaWpfGui.ViewModels.UI
         private void UpdateRoguelikeCoreCharList()
         {
             var filePath = $"resource/roguelike/{RoguelikeTheme}/recruitment.json";
-            if (File.Exists(filePath) is false)
+            if (!File.Exists(filePath))
             {
                 RoguelikeCoreCharList.Clear();
                 return;
@@ -3999,16 +3999,22 @@ namespace MaaWpfGui.ViewModels.UI
 
                     foreach (var operItem in opersArray)
                     {
-                        var isStart = (bool?)operItem.SelectToken("is_start") ?? false;
+                        var isStart = (bool?)operItem["is_start"] ?? false;
                         if (!isStart)
                         {
                             continue;
                         }
 
-                        var name = (string)operItem.SelectToken("name");
-                        if (!string.IsNullOrEmpty(name))
+                        var name = (string)operItem["name"];
+                        if (string.IsNullOrEmpty(name))
                         {
-                            roguelikeCoreCharList.Add(name);
+                            continue;
+                        }
+
+                        var localizedName = DataHelper.GetLocalizedCharacterName(name, _language);
+                        if (!string.IsNullOrEmpty(localizedName))
+                        {
+                            roguelikeCoreCharList.Add(localizedName);
                         }
                     }
                 }

--- a/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
@@ -1888,7 +1888,7 @@ namespace MaaWpfGui.ViewModels.UI
                     return;
                 }
 
-                if (value != string.Empty && DataHelper.GetCharacterByNameOrAlias(value) is null)
+                if (!string.IsNullOrEmpty(value) && DataHelper.GetCharacterByNameOrAlias(value) is null)
                 {
                     MessageBoxHelper.Show(
                         string.Format(LocalizationHelper.GetString("RoguelikeStartingCoreCharNotFound"), value),

--- a/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
@@ -1888,6 +1888,13 @@ namespace MaaWpfGui.ViewModels.UI
                     return;
                 }
 
+                if (value != string.Empty && DataHelper.GetCharacterByNameOrAlias(value) is null)
+                {
+                    MessageBoxHelper.Show(
+                        string.Format(LocalizationHelper.GetString("RoguelikeStartingCoreCharNotFound"), value),
+                        LocalizationHelper.GetString("Tip"));
+                }
+
                 SetAndNotify(ref _roguelikeCoreChar, value);
                 Instances.TaskQueueViewModel.AddLog(value);
                 ConfigurationHelper.SetValue(ConfigurationKeys.RoguelikeCoreChar, value);

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -1349,7 +1349,7 @@ namespace MaaWpfGui.ViewModels.UI
             return Instances.AsstProxy.AsstAppendRoguelike(
                 mode, Instances.SettingsViewModel.RoguelikeStartsCount,
                 Instances.SettingsViewModel.RoguelikeInvestmentEnabled, Instances.SettingsViewModel.RoguelikeInvestmentEnterSecondFloor, Instances.SettingsViewModel.RoguelikeInvestsCount, Instances.SettingsViewModel.RoguelikeStopWhenInvestmentFull,
-                Instances.SettingsViewModel.RoguelikeSquad, Instances.SettingsViewModel.RoguelikeRoles, Instances.SettingsViewModel.RoguelikeCoreChar,
+                Instances.SettingsViewModel.RoguelikeSquad, Instances.SettingsViewModel.RoguelikeRoles, DataHelper.GetCharacterByNameOrAlias(Instances.SettingsViewModel.RoguelikeCoreChar)?.Name ?? Instances.SettingsViewModel.RoguelikeCoreChar,
                 Instances.SettingsViewModel.RoguelikeStartWithEliteTwo, Instances.SettingsViewModel.RoguelikeOnlyStartWithEliteTwo, Instances.SettingsViewModel.RoguelikeUseSupportUnit,
                 Instances.SettingsViewModel.RoguelikeEnableNonfriendSupport, Instances.SettingsViewModel.RoguelikeTheme, Instances.SettingsViewModel.RoguelikeRefreshTraderWithDice);
         }

--- a/src/MaaWpfGui/Views/UserControl/RoguelikeSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/RoguelikeSettingsUserControl.xaml
@@ -123,7 +123,7 @@
                 IsTextSearchEnabled="False"
                 ItemsSource="{Binding RoguelikeCoreCharList}"
                 Loaded="{s:Action MakeComboBoxSearchable}"
-                Text="{Binding RoguelikeCoreChar}"
+                Text="{Binding RoguelikeCoreChar, UpdateSourceTrigger=LostFocus}"
                 ToolTip="{DynamicResource StartingCoreCharTip}" />
             <CheckBox
                 Margin="0,10"


### PR DESCRIPTION
![image](https://github.com/MaaAssistantArknights/MaaAssistantArknights/assets/99072975/e7431231-3582-4651-81a2-355994e44a78)

@Constrat All names in battle_data for characters that exist on official client but have not yet appeared on foreign client are in Chinese. Any good ideas?