### PR TITLE
chore: combox behaves as normal combox without IsEditable

### DIFF
--- a/src/MaaWpfGui/Views/UserControl/ConfigurationMgrUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/ConfigurationMgrUserControl.xaml
@@ -27,9 +27,7 @@
             Margin="10"
             HorizontalAlignment="Center"
             VerticalAlignment="Center"
-            IsEditable="True"
-            IsHitTestVisible="{Binding Idle}"
-            IsReadOnly="True"
+            IsEnabled="{Binding Idle}"
             ItemsSource="{Binding ConfigurationList}"
             SelectedValue="{Binding CurrentConfiguration}"
             SelectedValuePath="Value">
@@ -38,7 +36,7 @@
                     <Grid Width="{c:Binding 'ActualWidth - 20', RelativeSource={RelativeSource AncestorType=ComboBox}}">
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*" />
-                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="28" />
                         </Grid.ColumnDefinitions>
                         <TextBlock
                             Grid.Column="0"


### PR DESCRIPTION
Unfortunately `IsEditable` is used as a "way" to cover the button for deletion. But that adds some other issues such as not being able to open the combobox from anywhere, but only from the arrow dropdown.

Removing `IsEditable` shows the button which is a bit ugly but reimplements the full functionalities of the combobox 
![image](https://github.com/MaaAssistantArknights/MaaAssistantArknights/assets/56174894/9cf1743b-ce83-44ef-bbf5-4242570b218c)
![image](https://github.com/MaaAssistantArknights/MaaAssistantArknights/assets/56174894/c18efc91-aed2-4414-9621-419159a425ca)

I'm not very knowledgeable in XAML but maybe we can color the button border to the foreground color to mask it a bit more.