### PR TITLE
fix: 避免识别到不存在的连续作战图标

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -4472,6 +4472,7 @@
             380
         ],
         "cache": false,
+        "templThreshold": 0.9,
         "maskRange": [
             1,
             255


### PR DESCRIPTION
fix #8948
Require tests.
目前在日服版本中，选择“当前-上次”作战以进入 ZT-8 时，会直接识别到 FightSeries-Indicator.png ，得分 0.8 以上，如果此时选择了连战次数为1，就会点击到报酬区域，卡住流程。
所以将此项任务的 templThreshold 调整到 0.9，需要测试是否影响其他关卡。正常情况下应该可以达到 0.99 以上，不受影响。