### PR TITLE
feat: 捕获启动模拟器时产生的权限不足异常

### DIFF
--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -155,6 +155,7 @@
     <system:String x:Key="AdbException">Error in ADB detection\nPlease use administrator privileges to open this software\nor set connection manually</system:String>
     <system:String x:Key="EmulatorNotFound">No emulator detected\nPlease use administrator privileges to open this software\nor set connection manually</system:String>
     <system:String x:Key="EmulatorTooMany">Too many emulators detected\nPlease shutdown not needed emulators \nor set connection manually</system:String>
+    <system:String x:Key="EmulatorStartFailed">Failed to start the emulator\nPlease open this software with administrator privileges \nor start the emulator manually.</system:String>
     <system:String x:Key="SwitchLanguage">Switch Language</system:String>
     <system:String x:Key="Language">Language</system:String>
     <system:String x:Key="LanguageChangedTip">The language settings have been changed, restart the app now?</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -155,6 +155,7 @@
     <system:String x:Key="AdbException">ADB検出エラー\nこのソフトウェアを開くには管理者権限を使用するか\n手動で接続を設定してください</system:String>
     <system:String x:Key="EmulatorNotFound">エミュレータが検出されない\n管理者権限でこのアプリを開くか\n手動で接続設定を行ってください</system:String>
     <system:String x:Key="EmulatorTooMany">複数のシミュレータが検出されたため\n不要なエミュレータを閉じるか\n手動で接続設定を行ってください</system:String>
+    <system:String x:Key="EmulatorStartFailed">エミュレータの起動に失敗しました\n管理者権限でこのソフトウェアを開いていただくか\n手動でエミュレータを起動してください。</system:String>
     <system:String x:Key="SwitchLanguage">言語を切り替える</system:String>
     <system:String x:Key="Language">言語</system:String>
     <system:String x:Key="LanguageChangedTip">言語設定が変更されました、今すぐMAAを再起動して言語設定を適用しますか？</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -155,6 +155,7 @@
     <system:String x:Key="AdbException">ADB를 찾을 수 없었습니다.\n관리자 권한으로 실행하거나\n수동으로 연결을 설정해 주세요</system:String>
     <system:String x:Key="EmulatorNotFound">에뮬레이터를 찾을 수 없습니다.\n관리자 권한으로 실행하거나\n수동으로 연결을 설정해 주세요</system:String>
     <system:String x:Key="EmulatorTooMany">여러 에뮬레이터가 실행 중입니다.\n사용하지 않는 에뮬레이터를 종료하거나\n수동으로 연결을 설정해 주세요</system:String>
+    <system:String x:Key="EmulatorStartFailed">모의기를 시작하지 못했습니다.\n사용하지 않는 에뮬레이터를 종료하거나\n또는 에뮬레이터를 수동으로 시작하십시오.</system:String>
     <system:String x:Key="SwitchLanguage">언어 전환</system:String>
     <system:String x:Key="Language">언어</system:String>
     <system:String x:Key="LanguageChangedTip">언어가 변경되었습니다. 지금 MAA를 재실행하여 새 설정을 적용하시겠습니까?</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -155,6 +155,7 @@
     <system:String x:Key="AdbException">检测ADB出错\n请使用管理员权限打开本软件\n或手动设置连接</system:String>
     <system:String x:Key="EmulatorNotFound">未检测到任何模拟器\n请使用管理员权限打开本软件\n或手动设置连接</system:String>
     <system:String x:Key="EmulatorTooMany">检测到多个模拟器\n请关闭不需要的模拟器\n或手动设置连接</system:String>
+    <system:String x:Key="EmulatorStartFailed">未能成功启动模拟器\n请使用管理员权限打开本软件\n或手动启动模拟器</system:String>
     <system:String x:Key="SwitchLanguage">切换语言</system:String>
     <system:String x:Key="Language">语言</system:String>
     <system:String x:Key="LanguageChangedTip">语言设置已更改，是否现在重启 MAA 以应用语言设置？</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -155,6 +155,7 @@
     <system:String x:Key="AdbException">檢測 ADB 出錯\n請使用系統管理員身分執行本軟體\n或手動設定連接</system:String>
     <system:String x:Key="EmulatorNotFound">未檢測到任何模擬器\n請使用系統管理員身分執行本軟體\n或手動設定連接</system:String>
     <system:String x:Key="EmulatorTooMany">檢測到多個模擬器\n請關閉不需要的模擬器\n或手動設定連接</system:String>
+    <system:String x:Key="EmulatorStartFailed">無法成功啟動模擬器\n請使用管理員權限開啟本軟體\n或手動啟動模擬器。</system:String>
     <system:String x:Key="SwitchLanguage">切換語言</system:String>
     <system:String x:Key="Language">語言</system:String>
     <system:String x:Key="LanguageChangedTip">語言設定已變更，是否現在重開 MAA 以套用語言設定？</system:String>

--- a/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
@@ -1081,42 +1081,27 @@ namespace MaaWpfGui.ViewModels.UI
                 _logger.Information("Start emulator error, try to start using the default: \n" +
                     "EmulatorPath: " + EmulatorPath + "\n" +
                     "EmulatorAddCommand: " + EmulatorAddCommand);
