### PR TITLE
为文档的linux部分添加maax相关描述

### DIFF
--- a/docs/用户手册/模拟器和设备支持/Linux模拟器与容器.md
+++ b/docs/用户手册/模拟器和设备支持/Linux模拟器与容器.md
@@ -147,14 +147,15 @@ waydroid prop set persist.waydroid.height 720
 设置 adb 的 IP 地址：打开 `设置` - `关于` - `IP地址` ，记录第一个 `IP` ，将 `${记录的IP}:5555` 填入`sample.py` 的 adb IP 一栏。
 
 如果使用 amdgpu, `screencap` 命令可能向 stderr 输出信息导致图片解码失败.
-届时可以在终端看见类似这样的输出：
-```shell
-SILLY   [main /app/packages/main/coreLoader/callback.ts:11:12 <anonymous>]      {"details":{},"uuid":"","what":"ScreencapFailed","why":"ScreencapFailed"}
-```
+
 可以运行 `adb exec-out screencap | xxd | head` 并检查输出中是否有类似 `/vendor/etc/hwdata/amdgpu.ids: No such file...` 的文本来确认这一点.
 尝试将 `resource/config.json` 中的截图命令由 `adb exec-out screencap` 改为 `adb exec-out 'screencap 2>/dev/null'`.
 
