### PR TITLE
fix: 修复萨卡兹肉鸽的自动战斗文件 拆东补西.json 的语法问题

### DIFF
--- a/resource/roguelike/Sarkaz/autopilot/拆东补西.json
+++ b/resource/roguelike/Sarkaz/autopilot/拆东补西.json
@@ -31,7 +31,7 @@
         {
             "groups": ["单奶"],
             "location": [3, 3],
-            "direction": "righ"
+            "direction": "right"
         },
         {
             "groups": ["群奶"],


### PR DESCRIPTION
修复 #9901 的问题