### PR TITLE
1.AsstCaller.h添加dll接口：AdbStartService，用于拉起自动adb进程

### DIFF
--- a/include/AsstCaller.h
+++ b/include/AsstCaller.h
@@ -32,6 +32,8 @@ extern "C"
     AsstHandle ASSTAPI AsstCreateEx(AsstApiCallback callback, void* custom_arg);
     void ASSTAPI AsstDestroy(AsstHandle handle);
 
+    AsstAsyncCallId ASSTAPI AdbStartService(AsstHandle handle, const char* adb_path, const char* config);
+
     AsstBool ASSTAPI AsstSetInstanceOption(AsstHandle handle, AsstInstanceOptionKey key, const char* value);
 
     // 同步连接，功能已完全被异步连接取代

--- a/src/MaaCore/Assistant.cpp
+++ b/src/MaaCore/Assistant.cpp
@@ -138,6 +138,14 @@ bool asst::Assistant::set_instance_option(InstanceOptionKey key, const std::stri
     return false;
 }
 
+bool asst::Assistant::async_StartAdbServer(const std::string& adb_path, const std::string& config)
+{
+    LogTraceFunction;
+
+    return append_async_call(AsyncCallItem::Type::StartAdbServer,
+                             AsyncCallItem::ConnectParams { .adb_path = adb_path, .config = config });
+}
+
 bool asst::Assistant::ctrl_connect(const std::string& adb_path, const std::string& address, const std::string& config)
 {
     LogTraceFunction;
@@ -168,6 +176,13 @@ bool asst::Assistant::ctrl_click(int x, int y)
 bool asst::Assistant::ctrl_screencap()
 {
     return m_ctrler->screencap();
+}
+
+bool asst::Assistant::ctrl_StartAdbServer(const std::string& adb_path, const std::string& config)
+{
+    LogTraceFunction;
+
+    return m_ctrler->startAdbServer(adb_path, config);
 }
 
 asst::Assistant::TaskId asst::Assistant::append_task(const std::string& type, const std::string& params)
@@ -531,6 +546,11 @@ void asst::Assistant::call_proc()
             what = "Screencap";
             std::ignore = std::get<AsyncCallItem::ScreencapParams>(call_item.params);
             ret = ctrl_screencap();
+        } break;
+        case AsyncCallItem::Type::StartAdbServer: {
+            what = "StartAdbServer";
+            const auto& [adb_path, address, config] = std::get<AsyncCallItem::ConnectParams>(call_item.params);
+            ret = ctrl_StartAdbServer(adb_path, config);
         } break;
         default:
             what = "Unknown";

--- a/src/MaaCore/Assistant.h
+++ b/src/MaaCore/Assistant.h
@@ -23,6 +23,8 @@ public:
     static bool set_static_option(asst::StaticOptionKey key, const std::string& value);
     // 设置实例级参数
     virtual bool set_instance_option(asst::InstanceOptionKey key, const std::string& value) = 0;
+    // 启动adb server
+    virtual bool async_StartAdbServer(const std::string& adb_path, const std::string& config) = 0;
 
     // 同步连接，功能已完全被异步连接取代
     // FIXME: 5.0 版本将废弃此接口
@@ -72,8 +74,11 @@ namespace asst
 
         virtual bool set_instance_option(InstanceOptionKey key, const std::string& value) override;
 
+        virtual bool async_StartAdbServer(const std::string& adb_path, const std::string& config) override;
+
         virtual bool connect(const std::string& adb_path, const std::string& address,
                              const std::string& config) override;
+
         virtual AsyncCallId async_connect(const std::string& adb_path, const std::string& address,
                                           const std::string& config, bool block = false) override;
         virtual AsyncCallId async_click(int x, int y, bool block = false) override;
@@ -109,6 +114,7 @@ namespace asst
                 Connect,
                 Click,
                 Screencap,
