### PR TITLE
chore: 去掉太慢的clang-format配置

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -140,13 +140,13 @@ PackConstructorInitializers: Never
 # PenaltyIndentedWhitespace:
 # PenaltyReturnTypeOnItsOwnLine:
 PointerAlignment: Left
-QualifierAlignment: Custom
-QualifierOrder:
-  - inline
-  - static
-  - const
-  - constexpr
-  - type
+# QualifierAlignment: Custom
+# QualifierOrder:
+#  - inline
+#  - static
+#  - const
+#  - constexpr
+#  - type
 ReferenceAlignment: Left
 ReflowComments: true
 RemoveBracesLLVM: false


### PR DESCRIPTION
基于某单文件 40000+ 行屎山代码测试结果

```
基准 1:24

去掉 120-147 52秒
去掉 QualifierAlignment 和 QualifierOrder 55 秒

---------------------------

新基准 55秒

去掉 6-100 44秒
去掉 101-190 29秒
去掉 101-150 34秒
去掉 151-190 45秒
去掉 101-122 36秒
去掉 101-110 36秒
去掉 105-110 56秒
去掉 101-102 54秒
去掉 103 InsertBraces 37秒

--------------------------

新基准 37秒

去掉 6-100 27秒
去掉 101-190 28秒
去掉 6-58 36秒
去掉 60-80 37秒
去掉 90-99 36秒
去掉 80 37秒
去掉 89 36s
去掉 82 FixNamespaceComments 28s

-------------------------

新基准 28秒

去掉 101-150 29秒
去掉 151-175 22秒
去掉 151-162 21秒
去掉 151-156 22s
去掉 151-153 29s
去掉 155 29s
去掉 154 SeparateDefinitionBlocks 22s

--------------------------

新基准 22秒

去掉 6-100 19秒
去掉 101-190 21秒
```

```
InsertBraces: true
SeparateDefinitionBlocks: Always
FixNamespaceComments: true
```

这三个比较有用，先保留了