### PR TITLE
feat: MultiTemplMatcher

### DIFF
--- a/src/MaaCore/Vision/MultiMatcher.cpp
+++ b/src/MaaCore/Vision/MultiMatcher.cpp
@@ -15,19 +15,15 @@ using namespace asst;
 MultiMatcher::ResultsVecOpt MultiMatcher::analyze() const
 {
     auto match_results = Matcher::preproc_and_match(make_roi(m_image, m_roi), m_params);
-    if (match_results.empty()) {
-        return std::nullopt;
-    }
 
     std::vector<Result> results;
-    double threshold = m_params.templ_thres.front();
-
-    for (const auto& [matched, templ, templ_name] : match_results) {
-
+    for (size_t index = 0; index < match_results.size(); ++index) {
+        const auto& [matched, templ, templ_name] = match_results[index];
         if (matched.empty()) {
             continue;
         }
 
+        double threshold = m_params.templ_thres[index];
         int min_distance = (std::min)(templ.cols, templ.rows) / 2;
         for (int i = 0; i != matched.rows; ++i) {
             for (int j = 0; j != matched.cols; ++j) {

--- a/src/MaaCore/Vision/MultiMatcher.cpp
+++ b/src/MaaCore/Vision/MultiMatcher.cpp
@@ -19,45 +19,48 @@ MultiMatcher::ResultsVecOpt MultiMatcher::analyze() const
         return std::nullopt;
     }
 
-    const auto& [matched, templ, templ_name] = match_results.front();
-
-    if (matched.empty()) {
-        return std::nullopt;
-    }
-
     std::vector<Result> results;
     double threshold = m_params.templ_thres.front();
 
-    int min_distance = (std::min)(templ.cols, templ.rows) / 2;
-    for (int i = 0; i != matched.rows; ++i) {
-        for (int j = 0; j != matched.cols; ++j) {
-            auto value = matched.at<float>(i, j);
-            if (value < threshold || std::isnan(value) || std::isinf(value)) {
-                continue;
-            }
+    for (const auto& [matched, templ, templ_name] : match_results) {
 
-            Rect rect(j + m_roi.x, i + m_roi.y, templ.cols, templ.rows);
-            bool need_push = true;
-            // 如果有两个点离得太近，只取里面得分高的那个
-            // 一般相邻的都是刚刚push进去的，这里倒序快一点
-            for (auto& iter : ranges::reverse_view(results)) {
-                if (std::abs(j + m_roi.x - iter.rect.x) >= min_distance ||
-                    std::abs(i + m_roi.y - iter.rect.y) >= min_distance) {
+        if (matched.empty()) {
+            continue;
+        }
+
+        int min_distance = (std::min)(templ.cols, templ.rows) / 2;
+        for (int i = 0; i != matched.rows; ++i) {
+            for (int j = 0; j != matched.cols; ++j) {
+                auto value = matched.at<float>(i, j);
+                if (value < threshold || std::isnan(value) || std::isinf(value)) {
                     continue;
                 }
 
-                if (iter.score < value) {
-                    iter.rect = rect;
-                    iter.score = value;
-                } // else 这个点就放弃了
-                need_push = false;
-                break;
-            }
-            if (need_push) {
-                Result tmp;
-                tmp.rect = rect;
-                tmp.score = value;
-                results.emplace_back(std::move(tmp));
+                Rect rect(j + m_roi.x, i + m_roi.y, templ.cols, templ.rows);
+                bool need_push = true;
+                // 如果有两个点离得太近，只取里面得分高的那个
+                // 一般相邻的都是刚刚push进去的，这里倒序快一点
+                for (auto& iter : ranges::reverse_view(results)) {
+                    if (std::abs(j + m_roi.x - iter.rect.x) >= min_distance ||
+                        std::abs(i + m_roi.y - iter.rect.y) >= min_distance) {
+                        continue;
+                    }
+
+                    if (iter.score < value) {
+                        iter.rect = rect;
+                        iter.score = value;
+                        iter.templ_name = templ_name;
+                    } // else 这个点就放弃了
+                    need_push = false;
+                    break;
+                }
+                if (need_push) {
+                    Result tmp;
+                    tmp.rect = rect;
+                    tmp.score = value;
+                    tmp.templ_name = templ_name;
+                    results.emplace_back(std::move(tmp));
+                }
             }
         }
     }
@@ -75,7 +78,7 @@ MultiMatcher::ResultsVecOpt MultiMatcher::analyze() const
 #endif
 
     if (m_log_tracing) {
-        Log.trace("multi_match_templ | ", templ_name, "result:", results, "roi:", m_roi);
+        Log.trace("multi_match | ", "result:", results, "roi:", m_roi);
     }
 
     // FIXME: 老接口太难重构了，先弄个这玩意兼容下，后续慢慢全删掉


### PR DESCRIPTION
~~### MultiTemplMatcher 和 MultiMatcher 的区别
MultiMatcher 只能应用于单模版多匹配结果的情况。
而 MultiTemplMatcher 可以应用于多模版多匹配结果。
我不知道 MultiMatcher 之前为什么那么设计。
如果可以确认 MultiMatcher 仅用于单模版，则可以直接用 MultiTemplMatcher 替换 MultiMatcher。
本功能将用于集成战略节点地图识别功能 https://github.com/MaaAssistantArknights/MaaAssistantArknights/pull/9812 ，为未来肉鸽策略参数化打基础。~~

经（粗略）检查，目前所有使用 MultiMatcher 的情况都只有一个template，所以直接将改动应用至MultiMatcher。