+                StartAdbServer
             };
             struct ConnectParams
             {
@@ -144,6 +150,7 @@ namespace asst
         bool ctrl_connect(const std::string& adb_path, const std::string& address, const std::string& config);
         bool ctrl_click(int x, int y);
         bool ctrl_screencap();
+        bool ctrl_StartAdbServer(const std::string& adb_path, const std::string& config);
 
         std::string m_uuid;
 

--- a/src/MaaCore/AsstCaller.cpp
+++ b/src/MaaCore/AsstCaller.cpp
@@ -96,6 +96,14 @@ void AsstDestroy(AsstHandle handle)
     handle = nullptr;
 }
 
+AsstAsyncCallId ASSTAPI AdbStartService(AsstHandle handle, const char* adb_path, const char* config)
+{
+    if (!inited() || handle == nullptr) {
+        return InvalidId;
+    }
+    return handle->async_StartAdbServer(adb_path, config);
+}
+
 AsstBool AsstSetInstanceOption(AsstHandle handle, AsstInstanceOptionKey key, const char* value)
 {
     if (handle == nullptr) {

--- a/src/MaaCore/Config/GeneralConfig.cpp
+++ b/src/MaaCore/Config/GeneralConfig.cpp
@@ -64,6 +64,7 @@ bool asst::GeneralConfig::parse(const json::value& json)
         const AdbCfg& base_cfg = base_name.empty() ? AdbCfg() : m_adb_cfg.at(base_name);
 
         AdbCfg adb;
+        adb.devices = cfg_json.get("devices", base_cfg.devices);
         adb.connect = cfg_json.get("connect", base_cfg.connect);
         adb.display_id = cfg_json.get("displayId", base_cfg.display_id);
         adb.uuid = cfg_json.get("uuid", base_cfg.uuid);

--- a/src/MaaCore/Config/GeneralConfig.h
+++ b/src/MaaCore/Config/GeneralConfig.h
@@ -53,6 +53,7 @@ namespace asst
     struct AdbCfg
     {
         /* command */
+        std::string devices;
         std::string connect;
         std::string display_id;
         std::string uuid;

--- a/src/MaaCore/Controller/AdbController.h
+++ b/src/MaaCore/Controller/AdbController.h
@@ -19,6 +19,8 @@ namespace asst
         AdbController(AdbController&&) = delete;
         virtual ~AdbController();
 
+        virtual bool startAdbServer(const std::string& adb_path, const std::string& config) override;
+
         virtual bool connect(const std::string& adb_path, const std::string& address,
                              const std::string& config) override;
 
@@ -82,6 +84,7 @@ namespace asst
         struct AdbProperty
         {
             /* command */
+            std::string devices;
             std::string connect;
             std::string call_minitouch;
             std::string call_maatouch;

--- a/src/MaaCore/Controller/Controller.cpp
+++ b/src/MaaCore/Controller/Controller.cpp
@@ -142,6 +142,22 @@ asst::ControlFeat::Feat asst::Controller::support_features()
     return m_controller->support_features();
 }
 
+bool asst::Controller::startAdbServer(const std::string& adb_path, const std::string& config)
+{
+    LogTraceFunction;
+
+    m_controller = m_controller_factory->create_controller(m_controller_type, adb_path, "", config, m_platform_type);
+
+    if (!m_controller) {
+        Log.error("Initial m_controller failed");
+        return false;
+    }
+
+    sync_params();
+
+    return m_controller->startAdbServer(adb_path, config);
+}
+
 bool asst::Controller::connect(const std::string& adb_path, const std::string& address, const std::string& config)
 {
     LogTraceFunction;
@@ -152,9 +168,11 @@ bool asst::Controller::connect(const std::string& adb_path, const std::string& a
         m_controller_factory->create_controller(m_controller_type, adb_path, address, config, m_platform_type);
 
     if (!m_controller) {
-        Log.error("connect failed");
+        Log.error("m_controller Initialize failed");
         return false;
     }
+
+    m_controller->connect(adb_path, address, config);
 
     sync_params();
 

--- a/src/MaaCore/Controller/Controller.h
+++ b/src/MaaCore/Controller/Controller.h
@@ -37,7 +37,7 @@ namespace asst
         Controller(const Controller&) = delete;
         Controller(Controller&&) = delete;
         ~Controller();
-
+        bool startAdbServer(const std::string& adb_path, const std::string& config);
         bool connect(const std::string& adb_path, const std::string& address, const std::string& config);
         bool inited() noexcept;
         void set_touch_mode(const TouchMode& mode) noexcept;

--- a/src/MaaCore/Controller/ControllerAPI.h
+++ b/src/MaaCore/Controller/ControllerAPI.h
@@ -21,7 +21,7 @@ namespace asst
     {
     public:
         virtual ~ControllerAPI() = default;
-
+        virtual bool startAdbServer(const std::string& adb_path, const std::string& config) = 0;
         virtual bool connect(const std::string& adb_path, const std::string& address, const std::string& config) = 0;
         virtual bool inited() const noexcept = 0;
         virtual void set_swipe_with_pause([[maybe_unused]] bool enable) noexcept {}

--- a/src/MaaCore/Controller/ControllerFactory.h
+++ b/src/MaaCore/Controller/ControllerFactory.h
@@ -41,7 +41,7 @@ namespace asst
                 Log.error("Cannot create controller: {}", e.what());
                 return nullptr;
             }
-            if (controller->connect(adb_path, address, config)) {
+            if (controller) {
                 return controller;
             }
             return nullptr;

--- a/src/MaaCore/Controller/Platform/AdbLiteIO.cpp
+++ b/src/MaaCore/Controller/Platform/AdbLiteIO.cpp
@@ -58,6 +58,7 @@ std::optional<int> asst::AdbLiteIO::call_command(const std::string& cmd, bool re
 
     // adb connect
     // TODO: adb server 尚未实现，第一次连接需要执行一次 adb.exe 启动 daemon
+    // FIXME: 已经在 Controller类中实现了 startAdbServer 用于启动adb.exe的daemon
     if (std::regex_match(cmd, match, connect_regex)) {
         m_adb_client = adb::client::create(match[1].str()); // TODO: compare address with existing (if any)
 

--- a/src/MaaCore/Controller/PlayToolsController.h
+++ b/src/MaaCore/Controller/PlayToolsController.h
@@ -21,6 +21,8 @@ namespace asst
         PlayToolsController(PlayToolsController&&) = delete;
         virtual ~PlayToolsController();
 
+        virtual bool startAdbServer(const std::string& adb_path, const std::string& config) override {};//TODO FIXME: MAC上是否需要调起adb进程？
+
         virtual bool connect(const std::string& adb_path, const std::string& address,
                              const std::string& config) override;
         virtual bool inited() const noexcept override;

--- a/src/MaaCore/MaaCore.vcxproj.filters
+++ b/src/MaaCore/MaaCore.vcxproj.filters
@@ -95,6 +95,12 @@
     <Filter Include="源文件\Vision\Config">
       <UniqueIdentifier>{bf83678b-e9d7-4cf1-8616-aba2009072b6}</UniqueIdentifier>
     </Filter>
+    <Filter Include="源文件\Controller\ScaleProxy">
+      <UniqueIdentifier>{1803efe4-dfb8-4888-a08e-89c6a7792f68}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="源文件\Controller\Controllers">
+      <UniqueIdentifier>{2c18ecbc-8f0e-4a62-a5ba-1d1f08228206}</UniqueIdentifier>
+    </Filter>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\resource\config.json">
@@ -117,9 +123,6 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\include\AsstCaller.h">
-      <Filter>头文件</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\include\AsstPort.h">
       <Filter>头文件</Filter>
     </ClInclude>
@@ -531,18 +534,6 @@
     <ClInclude Include="Controller\ControllerFactory.h">
       <Filter>源文件\Controller</Filter>
     </ClInclude>
-    <ClInclude Include="Controller\ControlScaleProxy.h">
-      <Filter>源文件\Controller</Filter>
-    </ClInclude>
-    <ClInclude Include="Controller\MaatouchController.h">
-      <Filter>源文件\Controller</Filter>
-    </ClInclude>
-    <ClInclude Include="Controller\MinitouchController.h">
-      <Filter>源文件\Controller</Filter>
-    </ClInclude>
-    <ClInclude Include="Controller\AdbController.h">
-      <Filter>源文件\Controller</Filter>
-    </ClInclude>
     <ClInclude Include="Controller\Platform\AdbLiteIO.h">
       <Filter>源文件\Controller\Platform</Filter>
     </ClInclude>
@@ -594,9 +585,6 @@
     <ClInclude Include="Task\Experiment\SingleStepBattleProcessTask.h">
       <Filter>源文件\Task\Experiment</Filter>
     </ClInclude>
-    <ClInclude Include="Controller\PlayToolsController.h">
-      <Filter>源文件\Controller</Filter>
-    </ClInclude>
     <ClInclude Include="Task\Interface\OperBoxTask.h">
       <Filter>源文件\Task\Interface</Filter>
     </ClInclude>
@@ -611,6 +599,24 @@
     </ClInclude>
     <ClInclude Include="Vision\Config\OCRerConfig.h">
       <Filter>源文件\Vision\Config</Filter>
+    </ClInclude>
+    <ClInclude Include="Controller\ControlScaleProxy.h">
+      <Filter>源文件\Controller\ScaleProxy</Filter>
+    </ClInclude>
+    <ClInclude Include="Controller\PlayToolsController.h">
+      <Filter>源文件\Controller\Controllers</Filter>
+    </ClInclude>
+    <ClInclude Include="Controller\MinitouchController.h">
+      <Filter>源文件\Controller\Controllers</Filter>
+    </ClInclude>
+    <ClInclude Include="Controller\AdbController.h">
+      <Filter>源文件\Controller\Controllers</Filter>
+    </ClInclude>
+    <ClInclude Include="Controller\MaatouchController.h">
+      <Filter>源文件\Controller\Controllers</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\include\AsstCaller.h">
+      <Filter>源文件</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -938,15 +944,6 @@
     <ClCompile Include="Controller\adb-lite\protocol.cpp">
       <Filter>源文件\Controller\adb-lite</Filter>
     </ClCompile>
-    <ClCompile Include="Controller\MinitouchController.cpp">
-      <Filter>源文件\Controller</Filter>
-    </ClCompile>
-    <ClCompile Include="Controller\AdbController.cpp">
-      <Filter>源文件\Controller</Filter>
-    </ClCompile>
-    <ClCompile Include="Controller\ControlScaleProxy.cpp">
-      <Filter>源文件\Controller</Filter>
-    </ClCompile>
     <ClCompile Include="Controller\Platform\AdbLiteIO.cpp">
       <Filter>源文件\Controller\Platform</Filter>
     </ClCompile>
@@ -989,9 +986,6 @@
     <ClCompile Include="Task\Experiment\SingleStepBattleProcessTask.cpp">
       <Filter>源文件\Task\Experiment</Filter>
     </ClCompile>
-    <ClCompile Include="Controller\PlayToolsController.cpp">
-      <Filter>源文件\Controller</Filter>
-    </ClCompile>
     <ClCompile Include="Task\Interface\OperBoxTask.cpp">
       <Filter>源文件\Task\Interface</Filter>
     </ClCompile>
@@ -1006,6 +1000,18 @@
     </ClCompile>
     <ClCompile Include="Vision\Config\OCRerConfig.cpp">
       <Filter>源文件\Vision\Config</Filter>
+    </ClCompile>
+    <ClCompile Include="Controller\ControlScaleProxy.cpp">
+      <Filter>源文件\Controller\ScaleProxy</Filter>
+    </ClCompile>
+    <ClCompile Include="Controller\PlayToolsController.cpp">
+      <Filter>源文件\Controller\Controllers</Filter>
+    </ClCompile>
+    <ClCompile Include="Controller\MinitouchController.cpp">
+      <Filter>源文件\Controller\Controllers</Filter>
+    </ClCompile>
+    <ClCompile Include="Controller\AdbController.cpp">
+      <Filter>源文件\Controller\Controllers</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
2.Assistant、AsstExtAPI类添加async_StartAdbServer函数
3.AdbCfg 添加devices参数，GeneralConfig类同步添加devices参数解析 4.对创建首次connect的位置进行调整：移除ControllerFactory中的connect，移动到asst::Controller::connect函数中 5.调整MAACore VS工程文件的文件夹结构，层次更加清晰明了