### PR TITLE
fix: 移除 StageEncounterClickToLeave 任务

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -12138,21 +12138,6 @@
             "Roguelike@Stages#next"
         ]
     },
-    "Roguelike@StageEncounterClickToLeave": {
-        "algorithm": "JustReturn",
-        "action": "ClickRect",
-        "specificRect": [
-            600,
-            600,
-            50,
-            50
-        ],
-        "next": [
-            "Roguelike@StageEncounterOptions#next",
-            "Roguelike@Stages#next",
-            "Roguelike@StageEncounterClickToLeave"
-        ]
-    },
     "Roguelike@StageEncounterEnter": {
         "Doc": "base_task",
         "template": "empty.png",
@@ -12212,8 +12197,7 @@
         "Doc": "本任务注册了插件RoguelikeStageEncounterTaskPlugin",
         "next": [
             "Roguelike@StageEncounterOptions#next",
-            "Roguelike@Stages#next",
-            "Roguelike@StageEncounterClickToLeave"
+            "Roguelike@Stages#next"
         ]
     },
     "Roguelike@StageEncounterLeaveConfirm": {
@@ -12376,7 +12360,7 @@
             "Roguelike@StageVerticalConfirmSafeHouse",
             "Roguelike@StageSafeHouseEnter",
             "Roguelike@StageEncounterOptions#next",
-            "Roguelike@StageEncounterClickToLeave"
+            "Roguelike@NextLevel"
         ]
     },
     "Roguelike@StageTrader": {
@@ -12680,16 +12664,14 @@
         "template": "Roguelike@StageVerticalConfirm.png",
         "next": [
             "Roguelike@StageSafeHouseEnter",
-            "Roguelike@StageSafeHouseEnter",
             "Roguelike@StageEncounterOptions#next",
-            "Roguelike@StageEncounterClickToLeave"
+            "Roguelike@NextLevel"
         ]
     },
     "Roguelike@StageVerticalConfirmTrader": {
         "template": "Roguelike@StageVerticalConfirm.png",
         "baseTask": "Roguelike@StageVerticalConfirm",
         "next": [
-            "Roguelike@StageTraderEnter",
             "Roguelike@StageTraderEnter",
             "Roguelike@StageTraderRefreshWithDice",
             "Roguelike@StageTraderInvestSystem",
@@ -14632,13 +14614,6 @@
         "next": [
             "Sami@Roguelike@StageEncounterEnter",
             "Sami@Roguelike@Stages#next"
-        ]
-    },
-    "Sami@Roguelike@StageEncounterClickToLeave": {
-        "next": [
-            "Sami@Roguelike@StageEncounterOptions#next",
-            "Sami@Roguelike@Stages#next",
-            "Sami@Roguelike@StageEncounterClickToLeave"
         ]
     },
     "Sami@Roguelike@StageEncounterEnter": {},


### PR DESCRIPTION
作为 JustReturn 任务还有自己作为 next 也太危险了（
看了一下，应该所有任务都会通过 CloseEvent 退出，剩下的就是直接进下一层了，接上 NextLevel

（如果有除了 CloseEvent 和 NextLevel 之外的玩意才能退出不期而遇的话，这个 PR 可能会导致引入新问题卡在不期而遇）

should fix #7884 