### PR TITLE
fix: 针对XX-EX-\d的关卡名，移除ocr可能引入的错误前缀

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -639,6 +639,12 @@
         "isAscii": true,
         "cache": false,
         "text": [],
+        "ocrReplace": [
+            [
+                ".+(?=[A-Za-z]{2}-EX-\\d)",
+                ""
+            ]
+        ],
         "next": [
             "ClickedCorrectStageOrSwipe",
             "#self"


### PR DESCRIPTION
- close #8292 
~~（先兜个底~~