### PR TITLE
fix: 修正文档网页搜索结果点击后导航路径错误导致的404问题

### DIFF
--- a/docs/.vuepress/client.ts
+++ b/docs/.vuepress/client.ts
@@ -2,7 +2,19 @@ import { defineClientConfig } from "vuepress/client";
 import ImageGrid from "../components/ImageGrid.vue";
 
 export default defineClientConfig({
-  enhance: ({ app }) => {
-    app.component("ImageGrid", ImageGrid);
-  },
+    enhance: ({ app, router }) => {
+        app.component("ImageGrid", ImageGrid);
+        // 路由处理,处理搜索结果返回的多出的/docs
+        if (router) {
+            router.beforeEach((to, from, next) => {
+                if (to.fullPath.startsWith("/docs")) {
+                    next(to.fullPath.replace("/docs", ""));
+                } else {
+                    next();
+                }
+            });
+        } else {
+            console.error("Router is not available.");
+        }
+    },
 });


### PR DESCRIPTION
找不到vuepress docsearch2.0的自定义路由结果api,只能在这里修改了