### PR TITLE
chore: update maa-cli to 0.4.5 and build with vendored-openssl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,19 +224,18 @@ jobs:
           CC: ${{ matrix.arch == 'x86_64' && 'ccache gcc-12' || 'ccache aarch64-linux-gnu-gcc-12' }}
           CXX: ${{ matrix.arch == 'x86_64' && 'ccache g++-12' || 'ccache aarch64-linux-gnu-g++-12' }}
 
-      - name: Setup Rust
+      - name: Setup Cross Compile Toolchains for CLI
         uses: ./src/maa-cli/.github/actions/setup
         with:
           os: ubuntu-latest
-          arch: ${{ matrix.arch }}
+          target_arch: ${{ matrix.arch }}
 
       - name: Build CLI
         run: |
-          cargo build --release --locked --package maa-cli \
-             ${{ matrix.arch != 'x86_64' && '--features vendored-openssl' || '' }}
+          cargo build --release --locked --package maa-cli --features vendored-openssl
           cp -v target/$CARGO_BUILD_TARGET/release/maa $GITHUB_WORKSPACE/install/maa
           cargo build --release --locked --package maa-cli --no-default-features \
-            --features ${{ matrix.arch != 'x86_64' && 'git2,vendored-openssl' || 'git2' }}
+            --features git2,vendored-openssl
           cp -v target/$CARGO_BUILD_TARGET/release/maa $GITHUB_WORKSPACE/appimage-maa
         working-directory: src/maa-cli
 


### PR DESCRIPTION
- 更新 CLI 到 0.4.5，文档没有更新，因为我最近想重构一下 CLI 的文档，每次文档两边都要更新太麻烦了。
- 对所有架构都自行编译 openssl 而不是使用系统的 openssl，以防止部份发行版的 openssl 版本过低而无法使用。