-对于[MaaX](https://github.com/MaaAssistantArknights/MaaX),可以尝试更改设置-触控模式到Adb(兼容模式)。
+对于[MaaX](https://github.com/MaaAssistantArknights/MaaX),截图失败时可能图形界面可能不会有反应，但你应该能在终端看见类似这样的输出：
+```shell
+SILLY   [main /app/packages/main/coreLoader/callback.ts:11:12 <anonymous>]      {"details":{},"uuid":"","what":"ScreencapFailed","why":"ScreencapFailed"}
+```
+可以尝试更改设置-触控模式到Adb(兼容模式)。
 ### ✅ [redroid](https://github.com/remote-android/redroid-doc)
 
 安卓 11 版本的镜像可正常运行游戏, 需要暴露 5555 adb 端口.

--- a/docs/用户手册/模拟器和设备支持/Linux模拟器与容器.md
+++ b/docs/用户手册/模拟器和设备支持/Linux模拟器与容器.md
@@ -147,9 +147,13 @@ waydroid prop set persist.waydroid.height 720
 设置 adb 的 IP 地址：打开 `设置` - `关于` - `IP地址` ，记录第一个 `IP` ，将 `${记录的IP}:5555` 填入`sample.py` 的 adb IP 一栏。
 
 如果使用 amdgpu, `screencap` 命令可能向 stderr 输出信息导致图片解码失败.
+届时可以在终端看见类似这样的输出：
+'''shell
+SILLY   [main /app/packages/main/coreLoader/callback.ts:11:12 <anonymous>]      {"details":{},"uuid":"","what":"ScreencapFailed","why":"ScreencapFailed"}
+'''
 可以运行 `adb exec-out screencap | xxd | head` 并检查输出中是否有类似 `/vendor/etc/hwdata/amdgpu.ids: No such file...` 的文本来确认这一点.
 尝试将 `resource/config.json` 中的截图命令由 `adb exec-out screencap` 改为 `adb exec-out 'screencap 2>/dev/null'`.
-
+对于[MaaX](https://github.com/MaaAssistantArknights/MaaX),可以尝试更改设置-触控模式到Adb(兼容模式)。
 ### ✅ [redroid](https://github.com/remote-android/redroid-doc)
 
 安卓 11 版本的镜像可正常运行游戏, 需要暴露 5555 adb 端口.

--- a/docs/用户手册/模拟器和设备支持/Linux模拟器与容器.md
+++ b/docs/用户手册/模拟器和设备支持/Linux模拟器与容器.md
@@ -8,6 +8,13 @@ icon: teenyicons:linux-alt-solid
 ## 准备工作
 
 以下安装方式任选其一即可：
+### 使用 MaaX
+[MaaX](https://github.com/MaaAssistantArknights/MaaX)是一个基于electron的maa图形化前端，支持linux。
+如果是Arch Linux,可以通过AUR安装。
+   ```shell
+   yay -S --noconfirm maa-x-bin
+   ```
+
 
 ### 使用 maa-cli
 

--- a/docs/用户手册/模拟器和设备支持/Linux模拟器与容器.md
+++ b/docs/用户手册/模拟器和设备支持/Linux模拟器与容器.md
@@ -151,7 +151,7 @@ waydroid prop set persist.waydroid.height 720
 可以运行 `adb exec-out screencap | xxd | head` 并检查输出中是否有类似 `/vendor/etc/hwdata/amdgpu.ids: No such file...` 的文本来确认这一点.
 尝试将 `resource/config.json` 中的截图命令由 `adb exec-out screencap` 改为 `adb exec-out 'screencap 2>/dev/null'`.
 
-对于[MaaX](https://github.com/MaaAssistantArknights/MaaX),截图失败时可能图形界面可能不会有反应，但你应该能在终端看见类似这样的输出：
+对于[MaaX](https://github.com/MaaAssistantArknights/MaaX),截图失败时图形界面可能不会有反应，但你应该能在终端看见类似这样的输出：
 ```shell
 SILLY   [main /app/packages/main/coreLoader/callback.ts:11:12 <anonymous>]      {"details":{},"uuid":"","what":"ScreencapFailed","why":"ScreencapFailed"}
 ```

--- a/docs/用户手册/模拟器和设备支持/Linux模拟器与容器.md
+++ b/docs/用户手册/模拟器和设备支持/Linux模拟器与容器.md
@@ -148,9 +148,9 @@ waydroid prop set persist.waydroid.height 720
 
 如果使用 amdgpu, `screencap` 命令可能向 stderr 输出信息导致图片解码失败.
 届时可以在终端看见类似这样的输出：
-'''shell
+```shell
 SILLY   [main /app/packages/main/coreLoader/callback.ts:11:12 <anonymous>]      {"details":{},"uuid":"","what":"ScreencapFailed","why":"ScreencapFailed"}
-'''
+```
 可以运行 `adb exec-out screencap | xxd | head` 并检查输出中是否有类似 `/vendor/etc/hwdata/amdgpu.ids: No such file...` 的文本来确认这一点.
 尝试将 `resource/config.json` 中的截图命令由 `adb exec-out screencap` 改为 `adb exec-out 'screencap 2>/dev/null'`.
 对于[MaaX](https://github.com/MaaAssistantArknights/MaaX),可以尝试更改设置-触控模式到Adb(兼容模式)。

--- a/docs/用户手册/模拟器和设备支持/Linux模拟器与容器.md
+++ b/docs/用户手册/模拟器和设备支持/Linux模拟器与容器.md
@@ -153,6 +153,7 @@ SILLY   [main /app/packages/main/coreLoader/callback.ts:11:12 <anonymous>]      
 ```
 可以运行 `adb exec-out screencap | xxd | head` 并检查输出中是否有类似 `/vendor/etc/hwdata/amdgpu.ids: No such file...` 的文本来确认这一点.
 尝试将 `resource/config.json` 中的截图命令由 `adb exec-out screencap` 改为 `adb exec-out 'screencap 2>/dev/null'`.
+
 对于[MaaX](https://github.com/MaaAssistantArknights/MaaX),可以尝试更改设置-触控模式到Adb(兼容模式)。
 ### ✅ [redroid](https://github.com/remote-android/redroid-doc)
 


### PR DESCRIPTION
不提一嘴的话真不一定能看见maa有linux的原生gui了。以及似乎ScreencapFailed有概率通过GUI的方式解决，无需编写配置文件。