### PR TITLE
perf: 优化自动编队逻辑

### DIFF
--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -64,11 +64,20 @@ bool asst::BattleFormationTask::_run()
         return false;
     }
 
+    auto missing_operators = std::vector<OperGroup>();
+
     for (auto& [role, oper_groups] : m_formation) {
-        if (!add_formation(role, oper_groups)) {
-            report_missing_operators(oper_groups);
-            return false;
+        add_formation(role, oper_groups, missing_operators);
+    }
+    
+    if (!missing_operators.empty()) {
+        if (missing_operators.size()==1) {
+            // TODO: 自动借助战？
         }
+        
+        report_missing_operators(missing_operators);
+
+        return false;
     }
 
     if (m_add_user_additional) {
@@ -87,7 +96,7 @@ bool asst::BattleFormationTask::_run()
             ++m_size_of_operators_in_formation;
         }
         m_size_of_operators_in_formation -= (int)m_user_formation.size();
-        add_formation(battle::Role::Unknown, m_user_formation);
+        add_formation(battle::Role::Unknown, m_user_formation, missing_operators);
     }
 
     add_additional();
@@ -106,14 +115,14 @@ bool asst::BattleFormationTask::_run()
     return true;
 }
 
-bool asst::BattleFormationTask::add_formation(battle::Role role, std::vector<OperGroup> oper_group)
+bool asst::BattleFormationTask::add_formation(battle::Role role, std::vector<OperGroup> oper_group, std::vector<OperGroup>& missing)
 {
     LogTraceFunction;
 
     click_role_table(role);
     bool has_error = false;
     int swipe_times = 0;
-    int error_times = 0;
+    int overall_swipe_times = 0; // 完整从左到右滑动的次数
     while (!need_exit()) {
         if (select_opers_in_cur_page(oper_group)) {
             has_error = false;
@@ -133,12 +142,12 @@ bool asst::BattleFormationTask::add_formation(battle::Role role, std::vector<Ope
             has_error = false;
         }
         else {
-            if (error_times == m_missing_retry_times + 1) {
-                // return and notify the user
-                return false;
+            if (overall_swipe_times == m_missing_retry_times) {
+                 missing.insert(missing.end(), oper_group.begin(), oper_group.end());
+                return true;
             }
 
-            ++error_times;
+            ++overall_swipe_times;
 
             has_error = true;
             swipe_to_the_left(swipe_times);
@@ -254,11 +263,13 @@ void asst::BattleFormationTask::report_missing_operators(std::vector<OperGroup>&
 {
     auto info = basic_info();
 
-    std::vector<std::string> oper_names;
+    std::vector<std::vector<std::string>> oper_names;
     for (auto& group : groups) {
+        std::vector<std::string> names;
         for (auto& oper : group) {
-            oper_names.push_back(oper.name);
+            names.push_back(oper.name);
         }
+        oper_names.push_back(names);
     }
 
     info["why"] = "OperatorMissing";

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.h
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.h
@@ -48,7 +48,7 @@ namespace asst
         using OperGroup = std::vector<battle::OperUsage>;
 
         virtual bool _run() override;
-        bool add_formation(battle::Role role, std::vector<OperGroup> oper_group);
+        bool add_formation(battle::Role role, std::vector<OperGroup> oper_group, std::vector<OperGroup>& missing);
         // 追加附加干员（按部署费用等小分类）
         bool add_additional();
         // 补充刷信赖的干员，从最小的开始
@@ -79,6 +79,6 @@ namespace asst
         std::vector<AdditionalFormation> m_additional;
         std::string m_last_oper_name;
         int m_select_formation_index = 0;
-        int m_missing_retry_times = 2;
+        int m_missing_retry_times = 0; // 识别不到干员的重试次数，目前设置为不重试
     };
 } // namespace asst

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -833,8 +833,9 @@ namespace MaaWpfGui.Main
                         var why = details.TryGetValue("why", out var whyObj) ? whyObj.ToString() : string.Empty;
                         if (why == "OperatorMissing")
                         {
-                            var missingOpers = details["details"]["opers"].ToObject<List<string>>();
-                            Instances.CopilotViewModel.AddLog(LocalizationHelper.GetString("MissingOperators") + string.Join(", ", missingOpers), UiLogColor.Error);
+                            var missingOpers = details["details"]["opers"].ToObject<List<List<string>>>();
+                            var missingOpersStr = "[" + string.Join("]; [", missingOpers.Select(opers => string.Join(", ", opers))) + "]";
+                            Instances.CopilotViewModel.AddLog(LocalizationHelper.GetString("MissingOperators") + missingOpersStr, UiLogColor.Error);
                         }
 
                         break;

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -603,7 +603,7 @@ The video aspect ratio needs to be 16:9 without interference factors such as bla
     <system:String x:Key="DropRecognitionError">Drops recognition error</system:String>
     <system:String x:Key="GiveUpUploadingPenguins">Abort upload to Penguin Statistics</system:String>
     <system:String x:Key="TheEx">No bonus stage, stopped</system:String>
-    <system:String x:Key="MissingOperators">One or more of the following operators are missing: </system:String>
+    <system:String x:Key="MissingOperators">Operators of the following operator groups are missing: </system:String>
     <system:String x:Key="StageQueue">Stage Queue:</system:String>
     <system:String x:Key="UnableToAgent">Unable to use PRTS</system:String>
     <system:String x:Key="MissionStart">Mission started</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -603,7 +603,7 @@ Bilibili: ログイン インターフェイスに表示されるアカウント
     <system:String x:Key="DropRecognitionError">ドロップ認識エラー</system:String>
     <system:String x:Key="GiveUpUploadingPenguins">Penguin-Statsへのアップロードをあきらめました</system:String>
     <system:String x:Key="TheEx">ステージ報酬がないため停止します</system:String>
-    <system:String x:Key="MissingOperators">次のオペレーターは１つ以上欠落しています：</system:String>
+    <system:String x:Key="MissingOperators">次のオペレーターがオペレーターグループにありません：</system:String>
     <system:String x:Key="StageQueue">レベルキュー:</system:String>
     <system:String x:Key="UnableToAgent">自動指揮利用不可</system:String>
     <system:String x:Key="MissionStart">行動開始しました</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -603,7 +603,7 @@
     <system:String x:Key="DropRecognitionError">掉落识别错误</system:String>
     <system:String x:Key="GiveUpUploadingPenguins">放弃上传企鹅物流</system:String>
     <system:String x:Key="TheEx">无奖励关卡，已停止</system:String>
-    <system:String x:Key="MissingOperators">缺少以下干员中的一个或多个：</system:String>
+    <system:String x:Key="MissingOperators">缺少以下干员组中的干员：</system:String>
     <system:String x:Key="StageQueue">关卡队列:</system:String>
     <system:String x:Key="UnableToAgent">无法使用代理指挥</system:String>
     <system:String x:Key="MissionStart">已开始行动</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -601,7 +601,7 @@
     <system:String x:Key="DropRecognitionError">掉落辨識錯誤</system:String>
     <system:String x:Key="GiveUpUploadingPenguins">放棄上傳企鵝物流</system:String>
     <system:String x:Key="TheEx">無獎勵關卡，已停止</system:String>
-    <system:String x:Key="MissingOperators">缺少以下一個或多個幹員：</system:String>
+    <system:String x:Key="MissingOperators">缺少以下幹員組的幹員：</system:String>
     <system:String x:Key="StageQueue">關卡隊列:</system:String>
     <system:String x:Key="UnableToAgent">無法使用代理指揮</system:String>
     <system:String x:Key="MissionStart">已開始行動</system:String>


### PR DESCRIPTION
现在当识别到缺失的干员时会记录并继续编队，全部编队完成后一并报告并退出
并将自动编队重试次数调为0（不重试）
TODO：当仅缺失一个干员时自动借助战

fix #8390 