### PR TITLE
fix: screencap failure with amdgpu on some emulators (even with GeneralWithoutScreencapErr)

### DIFF
--- a/resource/config.json
+++ b/resource/config.json
@@ -157,8 +157,8 @@
         {
             "configName": "GeneralWithoutScreencapErr",
             "baseConfig": "General",
-            "screencapRawWithGzip": "[Adb] -s [AdbSerial] exec-out \"screencap 2>/tmp/maa-assistant-arknights.log | gzip -1\"",
-            "screencapEncode": "[Adb] -s [AdbSerial] exec-out \"screencap -p 2>/tmp/maa-assistant-arknights.log\""
+            "screencapRawWithGzip": "[Adb] -s [AdbSerial] exec-out \"screencap 2>/dev/null | gzip -1\"",
+            "screencapEncode": "[Adb] -s [AdbSerial] exec-out \"screencap -p 2>/dev/null\""
         }
     ]
 }


### PR DESCRIPTION
AMDGPU 现在需要使用 GeneralWithoutScreencapErr 来屏蔽 error 以保证 screencap 可用，但是现在 GeneralWithoutScreencapErr 实现是 2>/tmp/xxx.log, 而部分模拟器不会创建 /tmp 比如 redroid. 于是 screencap 会因为 permission denied 失败。

这个 PR 将 `GeneralWithoutScreencapErr` 行为改为 `2>/dev/null` 这样也与 config.json 中其他抛弃 error message 的行为一致。