-                if (EmulatorAddCommand.Length != 0)
+                try
                 {
-                    try
+                    if (EmulatorAddCommand.Length != 0)
                     {
                         Process.Start(EmulatorPath);
                     }
-                    catch (Win32Exception e)
-                    {
-                        // 740(0x2E4)
-                        // The requested operation requires elevation.
-                        if (e.NativeErrorCode == 740)
-                        {
-                           Execute.OnUIThread(() => Instances.TaskQueueViewModel.AddLog(
-                                LocalizationHelper.GetString("EmulatorStartFailed"), UiLogColor.Warning));
-                            _logger.Warning("Insufficient permissions to start the emulator: \n" +
-                                "EmulatorPath: " + EmulatorPath + "\n");
-                        }
-                    }
-                }
-                else
-                {
-                    try
+                    else
                     {
                         Process.Start(EmulatorPath, EmulatorAddCommand);
                     }
-                    catch (Win32Exception e)
+                }
+                catch (Win32Exception e)
+                {
+                    // 740(0x2E4)
+                    // The requested operation requires elevation.
+                    if (e.NativeErrorCode == 740)
                     {
-                        // 740(0x2E4)
-                        // The requested operation requires elevation.
-                        if (e.NativeErrorCode == 740)
-                        {
-                            Execute.OnUIThread(() => Instances.TaskQueueViewModel.AddLog(
-                                LocalizationHelper.GetString("EmulatorStartFailed"), UiLogColor.Warning));
-                            _logger.Warning("Insufficient permissions to start the emulator: \n" +
-                                "EmulatorPath: " + EmulatorPath + "\n");
-                        }
+                        Execute.OnUIThread(() => Instances.TaskQueueViewModel.AddLog(
+                             LocalizationHelper.GetString("EmulatorStartFailed"), UiLogColor.Warning));
+                        _logger.Warning("Insufficient permissions to start the emulator: \n" +
+                             "EmulatorPath: " + EmulatorPath + "\n");
                     }
                 }
             }

--- a/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
@@ -1083,11 +1083,41 @@ namespace MaaWpfGui.ViewModels.UI
                     "EmulatorAddCommand: " + EmulatorAddCommand);
                 if (EmulatorAddCommand.Length != 0)
                 {
-                    Process.Start(EmulatorPath);
+                    try
+                    {
+                        Process.Start(EmulatorPath);
+                    }
+                    catch (Win32Exception e)
+                    {
+                        // 740(0x2E4)
+                        // The requested operation requires elevation.
+                        if (e.NativeErrorCode == 740)
+                        {
+                           Execute.OnUIThread(() => Instances.TaskQueueViewModel.AddLog(
+                                LocalizationHelper.GetString("EmulatorStartFailed"), UiLogColor.Warning));
+                            _logger.Warning("Insufficient permissions to start the emulator: \n" +
+                                "EmulatorPath: " + EmulatorPath + "\n");
+                        }
+                    }
                 }
                 else
                 {
-                    Process.Start(EmulatorPath, EmulatorAddCommand);
+                    try
+                    {
+                        Process.Start(EmulatorPath, EmulatorAddCommand);
+                    }
+                    catch (Win32Exception e)
+                    {
+                        // 740(0x2E4)
+                        // The requested operation requires elevation.
+                        if (e.NativeErrorCode == 740)
+                        {
+                            Execute.OnUIThread(() => Instances.TaskQueueViewModel.AddLog(
+                                LocalizationHelper.GetString("EmulatorStartFailed"), UiLogColor.Warning));
+                            _logger.Warning("Insufficient permissions to start the emulator: \n" +
+                                "EmulatorPath: " + EmulatorPath + "\n");
+                        }
+                    }
                 }
             }
 

--- a/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
@@ -1092,16 +1092,19 @@ namespace MaaWpfGui.ViewModels.UI
                         Process.Start(EmulatorPath, EmulatorAddCommand);
                     }
                 }
-                catch (Win32Exception e)
+                catch (Exception e)
                 {
-                    // 740(0x2E4)
-                    // The requested operation requires elevation.
-                    if (e.NativeErrorCode == 740)
+                    if (e is Win32Exception win32Exception && win32Exception.NativeErrorCode == 740)
                     {
                         Execute.OnUIThread(() => Instances.TaskQueueViewModel.AddLog(
-                             LocalizationHelper.GetString("EmulatorStartFailed"), UiLogColor.Warning));
-                        _logger.Warning("Insufficient permissions to start the emulator: \n" +
-                             "EmulatorPath: " + EmulatorPath + "\n");
+                            LocalizationHelper.GetString("EmulatorStartFailed"), UiLogColor.Warning));
+
+                        _logger.Warning("Insufficient permissions to start the emulator:\n" +
+                            "EmulatorPath: " + EmulatorPath + "\n");
+                    }
+                    else
+                    {
+                        _logger.Warning("Emulator start failed with error: " + e.Message);
                     }
                 }
             }


### PR DESCRIPTION
#7890 中提到"启动时提示，请求的操作需要提升，从而导致无法正常打开MAA。"，加了一个判断去捕获这个异常，使得MAA能正常启动，并且给出Warning。翻译是AI翻译的

