### PR TITLE
fix: 查询进程时仅使用 packageName

### DIFF
--- a/resource/config.json
+++ b/resource/config.json
@@ -89,7 +89,7 @@
             "screencapEncode": "[Adb] -s [AdbSerial] exec-out screencap -p",
             "release": "[Adb] kill-server",
             "start": "[Adb] -s [AdbSerial] shell am start -n [Intent]",
-            "stop": "[Adb] -s [AdbSerial] shell \"PACKAGE_NAME=$(dumpsys activity activities 2>/dev/null | grep -i -o -E '(packageName|Activities)=.+arknights' 2>/dev/null | grep -i -o -E '[^= ]*arknights[^ /]*' | head -n 1); if [ -n \\\"$PACKAGE_NAME\\\" ]; then echo \\\"Closing $PACKAGE_NAME\\\"; am force-stop $PACKAGE_NAME; else echo \\\"app not running or arknights package name not found\\\"; fi\"",
+            "stop": "[Adb] -s [AdbSerial] shell \"PACKAGE_NAME=$(dumpsys activity activities 2>/dev/null | grep -i -o -E 'packageName=.+arknights' 2>/dev/null | grep -i -o -E '[^= ]*arknights[^ /]*' | head -n 1); if [ -n \\\"$PACKAGE_NAME\\\" ]; then echo \\\"Closing $PACKAGE_NAME\\\"; am force-stop $PACKAGE_NAME; else echo \\\"app not running or arknights package name not found\\\"; fi\"",
             "abilist": "[Adb] -s [AdbSerial] shell getprop ro.product.cpu.abilist",
             "version": "[Adb] -s [AdbSerial] shell getprop ro.build.version.release",
             "orientation": "[Adb] -s [AdbSerial] shell \"dumpsys input | grep SurfaceOrientation | grep -m 1 -o -E [0-9]\"",


### PR DESCRIPTION
fix #9349 
尝试仅使用 packageName 查找包名，以规避雷电模拟器优先匹配 ActivityRecord 的情况。