### PR TITLE
refactor: 肉鸽坍缩范式插件代码整理

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -8129,7 +8129,7 @@
         "baseTask": "Sami@Roguelike@CheckCollapsalParadigms",
         "roi": [945, 60, 335, 660]
     },
-    "Sami@Roguelike@CheckCollapsalParadigms_bannerCheckConfig": {
+    "Sami@Roguelike@CollapsalParadigmTaskBannerCheckConfig": {
         "Doc": "RoguelikeCollapsalParadigmTaskPlugin用参数",
         "algorithm": "OcrDetect",
         "roi": [0, 0, 1280, 720],
@@ -8179,7 +8179,7 @@
         "baseTask": "Sami@Roguelike@CheckCollapsalParadigms",
         "roi": [350, 120, 310, 520]
     },
-    "Sami@Roguelike@CheckCollapsalParadigms_panelCheckConfig": {
+    "Sami@Roguelike@CollapsalParadigmTaskPanelCheckConfig": {
         "Doc": "RoguelikeCollapsalParadigmTaskPlugin用参数",
         "algorithm": "OcrDetect",
         "action": "Swipe",

--- a/src/MaaCore/Task/Roguelike/AbstractRoguelikeTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/AbstractRoguelikeTaskPlugin.cpp
@@ -5,22 +5,3 @@ asst::AbstractRoguelikeTaskPlugin::AbstractRoguelikeTaskPlugin(const AsstCallbac
                                                                const std::shared_ptr<RoguelikeConfig>& config)
     : AbstractTaskPlugin(callback, inst, task_chain), m_config(config)
 {}
-
-std::optional<json::value> asst::AbstractRoguelikeTaskPlugin::notify_sibling_plugins(
-    RoguelikeEvent event,
-    const json::value& detail)
-{
-    for (const TaskPluginPtr& plugin : m_task_ptr->get_plugins()) {
-        plugin->set_task_id(m_task_id);
-        plugin->set_task_ptr(m_task_ptr);
-
-        if (std::shared_ptr<AbstractRoguelikeTaskPlugin> roguelike_plugin =
-                std::dynamic_pointer_cast<AbstractRoguelikeTaskPlugin>(plugin)) {
-            if (std::optional<json::value> response =
-                    roguelike_plugin->response_to_event(event, detail)) {
-                return response;
-            }
-        }
-    }
-    return std::nullopt;
-}

--- a/src/MaaCore/Task/Roguelike/AbstractRoguelikeTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/AbstractRoguelikeTaskPlugin.cpp
@@ -5,3 +5,22 @@ asst::AbstractRoguelikeTaskPlugin::AbstractRoguelikeTaskPlugin(const AsstCallbac
                                                                const std::shared_ptr<RoguelikeConfig>& config)
     : AbstractTaskPlugin(callback, inst, task_chain), m_config(config)
 {}
+
+std::optional<json::value> asst::AbstractRoguelikeTaskPlugin::notify_sibling_plugins(
+    RoguelikeEvent event,
+    const json::value& detail)
+{
+    for (const TaskPluginPtr& plugin : m_task_ptr->get_plugins()) {
+        plugin->set_task_id(m_task_id);
+        plugin->set_task_ptr(m_task_ptr);
+
+        if (std::shared_ptr<AbstractRoguelikeTaskPlugin> roguelike_plugin =
+                std::dynamic_pointer_cast<AbstractRoguelikeTaskPlugin>(plugin)) {
+            if (std::optional<json::value> response =
+                    roguelike_plugin->response_to_event(event, detail)) {
+                return response;
+            }
+        }
+    }
+    return std::nullopt;
+}

--- a/src/MaaCore/Task/Roguelike/AbstractRoguelikeTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/AbstractRoguelikeTaskPlugin.h
@@ -13,7 +13,7 @@ namespace asst
         AbstractRoguelikeTaskPlugin(const AsstCallback& callback, Assistant* inst, std::string_view task_chain,
                                     const std::shared_ptr<RoguelikeConfig>& data);
 
-        virtual void reset_variable() {}
+        virtual void reset() {}
 
         // 根据 params 设置插件专用参数, 返回插件是否适用
         virtual bool set_params([[maybe_unused]] const json::value& params) { return true; }

--- a/src/MaaCore/Task/Roguelike/AbstractRoguelikeTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/AbstractRoguelikeTaskPlugin.h
@@ -13,10 +13,11 @@ namespace asst
         AbstractRoguelikeTaskPlugin(const AsstCallback& callback, Assistant* inst, std::string_view task_chain,
                                     const std::shared_ptr<RoguelikeConfig>& data);
 
-        virtual void reset_in_run_variables() {}
-
         // 根据 params 设置插件专用参数, 返回插件是否适用
         virtual bool set_params([[maybe_unused]] const json::value& params) { return true; }
+
+        // 进入新的一轮坍缩时重置局内变量
+        virtual void reset_in_run_variables() {}
 
     protected:
         std::shared_ptr<RoguelikeConfig> m_config;

--- a/src/MaaCore/Task/Roguelike/AbstractRoguelikeTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/AbstractRoguelikeTaskPlugin.h
@@ -13,7 +13,7 @@ namespace asst
         AbstractRoguelikeTaskPlugin(const AsstCallback& callback, Assistant* inst, std::string_view task_chain,
                                     const std::shared_ptr<RoguelikeConfig>& data);
 
-        virtual void reset() {}
+        virtual void reset_in_run_variables() {}
 
         // 根据 params 设置插件专用参数, 返回插件是否适用
         virtual bool set_params([[maybe_unused]] const json::value& params) { return true; }

--- a/src/MaaCore/Task/Roguelike/AbstractRoguelikeTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/AbstractRoguelikeTaskPlugin.h
@@ -20,6 +20,8 @@ namespace asst
 
     protected:
         std::shared_ptr<RoguelikeConfig> m_config;
+        std::optional<json::value>
+            notify_sibling_plugins(RoguelikeEvent event, const json::value& detail = json::object());
     };
 
     using RoguelikeTaskPluginPtr = std::shared_ptr<AbstractRoguelikeTaskPlugin>;

--- a/src/MaaCore/Task/Roguelike/AbstractRoguelikeTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/AbstractRoguelikeTaskPlugin.h
@@ -20,8 +20,6 @@ namespace asst
 
     protected:
         std::shared_ptr<RoguelikeConfig> m_config;
-        std::optional<json::value>
-            notify_sibling_plugins(RoguelikeEvent event, const json::value& detail = json::object());
     };
 
     using RoguelikeTaskPluginPtr = std::shared_ptr<AbstractRoguelikeTaskPlugin>;

--- a/src/MaaCore/Task/Roguelike/RoguelikeConfig.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeConfig.cpp
@@ -63,6 +63,4 @@ void asst::RoguelikeConfig::clear()
 
     // ------------------ 萨米主题专用参数 ------------------
     m_foldartal = std::vector<std::string>();
-    m_clp_pds = std::vector<std::string>();
-    m_need_check_panel = false;
 }

--- a/src/MaaCore/Task/Roguelike/RoguelikeConfig.h
+++ b/src/MaaCore/Task/Roguelike/RoguelikeConfig.h
@@ -166,12 +166,4 @@ namespace asst
         std::vector<std::string> m_clp_pds;           // 已受到的坍缩范式
         bool m_need_check_panel = false;              // 是否在下次回到关卡选择界面时检查坍缩范式
     };
-
-    enum class RoguelikeEvent
-    {
-        None = 0,
-        EncounterClickOption     = 1, // -> CollapsalParadigm
-        ShoppingConsiderGoods    = 2, // -> CollapsalParadigm
-        SamiFoldartalDeclaration = 3  // -> CollapsalParadigm
-    };
 } // namespace asst

--- a/src/MaaCore/Task/Roguelike/RoguelikeConfig.h
+++ b/src/MaaCore/Task/Roguelike/RoguelikeConfig.h
@@ -166,4 +166,9 @@ namespace asst
         std::vector<std::string> m_clp_pds;           // 已受到的坍缩范式
         bool m_need_check_panel = false;              // 是否在下次回到关卡选择界面时检查坍缩范式
     };
+
+    enum class RoguelikeEvent
+    {
+        None = 0
+    };
 } // namespace asst

