### PR TITLE
feat: stop and log when missing operators during formarion

### DIFF
--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -65,8 +65,7 @@ bool asst::BattleFormationTask::_run()
     }
     
     for (auto& [role, oper_groups] : m_formation) {
-        if (!add_formation(role, oper_groups)) {
-            
+        if (!add_formation(role,oper_groups)) {
             report_missing_operators(oper_groups);
             return false;
         }
@@ -134,7 +133,7 @@ bool asst::BattleFormationTask::add_formation(battle::Role role, std::vector<Ope
             has_error = false;
         }
         else {
-            if (error_times == m_missing_retry_times+1) {
+            if (error_times == m_missing_retry_times + 1) {
                 // return and notify the user
                 return false;
             }

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -58,7 +58,7 @@ bool asst::BattleFormationTask::_run()
     if (m_select_formation_index > 0 && !select_formation(m_select_formation_index)) {
         return false;
     }
-
+    
     if (!enter_selection_page()) {
         save_img(utils::path("debug") / utils::path("other"));
         return false;

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.h
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.h
@@ -62,6 +62,7 @@ namespace asst
         bool parse_formation();
         bool select_formation(int select_index);
         bool select_random_support_unit();
+        void report_missing_operators(std::vector<OperGroup>& groups);
 
         std::vector<asst::TemplDetOCRer::Result> analyzer_opers();
 
@@ -78,5 +79,6 @@ namespace asst
         std::vector<AdditionalFormation> m_additional;
         std::string m_last_oper_name;
         int m_select_formation_index = 0;
+        int m_missing_retry_times = 2;
     };
 } // namespace asst

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -830,6 +830,18 @@ namespace MaaWpfGui.Main
                 case "CheckStageValid":
                     Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("TheEx"), UiLogColor.Error);
                     break;
+
+                case "BattleFormationTask":
+                    {
+                        var why = details.TryGetValue("why", out var whyObj) ? whyObj.ToString() : string.Empty;
+                        if (why == "OperatorMissing")
+                        {
+                            var missingOpers = details["details"]["opers"].ToObject<List<string>>();
+                            Instances.CopilotViewModel.AddLog(LocalizationHelper.GetString("MissingOperators") + string.Join(", ", missingOpers), UiLogColor.Error);
+                        }
+
+                        break;
+                    }
             }
         }
 

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -583,6 +583,7 @@ The video aspect ratio needs to be 16:9 without interference factors such as bla
     <system:String x:Key="DropRecognitionError">Drops recognition error</system:String>
     <system:String x:Key="GiveUpUploadingPenguins">Abort upload to Penguin Statistics</system:String>
     <system:String x:Key="TheEx">No bonus stage, stopped</system:String>
+    <system:String x:Key="MissingOperators">One or more of the following operators are missing: </system:String>
     <system:String x:Key="StageQueue">Stage Queue:</system:String>
     <system:String x:Key="UnableToAgent">Unable to use PRTS</system:String>
     <system:String x:Key="MissionStart">Mission started</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -583,6 +583,7 @@ Bilibili: ログイン インターフェイスに表示されるアカウント
     <system:String x:Key="DropRecognitionError">ドロップ認識エラー</system:String>
     <system:String x:Key="GiveUpUploadingPenguins">Penguin-Statsへのアップロードをあきらめました</system:String>
     <system:String x:Key="TheEx">ステージ報酬がないため停止します</system:String>
+    <system:String x:Key="MissingOperators">次のオペレーターは１つ以上欠落しています：</system:String>
     <system:String x:Key="StageQueue">レベルキュー:</system:String>
     <system:String x:Key="UnableToAgent">自動指揮利用不可</system:String>
     <system:String x:Key="MissionStart">行動開始しました</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -583,6 +583,7 @@ Bilibili: 로그인 인터페이스에 표시되는 계정 이름(예: 장산)�
     <system:String x:Key="DropRecognitionError">드롭 인식 오류</system:String>
     <system:String x:Key="GiveUpUploadingPenguins">펭귄 물류에 업로드 불가</system:String>
     <system:String x:Key="TheEx">EX 스테이지가 없어 중단되었습니다</system:String>
+    <system:String x:Key="MissingOperators">다음 연산자 중 하나 이상이 누락되었습니다.</system:String>
     <system:String x:Key="StageQueue">레벨 대기열:</system:String>
     <system:String x:Key="UnableToAgent">프록시 명령을 사용할 수 없습니다</system:String>
     <system:String x:Key="MissionStart">행동 개시</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -583,6 +583,7 @@
     <system:String x:Key="DropRecognitionError">掉落识别错误</system:String>
     <system:String x:Key="GiveUpUploadingPenguins">放弃上传企鹅物流</system:String>
     <system:String x:Key="TheEx">无奖励关卡，已停止</system:String>
+    <system:String x:Key="MissingOperators">缺少以下干员中的一个或多个：</system:String>
     <system:String x:Key="StageQueue">关卡队列:</system:String>
     <system:String x:Key="UnableToAgent">无法使用代理指挥</system:String>
     <system:String x:Key="MissionStart">已开始行动</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -581,6 +581,7 @@
     <system:String x:Key="DropRecognitionError">掉落辨識錯誤</system:String>
     <system:String x:Key="GiveUpUploadingPenguins">放棄上傳企鵝物流</system:String>
     <system:String x:Key="TheEx">無獎勵關卡，已停止</system:String>
+    <system:String x:Key="MissingOperators">缺少以下一個或多個幹員：</system:String>
     <system:String x:Key="StageQueue">關卡隊列:</system:String>
     <system:String x:Key="UnableToAgent">無法使用代理指揮</system:String>
     <system:String x:Key="MissionStart">已開始行動</system:String>


### PR DESCRIPTION
Now task would report an error and stop after two more failed retries instead of looping forever when a required operator is missing

This is a solution to #8042 