### PR TITLE
fix: Mac编译脚本自动移除之前的build文件夹

### DIFF
--- a/tools/build_macos_universal.zsh
+++ b/tools/build_macos_universal.zsh
@@ -4,6 +4,8 @@ basedir=$(dirname "$0")/..
 pushd ${basedir}
 
 build_arch() {
+    // remove previous artifacts
+    rm -rf build-$1
     [[ $1 = "arm64" ]] && triplet="arm64-osx" || triplet="x64-osx"
     python3 maadeps-download.py ${triplet}
 


### PR DESCRIPTION
auto remove previous builds upon build
or it could cause errors when rebuilding