### PR TITLE
perf: 优化仓库识别结果展示，支持多语言显示

### DIFF
--- a/src/MaaWpfGui/Helper/ItemListHelper.cs
+++ b/src/MaaWpfGui/Helper/ItemListHelper.cs
@@ -15,6 +15,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
+using System.Windows.Media.Imaging;
 using MaaWpfGui.Constants;
 using MaaWpfGui.Models;
 using Serilog;
@@ -76,11 +77,29 @@ namespace MaaWpfGui.Helper
             ArkItems = tempItems ?? new Dictionary<string, ArkItem>();
         }
 
+        /// <summary>
+        /// 获取当前语言下的物品名称 / Get the name of the item in the current language
+        /// </summary>
+        /// <param name="itemId">物品 id / Item id</param>
+        /// <returns></returns>
         public static string GetItemName(string itemId)
         {
             return ArkItems.TryGetValue(itemId, out var item)
                 ? item.Name
                 : itemId;
+        }
+
+        /// <summary>
+        /// 获取对应物品的图标 / Get the icon of the corresponding item
+        /// </summary>
+        /// <param name="itemId">物品 id / Item id</param>
+        /// <returns></returns>
+        public static BitmapImage GetItemImage(string itemId)
+        {
+            var imagePath = Path.Combine(Environment.CurrentDirectory, $"resource/template/items/{itemId}.png");
+            return File.Exists(imagePath)
+                ? new BitmapImage(new Uri(imagePath, UriKind.RelativeOrAbsolute))
+                : new BitmapImage();
         }
     }
 }

--- a/src/MaaWpfGui/ViewModels/UI/RecognizerViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/RecognizerViewModel.cs
@@ -377,6 +377,10 @@ namespace MaaWpfGui.ViewModels.UI
         {
             public string Name { get; set; }
 
+            public string Id { get; set; }
+
+            public BitmapImage Image { get; set; }
+
             public int Count { get; set; }
         }
 
@@ -405,7 +409,14 @@ namespace MaaWpfGui.ViewModels.UI
             DepotResult.Clear();
             foreach (var item in details["arkplanner"]?["object"]?["items"]?.Cast<JObject>()!)
             {
-                DepotResultDate result = new DepotResultDate() { Name = (string)item["name"], Count = (int)item["have"] };
+                var id = (string)item["id"];
+                DepotResultDate result = new DepotResultDate()
+                {
+                    Id = id,
+                    Name = ItemListHelper.GetItemName(id),
+                    Image = ItemListHelper.GetItemImage(id),
+                    Count = (int)item["have"]
+                };
                 DepotResult.Add(result);
             }
 

--- a/src/MaaWpfGui/Views/UI/RecognizerView.xaml
+++ b/src/MaaWpfGui/Views/UI/RecognizerView.xaml
@@ -205,15 +205,39 @@
                 </StackPanel>
                 <DataGrid
                     Grid.Row="1"
-                    Width="600"
+                    Width="680"
                     HorizontalAlignment="Center"
+                    AutoGenerateColumns="False"
+                    HeadersVisibility="None"
                     IsReadOnly="True"
-                    ItemsSource="{Binding DepotResult}">
+                    ItemsSource="{Binding DepotResult}"
+                    ScrollViewer.CanContentScroll="True"
+                    ScrollViewer.HorizontalScrollBarVisibility="Disabled">
                     <DataGrid.ItemsPanel>
                         <ItemsPanelTemplate>
-                            <UniformGrid Columns="3" />
+                            <WrapPanel  HorizontalAlignment="Center"/>
                         </ItemsPanelTemplate>
                     </DataGrid.ItemsPanel>
+                    <DataGrid.Columns>
+                        <DataGridTemplateColumn>
+                            <DataGridTemplateColumn.CellTemplate>
+                                <DataTemplate>
+                                    <Image
+                                        Width="30"
+                                        Height="30"
+                                        Source="{Binding Image}" />
+                                </DataTemplate>
+                            </DataGridTemplateColumn.CellTemplate>
+                        </DataGridTemplateColumn>
+                        <DataGridTextColumn Binding="{Binding Name}" Header="Name" />
+                        <DataGridTextColumn Binding="{Binding Count}" Header="Count" />
+                    </DataGrid.Columns>
+                    <DataGrid.RowStyle>
+                        <Style BasedOn="{StaticResource DataGridRowStyle}" TargetType="DataGridRow">
+                            <Setter Property="HorizontalAlignment" Value="Center" />
+                            <Setter Property="VerticalAlignment" Value="Center" />
+                        </Style>
+                    </DataGrid.RowStyle>
                 </DataGrid>
                 <StackPanel
                     Grid.Row="2"
@@ -358,9 +382,9 @@
                         Margin="6"
                         HorizontalAlignment="Center"
                         VerticalContentAlignment="Center"
-                        IsEnabled="False"
                         Content="{DynamicResource ShowDisclaimerNoMore}"
-                        IsChecked="{Binding GachaShowDisclaimerNoMore}" />
+                        IsChecked="{Binding GachaShowDisclaimerNoMore}"
+                        IsEnabled="False" />
                 </StackPanel>
 
                 <StackPanel


### PR DESCRIPTION
![baf12f45ab9e3806d5040103deed8055](https://github.com/MaaAssistantArknights/MaaAssistantArknights/assets/99072975/0c1c3c82-886f-4871-baef-cdf2bbf0e4d6)
![990d697f72329449be9b4be76880b4e0](https://github.com/MaaAssistantArknights/MaaAssistantArknights/assets/99072975/dcc12207-4222-4997-96a5-c3fc6289187d)

cc @Constrat due to longer item names in English, we can only fit two per line compared to three in Chinese. Any thoughts on this?