### PR TITLE
feat: close inactive issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -24,7 +24,7 @@ jobs:
           stale-issue-message: |
             "This issue has been inactive for a prolonged period and will be closed automatically in 3 days."
             "该问题已长时间处于闲置状态，3 天后将自动关闭。"
-          exempt-issue-labels: "keep-open"
+          exempt-issue-labels: 'keep-open, MAA Team'
           # Completely disable staling for PRs
           days-before-pr-stale: -1
           days-before-pr-close: -1

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,8 +2,8 @@ name: "Mark stale issues and pull requests"
 
 on:
   schedule:
-    - cron: "0 0 * * *"  # Runs daily at midnight
-  workflow_dispatch:  # Allows manual triggering
+    - cron: "0 0 * * *" # Runs daily at midnight
+  workflow_dispatch: # Allows manual triggering
 
 jobs:
   stale:
@@ -18,8 +18,8 @@ jobs:
         uses: actions/stale@v9
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          days-before-stale: 30  # Number of days of inactivity before marking as stale
-          days-before-close: 3   # Number of days to wait after marking as stale before closing
+          days-before-stale: 30 # Number of days of inactivity before marking as stale
+          days-before-close: 3 # Number of days to wait after marking as stale before closing
           stale-issue-label: "stale"
           stale-issue-message: |
             "This issue has been inactive for a prolonged period and will be closed automatically in 3 days."

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
-      # Completely disable staling for PRs
+      # Completely disable stalling for PRs
       pull-requests: none
       contents: none
     steps:
@@ -25,6 +25,8 @@ jobs:
             "This issue has been inactive for a prolonged period and will be closed automatically in 3 days."
             "该问题已长时间处于闲置状态，3 天后将自动关闭。"
           exempt-issue-labels: "keep-open, MAA Team"
-          # Completely disable staling for PRs
+          # Completely disable stalling for PRs
           days-before-pr-stale: -1
           days-before-pr-close: -1
+
+          debug-only: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,7 +20,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-stale: 30 # Number of days of inactivity before marking as stale
           days-before-close: 3 # Number of days to wait after marking as stale before closing
-          stale-issue-label: 'stale'
+          stale-issue-label: "stale"
           stale-issue-message: |
             "This issue has been inactive for a prolonged period and will be closed automatically in 3 days."
             "该问题已长时间处于闲置状态，3 天后将自动关闭。"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -29,4 +29,5 @@ jobs:
           days-before-pr-stale: -1
           days-before-pr-close: -1
 
+          operations-per-run: 80
           debug-only: true

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,30 @@
+name: "Mark stale issues and pull requests"
+
+on:
+  schedule:
+    - cron: "0 0 * * *"  # Runs daily at midnight
+  workflow_dispatch:  # Allows manual triggering
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      # Completely disable staling for PRs
+      pull-requests: none
+      contents: none
+    steps:
+      - name: Close inactive issues
+        uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          days-before-stale: 30  # Number of days of inactivity before marking as stale
+          days-before-close: 3   # Number of days to wait after marking as stale before closing
+          stale-issue-label: "stale"
+          stale-issue-message: |
+            "This issue has been inactive for a prolonged period and will be closed automatically in 3 days."
+            "该问题已长时间处于闲置状态，3 天后将自动关闭。"
+          exempt-issue-labels: "keep-open"
+          # Completely disable staling for PRs
+          days-before-pr-stale: -1
+          days-before-pr-close: -1

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -24,7 +24,7 @@ jobs:
           stale-issue-message: |
             "This issue has been inactive for a prolonged period and will be closed automatically in 3 days."
             "该问题已长时间处于闲置状态，3 天后将自动关闭。"
-          exempt-issue-labels: 'keep-open, MAA Team'
+          exempt-issue-labels: "keep-open, MAA Team"
           # Completely disable staling for PRs
           days-before-pr-stale: -1
           days-before-pr-close: -1

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,7 +20,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           days-before-stale: 30 # Number of days of inactivity before marking as stale
           days-before-close: 3 # Number of days to wait after marking as stale before closing
-          stale-issue-label: "stale"
+          stale-issue-label: 'stale'
           stale-issue-message: |
             "This issue has been inactive for a prolonged period and will be closed automatically in 3 days."
             "该问题已长时间处于闲置状态，3 天后将自动关闭。"


### PR DESCRIPTION
ref: https://github.com/MaaAssistantArknights/MaaAssistantArknights/issues/9853#issuecomment-2243230911

`exempt-issue-labels`  can be used to skip (for example) `MAA Team`  issues, or any issue that has a specific label, plus the custom made label `keep-open`, in case we want to use that.