### PR TITLE
增加存储库元信息

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,17 @@
+# This CITATION.cff file was generated with cffinit.
+# Visit https://bit.ly/cffinit to generate yours today!
+
+cff-version: 1.2.0
+title: MaaAssistantArknights
+message: >-
+  If you use this software, please cite it using the
+  metadata from this file.
+type: software
+authors:
+  - name: Maa Team
+    website: 'https://maa.plus/'
+    date-start: '2021-07-10'
+repository-code: >-
+  https://github.com/MaaAssistantArknights/MaaAssistantArknights/
+url: 'https://maa.plus/'
+license: AGPL-3.0-only

--- a/LICENSE.spdx
+++ b/LICENSE.spdx
@@ -1,0 +1,6 @@
+SPDXVersion: SPDX-2.3
+DataLicense: CC0-1.0
+PackageName: MaaAssistantArknights
+PackageOriginator: Maa Team and all contributors
+PackageHomePage: https://github.com/MaaAssistantArknights/MaaAssistantArknights
+PackageLicenseDeclared: AGPL-3.0-only


### PR DESCRIPTION
1. 增加SPDX标识符以便于非中文软件源维护者理解许可证信息
2. 根据用户请求，增加引用元数据

作为 https://github.com/MaaAssistantArknights/MaaAssistantArknights/pull/8696 的增强