### PR TITLE
feat: 新增公招 3 星 Tag 的倾向策略

### DIFF
--- a/docs/en-us/3.1-INTEGRATION.md
+++ b/docs/en-us/3.1-INTEGRATION.md
@@ -105,6 +105,10 @@ Supports some of the special stages,Please refer to [autoLocalization example](.
         int,
         ...
     ],
+    "first_tags": [             // Preferred Tags, valid only if 3★ tags. Optional, by default empty
+        string,                 // When Tag is level-3, as many Tags here as possible (if any) will be selected.
+        ...                     // It's a forced selection, i.e. it ignores all "unselect 3★ Tags" settings.
+    ],
     "extra_tags_mode": int,     // Select more tags, optional
                                 // 0 - default
                                 // 1 - click 3 tags anyway, even if they are in conflict

--- a/docs/ja-jp/プロトコルドキュメント/統合ドキュメント.md
+++ b/docs/ja-jp/プロトコルドキュメント/統合ドキュメント.md
@@ -116,6 +116,10 @@ TaskId ASSTAPI AsstAppendTask(AsstHandle handle, const char* type, const char* p
         int,
         ...
     ],
+    "first_tags": [             // 優先タグ。タグレベルが3の場合のみ有効。 オプション、デフォルトは 空
+        string,                 // ★3 タグの場合、可能な限り多くのタグが選択されます。
+        ...                     // これは強制的に選択されます。つまり、「★3 タグは非選択にする」設定はすべて無視されます。
+    ],
     "extra_tags_mode": int,     // その他のタグを選択、省略可能、デフォルトは 0
                                 // 0 - デフォルトの動作
                                 // 1 - 競合する可能性があっても3つのTagsを選択

--- a/docs/ko-kr/스키마/1.통합문서.md
+++ b/docs/ko-kr/스키마/1.통합문서.md
@@ -109,11 +109,13 @@ TaskId ASSTAPI AsstAppendTask(AsstHandle handle, const char* type, const char* p
         int,
         ...
     ],
-    "confirm": [                // 확인용 태그 레벨, 필수. 계산용으로만
-
- 빈 배열로 설정할 수 있습니다.
+    "confirm": [                // 확인용 태그 레벨, 필수. 계산용으로만. 빈 배열로 설정할 수 있습니다.
         int,
         ...
+    ],
+    "first_tags": [             // 기본 태그, 태그 레벨이 3인 경우에만 유효합니다. 선택 사항, 기본값은 비어 있습니다.
+        string,                 // 태그 레벨이 3이면 여기에 있는 태그(있는 경우)가 최대한 많이 선택됩니다.
+        ...                     // 또한 강제 선택이므로 '3등급 태그 선택 해제' 설정은 모두 무시됩니다.
     ],
     "extra_tags_mode": int,
     "times": int,               // 고용 횟수, 선택 사항, 기본값은 0입니다. 계산용으로만 0으로 설정할 수 있습니다.

--- a/docs/zh-tw/3.1-集成文件.md
+++ b/docs/zh-tw/3.1-集成文件.md
@@ -112,6 +112,10 @@ AsstTaskId ASSTAPI AsstAppendTask(AsstHandle handle, const char* type, const cha
         int,
         ...
     ],
+    "first_tags": [             // 首選 Tags，僅在 Tag 等級為 3 時有效。可選，預設為空
+        string,                 // 當 Tag 等級為 3 時，會盡可能多地選擇這裡的 Tags（如果有）
+        ...                     // 且是強制選擇，也就是會忽略所有“讓 3 星 Tags 不被選擇”的設定
+    ],
     "extra_tags_mode": int,     // 選擇更多的 Tags, 可選, 預設為 0
                                 // 0 - 預設行為
                                 // 1 - 選 3 個 Tags, 即使可能衝突

--- a/docs/协议文档/集成文档.md
+++ b/docs/协议文档/集成文档.md
@@ -114,6 +114,10 @@ AsstTaskId ASSTAPI AsstAppendTask(AsstHandle handle, const char* type, const cha
         int,
         ...
     ],
+    "first_tags": [             // 首选 Tags，仅在 Tag 等级为 3 时有效。可选，默认为空
+        string,                 // 当 Tag 等级为 3 时，会尽可能多地选择这里的 Tags（如果有）
+        ...                     // 而且是强制选择，也就是会忽略所有“让 3 星 Tag 不被选择”的设置
+    ],
     "extra_tags_mode": int,     // 选择更多的 Tags, 可选, 默认为 0
                                 // 0 - 默认行为
                                 // 1 - 选 3 个 Tags, 即使可能冲突

--- a/src/MaaCore/Task/Interface/RecruitTask.cpp
+++ b/src/MaaCore/Task/Interface/RecruitTask.cpp
@@ -52,6 +52,7 @@ bool asst::RecruitTask::set_params(const json::value& params)
     bool expedite = params.get("expedite", false);
     [[maybe_unused]] int expedite_times = params.get("expedite_times", 0);
     bool skip_robot = params.get("skip_robot", true);
+    std::vector<std::string> first_tags = params.get("first_tags", std::vector<std::string>(0));
 
     std::unordered_map<int /*level*/, int /*minute*/> recruitment_time_map;
     recruitment_time_map[3] = std::clamp(params.get("recruitment_time", "3", 9 * 60), 1 * 60, 9 * 60);
@@ -71,6 +72,7 @@ bool asst::RecruitTask::set_params(const json::value& params)
         .set_need_refresh(refresh)
         .set_use_expedited(expedite)
         .set_select_extra_tags(extra_tags_mode)
+        .set_first_tags(first_tags)
         .set_select_level(std::move(select))
         .set_confirm_level(std::move(confirm))
         .set_skip_robot(skip_robot)

--- a/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.cpp
@@ -756,6 +756,9 @@ std::vector<std::string> asst::AutoRecruitTask::get_select_tags(const std::vecto
         }
         return select;
     }
