### PR TITLE
fix: 修复坍缩范式插件导致的Gui和傀影/水月肉鸽初始化Bug

### DIFF
--- a/resource/global/YoStarEN/resource/tasks.json
+++ b/resource/global/YoStarEN/resource/tasks.json
@@ -7074,131 +7074,6 @@
             ]
         ]
     },
-    "Sami@Roguelike@CheckCollapsalParadigms_banner": {
-        "ocrReplace": [
-            [
-                "Collapsal Paradigm intensifies",
-                "坍缩范式加深"
-            ],
-            [
-                "Collapsal Paradigm wanes",
-                "坍缩范式消退"
-            ],
-            [
-                "De-quantification",
-                "去量化"
-            ],
-            [
-                "Intensified De-quantification",
-                "去量深化"
-            ],
-            [
-                "Substantial Collapse",
-                "实质性坍缩"
-            ],
-            [
-                "Propagating Collapse",
-                "蔓延性坍缩"
-            ],
-            [
-                "Non-linear Movement",
-                "非线性移动"
-            ],
-            [
-                "Non-linear Action",
-                "非线性行动"
-            ],
-            [
-                "Emotional Entity",
-                "情绪实体"
-            ],
-            [
-                "Terrifying Entity",
-                "恐怖实体"
-            ],
-            [
-                "Pan-Society Paradox",
-                "泛社会悖论"
-            ],
-            [
-                "Pan-Civilization Paradox",
-                "泛文明悖论"
-            ],
-            [
-                "Barometric Anomaly",
-                "气压异常"
-            ],
-            [
-                "Barometric Disorder",
-                "气压失序"
-            ],
-            [
-                "Injury Trigger",
-                "触发性损伤"
-            ],
-            [
-                "Crisis Trigger",
-                "触发性危殆"
-            ],
-            [
-                "Convergence Consumption",
-                "趋同性消耗"
-            ],
-            [
-                "Convergence Deficiency",
-                "趋同性缺失"
-            ],
-            [
-                "Partial Cecity",
-                "目空一些"
-            ],
-            [
-                "Complete Cecity",
-                "睁眼瞎"
-            ],
-            [
-                "Image Corruption",
-                "图像损坏"
-            ],
-            [
-                "Image Blackout",
-                "一抹黑"
-            ]
-        ],
-        "algorithm": "OcrDetect",
-        "action": "DoNothing",
-        "cache": false,
-        "text": [
-            "坍缩范式加深",
-            "坍缩范式消退",
-            "去量化",
-            "去量深化",
-            "实质性坍缩",
-            "蔓延性坍缩",
-            "非线性移动",
-            "非线性行动",
-            "情绪实体",
-            "恐怖实体",
-            "泛社会悖论",
-            "泛文明悖论",
-            "气压异常",
-            "气压失序",
-            "触发性损伤",
-            "触发性危殆",
-            "趋同性消耗",
-            "趋同性缺失",
-            "目空一些",
-            "睁眼瞎",
-            "图像损坏",
-            "一抹黑"
-        ],
-        "roi": [
-            945,
-            60,
-            335,
-            660
-        ]
-    },
     "Sami@Roguelike@CheckCollapsalParadigms_loading": {
         "algorithm": "OcrDetect",
         "action": "DoNothing",
@@ -7219,12 +7094,8 @@
             45
         ]
     },
