### PR TITLE
fix: linux build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,7 +228,7 @@ jobs:
         uses: ./src/maa-cli/.github/actions/setup
         with:
           os: ubuntu-latest
-          target_arch: ${{ matrix.arch }}
+          arch: ${{ matrix.arch }}
 
       - name: Build CLI
         run: |


### PR DESCRIPTION
#8717 后，所有的 ci action 的 ubuntu build 都卡在 Setup Cross Compile Toolchains for CLI ，看报错信息是不能接收 target_arch ，需要 arch，所以改了回去，看起来正常了。
skip changelog please
