### PR TITLE
ci: generate changelog with python script for nightly

### DIFF
--- a/.github/workflows/release-nightly-ota.yml
+++ b/.github/workflows/release-nightly-ota.yml
@@ -96,9 +96,11 @@ jobs:
       - name: Generate Changelog
         id: generate_changelog
         run: |
-          $content=$(git log --pretty=format:"* %s [@%an](https://github.com/%an) \n\n" ${{ steps.set_tag.outputs.latest_tag }}..alpha/${{ steps.set_tag.outputs.tag }})
+          $content=$(python3 tools/ChangelogGenerator/changelog_generator.py --latest "${{ steps.set_tag.outputs.latest_tag }}" --tag "${{ steps.set_tag.outputs.tag }}")
           echo "changelog=### Commits\n\n$content" >> $env:GITHUB_OUTPUT
           echo $content
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache .nuke/temp, ~/.nuget/packages
         id: cache-nuget
@@ -108,7 +110,7 @@ jobs:
             .nuke/temp
             ~/.nuget/packages
           key: ${{ runner.os }}-${{ hashFiles('**/global.json', '**/*.csproj') }}
-  
+
       - name: Restore dependencies
         if: steps.cache-nuget.outputs.cache-hit != 'true'
         run: dotnet restore


### PR DESCRIPTION
`changelog_generator.py` 用 GitHub API 来获得对应的作者和 committer 登陆名。

https://github.com/MaaAssistantArknights/MaaAssistantArknights/blob/df90caba1b4f61565d87dae8742dbdb59b249924/tools/ChangelogGenerator/changelog_generator.py#L186-L202

Fixes #8725 