### PR TITLE
fix: 修正繁中服薩米肉鴿獎勵無法多選一的問題

### DIFF
--- a/resource/global/txwy/resource/tasks.json
+++ b/resource/global/txwy/resource/tasks.json
@@ -2853,6 +2853,10 @@
                 "低空机动"
             ],
             [
+                "低室機動",
+                "低空机动"
+            ],
+            [
                 "幽影與鬼魅",
                 "幽影与鬼魅"
             ],
@@ -6379,6 +6383,9 @@
                 "空无"
             ]
         ]
+    },
+    "Sami@Roguelike@GetDropSelectReward": {
+        "templThreshold": 0.9
     },
     "Sami@Roguelike@NextLevel": {
         "text": [


### PR DESCRIPTION
fix #9574, fix #9547, fix #9514, fix #9472 

如題，修正了繁中服薩米肉鴿獎勵無法多選一的問題

提個 PR 送合併先，不然感覺同問題的 issue 會一直出現 QQ