### PR TITLE
fix: 修复萨卡兹肉鸽自动战斗文件中的一项拼写错误

### DIFF
--- a/resource/roguelike/Sarkaz/autopilot/拆东补西.json
+++ b/resource/roguelike/Sarkaz/autopilot/拆东补西.json
@@ -31,7 +31,7 @@
         {
             "groups": ["单奶"],
             "location": [3, 3],
-            "direction": "righ"
+            "direction": "right"
         },
         {
             "groups": ["群奶"],


### PR DESCRIPTION
如题。
issue: #9901 