### PR TITLE
fix: 肉鸽卡在干员技能面板

### DIFF
--- a/src/MaaCore/Task/Roguelike/RoguelikeBattleTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeBattleTaskPlugin.cpp
@@ -448,6 +448,8 @@ bool asst::RoguelikeBattleTaskPlugin::do_best_deploy()
                 return true;
             }
             deploy_oper(deploy_plan.oper_name, deploy_plan.placed, deploy_plan.direction);
+            // 防止滑动丢失(有些物体比如鸟笼没有方向),点一下右下角费用那里
+            asst::BattleHelper::cancel_oper_selection();
             // 开始计时
             auto deployed_time = std::chrono::steady_clock::now();
             m_deployed_time.insert_or_assign(deploy_plan.oper_name, deployed_time);


### PR DESCRIPTION
有的玩意没有方向（比如鸟笼地雷），但是作业里面有方向，就表现为点开滑动末端干员的使用技能
link to #7141
fix #7790 
fix #8997