--- a/src/MaaCore/Task/Roguelike/RoguelikeConfig.h
+++ b/src/MaaCore/Task/Roguelike/RoguelikeConfig.h
@@ -171,6 +171,7 @@ namespace asst
     {
         None = 0,
         EncounterClickOption     = 1, // -> CollapsalParadigm
+        ShoppingConsiderGoods    = 2, // -> CollapsalParadigm
         SamiFoldartalDeclaration = 3  // -> CollapsalParadigm
     };
 } // namespace asst

--- a/src/MaaCore/Task/Roguelike/RoguelikeConfig.h
+++ b/src/MaaCore/Task/Roguelike/RoguelikeConfig.h
@@ -146,24 +146,13 @@ namespace asst
 
         std::unordered_map<std::string, RoguelikeOper> m_oper; // 干员精英&等级
 
-
     public:
         // ------------------ 密文板 ------------------
         void set_foldartal(auto foldartal) { m_foldartal = std::move(foldartal); }
         const auto& get_foldartal() const { return m_foldartal; }
 
-        // ------------------ 坍缩范式 ------------------
-        void set_clp_pds(std::vector<std::string> clp_pds) { m_clp_pds = std::move(clp_pds); }
-        const auto& get_clp_pds() const { return m_clp_pds; }
-        void set_need_check_panel(bool need_check_panel) { m_need_check_panel = need_check_panel; }
-        bool get_need_check_panel() const { return m_need_check_panel; }
-
     private:
         // ------------------ 密文板 ------------------
         std::vector<std::string> m_foldartal;         // 所有已获得密文板
-
-        // ------------------ 坍缩范式 ------------------
-        std::vector<std::string> m_clp_pds;           // 已受到的坍缩范式
-        bool m_need_check_panel = false;              // 是否在下次回到关卡选择界面时检查坍缩范式
     };
 } // namespace asst

--- a/src/MaaCore/Task/Roguelike/RoguelikeConfig.h
+++ b/src/MaaCore/Task/Roguelike/RoguelikeConfig.h
@@ -169,6 +169,8 @@ namespace asst
 
     enum class RoguelikeEvent
     {
-        None = 0
+        None = 0,
+        EncounterClickOption     = 1, // -> CollapsalParadigm
+        SamiFoldartalDeclaration = 3  // -> CollapsalParadigm
     };
 } // namespace asst

--- a/src/MaaCore/Task/Roguelike/RoguelikeRecruitTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeRecruitTaskPlugin.cpp
@@ -415,7 +415,7 @@ bool asst::RoguelikeRecruitTaskPlugin::_run()
     return recruit_appointed_char(char_name, is_rtl);
 }
 
-void asst::RoguelikeRecruitTaskPlugin::reset_variable()
+void asst::RoguelikeRecruitTaskPlugin::reset()
 {
     m_recruit_count = 0;
     m_starts_complete = false; 

--- a/src/MaaCore/Task/Roguelike/RoguelikeRecruitTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeRecruitTaskPlugin.cpp
@@ -415,7 +415,7 @@ bool asst::RoguelikeRecruitTaskPlugin::_run()
     return recruit_appointed_char(char_name, is_rtl);
 }
 
