### PR TITLE
fix: 一图流 243 一天四换换班结束时的日志信息

### DIFF
--- a/resource/custom_infrast/243_layout_4_times_a_day_yituliu_1713115015768723.json
+++ b/resource/custom_infrast/243_layout_4_times_a_day_yituliu_1713115015768723.json
@@ -8,7 +8,7 @@
   "plans": [
     {
       "name": "A+B 高效长班 1",
-      "description": "请在八小时后换班",
+      "description_post": "请在八小时后换班",
       "Fiammetta": {
         "enable": true,
         "target": "巫恋",
@@ -203,7 +203,7 @@
     },
     {
       "name": "A+B 高效长班 2",
-      "description": "请在八小时后换班",
+      "description_post": "请在八小时后换班",
       "Fiammetta": {
         "enable": true,
         "target": "龙舌兰",
@@ -398,7 +398,7 @@
     },
     {
       "name": "B+C 替补短班 1",
-      "description": "请在四小时后换班",
+      "description_post": "请在四小时后换班",
       "Fiammetta": {
         "enable": true,
         "target": "但书",
@@ -606,7 +606,7 @@
     },
     {
       "name": "A+C 替补短班 2",
-      "description": "请在四小时后换班（提前十分钟左右把回满 15 心情的令移出宿舍）",
+      "description_post": "请在四小时后换班（提前十分钟左右把回满 15 心情的令移出宿舍）",
       "Fiammetta": {
         "enable": false,
         "target": "",


### PR DESCRIPTION
根据排班表协议，提示下一次换班时间的信息应该使用 `description_post` 字段，而目前一图流的编辑器貌似不支持，所以姑且先这样手动改一下吧。

虽然可能并不是大问题，~毕竟之前的一图流版配置也是这么写的，这么长时间也没见有人提~，但如果是写在 `description` 里就会在“自动保存为下个计划”时提前显示出来，用户如果真的按这个提示时间去换班那就错了。