### PR TITLE
Update tasks.json

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -6818,7 +6818,8 @@
         "next": [
             "InfrastNotification",
             "Stop"
-        ]
+        ],
+        "postDelay": 5000,
     },
     "InfrastNotification": {
         "roi": [


### PR DESCRIPTION
add postDelay for InfrastEnteredFlag to avoid office notification confliction
为InfrastEnteredFlag添加延迟以避免信用通知对右上角基建提醒的遮挡