### PR TITLE
fix: 修复萨米肉鸽因插件注册顺序导致的无法运行问题

### DIFF
--- a/src/MaaCore/Task/Interface/RoguelikeTask.cpp
+++ b/src/MaaCore/Task/Interface/RoguelikeTask.cpp
@@ -56,8 +56,6 @@ bool asst::RoguelikeTask::set_params(const json::value& params)
         return false;
     }
 
-    m_roguelike_register_plugins(theme);
-
     auto mode = static_cast<RoguelikeMode>(params.get("mode", 0));
     if (!RoguelikeConfig::is_valid_mode(mode, theme)) {
         m_roguelike_task_ptr->set_tasks({ "Stop" });
@@ -108,7 +106,7 @@ bool asst::RoguelikeTask::set_params(const json::value& params)
     }
     // ––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––––
 
-    m_roguelike_register_plugins(theme);
+    m_roguelike_register_plugins();
 
     m_roguelike_config_ptr->set_invest_maximum(params.get("investments_count", INT_MAX));
     m_roguelike_config_ptr->set_invest_stop_when_full(params.get("stop_when_investment_full", false));
@@ -181,7 +179,10 @@ bool asst::RoguelikeTask::set_params(const json::value& params)
     return true;
 }
 
-void asst::RoguelikeTask::m_roguelike_register_plugins(std::string theme) {
+void asst::RoguelikeTask::m_roguelike_register_plugins() {
+
+    LogTraceFunction;
+
     // 通用插件
     m_roguelike_task_ptr->register_plugin<ScreenshotTaskPlugin>();
     m_roguelike_task_ptr->register_plugin<RoguelikeFormationTaskPlugin>(m_roguelike_config_ptr);
@@ -214,7 +215,7 @@ void asst::RoguelikeTask::m_roguelike_register_plugins(std::string theme) {
     m_roguelike_task_ptr->register_plugin<RoguelikeStrategyChangeTaskPlugin>(m_roguelike_config_ptr);
 
     // 萨米肉鸽专用插件
-    if (theme == RoguelikeTheme::Sami) {
+    if (m_roguelike_config_ptr->get_theme() == RoguelikeTheme::Sami) {
         m_roguelike_task_ptr->register_plugin<RoguelikeFoldartalGainTaskPlugin>(m_roguelike_config_ptr);
         m_roguelike_task_ptr->register_plugin<RoguelikeFoldartalUseTaskPlugin>(m_roguelike_config_ptr);
         m_roguelike_task_ptr->register_plugin<RoguelikeFoldartalStartTaskPlugin>(m_roguelike_config_ptr);

--- a/src/MaaCore/Task/Interface/RoguelikeTask.cpp
+++ b/src/MaaCore/Task/Interface/RoguelikeTask.cpp
@@ -95,7 +95,7 @@ bool asst::RoguelikeTask::set_params(const json::value& params)
         }
 
         // 是否使用密文版, 非CLP_PDS模式下默认为True, CLP_PDS模式下默认为False
-        m_roguelike_config_ptr->set_use_foldartal(params.get("use_foldartal", !(mode == RoguelikeMode::CLP_PDS)));
+        m_roguelike_config_ptr->set_use_foldartal(params.get("use_foldartal", mode != RoguelikeMode::CLP_PDS));
 
         // 是否检查坍缩范式，非CLP_PDS模式下默认为False, CLP_PDS模式下默认为True
         m_roguelike_config_ptr->set_check_clp_pds(params.get("check_collapsal_paradigms", mode == RoguelikeMode::CLP_PDS));

--- a/src/MaaCore/Task/Interface/RoguelikeTask.h
+++ b/src/MaaCore/Task/Interface/RoguelikeTask.h
@@ -23,7 +23,7 @@ namespace asst
         std::shared_ptr<RoguelikeConfig> m_roguelike_config_ptr = nullptr;
         std::shared_ptr<RoguelikeCustomStartTaskPlugin> m_custom_start_plugin_ptr = nullptr;
         std::shared_ptr<RoguelikeDebugTaskPlugin> m_debug_plugin_ptr = nullptr;
-        void m_roguelike_register_plugins(std::string theme);
+        void m_roguelike_register_plugins();
 
     };
 }


### PR DESCRIPTION
- 修复肉鸽插件注册顺序，close #9631

破案了，我的坍缩范式插件pr和refactor/roguelike都修改了RoguelikeTask，merge后插件注册了两遍，第一遍注册早了，那会儿theme还没存进config里呢。