### PR TITLE
feat!: 增加图像匹配算法 RGBCount, HSVCount

### DIFF
--- a/docs/zh-cn/protocol/task-schema.md
+++ b/docs/zh-cn/protocol/task-schema.md
@@ -110,6 +110,9 @@ icon: material-symbols:task
                                             // 不填写时默认为 Ccoeff
                                             //      - Ccoeff:       对应 cv::TM_CCOEFF_NORMED
                                             //      - CcoeffHSV:    转换为 HSV 颜色空间后再进行 CCOEFF
+                                            //      - RGBCount:     先将待匹配区域和模板图片依据 maskRange 二值化，
+                                            //                      以 F1-score 为指标计算 RGB 颜色空间内的相似度
+                                            //      - HSVCount:     类似 RGBCount，颜色空间换为 HSV
 
         /* 以下字段仅当 algorithm 为 OcrDetect 时有效 */
 

--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -9957,6 +9957,13 @@
     },
     "Sarkaz@Roguelike@StageBoskyPassageEnter": {
         "baseTask": "Sarkaz@Roguelike@StageEnter",
+        "method": "HSVCount",
+        "maskRange": [
+            [
+                [137, 150, 40],
+                [138, 180, 180]
+            ]
+        ],
         "next": [
             "Sarkaz@Roguelike@StageBoskyPassageEnter",
             "Sarkaz@Roguelike@StageEncounterJudgeClick"
@@ -10007,7 +10014,15 @@
             "Sarkaz@Roguelike@Stages#next"
         ]
     },
-    "Sarkaz@Roguelike@StageCombatDpsEnter": {},
+    "Sarkaz@Roguelike@StageCombatDpsEnter": {
+        "method": "HSVCount",
+        "maskRange": [
+            [
+                [130, 130, 40],
+                [131, 180, 180]
+            ]
+        ]
+    },
     "Sarkaz@Roguelike@StageConfrontation": {
         "Doc": "狭路相逢",
         "baseTask": "Sarkaz@Roguelike@Stage",
@@ -10255,6 +10270,13 @@
         ]
     },
     "Sarkaz@Roguelike@StageSafeHouseEnter": {
+        "method": "HSVCount",
+        "maskRange": [
+            [
+                [106, 100, 50],
+                [107, 160, 180]
+            ]
+        ],
         "next": [
             "Sarkaz@Roguelike@StageSafeHouseEnter",
             "Sarkaz@Roguelike@StageEncounterJudgeClick"

--- a/src/MaaCore/Common/AsstTypes.h
+++ b/src/MaaCore/Common/AsstTypes.h
@@ -362,6 +362,8 @@ namespace asst
         Invalid = -1,
         Ccoeff = 0,
         CcoeffHSV,
+        RGBCount,
+        HSVCount,
     };
 
     inline MatchMethod get_match_method(std::string method_str)
@@ -369,6 +371,7 @@ namespace asst
         utils::tolowers(method_str);
         static const std::unordered_map<std::string, MatchMethod> method_map = {
             { "ccoeff", MatchMethod::Ccoeff }, { "ccoeffhsv", MatchMethod::CcoeffHSV },
+            { "rgbcount", MatchMethod::RGBCount }, { "hsvcount", MatchMethod::HSVCount },
         };
         if (auto it = method_map.find(method_str); it != method_map.end()) {
             return it->second;
@@ -382,6 +385,8 @@ namespace asst
             { MatchMethod::Invalid, "Invalid" },
             { MatchMethod::Ccoeff, "Ccoeff" },
             { MatchMethod::CcoeffHSV, "CcoeffHSV" },
+            { MatchMethod::RGBCount, "RGBCount" },
+            { MatchMethod::HSVCount, "HSVCount" },
         };
         if (auto it = method_map.find(method); it != method_map.end()) {
             return it->second;

--- a/src/MaaCore/Task/Interface/DebugTask.cpp
+++ b/src/MaaCore/Task/Interface/DebugTask.cpp
@@ -17,7 +17,7 @@ asst::DebugTask::DebugTask(const AsstCallback& callback, Assistant* inst) : Inte
 
 bool asst::DebugTask::run()
 {
-    test_drops();
+    test_match_template();
     return true;
 }
 
@@ -79,14 +79,40 @@ void asst::DebugTask::test_match_template()
     cv::Mat image = asst::imread(utils::path("../../test/match_template/1.png"));
     cv::Mat resized;
     cv::resize(image, resized, cv::Size(1280, 720), 0, 0, cv::INTER_AREA);
-    Matcher match_analyzer(resized, Rect(0, 0, 1280, 720));
-    const auto& task_ptr = Task.get("Sami@Roguelike@StageEncounterOptionLeave");
-    const auto match_task_ptr = std::dynamic_pointer_cast<MatchTaskInfo>(task_ptr);
-    match_analyzer.set_task_info(match_task_ptr);
-    match_analyzer.analyze();
-    const auto& result_opt = match_analyzer.analyze();
-    if (result_opt) {
-        const auto& result = result_opt.value().to_string();
-        Log.info(__FUNCTION__, result);
+
+    {
+        Matcher match_analyzer(resized, Rect(0, 0, 1280, 720));
+        const auto& task_ptr = Task.get("Sarkaz@Roguelike@StageSafeHouseEnter");
+        const auto match_task_ptr = std::dynamic_pointer_cast<MatchTaskInfo>(task_ptr);
+        match_analyzer.set_task_info(match_task_ptr);
+        const auto& result_opt = match_analyzer.analyze();
+        if (result_opt) {
+            const auto& result = result_opt.value().to_string();
+            Log.info(__FUNCTION__, result);
+        }
+    }
+
+    {
+        Matcher match_analyzer(resized, Rect(0, 0, 1280, 720));
+        const auto& task_ptr = Task.get("Sarkaz@Roguelike@StageBoskyPassageEnter");
+        const auto match_task_ptr = std::dynamic_pointer_cast<MatchTaskInfo>(task_ptr);
+        match_analyzer.set_task_info(match_task_ptr);
+        const auto& result_opt = match_analyzer.analyze();
+        if (result_opt) {
+            const auto& result = result_opt.value().to_string();
+            Log.info(__FUNCTION__, result);
+        }
+    }
+
+    {
+        Matcher match_analyzer(resized, Rect(0, 0, 1280, 720));
+        const auto& task_ptr = Task.get("Sarkaz@Roguelike@StageCombatDpsEnter");
+        const auto match_task_ptr = std::dynamic_pointer_cast<MatchTaskInfo>(task_ptr);
+        match_analyzer.set_task_info(match_task_ptr);
+        const auto& result_opt = match_analyzer.analyze();
+        if (result_opt) {
+            const auto& result = result_opt.value().to_string();
+            Log.info(__FUNCTION__, result);
+        }
     }
 }


### PR DESCRIPTION
新增基于找色的图像匹配算法（

- RGBCount
   先将待匹配区域和模板图片依据 maskRange 二值化，以 F1-score 为指标计算 RGB 颜色空间内的相似度
- HSVCount
   类似 RGBCount，颜色空间换为 HSV
