### PR TITLE
fix: 自动战斗开始时移除召唤物类头像缓存，以避免跨局错误识别相似技能的召唤物

### DIFF
--- a/src/MaaCore/Config/Miscellaneous/AvatarCacheManager.cpp
+++ b/src/MaaCore/Config/Miscellaneous/AvatarCacheManager.cpp
@@ -44,6 +44,11 @@ const asst::AvatarCacheManager::AvatarsMap& asst::AvatarCacheManager::get_avatar
     return m_avatars[role];
 }
 
+void asst::AvatarCacheManager::remove_avatars(battle::Role role)
+{
+    m_avatars.erase(role);
+}
+
 void asst::AvatarCacheManager::set_avatar(const std::string& name, battle::Role role, const cv::Mat& avatar,
                                           bool overlay)
 {

--- a/src/MaaCore/Config/Miscellaneous/AvatarCacheManager.h
+++ b/src/MaaCore/Config/Miscellaneous/AvatarCacheManager.h
@@ -25,6 +25,7 @@ namespace asst
         virtual bool load(const std::filesystem::path& path) override;
 
         const AvatarsMap& get_avatars(battle::Role role);
+        void remove_avatars(battle::Role role);
         void set_avatar(const std::string& name, battle::Role role, const cv::Mat& avatar, bool overlay = true);
 
     private:

--- a/src/MaaCore/Task/BattleHelper.cpp
+++ b/src/MaaCore/Task/BattleHelper.cpp
@@ -99,6 +99,7 @@ bool asst::BattleHelper::update_deployment(bool init, const cv::Mat& reusable)
     LogTraceFunction;
 
     if (init) {
+        AvatarCache.remove_avatars(Role::Drone);
         wait_until_start(false);
     }
 
@@ -153,7 +154,7 @@ bool asst::BattleHelper::update_deployment(bool init, const cv::Mat& reusable)
         BestMatcher avatar_analyzer(oper.avatar);
         if (oper.cooling) {
             Log.trace("start matching cooling", oper.index);
-            static const double cooling_threshold =
+            static const auto cooling_threshold =
                 Task.get<MatchTaskInfo>("BattleAvatarCoolingData")->templ_thresholds.front();
             static const auto cooling_mask_range =
                 Task.get<MatchTaskInfo>("BattleAvatarCoolingData")->mask_range;
@@ -162,9 +163,9 @@ bool asst::BattleHelper::update_deployment(bool init, const cv::Mat& reusable)
                 .set_mask_range(cooling_mask_range.first, cooling_mask_range.second, true, true);
         }
         else {
-            static const double threshold =
+            static const auto threshold =
                 Task.get<MatchTaskInfo>("BattleAvatarData")->templ_thresholds.front();
-            static const double drone_threshold =
+            static const auto drone_threshold =
                 Task.get<MatchTaskInfo>("BattleDroneAvatarData")->templ_thresholds.front();
             avatar_analyzer.set_threshold(oper.role == Role::Drone ? drone_threshold : threshold);
         }

--- a/src/MaaCore/Task/BattleHelper.cpp
+++ b/src/MaaCore/Task/BattleHelper.cpp
@@ -99,7 +99,7 @@ bool asst::BattleHelper::update_deployment(bool init, const cv::Mat& reusable)
     LogTraceFunction;
 
     if (init) {
-        AvatarCache.remove_avatars(Role::Drone);
+        AvatarCache.remove_avatars(Role::Drone);// 移除小龙等不同技能很像的召唤物，防止错误识别
         wait_until_start(false);
     }
 


### PR DESCRIPTION
- close #9646 
- close #6024 
- close #6060