### PR TITLE
fix: Recruit 公招手动确认『元素』

### DIFF
--- a/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.cpp
@@ -443,7 +443,7 @@ asst::AutoRecruitTask::calc_task_result_type
         }
 
         // robot tags
-        const std::vector<RecruitConfig::TagId> RobotTags = { "支援机械" };
+        const std::vector<RecruitConfig::TagId> RobotTags = { "支援机械", "元素" };
         if (auto robot_iter = ranges::find_first_of(RobotTags, tag_ids);
             robot_iter != RobotTags.cend()) [[unlikely]] {
             has_robot_tag = true;

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -721,7 +721,7 @@ The video aspect ratio needs to be 16:9 without interference factors such as bla
     <system:String x:Key="Level3UseShortTime2">Set 1:00 instead of 9:00 for 3★ Tags</system:String>
     <system:String x:Key="Level3UseShortTimeTip">Doesn't interfere with other ★ stars</system:String>
     <system:String x:Key="RecruitMaxTimes">Recruit max times</system:String>
-    <system:String x:Key="ManuallySelectLevel1">Manually confirm Robot tag</system:String>
+    <system:String x:Key="ManuallySelectLevel1">Manually confirm 1★</system:String>
     <system:String x:Key="AutoSelectLevel3">Auto confirm 3★</system:String>
     <system:String x:Key="AutoSelectLevel4">Auto confirm 4★</system:String>
     <system:String x:Key="AutoSelectLevel5">Auto confirm 5★</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -722,7 +722,7 @@
     <system:String x:Key="Level3UseShortTime2">星3タグを1:00に設定する</system:String>
     <system:String x:Key="Level3UseShortTimeTip">他のレアリティには影響しない</system:String>
     <system:String x:Key="RecruitMaxTimes">1回の実行あたりの求人の最大回数</system:String>
-    <system:String x:Key="ManuallySelectLevel1">「ロボット」を手動的に確認する</system:String>
+    <system:String x:Key="ManuallySelectLevel1">星1を手動的に確認する</system:String>
     <system:String x:Key="AutoSelectLevel3">星3を自動的に確認する</system:String>
     <system:String x:Key="AutoSelectLevel4">星4を自動的に確認する</system:String>
     <system:String x:Key="AutoSelectLevel5">星5を自動的に確認する</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -722,7 +722,7 @@ OF-1을 해금하지 않았다면 선택하지 말아 주세요.</system:String>
     <system:String x:Key="Level3UseShortTime2">★3 태그 9:00 대신 1:00 설정</system:String>
     <system:String x:Key="Level3UseShortTimeTip">다른 등급에는 적용되지 않습니다</system:String>
     <system:String x:Key="RecruitMaxTimes">시행 시의 최대 모집횟수</system:String>
-    <system:String x:Key="ManuallySelectLevel1">로봇 수동 모집</system:String>
+    <system:String x:Key="ManuallySelectLevel1">★1 수동 모집</system:String>
     <system:String x:Key="AutoSelectLevel3">★3 자동 모집</system:String>
     <system:String x:Key="AutoSelectLevel4">★4 자동 모집</system:String>
     <system:String x:Key="AutoSelectLevel5">★5 자동 모집</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -721,7 +721,7 @@
     <system:String x:Key="Level3UseShortTime2">3 星设置 1:00 而非 9:00</system:String>
     <system:String x:Key="Level3UseShortTimeTip">不影响其他星级 Tags</system:String>
     <system:String x:Key="RecruitMaxTimes">每次执行时最大招募次数</system:String>
-    <system:String x:Key="ManuallySelectLevel1">手动确认「支援机械」和「元素」</system:String>
+    <system:String x:Key="ManuallySelectLevel1">手动确认 1 星</system:String>
     <system:String x:Key="AutoSelectLevel3">自动确认 3 星</system:String>
     <system:String x:Key="AutoSelectLevel4">自动确认 4 星</system:String>
     <system:String x:Key="AutoSelectLevel5">自动确认 5 星</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -721,7 +721,7 @@
     <system:String x:Key="Level3UseShortTime2">3 星设置 1:00 而非 9:00</system:String>
     <system:String x:Key="Level3UseShortTimeTip">不影响其他星级 Tags</system:String>
     <system:String x:Key="RecruitMaxTimes">每次执行时最大招募次数</system:String>
-    <system:String x:Key="ManuallySelectLevel1">手动确认「支援机械」</system:String>
+    <system:String x:Key="ManuallySelectLevel1">手动确认「支援机械」和「元素」</system:String>
     <system:String x:Key="AutoSelectLevel3">自动确认 3 星</system:String>
     <system:String x:Key="AutoSelectLevel4">自动确认 4 星</system:String>
     <system:String x:Key="AutoSelectLevel5">自动确认 5 星</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -719,7 +719,7 @@
     <system:String x:Key="Level3UseShortTime2">3 星設定 1:00 而非 9:00</system:String>
     <system:String x:Key="Level3UseShortTimeTip">不影響其他星級 Tags</system:String>
     <system:String x:Key="RecruitMaxTimes">每次執行時最大招募次數</system:String>
-    <system:String x:Key="ManuallySelectLevel1">手動確認「支援機械」</system:String>
+    <system:String x:Key="ManuallySelectLevel1">手動確認 1 星</system:String>
     <system:String x:Key="AutoSelectLevel3">自動確認 3 星</system:String>
     <system:String x:Key="AutoSelectLevel4">自動確認 4 星</system:String>
     <system:String x:Key="AutoSelectLevel5">自動確認 5 星</system:String>


### PR DESCRIPTION
resolved #8953 

鉴于目前公招『元素』标签只有辅助小车有，所以就先硬编码进去吧，日后如果有变化再revert就好了

另外只改了中文界面的描述，不知道其他语言是否需要更改
