### PR TITLE
chore: modify YoStarEN operator name ocr

### DIFF
--- a/resource/global/YoStarEN/resource/tasks.json
+++ b/resource/global/YoStarEN/resource/tasks.json
@@ -2296,6 +2296,14 @@
                 "无需增调干员"
             ],
             [
+                "Executor the Ex.*",
+                "Executor the Ex Foedere"
+            ],
+			[
+                ".*the Ex Foedere",
+                "Executor the Ex Foedere"
+            ],
+            [
                 "Executor the Ex Foedere",
                 "圣约送葬人"
             ],


### PR DESCRIPTION
在战斗中，圣约送葬人名字的后半部分识别时可能会缺少空格或者字母。
在干员识别中，圣约送葬人被特别关注时名字的前半部分因背景的黄白条而无法识别。
In battle, the second half of Executor the Ex Foedere's name may be missing spaces or letters when recognized.
In operator identification, the first half of his name is not recognized properly when being marked due to the yellow and white stripes in the background.