### PR TITLE
fix: 掉落物识别时滑动起始位置过于偏右导致崩溃

### DIFF
--- a/src/MaaCore/Task/Fight/StageDropsTaskPlugin.cpp
+++ b/src/MaaCore/Task/Fight/StageDropsTaskPlugin.cpp
@@ -143,7 +143,7 @@ bool asst::StageDropsTaskPlugin::recognize_drops()
 
         // more materials to reveal?
 
-        auto swipe_begin = Point { WindowWidthDefault - 40, 632 };
+        auto swipe_begin = Point { WindowWidthDefault - 240, 632 };
 
         const int swipe_dist = 200;
         ctrler()->swipe(swipe_begin, swipe_begin + swipe_dist * Point::left(), 500, true, 2, 0);


### PR DESCRIPTION
fix #8942

现在掉落物识别时，滑动的位置靠近屏幕右边缘，导致呼出安卓的系统导航栏（HOME/返回/最近按钮)，使截图拼接时图片出现撕裂，最终导致 OCR 时 MAA 崩溃。

此 PR 只是一个简单的 workaround，将滑动起始位置向左移动 200，已测试一周，没有再出现崩溃的情况。