### PR TITLE
fix: 公招 `m_first_tag` 匹配个数少于 3 个时的非预期情况

### DIFF
--- a/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.cpp
@@ -691,6 +691,7 @@ asst::AutoRecruitTask::calc_task_result_type
             return result;
         }
 
+        // get selections
         auto final_select = get_select_tags(result_vec, tag_ids);
 
         // select tags
@@ -862,12 +863,13 @@ std::vector<std::string> asst::AutoRecruitTask::get_select_tags(
                     return select;
                 }
             }
+            return select;
         }
     }
     if (m_select_extra_tags_mode == ExtraTagsMode::NoExtra) {
         return combinations.front().tags;
     }
-    if (m_select_extra_tags_mode == ExtraTagsMode::Extra) {
+    else if (m_select_extra_tags_mode == ExtraTagsMode::Extra) {
         while (select.size() < 3) {
             for (const asst::RecruitCombs& comb : combinations) {
                 for (const std::string& tag : comb.tags) {

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -731,7 +731,7 @@
     <system:String x:Key="Issue">问题反馈</system:String>
     <!--  !About  -->
     <!--  AutoRecruitSettings  -->
-    <system:String x:Key="AutoRefresh">自动刷新 3 星 Tags</system:String>
+    <system:String x:Key="AutoRefresh">无倾向 Tag 时自动刷新 3 星 Tags</system:String>
     <system:String x:Key="ForceRefresh">无招聘许可时继续尝试刷新 Tags</system:String>
     <system:String x:Key="AutoUseExpedited">自动使用加急许可*</system:String>
     <system:String x:Key="Level3UseShortTime">3 星设置 7:40 而非 9:00</system:String>

--- a/tools/AutoLocalization/example/en-us_force.xaml
+++ b/tools/AutoLocalization/example/en-us_force.xaml
@@ -304,7 +304,7 @@
 
         <ResourceDictionary x:Uid="RecruitingSettings">
             <!--$RecruitingSettings:-->
-            <s:String x:Key="AutoRefresh">自动刷新 3 星 Tags</s:String>
+            <s:String x:Key="AutoRefresh">无倾向 Tag 时自动刷新 3 星 Tags</s:String>
             <s:String x:Key="AutoUseExpedited">自动使用加急许可*</s:String>
             <s:String x:Key="Level3UseShortTime">3 星设置 7:40 而非 9:00</s:String>
             <s:String x:Key="Level3UseShortTimeTip">不影响其他星级 Tags</s:String>

--- a/tools/AutoLocalization/example/zh-cn.xaml
+++ b/tools/AutoLocalization/example/zh-cn.xaml
@@ -293,7 +293,7 @@
         </ResourceDictionary>
 
         <ResourceDictionary x:Uid="RecruitingSettings">
-            <s:String x:Key="AutoRefresh">自动刷新 3 星 Tags</s:String>
+            <s:String x:Key="AutoRefresh">无倾向 Tag 时自动刷新 3 星 Tags</s:String>
             <s:String x:Key="AutoUseExpedited">自动使用加急许可*</s:String>
             <s:String x:Key="Level3UseShortTime">3 星设置 7:40 而非 9:00</s:String>
             <s:String x:Key="Level3UseShortTimeTip">不影响其他星级 Tags</s:String>

--- a/tools/AutoLocalization/example/zh-cn_new.xaml
+++ b/tools/AutoLocalization/example/zh-cn_new.xaml
@@ -296,7 +296,7 @@
         </ResourceDictionary>
 
         <ResourceDictionary x:Uid="RecruitingSettings">
-            <s:String x:Key="AutoRefresh">自动刷新 3 星 Tags</s:String>
+            <s:String x:Key="AutoRefresh">无倾向 Tag 时自动刷新 3 星 Tags</s:String>
             <s:String x:Key="AutoUseExpedited">自动使用加急许可*</s:String>
             <s:String x:Key="Level3UseShortTime">3 星设置 7:40 而非 9:00</s:String>
             <s:String x:Key="Level3UseShortTimeTip">不影响其他星级 Tags</s:String>


### PR DESCRIPTION
对 https://github.com/MaaAssistantArknights/MaaAssistantArknights/pull/8868 的补充

顺带给刷新 3 星 Tags 的 GUI 选项前面补充了没有倾向 Tag 的前提描述

- fixes https://github.com/MaaAssistantArknights/MaaAssistantArknights/issues/9141