### PR TITLE
fix: 修复 自动战斗-自动编队 当干员过于接近屏幕边缘时，编入操作可能被UI遮挡的问题

### DIFF
--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -11,7 +11,6 @@
 #include "Utils/ImageIo.hpp"
 #include "Utils/Logger.hpp"
 #include "Vision/MultiMatcher.h"
-#include "Vision/TemplDetOCRer.h"
 
 void asst::BattleFormationTask::append_additional_formation(AdditionalFormation formation)
 {

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -239,7 +239,7 @@ bool asst::BattleFormationTask::select_random_support_unit()
     return ProcessTask(*this, { "BattleSupportUnitFormation" }).run();
 }
 
-std::vector<asst::TextRect> asst::BattleFormationTask::analyzer_opers()
+std::vector<asst::TemplDetOCRer::Result> asst::BattleFormationTask::analyzer_opers()
 {
     auto formation_task_ptr = Task.get("BattleQuickFormationOCR");
     auto image = ctrler()->get_image();
@@ -280,12 +280,8 @@ std::vector<asst::TextRect> asst::BattleFormationTask::analyzer_opers()
     }
     sort_by_vertical_(opers_result);
 
-    std::vector<TextRect> tr_res;
-    for (const auto& res : opers_result) {
-        tr_res.emplace_back(TextRect { res.rect, res.score, res.text });
-    }
-    Log.info(tr_res);
-    return tr_res;
+    Log.info(opers_result);
+    return std::move(opers_result);
 }
 
 bool asst::BattleFormationTask::enter_selection_page()
@@ -337,7 +333,7 @@ bool asst::BattleFormationTask::select_opers_in_cur_page(std::vector<OperGroup>&
             continue;
         }
 
-        ctrler()->click(res.rect);
+        ctrler()->click(res.flag_rect);
         sleep(delay);
         if (1 <= skill && skill <= 3) {
             if (skill == 3) {

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -280,7 +280,7 @@ std::vector<asst::TemplDetOCRer::Result> asst::BattleFormationTask::analyzer_ope
     sort_by_vertical_(opers_result);
 
     Log.info(opers_result);
-    return std::move(opers_result);
+    return opers_result;
 }
 
 bool asst::BattleFormationTask::enter_selection_page()

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.h
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.h
@@ -3,6 +3,7 @@
 
 #include "Common/AsstBattleDef.h"
 #include "Task/AbstractTask.h"
+#include "Vision/TemplDetOCRer.h"
 
 namespace asst
 {

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.h
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.h
@@ -68,15 +68,11 @@ namespace asst
         std::string m_stage_name;
         std::unordered_map<battle::Role, std::vector<OperGroup>> m_formation;
         std::vector<OperGroup> m_user_formation;
-        // 编队中干员个数
-        int m_size_of_operators_in_formation = 0;
-        // 编队中的干员名称，用来判断能不能追加某个干员
-        std::set<std::string> m_operators_in_formation;
-        bool m_add_user_additional = false;
-        // 追加干员表，从头往后加
-        std::vector<std::pair<std::string, int>> m_user_additional;
-        // 是否需要追加信赖干员
-        bool m_add_trust = false;
+        int m_size_of_operators_in_formation = 0;       // 编队中干员个数
+        std::set<std::string> m_operators_in_formation; // 编队中的干员名称，用来判断能不能追加某个干员
+        bool m_add_trust = false;                       // 是否需要追加信赖干员
+        bool m_add_user_additional = false;             // 补用户自定义干员
+        std::vector<std::pair<std::string, int>> m_user_additional; // 追加干员表，从头往后加
         std::string m_support_unit_name;
         DataResource m_data_resource = DataResource::Copilot;
         std::vector<AdditionalFormation> m_additional;

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.h
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.h
@@ -62,7 +62,7 @@ namespace asst
         bool select_formation(int select_index);
         bool select_random_support_unit();
 
-        std::vector<TextRect> analyzer_opers();
+        std::vector<asst::TemplDetOCRer::Result> analyzer_opers();
 
         std::string m_stage_name;
         std::unordered_map<battle::Role, std::vector<OperGroup>> m_formation;


### PR DESCRIPTION
- fix #7395

从点干员名改成点左上角的职业标（感觉是从一坨变成另一坨（