### PR TITLE
perf: 肉鸽开局干员 隐藏未实装干员

### DIFF
--- a/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
@@ -4180,7 +4180,7 @@ namespace MaaWpfGui.ViewModels.UI
                         }
 
                         var localizedName = DataHelper.GetLocalizedCharacterName(name, _language);
-                        if (!string.IsNullOrEmpty(localizedName))
+                        if (!string.IsNullOrEmpty(localizedName) && !(_clientType.Contains("YoStar") && DataHelper.GetLocalizedCharacterName(name, "en-us") == DataHelper.GetLocalizedCharacterName(name, "zh-cn")))
                         {
                             roguelikeCoreCharList.Add(localizedName);
                         }


### PR DESCRIPTION
对于YoStar服务器，肉鸽开局干员选项中，隐藏未实装干员。
原理为判断当前MAA针对的服务器名称是否包含YoStar，然后判断battle_data.json中的干员名称的中文名称和英文名称是否相同。对于YoStar服务器，这一判断方法目前适用于除W外的所有5、6星干员（此外还有九色鹿中日文名称相同，但不影响）。
效果如下，隐藏了锏。
![图片](https://github.com/MaaAssistantArknights/MaaAssistantArknights/assets/63437036/5eb1f76e-780b-4ec8-9d60-8eaee2e30032)
![图片](https://github.com/MaaAssistantArknights/MaaAssistantArknights/assets/63437036/f810101f-0f1d-4e77-a4ae-1e64f5fedf78)
该方法不适用于繁中服，我没想好该怎么设置条件。