### PR TITLE
ci: added "merge" keyword bypass

### DIFF
--- a/.github/workflows/pr-checker.yml
+++ b/.github/workflows/pr-checker.yml
@@ -45,7 +45,7 @@ jobs:
               per_page: 100
             });
 
-            const regex = /^((build|chore|ci|docs?|feat|fix|perf|refactor|rft|style|test|i18n|typo)[\:\.\(\,]|[Rr]evert|[Rr]elease)/;
+            const regex = /^((build|chore|ci|docs?|feat|fix|perf|refactor|rft|style|test|i18n|typo)[\:\.\(\,]|[Rr]evert|[Rr]elease|[Mm]erge)/;
             const invalidCommits = commits.filter(commit => !regex.test(commit.commit.message) || commit.parents.length > 1);
 
             console.log(`Checked ${commits.length} commit(s)`);


### PR DESCRIPTION
https://github.com/MaaAssistantArknights/MaaAssistantArknights/pull/7872/#issuecomment-1875265861

When working with tasks, conflicts may happen and fixing them through GitHub web-based merger will create a
`Merge branch 'dev' into %%branch%%` which is not allowed.