### PR TITLE
fix: adding delay between swipe and click

### DIFF
--- a/src/MaaCore/Task/Infrast/InfrastAbstractTask.cpp
+++ b/src/MaaCore/Task/Infrast/InfrastAbstractTask.cpp
@@ -199,7 +199,7 @@ bool asst::InfrastAbstractTask::enter_facility(int index)
         Log.warn("index out of range:", index, m_custom_config.size());
         return false;
     }
-
+    
     InfrastFacilityImageAnalyzer analyzer(ctrler()->get_image());
     analyzer.set_to_be_analyzed({ facility_name() });
     if (!analyzer.analyze()) {
@@ -211,6 +211,8 @@ bool asst::InfrastAbstractTask::enter_facility(int index)
         Log.info("facility index is out of range");
         return false;
     }
+    // 点击前先等一下，避免点太快 | Wait a moment before clicking to avoid clicking too fast
+    sleep(500);
     ctrler()->click(rect);
     m_cur_facility_index = index;
 


### PR DESCRIPTION
Trying to fix #9138.
This is just a patch and not the permanent solution. 
InfrastAbstracttTask.cpp does not have any check after `ctrler()->click` meaning that it will always `return true` independently if the click is correct or not.

Other solutions are happily accepted (for example changing the enter_facilty algorithm, to allow usage of a flag (reception already has one for example))