### PR TITLE
fix: encounter number in Mizuki IS

### DIFF
--- a/resource/roguelike/Mizuki/encounter.json
+++ b/resource/roguelike/Mizuki/encounter.json
@@ -216,7 +216,7 @@
         },
         {
             "name": "开端",
-            "option_num": 3,
+            "option_num": 2,
             "choose": 2
         },
         {

--- a/resource/roguelike/Mizuki/encounter_for_deposit.json
+++ b/resource/roguelike/Mizuki/encounter_for_deposit.json
@@ -216,7 +216,7 @@
         },
         {
             "name": "开端",
-            "option_num": 3,
+            "option_num": 2,
             "choose": 2
         },
         {


### PR DESCRIPTION
This was changed in #6102  4a6316c76a8db1e5ca101b14c53ec2ff429056d0 @Yumi0606 @Lancarus
This is the encounter for the 3rd ending. There should only be two options. Not three. In my case, MAA selected the "second" options out of 3 which resulted in choosing the 3rd ending which loses a lot of light.