-    "Sami@Roguelike@CheckCollapsalParadigms_panel": {
+    "Sami@Roguelike@CheckCollapsalParadigms": {
         "ocrReplace": [
-            [
-                "Current Collapse Value",
-                "当前坍缩值"
-            ],
             [
                 "De-quantification",
                 "去量化"
@@ -7310,7 +7181,6 @@
         "action": "DoNothing",
         "cache": false,
         "text": [
-            "当前坍缩值",
             "去量化",
             "去量深化",
             "实质性坍缩",
@@ -7331,6 +7201,45 @@
             "睁眼瞎",
             "图像损坏",
             "一抹黑"
+        ]
+    },
+    "Sami@Roguelike@CheckCollapsalParadigms_onBanner": {
+        "ocrReplace": [
+            [
+                "Collapsal Paradigm intensifies",
+                "坍缩范式加深"
+            ],
+            [
+                "Collapsal Paradigm wanes",
+                "坍缩范式消退"
+            ]
+        ],
+        "algorithm": "OcrDetect",
+        "action": "DoNothing",
+        "cache": false,
+        "text": [
+            "坍缩范式加深",
+            "坍缩范式消退"
+        ],
+        "roi": [
+            945,
+            60,
+            335,
+            660
+        ]
+    },
+    "Sami@Roguelike@CheckCollapsalParadigms_panel": {
+        "ocrReplace": [
+            [
+                "Current Collapse Value",
+                "当前坍缩值"
+            ]
+        ],
+        "algorithm": "OcrDetect",
+        "action": "DoNothing",
+        "cache": false,
+        "text": [
+            "当前坍缩值"
         ],
         "roi": [
             350,

--- a/resource/global/YoStarJP/resource/tasks.json
+++ b/resource/global/YoStarJP/resource/tasks.json
@@ -8344,132 +8344,6 @@
             ]
         ]
     },
-    "Sami@Roguelike@CheckCollapsalParadigms_banner": {
-        "doc": "The translations パラダイムロストの進行により and パラダイムロストの減退により are not verified.",
-        "ocrReplace": [
-            [
-                "パラダイムロストの進行により",
-                "坍缩范式加深"
-            ],
-            [
-                "パラダイムロストの減退により",
-                "坍缩范式消退"
-            ],
-            [
-                "数的崩壊",
-                "去量化"
-            ],
-            [
-                "完全なる数的崩壊",
-                "去量深化"
-            ],
-            [
-                "具現する崩壊",
-                "实质性坍缩"
-            ],
-            [
-                "蔓延する崩壊",
-                "蔓延性坍缩"
-            ],
-            [
-                "非直線移動",
-                "非线性移动"
-            ],
-            [
-                "非直線行動",
-                "非线性行动"
-            ],
-            [
-                "実体化する感情",
-                "情绪实体"
-            ],
-            [
-                "実体化する恐怖",
-                "恐怖实体"
-            ],
-            [
-                "広義的社会パラドクス",
-                "泛社会悖论"
-            ],
-            [
-                "広義的文化パラドクス",
-                "泛文明悖论"
-            ],
-            [
-                "気圧異常",
-                "气压异常"
-            ],
-            [
-                "気圧暴走",
-                "气压失序"
-            ],
-            [
-                "接触性損傷",
-                "触发性损伤"
-            ],
-            [
-                "接触性危機",
-                "触发性危殆"
-            ],
-            [
-                "同期性消耗",
-                "趋同性消耗"
-            ],
-            [
-                "同期性喪失",
-                "趋同性缺失"
-            ],
-            [
-                "局部的認識不可",
-                "目空一些"
-            ],
-            [
-                "広域的認識不可",
-                "睁眼瞎"
-            ],
-            [
-                "画像破損",
-                "图像损坏"
-            ],
-            [
-                "ブラックアウト",
-                "一抹黑"
-            ]
-        ],
-        "algorithm": "OcrDetect",
-        "action": "DoNothing",
-        "cache": false,
-        "text": [
-            "坍缩范式加深",
-            "坍缩范式消退",
-            "去量化",
-            "去量深化",
-            "实质性坍缩",
-            "蔓延性坍缩",
-            "非线性移动",
-            "非线性行动",
-            "情绪实体",
-            "恐怖实体",
-            "泛社会悖论",
-            "泛文明悖论",
-            "气压异常",
-            "气压失序",
-            "触发性损伤",
-            "触发性危殆",
-            "趋同性消耗",
-            "趋同性缺失",
-            "目空一些",
-            "睁眼瞎",
-            "图像损坏",
-            "一抹黑"
-        ],
-        "roi": [
-            945,
-            60,
-            335,
-            660
-        ]
-    },
     "Sami@Roguelike@CheckCollapsalParadigms_loading": {
         "algorithm": "OcrDetect",
         "action": "DoNothing",
@@ -8498,13 +8372,8 @@
             45
         ]
     },
-    "Sami@Roguelike@CheckCollapsalParadigms_panel": {
-        "doc": "The translation 現在の崩壊値 is not verified.",
+    "Sami@Roguelike@CheckCollapsalParadigms": {
         "ocrReplace": [
-            [
-                "現在の崩壊値",
-                "当前坍缩值"
-            ],
             [
                 "数的崩壊",
                 "去量化"
@@ -8590,7 +8459,6 @@
         "action": "DoNothing",
         "cache": false,
         "text": [
-            "当前坍缩值",
             "去量化",
             "去量深化",
             "实质性坍缩",
@@ -8611,6 +8479,47 @@
             "睁眼瞎",
             "图像损坏",
             "一抹黑"
+        ]
+    },
+    "Sami@Roguelike@CheckCollapsalParadigms_onBanner": {
+        "doc": "The translations are not verified.",
+        "ocrReplace": [
+            [
+                "パラダイムロストの進行により",
+                "坍缩范式加深"
+            ],
+            [
+                "パラダイムロストの減退により",
+                "坍缩范式消退"
+            ]
+        ],
+        "algorithm": "OcrDetect",
+        "action": "DoNothing",
+        "cache": false,
+        "text": [
+            "坍缩范式加深",
+            "坍缩范式消退"
+        ],
+        "roi": [
+            945,
+            60,
+            335,
+            660
+        ]
+    },
+    "Sami@Roguelike@CheckCollapsalParadigms_onPanel": {
+        "doc": "The translation is not verified.",
+        "ocrReplace": [
+            [
+                "現在の崩壊値",
+                "当前坍缩值"
+            ]
+        ],
+        "algorithm": "OcrDetect",
+        "action": "DoNothing",
+        "cache": false,
+        "text": [
+            "当前坍缩值"
         ],
         "roi": [
             350,

--- a/resource/global/YoStarJP/resource/tasks.json
+++ b/resource/global/YoStarJP/resource/tasks.json
@@ -8482,14 +8482,13 @@
         ]
     },
     "Sami@Roguelike@CheckCollapsalParadigms_onBanner": {
-        "doc": "The translations are not verified.",
         "ocrReplace": [
             [
-                "パラダイムロストの進行により",
+                "パラダイムロスト進行",
                 "坍缩范式加深"
             ],
             [
-                "パラダイムロストの減退により",
+                "パラダイムロスト減退",
                 "坍缩范式消退"
             ]
         ],
@@ -8508,7 +8507,6 @@
         ]
     },
     "Sami@Roguelike@CheckCollapsalParadigms_onPanel": {
-        "doc": "The translation is not verified.",
         "ocrReplace": [
             [
                 "現在の崩壊値",

--- a/resource/global/YoStarKR/resource/tasks.json
+++ b/resource/global/YoStarKR/resource/tasks.json
@@ -6910,132 +6910,6 @@
             ]
         ]
     },
-    "Sami@Roguelike@CheckCollapsalParadigms_banner": {
-        "doc": "The translations 붕괴패러다임심화 and 붕괴패러다임약화 are not verified.",
-        "ocrReplace": [
-            [
-                "붕괴패러다임심화",
-                "坍缩范式加深"
-            ],
-            [
-                "붕괴패러다임약화",
-                "坍缩范式消退"
-            ],
-            [
-                "수적붕괴",
-                "去量化"
-            ],
-            [
-                "수적붕괴심화",
-                "去量深化"
-            ],
-            [
-                "실질적붕괴",
-                "实质性坍缩"
-            ],
-            [
-                "확산적붕괴",
-                "蔓延性坍缩"
-            ],
-            [
-                "비선형이동",
-                "非线性移动"
-            ],
-            [
-                "비선형행동",
-                "非线性行动"
-            ],
-            [
-                "정서의실체화",
-                "情绪实体"
-            ],
-            [
-                "공포의실체화",
-                "恐怖实体"
-            ],
-            [
-                "범사회적역설",
-                "泛社会悖论"
-            ],
-            [
-                "범문명적역설",
-                "泛文明悖论"
-            ],
-            [
-                "기압이상",
-                "气压异常"
-            ],
-            [
-                "기압무질서",
-                "气压失序"
-            ],
-            [
-                "촉발성손상",
-                "触发性损伤"
-            ],
-            [
-                "촉발성위태",
-                "触发性危殆"
-            ],
-            [
-                "일치성소모",
-                "趋同性消耗"
-            ],
-            [
-                "일치성손실",
-                "趋同性缺失"
-            ],
-            [
-                "선택적무시",
-                "目空一些"
-            ],
-            [
-                "안하무인",
-                "睁眼瞎"
-            ],
-            [
-                "이미지에러",
-                "图像损坏"
-            ],
-            [
-                "블랙아웃",
-                "一抹黑"
-            ]
-        ],
-        "algorithm": "OcrDetect",
-        "action": "DoNothing",
-        "cache": false,
-        "text": [
-            "坍缩范式加深",
-            "坍缩范式消退",
-            "去量化",
-            "去量深化",
-            "实质性坍缩",
-            "蔓延性坍缩",
-            "非线性移动",
-            "非线性行动",
-            "情绪实体",
-            "恐怖实体",
-            "泛社会悖论",
-            "泛文明悖论",
-            "气压异常",
-            "气压失序",
-            "触发性损伤",
-            "触发性危殆",
-            "趋同性消耗",
-            "趋同性缺失",
-            "目空一些",
-            "睁眼瞎",
-            "图像损坏",
-            "一抹黑"
-        ],
-        "roi": [
-            945,
-            60,
-            335,
-            660
-        ]
-    },
     "Sami@Roguelike@CheckCollapsalParadigms_loading": {
         "algorithm": "OcrDetect",
         "action": "DoNothing",
@@ -7060,13 +6934,8 @@
             45
         ]
     },
-    "Sami@Roguelike@CheckCollapsalParadigms_panel": {
-        "doc": "The translation 현재붕괴값 is not verified.",
+    "Sami@Roguelike@CheckCollapsalParadigms": {
         "ocrReplace": [
-            [
-                "현재붕괴값",
-                "当前坍缩值"
-            ],
             [
                 "수적붕괴",
                 "去量化"
@@ -7152,7 +7021,6 @@
         "action": "DoNothing",
         "cache": false,
         "text": [
-            "当前坍缩值",
             "去量化",
             "去量深化",
             "实质性坍缩",
@@ -7173,6 +7041,47 @@
             "睁眼瞎",
             "图像损坏",
             "一抹黑"
+        ]
+    },
+    "Sami@Roguelike@CheckCollapsalParadigms_onBanner": {
+        "doc": "The translations are not verified.",
+        "ocrReplace": [
+            [
+                "붕괴패러다임심화",
+                "坍缩范式加深"
+            ],
+            [
+                "붕괴패러다임약화",
+                "坍缩范式消退"
+            ]
+        ],
+        "algorithm": "OcrDetect",
+        "action": "DoNothing",
+        "cache": false,
+        "text": [
+            "坍缩范式加深",
+            "坍缩范式消退"
+        ],
+        "roi": [
+            945,
+            60,
+            335,
+            660
+        ]
+    },
+    "Sami@Roguelike@CheckCollapsalParadigms_onPanel": {
+        "doc": "The translation is not verified.",
+        "ocrReplace": [
+            [
+                "현재붕괴값",
+                "当前坍缩值"
+            ]
+        ],
+        "algorithm": "OcrDetect",
+        "action": "DoNothing",
+        "cache": false,
+        "text": [
+            "当前坍缩值"
         ],
         "roi": [
             350,

--- a/resource/global/txwy/resource/tasks.json
+++ b/resource/global/txwy/resource/tasks.json
@@ -5895,17 +5895,29 @@
             ]
         ]
     },
-    "Sami@Roguelike@CheckCollapsalParadigms_banner": {
-        "doc": "The translations are not verified.",
+    "Sami@Roguelike@CheckCollapsalParadigms_loading": {
+        "algorithm": "OcrDetect",
+        "action": "DoNothing",
+        "cache": false,
+        "text": [
+            "正在提交反馈至神经"
+        ],
         "ocrReplace": [
             [
-                "坍縮範式加深",
-                "坍缩范式加深"
-            ],
-            [
-                "坍縮範式消退",
-                "坍缩范式消退"
-            ],
+                "正在提交反饋至神經",
+                "正在提交反馈至神经"
+            ]
+        ],
+        "roi": [
+            720,
+            645,
+            355,
+            45
+        ]
+    },
+    "Sami@Roguelike@CheckCollapsalParadigms": {
+        "doc": "The translations are not verified.",
+        "ocrReplace": [
             [
                 "去量化",
                 "去量化"
@@ -5991,8 +6003,6 @@
         "action": "DoNothing",
         "cache": false,
         "text": [
-            "坍缩范式加深",
-            "坍缩范式消退",
             "去量化",
             "去量深化",
             "实质性坍缩",
@@ -6021,139 +6031,45 @@
             660
         ]
     },
-    "Sami@Roguelike@CheckCollapsalParadigms_loading": {
+    "Sami@Roguelike@CheckCollapsalParadigms_onBanner": {
+        "doc": "The translations are not verified.",
+        "ocrReplace": [
+            [
+                "坍縮範式加深",
+                "坍缩范式加深"
+            ],
+            [
+                "坍縮範式消退",
+                "坍缩范式消退"
+            ]
+        ],
         "algorithm": "OcrDetect",
         "action": "DoNothing",
         "cache": false,
         "text": [
-            "正在提交反馈至神经"
-        ],
-        "ocrReplace": [
-            [
-                "正在提交反饋至神經",
-                "正在提交反馈至神经"
-            ]
+            "坍缩范式加深",
+            "坍缩范式消退"
         ],
         "roi": [
-            720,
-            645,
-            355,
-            45
+            945,
+            60,
+            335,
+            660
         ]
     },
-    "Sami@Roguelike@CheckCollapsalParadigms_panel": {
+    "Sami@Roguelike@CheckCollapsalParadigms_onPanel": {
         "doc": "The translations are not verified.",
         "ocrReplace": [
             [
                 "目前坍縮值",
                 "当前坍缩值"
-            ],
-            [
-                "去量化",
-                "去量化"
-            ],
-            [
-                "去量深化",
-                "去量深化"
-            ],
-            [
-                "實質坍縮",
-                "实质性坍缩"
-            ],
-            [
-                "蔓延性坍縮",
-                "蔓延性坍缩"
-            ],
-            [
-                "非線性移動",
-                "非线性移动"
-            ],
-            [
-                "非線性行動",
-                "非线性行动"
-            ],
-            [
-                "情緒實體",
-                "情绪实体"
-            ],
-            [
-                "恐怖實體",
-                "恐怖实体"
-            ],
-            [
-                "泛社會悖論",
-                "泛社会悖论"
-            ],
-            [
-                "泛文明悖論",
-                "泛文明悖论"
-            ],
-            [
-                "氣壓異常",
-                "气压异常"
-            ],
-            [
-                "氣壓失序",
-                "气压失序"
-            ],
-            [
-                "觸發性損傷",
-                "触发性损伤"
-            ],
-            [
-                "觸發性危殆",
-                "触发性危殆"
-            ],
-            [
-                "趨同性消耗",
-                "趋同性消耗"
-            ],
-            [
-                "趨同性缺失",
-                "趋同性缺失"
-            ],
-            [
-                "目空一些",
-                "目空一些"
-            ],
-            [
-                "睜眼瞎",
-                "睁眼瞎"
-            ],
-            [
-                "影像損壞",
-                "图像损坏"
-            ],
-            [
-                "一抹黑",
-                "一抹黑"
             ]
         ],
         "algorithm": "OcrDetect",
         "action": "DoNothing",
         "cache": false,
         "text": [
-            "当前坍缩值",
-            "去量化",
-            "去量深化",
-            "实质性坍缩",
-            "蔓延性坍缩",
-            "非线性移动",
-            "非线性行动",
-            "情绪实体",
-            "恐怖实体",
-            "泛社会悖论",
-            "泛文明悖论",
-            "气压异常",
-            "气压失序",
-            "触发性损伤",
-            "触发性危殆",
-            "趋同性消耗",
-            "趋同性缺失",
-            "目空一些",
-            "睁眼瞎",
-            "图像损坏",
-            "一抹黑"
+            "当前坍缩值"
         ],
         "roi": [
             350,

--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -15185,6 +15185,109 @@
             "mask": []
         }
     },
+    "Sami@Roguelike@CheckCollapsalParadigms_bannerCheckConfig": {
+        "Doc": "RoguelikeCollapsalParadigmTaskPlugin用参数",
+        "algorithm": "OcrDetect",
+        "sub": [
+            "Sami@Roguelike@MissionCompletedFlag"
+        ],
+        "text": [
+            "坍缩范式加深"
+        ],
+        "next": [
+            "Sami@Roguelike@GetDrop1",
+            "Sami@Roguelike@GetDrop2",
+            "Sami@Roguelike@GetDrop3",
+            "Sami@Roguelike@GetDrop4",
+            "Sami@Roguelike@GetDropSelectReward",
+            "Sami@Roguelike@GetDropSelectReward2",
+            "Sami@Roguelike@TraderRandomShoppingConfirm"
+        ]
+    },
+    "Sami@Roguelike@CheckCollapsalParadigms_panelCheckConfig": {
+        "Doc": "RoguelikeCollapsalParadigmTaskPlugin用参数",
+        "algorithm": "OcrDetect",
+        "action": "Swipe",
+        "roi": [
+            655,
+            20,
+            10,
+            10
+        ],
+        "specificRect": [
+            640,
+            300,
+            0,
+            0 
+        ],
+        "rectMove": [
+            640,
+            0,
+            0,
+            0
+        ],
+        "sub": [
+            "Sami@Roguelike@StageCombatDps",
+            "Sami@Roguelike@StageCombatDpsAI6",
+            "Sami@Roguelike@StageVerticalCombatDps",
+            "Sami@Roguelike@StageVerticalCombatDpsAI6",
+            "Sami@Roguelike@StageEmergencyDps",
+            "Sami@Roguelike@StageEmergencyDpsAI6",
+            "Sami@Roguelike@StageVerticalEmergencyDps",
+            "Sami@Roguelike@StageVerticalEmergencyDpsAI6",
+            "Sami@Roguelike@StageDreadfulFoe",
+            "Sami@Roguelike@StageDreadfulFoe-5",
+            "Sami@Roguelike@StageEncounter",
+            "Sami@Roguelike@StageEncounterAI6",
+            "Sami@Roguelike@StageVerticalEncounter",
+            "Sami@Roguelike@StageVerticalEncounterAI6",
+            "Sami@Roguelike@StageSafeHouse",
+            "Sami@Roguelike@StageSafeHouseAI6",
+            "Sami@Roguelike@StageVerticalSafeHouse",
+            "Sami@Roguelike@StageVerticalSafeHouseAI6",
+            "Sami@Roguelike@StageGambling",
+            "Sami@Roguelike@StageGamblingAI6",
+            "Sami@Roguelike@StageVerticalGambling",
+            "Sami@Roguelike@StageVerticalGamblingAI6",
+            "Sami@Roguelike@StageProphecy",
+            "Sami@Roguelike@StageProphecyAI6",
+            "Sami@Roguelike@StageVerticalProphecy",
+            "Sami@Roguelike@StageVerticalProphecyAI6",
+            "Sami@Roguelike@StageBoons",
+            "Sami@Roguelike@StageBoonsAI6",
+            "Sami@Roguelike@StageVerticalBoons",
+            "Sami@Roguelike@StageVerticalBoonsAI6",
+            "Sami@Roguelike@StageTrader",
+            "Sami@Roguelike@StageTraderAI6",
+            "Sami@Roguelike@StageVerticalTrader",
+            "Sami@Roguelike@StageVerticalTraderAI6",
+            "Sami@Roguelike@StageWindAndRain",
+            "Sami@Roguelike@StageWindAndRainAI6",
+            "Sami@Roguelike@StageVerticalWindAndRain",
+            "Sami@Roguelike@StageVerticalWindAndRainAI6",
+            "Sami@Roguelike@StageEmergencyTransportation",
+            "Sami@Roguelike@StageEmergencyTransportationAI6",
+            "Sami@Roguelike@StageVerticalEmergencyTransportation",
+            "Sami@Roguelike@StageVerticalEmergencyTransportationAI6",
+            "Sami@Roguelike@StageBoskyPassage",
+            "Sami@Roguelike@StageBoskyPassageAI6",
+            "Sami@Roguelike@StageVerticalBoskyPassage",
+            "Sami@Roguelike@StageVerticalBoskyPassageAI6",
+            "Sami@Roguelike@StageMysteriousPresage",
+            "Sami@Roguelike@StageFerociousPresage"
+        ],
+        "ocrReplace": [
+            ["Sami@Roguelike@OnStage_0", "深埋迷境"],
+            ["Sami@Roguelike@OnStage_1", "初霜湖泽"],
+            ["Sami@Roguelike@OnStage_2", "密静林地"],
+            ["Sami@Roguelike@OnStage_3", "昧明冻土"],
+            ["Sami@Roguelike@OnStage_4", "积冰岩骸"],
+            ["Sami@Roguelike@OnStage_5", "无瑕花园"],
+            ["Sami@Roguelike@OnStage_6", "远见之构"],
+            ["Sami@Roguelike@OnStage_7", "永恒之尘"]
+        ],
+        "text": []
+    },
     "Sami@Roguelike@CheckCollapsalParadigms_loading": {
         "algorithm": "OcrDetect",
         "action": "DoNothing",

--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -15185,41 +15185,6 @@
             "mask": []
         }
     },
-    "Sami@Roguelike@CheckCollapsalParadigms_banner": {
-        "algorithm": "OcrDetect",
-        "action": "DoNothing",
-        "cache": false,
-        "text": [
-            "坍缩范式加深",
-            "坍缩范式消退",
-            "去量化",
-            "去量深化",
-            "实质性坍缩",
-            "蔓延性坍缩",
-            "非线性移动",
-            "非线性行动",
-            "情绪实体",
-            "恐怖实体",
-            "泛社会悖论",
-            "泛文明悖论",
-            "气压异常",
-            "气压失序",
-            "触发性损伤",
-            "触发性危殆",
-            "趋同性消耗",
-            "趋同性缺失",
-            "目空一些",
-            "睁眼瞎",
-            "图像损坏",
-            "一抹黑"
-        ],
-        "roi": [
-            945,
-            60,
-            335,
-            660
-        ]
-    },
     "Sami@Roguelike@CheckCollapsalParadigms_loading": {
         "algorithm": "OcrDetect",
         "action": "DoNothing",
@@ -15262,12 +15227,11 @@
             35
         ]
     },
-    "Sami@Roguelike@CheckCollapsalParadigms_panel": {
+    "Sami@Roguelike@CheckCollapsalParadigms": {
         "algorithm": "OcrDetect",
         "action": "DoNothing",
         "cache": false,
         "text": [
-            "当前坍缩值",
             "去量化",
             "去量深化",
             "实质性坍缩",
@@ -15288,6 +15252,47 @@
             "睁眼瞎",
             "图像损坏",
             "一抹黑"
+        ]
+    },
+    "Sami@Roguelike@CheckCollapsalParadigms_banner": {
+        "baseTask": "Sami@Roguelike@CheckCollapsalParadigms",
+        "roi": [
+            945,
+            60,
+            335,
+            660
+        ]
+    },
+    "Sami@Roguelike@CheckCollapsalParadigms_onBanner": {
+        "algorithm": "OcrDetect",
+        "action": "DoNothing",
+        "cache": false,
+        "text": [
+            "坍缩范式加深",
+            "坍缩范式消退"
+        ],
+        "roi": [
+            945,
+            60,
+            335,
+            660
+        ]
+    },
+    "Sami@Roguelike@CheckCollapsalParadigms_panel": {
+        "baseTask": "Sami@Roguelike@CheckCollapsalParadigms",
+        "roi": [
+            350,
+            120,
+            310,
+            520
+        ]
+    },
+    "Sami@Roguelike@CheckCollapsalParadigms_onPanel": {
+        "algorithm": "OcrDetect",
+        "action": "DoNothing",
+        "cache": false,
+        "text": [
+            "当前坍缩值"
         ],
         "roi": [
             350,

--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -15277,14 +15277,38 @@
             "Sami@Roguelike@StageFerociousPresage"
         ],
         "ocrReplace": [
-            ["Sami@Roguelike@OnStage_0", "深埋迷境"],
-            ["Sami@Roguelike@OnStage_1", "初霜湖泽"],
-            ["Sami@Roguelike@OnStage_2", "密静林地"],
-            ["Sami@Roguelike@OnStage_3", "昧明冻土"],
-            ["Sami@Roguelike@OnStage_4", "积冰岩骸"],
-            ["Sami@Roguelike@OnStage_5", "无瑕花园"],
-            ["Sami@Roguelike@OnStage_6", "远见之构"],
-            ["Sami@Roguelike@OnStage_7", "永恒之尘"]
+            [
+                "Sami@Roguelike@OnStage_0",
+                "深埋迷境"
+            ],
+            [
+                "Sami@Roguelike@OnStage_1",
+                "初霜湖泽"
+            ],
+            [
+                "Sami@Roguelike@OnStage_2",
+                "密静林地"
+            ],
+            [
+                "Sami@Roguelike@OnStage_3",
+                "昧明冻土"
+            ],
+            [
+                "Sami@Roguelike@OnStage_4",
+                "积冰岩骸"
+            ],
+            [
+                "Sami@Roguelike@OnStage_5",
+                "无瑕花园"
+            ],
+            [
+                "Sami@Roguelike@OnStage_6",
+                "远见之构"
+            ],
+            [
+                "Sami@Roguelike@OnStage_7",
+                "永恒之尘"
+            ]
         ],
         "text": []
     },

--- a/src/MaaCore/Config/Roguelike/RoguelikeCollapsalParadigmConfig.h
+++ b/src/MaaCore/Config/Roguelike/RoguelikeCollapsalParadigmConfig.h
@@ -23,7 +23,13 @@ namespace asst
 
         const auto& get_clp_pd_classes(const std::string& theme) const noexcept { return m_clp_pd_classes.at(theme); }
         const auto& get_clp_pd_dict(const std::string& theme) const noexcept { return m_clp_pd_dict.at(theme); }
-        const auto& get_rare_clp_pds(const std::string& theme) const noexcept { return m_rare_clp_pds.at(theme); }
+        const auto& get_rare_clp_pds(std::string theme) const noexcept {
+            if (auto it = m_rare_clp_pds.find(theme); it == m_rare_clp_pds.end()) {
+                static std::unordered_set<std::string> empty_set;
+                return empty_set;
+            }
+            return m_rare_clp_pds.at(theme);
+        }
         
     private:
         virtual bool parse(const json::value& json) override;

--- a/src/MaaCore/Config/Roguelike/RoguelikeCollapsalParadigmConfig.h
+++ b/src/MaaCore/Config/Roguelike/RoguelikeCollapsalParadigmConfig.h
@@ -23,12 +23,15 @@ namespace asst
 
         const auto& get_clp_pd_classes(const std::string& theme) const noexcept { return m_clp_pd_classes.at(theme); }
         const auto& get_clp_pd_dict(const std::string& theme) const noexcept { return m_clp_pd_dict.at(theme); }
-        const auto& get_rare_clp_pds(std::string theme) const noexcept {
-            if (auto it = m_rare_clp_pds.find(theme); it == m_rare_clp_pds.end()) {
-                static std::unordered_set<std::string> empty_set;
+        const auto& get_rare_clp_pds(const std::string& theme) const noexcept {
+            auto it = m_rare_clp_pds.find(theme); 
+            if (it == m_rare_clp_pds.end()) {
+                static const std::unordered_set<std::string> empty_set;
                 return empty_set;
             }
-            return m_rare_clp_pds.at(theme);
+            else {
+                return it->second;
+            }
         }
         
     private:

--- a/src/MaaCore/Task/Interface/RoguelikeTask.cpp
+++ b/src/MaaCore/Task/Interface/RoguelikeTask.cpp
@@ -96,14 +96,13 @@ bool asst::RoguelikeTask::set_params(const json::value& params)
 
         // 是否使用密文版, 非CLP_PDS模式下默认为True, CLP_PDS模式下默认为False
         m_roguelike_config_ptr->set_use_foldartal(params.get("use_foldartal", !(mode == RoguelikeMode::CLP_PDS)));
-        Log.info(123);
+
         // 是否检查坍缩范式，非CLP_PDS模式下默认为False, CLP_PDS模式下默认为True
         m_roguelike_config_ptr->set_check_clp_pds(params.get("check_collapsal_paradigms", mode == RoguelikeMode::CLP_PDS));
         m_roguelike_config_ptr->set_double_check_clp_pds(params.get("double_check_collapsal_paradigms", mode == RoguelikeMode::CLP_PDS));
-        Log.info(123);
+
         const std::unordered_set<std::string>& rare_clp_pds = RoguelikeCollapsalParadigms.get_rare_clp_pds(theme);
         m_roguelike_config_ptr->set_expected_clp_pds(params.get("expected_collapsal_paradigms", rare_clp_pds));
-        Log.info(123);
     }
     // ––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––
 

--- a/src/MaaCore/Task/Interface/RoguelikeTask.h
+++ b/src/MaaCore/Task/Interface/RoguelikeTask.h
@@ -23,6 +23,7 @@ namespace asst
         std::shared_ptr<RoguelikeConfig> m_roguelike_config_ptr = nullptr;
         std::shared_ptr<RoguelikeCustomStartTaskPlugin> m_custom_start_plugin_ptr = nullptr;
         std::shared_ptr<RoguelikeDebugTaskPlugin> m_debug_plugin_ptr = nullptr;
+        void m_roguelike_register_plugins(std::string theme);
 
     };
 }

--- a/src/MaaCore/Task/Roguelike/RoguelikeCollapsalParadigmTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeCollapsalParadigmTaskPlugin.cpp
@@ -41,20 +41,20 @@ bool asst::RoguelikeCollapsalParadigmTaskPlugin::verify(const AsstMsg msg, const
 
     if(msg == AsstMsg::SubTaskStart && m_panel_triggers.find(task_name) != m_panel_triggers.end()) {
         if (new_zone()) {
-            m_need_check_panel = true;
+            m_config->set_need_check_panel(true);
             m_verification_check = false;
         }
         
-        if (m_need_check_panel) {
-            m_need_check_panel = false;
+        if (m_config->get_need_check_panel()) {
+            m_config->set_need_check_panel(false);
             m_check_panel = true;
             return true;
         }
     }
     
-    if (!m_need_check_panel && m_config->get_double_check_clp_pds() && msg == AsstMsg::SubTaskCompleted
+    if (!m_config->get_need_check_panel() && m_config->get_double_check_clp_pds() && msg == AsstMsg::SubTaskCompleted
         && m_panel_triggers.find(task_name) == m_panel_triggers.end()) {
-        m_need_check_panel = true;
+        m_config->set_need_check_panel(true);
         m_verification_check = true;
     };
 
@@ -167,7 +167,7 @@ bool asst::RoguelikeCollapsalParadigmTaskPlugin::check_collapsal_paradigm_banner
                             clp_pd_callback(cur_class.level_1, -1, cur_clp_pd);
                             *it = cur_class.level_1;
                             // 如果2级直接消退到0级的话会有几次提示？这里可能会出问题，谨慎一些，再检查一次。
-                            m_need_check_panel = true;
+                            m_config->set_need_check_panel(true);
                         }
                         else {
                             clp_pd_callback("", -1, cur_clp_pd);
@@ -292,14 +292,14 @@ void asst::RoguelikeCollapsalParadigmTaskPlugin::exit_then_restart()
 
 void asst::RoguelikeCollapsalParadigmTaskPlugin::clp_pd_callback(std::string cur, int deepen_or_weaken, std::string prev)
 {
-    callback(AsstMsg::SubTaskExtraInfo, json::object { 
-        { "what", "RoguelikeCollapsalParadigms" },
-        { "details", json::object {
-            { "cur", cur },
-            { "deepen_or_weaken", deepen_or_weaken },
-            { "prev", prev }
-        } }
-    });
+    LogTraceFunction;
+    Log.info(cur + ", " + std::to_string(deepen_or_weaken) + ", " + prev);
+    // 未来需要GUI日志适配可以使用以下代码callback
+    // auto info = basic_info_with_what("RoguelikeCollapsalParadigms");
+    // info["details"]["cur"] = cur;
+    // info["details"]["deepen_or_weaken"] = deepen_or_weaken;
+    // info["details"]["prev"] = prev;
+    // callback(AsstMsg::SubTaskExtraInfo, info);
 }
 
 void asst::RoguelikeCollapsalParadigmTaskPlugin::toggle_collapsal_status_panel()

--- a/src/MaaCore/Task/Roguelike/RoguelikeCollapsalParadigmTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeCollapsalParadigmTaskPlugin.cpp
@@ -83,103 +83,96 @@ bool asst::RoguelikeCollapsalParadigmTaskPlugin::check_collapsal_paradigm_banner
 
     wait_for_loading(200);
 
-    OCRer analyzer(ctrler()->get_image());
-    if (DEBUG) { analyzer.save_img(utils::path("debug") / utils::path("collapsalParadigms")); }
-    analyzer.set_task_info(theme + "@Roguelike@CheckCollapsalParadigms_banner");
-    auto detected = analyzer.analyze();
+    cv::Mat image = ctrler()->get_image();
+    OCRer analyzer1(image); // 检测 "坍缩范式加深" 或 "坍缩范式消退"
+    if (DEBUG) { analyzer1.save_img(utils::path("debug") / utils::path("collapsalParadigms")); }
+    analyzer1.set_task_info(theme + "@Roguelike@CheckCollapsalParadigms_onBanner");
+    auto detected = analyzer1.analyze();
     if (!detected) { // 以防万一，再识别一次
         wait_for_loading(200);
-        analyzer.set_image(ctrler()->get_image());
-        if (DEBUG) { analyzer.save_img(utils::path("debug") / utils::path("collapsalParadigms")); }
-        detected = analyzer.analyze();
+        image = ctrler()->get_image();
+        analyzer1.set_image(image);
+        if (DEBUG) { analyzer1.save_img(utils::path("debug") / utils::path("collapsalParadigms")); }
+        detected = analyzer1.analyze();
     }
     if (detected) {
         const std::vector<CollapsalParadigmClass>& clp_pd_classes = RoguelikeCollapsalParadigms.get_clp_pd_classes(theme);
         const std::unordered_map<std::string, unsigned int>& clp_pd_dict = RoguelikeCollapsalParadigms.get_clp_pd_dict(theme);
         const std::unordered_set<std::string>& expected_clp_pds = m_config->get_expected_clp_pds();
         std::vector<std::string> prev_clp_pds = m_config->get_clp_pds();
-        
-        std::string_view deepen_text = (Task.get<OcrTaskInfo>(theme + "@Roguelike@CheckCollapsalParadigms_banner")->text)[0]; // "坍缩范式加深"
-        std::string_view weaken_text = (Task.get<OcrTaskInfo>(theme + "@Roguelike@CheckCollapsalParadigms_banner")->text)[1]; // "坍缩范式消退"
 
-        int banner_y = 0;
-        int deepen_or_weaken = 0; // 1 = deepen; 0 = unknown; -1 = weaken;
-        std::string cur_clp_pd;
-        std::vector<std::string>::iterator it;
+        OCRer analyzer2(image); // 检测坍缩范式
+        analyzer2.set_task_info(theme + "@Roguelike@CheckCollapsalParadigms_banner");
+        if (!analyzer2.analyze()) {
+            clp_pd_callback("Erroneous Recognition in Banner Check" , 0, "CollapsalParadigmError");
+            return false;
+        }
 
-        OCRer::ResultsVec ocr_results = analyzer.get_result();
-        std::sort(ocr_results.begin(), ocr_results.end(),
+        OCRer::ResultsVec ocr_results1 = analyzer1.get_result();
+        std::sort(ocr_results1.begin(), ocr_results1.end(),
             [](const OCRer::Result& x1, const OCRer::Result& x2){ return x1.rect.y < x2.rect.y; });
-        for (const OCRer::Result& result : ocr_results) {
-            if (!deepen_or_weaken) {
-                if (result.text != deepen_text && result.text != weaken_text) {
-                    clp_pd_callback("Erroneous Recognition in Banner Check" , 0, "CollapsalParadigmError");
-                    continue;
-                }
-                if (result.text == deepen_text) {
-                    deepen_or_weaken = 1;
-                }
-                else {
-                    deepen_or_weaken = -1;
-                }
-                banner_y = result.rect.y + result.rect.height;
-            } else {
-                if (result.text == deepen_text || result.text == weaken_text
-                    || result.rect.y >= banner_y + 25) {
-                    clp_pd_callback("Erroneous Recognition in Banner Check" , 0, "CollapsalParadigmError");
-                    continue;
-                }
-                cur_clp_pd = result.text;
-                const CollapsalParadigmClass& cur_class = clp_pd_classes.at(clp_pd_dict.at(cur_clp_pd));
-                if (deepen_or_weaken == 1) {
-                    it = std::find(prev_clp_pds.begin(), prev_clp_pds.end(), cur_clp_pd);
-                    if (it == prev_clp_pds.end()) {
-                        if (cur_clp_pd == cur_class.level_2) {
-                            it = std::find(prev_clp_pds.begin(), prev_clp_pds.end(), cur_class.level_1);
-                            if (it != prev_clp_pds.end()) {
-                                clp_pd_callback(cur_clp_pd, 1, *it);
-                                *it = cur_clp_pd;
-                            }
-                            else {
-                                clp_pd_callback(cur_clp_pd, 1);
-                                prev_clp_pds.emplace_back(cur_clp_pd);
-                            }
-                        } else {
+        
+        OCRer::ResultsVec ocr_results2 = analyzer2.get_result();
+        std::sort(ocr_results2.begin(), ocr_results2.end(),
+            [](const OCRer::Result& x1, const OCRer::Result& x2){ return x1.rect.y < x2.rect.y; });
+        
+        OCRer::ResultsVec::iterator result_it1 = ocr_results1.begin();
+        OCRer::ResultsVec::iterator result_it2 = ocr_results2.begin();
+
+        std::vector<std::string>::iterator it;
+        while (result_it1 != ocr_results1.end() && result_it2 != ocr_results2.end()) {
+            if ((*result_it2).rect.y >= (*result_it1).rect.y + (*result_it1).rect.height + 25) {
+                clp_pd_callback("Erroneous Recognition in Banner Check" , 0, "CollapsalParadigmError");
+                ++result_it1;
+                ++result_it2;
+                continue;
+            }
+            std::string cur_clp_pd = (*result_it2).text;
+            const CollapsalParadigmClass& cur_class = clp_pd_classes.at(clp_pd_dict.at(cur_clp_pd));
+            if ((*result_it1).text == "坍缩范式加深") {
+                if (it = std::find(prev_clp_pds.begin(), prev_clp_pds.end(), cur_clp_pd); it == prev_clp_pds.end()) {
+                    if (cur_clp_pd == cur_class.level_2) {
+                        if (it = std::find(prev_clp_pds.begin(), prev_clp_pds.end(), cur_class.level_1); it != prev_clp_pds.end()) {
+                            clp_pd_callback(cur_clp_pd, 1, *it);
+                            *it = cur_clp_pd;
+                        }
+                        else {
                             clp_pd_callback(cur_clp_pd, 1);
                             prev_clp_pds.emplace_back(cur_clp_pd);
                         }
-                        // check whether cur_clp_pd is an expected collapsal paradigm
-                        // 判断 cur_clp_pd 是否为需要的坍缩范式
-                        if (expected_clp_pds.find(cur_clp_pd) != expected_clp_pds.end()) {
-                            exit_then_stop();
-                            return true;
-                        } else if (m_config->get_mode() == RoguelikeMode::CLP_PDS) { // 刷坍缩范式模式下，获得了不想要的坍缩范式
-                            exit_then_restart();
-                            return true;
-                        }
-                    } else {
-                        clp_pd_callback("Duplicate Recognition in Banner Check" , 0, "CollapsalParadigmInfo");
-                    }
-                } else {
-                    it = std::find(prev_clp_pds.begin(), prev_clp_pds.end(), cur_clp_pd);
-                    if (it != prev_clp_pds.end()) {
-                        if (cur_clp_pd == cur_class.level_2) {
-                            clp_pd_callback(cur_class.level_1, -1, cur_clp_pd);
-                            *it = cur_class.level_1;
-                            // 如果2级直接消退到0级的话会有几次提示？这里可能会出问题，谨慎一些，再检查一次。
-                            m_config->set_need_check_panel(true);
-                        }
-                        else {
-                            clp_pd_callback("", -1, cur_clp_pd);
-                            prev_clp_pds.erase(it);
-                        }
                     }
                     else {
-                        clp_pd_callback("Duplicate Recognition in Banner Check" , 0, "CollapsalParadigmInfo");
+                        clp_pd_callback(cur_clp_pd, 1);
+                        prev_clp_pds.emplace_back(cur_clp_pd);
+                    }
+                    // check whether cur_clp_pd is an expected collapsal paradigm
+                    // 判断 cur_clp_pd 是否为需要的坍缩范式
+                    if (expected_clp_pds.find(cur_clp_pd) != expected_clp_pds.end()) {
+                        exit_then_stop();
+                        return true;
+                    }
+                    else if (m_config->get_mode() == RoguelikeMode::CLP_PDS) { // 刷坍缩范式模式下，获得了不想要的坍缩范式
+                        exit_then_restart();
+                        return true;
                     }
                 }
-                deepen_or_weaken = 0;
             }
+            else {
+                if (it = std::find(prev_clp_pds.begin(), prev_clp_pds.end(), cur_clp_pd); it != prev_clp_pds.end()) {
+                    if (cur_clp_pd == cur_class.level_2) {
+                        clp_pd_callback(cur_class.level_1, -1, cur_clp_pd);
+                        *it = cur_class.level_1;
+                        // 如果2级直接消退到0级的话会有几次提示？这里可能会出问题，谨慎一些，晚些再检查一次。
+                        m_config->set_need_check_panel(true);
+                    }
+                    else {
+                        clp_pd_callback("", -1, cur_clp_pd);
+                        prev_clp_pds.erase(it);
+                    }
+                }
+            }
+            ++result_it1;
+            ++result_it2;
         }
         m_config->set_clp_pds(std::move(prev_clp_pds));
     }
@@ -194,43 +187,52 @@ bool asst::RoguelikeCollapsalParadigmTaskPlugin::check_collapsal_paradigm_panel(
     const std::unordered_map<std::string, unsigned int>& clp_pd_dict = RoguelikeCollapsalParadigms.get_clp_pd_dict(theme);
     const std::unordered_set<std::string>& expected_clp_pds = m_config->get_expected_clp_pds();
     std::vector<std::string> prev_clp_pds = m_config->get_clp_pds();
-    std::vector<std::string>::iterator it = prev_clp_pds.begin();
 
     wait_for_stage(200);
 
+    cv::Mat image;
     OCRer analyzer;
-    analyzer.set_task_info(theme + "@Roguelike@CheckCollapsalParadigms_panel");
+    analyzer.set_task_info(theme + "@Roguelike@CheckCollapsalParadigms_onPanel"); // 检测 "当前坍缩值"
     do {
         toggle_collapsal_status_panel();
-        analyzer.set_image(ctrler()->get_image());
-    } while (!analyzer.analyze()); // 即便没有坍缩范式也应当检测到“当前坍缩值”
-    if (DEBUG) { analyzer.save_img(utils::path("debug") / utils::path("collapsalParadigms")); }
+        image = ctrler()->get_image();
+        analyzer.set_image(image);
+    } while (!analyzer.analyze());
 
-    OCRer::ResultsVec ocr_results = analyzer.get_result();
-    // 识别到两个及以上坍缩范式的时候，向上滑动一下再识别一次
-    // if detect more than three collapsal paradigms, swipe up and analyze again
-    if (ocr_results.size() >= 3) {
-        ctrler()->swipe(m_swipe_begin, m_swipe_end, 500);
-        sleep(500);
-        analyzer.set_image(ctrler()->get_image());
-        if (DEBUG) { analyzer.save_img(utils::path("debug") / utils::path("collapsalParadigms")); }
-        if (analyzer.analyze()) {
-            ocr_results = analyzer.get_result();
+    // 获取当前坍缩范式
+    std::vector<std::string> cur_clp_pds;
+    analyzer.set_task_info(theme + "@Roguelike@CheckCollapsalParadigms_panel"); // 检测坍缩范式
+    if (analyzer.analyze()) {
+        OCRer::ResultsVec ocr_results = analyzer.get_result();
+        // 识别到两个及以上坍缩范式的时候，向上滑动一下再识别一次
+        // if detect more than two collapsal paradigms, swipe up and analyze again
+        if (ocr_results.size() >= 2) {
+            ctrler()->swipe(m_swipe_begin, m_swipe_end, 500);
+            sleep(500);
+            analyzer.set_image(ctrler()->get_image());
+            if (analyzer.analyze()) {
+                ocr_results = analyzer.get_result();
+            }
+        }
+        std::sort(ocr_results.begin(), ocr_results.end(),
+            [](const OCRer::Result& x1, const OCRer::Result& x2){ return x1.rect.y < x2.rect.y; });
+        
+        std::transform(ocr_results.begin(), ocr_results.end(),
+            std::back_inserter(cur_clp_pds),
+            [](OCRer::Result x) { return x.text; });
+    }
+    
+    if (m_verification_check) {
+        if (prev_clp_pds != cur_clp_pds) {
+            clp_pd_callback("Collapsal Paradigm Verification Failed", 0, "CollapsalParadigmError");
+        }
+        else {
+            toggle_collapsal_status_panel();
+            return true;
         }
     }
 
-    std::sort(ocr_results.begin(), ocr_results.end(),
-        [](const OCRer::Result& x1, const OCRer::Result& x2){ return x1.rect.y < x2.rect.y; });
-    
-    std::vector<std::string> cur_clp_pds;
-    std::transform(ocr_results.begin() + 1, ocr_results.end(), // 第一个结果肯定是“当前坍缩值”
-        std::back_inserter(cur_clp_pds),
-        [](OCRer::Result x) { return x.text; });
-    
-    if (m_verification_check && prev_clp_pds != cur_clp_pds) {
-        clp_pd_callback("Collapsal Paradigm Verification Failed", 0, "CollapsalParadigmError");
-    }
-
+    std::vector<std::string>::iterator it = prev_clp_pds.begin();
     for (const std::string& cur_clp_pd : cur_clp_pds) {
         // 判断坍缩范式变动
         const unsigned int& cur_index = clp_pd_dict.at(cur_clp_pd);
@@ -271,7 +273,6 @@ bool asst::RoguelikeCollapsalParadigmTaskPlugin::check_collapsal_paradigm_panel(
     m_config->set_clp_pds(std::move(cur_clp_pds));
     
     toggle_collapsal_status_panel();
-
     return true;
 }
 

--- a/src/MaaCore/Task/Roguelike/RoguelikeCollapsalParadigmTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeCollapsalParadigmTaskPlugin.cpp
@@ -124,6 +124,10 @@ bool asst::RoguelikeCollapsalParadigmTaskPlugin::check_collapsal_paradigm_banner
             if ((*result_it2).rect.y >= (*result_it1).rect.y + (*result_it1).rect.height + 25) {
                 clp_pd_callback("Erroneous Recognition in Banner Check" , 0, "CollapsalParadigmError");
                 ++result_it1;
+                continue;
+            }
+            else if ((*result_it2).rect.y <= (*result_it1).rect.y) {
+                clp_pd_callback("Erroneous Recognition in Banner Check" , 0, "CollapsalParadigmError");
                 ++result_it2;
                 continue;
             }

--- a/src/MaaCore/Task/Roguelike/RoguelikeCollapsalParadigmTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeCollapsalParadigmTaskPlugin.cpp
@@ -1,8 +1,3 @@
-#ifdef ASST_DEBUG
-#define CLP_PD_DEBUG
-#undef ASST_DEBUG
-#endif
-
 #include "RoguelikeCollapsalParadigmTaskPlugin.h"
 #include "Config/Roguelike/RoguelikeCollapsalParadigmConfig.h"
 
@@ -87,7 +82,7 @@ bool asst::RoguelikeCollapsalParadigmTaskPlugin::check_collapsal_paradigm_banner
 
     cv::Mat image = ctrler()->get_image();
     OCRer analyzer1(image); // 检测 "坍缩范式加深" 或 "坍缩范式消退"
-#ifdef CLP_PD_DEBUG
+#ifdef ASST_DEBUG
     analyzer1.save_img(utils::path("debug") / utils::path("collapsalParadigms"));
 #endif
     analyzer1.set_task_info(theme + "@Roguelike@CheckCollapsalParadigms_onBanner");
@@ -96,7 +91,7 @@ bool asst::RoguelikeCollapsalParadigmTaskPlugin::check_collapsal_paradigm_banner
         wait_for_loading(200);
         image = ctrler()->get_image();
         analyzer1.set_image(image);
-#ifdef CLP_PD_DEBUG
+#ifdef ASST_DEBUG
         analyzer1.save_img(utils::path("debug") / utils::path("collapsalParadigms"));
 #endif
         detected = analyzer1.analyze();
@@ -191,7 +186,7 @@ bool asst::RoguelikeCollapsalParadigmTaskPlugin::check_collapsal_paradigm_panel(
 {   
     LogTraceFunction;
 
-#ifdef CLP_PD_DEBUG
+#ifdef ASST_DEBUG
     if (m_verification_check) {
         Log.info("Roguelike Collapsal Paradigm Task Plugin: Verification");
     }
@@ -214,7 +209,7 @@ bool asst::RoguelikeCollapsalParadigmTaskPlugin::check_collapsal_paradigm_panel(
         image = ctrler()->get_image();
         analyzer.set_image(image);
     } while (!analyzer.analyze());
-#ifdef CLP_PD_DEBUG
+#ifdef ASST_DEBUG
     analyzer.save_img(utils::path("debug") / utils::path("collapsalParadigms"));
 #endif
 
@@ -229,7 +224,7 @@ bool asst::RoguelikeCollapsalParadigmTaskPlugin::check_collapsal_paradigm_panel(
             ctrler()->swipe(m_swipe_begin, m_swipe_end, 500);
             sleep(500);
             analyzer.set_image(ctrler()->get_image());
-#ifdef CLP_PD_DEBUG
+#ifdef ASST_DEBUG
             analyzer.save_img(utils::path("debug") / utils::path("collapsalParadigms"));
 #endif
             if (analyzer.analyze()) {
@@ -246,7 +241,7 @@ bool asst::RoguelikeCollapsalParadigmTaskPlugin::check_collapsal_paradigm_panel(
     if (m_verification_check) {
         if (prev_clp_pds != cur_clp_pds) {
             Log.info("Roguelike Collapsal Paradigm Task Plugin: Verification Failed");
-#ifdef CLP_PD_DEBUG
+#ifdef ASST_DEBUG
             Log.info("–––––––– Previous ––––––––––––––");
             for (const std::string& clp_pd: prev_clp_pds) {
                 Log.info(clp_pd);
@@ -340,14 +335,14 @@ void asst::RoguelikeCollapsalParadigmTaskPlugin::toggle_collapsal_status_panel()
 void asst::RoguelikeCollapsalParadigmTaskPlugin::wait_for_loading(unsigned int millisecond)
 {
     OCRer analyzer(ctrler()->get_image());
-#ifdef CLP_PD_DEBUG
+#ifdef ASST_DEBUG
     analyzer.save_img(utils::path("debug") / utils::path("collapsalParadigms"));
 #endif
     analyzer.set_task_info(m_config->get_theme() + "@Roguelike@CheckCollapsalParadigms_loading");
     while (analyzer.analyze()) {
         sleep(100);
         analyzer.set_image(ctrler()->get_image());
-#ifdef CLP_PD_DEBUG
+#ifdef ASST_DEBUG
         analyzer.save_img(utils::path("debug") / utils::path("collapsalParadigms"));
 #endif
     }
@@ -357,14 +352,14 @@ void asst::RoguelikeCollapsalParadigmTaskPlugin::wait_for_loading(unsigned int m
 void asst::RoguelikeCollapsalParadigmTaskPlugin::wait_for_stage(unsigned int millisecond)
 {
     Matcher matcher(ctrler()->get_image());
-#ifdef CLP_PD_DEBUG
+#ifdef ASST_DEBUG
     matcher.save_img(utils::path("debug") / utils::path("collapsalParadigms"));
 #endif
     matcher.set_task_info(m_config->get_theme() + "@Roguelike@CheckCollapsalParadigms_onStage");
     while (!matcher.analyze()) {
         sleep(100);
         matcher.set_image(ctrler()->get_image());
-#ifdef CLP_PD_DEBUG
+#ifdef ASST_DEBUG
         matcher.save_img(utils::path("debug") / utils::path("collapsalParadigms"));
 #endif
     }
@@ -379,7 +374,7 @@ bool asst::RoguelikeCollapsalParadigmTaskPlugin::new_zone() const
         std::string zone = m_zone_dict.at(matcher.get_result().templ_name);
         if (zone != m_zone) {
             m_zone = zone;
-#ifdef CLP_PD_DEBUG
+#ifdef ASST_DEBUG
             Log.info("Roguelike Collapsal Paradigm Task Plugin: Current Zone is " + m_zone);
 #endif
             return true;
@@ -387,5 +382,3 @@ bool asst::RoguelikeCollapsalParadigmTaskPlugin::new_zone() const
     }
     return false;
 }
-
-#undef CLP_PD_DEBUG

--- a/src/MaaCore/Task/Roguelike/RoguelikeCollapsalParadigmTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeCollapsalParadigmTaskPlugin.cpp
@@ -109,12 +109,10 @@ bool asst::RoguelikeCollapsalParadigmTaskPlugin::check_collapsal_paradigm_banner
         }
 
         OCRer::ResultsVec ocr_results1 = analyzer1.get_result();
-        std::sort(ocr_results1.begin(), ocr_results1.end(),
-            [](const OCRer::Result& x1, const OCRer::Result& x2){ return x1.rect.y < x2.rect.y; });
+        std::sort(ocr_results1.begin(), ocr_results1.end(), m_compare);
         
         OCRer::ResultsVec ocr_results2 = analyzer2.get_result();
-        std::sort(ocr_results2.begin(), ocr_results2.end(),
-            [](const OCRer::Result& x1, const OCRer::Result& x2){ return x1.rect.y < x2.rect.y; });
+        std::sort(ocr_results2.begin(), ocr_results2.end(), m_compare);
         
         OCRer::ResultsVec::iterator result_it1 = ocr_results1.begin();
         OCRer::ResultsVec::iterator result_it2 = ocr_results2.begin();
@@ -133,7 +131,7 @@ bool asst::RoguelikeCollapsalParadigmTaskPlugin::check_collapsal_paradigm_banner
             }
             std::string cur_clp_pd = (*result_it2).text;
             const CollapsalParadigmClass& cur_class = clp_pd_classes.at(clp_pd_dict.at(cur_clp_pd));
-            if ((*result_it1).text == "坍缩范式加深") {
+            if ((*result_it1).text == m_deepen_text) {
                 if (it = std::find(prev_clp_pds.begin(), prev_clp_pds.end(), cur_clp_pd); it == prev_clp_pds.end()) {
                     if (cur_clp_pd == cur_class.level_2) {
                         if (it = std::find(prev_clp_pds.begin(), prev_clp_pds.end(), cur_class.level_1); it != prev_clp_pds.end()) {
@@ -218,8 +216,7 @@ bool asst::RoguelikeCollapsalParadigmTaskPlugin::check_collapsal_paradigm_panel(
                 ocr_results = analyzer.get_result();
             }
         }
-        std::sort(ocr_results.begin(), ocr_results.end(),
-            [](const OCRer::Result& x1, const OCRer::Result& x2){ return x1.rect.y < x2.rect.y; });
+        std::sort(ocr_results.begin(), ocr_results.end(), m_compare);
         
         std::transform(ocr_results.begin(), ocr_results.end(),
             std::back_inserter(cur_clp_pds),

--- a/src/MaaCore/Task/Roguelike/RoguelikeCollapsalParadigmTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/RoguelikeCollapsalParadigmTaskPlugin.h
@@ -31,7 +31,7 @@ namespace asst
             m_swipe_end.x = panelCheckConfig->rect_move.x;
             m_swipe_end.y = panelCheckConfig->rect_move.y;
             m_panel_triggers.insert(panelCheckConfig->sub.begin(), panelCheckConfig->sub.end());
-            std::for_each(panelCheckConfig->replace_map.begin(), panelCheckConfig->replace_map.end(),
+            std::ranges::for_each(panelCheckConfig->replace_map,
                 [&](const std::pair<std::string, std::string>& p) { m_zone_dict.emplace(p.first, p.second); });
         }
         // using AbstractRoguelikeTaskPlugin::AbstractRoguelikeTaskPlugin;

--- a/src/MaaCore/Task/Roguelike/RoguelikeCollapsalParadigmTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/RoguelikeCollapsalParadigmTaskPlugin.h
@@ -13,6 +13,8 @@ namespace asst
     public:
         virtual bool verify(AsstMsg msg, const json::value& details) const override;
 
+        bool check_collapsal_paradigm_banner();
+
     protected:
         virtual bool _run() override;
 
@@ -23,12 +25,10 @@ namespace asst
 
         mutable bool m_check_banner = false;
         mutable bool m_check_panel = false;
-        mutable bool m_need_check_panel = false;
         mutable bool m_verification_check = false;
         mutable std::string m_zone;
 
         const std::unordered_set<std::string_view> m_banner_triggers_start = {
-            "NeedCheckCollapsalParadigmBanner",
             "Sami@Roguelike@MissionCompletedFlag"
             // "Sami@Roguelike@DropsFlag"
         };
@@ -121,7 +121,6 @@ namespace asst
 
         bool new_zone() const;
 
-        bool check_collapsal_paradigm_banner();
         bool check_collapsal_paradigm_panel();
 
         void toggle_collapsal_status_panel();

--- a/src/MaaCore/Task/Roguelike/RoguelikeCollapsalParadigmTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/RoguelikeCollapsalParadigmTaskPlugin.h
@@ -37,6 +37,10 @@ namespace asst
         // using AbstractRoguelikeTaskPlugin::AbstractRoguelikeTaskPlugin;
         virtual ~RoguelikeCollapsalParadigmTaskPlugin() override = default;
 
+        static bool enabled(std::shared_ptr<RoguelikeConfig> config) {
+            return config->get_theme() == RoguelikeTheme::Sami && config->get_check_clp_pds();
+        }
+
     public:
         virtual bool verify(AsstMsg msg, const json::value& details) const override;
 

--- a/src/MaaCore/Task/Roguelike/RoguelikeCollapsalParadigmTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/RoguelikeCollapsalParadigmTaskPlugin.h
@@ -1,13 +1,40 @@
 #pragma once
 #include "AbstractRoguelikeTaskPlugin.h"
 #include "Common/AsstTypes.h"
+#include "Vision/OCRer.h"
+#include "Config/TaskData.h"
 
 namespace asst
 {
     class RoguelikeCollapsalParadigmTaskPlugin : public AbstractRoguelikeTaskPlugin
     {
     public:
-        using AbstractRoguelikeTaskPlugin::AbstractRoguelikeTaskPlugin;
+        RoguelikeCollapsalParadigmTaskPlugin(const AsstCallback& callback,
+                                             Assistant* inst,
+                                             std::string_view task_chain,
+                                             std::shared_ptr<RoguelikeConfig> config)
+                                             : AbstractRoguelikeTaskPlugin(callback, inst, task_chain, config)
+        {
+            const std::string& theme = config->get_theme();
+            
+            std::shared_ptr<OcrTaskInfo> bannerCheckConfig =
+                Task.get<OcrTaskInfo>(theme + "@Roguelike@CheckCollapsalParadigms_bannerCheckConfig");
+            m_deepen_text = bannerCheckConfig->text.front();
+            m_banner_triggers_start.insert(bannerCheckConfig->sub.begin(), bannerCheckConfig->sub.end());
+            m_banner_triggers_completed.insert(bannerCheckConfig->next.begin(), bannerCheckConfig->next.end());
+
+            std::shared_ptr<OcrTaskInfo> panelCheckConfig =
+                Task.get<OcrTaskInfo>(theme + "@Roguelike@CheckCollapsalParadigms_panelCheckConfig");
+            m_roi = panelCheckConfig->roi;
+            m_swipe_begin.x = panelCheckConfig->specific_rect.x;
+            m_swipe_begin.y = panelCheckConfig->specific_rect.y;
+            m_swipe_end.x = panelCheckConfig->rect_move.x;
+            m_swipe_end.y = panelCheckConfig->rect_move.y;
+            m_panel_triggers.insert(panelCheckConfig->sub.begin(), panelCheckConfig->sub.end());
+            std::for_each(panelCheckConfig->replace_map.begin(), panelCheckConfig->replace_map.end(),
+                [&](const std::pair<std::string, std::string>& p) { m_zone_dict.emplace(p.first, p.second); });
+        }
+        // using AbstractRoguelikeTaskPlugin::AbstractRoguelikeTaskPlugin;
         virtual ~RoguelikeCollapsalParadigmTaskPlugin() override = default;
 
     public:
@@ -19,105 +46,28 @@ namespace asst
         virtual bool _run() override;
 
     private:
-        const Rect m_roi = { 655, 20, 10, 10 };  // 屏幕上方居中区域，点击以检查坍缩状态
-        const Point m_swipe_begin = {640, 300}; // 滑动起点
-        const Point m_swipe_end = {640, 0};     // 滑动终点
-
         mutable bool m_check_banner = false;
         mutable bool m_check_panel = false;
         mutable bool m_verification_check = false;
+
+        std::string m_deepen_text;
+
+        std::unordered_set<std::string> m_banner_triggers_start;
+
+        std::unordered_set<std::string> m_banner_triggers_completed;
+
         mutable std::string m_zone;
 
-        const std::unordered_set<std::string_view> m_banner_triggers_start = {
-            "Sami@Roguelike@MissionCompletedFlag"
-            // "Sami@Roguelike@DropsFlag"
-        };
+        Rect m_roi;          // 屏幕上方居中区域，点击以检查坍缩状态
+        Point m_swipe_begin; // 滑动起点
+        Point m_swipe_end;   // 滑动终点
 
-        const std::unordered_set<std::string_view> m_banner_triggers_completed = {
-            "Sami@Roguelike@GetDrop1",
-            "Sami@Roguelike@GetDrop2",
-            "Sami@Roguelike@GetDrop3",
-            "Sami@Roguelike@GetDrop4",
-            "Sami@Roguelike@GetDropSelectReward",
-            "Sami@Roguelike@GetDropSelectReward2",
-            // "Sami@Roguelike@ClickToDrops",
-            "Sami@Roguelike@TraderRandomShoppingConfirm"
-        };
+        std::unordered_set<std::string> m_panel_triggers;
 
-        const std::unordered_set<std::string_view> m_panel_triggers = {
-            // 作战
-            "Sami@Roguelike@StageCombatDps",
-            "Sami@Roguelike@StageCombatDpsAI6",
-            "Sami@Roguelike@StageVerticalCombatDps",
-            "Sami@Roguelike@StageVerticalCombatDpsAI6",
-            // 紧急作战
-            "Sami@Roguelike@StageEmergencyDps",
-            "Sami@Roguelike@StageEmergencyDpsAI6",
-            "Sami@Roguelike@StageVerticalEmergencyDps",
-            "Sami@Roguelike@StageVerticalEmergencyDpsAI6",
-            // 险路恶敌
-            "Sami@Roguelike@StageDreadfulFoe",
-            "Sami@Roguelike@StageDreadfulFoe-5",
-            // 不期而遇
-            "Sami@Roguelike@StageEncounter",
-            "Sami@Roguelike@StageEncounterAI6",
-            "Sami@Roguelike@StageVerticalEncounter",
-            "Sami@Roguelike@StageVerticalEncounterAI6",
-            // 安全的角落
-            "Sami@Roguelike@StageSafeHouse",
-            "Sami@Roguelike@StageSafeHouseAI6",
-            "Sami@Roguelike@StageVerticalSafeHouse",
-            "Sami@Roguelike@StageVerticalSafeHouseAI6",
-            // 兴致盎然
-            "Sami@Roguelike@StageGambling",
-            "Sami@Roguelike@StageGamblingAI6",
-            "Sami@Roguelike@StageVerticalGambling",
-            "Sami@Roguelike@StageVerticalGamblingAI6",
-            // 命运所指
-            "Sami@Roguelike@StageProphecy",
-            "Sami@Roguelike@StageProphecyAI6",
-            "Sami@Roguelike@StageVerticalProphecy",
-            "Sami@Roguelike@StageVerticalProphecyAI6",
-            // 得偿所愿
-            "Sami@Roguelike@StageBoons",
-            "Sami@Roguelike@StageBoonsAI6",
-            "Sami@Roguelike@StageVerticalBoons",
-            "Sami@Roguelike@StageVerticalBoonsAI6",
-            // 诡意行商
-            "Sami@Roguelike@StageTrader",
-            "Sami@Roguelike@StageTraderAI6",
-            "Sami@Roguelike@StageVerticalTrader",
-            "Sami@Roguelike@StageVerticalTraderAI6",
-            // 失与得
-            "Sami@Roguelike@StageWindAndRain",
-            "Sami@Roguelike@StageWindAndRainAI6",
-            "Sami@Roguelike@StageVerticalWindAndRain",
-            "Sami@Roguelike@StageVerticalWindAndRainAI6",
-            // 先行一步
-            "Sami@Roguelike@StageEmergencyTransportation",
-            "Sami@Roguelike@StageEmergencyTransportationAI6",
-            "Sami@Roguelike@StageVerticalEmergencyTransportation",
-            "Sami@Roguelike@StageVerticalEmergencyTransportationAI6",
-            // 树篱之途
-            "Sami@Roguelike@StageBoskyPassage",
-            "Sami@Roguelike@StageBoskyPassageAI6",
-            "Sami@Roguelike@StageVerticalBoskyPassage",
-            "Sami@Roguelike@StageVerticalBoskyPassageAI6",
-            // 模糊的预感
-            "Sami@Roguelike@StageMysteriousPresage",
-            "Sami@Roguelike@StageFerociousPresage"
-        };
+        std::unordered_map<std::string, std::string> m_zone_dict;
 
-        const std::unordered_map<std::string_view, std::string> m_zone_dict = {
-            {"Sami@Roguelike@OnStage_0", "深埋迷境"},
-            {"Sami@Roguelike@OnStage_1", "初霜湖泽"},
-            {"Sami@Roguelike@OnStage_2", "密静林地"},
-            {"Sami@Roguelike@OnStage_3", "昧明冻土"},
-            {"Sami@Roguelike@OnStage_4", "积冰岩骸"},
-            {"Sami@Roguelike@OnStage_5", "无瑕花园"},
-            {"Sami@Roguelike@OnStage_6", "远见之构"},
-            {"Sami@Roguelike@OnStage_7", "永恒之尘"}
-        };
+        std::function<bool(const OCRer::Result&, const OCRer::Result&)> m_compare =
+            [](const OCRer::Result& x1, const OCRer::Result& x2){ return x1.rect.y < x2.rect.y; };
 
         bool new_zone() const;
 

--- a/src/MaaCore/Task/Roguelike/RoguelikeConfig.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeConfig.cpp
@@ -15,4 +15,5 @@ void asst::RoguelikeConfig::clear()
     m_foldartal = std::vector<std::string>();
 
     m_clp_pds = std::vector<std::string>();
+    m_need_check_panel = false;
 }

--- a/src/MaaCore/Task/Roguelike/RoguelikeConfig.h
+++ b/src/MaaCore/Task/Roguelike/RoguelikeConfig.h
@@ -125,6 +125,8 @@ namespace asst
         const std::vector<std::string>& get_foldartal() const { return m_foldartal; }
         void set_clp_pds(std::vector<std::string> clp_pds) { m_clp_pds = std::move(clp_pds); }
         const std::vector<std::string>& get_clp_pds() const { return m_clp_pds; }
+        void set_need_check_panel(bool need_check_panel) { m_need_check_panel = need_check_panel; }
+        bool get_need_check_panel() const { return m_need_check_panel; }
 
     private:
         int m_recruitment_count = 0;                           // 招募次数
@@ -139,5 +141,6 @@ namespace asst
         std::optional<std::string> m_foldartal_floor;          // 当前层的预见密文板，在下一层获得
         std::vector<std::string> m_foldartal;                  // 所有已获得密文板
         std::vector<std::string> m_clp_pds;                    // 已受到的坍缩范式
+        bool m_need_check_panel = false;
     };
 } // namespace asst

--- a/src/MaaCore/Task/Roguelike/RoguelikeConfig.h
+++ b/src/MaaCore/Task/Roguelike/RoguelikeConfig.h
@@ -141,6 +141,6 @@ namespace asst
         std::optional<std::string> m_foldartal_floor;          // 当前层的预见密文板，在下一层获得
         std::vector<std::string> m_foldartal;                  // 所有已获得密文板
         std::vector<std::string> m_clp_pds;                    // 已受到的坍缩范式
-        bool m_need_check_panel = false;
+        bool m_need_check_panel = false;                       // 是否在下次回到关卡选择界面时检查坍缩范式
     };
 } // namespace asst

--- a/src/MaaCore/Task/Roguelike/RoguelikeFoldartalUseTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeFoldartalUseTaskPlugin.cpp
@@ -164,10 +164,11 @@ void asst::RoguelikeFoldartalUseTaskPlugin::use_enable_pair(
                     list.erase(ranges::find(list, up_board));
                     list.erase(ranges::find(list, down_board));
                     Log.trace("Board pair used, up:", up_board, ", down:", down_board);
-                    callback(AsstMsg::SubTaskStart, json::object {
-                        { "subtask", "ProcessTask" },
-                        { "details", json::object { { "task", "NeedCheckCollapsalParadigmBanner" }, { "pre_task", "RoguelikeFoldartalUseTask"} } }
-                    });
+                    
+                    if (m_config->get_theme() == RoguelikeTheme::Sami && m_config->get_check_clp_pds()) {
+                        m_clp_pd_plugin->check_collapsal_paradigm_banner();
+                    }
+                    
                     break;
                 }
             }

--- a/src/MaaCore/Task/Roguelike/RoguelikeFoldartalUseTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeFoldartalUseTaskPlugin.cpp
@@ -165,7 +165,7 @@ void asst::RoguelikeFoldartalUseTaskPlugin::use_enable_pair(
                     list.erase(ranges::find(list, down_board));
                     Log.trace("Board pair used, up:", up_board, ", down:", down_board);
                     
-                    if (m_config->get_theme() == RoguelikeTheme::Sami && m_config->get_check_clp_pds()) {
+                    if (m_clp_pd_plugin) {
                         m_clp_pd_plugin->check_collapsal_paradigm_banner();
                     }
                     

--- a/src/MaaCore/Task/Roguelike/RoguelikeFoldartalUseTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/RoguelikeFoldartalUseTaskPlugin.h
@@ -15,7 +15,7 @@ namespace asst
                                              std::shared_ptr<RoguelikeConfig> config)
                                              : AbstractRoguelikeTaskPlugin(callback, inst, task_chain, config)
         {
-            if (m_config->get_theme() == RoguelikeTheme::Sami && m_config->get_check_clp_pds()) {
+            if (RoguelikeCollapsalParadigmTaskPlugin::enabled(config)) {
                 m_clp_pd_plugin = std::make_shared<RoguelikeCollapsalParadigmTaskPlugin>(callback, inst, task_chain, config);
             }
         }

--- a/src/MaaCore/Task/Roguelike/RoguelikeFoldartalUseTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/RoguelikeFoldartalUseTaskPlugin.h
@@ -15,7 +15,9 @@ namespace asst
                                              std::shared_ptr<RoguelikeConfig> config)
                                              : AbstractRoguelikeTaskPlugin(callback, inst, task_chain, config)
         {
-            register_plugin<RoguelikeCollapsalParadigmTaskPlugin>(config);
+            if (m_config->get_theme() == RoguelikeTheme::Sami && m_config->get_check_clp_pds()) {
+                m_clp_pd_plugin = std::make_shared<RoguelikeCollapsalParadigmTaskPlugin>(callback, inst, task_chain, config);
+            }
         }
         virtual ~RoguelikeFoldartalUseTaskPlugin() override = default;
 
@@ -51,5 +53,7 @@ namespace asst
         void slowly_swipe(bool direction, int swipe_dist = 200) const;
         // 节点类型
         mutable std::string m_stage;
+        
+        std::shared_ptr<RoguelikeCollapsalParadigmTaskPlugin> m_clp_pd_plugin;
     };
 }

--- a/src/MaaCore/Task/Roguelike/RoguelikeStageEncounterTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeStageEncounterTaskPlugin.cpp
@@ -108,10 +108,9 @@ bool asst::RoguelikeStageEncounterTaskPlugin::_run()
         ProcessTask(*this, { click_option_task_name(choose_option, event.option_num) }).run();
         sleep(300);
     }
-    callback(AsstMsg::SubTaskStart, json::object {
-        { "subtask", "ProcessTask" },
-        { "details", json::object { { "task", "NeedCheckCollapsalParadigmBanner" }, { "pre_task", "RoguelikeStageEncounterTask"} } }
-    });
+    if (m_config->get_theme() == RoguelikeTheme::Sami && m_config->get_check_clp_pds()) {
+        m_clp_pd_plugin->check_collapsal_paradigm_banner();
+    }
 
     // 判断是否点击成功，成功进入对话后左上角的生命值会消失
     sleep(500);
@@ -128,10 +127,9 @@ bool asst::RoguelikeStageEncounterTaskPlugin::_run()
                 ProcessTask(*this, { click_option_task_name(i, max_time) }).run();
                 sleep(300);
             }
-            callback(AsstMsg::SubTaskStart, json::object {
-                { "subtask", "ProcessTask" },
-                { "details", json::object { { "task", "NeedCheckCollapsalParadigmBanner" }, { "pre_task", "RoguelikeStageEncounterTask"} } }
-            });
+            if (m_config->get_theme() == RoguelikeTheme::Sami && m_config->get_check_clp_pds()) {
+                m_clp_pd_plugin->check_collapsal_paradigm_banner();
+            }
 
             if (need_exit()) {
                 return false;

--- a/src/MaaCore/Task/Roguelike/RoguelikeStageEncounterTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeStageEncounterTaskPlugin.cpp
@@ -108,7 +108,7 @@ bool asst::RoguelikeStageEncounterTaskPlugin::_run()
         ProcessTask(*this, { click_option_task_name(choose_option, event.option_num) }).run();
         sleep(300);
     }
-    if (m_config->get_theme() == RoguelikeTheme::Sami && m_config->get_check_clp_pds()) {
+    if (m_clp_pd_plugin) {
         m_clp_pd_plugin->check_collapsal_paradigm_banner();
     }
 
@@ -127,7 +127,7 @@ bool asst::RoguelikeStageEncounterTaskPlugin::_run()
                 ProcessTask(*this, { click_option_task_name(i, max_time) }).run();
                 sleep(300);
             }
-            if (m_config->get_theme() == RoguelikeTheme::Sami && m_config->get_check_clp_pds()) {
+            if (m_clp_pd_plugin) {
                 m_clp_pd_plugin->check_collapsal_paradigm_banner();
             }
 

--- a/src/MaaCore/Task/Roguelike/RoguelikeStageEncounterTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/RoguelikeStageEncounterTaskPlugin.h
@@ -17,7 +17,7 @@ namespace asst
                                              std::shared_ptr<RoguelikeConfig> config)
                                              : AbstractRoguelikeTaskPlugin(callback, inst, task_chain, config)
         {
-            if (m_config->get_theme() == RoguelikeTheme::Sami && m_config->get_check_clp_pds()) {
+            if (RoguelikeCollapsalParadigmTaskPlugin::enabled(config)) {
                 m_clp_pd_plugin = std::make_shared<RoguelikeCollapsalParadigmTaskPlugin>(callback, inst, task_chain, config);
             }
         }

--- a/src/MaaCore/Task/Roguelike/RoguelikeStageEncounterTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/RoguelikeStageEncounterTaskPlugin.h
@@ -17,7 +17,9 @@ namespace asst
                                              std::shared_ptr<RoguelikeConfig> config)
                                              : AbstractRoguelikeTaskPlugin(callback, inst, task_chain, config)
         {
-            register_plugin<RoguelikeCollapsalParadigmTaskPlugin>(config);
+            if (m_config->get_theme() == RoguelikeTheme::Sami && m_config->get_check_clp_pds()) {
+                m_clp_pd_plugin = std::make_shared<RoguelikeCollapsalParadigmTaskPlugin>(callback, inst, task_chain, config);
+            }
         }
         using Config = RoguelikeStageEncounterConfig;
         virtual ~RoguelikeStageEncounterTaskPlugin() override = default;
@@ -30,5 +32,7 @@ namespace asst
         static bool satisfies_condition(const Config::ChoiceRequire& requirement, int special_val);
         static int process_task(const Config::RoguelikeEvent& event, const int special_val);
         static int hp(const cv::Mat& image);
+    private:
+        std::shared_ptr<RoguelikeCollapsalParadigmTaskPlugin> m_clp_pd_plugin;
     };
 }


### PR DESCRIPTION
Gui的Bug是由于非标准格式Callback信息导致的，已舍弃。
傀影/水月肉鸽初始化Bug是由于调用了m_rare_clp_pds.at(theme)，而报错，已加了两层判定，双重保险。
给大家添麻烦了Orz

close #9559