### PR TITLE
docs: sync with upstream, re-arrange for linux users

### DIFF
--- a/docs/en-us/1.5-EMULATOR_SUPPORTS_FOR_LINUX.md
+++ b/docs/en-us/1.5-EMULATOR_SUPPORTS_FOR_LINUX.md
@@ -2,9 +2,20 @@
 
 ## Preparation
 
-### 1. Installing
+You can choose one of the following installation methods:
 
-1. Download and extract `Linux 动态库` in [MAA Website](https://maa.plus/)
+### Use maa-cli
+
+[maa-cli](https://github.com/MaaAssistantArknights/maa-cli) is a simple CLI for MAA by Rust. Please read installation and usage tutorials in [User Guide for CLI](./1.6-USER_GUIDE_FOR_CLI)。
+
+### Use Python
+
+#### 1. Installing dynamic library
+
+1. Download and extract `Linux library` in [MAA Website](https://maa.plus/), or install from linux software repository:
+
+   - AUR：[maa-assistant-arknights](https://aur.archlinux.org/packages/maa-assistant-arknights), edit the script according to the post-install instruction.
+   - Nixpkgs: [maa-assistant-arknights](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/ma/maa-assistant-arknights/package.nix)
 
 2. Open `sample.py` in `./MAA-v{VERSION}-linux-{ARCH}/Python/`
 
@@ -12,10 +23,7 @@
 > The precompiled version is built in a relatively new distro (Ubuntu 22.04), you may run into binary compatability problem, if libstdc++ in your environment is too old.
 > Where you should reference to [Linux tutorial](./2.1-LINUX_TUTORIAL.md), or run inside a container instead.
 
-- If you are running an Arch based distro, you may install from aur [maa-assistant-arknights](https://aur.archlinux.org/packages/maa-assistant-arknights),
-  and edit the script according to the post-install instruction.
-
-### 2. `adb` Settings
+#### 2. `adb` Settings
 
 1. Target to [`if asst.connect('adb.exe', '127.0.0.1:5554'):`](https://github.com/MaaAssistantArknights/MaaAssistantArknights/blob/722f0ddd4765715199a5dc90ea1bec2940322344/src/Python/sample.py#L48)
 
@@ -47,7 +55,7 @@
 
 4. Now you can test: `$ python3 sample.py` , if return `连接成功` , you almost finish setting.
 
-### 3. Tasks Settings
+#### 3. Tasks Settings
 
 Customizing tasks: Reference to [AsstAppendTask](https://maa.plus/docs/en-us/3.1-INTEGRATION.html#asstappendtask) and modify [`# 任务及参数请参考 docs/集成文档.md`](https://github.com/MaaAssistantArknights/MaaAssistantArknights/blob/722f0ddd4765715199a5dc90ea1bec2940322344/src/Python/sample.py#L54) section in `sample.py`.
 

--- a/docs/en-us/1.5-EMULATOR_SUPPORTS_FOR_LINUX.md
+++ b/docs/en-us/1.5-EMULATOR_SUPPORTS_FOR_LINUX.md
@@ -6,7 +6,7 @@ You can choose one of the following installation methods:
 
 ### Use maa-cli
 
-[maa-cli](https://github.com/MaaAssistantArknights/maa-cli) is a simple CLI for MAA by Rust. Please read installation and usage tutorials in [User Guide for CLI](./1.6-USER_GUIDE_FOR_CLI)。
+[maa-cli](https://github.com/MaaAssistantArknights/maa-cli) is a simple CLI for MAA made with Rust. Please read installation and usage tutorials in [User Guide for CLI](./1.6-USER_GUIDE_FOR_CLI).
 
 ### Use Python
 

--- a/docs/en-us/1.6-USER_GUIDE_FOR_CLI.md
+++ b/docs/en-us/1.6-USER_GUIDE_FOR_CLI.md
@@ -13,7 +13,7 @@ icon: material-symbols:terminal
 
 ### Appimage
 
-The CLI is the default interface of MAA on Linux. You can use the CLI directly by [download](https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases/latest) the latest Appimage.
+The CLI is the default interface of MAA on Linux. You can use the CLI directly by [downloading](https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases/latest) the latest Appimage.
 
 ### Package manager
 
@@ -29,9 +29,9 @@ brew install MaaAssistantArknights/tap/maa-cli
 
 - Arch Linux users can install [AUR package](https://aur.archlinux.org/packages/maa-cli/):
 
-   ```bash
-   yay -S maa-cli
-   ```
+    ```bash
+    yay -S maa-cli
+    ```
 
 - Nix users can run directly:
 
@@ -45,7 +45,7 @@ brew install MaaAssistantArknights/tap/maa-cli
   nix run github:Cryolitia/nur-packages#maa-cli-nightly
   ```
 
-  Stable is the `maa-cli` that packaged in [nixpkgs](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/ma/maa-cli/package.nix), using the nixpkgs's Rust toolchain；Nightly is in [NUR](https://github.com/Cryolitia/nur-packages/blob/master/pkgs/maa-assistant-arknights/maa-cli.nix), use the Beta Channel of Rust toolchain, automatically update and builds for verification by Github Action daily.
+  Stable is the `maa-cli` that is packaged in [nixpkgs](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/ma/maa-cli/package.nix), using the nixpkgs's Rust toolchain；Nightly is in [NUR](https://github.com/Cryolitia/nur-packages/blob/master/pkgs/maa-assistant-arknights/maa-cli.nix), it uses the Beta Channel of Rust toolchain, automatically updates and builds for verification by Github Action daily.
 
 - For Linux Brew users, you can install with [Linux Brew](https://docs.brew.sh/Homebrew-on-Linux):
 

--- a/docs/en-us/1.6-USER_GUIDE_FOR_CLI.md
+++ b/docs/en-us/1.6-USER_GUIDE_FOR_CLI.md
@@ -13,7 +13,7 @@ icon: material-symbols:terminal
 
 ### Appimage
 
-The CLI is the default interface of MAA on Linux. You can use the CLI directly by [downloading](https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases/latest) the latest Appimage.
+The CLI is the default interface of MAA on Linux. You can use the CLI directly by downloading the latest [Appimage](https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases/latest).
 
 ### Package manager
 

--- a/docs/en-us/1.6-USER_GUIDE_FOR_CLI.md
+++ b/docs/en-us/1.6-USER_GUIDE_FOR_CLI.md
@@ -27,17 +27,31 @@ brew install MaaAssistantArknights/tap/maa-cli
 
 #### Linux
 
-ArchLinux user can install [AUR package](https://aur.archlinux.org/packages/maa-cli/):
+- Arch Linux users can install [AUR package](https://aur.archlinux.org/packages/maa-cli/):
 
-```bash
-yay -S maa-cli
-```
+   ```bash
+   yay -S maa-cli
+   ```
 
-For LinuxBrew user, you can install with [LinuxBrew](https://docs.brew.sh/Homebrew-on-Linux):
+- Nix users can run directly:
 
-```bash
-brew install MaaAssistantArknights/tap/maa-cli
-```
+  ```bash
+  # Stable
+  nix run nixpkgs#maa-cli
+  ```
+
+  ```bash
+  # Nightly
+  nix run github:Cryolitia/nur-packages#maa-cli-nightly
+  ```
+
+  Stable is the `maa-cli` that packaged in [nixpkgs](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/ma/maa-cli/package.nix), using the nixpkgs's Rust toolchain；Nightly is in [NUR](https://github.com/Cryolitia/nur-packages/blob/master/pkgs/maa-assistant-arknights/maa-cli.nix), use the Beta Channel of Rust toolchain, automatically update and builds for verification by Github Action daily.
+
+- For Linux Brew users, you can install with [Linux Brew](https://docs.brew.sh/Homebrew-on-Linux):
+
+   ```bash
+   brew install MaaAssistantArknights/tap/maa-cli
+   ```
 
 ### Prebuilt binary
 

--- a/docs/en-us/1.6-USER_GUIDE_FOR_CLI.md
+++ b/docs/en-us/1.6-USER_GUIDE_FOR_CLI.md
@@ -13,7 +13,7 @@ icon: material-symbols:terminal
 
 ### Appimage
 
-The CLI is the default interface of MAA on Linux. You can use the CLI directly by download the latest Appimage.
+The CLI is the default interface of MAA on Linux. You can use the CLI directly by [download](https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases/latest) the latest Appimage.
 
 ### Package manager
 

--- a/docs/en-us/2.1-LINUX_TUTORIAL.md
+++ b/docs/en-us/2.1-LINUX_TUTORIAL.md
@@ -1,9 +1,10 @@
 # Linux Compilation Tutorial
 
-**The tutorial requires some basic knowledge about Linux OS!**
+**The tutorial requires some basic knowledge about Linux OS!**, If you just want to install MAA directly instead of compiling it yourself, please read [Emulator Support for Linux](./1.5-EMULATOR_SUPPORTS_FOR_LINUX).
 
-> **Note**
-> Linux build of MAA is still under discussion, some of the content might be outdated, please follow the script in [GitHub workflow file](../.github/workflows/release-maa-linux.yml)
+::: info **Note**
+Linux build of MAA is still under discussion, some of the content might be outdated, please follow the script in [GitHub workflow file](../.github/workflows/release-maa-linux.yml), also reference [AUR PKGBUILD](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=maa-assistant-arknights), [nixpkgs](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/ma/maa-assistant-arknights/package.nix)
+:::
 
 ## Compiling MAA
 
@@ -29,6 +30,7 @@
 
         > **Note**
         > It contains shared objects built on a relatively new linux distro (Ubuntu 22.04), which may cause ABI incompatibility if you are working on a system with older version of libstdc++.
+
         ```bash
         python maadeps-download.py
         ```
@@ -59,10 +61,6 @@
     cmake --install build --prefix <target_directory>
     ```
 
-## Other methods
-- AUR: [maa-assistant-arknights](https://aur.archlinux.org/packages/maa-assistant-arknights)
-
-
 ## Integration
 
 [~~Maybe not a doc~~](https://github.com/MistEO/MaaCoreArknights/wiki)
@@ -75,6 +73,6 @@ Refer to the implementation of `__main__` in [Python demo](https://github.com/Ma
 
 Refer to the implementation of [CppSample](https://github.com/MaaAssistantArknights/MaaAssistantArknights/blob/master/src/CppSample/main.cpp)
 
-### C sharp
+### C Sharp
 
 Refer to the implementation of [MaaWpfGui](https://github.com/MaaAssistantArknights/MaaAssistantArknights/blob/master/src/MaaWpfGui/Helper/AsstProxy.cs)

--- a/docs/en-us/2.1-LINUX_TUTORIAL.md
+++ b/docs/en-us/2.1-LINUX_TUTORIAL.md
@@ -1,6 +1,7 @@
-# Linux Compilation Tutorial
+# Linux Compiling Tutorial
 
-**The tutorial requires some basic knowledge about Linux OS!**, If you just want to install MAA directly instead of compiling it yourself, please read [Emulator Support for Linux](./1.5-EMULATOR_SUPPORTS_FOR_LINUX).
+**The tutorial requires some basic knowledge about Linux OS!**
+If you just want to install MAA directly instead of compiling it yourself, please read [Emulator Support for Linux](./1.5-EMULATOR_SUPPORTS_FOR_LINUX).
 
 ::: info **Note**
 Linux build of MAA is still under discussion, some of the content might be outdated, please follow the script in [GitHub workflow file](../.github/workflows/release-maa-linux.yml), also reference [AUR PKGBUILD](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=maa-assistant-arknights), [nixpkgs](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/ma/maa-assistant-arknights/package.nix)
@@ -12,15 +13,15 @@ Linux build of MAA is still under discussion, some of the content might be outda
 
     - Ubuntu/Debian
 
-    ```bash
-    sudo apt install gcc-12 g++-12 cmake zlib1g-dev
-    ```
+        ```bash
+        sudo apt install gcc-12 g++-12 cmake zlib1g-dev
+        ```
 
     - Arch Linux
 
-    ```bash
-    sudo pacman -S --needed gcc cmake zlib
-    ```
+        ```bash
+        sudo pacman -S --needed gcc cmake zlib
+        ```
 
 2. Build or download third-party libraries
 

--- a/docs/zh-tw/1.5-Linux模擬器支援.md
+++ b/docs/zh-tw/1.5-Linux模擬器支援.md
@@ -5,9 +5,20 @@ icon: teenyicons:linux-alt-solid
 
 ## 準備工作
 
-### 1. 安裝 MAA
+以下安裝方式任選其一即可：
 
-1. 在 [MAA 官網](https://maa.plus/) 下載 Linux 動態庫並解壓縮
+### 使用 maa-cli
+
+[maa-cli](https://github.com/MaaAssistantArknights/maa-cli) 是一個使用 Rust 編寫的簡單 MAA 命令列工具。相關安裝與使用教程請閱讀[CLI 使用指南](./1.6-CLI使用說明)。
+
+### 使用 Python
+
+#### 1. 安裝 MAA 動態庫
+
+1. 在 [MAA 官網](https://maa.plus/) 下載 Linux 動態庫並解壓，或從軟體源安裝：
+
+   - AUR：[maa-assistant-arknights](https://aur.archlinux.org/packages/maa-assistant-arknights)，按照安裝後的提示編輯檔案
+   - Nixpkgs: [maa-assistant-arknights](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/ma/maa-assistant-arknights/package.nix)
 
 2. 進入 `./MAA-v{版本號}-linux-{架構}/Python/` 目錄下打開 `sample.py` 文件
 
@@ -16,9 +27,7 @@ icon: teenyicons:linux-alt-solid
 可以參考 [2.1-Linux編譯教學](./2.1-Linux編譯教學.md) 重新編譯或使用容器執行
 :::
 
-- Arch Linux 系列發行版可以選擇使用 aur 包 [maa-assistant-arknights](https://aur.archlinux.org/packages/maa-assistant-arknights) ，並按照安裝後的提示編輯文件。
-
-### 2. `adb` 配置
+#### 2. `adb` 配置
 
 1. 找到 [`if asst.connect('adb.exe', '127.0.0.1:5554'):`](https://github.com/MaaAssistantArknights/MaaAssistantArknights/blob/722f0ddd4765715199a5dc90ea1bec2940322344/src/Python/sample.py#L48) 一欄
 
@@ -50,7 +59,7 @@ icon: teenyicons:linux-alt-solid
 
 4. 這時候可以測試下： `$ python3 sample.py` ，如果返回 `連接成功` 則基本成功了
 
-### 3. 任務配置
+#### 3. 任務配置
 
 自定義任務： 根據需要參考 [3.x 集成文件](https://maa.plus/docs/3.1-%E9%9B%86%E6%88%90%E6%96%87%E6%A1%A3.html) 對 `sample.py` 的 [`# 任務及參數請參考 docs/集成文件.md`](https://github.com/MaaAssistantArknights/MaaAssistantArknights/blob/722f0ddd4765715199a5dc90ea1bec2940322344/src/Python/sample.py#L54) 一欄進行修改
 

--- a/docs/zh-tw/1.6-CLI使用說明.md
+++ b/docs/zh-tw/1.6-CLI使用說明.md
@@ -1,137 +1,201 @@
-# CLI使用指南
+# CLI 使用指南
 
 ## 功能介紹
 
-- 通過 TOML、JSON、YAML 格式的配置檔案定義 MAA 任務流程，並通過 `maa run <task>` 命令執行任務。
-- 通過 `maa list` 命令列出所有可用任務。
-- 通過 `maa install` 和 `maa update` 命令安裝和更新 MAA 共享庫和資源。
-- 通過 `maa self update` 命令更新CLI自身。
+- 執行預定義或自定義的任務，例如 `maa fight`， `maa run <task>`;
+- 使用 `maa install` 和 `maa update` 安裝和更新`MaaCore`及資源；
+- 使用 `maa self-update` 更新自身。
 
 ## 安裝
 
-### Linux
+### Appimage
 
-對於最新版本的 MAA，CLI 已經打包在 MAA 壓縮檔中，如果你下載了最新版 MAA，解壓縮後就可以使用 CLI，無需額外安裝。 **注意**: 請不要將庫檔案和資源檔案隨便移動到其他位置，否則 CLI 將無法找到它們。 如果你想將它們移動到其他位置，你可以通過以下命令：
+CLI 是 MAA 在 Linux 平臺的預設介面，你可以直接 [下載](https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases/latest) 最新的 AppImage 包來使用 CLI。
+
+### 包管理器
+
+#### macOS
+
+使用 [Homebrew](https://brew.sh/) 安裝：
 
 ```bash
-# 請確保你目前的工作目錄是解壓縮後的 MAA 目錄
-lib_dir="$(./maa dir data)/lib"
-resource_dir="$(./maa dir data)/resource"
-mv lib* "$lib_dir"
-mv resource "$resource_dir"
+brew install MaaAssistantArknights/tap/maa-cli
 ```
 
-如果你目前使用的是舊版本的 MAA 或者希望單獨安裝 CLI，你可以前往 [CLI Release頁面](https://github.com/MaaAssistantArknights/maa-cli/releases/latest) 根據你的架構下載對應的預編譯的 CLI 二進制檔案（對於 x86_64 架構，你可以下載以 `x86_64-unknown-linux-gnu.tar.gz` 結尾的檔案，對於 aarch64 架構，你可以下載以 `aarch64-unknown-linux-gnu.tar.gz` 結尾的檔案），解壓縮後將 `maa` 檔案移動到你任何在 `PATH` 環境變量中的目錄下，然後使用 `maa install` 命令安裝 MAA 共享庫和資源。
+#### Linux
 
-### macOS
+- Arch Linux 使用者可以安裝 [AUR 包](https://aur.archlinux.org/packages/maa-cli/):
 
-macOS 用戶和 Linux 用戶一樣，可以在 [CLI Release 頁面](https://github.com/MaaAssistantArknights/maa-cli/releases/latest)下載對應的預編譯的 CLI 二進制檔案（macOS 提供通用的二進制檔案，以 `universal-apple-darwin.zip` 結尾），解壓縮後將 `maa` 檔案移動到你任何在 `PATH` 環境變量中的目錄下，然後使用 `maa install` 命令安裝 MAA 共享庫和資源。
+  ```bash
+  yay -S maa-cli
+  ```
 
-### Windows
+- ❄️ Nix 使用者可以直接執行:
 
-CLI 目前尚不支援 Windows。
+  ```bash
+  # 穩定版
+  nix run nixpkgs#maa-cli
+  ```
 
-## 使用和配置
+  ```bash
+  # 每夜構建
+  nix run github:Cryolitia/nur-packages#maa-cli-nightly
+  ```
+
+  穩定版打包至 [nixpkgs](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/ma/maa-cli/package.nix) 中，使用 `nixpkgs` 中的 Rust 工具鏈；每夜構建位於 [NUR](https://github.com/Cryolitia/nur-packages/blob/master/pkgs/maa-assistant-arknights/maa-cli.nix) 中，使用 Beta channel 的 Rust 工具鏈，由 Github Action 每日自動更新和構建驗證。
+
+- 對於 Linux Brew 使用者，可以使用 [Linux Brew](https://docs.brew.sh/Homebrew-on-Linux) 安裝：
+
+  ```bash
+  brew install MaaAssistantArknights/tap/maa-cli
+  ```
+
+### 預編譯二進位制檔案
+
+你可以從 [`maa-cli` release 頁面](https://github.com/MaaAssistantArknights/maa-cli/releases/latest)下載預編譯的二進位制檔案，將其解壓後得到的可執行檔案放在你喜歡的位置。不同的平臺對應的檔名如下：
+
+<table>
+    <thead>
+        <tr>
+            <th>作業系統</th>
+            <th>處理器架構</th>
+            <th>檔名</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td rowspan=2>Linux</td>
+            <td>x86_64</td>
+            <td>maa_cli-x86_64-unknown-linux-gnu.tar.gz</td>
+        </tr>
+        <tr>
+            <td>aarch64</td>
+            <td>maa_cli-aarch64-unknown-linux-gnu.tar.gz</td>
+        </tr>
+        <tr>
+            <td rowspan=2>macOS</td>
+            <td>x86_64</td>
+            <td rowspan=2>
+              maa_cli-universal-apple-darwin.zip
+            </td>
+        </tr>
+        <tr>
+            <td>aaarch64</td>
+        </tr>
+        <tr>
+            <td rowspan=2>Windows</td>
+            <td>x86_64</td>
+            <td>maa_cli-x86_64-pc-windows-msvc.zip</td>
+        </tr>
+    </tbody>
+</table>
+
+## 使用
+
+`maa-cli` 的主要功能是執行任務，你可以透過 `maa run <task>` 來執行一個任務。這裡的 `<task>` 是一個任務的名字，你可以透過 `maa list` 來列出所有可用的任務。
+
+更多資訊可以透過 `maa help` 獲取。
+
+### 執行任務
+
+`maa-cli` 的主要功能是執行任務，包括預定義的任務和自定義的任務。
+
+#### 預定義任務
+
+- `maa startup [client]`: 啟動遊戲並進入主介面，`[client]` 是客戶端型別，如果留空則不會啟動遊戲客戶端。
+- `maa closedown`: 關閉遊戲客戶端；
+- `maa fight [stage]`: 執行戰鬥任務，`[stage]` 是關卡名稱，例如 `1-7`；留空選擇上次或者當前關卡；
+- `maa copilot <maa_uri>`: 執行自動戰鬥任務，其中 `<maa_uri>` 是作業的 URI，其可以是 `maa://1234` 或者本地檔案路徑 `./1234.json`；
+- `maa roguelike [theme]`: 執行 roguelike 模式的戰鬥任務，`[theme]` 是 roguelike 模式的主題，可選值為 `Phantom`，`Mizuki` 以及 `Sami`；
+
+#### 自定義任務
+
+你可以透過 `maa run <task>` 來執行自定義任務。這裡的 `<task>` 是一個任務的名字，你可以透過 `maa list` 來列出所有可用的任務。
+具體的任務定義可以在 [配置小節](#定義自定義任務) 中找到。
+
+#### 任務總結
+
+`maa-cli` 會在任務執行結束後向 stdout 輸出任務總結，包括每個子任務的執行時間和結果。你可以透過 `--no-summary` 選項來停用任務總結。
+
+任務總結主要包括各任務的執行時間。對於以下任務，還會包括其他資訊：
+
+- 刷理智 `fight`: 關卡名稱，次數以及掉落統計；
+- 基建換班 `infrast`: 各設施進駐的幹員，對於製造站和貿易站，還會包括產物型別；
+- 公招 `recruit`: 公招標籤重新整理次數，招募次數以及檢測到的 tag 及星級。
+- 肉鴿 `roguelike`: 進行的次數，投資的次數。
+
+#### 日誌輸出
+
+`maa-cli` 預設會向 stderr 輸出日誌。日誌輸出級別從低到高分別為 `Error`，`Warn`，`Info`，`Debug` 和 `Trace`。預設的日誌輸出級別為 `Warn`。日誌級別可以透過 `MAA_LOG` 環境變數來設定，例如 `MAA_LOG=debug`。你也可以透過 `-v` 或者 `-q` 來增加或者減少日誌輸出級別。
+
+`--log-file` 選項可以將日誌輸出到檔案中，日誌儲存在 `$(maa dir log)/YYYY/MM/DD/HH:MM:SS.log` 中，其中 `$(maa dir log)` 是日誌目錄，你可以透過 `maa dir log` 獲取。你也可以透過 `--log-file=path/to/log` 來指定日誌檔案的路徑。
+
+### 安裝和更新
+
+#### 安裝和更新 MaaCore
+
+你可以透過 `maa install` 和 `maa update` 來安裝和更新 `MaaCore` 及資源，更多資訊可以透過 `maa help install` 和 `maa help update` 獲取。
+
+#### 資源熱更新
+
+由於遊戲的更新，`MaaCore` 需要最新的資源才能正常執行，你可以透過 `maa hot-update` 來更新資源，或者設定資源自動更新，詳見 [CLI 相關配置](#maa-cli-相關配置)
+
+#### 更新自身
+
+你可以透過 `maa self update` 來更新 `maa-cli` 自身，注意對於由包管理器安裝的 `maa-cli`，你應該使用包管理器來更新 `maa-cli`。
+
+更多其他的命令可以透過 `maa help` 獲取。
+
+### 其他子命令
+
+- `maa list`: 列出所有可用的任務；
+- `maa dir <dir>`: 獲取特定目錄的路徑，比如 `maa dir config` 可以用來獲取配置目錄的路徑;
+- `maa version`: 獲取 `maa-cli` 以及 `MaaCore` 的版本資訊；
+- `maa convert <input> [output]`: 將 `JSON`，`YAML` 或者 `TOML` 格式的檔案轉換為其他格式;
+- `maa complete <shell>`: 生成自動補全指令碼;
+- `maa activity [client]`: 獲取遊戲的當前活動資訊，`client` 是客戶端型別，預設為 `Official`。
+
+## 配置
 
 ### 配置目錄
 
-你的配置檔案（選項、任務等）位於配置目錄中，你可以通過 `maa dir config` 獲取配置目錄，並通過 `mkdir -p "$(maa dir config)"` 建立它。在以下的介紹中，配置目錄的將被稱為 `$MAA_CONFIG_DIR`。此外儘管所有的例子都是針對 TOML 格式的，但是以下所有配置檔案的格式可以是 TOML、JSON 或 YAML。
+`maa-cli` 配置檔案位於特定的配置目錄中，你可以透過`maa dir config`獲取配置目錄。配置目錄也可以透過環境變數 `MAA_CONFIG_DIR` 更改。在下面的例子中，我們將用 `$MAA_CONFIG_DIR` 來表示配置目錄。
 
-### MAA 選項
+所有的配置檔案都可以使用 TOML，YAML 或者 JSON 格式，在下面的例子中，我們將使用 TOML 格式，並使用 `.toml` 作為副檔名。但是你可以混合這三種格式中的任意一種，只要你的副檔名正確。
 
-針對 MAA 本身的選項，你可以在 `$MAA_CONFIG_DIR/asst.toml` 中進行配置。這裡的選項包括三個部分：
+### 定義自定義任務
 
-- `connection`：MAA 連接設定；
-- `instance_options`：MAA 實例選項；
-- `resources`: 額外資源地址。
+每一個自定義任務都是一個單獨的檔案，它們應該位於 `$MAA_CONFIG_DIR/tasks` 目錄中。
 
-#### `connection` 設定
+#### 基本結構
 
-`connection` 設定用於配置 MAA 連接遊戲，其包括兩種方式：通過 ADB 連接和通過 PlayTools 連接。
-
-##### ADB 連接
-
-當你使用 ADB 連接時，你需要提供 `adb` 的路徑和設備的序列號:
-
-```toml
-[connection]
-type = "ADB"
-adb_path = "adb" # adb 執行檔的路徑
-device = "emulator-5554" # 你的 android 設備的序列號
-config = "General" # maa connect 的配置名稱，可選，不建議修改
-```
-
-設備的序列號可以是地址加通訊埠號，也可以是非地址的任意字符串，可以通過 `adb devices` 命令獲取。更多資訊請參考模擬器支援檔案。
-
-##### PlayTools 連接
-
-當你使用 PlayTools 連接時，你需要提供在 PlayCover 中設定的 MacTools 的地址:
-
-```toml
-[connection]
-type = "PlayTools"
-client_address = "localhost:1717" # MacTools 的地址
-config = "CompatMac" # maa connect 的配置，可選，不建議修改
-```
-
-使用之前請先閱讀 [Mac 模擬器支援](https://maa.plus/docs/1.4-Mac模擬器支援.html#✅-playcover-原生執行最流暢🚀)。
-
-#### `instance_options` 設定
-
-`instance_options` 部分用於配置 MAA 實例的選項：
-
-```toml
-[instance_options]
-touch_mode = "ADB" # 使用的觸摸模式，可選值為 "ADB"，"MiniTouch"，"MaaTouch" 或者 "MacPlayTools"（僅適用於PlayTools連接）
-deployment_with_pause = false # 是否在部署時暫停遊戲
-adb_lite_enabled = false # 是否使用 adb-lite
-kill_adb_on_exit = false # 是否在退出時殺死 adb
-```
-
-注意，如果你使用 PlayTools 連接，`touch_mode` 欄位將被忽略並被設定為 `MacPlayTools`。
-
-#### `resources` 設定
-
-`resources` 部分用於指定資源的路徑，這是一個資源目錄列表（如果是相對路徑，路徑應該相對於 MAA 主倉庫的 `resource` 目錄）：
-
-```toml
-resources = ["platform_diff/iOS", "global/YoStarEN"]
-```
-
-這對於指定不同平台的資源和使用外服的用戶非常有用。
-
-### 定義任務
-
-任務檔案位於 `$MAA_CONFIG_DIR/tasks` 目錄下。 每一個任務檔案都是一個任務列表，每一個子任務是一個 MAA 任務，其中包含任務類型和參數，可用的任務及其參數參見[集成文件](https://maa.plus/docs/3.1-集成文件.html#asstappendtask)。
-
-一個簡單的任務檔案範例：
+一個任務檔案包含多個子任務，每一個子任務是一個 [MAA 任務](../協議文件/整合文件.md#asstappendtask)，其包含一下幾個選項：
 
 ```toml
 [[tasks]]
-type = "StartUp"
-params = { client_type = "Official", start_game_enabled = true }
-
-[[tasks]]
-type = "CloseDown"
+name = "啟動遊戲" # 任務的名字，可選，預設為任務型別
+type = "StartUp" # maa任務的型別
+params = { client_type = "Official", start_game_enabled = true } # maa任務的引數
 ```
 
-建議每個任務中都包含 `StartUp` 並聲明參數 `client_type`，這個參數用於指定用戶端類型，並會在 CLI 其他部分使用。
+#### 任務條件
 
-如果你想要根據一些條件執行不同參數的任務，你可以定義多個任務的變體：
+如果你想要根據一些條件執行不同引數的任務，你可以定義多個任務的變體：
 
 ```toml
 [[tasks]]
+name = "基建換班"
 type = "Infrast"
 
 [tasks.params]
 mode = 10000
 facility = ["Trade", "Reception", "Mfg", "Control", "Power", "Office", "Dorm"]
 dorm_trust_enabled = true
-filename = "normal.json" # 自定義的基建計劃的檔案名應該位於 `$MAA_CONFIG_DIR/infrast`
+filename = "normal.json" # 自定義的基建計劃的檔名應該位於`$MAA_CONFIG_DIR/infrast`
 
-# 在 12:00:00 之前使用計劃 1，在 12:00:00 到 18:00:00 之間使用計劃 2，在 18:00:00 之後使用計劃 0
+# 在12:00:00之前使用計劃1，在12:00:00到18:00:00之間使用計劃2，在18:00:00之後使用計劃0
 [[tasks.variants]]
-condition = { type = "Time", end = "12:00:00" } # 如果沒有定義 start，那麽它將會是 00:00:00
+condition = { type = "Time", end = "12:00:00" } # 如果沒有定義start，那麼它將會是00:00:00
 params = { plan_index = 1 }
 
 [[tasks.variants]]
@@ -143,73 +207,371 @@ condition = { type = "Time", start = "18:00:00" }
 params = { plan_index = 0 }
 ```
 
-這裡的 `condition` 欄位用於確定哪一個變體應該被使用，而匹配的變體的 `params` 欄位將會被合併到主任務的 `params` 欄位中。
+這裡的 `condition` 欄位用於確定哪一個變體應該被使用，而匹配的變體的 `params` 欄位將會被合併到任務的引數中。
 
-**注意**：這個 CLI 不會讀取基建計劃檔案中的任何內容，包括基建計劃檔案中定義的時間段，所以你必須在 `condition` 欄位中定義時間段來在不同的時間執行不同的基建計劃。
+**注意**：如果你的自定義基建計劃檔案使用相對路徑，應該相對於 `$MAA_CONFIG_DIR/infrast`。此外，由於基建檔案是由 `MaaCore` 而不是 `maa-cli` 讀取的，因此這些檔案的格式必須是 `JSON`。同時，`maa-cli` 不會讀取基建檔案，也不會根據其中定義的時間段來選擇相應的子計劃。因此，必須透過 `condition` 欄位來指定在相應時間段使用正確的基建計劃的引數中的 `plan_index` 欄位。這樣可以確保在適當的時間段使用正確的基建計劃。
 
-除了 `Time` 條件，還有 `DateTime`、`Weakday` 和 `Combined`（其他條件的組合）條件：
+除了 `Time` 條件，還有 `DateTime`，`Weekday`，`DayMod`條件。`DateTime` 條件用於指定一個時間段，`Weekday` 條件用於指定一週中的某些天，`DayMod` 見下文多天排班。
 
 ```toml
 [[tasks]]
 type = "Fight"
 
-# 周一早上刷 5 次剿滅
-[[tasks.variants]]
-params = { "stage" = "Annihilation", times = 5 }
-[tasks.variants.condition]
-type = "Combined"
-conditions = [
-  { type = "Weekday", weekdays = ["Mon"] },
-  { type = "Time", end = "12:00:00" },
-]
-
-# 在夏活期間，刷 SL-8
+# 在夏活期間，刷SL-8
 [[tasks.variants]]
 params = { stage = "SL-8" }
 condition = { type = "DateTime", start = "2023-08-01T16:00:00", end = "2023-08-21T03:59:59" }
 
-# 在夏活期間以外的周二、周四和周六，刷 CE-6
+# 在夏活期間以外的週二、週四和週六，刷CE-6
 [[tasks.variants]]
 condition = { type = "Weekday", weekdays = ["Tue", "Thu", "Sat"] }
 params = { stage = "CE-6" }
 
-# 其他時間，刷 1-7
+# 其他時間，刷1-7
 [[tasks.variants]]
 params = { stage = "1-7" }
 ```
 
-如果有多個變體被匹配，第一個將會被使用。如果沒有給出條件，那麽變體將會總是被匹配，所以你可以把沒有條件的變體放在最後作為預設的情況。
+除了上述確定的條件之外，還有一個依賴於熱更新資源的條件 `OnSideStory`，當你啟動該條件後，`maa-cli` 會嘗試讀取相應的資源來判斷當前是否有正在開啟的活動，如果有那麼對應的變體會被匹配。 比如上述夏活期間刷 `SL-8` 的條件就可以簡化為 `{ type = "OnSideStory", client = "Official" }`，這裡的 `client` 引數用於確定你使用的客戶端，因為不同的客戶端的活動時間不同，對於使用官服或者 b 服的使用者，這可以省略。透過這個條件，每次活動更新之後你可以只需要更新需要刷的關卡而不需要手動編輯對應活動的開放時間。
 
-如果沒有變體被匹配，那麽任務將不會被執行，這在你想要任務只在某些條件下執行任務時很有用：
+除了以上基礎條件之外，你可以使用 `{ type = "And", conditions = [...] }`，`{ type = "Or", conditions = [...] }`, `{ type = "Not", condition = ... }` 來對條件進行邏輯運算。
+
+對於想要基建多天排班的使用者，可以將 `DayMod` 和 `Time` 組合使用，可以實現多天排班。比如，你想要實現每兩天換六次班，那麼你可以這樣寫：
 
 ```toml
-# 只在 18:00:00 之後進行信用商店相關的操作
+[[tasks]]
+name = "基建換班 (2天6班)"
+type = "Infrast"
+
+[tasks.params]
+mode = 10000
+facility = ["Trade", "Reception", "Mfg", "Control", "Power", "Office", "Dorm"]
+dorm_trust_enabled = true
+filename = "normal.json"
+
+# 第一班，第一天 4:00:00 - 12:00:00
+[[tasks.variants]]
+params = { plan_index = 0 }
+[tasks.variants.condition]
+type = "And"
+conditions = [
+    # 這裡的 divisor 用來指定週期，remainder 用來指定偏移量
+    # 偏移量等於 num_days_since_ce % divisor
+    # 這裡的 num_days_since_ce 是公元以來的天數，0001-01-01 是第一天
+    # 當天偏移量你可以透過 `maa remainder <divisor>` 來獲取.
+    # 比如，2024-1-27 是第 738,912 天，那麼 738912 % 2 = 0
+    # 當天的偏移量為 0，那麼本條件將會被匹配
+    { type = "DayMod", divisor = 2, remainder = 0 },
+    { type = "Time", start = "04:00:00", end = "12:00:00" },
+]
+
+# 第二班，第一天 12:00:00 - 20:00:00
+[[tasks.variants]]
+params = { plan_index = 1 }
+[tasks.variants.condition]
+type = "And"
+conditions = [
+  { type = "DayMod", divisor = 2, remainder = 0 },
+  { type = "Time", start = "12:00:00", end = "20:00:00" },
+]
+
+# 第三班，第一天 20:00:00 - 第二天 4:00:00
+[[tasks.variants]]
+params = { plan_index = 2 }
+[tasks.variants.condition]
+# 注意這裡必須使用 Or 條件，不能直接使用 Time { start = "20:00:00", end = "04:00:00" }
+# 在這種情況下， 第二天的 00:00:00 - 04:00:00 不會被匹配
+# 當然透過調整你的排班時間避免跨天是更好的選擇，這裡只是為了演示
+type = "Or"
+conditions = [
+  { type = "And", conditions = [
+     { type = "DayMod", divisor = 2, remainder = 0 },
+     { type = "Time", start = "20:00:00" },
+  ] },
+  { type = "And", conditions = [
+     { type = "DayMod", divisor = 2, remainder = 1 },
+     { type = "Time", end = "04:00:00" },
+  ] },
+]
+
+# 第四班，第二天 4:00:00 - 12:00:00
+[[tasks.variants]]
+params = { plan_index = 3 }
+[tasks.variants.condition]
+type = "And"
+conditions = [
+  { type = "DayMod", divisor = 2, remainder = 1 },
+  { type = "Time", start = "04:00:00", end = "12:00:00" },
+]
+
+# 第五班，第二天 12:00:00 - 20:00:00
+[[tasks.variants]]
+params = { plan_index = 4 }
+[tasks.variants.condition]
+type = "And"
+conditions = [
+  { type = "DayMod", divisor = 2, remainder = 1 },
+  { type = "Time", start = "12:00:00", end = "20:00:00" },
+]
+
+# 第六班，第二天 20:00:00 - 第三天（新的第一天）4:00:00
+[[tasks.variants]]
+params = { plan_index = 5 }
+[tasks.variants.condition]
+type = "Or"
+conditions = [
+  { type = "And", conditions = [
+     { type = "DayMod", divisor = 2, remainder = 1 },
+     { type = "Time", start = "20:00:00" },
+  ] },
+  { type = "And", conditions = [
+     { type = "DayMod", divisor = 2, remainder = 0 },
+     { type = "Time", end = "04:00:00" },
+  ] },
+]
+```
+
+在預設的策略下，如果有多個變體被匹配，第一個將會被使用。如果沒有給出條件，那麼變體將會總是被匹配，所以你可以把沒有條件的變體放在最後，作為預設的情況。
+
+你可以使用 `strategy` 欄位來改變匹配策略：
+
+```toml
+[[tasks]]
+type = "Fight"
+strategy = "merge" # 或者 "first" (預設)
+
+# 在周天晚上使用所有的將要過期的理智藥
+[[tasks.variants]]
+params = { expiring_medicine = 1000 }
+
+[tasks.variants.condition]
+type = "And"
+conditions = [
+  { type = "Time", start = "18:00:00" },
+  { type = "Weekday", weekdays = ["Sun"] },
+]
+
+# 預設刷1-7
+[[tasks.variants]]
+params = { stage = "1-7" }
+
+# 在週二、週四和週六，刷CE-6
+[[tasks.variants]]
+condition = { type = "Weekday", weekdays = ["Tue", "Thu", "Sat"] }
+params = { stage = "CE-6" }
+
+# 在夏活期間，刷SL-8
+[[tasks.variants]]
+params = { stage = "SL-8" }
+condition = { type = "DateTime", start = "2023-08-01T16:00:00", end = "2023-08-21T03:59:59" }
+```
+
+這個例子和上面的例子將刷同樣的關卡，但是在周天晚上，將會使用所有的將要過期的理智藥。在 `merge` 策略下，如果有多個變體被匹配，後面的變體的引數將合併入前面的變體的引數中。如果多個變體都有相同的引數，那麼後面的變體的引數將會覆蓋前面的變體的引數。
+
+如果沒有變體被匹配，那麼任務將不會被執行，這可以用於只在特定的條件下執行子任務：
+
+```toml
+# 只在在18:00:00之後進行信用商店相關的操作
 [[tasks]]
 type = "Mall"
-[tasks.params]
-shopping = true
-credit_fight = true
-buy_first = ["招聘許可", "龍門幣"]
-blacklist = ["碳", "家具", "加急許可"]
+
 [[tasks.variants]]
 condition = { type = "Time", start = "18:00:00" }
 ```
 
-### 執行任務
+#### 使用者輸入
 
-當你定義了任務後，你可以通過 `maa run <task>` 命令執行任務，所有可用的任務可以通過 `maa list` 命令列出。更多其他可用命令參見 `maa --help`。
+對於一些任務，你可能想要在執行時輸入一些引數，例如關卡名稱。 你可以將對應需要輸入的引數設定為 `Input` 或者 `Select` 型別：
 
-#### 日誌層級
+```toml
+[[tasks]]
+type = "Fight"
 
-當執行任務時，CLI 會處理 MAA 的消息。但是不是所有的消息都會輸出。日誌層級用於控制哪些消息會被輸出。目前有 6 個日誌層級：
+# 選擇一個關卡
+[[tasks.variants]]
+condition = { type = "DateTime", start = "2023-08-01T16:00:00", end = "2023-08-21T03:59:59" }
+[tasks.variants.params.stage]
+# 可選的關卡，必須提供至少一個可選值
+# 可選值可以是一個值，也可以是同時包含值和描述的一個表
+alternatives = [
+    "SL-7", # 將被顯示為 "1. SL-7"
+    { value = "SL-8", desc = "輕錳礦" } # 將被顯示為 "2. SL-8 (輕錳礦)"
+]
+default_index = 1 # 預設值的索引，從 1 開始，如果沒有設定，輸入空值將會重新提示輸入
+description = "a stage to fight in summer event" # 描述，可選
+allow_custom = true # 是否允許輸入自定義的值，預設為 false，如果允許，那麼非整數的值將會被視為自定義的值
 
-- Error：出現錯誤，MAA 將會停止執行或者無法正常工作；
-- Warning：出現錯誤，但是 MAA 仍然可以正常工作；
-- Normal：一些簡要的資訊，例如任務開始和結束；
-- Info：更詳細的資訊，例如關卡掉落統計、基建自定義換班幹員、肉鴿關卡資訊等；
-- Debug：關於你的配置的詳細資訊，例如將要執行任務的類型和參數；
-- Trace：任何沒有被 CLI 正確解析的 MAA 消息。
+# 無需任何輸入
+[[tasks.variants]]
+condition = { type = "Weekday", weekdays = ["Tue", "Thu", "Sat"] }
+params = { stage = "CE-6" }
 
-預設的日誌層級是 `Normal`，你可以通過 `-v` 和 `-q` 選項來控制日誌層級：`-v` 將會提高日誌層級以顯示更多消息，`-q` 將會降低日誌層級以顯示更少的消息，重覆使用 `-v` 和 `-q` 將會提高或降低日誌層級，直到達到最高或最低層級。比如，`-vv` 將會顯示 `Debug` 層級及以上的消息，而 `-qq` 將會顯示 `Warning` 層級及以下的消息。
+# 輸入一個關卡
+[[tasks.variants]]
+[tasks.variants.params.stage]
+default = "1-7" # 預設的關卡，可選（如果沒有預設值，輸入空值將會重新提示輸入）
+description = "a stage to fight" # 描述，可選
+[tasks.variants.params.medicine]
+# 依賴的引數，鍵為引數名，值為依賴的引數的預期值
+# 當設定時，只有所有的依賴引數都滿足預期值時，這個引數才會被要求輸入
+deps = { stage = "1-7" }
+default = 1000
+description = "medicine to use"
+```
 
-對於一般使用，建議使用 `maa run -v <task>`，這樣你可以看到 MAA 的所有有用的消息。當你在調試配置時，你可以使用 `maa run -vv <task>` 來看到更多的調試資訊。
+對於 `Input` 型別，當執行任務時，你將會被提示輸入一個值。如果你輸入了一個空值，如果有預設值，那麼預設值將會被使用，否則你將會被提示重新輸入。
+對於 `Select` 型別，當執行任務時，你將會被提示輸入一個的索引或者自定義的值（如果允許）。如果你輸入了一個空值，如果有預設值，那麼預設值將會被使用，否則你將會被提示重新輸入。
+
+`--batch` 選項可以用於在執行任務時跳過所有的輸入，這將會使用預設值；如果有任何輸入沒有預設值，那麼將會導致錯誤。
+
+### MaaCore 相關配置
+
+和 MaaCore 相關的配置需要放在 `$MAA_CONFIG_DIR/asst.toml` 中。
+目前其包含的配置有：
+
+```toml
+[connection]
+type = "ADB"
+adb_path = "adb"
+device = "emulator-5554"
+config = "CompatMac"
+
+[resource]
+global_resource = "YoStarEN"
+platform_diff_resource = "iOS"
+user_resource = true
+
+[static_options]
+cpu_ocr = false
+gpu_ocr = 1
+
+[instance_options]
+touch_mode = "MAATouch"
+deployment_with_pause = false
+adb_lite_enabled = false
+kill_adb_on_exit = false
+```
+
+#### 連線配置
+
+`[connection]` 相關欄位用於指定 MaaCore 連線遊戲的方式和引數。目前可用的連線方式有 `ADB` 和 `PlayTools`。
+
+當你使用 `ADB` 連線時，你需要提供 `adb` 的路徑和裝置的序列號：
+
+```toml
+[connection]
+type = "ADB"
+adb_path = "adb" # adb可執行檔案的路徑
+device = "emulator-5554" # 你的android裝置的序列號
+config = "General" # maa connect的配置
+```
+
+注意，此處的 device 是任何 `adb -s` 可以接受的值，比如 `emulator-5554` 和 `127.0.0.1:5555`。
+
+當你使用 `PlayTools` 連線時，你需要提供 `PlayTools` 的地址：
+
+```toml
+[connection]
+type = "PlayCover"
+address = "localhost:1717" # PlayTools的地址
+config = "CompatMac" # maa connect的配置
+```
+
+兩者都需要提供 `config`，這個值將被傳給 MaaCore，用於指定一些平臺和模擬器相關的配置。對於 Linux 他預設為 `CompatPOSIXShell`，對於 macOS 他預設為 `CompatMac`，對於 Windows 他預設為 `General`。更多可選配置可以在資原始檔夾中的 `config.json` 檔案中找到。
+
+#### 資源配置
+
+`[resource]` 相關欄位用於指定 MaaCore 載入的資源：
+
+```toml
+[resource]
+global_resource = "YoStarEN" # 非中文版本的資源
+platform_diff_resource = "iOS" # 非安卓版本的資源
+user_resource = true # 是否載入使用者自定義的資源
+```
+
+當使用非簡體中文遊戲客戶端時，由於 `MaaCore` 預設載入的資源是簡體中文的，你需要指定 `global_resource` 欄位來載入非中文版本的資源。當使用 iOS 版本的遊戲客戶端時，你需要指定 `platform_diff_resource` 欄位來載入 iOS 版本的資源。這兩者都是可選的，如果你不需要載入這些資源，你可以將這兩個欄位設定為空。其次，這兩者也會被自動設定，如果你的 `startup` 任務中指定了 `client_type` 欄位，那麼 `global_resource` 將會被設定為對應客戶端的資源，而當你使用 `PlayTools` 連線時，`platform_diff_resource` 將會被設定為 `iOS`。最後，當你想要載入使用者自定義的資源時，你需要將 `user_resource` 欄位設定為 `true`。
+
+#### 靜態選項
+
+`[static_options]` 相關欄位用於指定 MaaCore 靜態選項，詳見 [整合文件](../協議文件/整合文件.html#asstsetstaticoption)：
+
+```toml
+[static_options]
+cpu_ocr = false # 是否使用 CPU OCR，預設使用 CPU OCR
+gpu_ocr = 1 # 使用 GPU OCR 時使用的 GPU ID，如果這個值被留空，那麼將會使用 CPU OCR
+```
+
+#### 例項選項
+
+`[instance_options]` 相關欄位用於指定 MaaCore 例項的選項，詳見 [整合文件](../協議文件/整合文件.html#asstsetinstanceoption)：
+
+```toml
+[instance_options]
+touch_mode = "ADB" # 使用的觸控模式，可選值為 "ADB"，"MiniTouch"，"MAATouch" 或者 "MacPlayTools"
+deployment_with_pause = false # 是否在部署時暫停遊戲
+adb_lite_enabled = false # 是否使用 adb-lite
+kill_adb_on_exit = false # 是否在退出時殺死 adb
+```
+
+注意，`touch_mode` 可選項 `MacPlayTools` 和連線方式 `PlayTools` 繫結。當你使用 `PlayTools` 連線時，`touch_mode` 將會被強制設定為 `MacPlayTools`。
+
+### `maa-cli` 相關配置
+
+`maa-cli` 相關的配置需要放在 `$MAA_CONFIG_DIR/cli.toml` 中。目前其包含的配置如下：
+
+```toml
+# MaaCore 安裝和更新相關配置
+[core]
+channel = "Stable" # 更新通道，可選值為 "Alpha"，"Beta" "Stable"，預設為 "Stable"
+test_time = 0    # 用於測試映象速度的時間，0 表示不測試，預設為 3
+# 查詢 MaaCore 最新版本的 api 地址，留空表示使用預設地址
+api_url = "https://github.com/MaaAssistantArknights/MaaRelease/raw/main/MaaAssistantArknights/api/version/"
+
+# 配置是否安裝 MaaCore 對應的元件，不推薦使用，分開安裝可能會導致版本不一致，從而導致一些問題，該選項可能在未來的版本中移除
+[core.components]
+library = true  # 是否安裝 MaaCore 的庫，預設為 true
+resource = true # 是否安裝 MaaCore 的資源，預設為 true
+
+# CLI 更新相關配置
+[cli]
+channel = "Stable" # 更新通道，可選值為 "Alpha"，"Beta" "Stable"，預設為 "Stable"
+# 查詢 maa-cli 最新版本的 api 地址，留空表示使用預設地址
+api_url = "https://github.com/MaaAssistantArknights/maa-cli/raw/version/"
+# 下載預編譯二進位制檔案的地址，留空表示使用預設地址
+download_url = "https://github.com/MaaAssistantArknights/maa-cli/releases/download/"
+
+# 配置是否安裝 maa-cli 對應的元件
+[cli.components]
+binary = true # 是否安裝 maa-cli 的二進位制檔案，預設為 true
+
+# 資源熱更新相關配置
+[resource]
+auto_update = true  # 是否在每次執行任務時自動更新資源，預設為 false
+backend = "libgit2" # 資源熱更新後端，可選值為 "git" 或者 "libgit2"，預設為 "git"
+
+# 資源熱更新遠端倉庫相關配置
+[resource.remote]
+branch = "main" # 遠端倉庫的分支，預設為 "main"
+# 遠端倉庫的 url，如果你想要使用 ssh，你必須配置 ssh_key 的路徑
+url = "https://github.com/MaaAssistantArknights/MaaResource.git"
+# url = "git@github.com:MaaAssistantArknights/MaaResource.git"
+# ssh_key = "~/.ssh/id_ed25519" # ssh 私鑰的路徑，支援展開 ~ 但不支援其他環境變數
+```
+
+**注意事項**：
+
+- MaaCore 的更新通道中 `Alpha` 只在 Windows 上可用；
+- 由於 CLI 預設的 API 連結和下載連結都是 GitHub 的連結，因此在國內可能會有一些問題，你可以透過配置 `api_url` 和 `download_url` 來使用映象。
+- 即使啟動了資源熱更新，你依然需要安裝 `MaaCore` 的資源，因為資源熱更新並不包含所有的資原始檔，只是包含部份可更新的資原始檔，基礎資原始檔仍然需要安裝。
+- 資源熱更新是透過 Git 來拉取遠端倉庫，如果後端設定為 `git` 那麼 `git` 命令列工具必須可用。
+- 如果你想要使用 SSH 協議來拉取遠端倉庫，你必須配置 `ssh_key` 欄位，這個欄位應該是一個路徑，指向你的 SSH 私鑰。
+- 遠端倉庫的 `url` 設定目前只對首次安裝資源有效，如果你想要更改遠端倉庫的地址，你需要透過 `git` 命令列工具手動更改，或者刪除對應的倉庫。倉庫所在位置可以透過 `maa dir hot-update` 獲取。
+- 遠端倉庫的 `url` 會根據你本機的語言自動設定，如果你的語言是簡體中文，那麼遠端倉庫的 `url` 將會被設定為國內的映象 `https://git.maa-org.net/MAA/MaaResource.git`，在其他情況則會被設定為 Github。如果你在國內但是使用的不是簡體中文，或者在國外使用簡體中文，那麼你可能需要手動設定以獲得最佳的體驗。
+
+### JSON Schema
+
+你可以在 CLI 倉庫的 `maa-cli/schemas` 目錄下找到 `maa-cli` 的 JSON Schema 檔案，你可以使用這些檔案來驗證你的配置檔案，或者在編輯器中獲得自動補全。
+任務檔案的 JSON Schema 檔案為 [`task.schema.json`](https://github.com/MaaAssistantArknights/maa-cli/raw/v0.4.0/maa-cli/schemas/task.schema.json)；
+MaaCore 相關配置的 JSON Schema 檔案為 [`asst.schema.json`](https://github.com/MaaAssistantArknights/maa-cli/raw/v0.4.0/maa-cli/schemas/task.schema.json)；
+CLI 相關配置的 JSON Schema 檔案為 [`cli.schema.json`](https://github.com/MaaAssistantArknights/maa-cli/raw/v0.4.0/maa-cli/schemas/task.schema.json)。

--- a/docs/zh-tw/2.1-Linux編譯教學.md
+++ b/docs/zh-tw/2.1-Linux編譯教學.md
@@ -3,10 +3,10 @@ icon: teenyicons:linux-alt-solid
 ---
 # Linux 編譯教學
 
-**本教學需要讀者有一定的 Linux 環境配置能力及程式基礎！**
+**本教程需要讀者有一定的 Linux 環境配置能力及程式設計基礎！**，若您僅希望直接安裝MAA而非自行編譯，請閱讀[使用者手冊 - Linux 模擬器&容器](./1.5-Linux模擬器支援)。
 
 ::: info 注意
-MAA 的構建方法仍在討論中，本教學的內容可能過時，請以 [GitHub workflow file](https://github.com/MaaAssistantArknights/MaaAssistantArknights/blob/master/.github/workflows/ci.yml#L134) 中的腳本為準。
+MAA 的構建方法仍在討論中, 本教程的內容可能過時, 請以 [GitHub workflow file](https://github.com/MaaAssistantArknights/MaaAssistantArknights/blob/master/.github/workflows/ci.yml#L134) 中的指令碼為準。也可參考 [AUR PKGBUILD](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=maa-assistant-arknights)、[nixpkgs](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/ma/maa-assistant-arknights/package.nix)。
 :::
 
 ## 編譯過程
@@ -25,13 +25,14 @@ MAA 的構建方法仍在討論中，本教學的內容可能過時，請以 [Gi
 
         > **Note**
         > 包含在相對較新的 Linux 發行版 (Ubuntu 22.04) 中編譯的動態庫，如果您系統中的 libstdc++ 版本較老，可能遇到 ABI 不兼容的問題。
-        ```cmd
+
+        ```bash
         python maadeps-download.py
         ```
 
     - 自行構建第三方庫
 
-        ```cmd
+        ```bash
         git submodule update --init --recursive
         python maadeps-build.py
         ```
@@ -53,9 +54,6 @@ MAA 的構建方法仍在討論中，本教學的內容可能過時，請以 [Gi
     cmake --install build --prefix <target_directory>
     ```
 
-## 其他安裝方法
-- AUR: [maa-assistant-arknights](https://aur.archlinux.org/packages/maa-assistant-arknights)
-
 ## 集成文件
 
 [~~或許算不上文件~~](3.1-集成文件.md)
@@ -68,6 +66,6 @@ MAA 的構建方法仍在討論中，本教學的內容可能過時，請以 [Gi
 
 可參考 [CppSample](https://github.com/MaaAssistantArknights/MaaAssistantArknights/blob/master/src/Cpp/main.cpp) 中的實現
 
-### C#
+### C Sharp
 
 可參考 [MaaWpfGui](https://github.com/MaaAssistantArknights/MaaAssistantArknights/blob/master/src/MaaWpfGui/Main/AsstProxy.cs) 中的實現

--- a/docs/开发文档/Linux编译教程.md
+++ b/docs/开发文档/Linux编译教程.md
@@ -5,10 +5,10 @@ icon: teenyicons:linux-alt-solid
 
 # Linux 编译教程
 
-**本教程需要读者有一定的 Linux 环境配置能力及编程基础！**
+**本教程需要读者有一定的 Linux 环境配置能力及编程基础！**，若您仅希望直接安装MAA而非自行编译，请阅读[用户手册 - Linux 模拟器与容器](../用户手册/模拟器和设备支持/Linux模拟器与容器)。
 
 ::: info 注意
-MAA 的构建方法仍在讨论中, 本教程的内容可能过时, 请以 [GitHub workflow file](https://github.com/MaaAssistantArknights/MaaAssistantArknights/blob/master/.github/workflows/ci.yml#L134) 中的脚本为准
+MAA 的构建方法仍在讨论中, 本教程的内容可能过时, 请以 [GitHub workflow file](https://github.com/MaaAssistantArknights/MaaAssistantArknights/blob/master/.github/workflows/ci.yml#L134) 中的脚本为准。也可参考 [AUR PKGBUILD](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=maa-assistant-arknights)、[nixpkgs](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/ma/maa-assistant-arknights/package.nix)。
 :::
 
 ## 编译过程
@@ -60,11 +60,6 @@ MAA 的构建方法仍在讨论中, 本教程的内容可能过时, 请以 [GitH
    cmake --install build --prefix <target_directory>
    ```
 
-## 其他安装方法
-
-- AUR: [maa-assistant-arknights](https://aur.archlinux.org/packages/maa-assistant-arknights)
-- NUR: [nur.repos.cryolitia.MaaAssistantArknights](https://github.com/nix-community/nur-combined/tree/master/repos/cryolitia/pkgs/MaaAssistantArknights/default.nix#L138)
-
 ## 集成文档
 
 [~~或许算不上文档~~](../协议文档/集成文档.md)
@@ -77,6 +72,8 @@ MAA 的构建方法仍在讨论中, 本教程的内容可能过时, 请以 [GitH
 
 可参考 [CppSample](https://github.com/MaaAssistantArknights/MaaAssistantArknights/blob/master/src/Cpp/main.cpp) 中的实现
 
-### C#
+### C Sharp
+
+<!-- Do not use C#, MD003/heading-style: Heading style [Expected: atx; Actual: atx_closed] -->
 
 可参考 [MaaWpfGui](https://github.com/MaaAssistantArknights/MaaAssistantArknights/blob/master/src/MaaWpfGui/Main/AsstProxy.cs) 中的实现

--- a/docs/用户手册/CLI使用指南.md
+++ b/docs/用户手册/CLI使用指南.md
@@ -14,7 +14,7 @@ icon: material-symbols:terminal
 
 ### Appimage
 
-CLI 是 MAA 在 Linux 平台的默认界面，你可以直接下载最新的 Appimage 包来使用 CLI。
+CLI 是 MAA 在 Linux 平台的默认界面，你可以直接 [下载](https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases/latest) 最新的 AppImage 包来使用 CLI。
 
 ### 包管理器
 
@@ -158,7 +158,6 @@ brew install MaaAssistantArknights/tap/maa-cli
 - `maa convert <input> [output]`: 将 `JSON`，`YAML` 或者 `TOML` 格式的文件转换为其他格式;
 - `maa complete <shell>`: 生成自动补全脚本;
 - `maa activity [client]`: 获取游戏的当前活动信息，`client` 是客户端类型，默认为 `Official`。
-
 
 ## 配置
 

--- a/docs/用户手册/CLI使用指南.md
+++ b/docs/用户手册/CLI使用指南.md
@@ -28,17 +28,31 @@ brew install MaaAssistantArknights/tap/maa-cli
 
 #### Linux
 
-ArchLinux 用户可以安装 [AUR 包](https://aur.archlinux.org/packages/maa-cli/):
+- Arch Linux 用户可以安装 [AUR 包](https://aur.archlinux.org/packages/maa-cli/):
 
-```bash
-yay -S maa-cli
-```
+  ```bash
+  yay -S maa-cli
+  ```
 
-对于 LinuxBrew 用户，可以使用 [LinuxBrew](https://docs.brew.sh/Homebrew-on-Linux) 安装：
+- ❄️ Nix 用户可以直接运行:
 
-```bash
-brew install MaaAssistantArknights/tap/maa-cli
-```
+  ```bash
+  # 稳定版
+  nix run nixpkgs#maa-cli
+  ```
+
+  ```bash
+  # 每夜构建
+  nix run github:Cryolitia/nur-packages#maa-cli-nightly
+  ```
+
+  稳定版打包至 [nixpkgs](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/ma/maa-cli/package.nix) 中，使用 `nixpkgs` 中的 Rust 工具链；每夜构建位于 [NUR](https://github.com/Cryolitia/nur-packages/blob/master/pkgs/maa-assistant-arknights/maa-cli.nix) 中，使用 Beta channel 的 Rust 工具链，由 Github Action 每日自动更新和构建验证。
+
+- 对于 Linux Brew 用户，可以使用 [Linux Brew](https://docs.brew.sh/Homebrew-on-Linux) 安装：
+
+  ```bash
+  brew install MaaAssistantArknights/tap/maa-cli
+  ```
 
 ### 预编译二进制文件
 

--- a/docs/用户手册/模拟器和设备支持/Linux模拟器与容器.md
+++ b/docs/用户手册/模拟器和设备支持/Linux模拟器与容器.md
@@ -3,13 +3,24 @@ order: 3
 icon: teenyicons:linux-alt-solid
 ---
 
-# Linux 模拟器&容器
+# Linux 模拟器与容器
 
 ## 准备工作
 
-### 1. 安装 MAA
+以下安装方式任选其一即可：
 
-1. 在 [MAA 官网](https://maa.plus/) 下载 Linux 动态库并解压
+### 使用 maa-cli
+
+[maa-cli](https://github.com/MaaAssistantArknights/maa-cli) 是一个使用 Rust 编写的简单 MAA 命令行工具。相关安装与使用教程请阅读[用户手册 - CLI使用指南](../CLI使用指南)。
+
+### 使用 Python
+
+#### 1. 安装 MAA 动态库
+
+1. 在 [MAA 官网](https://maa.plus/) 下载 Linux 动态库并解压，或从软件源安装：
+
+   - AUR：[maa-assistant-arknights](https://aur.archlinux.org/packages/maa-assistant-arknights)，按照安装后的提示编辑文件
+   - Nixpkgs: [maa-assistant-arknights](https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/by-name/ma/maa-assistant-arknights/package.nix)
 
 2. 进入 `./MAA-v{版本号}-linux-{架构}/Python/` 目录下打开 `sample.py` 文件
 
@@ -18,10 +29,7 @@ icon: teenyicons:linux-alt-solid
 可以参考 [Linux 编译教程](../../开发文档/Linux编译教程.md) 重新编译或使用容器运行
 :::
 
-- Arch Linux 系列发行版可以选择使用 aur 包 [maa-assistant-arknights](https://aur.archlinux.org/packages/maa-assistant-arknights),
-  并按照安装后的提示编辑文件.
-
-### 2. `adb` 配置
+#### 2. `adb` 配置
 
 1. 找到 [`if asst.connect('adb.exe', '127.0.0.1:5554'):`](https://github.com/MaaAssistantArknights/MaaAssistantArknights/blob/722f0ddd4765715199a5dc90ea1bec2940322344/src/Python/sample.py#L48) 一栏
 
@@ -53,7 +61,7 @@ icon: teenyicons:linux-alt-solid
 
 4. 这时候可以测试下： `$ python3 sample.py` ，如果返回 `连接成功` 则基本成功了。
 
-### 3. 任务配置
+#### 3. 任务配置
 
 自定义任务： 根据需要参考 [集成文档](../../协议文档/集成文档.md) 对 `sample.py` 的 [`# 任务及参数请参考 docs/集成文档.md`](https://github.com/MaaAssistantArknights/MaaAssistantArknights/blob/722f0ddd4765715199a5dc90ea1bec2940322344/src/Python/sample.py#L54) 一栏进行修改
 


### PR DESCRIPTION
- Upstream docs update: https://github.com/MaaAssistantArknights/maa-cli/pull/248

- 明确区分编译MAA动态库，安装MAA动态库与安装maa-cli并添加相关指引

- 使用 markdownlint 格式化文本

- docs/zh-tw/1.6-CLI使用說明.md: 使用OpenCC转换，与简体中文最新文档同步

_TODO_: 日语与韩语文档待同步

---

review point: 需繁体中文文化环境相关的本地人员审阅繁体中文部分用语及习惯用词

*请勿 squash merge，应直接merge或rebase