### PR TITLE
docs: 添加粥专用版mumu不支持最新的低延迟模式的提示

### DIFF
--- a/docs/用户手册/模拟器和设备支持/Windows模拟器.md
+++ b/docs/用户手册/模拟器和设备支持/Windows模拟器.md
@@ -48,6 +48,7 @@ const fullySupport = shuffleArray([
 #### MuMu 独家极速操控模式
 
 需使用 MuMu 12 3.8.13 及更新版本，并关闭后台保活。
+- 粥专用版mumu不支持最新的低延迟模式
 
 ##### 连接设置
 


### PR DESCRIPTION
之前翻半天不知道为啥低延迟模式失败，结果看issue说专版和官网版是俩版本不支持，所以来添加个提示