-void asst::RoguelikeRecruitTaskPlugin::reset()
+void asst::RoguelikeRecruitTaskPlugin::reset_in_run_variables()
 {
     m_recruit_count = 0;
     m_starts_complete = false; 

--- a/src/MaaCore/Task/Roguelike/RoguelikeRecruitTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/RoguelikeRecruitTaskPlugin.h
@@ -23,7 +23,7 @@ public:
 
 protected:
     virtual bool _run() override;
-    virtual void reset() override;
+    virtual void reset_in_run_variables() override;
     // 滑动到干员列表的最左侧
     void swipe_to_the_left_of_operlist(int loop_times = 2);
     // 缓慢向干员列表的左侧/右侧滑动

--- a/src/MaaCore/Task/Roguelike/RoguelikeRecruitTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/RoguelikeRecruitTaskPlugin.h
@@ -23,7 +23,7 @@ public:
 
 protected:
     virtual bool _run() override;
-    virtual void reset_variable() override;
+    virtual void reset() override;
     // 滑动到干员列表的最左侧
     void swipe_to_the_left_of_operlist(int loop_times = 2);
     // 缓慢向干员列表的左侧/右侧滑动

--- a/src/MaaCore/Task/Roguelike/RoguelikeResetTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeResetTaskPlugin.cpp
@@ -31,7 +31,7 @@ bool asst::RoguelikeResetTaskPlugin::_run()
 {
     for (const auto& plugin : m_task_ptr->get_plugins()) {
         if (auto ptr = std::dynamic_pointer_cast<AbstractRoguelikeTaskPlugin>(plugin)) {
-            ptr->reset();
+            ptr->reset_in_run_variables();
         }
     }
     m_config->clear();

--- a/src/MaaCore/Task/Roguelike/RoguelikeResetTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeResetTaskPlugin.cpp
@@ -31,7 +31,7 @@ bool asst::RoguelikeResetTaskPlugin::_run()
 {
     for (const auto& plugin : m_task_ptr->get_plugins()) {
         if (auto ptr = std::dynamic_pointer_cast<AbstractRoguelikeTaskPlugin>(plugin)) {
-            ptr->reset_variable();
+            ptr->reset();
         }
     }
     m_config->clear();

--- a/src/MaaCore/Task/Roguelike/RoguelikeShoppingTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeShoppingTaskPlugin.cpp
@@ -125,10 +125,9 @@ bool asst::RoguelikeShoppingTaskPlugin::buy_once()
         if (no_longer_buy && !goods.ignore_no_longer_buy) {
             continue;
         }
-        std::optional<json::value> opt = notify_sibling_plugins(
-            RoguelikeEvent::ShoppingConsiderGoods,
-            json::object { { "decrease_collapse", goods.decrease_collapse } });
-        if (opt && opt.value().get("reject_goods", false)) {
+
+        // 在萨米肉鸽刷坍缩范式时不再购买会减少坍缩值的藏品
+        if (m_config->get_mode() == RoguelikeMode::CLP_PDS && goods.decrease_collapse) {
             continue;
         }
 

--- a/src/MaaCore/Task/Roguelike/RoguelikeShoppingTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeShoppingTaskPlugin.cpp
@@ -118,7 +118,6 @@ bool asst::RoguelikeShoppingTaskPlugin::buy_once()
         m_config->get_theme() == RoguelikeTheme::Sami
             ? Task.get<OcrTaskInfo>("Sami@Roguelike@FoldartalGainOcr")->text
             : std::vector<std::string>();
-    const RoguelikeMode& mode = m_config->get_mode();
     for (const auto& goods : all_goods) {
         if (need_exit()) {
             return false;
@@ -126,7 +125,10 @@ bool asst::RoguelikeShoppingTaskPlugin::buy_once()
         if (no_longer_buy && !goods.ignore_no_longer_buy) {
             continue;
         }
-        if (mode == RoguelikeMode::CLP_PDS && goods.decrease_collapse) {
+        std::optional<json::value> opt = notify_sibling_plugins(
+            RoguelikeEvent::ShoppingConsiderGoods,
+            json::object { { "decrease_collapse", goods.decrease_collapse } });
+        if (opt && opt.value().get("reject_goods", false)) {
             continue;
         }
 

--- a/src/MaaCore/Task/Roguelike/RoguelikeStageEncounterTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeStageEncounterTaskPlugin.cpp
@@ -97,7 +97,6 @@ bool asst::RoguelikeStageEncounterTaskPlugin::_run()
         ProcessTask(*this, { click_option_task_name(choose_option, event.option_num) }).run();
         sleep(300);
     }
-    notify_sibling_plugins(RoguelikeEvent::EncounterClickOption);
 
     // 判断是否点击成功，成功进入对话后左上角的生命值会消失
     sleep(500);
@@ -114,7 +113,6 @@ bool asst::RoguelikeStageEncounterTaskPlugin::_run()
                 ProcessTask(*this, { click_option_task_name(i, max_time) }).run();
                 sleep(300);
             }
-            notify_sibling_plugins(RoguelikeEvent::EncounterClickOption);
 
             if (need_exit()) {
                 return false;

--- a/src/MaaCore/Task/Roguelike/RoguelikeStageEncounterTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeStageEncounterTaskPlugin.cpp
@@ -35,18 +35,6 @@ bool asst::RoguelikeStageEncounterTaskPlugin::verify(AsstMsg msg, const json::va
 bool asst::RoguelikeStageEncounterTaskPlugin::_run()
 {
     LogTraceFunction;
-    if (!m_plugin_gained) {
-        m_plugin_gained = true;
-        if (RoguelikeCollapsalParadigmTaskPlugin::enabled(m_config)) {
-            typedef RoguelikeCollapsalParadigmTaskPlugin Plugin;
-            for (const auto& plugin : m_task_ptr->get_plugins()) {
-                if (auto ptr = std::dynamic_pointer_cast<Plugin>(plugin)) {
-                    m_clp_pd_plugin = ptr;
-                    break;
-                }
-            }
-        }
-    }
 
     const std::string& theme = m_config->get_theme();
     const RoguelikeMode& mode = m_config->get_mode();
@@ -109,9 +97,7 @@ bool asst::RoguelikeStageEncounterTaskPlugin::_run()
         ProcessTask(*this, { click_option_task_name(choose_option, event.option_num) }).run();
         sleep(300);
     }
-    if (m_clp_pd_plugin) {
-        m_clp_pd_plugin->check_collapsal_paradigm_banner();
-    }
+    notify_sibling_plugins(RoguelikeEvent::EncounterClickOption);
 
     // 判断是否点击成功，成功进入对话后左上角的生命值会消失
     sleep(500);
@@ -128,9 +114,7 @@ bool asst::RoguelikeStageEncounterTaskPlugin::_run()
                 ProcessTask(*this, { click_option_task_name(i, max_time) }).run();
                 sleep(300);
             }
-            if (m_clp_pd_plugin) {
-                m_clp_pd_plugin->check_collapsal_paradigm_banner();
-            }
+            notify_sibling_plugins(RoguelikeEvent::EncounterClickOption);
 
             if (need_exit()) {
                 return false;

--- a/src/MaaCore/Task/Roguelike/RoguelikeStageEncounterTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/RoguelikeStageEncounterTaskPlugin.h
@@ -22,9 +22,5 @@ namespace asst
         static bool satisfies_condition(const Config::ChoiceRequire& requirement, int special_val);
         static int process_task(const Config::RoguelikeEvent& event, const int special_val);
         static int hp(const cv::Mat& image);
-    private:
-        std::shared_ptr<RoguelikeCollapsalParadigmTaskPlugin> m_clp_pd_plugin;
-
-        bool m_plugin_gained = false;
     };
 }

--- a/src/MaaCore/Task/Roguelike/Sami/RoguelikeCollapsalParadigmTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/Sami/RoguelikeCollapsalParadigmTaskPlugin.cpp
@@ -54,7 +54,7 @@ void asst::RoguelikeCollapsalParadigmTaskPlugin::reset()
     m_zone.clear();
 }
 
-void asst::RoguelikeCollapsalParadigmTaskPlugin::reset()
+void asst::RoguelikeCollapsalParadigmTaskPlugin::reset_in_run_variables()
 {
     m_clp_pds.clear();
     m_check_banner = false;

--- a/src/MaaCore/Task/Roguelike/Sami/RoguelikeCollapsalParadigmTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/Sami/RoguelikeCollapsalParadigmTaskPlugin.cpp
@@ -12,15 +12,18 @@
 
 bool asst::RoguelikeCollapsalParadigmTaskPlugin::set_params(const json::value& params)
 {
+    // ———————— 检查适用主题 ————————————————————————
     const std::string& theme = m_config->get_theme();
     if (theme != RoguelikeTheme::Sami) {
         return false;
     }
 
+    // 仅萨米肉鸽使用 TODO: 去掉名字里的下划线, _b -> B, _p -> P
+    // ———————— 根据 params 设置插件 ————————————————
     const RoguelikeMode& mode = m_config->get_mode();
     m_double_check_clp_pds = params.get("double_check_collapsal_paradigms", mode == RoguelikeMode::CLP_PDS);
 
-    // 仅萨米肉鸽使用 TODO: 去掉名字里的下划线, _b -> B, _p -> P
+    // ———————— 从 tasks.json 获取插件设置，由于仅有萨米肉鸽使用，任务名暂定写死 ———————————
     const auto& bannerCheckConfig =
         Task.get<OcrTaskInfo>("Sami@Roguelike@CheckCollapsalParadigms_bannerCheckConfig");
     const auto& panelCheckConfig =
@@ -41,6 +44,26 @@ bool asst::RoguelikeCollapsalParadigmTaskPlugin::set_params(const json::value& p
     return true;
 }
 
+void asst::RoguelikeCollapsalParadigmTaskPlugin::reset()
+{
+    m_clp_pds.clear();
+    m_check_banner = false;
+    m_check_panel = false;
+    m_need_check_panel = false;
+    m_verification_check = false;
+    m_zone.clear();
+}
+
+void asst::RoguelikeCollapsalParadigmTaskPlugin::reset()
+{
+    m_clp_pds.clear();
+    m_check_banner = false;
+    m_check_panel = false;
+    m_need_check_panel = false;
+    m_verification_check = false;
+    m_zone.clear();
+}
+
 bool asst::RoguelikeCollapsalParadigmTaskPlugin::verify(const AsstMsg msg, const json::value& details) const
 {
     if ((msg != AsstMsg::SubTaskStart && msg != AsstMsg::SubTaskCompleted) ||
@@ -54,33 +77,37 @@ bool asst::RoguelikeCollapsalParadigmTaskPlugin::verify(const AsstMsg msg, const
 
     const auto task_name = details.get("details", "task", "");
 
-    if (msg == AsstMsg::SubTaskStart && m_banner_triggers_start.find(task_name) != m_banner_triggers_start.end()) {
+    // banner check
+    if (msg == AsstMsg::SubTaskStart &&
+        m_banner_triggers_start.find(task_name) != m_banner_triggers_start.end()) {
         m_check_banner = true;
         return true;
     }
-
     if (msg == AsstMsg::SubTaskCompleted &&
         m_banner_triggers_completed.find(task_name) != m_banner_triggers_completed.end()) {
         m_check_banner = true;
         return true;
     }
 
-    if (msg == AsstMsg::SubTaskStart && m_panel_triggers.find(task_name) != m_panel_triggers.end()) {
+    // panel check
+    if (msg == AsstMsg::SubTaskStart &&
+        m_panel_triggers.find(task_name) != m_panel_triggers.end()) {
         if (new_zone()) {
-            m_config->set_need_check_panel(true);
+            m_need_check_panel = true;
             m_verification_check = false;
         }
 
-        if (m_config->get_need_check_panel()) {
-            m_config->set_need_check_panel(false);
+        if (m_need_check_panel) {
+            m_need_check_panel = false;
             m_check_panel = true;
             return true;
         }
     }
 
-    if (msg == AsstMsg::SubTaskCompleted && !m_config->get_need_check_panel() && m_double_check_clp_pds &&
-        m_panel_triggers.find(task_name) == m_panel_triggers.end()) {
-        m_config->set_need_check_panel(true);
+    if (msg == AsstMsg::SubTaskCompleted &&
+        m_panel_triggers.find(task_name) == m_panel_triggers.end() &&
+        !m_need_check_panel && m_double_check_clp_pds) {
+        m_need_check_panel = true;
         m_verification_check = true;
     };
 
@@ -91,37 +118,31 @@ bool asst::RoguelikeCollapsalParadigmTaskPlugin::_run()
 {
     if (m_check_banner) {
         m_check_banner = false;
-        return check_collapsal_paradigm_banner();
+        check_banner();
     }
     if (m_check_panel) {
         m_check_panel = false;
-        return check_collapsal_paradigm_panel();
+        check_panel();
     }
-    return false;
+    return true;
 }
 
-bool asst::RoguelikeCollapsalParadigmTaskPlugin::check_collapsal_paradigm_banner()
+void asst::RoguelikeCollapsalParadigmTaskPlugin::check_banner()
 {
     LogTraceFunction;
 
     const std::string& theme = m_config->get_theme();
 
-    wait_for_loading(200);
-
+    // analyzer1 检测坍缩范式变动，即 "坍缩范式加深" 或 "坍缩范式消退"
+    wait_for_loading();
     cv::Mat image = ctrler()->get_image();
-    OCRer analyzer1(image); // 检测 "坍缩范式加深" 或 "坍缩范式消退"
-#ifdef ASST_DEBUG
-    analyzer1.save_img(utils::path("debug") / utils::path("collapsalParadigms"));
-#endif
+    OCRer analyzer1(image);
     analyzer1.set_task_info(theme + "@Roguelike@CheckCollapsalParadigms_onBanner");
     auto detected = analyzer1.analyze();
-    if (!detected) { // 以防万一，再识别一次
-        wait_for_loading(200);
+    if (!detected) { // 以防万一，等一等再识别一次
+        wait_for_loading();
         image = ctrler()->get_image();
         analyzer1.set_image(image);
-#ifdef ASST_DEBUG
-        analyzer1.save_img(utils::path("debug") / utils::path("collapsalParadigms"));
-#endif
         detected = analyzer1.analyze();
     }
     if (detected) {
@@ -130,94 +151,98 @@ bool asst::RoguelikeCollapsalParadigmTaskPlugin::check_collapsal_paradigm_banner
         const std::unordered_map<std::string, unsigned int>& clp_pd_dict =
             RoguelikeCollapsalParadigms.get_clp_pd_dict(theme);
         const auto& expected_clp_pds = RoguelikeCollapsalParadigms.get_rare_clp_pds(theme);
-        std::vector<std::string> prev_clp_pds = m_config->get_clp_pds();
+        std::vector<std::string> prev_clp_pds = m_clp_pds;
 
-        OCRer analyzer2(image); // 检测坍缩范式
+        OCRer analyzer2(image); // 检测坍缩范式名
         analyzer2.set_task_info(theme + "@Roguelike@CheckCollapsalParadigms_banner");
         if (!analyzer2.analyze()) {
-            Log.info("Roguelike Collapsal Paradigm Task Plugin: Erroneous Recognition in Banner Check");
-            return false;
+            Log.info(m_banner_check_error_message);
+            return;
         }
 
         OCRer::ResultsVec ocr_results1 = analyzer1.get_result();
         OCRer::ResultsVec ocr_results2 = analyzer2.get_result();
-        sort_by_vertical_(ocr_results1); // 按照水平方向排序(从左到右
-        sort_by_vertical_(ocr_results2); // 按照水平方向排序(从左到右
+        sort_by_vertical_(ocr_results1); // 按照垂直方向排序（从上到下）
+        sort_by_vertical_(ocr_results2); // 按照垂直方向排序（从上到下）
 
         OCRer::ResultsVec::iterator result_it1 = ocr_results1.begin();
         OCRer::ResultsVec::iterator result_it2 = ocr_results2.begin();
 
         std::vector<std::string>::iterator it;
         while (result_it1 != ocr_results1.end() && result_it2 != ocr_results2.end()) {
+
+            // 如果坍缩范式名与坍缩范式变动之间的距离太远，则提示识别出错，跳到下一个坍缩范式变动
             if ((*result_it2).rect.y >= (*result_it1).rect.y + (*result_it1).rect.height + 25) {
-                Log.info(
-                    "Roguelike Collapsal Paradigm Task Plugin: Erroneous Recognition in Banner "
-                    "Check");
+                Log.info(m_banner_check_error_message);
                 ++result_it1;
                 continue;
             }
+            // 如果坍缩范式名在坍缩范式变动之前，则提示识别出错，跳到下一个坍缩范式名
             else if ((*result_it2).rect.y <= (*result_it1).rect.y) {
-                Log.info(
-                    "Roguelike Collapsal Paradigm Task Plugin: Erroneous Recognition in Banner "
-                    "Check");
+                Log.info(m_banner_check_error_message);
                 ++result_it2;
                 continue;
             }
+
             std::string cur_clp_pd = (*result_it2).text;
             const CollapsalParadigmClass& cur_class = clp_pd_classes.at(clp_pd_dict.at(cur_clp_pd));
+
+            // 如果检测到坍缩范式加深，根据之前的坍缩范式，将其添加或替换到当前拥有的坍缩范式列表
             if ((*result_it1).text == m_deepen_text) {
-                if (it = std::find(prev_clp_pds.begin(), prev_clp_pds.end(), cur_clp_pd); it == prev_clp_pds.end()) {
-                    if (cur_clp_pd == cur_class.level_2) {
-                        if (it = std::find(prev_clp_pds.begin(), prev_clp_pds.end(), cur_class.level_1);
-                            it != prev_clp_pds.end()) {
-                            clp_pd_callback(cur_clp_pd, 1, *it);
-                            *it = cur_clp_pd;
-                        }
-                        else {
-                            clp_pd_callback(cur_clp_pd, 1);
-                            prev_clp_pds.emplace_back(cur_clp_pd);
-                        }
-                    }
-                    else {
-                        clp_pd_callback(cur_clp_pd, 1);
-                        prev_clp_pds.emplace_back(cur_clp_pd);
-                    }
-                    // check whether cur_clp_pd is an expected collapsal paradigm
-                    // 判断 cur_clp_pd 是否为需要的坍缩范式
-                    if (expected_clp_pds.find(cur_clp_pd) != expected_clp_pds.end()) {
-                        exit_then_stop();
-                        return true;
-                    }
-                    else if (
-                        m_config->get_mode() == RoguelikeMode::CLP_PDS) { // 刷坍缩范式模式下，获得了不想要的坍缩范式
-                        exit_then_restart();
-                        return true;
-                    }
+                // 已拥有坍缩范式，跳到下一组
+                if (it = std::ranges::find(prev_clp_pds, cur_clp_pd); it != prev_clp_pds.end()) {
+                    ++result_it1;
+                    ++result_it2;
+                    continue;
+                }
+                // 新获得二级坍缩范式，检查是否拥有其一级，如果获得是已拥有的一级坍缩范式，会在上一个 if 进行判定
+                if (it = std::ranges::find(prev_clp_pds, cur_class.level_1); it != prev_clp_pds.end()) {
+                    clp_pd_callback(cur_clp_pd, 1, *it);
+                    *it = cur_clp_pd;
+                }
+                else {
+                    clp_pd_callback(cur_clp_pd, 1);
+                    prev_clp_pds.emplace_back(cur_clp_pd);
+                }
+
+                // 如果 cur_clp_pd 是需要的坍缩范式
+                if (expected_clp_pds.find(cur_clp_pd) != expected_clp_pds.end()) {
+                    exit_then_stop();
+                    return;
+                }
+                // 刷坍缩范式模式下，获得了不想要的坍缩范式
+                else if (m_config->get_mode() == RoguelikeMode::CLP_PDS) {
+                    exit_then_restart();
+                    return;
                 }
             }
+            // 如果检测到坍缩范式消退，根据之前的坍缩范式，将其移除当前拥有的坍缩范式列表或替换为低一级的坍缩范式
             else {
-                if (it = std::find(prev_clp_pds.begin(), prev_clp_pds.end(), cur_clp_pd); it != prev_clp_pds.end()) {
-                    if (cur_clp_pd == cur_class.level_2) {
-                        clp_pd_callback(cur_class.level_1, -1, cur_clp_pd);
-                        *it = cur_class.level_1;
-                        // 如果2级直接消退到0级的话会有几次提示？这里可能会出问题，谨慎一些，晚些再检查一次。
-                        m_config->set_need_check_panel(true);
-                    }
-                    else {
-                        clp_pd_callback("", -1, cur_clp_pd);
-                        prev_clp_pds.erase(it);
-                    }
+                // 未拥有坍缩范式，跳到下一组
+                if (it = std::ranges::find(prev_clp_pds, cur_clp_pd); it == prev_clp_pds.end()) {
+                    ++result_it1;
+                    ++result_it2;
+                    continue;
+                }
+                if (cur_clp_pd == cur_class.level_2) {
+                    clp_pd_callback(cur_class.level_1, -1, cur_clp_pd);
+                    *it = cur_class.level_1;
+                    // 如果2级直接消退到0级的话会有几次提示？这里可能会出问题，谨慎一些，晚些再检查一次。
+                    m_need_check_panel = true;
+                }
+                else {
+                    clp_pd_callback("", -1, cur_clp_pd);
+                    prev_clp_pds.erase(it);
                 }
             }
             ++result_it1;
             ++result_it2;
         }
-        m_config->set_clp_pds(std::move(prev_clp_pds));
+        m_clp_pds = std::move(prev_clp_pds);
     }
-    return true;
 }
 
-bool asst::RoguelikeCollapsalParadigmTaskPlugin::check_collapsal_paradigm_panel()
+void asst::RoguelikeCollapsalParadigmTaskPlugin::check_panel()
 {
     LogTraceFunction;
 
@@ -228,30 +253,26 @@ bool asst::RoguelikeCollapsalParadigmTaskPlugin::check_collapsal_paradigm_panel(
 #endif
 
     const std::string& theme = m_config->get_theme();
-
     const std::vector<CollapsalParadigmClass>& clp_pd_classes = RoguelikeCollapsalParadigms.get_clp_pd_classes(theme);
     const std::unordered_map<std::string, unsigned int>& clp_pd_dict =
         RoguelikeCollapsalParadigms.get_clp_pd_dict(theme);
     const auto& expected_clp_pds = RoguelikeCollapsalParadigms.get_rare_clp_pds(theme);
-    std::vector<std::string> prev_clp_pds = m_config->get_clp_pds();
+    std::vector<std::string> prev_clp_pds = m_clp_pds;
 
-    wait_for_stage(200);
+    wait_for_stage();
 
     cv::Mat image;
     OCRer analyzer;
-    analyzer.set_task_info(theme + "@Roguelike@CheckCollapsalParadigms_onPanel"); // 检测 "当前坍缩值" 字样
+    analyzer.set_task_info(theme + "@Roguelike@CheckCollapsalParadigms_onPanel");
     do {
-        toggle_collapsal_status_panel();
+        toggle_panel();
         image = ctrler()->get_image();
         analyzer.set_image(image);
-    } while (!analyzer.analyze());
-#ifdef ASST_DEBUG
-    analyzer.save_img(utils::path("debug") / utils::path("collapsalParadigms"));
-#endif
+    } while (!analyzer.analyze()); // 检测 "当前坍缩值" 字样以确保坍缩范式列表已展开
 
-    // 获取当前坍缩范式
+    // ================================================================================
     std::vector<std::string> cur_clp_pds;
-    analyzer.set_task_info(theme + "@Roguelike@CheckCollapsalParadigms_panel"); // 检测坍缩范式
+    analyzer.set_task_info(theme + "@Roguelike@CheckCollapsalParadigms_panel"); // 检测坍缩范式状态栏上的坍缩范式
     if (analyzer.analyze()) {
         OCRer::ResultsVec ocr_results = analyzer.get_result();
         // 识别到两个及以上坍缩范式的时候，向上滑动一下再识别一次
@@ -260,38 +281,34 @@ bool asst::RoguelikeCollapsalParadigmTaskPlugin::check_collapsal_paradigm_panel(
             ctrler()->swipe(m_swipe_begin, m_swipe_end, 500);
             sleep(500);
             analyzer.set_image(ctrler()->get_image());
-#ifdef ASST_DEBUG
-            analyzer.save_img(utils::path("debug") / utils::path("collapsalParadigms"));
-#endif
             if (analyzer.analyze()) {
                 ocr_results = analyzer.get_result();
             }
         }
-        sort_by_vertical_(ocr_results); // 按照水平方向排序(从左到右
 
-        std::transform(ocr_results.begin(), ocr_results.end(), std::back_inserter(cur_clp_pds), [](OCRer::Result x) {
-            return x.text;
-        });
+        // 将 OCRer::Result 按照垂直方向排序（从上到下）并转换为坍缩范式名称
+        sort_by_vertical_(ocr_results);
+        std::ranges::transform(ocr_results, std::back_inserter(cur_clp_pds), [](OCRer::Result x) { return x.text; });
     }
 
-    if (m_verification_check) {
-        if (prev_clp_pds != cur_clp_pds) {
-            Log.info("Roguelike Collapsal Paradigm Task Plugin: Verification Failed");
+    // ================================================================================
+    toggle_panel(); // 坍缩范式状态栏检查完毕，关闭状态栏，以下为处理识别到的结果
+
+    if (prev_clp_pds != cur_clp_pds) { // 如果坍缩范式没有变动
+        return;
+    }
+    else if (m_verification_check) {
+        Log.info("Roguelike Collapsal Paradigm Task Plugin: Verification Failed");
 #ifdef ASST_DEBUG
-            Log.info("–––––––– Previous ––––––––––––––");
-            for (const std::string& clp_pd : prev_clp_pds) {
-                Log.info(clp_pd);
-            }
-            Log.info("–––––––– Current –––––––––––––––");
-            for (const std::string& clp_pd : cur_clp_pds) {
-                Log.info(clp_pd);
-            }
+        Log.info("–––––––– Previous ––––––––––––––");
+        for (const std::string& clp_pd : prev_clp_pds) {
+            Log.info(clp_pd);
+        }
+        Log.info("–––––––– Current –––––––––––––––");
+        for (const std::string& clp_pd : cur_clp_pds) {
+            Log.info(clp_pd);
+        }
 #endif
-        }
-        else {
-            toggle_collapsal_status_panel();
-            return true;
-        }
     }
 
     std::vector<std::string>::iterator it = prev_clp_pds.begin();
@@ -316,27 +333,59 @@ bool asst::RoguelikeCollapsalParadigmTaskPlugin::check_collapsal_paradigm_panel(
             ++it;
         }
         // 判断 cur_clp_pd 是否为需要的坍缩范式
-        // check whether cur_clp_pd is an expected collapsal paradigm
         if (expected_clp_pds.find(cur_clp_pd) != expected_clp_pds.end()) {
-            toggle_collapsal_status_panel();
             exit_then_stop();
-            return true;
+            return;
         }
-        else if (m_config->get_mode() == RoguelikeMode::CLP_PDS) { // 刷坍缩范式模式下，获得了不想要的坍缩范式
-            toggle_collapsal_status_panel();
+        // 刷坍缩范式模式下，获得了不想要的坍缩范式
+        else if (m_config->get_mode() == RoguelikeMode::CLP_PDS) {
             exit_then_restart();
-            return true;
+            return;
         }
     }
+
+    // 之前拥有的坍缩范式没有被识别到，判定为消退掉了
     while (it != prev_clp_pds.end()) {
         clp_pd_callback("", -1, *it);
         ++it;
     }
 
-    m_config->set_clp_pds(std::move(cur_clp_pds));
+    m_clp_pds = std::move(cur_clp_pds);
+}
 
-    toggle_collapsal_status_panel();
-    return true;
+void asst::RoguelikeCollapsalParadigmTaskPlugin::toggle_panel()
+{
+    ctrler()->click(m_roi);
+    sleep(500);
+}
+
+void asst::RoguelikeCollapsalParadigmTaskPlugin::wait_for_loading()
+{
+    OCRer analyzer(ctrler()->get_image());
+    analyzer.set_task_info(m_config->get_theme() + "@Roguelike@CheckCollapsalParadigms_loading");
+    while (analyzer.analyze()) {
+        sleep(100);
+        analyzer.set_image(ctrler()->get_image());
+    }
+    sleep(200);
+}
+
+void asst::RoguelikeCollapsalParadigmTaskPlugin::wait_for_stage()
+{
+    Matcher matcher(ctrler()->get_image());
+    matcher.set_task_info(m_config->get_theme() + "@Roguelike@CheckCollapsalParadigms_onStage");
+    while (!matcher.analyze()) {
+        sleep(100);
+        matcher.set_image(ctrler()->get_image());
+    }
+    sleep(200);
+}
+
+void asst::RoguelikeCollapsalParadigmTaskPlugin::exit_then_restart()
+{
+    ProcessTask(*this, { m_config->get_theme() + "@Roguelike@ExitThenAbandon" })
+        .set_times_limit("Roguelike@Abandon", 0)
+        .run();
 }
 
 void asst::RoguelikeCollapsalParadigmTaskPlugin::exit_then_stop()
@@ -347,11 +396,22 @@ void asst::RoguelikeCollapsalParadigmTaskPlugin::exit_then_stop()
     m_task_ptr->set_enable(false);
 }
 
-void asst::RoguelikeCollapsalParadigmTaskPlugin::exit_then_restart()
+bool asst::RoguelikeCollapsalParadigmTaskPlugin::new_zone() const
 {
-    ProcessTask(*this, { m_config->get_theme() + "@Roguelike@ExitThenAbandon" })
-        .set_times_limit("Roguelike@Abandon", 0)
-        .run();
+    Matcher matcher(ctrler()->get_image());
+    matcher.set_task_info(m_config->get_theme() + "@Roguelike@CheckCollapsalParadigms_onStage");
+    if (!matcher.analyze()) {
+        return false;
+    }
+    std::string zone = m_zone_dict.at(matcher.get_result().templ_name);
+    if (zone != m_zone) {
+        m_zone = zone;
+#ifdef ASST_DEBUG
+        Log.info("Collapsal Paradigm ｜ Current Zone is " + m_zone);
+#endif
+        return true;
+    }
+    return false;
 }
 
 void asst::RoguelikeCollapsalParadigmTaskPlugin::clp_pd_callback(
@@ -364,61 +424,4 @@ void asst::RoguelikeCollapsalParadigmTaskPlugin::clp_pd_callback(
     info["details"]["deepen_or_weaken"] = deepen_or_weaken;
     info["details"]["prev"] = prev;
     callback(AsstMsg::SubTaskExtraInfo, info);
-}
-
-void asst::RoguelikeCollapsalParadigmTaskPlugin::toggle_collapsal_status_panel()
-{
-    ctrler()->click(m_roi); // 点击屏幕上方居中区域以开始检查坍缩状态
-    sleep(500);
-}
-
-void asst::RoguelikeCollapsalParadigmTaskPlugin::wait_for_loading(unsigned int millisecond)
-{
-    OCRer analyzer(ctrler()->get_image());
-#ifdef ASST_DEBUG
-    analyzer.save_img(utils::path("debug") / utils::path("collapsalParadigms"));
-#endif
-    analyzer.set_task_info(m_config->get_theme() + "@Roguelike@CheckCollapsalParadigms_loading");
-    while (analyzer.analyze()) {
-        sleep(100);
-        analyzer.set_image(ctrler()->get_image());
-#ifdef ASST_DEBUG
-        analyzer.save_img(utils::path("debug") / utils::path("collapsalParadigms"));
-#endif
-    }
-    sleep(millisecond);
-}
-
-void asst::RoguelikeCollapsalParadigmTaskPlugin::wait_for_stage(unsigned int millisecond)
-{
-    Matcher matcher(ctrler()->get_image());
-#ifdef ASST_DEBUG
-    matcher.save_img(utils::path("debug") / utils::path("collapsalParadigms"));
-#endif
-    matcher.set_task_info(m_config->get_theme() + "@Roguelike@CheckCollapsalParadigms_onStage");
-    while (!matcher.analyze()) {
-        sleep(100);
-        matcher.set_image(ctrler()->get_image());
-#ifdef ASST_DEBUG
-        matcher.save_img(utils::path("debug") / utils::path("collapsalParadigms"));
-#endif
-    }
-    sleep(millisecond);
-}
-
-bool asst::RoguelikeCollapsalParadigmTaskPlugin::new_zone() const
-{
-    Matcher matcher(ctrler()->get_image());
-    matcher.set_task_info(m_config->get_theme() + "@Roguelike@CheckCollapsalParadigms_onStage");
-    if (matcher.analyze()) {
-        std::string zone = m_zone_dict.at(matcher.get_result().templ_name);
-        if (zone != m_zone) {
-            m_zone = zone;
-#ifdef ASST_DEBUG
-            Log.info("Roguelike Collapsal Paradigm Task Plugin: Current Zone is " + m_zone);
-#endif
-            return true;
-        }
-    }
-    return false;
 }

--- a/src/MaaCore/Task/Roguelike/Sami/RoguelikeCollapsalParadigmTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/Sami/RoguelikeCollapsalParadigmTaskPlugin.cpp
@@ -432,6 +432,13 @@ std::optional<json::value> asst::RoguelikeCollapsalParadigmTaskPlugin::response_
         case RoguelikeEvent::EncounterClickOption:
             check_collapsal_paradigm_banner();
             break;
+        case RoguelikeEvent::ShoppingConsiderGoods:
+            if (m_config->get_theme() == RoguelikeTheme::Sami &&
+                m_config->get_mode() == RoguelikeMode::CLP_PDS &&
+                detail.get("decrease_collapse", false)) {
+                return json::object { {"reject_goods", true} };
+            }
+            break;
         case RoguelikeEvent::SamiFoldartalDeclaration:
             check_collapsal_paradigm_banner();
             break;

--- a/src/MaaCore/Task/Roguelike/Sami/RoguelikeCollapsalParadigmTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/Sami/RoguelikeCollapsalParadigmTaskPlugin.cpp
@@ -12,22 +12,21 @@
 
 bool asst::RoguelikeCollapsalParadigmTaskPlugin::set_params(const json::value& params)
 {
-    // ———————— 检查适用主题 ————————————————————————
+    // ———————— 检查适用主题, 仅萨米肉鸽使用 ———————————————————————————————————————
     const std::string& theme = m_config->get_theme();
     if (theme != RoguelikeTheme::Sami) {
         return false;
     }
 
-    // 仅萨米肉鸽使用 TODO: 去掉名字里的下划线, _b -> B, _p -> P
-    // ———————— 根据 params 设置插件 ————————————————
+    // ———————— 根据 params 设置插件, TODO: 去掉名字里的下划线, _b -> B, _p -> P —————
     const RoguelikeMode& mode = m_config->get_mode();
     m_double_check_clp_pds = params.get("double_check_collapsal_paradigms", mode == RoguelikeMode::CLP_PDS);
 
     // ———————— 从 tasks.json 获取插件设置，由于仅有萨米肉鸽使用，任务名暂定写死 ———————————
     const auto& bannerCheckConfig =
-        Task.get<OcrTaskInfo>("Sami@Roguelike@CheckCollapsalParadigms_bannerCheckConfig");
+        Task.get<OcrTaskInfo>("Sami@Roguelike@CollapsalParadigmTaskBannerCheckConfig");
     const auto& panelCheckConfig =
-        Task.get<OcrTaskInfo>("Sami@Roguelike@CheckCollapsalParadigms_panelCheckConfig");
+        Task.get<OcrTaskInfo>("Sami@Roguelike@CollapsalParadigmTaskPanelCheckConfig");
 
     m_deepen_text = bannerCheckConfig->text.front();
     m_roi = panelCheckConfig->roi;
@@ -35,6 +34,7 @@ bool asst::RoguelikeCollapsalParadigmTaskPlugin::set_params(const json::value& p
     m_swipe_begin.y = panelCheckConfig->specific_rect.y;
     m_swipe_end.x = panelCheckConfig->rect_move.x;
     m_swipe_end.y = panelCheckConfig->rect_move.y;
+
     m_banner_triggers_start = std::unordered_set(bannerCheckConfig->sub.begin(), bannerCheckConfig->sub.end());
     m_banner_triggers_completed = std::unordered_set(bannerCheckConfig->next.begin(), bannerCheckConfig->next.end());
     m_panel_triggers = std::unordered_set(panelCheckConfig->sub.begin(), panelCheckConfig->sub.end());

--- a/src/MaaCore/Task/Roguelike/Sami/RoguelikeCollapsalParadigmTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/Sami/RoguelikeCollapsalParadigmTaskPlugin.cpp
@@ -283,7 +283,7 @@ void asst::RoguelikeCollapsalParadigmTaskPlugin::check_panel()
     // ================================================================================
     toggle_panel(); // 坍缩范式状态栏检查完毕，关闭状态栏，以下为处理识别到的结果
 
-    if (prev_clp_pds != cur_clp_pds) { // 如果坍缩范式没有变动
+    if (prev_clp_pds == cur_clp_pds) { // 如果坍缩范式没有变动
         return;
     }
     else if (m_verification_check) {

--- a/src/MaaCore/Task/Roguelike/Sami/RoguelikeCollapsalParadigmTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/Sami/RoguelikeCollapsalParadigmTaskPlugin.cpp
@@ -422,28 +422,3 @@ bool asst::RoguelikeCollapsalParadigmTaskPlugin::new_zone() const
     }
     return false;
 }
-
-std::optional<json::value> asst::RoguelikeCollapsalParadigmTaskPlugin::response_to_event
-    (RoguelikeEvent event, const json::value& detail)
-{
-    LogTraceFunction;
-
-    switch (event) {
-        case RoguelikeEvent::EncounterClickOption:
-            check_collapsal_paradigm_banner();
-            break;
-        case RoguelikeEvent::ShoppingConsiderGoods:
-            if (m_config->get_theme() == RoguelikeTheme::Sami &&
-                m_config->get_mode() == RoguelikeMode::CLP_PDS &&
-                detail.get("decrease_collapse", false)) {
-                return json::object { {"reject_goods", true} };
-            }
-            break;
-        case RoguelikeEvent::SamiFoldartalDeclaration:
-            check_collapsal_paradigm_banner();
-            break;
-        default:
-            break;
-    }
-    return std::nullopt;
-}

--- a/src/MaaCore/Task/Roguelike/Sami/RoguelikeCollapsalParadigmTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/Sami/RoguelikeCollapsalParadigmTaskPlugin.cpp
@@ -268,7 +268,7 @@ void asst::RoguelikeCollapsalParadigmTaskPlugin::check_panel()
         toggle_panel();
         image = ctrler()->get_image();
         analyzer.set_image(image);
-    } while (!analyzer.analyze()); // 检测 "当前坍缩值" 字样以确保坍缩范式列表已展开
+    } while (!need_exit() && !analyzer.analyze()); // 检测 "当前坍缩值" 字样以确保坍缩范式列表已展开
 
     // ================================================================================
     std::vector<std::string> cur_clp_pds;
@@ -363,7 +363,7 @@ void asst::RoguelikeCollapsalParadigmTaskPlugin::wait_for_loading()
 {
     OCRer analyzer(ctrler()->get_image());
     analyzer.set_task_info(m_config->get_theme() + "@Roguelike@CheckCollapsalParadigms_loading");
-    while (analyzer.analyze()) {
+    while (!need_exit() && analyzer.analyze()) {
         sleep(100);
         analyzer.set_image(ctrler()->get_image());
     }
@@ -374,7 +374,7 @@ void asst::RoguelikeCollapsalParadigmTaskPlugin::wait_for_stage()
 {
     Matcher matcher(ctrler()->get_image());
     matcher.set_task_info(m_config->get_theme() + "@Roguelike@CheckCollapsalParadigms_onStage");
-    while (!matcher.analyze()) {
+    while (!need_exit() && !matcher.analyze()) {
         sleep(100);
         matcher.set_image(ctrler()->get_image());
     }

--- a/src/MaaCore/Task/Roguelike/Sami/RoguelikeCollapsalParadigmTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/Sami/RoguelikeCollapsalParadigmTaskPlugin.cpp
@@ -35,23 +35,12 @@ bool asst::RoguelikeCollapsalParadigmTaskPlugin::set_params(const json::value& p
     m_swipe_begin.y = panelCheckConfig->specific_rect.y;
     m_swipe_end.x = panelCheckConfig->rect_move.x;
     m_swipe_end.y = panelCheckConfig->rect_move.y;
-
     m_banner_triggers_start = std::unordered_set(bannerCheckConfig->sub.begin(), bannerCheckConfig->sub.end());
     m_banner_triggers_completed = std::unordered_set(bannerCheckConfig->next.begin(), bannerCheckConfig->next.end());
     m_panel_triggers = std::unordered_set(panelCheckConfig->sub.begin(), panelCheckConfig->sub.end());
     m_zone_dict = std::unordered_map(panelCheckConfig->replace_map.begin(), panelCheckConfig->replace_map.end());
 
     return true;
-}
-
-void asst::RoguelikeCollapsalParadigmTaskPlugin::reset()
-{
-    m_clp_pds.clear();
-    m_check_banner = false;
-    m_check_panel = false;
-    m_need_check_panel = false;
-    m_verification_check = false;
-    m_zone.clear();
 }
 
 void asst::RoguelikeCollapsalParadigmTaskPlugin::reset_in_run_variables()

--- a/src/MaaCore/Task/Roguelike/Sami/RoguelikeCollapsalParadigmTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/Sami/RoguelikeCollapsalParadigmTaskPlugin.cpp
@@ -422,3 +422,21 @@ bool asst::RoguelikeCollapsalParadigmTaskPlugin::new_zone() const
     }
     return false;
 }
+
+std::optional<json::value> asst::RoguelikeCollapsalParadigmTaskPlugin::response_to_event
+    (RoguelikeEvent event, const json::value& detail)
+{
+    LogTraceFunction;
+
+    switch (event) {
+        case RoguelikeEvent::EncounterClickOption:
+            check_collapsal_paradigm_banner();
+            break;
+        case RoguelikeEvent::SamiFoldartalDeclaration:
+            check_collapsal_paradigm_banner();
+            break;
+        default:
+            break;
+    }
+    return std::nullopt;
+}

--- a/src/MaaCore/Task/Roguelike/Sami/RoguelikeCollapsalParadigmTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/Sami/RoguelikeCollapsalParadigmTaskPlugin.h
@@ -12,8 +12,8 @@ public:
     using AbstractRoguelikeTaskPlugin::AbstractRoguelikeTaskPlugin;
     virtual ~RoguelikeCollapsalParadigmTaskPlugin() override = default;
     virtual bool verify(AsstMsg msg, const json::value& details) const override;
-    virtual void reset() override;
-    virtual bool set_params(const json::value& params) override;
+    virtual void reset_in_run_variables() override;
+    virtual void config(const json::value& params) override;
 
 protected:
     virtual bool _run() override;

--- a/src/MaaCore/Task/Roguelike/Sami/RoguelikeCollapsalParadigmTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/Sami/RoguelikeCollapsalParadigmTaskPlugin.h
@@ -12,8 +12,8 @@ public:
     using AbstractRoguelikeTaskPlugin::AbstractRoguelikeTaskPlugin;
     virtual ~RoguelikeCollapsalParadigmTaskPlugin() override = default;
     virtual bool verify(AsstMsg msg, const json::value& details) const override;
-    virtual void reset_in_run_variables() override;
     virtual bool set_params(const json::value& params) override;
+    virtual void reset_in_run_variables() override;
 
 protected:
     virtual bool _run() override;

--- a/src/MaaCore/Task/Roguelike/Sami/RoguelikeCollapsalParadigmTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/Sami/RoguelikeCollapsalParadigmTaskPlugin.h
@@ -20,13 +20,13 @@ public:
 
 public:
     void set_double_check_clp_pds(bool value) { m_double_check_clp_pds = value; }
-    bool check_collapsal_paradigm_banner();
 
 protected:
     virtual bool _run() override;
 
     bool new_zone() const;
 
+    bool check_collapsal_paradigm_banner();
     bool check_collapsal_paradigm_panel();
 
     void toggle_collapsal_status_panel();

--- a/src/MaaCore/Task/Roguelike/Sami/RoguelikeCollapsalParadigmTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/Sami/RoguelikeCollapsalParadigmTaskPlugin.h
@@ -13,7 +13,7 @@ public:
     virtual ~RoguelikeCollapsalParadigmTaskPlugin() override = default;
     virtual bool verify(AsstMsg msg, const json::value& details) const override;
     virtual void reset_in_run_variables() override;
-    virtual void config(const json::value& params) override;
+    virtual bool set_params(const json::value& params) override;
 
 protected:
     virtual bool _run() override;

--- a/src/MaaCore/Task/Roguelike/Sami/RoguelikeCollapsalParadigmTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/Sami/RoguelikeCollapsalParadigmTaskPlugin.h
@@ -12,50 +12,58 @@ public:
     using AbstractRoguelikeTaskPlugin::AbstractRoguelikeTaskPlugin;
     virtual ~RoguelikeCollapsalParadigmTaskPlugin() override = default;
     virtual bool verify(AsstMsg msg, const json::value& details) const override;
+    virtual void reset() override;
     virtual bool set_params(const json::value& params) override;
-    static bool enabled(std::shared_ptr<RoguelikeConfig> config)
-    {
-        return config->get_theme() == RoguelikeTheme::Sami && config->get_check_clp_pds();
-    }
-
-public:
-    void set_double_check_clp_pds(bool value) { m_double_check_clp_pds = value; }
 
 protected:
     virtual bool _run() override;
 
-    bool new_zone() const;
+private:
+    void check_banner();      // 检查坍缩范式变动通知
+    void check_panel();       // 检查坍缩范式状态栏
 
-    bool check_collapsal_paradigm_banner();
-    bool check_collapsal_paradigm_panel();
+    void toggle_panel();      // 开关坍缩范式状态栏
 
-    void toggle_collapsal_status_panel();
-    void exit_then_restart();
-    void exit_then_stop();
-    void wait_for_loading(unsigned int millisecond = 0);
-    void wait_for_stage(unsigned int millisecond = 0);
+    void wait_for_loading();  // 等待"正在反馈至神经"结束
+    void wait_for_stage();    // 等待回到地图
+
+    void exit_then_restart(); // 退出当前肉鸽局并重开
+    void exit_then_stop();    // 退出当前肉鸽局并停止任务
+
+    bool new_zone() const;    // 判断是否进入了新的区域
+
+    // 向 Gui 回调坍缩范式变动情况，表示坍缩范式 prev 变动为 cur
+    // deepen_or_weaken = 1 表示加深
+    // deepen_or_weaken = -1 表示消退
+    // deepen_or_weaken = 0 表示其它信息
     void clp_pd_callback(std::string cur, int deepen_or_weaken = 0, std::string prev = "");
 
-private:
-    mutable bool m_check_banner = false;
-    mutable bool m_check_panel = false;
-    mutable bool m_verification_check = false;
+    // ————————  局内临时变量，在 reset 时 重制 ——————————————————————————————————
+    std::vector<std::string> m_clp_pds;        // 当前拥有的坍缩范式
+    mutable bool m_check_banner = false;       // 在下一次 run 时运行 check_banner()
+    mutable bool m_check_panel = false;        // 在下一次 run 时运行 check_panel()
+    mutable bool m_need_check_panel = false;   // 是否在下次回到关卡选择界面时检查坍缩范式
+    mutable bool m_verification_check = false; // 下一次 panel check 负责验证坍缩范式
+    mutable std::string m_zone;                // 当前所在区域
 
-    std::string m_deepen_text;
+    // ———————— 插件配置信息，从 params 中读取  ——————————————————————————————————
+    bool m_double_check_clp_pds = false; // 是否在每次回到地图时验证坍缩范式
 
-    std::unordered_set<std::string> m_banner_triggers_start;
+    // ———————— 插件配置信息，从 tasks.json 中读取  ——————————————————————————————
+    std::string m_deepen_text; // 坍缩范式变动通知中"坍缩范式加深"的文字
 
-    std::unordered_set<std::string> m_banner_triggers_completed;
+    std::unordered_set<std::string> m_banner_triggers_start;     // 通过 SubTaskStart 触发 banner check 的任务
+    std::unordered_set<std::string> m_banner_triggers_completed; // 通过 SubTaskCompleted 触发 banner check 的任务
+    std::unordered_set<std::string> m_panel_triggers;            // 通过 SubTaskStart 触发 panel check 的任务
 
-    mutable std::string m_zone;
+    Rect m_roi;          // 屏幕上方居中区域，点击以展开坍缩范式状态栏
+    Point m_swipe_begin; // 坍缩范式状态栏向上滑动的起点
+    Point m_swipe_end;   // 坍缩范式状态栏向上滑动的终点
 
-    Rect m_roi;          // 屏幕上方居中区域，点击以检查坍缩状态
-    Point m_swipe_begin; // 滑动起点
-    Point m_swipe_end;   // 滑动终点
+    std::unordered_map<std::string, std::string> m_zone_dict; // template 名与区域名的映射关系
 
-    std::unordered_set<std::string> m_panel_triggers;
-    std::unordered_map<std::string, std::string> m_zone_dict;
-
-    bool m_double_check_clp_pds = false; // 是否反复检查坍缩范式
+    // ———————— 插件内部常量  ———————————————————————————————————————————————
+    const std::string_view m_banner_check_error_message =
+        "CollapsalParadigm ｜ Task Plugin: Erroneous Recognition in Banner Check";
 };
 }

--- a/src/MaaCore/Task/Roguelike/Sami/RoguelikeFoldartalGainTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/Sami/RoguelikeFoldartalGainTaskPlugin.cpp
@@ -73,7 +73,7 @@ bool asst::RoguelikeFoldartalGainTaskPlugin::_run()
     }
 }
 
-void asst::RoguelikeFoldartalGainTaskPlugin::reset_variable()
+void asst::RoguelikeFoldartalGainTaskPlugin::reset()
 {
     m_foldartal_floor.reset();
 }

--- a/src/MaaCore/Task/Roguelike/Sami/RoguelikeFoldartalGainTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/Sami/RoguelikeFoldartalGainTaskPlugin.cpp
@@ -73,7 +73,7 @@ bool asst::RoguelikeFoldartalGainTaskPlugin::_run()
     }
 }
 
-void asst::RoguelikeFoldartalGainTaskPlugin::reset()
+void asst::RoguelikeFoldartalGainTaskPlugin::reset_in_run_variables()
 {
     m_foldartal_floor.reset();
 }

--- a/src/MaaCore/Task/Roguelike/Sami/RoguelikeFoldartalGainTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/Sami/RoguelikeFoldartalGainTaskPlugin.h
@@ -16,7 +16,7 @@ namespace asst
 
     protected:
         virtual bool _run() override;
-        virtual void reset_variable() override;
+        virtual void reset() override;
 
     private:
         void enter_next_floor();

--- a/src/MaaCore/Task/Roguelike/Sami/RoguelikeFoldartalGainTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/Sami/RoguelikeFoldartalGainTaskPlugin.h
@@ -16,7 +16,7 @@ namespace asst
 
     protected:
         virtual bool _run() override;
-        virtual void reset() override;
+        virtual void reset_in_run_variables() override;
 
     private:
         void enter_next_floor();

--- a/src/MaaCore/Task/Roguelike/Sami/RoguelikeFoldartalUseTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/Sami/RoguelikeFoldartalUseTaskPlugin.cpp
@@ -73,18 +73,6 @@ bool asst::RoguelikeFoldartalUseTaskPlugin::verify(const AsstMsg msg, const json
 bool asst::RoguelikeFoldartalUseTaskPlugin::_run()
 {
     LogTraceFunction;
-    if (!m_plugin_gained) {
-        m_plugin_gained = true;
-        if (RoguelikeCollapsalParadigmTaskPlugin::enabled(m_config)) {
-            typedef RoguelikeCollapsalParadigmTaskPlugin Plugin;
-            for (const auto& plugin : m_task_ptr->get_plugins()) {
-                if (auto ptr = std::dynamic_pointer_cast<Plugin>(plugin)) {
-                    m_clp_pd_plugin = ptr;
-                    break;
-                }
-            }
-        }
-    }
 
     std::vector<RoguelikeFoldartalCombination> combination =
         RoguelikeFoldartal.get_combination(m_config->get_theme());
@@ -173,11 +161,7 @@ void asst::RoguelikeFoldartalUseTaskPlugin::use_enable_pair(
                     list.erase(ranges::find(list, up_board));
                     list.erase(ranges::find(list, down_board));
                     Log.trace("Board pair used, up:", up_board, ", down:", down_board);
-                    
-                    if (m_clp_pd_plugin) {
-                        m_clp_pd_plugin->check_collapsal_paradigm_banner();
-                    }
-                    
+                    notify_sibling_plugins(RoguelikeEvent::SamiFoldartalDeclaration);
                     break;
                 }
             }

--- a/src/MaaCore/Task/Roguelike/Sami/RoguelikeFoldartalUseTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/Sami/RoguelikeFoldartalUseTaskPlugin.cpp
@@ -161,7 +161,6 @@ void asst::RoguelikeFoldartalUseTaskPlugin::use_enable_pair(
                     list.erase(ranges::find(list, up_board));
                     list.erase(ranges::find(list, down_board));
                     Log.trace("Board pair used, up:", up_board, ", down:", down_board);
-                    notify_sibling_plugins(RoguelikeEvent::SamiFoldartalDeclaration);
                     break;
                 }
             }

--- a/src/MaaCore/Task/Roguelike/Sami/RoguelikeFoldartalUseTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/Sami/RoguelikeFoldartalUseTaskPlugin.h
@@ -44,9 +44,6 @@ namespace asst
         void slowly_swipe(bool direction, int swipe_dist = 200) const;
         // 节点类型
         mutable std::string m_stage;
-        
-        bool m_plugin_gained;
-        std::shared_ptr<RoguelikeCollapsalParadigmTaskPlugin> m_clp_pd_plugin;
         bool m_use_foldartal = true; // 是否使用密文板
     };
 }


### PR DESCRIPTION
~~Todo: （每做一步请示一遍102老师）~~
- [x] ~~为肉鸽插件加入联动功能~~
- [x] ~~修复潜在的插件加载bug 。我写的部分插件会在初始化时根据theme读取tasks.json，我估计102老师把插件注册放到开头后会出很多bug，准备重写一下这部分。~~
- [ ] ~~重写坍缩范式插件，主要是缩短各种命名。~~


掀桌！删代码跑路！刷个隐藏坍缩范式不需要那么完善的功能。

（最后宣泄一点情绪，通宵好几天了情绪不太稳定）RoguelikeControlTaskPlugin 可能是插件间缺乏互动最早的受害者，怪不得我几乎没看到多少地方调用它。你可能会问可不可以ProcessTask(...).run(), 答案是不行，因为这样disable的不是主任务而是新的ProcessTask。我能想到的 workaround 是把 RoguelikeControlTaskPlugin-ExitThenStop 加到下一个任务的 sub 里。