### PR TITLE
chore: unlocks update options

### DIFF
--- a/src/MaaWpfGui/Views/UserControl/VersionUpdateSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/VersionUpdateSettingsUserControl.xaml
@@ -39,22 +39,19 @@
                     Margin="10"
                     HorizontalAlignment="Left"
                     VerticalAlignment="Center"
-                    Content="{DynamicResource UpdateAutoCheck}"
-                    IsChecked="{Binding UpdateAutoCheck}" />
+                    Content="{DynamicResource UpdateAutoCheck}"/>
                 <CheckBox
                     Margin="10"
                     HorizontalAlignment="Left"
                     VerticalAlignment="Center"
                     Content="{DynamicResource UpdateAutoDownload}"
-                    IsChecked="{Binding AutoDownloadUpdatePackage}"
-                    IsEnabled="{Binding UpdateCheck}" />
+                    IsChecked="{Binding AutoDownloadUpdatePackage}"/>
                 <CheckBox
                     Margin="10"
                     HorizontalAlignment="Left"
                     VerticalAlignment="Center"
                     Content="{DynamicResource AutoInstallUpdatePackage}"
-                    IsChecked="{Binding AutoInstallUpdatePackage}"
-                    IsEnabled="{Binding UpdateCheck}" />
+                    IsChecked="{Binding AutoInstallUpdatePackage}"/>
                 <StackPanel VerticalAlignment="Center" Orientation="Horizontal">
                     <controls:TextBlock
                         Margin="10,10,0,10"
@@ -64,7 +61,6 @@
                         Width="120"
                         Margin="10"
                         DisplayMemberPath="Display"
-                        IsEnabled="{Binding UpdateCheck}"
                         ItemsSource="{Binding VersionTypeList}"
                         SelectedValue="{Binding VersionType}"
                         SelectedValuePath="Value" />


### PR DESCRIPTION
Scenario: automated MAA environment (multiple MAAs running at the same time).
The machine has an auto restart option to allow memory and register unload. MAA is restarted automatically meaning it will check update (good).
In the case of a one click update install by the user, these options need to be "trued".
But in the case of an auto restart, the first option is also true, meaning it will auto install and the user doesn't know / doesn't want to.
Disabling "Startup Update Check", currently also disables all the other options. Making it impossible for a user to one click install update when it doesn't want auto install after restart. 
![image](https://github.com/MaaAssistantArknights/MaaAssistantArknights/assets/56174894/702860e4-15ad-4444-9e25-81bb947f5cca)

This PR allows the user to change update settings even when the Startup Update Check is off. For example when a breaking change is fixed and a nightly is pushed, allowing MAA to auto install everything without multiple clicks. But still not allowing the auto install after a machine restart.
To disable the important Startup Update Check, the user would still need to know how to change the conf.json file, making it "impossible" for the generic user, and an option for the power user, very much like #9444 https://github.com/MaaAssistantArknights/MaaAssistantArknights/commit/e295c1a8307b0e2dc1d76a4262dc2dbe274ed41b

