### PR TITLE
fix: handling KR-specific announcements

### DIFF
--- a/resource/global/YoStarKR/resource/tasks.json
+++ b/resource/global/YoStarKR/resource/tasks.json
@@ -1,4 +1,15 @@
 {
+    "StartUpNotificationKR": {
+        "doc": "This is a task for handling KR-specific announcements (linked StartUpThemes)",
+        "action": "ClickSelf",
+        "algorithm": "OcrDetect",
+        "text": [
+            "알겠습니다"
+        ],
+        "next": [
+            "StartUpThemes#next"
+        ]
+    },
     "ClickChapter1": {
         "text": [
             "각성"
@@ -2456,6 +2467,19 @@
                 "조화장치",
                 "调谐节点"
             ]
+        ]
+    },
+    "StartUpThemes": {
+        "next": [
+            "GameStart",
+            "StartUpNotificationKR",
+            "StartToWakeUp",
+            "StartToWakeUpOCR",
+            "StartLoginBServer",
+            "StartUpConnectingFlag",
+            "MainThemes#next",
+            "CloseAnnos#next",
+            "OfflineConfirm"
         ]
     },
     "StartToWakeUp": {


### PR DESCRIPTION
fix #9175

![image](https://github.com/MaaAssistantArknights/MaaAssistantArknights/assets/128385247/5fd35066-e187-4dcb-8040-bc8ae7cde992)

created task on YoStarKR, since the announcement does not appear on other servers.   
Adding a new task shouldn't be a problem, right?