+    else if (m_select_extra_tags_mode == ExtraTagsMode::NoExtra) {
+        return combinations.front().tags;
+    }
     else if (m_select_extra_tags_mode == ExtraTagsMode::Extra) {
         while (select.size() < 3) {
             for (const asst::RecruitCombs& comb : combinations)

--- a/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.h
+++ b/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.h
@@ -24,6 +24,7 @@ namespace asst
         AutoRecruitTask& set_max_times(int max_times) noexcept;
         AutoRecruitTask& set_use_expedited(bool use_or_not) noexcept;
         AutoRecruitTask& set_select_extra_tags(ExtraTagsMode select_extra_tags_mode) noexcept;
+        AutoRecruitTask& set_first_tags(std::vector<std::string> first_tags) noexcept;
         AutoRecruitTask& set_skip_robot(bool skip_robot) noexcept;
         AutoRecruitTask& set_set_time(bool set_time) noexcept;
         AutoRecruitTask& set_force_refresh(bool force_refrest) noexcept;
@@ -49,7 +50,7 @@ namespace asst
         bool hire_all();
         bool initialize_dirty_slot_info(const cv::Mat&);
         std::vector<std::string> get_tag_names(const std::vector<RecruitConfig::TagId>& ids) const;
-        std::vector<std::string> get_select_tags(const std::vector<RecruitCombs>& combinations);
+        std::vector<std::string> get_select_tags(const std::vector<RecruitCombs>& combinations, std::vector<RecruitConfig::TagId> tag_ids);
         static std::vector<TextRect> start_recruit_analyze(const cv::Mat& image);
 
         template <typename Rng>
@@ -77,6 +78,7 @@ namespace asst
         bool m_need_refresh = false;
         bool m_use_expedited = false;
         ExtraTagsMode m_select_extra_tags_mode = ExtraTagsMode::NoExtra;
+        std::vector<std::string> m_first_tags;
         int m_max_times = 0;
         bool m_has_permit = true;
         bool m_has_refresh = true;

--- a/src/MaaWpfGui/Constants/ConfigurationKeys.cs
+++ b/src/MaaWpfGui/Constants/ConfigurationKeys.cs
@@ -129,6 +129,7 @@ namespace MaaWpfGui.Constants
         public const string CreditFightSelectFormation = "Visit.CreditFightSelectFormation";
 
         public const string RecruitMaxTimes = "AutoRecruit.MaxTimes";
+        public const string AutoRecruitFirstList = "AutoRecruit.AutoRecruitFirstList";
         public const string RefreshLevel3 = "AutoRecruit.RefreshLevel3";
         public const string ForceRefresh = "AutoRecruit.ForceRefresh";
         public const string SelectExtraTags = "AutoRecruit.SelectExtraTags";

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -1881,6 +1881,7 @@ namespace MaaWpfGui.Main
         /// 公开招募。
         /// </summary>
         /// <param name="maxTimes">加急次数，仅在 <paramref name="useExpedited"/> 为 <see langword="true"/> 时有效。</param>
+        /// <param name="firstTags">首选 Tags，仅在 Tag 等级为 3 时有效。</param>
         /// <param name="selectLevel">会去点击标签的 Tag 等级。</param>
         /// <param name="confirmLevel">会去点击确认的 Tag 等级。若仅公招计算，可设置为空数组。</param>
         /// <param name="needRefresh">是否刷新三星 Tags。</param>
@@ -1907,7 +1908,7 @@ namespace MaaWpfGui.Main
         /// <param name="isLevel3UseShortTime">三星Tag是否使用短时间（7:40）</param>
         /// <param name="isLevel3UseShortTime2">三星Tag是否使用短时间（1:00）</param>
         /// <returns>是否成功。</returns>
-        public bool AsstAppendRecruit(int maxTimes, int[] selectLevel, int[] confirmLevel, bool needRefresh, bool needForceRefresh, bool useExpedited,
+        public bool AsstAppendRecruit(int maxTimes, string[] firstTags, int[] selectLevel, int[] confirmLevel, bool needRefresh, bool needForceRefresh, bool useExpedited,
             int selectExtraTagsMode, bool skipRobot, bool isLevel3UseShortTime, bool isLevel3UseShortTime2 = false)
         {
             var taskParams = new JObject
@@ -1922,6 +1923,7 @@ namespace MaaWpfGui.Main
                 ["extra_tags_mode"] = selectExtraTagsMode,
                 ["expedite_times"] = maxTimes,
                 ["skip_robot"] = skipRobot,
+                ["first_tags"] = new JArray(firstTags),
             };
             if (isLevel3UseShortTime)
             {

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -671,8 +671,8 @@ The video aspect ratio needs to be 16:9 without interference factors such as bla
     <system:String x:Key="DefaultNoExtraTags">Additional Tags are not selected by default</system:String>
     <system:String x:Key="SelectExtraTags">If higher ★ tags appear, always select 3 tags</system:String>
     <system:String x:Key="SelectExtraOnlyRareTags">Pick as many high-star Tags as possible</system:String>
-    <system:String x:Key="AutoRecruitHighPriority">Preference for 3★ Tags (split by semicolon)</system:String>.
-    <system:String x:Key="AutoRecruitHighPriorityTooltip">Substring is sufficient, will select as many Tag preferences as possible</system:String>.
+    <system:String x:Key="AutoRecruitHighPriority">Preference for 3★ Tags (split by semicolon)</system:String>
+    <system:String x:Key="AutoRecruitHighPriorityTooltip">Substring is sufficient, will select as many Tag preferences as possible</system:String>
     <system:String x:Key="NotEnoughStaff">Insufficient operators</system:String>
     <system:String x:Key="StageInfoError">Stage recognition error</system:String>
     <system:String x:Key="UseFormation">Use formation</system:String>

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -669,8 +669,10 @@ The video aspect ratio needs to be 16:9 without interference factors such as bla
     <system:String x:Key="NoRecruitmentPermit">No recruitment permit, returned</system:String>
     <system:String x:Key="AutoRecruitSelectStrategy">Strategies for Additional Tags</system:String>
     <system:String x:Key="DefaultNoExtraTags">Additional Tags are not selected by default</system:String>
-    <system:String x:Key="SelectExtraTags">If higher ★ tags appear, always select 3★ tags</system:String>
+    <system:String x:Key="SelectExtraTags">If higher ★ tags appear, always select 3 tags</system:String>
     <system:String x:Key="SelectExtraOnlyRareTags">Pick as many high-star Tags as possible</system:String>
+    <system:String x:Key="AutoRecruitHighPriority">Preference for 3★ Tags (split by semicolon)</system:String>.
+    <system:String x:Key="AutoRecruitHighPriorityTooltip">Substring is sufficient, will select as many Tag preferences as possible</system:String>.
     <system:String x:Key="NotEnoughStaff">Insufficient operators</system:String>
     <system:String x:Key="StageInfoError">Stage recognition error</system:String>
     <system:String x:Key="UseFormation">Use formation</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -672,6 +672,8 @@
     <system:String x:Key="DefaultNoExtraTags">デフォルトでは、追加のタグを選択しない</system:String>
     <system:String x:Key="SelectExtraTags">タグを選択すると、常に 3 つのタグが選択されます</system:String>
     <system:String x:Key="SelectExtraOnlyRareTags">可能な限り多くのタグを選択し、高い星のタグのみを選択する</system:String>
+    <system:String x:Key="AutoRecruitHighPriority">優先タグ（セミコロンで区切）</system:String>
+    <system:String x:Key="AutoRecruitHighPriorityTooltip">サブストリングで十分です、できるだけ多くのタグの傾向を選択します</system:String>
     <system:String x:Key="NotEnoughStaff">利用可能なオペレーターが不足しています</system:String>
     <system:String x:Key="StageInfoError">ステージ認識エラー</system:String>
     <system:String x:Key="UseFormation">使用編成</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -672,6 +672,8 @@ OF-1을 해금하지 않았다면 선택하지 말아 주세요.</system:String>
     <system:String x:Key="DefaultNoExtraTags">기본값: 추가 태그 없음</system:String>
     <system:String x:Key="SelectExtraTags">항상 3개의 태그를 선택</system:String>
     <system:String x:Key="SelectExtraOnlyRareTags">가능한 한 많은 태그를 선택하고 높은 등급의 태그만 선택</system:String>
+    <system:String x:Key="AutoRecruitHighPriority">태그 경향을 세미콜론으로 구분한 3단계 태그로 표시합니다 (세미콜론으로 구분)</system:String>
+    <system:String x:Key="AutoRecruitHighPriorityTooltip">하위 문자열이면 충분하며 가능한 한 많은 태그 기본 설정을 선택합니다</system:String>
     <system:String x:Key="NotEnoughStaff">오퍼레이터 부족</system:String>
     <system:String x:Key="StageInfoError">스테이지 인식 오류</system:String>
     <system:String x:Key="UseFormation">편성 사용</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -671,6 +671,8 @@
     <system:String x:Key="DefaultNoExtraTags">默认不选择额外 Tag</system:String>
     <system:String x:Key="SelectExtraTags">选择高星时总是选择三个 Tag</system:String>
     <system:String x:Key="SelectExtraOnlyRareTags">尽可能多地选且只选高星 Tag</system:String>
+    <system:String x:Key="AutoRecruitHighPriority">3 星 Tag 时的 Tag 倾向，分号分隔</system:String>
+    <system:String x:Key="AutoRecruitHighPriorityTooltip">子串即可，会尽可能多的选择倾向的 Tag</system:String>
     <system:String x:Key="NotEnoughStaff">可用干员不足</system:String>
     <system:String x:Key="StageInfoError">关卡识别错误</system:String>
     <system:String x:Key="UseFormation">使用编队</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -670,6 +670,8 @@
     <system:String x:Key="DefaultNoExtraTags">默認不選擇額外的 Tags</system:String>
     <system:String x:Key="SelectExtraTags">選擇高星時總是選擇三個 Tag</system:String>
     <system:String x:Key="SelectExtraOnlyRareTags">盡可能多地選且只選高星 Tags</system:String>
+    <system:String x:Key="AutoRecruitHighPriority">3 星 Tags 時的 Tags 傾向，分號分隔</system:String>
+    <system:String x:Key="AutoRecruitHighPriorityTooltip">子串即可，會盡可能多的選擇傾向的 Tags</system:String>
     <system:String x:Key="StageInfoError">關卡辨識錯誤</system:String>
     <system:String x:Key="UseFormation">使用編隊</system:String>
     <system:String x:Key="Current">當前</system:String>

--- a/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
@@ -2697,6 +2697,21 @@ namespace MaaWpfGui.ViewModels.UI
         }
 
         /* 自动公招设置 */
+        private string _autoRecruitFirstList = ConfigurationHelper.GetValue(ConfigurationKeys.AutoRecruitFirstList, string.Empty);
+
+        /// <summary>
+        /// Gets or sets the priority tag list of level-3 tags.
+        /// </summary>
+        public string AutoRecruitFirstList
+        {
+            get => _autoRecruitFirstList;
+            set
+            {
+                SetAndNotify(ref _autoRecruitFirstList, value);
+                ConfigurationHelper.SetValue(ConfigurationKeys.AutoRecruitFirstList, value);
+            }
+        }
+
         private string _recruitMaxTimes = ConfigurationHelper.GetValue(ConfigurationKeys.RecruitMaxTimes, "4");
 
         /// <summary>

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -1358,6 +1358,9 @@ namespace MaaWpfGui.ViewModels.UI
                 maxTimes = 0;
             }
 
+            var firstList = Instances.SettingsViewModel.AutoRecruitFirstList.Split(';', '；')
+                .Select(s => s.Trim());
+
             var reqList = new List<int>();
             var cfmList = new List<int>();
 
@@ -1382,7 +1385,7 @@ namespace MaaWpfGui.ViewModels.UI
             int.TryParse(Instances.SettingsViewModel.SelectExtraTags, out var selectExtra);
 
             return Instances.AsstProxy.AsstAppendRecruit(
-                maxTimes, reqList.ToArray(), cfmList.ToArray(), Instances.SettingsViewModel.RefreshLevel3, Instances.SettingsViewModel.ForceRefresh, Instances.SettingsViewModel.UseExpedited,
+                maxTimes, firstList.ToArray(), reqList.ToArray(), cfmList.ToArray(), Instances.SettingsViewModel.RefreshLevel3, Instances.SettingsViewModel.ForceRefresh, Instances.SettingsViewModel.UseExpedited,
                 selectExtra, Instances.SettingsViewModel.NotChooseLevel1, Instances.SettingsViewModel.IsLevel3UseShortTime, Instances.SettingsViewModel.IsLevel3UseShortTime2);
         }
 

--- a/src/MaaWpfGui/Views/UserControl/AutoRecruitSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/AutoRecruitSettingsUserControl.xaml
@@ -42,6 +42,12 @@
                 SelectedValue="{Binding SelectExtraTags}"
                 SelectedValuePath="Value" 
                 Style="{StaticResource ComboBoxExtend}" />
+            <TextBox
+                Margin="0,10"
+                hc:InfoElement.Title="{DynamicResource AutoRecruitHighPriority}"
+                Style="{StaticResource TextBoxExtend}"
+                Text="{Binding AutoRecruitFirstList}" 
+                ToolTip="{DynamicResource AutoRecruitHighPriorityTooltip}"/>
             <CheckBox
                 Margin="0,10"
                 Content="{DynamicResource AutoRefresh}"


### PR DESCRIPTION
增加了遇到 3 星 Tag 时的会选择的 Tag 倾向，并且如果有倾向的 Tag 会阻止试图刷新的行为，也会忽略“不选择 3 星 Tag”的设定（如果有）而选择并确认（如果需要确认）

在 GUI 中也添加了这一选项，如图：
![image](https://github.com/MaaAssistantArknights/MaaAssistantArknights/assets/63957117/c399f709-e733-4b6f-aef1-e9dad473593f)

已做过一些公招的测试，确保功能在默认情况下可以使用。外文文档使用 DeepL 机翻。

_作为个人给 MAA 投的第一个 PR，如果有不规范的地方也请指出（_

- Closes https://github.com/MaaAssistantArknights/MaaAssistantArknights/issues/8818