### PR TITLE
docs: fix Weblate status preview in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ MAA 支持多国语言，并使用 Weblate 进行本地化管理。如果您通�
 
 MAA 以中文（简体）为第一语言，翻译词条均以中文（简体）为准。
 
-[![Weblate](https://weblate.maa-org.net/widgets/maa-assistant-arknights/zh_Hans/maa-wpf-gui/multi-auto.svg)](https://weblate.maa-org.net/engage/maa-assistant-arknights/zh_Hans/)
+[![Weblate](https://weblate.maa-org.net/widget/maa/wpf-gui/multi-auto.svg)](https://weblate.maa-org.net/engage/maa/)
 
 ### 参与开发
 


### PR DESCRIPTION
Fix Weblate preview images and links in [README.md](https://github.com/MaaAssistantArknights/MaaAssistantArknights/blob/dev/README.md#%E5%A4%9A%E8%AF%AD%E8%A8%80-i18n) .
![image](https://github.com/MaaAssistantArknights/MaaAssistantArknights/assets/61692393/3546cb41-acad-4aaa-bcab-a850ef337010)

↓

![image](https://github.com/MaaAssistantArknights/MaaAssistantArknights/assets/61692393/c11b272c-d077-4f4a-902e-ecf999ac0c66)