### PR TITLE
feat: Copilot view i18n

### DIFF
--- a/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
@@ -311,6 +311,8 @@ namespace MaaWpfGui.ViewModels.UI
 
         private void ParseJsonAndShowInfo(string jsonStr)
         {
+            string language = Instances.SettingsViewModel.Language;
+            
             try
             {
                 var json = (JObject?)JsonConvert.DeserializeObject(jsonStr);
@@ -329,9 +331,32 @@ namespace MaaWpfGui.ViewModels.UI
 
                 var doc = (JObject?)json["doc"];
                 string title = string.Empty;
+                bool languageIsGlobal = language is "zh-tw" or "en-us" or "ja-jp" or "ko-kr";
+                
                 if (doc != null && doc.TryGetValue("title", out var titleValue))
                 {
                     title = titleValue.ToString();
+                    
+                    if (language == "zh-tw")
+                    {
+                        if (doc.TryGetValue("title_zh_tw", out var localizedTitleValueZhTw))
+                        {
+                            title = localizedTitleValueZhTw.ToString();
+                        }
+                    }
+                    else if (languageIsGlobal)
+                    {
+                        string localizedTitleKey = $"title_{language.Replace("-", "_")}";
+                        if (doc.TryGetValue(localizedTitleKey, out var localizedTitleValue))
+                        {
+                            title = localizedTitleValue.ToString();
+                        }
+                        else if (doc.TryGetValue("title_global", out var titleGlobalValue))
+                        {
+                            title = titleGlobalValue.ToString();
+                        }
+                    }
+                    
                     CopilotTaskName = FindStageName((IsDataFromWeb ? string.Empty : _filename).Split(Path.DirectorySeparatorChar).LastOrDefault()?.Split('.').FirstOrDefault() ?? string.Empty, title);
                 }
 
@@ -350,6 +375,26 @@ namespace MaaWpfGui.ViewModels.UI
                 if (doc != null && doc.TryGetValue("details", out var detailsValue))
                 {
                     details = detailsValue.ToString();
+                    
+                    if (language == "zh-tw")
+                    {
+                        if (doc.TryGetValue("details_zh_tw", out var localizedDetailsValueZhTw))
+                        {
+                            details = localizedDetailsValueZhTw.ToString();
+                        }
+                    }
+                    else if (languageIsGlobal)
+                    {
+                        string localizedDetailsKey = $"details_{language.Replace("-", "_")}";
+                        if (doc.TryGetValue(localizedDetailsKey, out var localizedDetailsValue))
+                        {
+                            details = localizedDetailsValue.ToString();
+                        }
+                        else if (doc.TryGetValue("details_global", out var detailsGlobalValue))
+                        {
+                            details = detailsGlobalValue.ToString();
+                        }
+                    }
                 }
 
                 if (details.Length != 0)


### PR DESCRIPTION
允许作业json文件通过添加 title_global 和 details_global 字段为非中文用户显示一种外文说明，没有该字段则显示默认内容。
干员名称显示程序对应语言的版本。
新增保全派驻作业显示导能原件。
说明部分和干员列表间加了一行分割线。
很糟糕的实现方式，屎山+1。

测试作业 
[SSS_阿尔斯特甜品制作平台_浊蒂版.json](https://github.com/user-attachments/files/15942452/SSS_._.json)

![图片](https://github.com/MaaAssistantArknights/MaaAssistantArknights/assets/63437036/adf6dfb8-d839-4aaa-9b5e-e9097cebd4ee)
![图片](https://github.com/MaaAssistantArknights/MaaAssistantArknights/assets/63437036/808971b3-4bd6-47e6-b8e6-365adf6dbbf5)
