### PR TITLE
fix: 修复部分amd显卡在linux redorid环境下抓图时会头部插入提示消息的问题

### DIFF
--- a/src/MaaCore/Controller/AdbController.cpp
+++ b/src/MaaCore/Controller/AdbController.cpp
@@ -289,6 +289,19 @@ const std::string& asst::AdbController::get_uuid() const
     return m_uuid;
 }
 
+bool asst::AdbController::delete_DRM(std::string& data)
+{
+    const std::string drm_str =
+        "amdgpu: os_same_file_description couldn't determine if two DRM fds reference the same file description.\n"
+        "If they do, bad things may happen!\n";
+    auto pos = data.find(drm_str);
+    if (pos != std::string::npos) {
+        data.erase(pos, drm_str.length());
+        return true;
+    }
+    return false;
+}
+
 bool asst::AdbController::convert_lf(std::string& data)
 {
     if (data.empty() || data.size() < 2) {
@@ -515,6 +528,8 @@ bool asst::AdbController::screencap(const std::string& cmd, const DecodeFunc& de
             m_adb.screencap_end_of_line = AdbProperty::ScreencapEndOfLine::LF;
         }
     }
+
+    delete_DRM(data);
 
     if (decode_func(data)) [[likely]] {
         if (m_adb.screencap_end_of_line == AdbProperty::ScreencapEndOfLine::UnknownYet) [[unlikely]] {

--- a/src/MaaCore/Controller/AdbController.h
+++ b/src/MaaCore/Controller/AdbController.h
@@ -73,6 +73,9 @@ namespace asst
         // 转换 data 中的 CRLF 为 LF：有些模拟器自带的 adb，exec-out 输出的 \n 会被替换成 \r\n，
         // 导致解码错误，所以这里转一下回来（点名批评 mumu 和雷电）
         static bool convert_lf(std::string& data);
+        // 去掉 data 中的 amdgpu: os_same_file_description couldn't determine if two DRM fds reference the same file
+        // description.\nIf they do, bad things may happen!\n
+        static bool delete_DRM(std::string& data);
 
         AsstCallback m_callback;
 


### PR DESCRIPTION
![image](https://github.com/MaaAssistantArknights/MaaAssistantArknights/assets/8674798/4648bc7f-71ea-442a-82f2-698601a67198)
