### PR TITLE
ci(perf): add concurrency to block previous runs in case of new pushes

### DIFF
--- a/.github/workflows/smoke-testing.yml
+++ b/.github/workflows/smoke-testing.yml
@@ -25,6 +25,10 @@ on:
       - "!**/*.md"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   smoke-testing:
     runs-on: windows-latest


### PR DESCRIPTION
This DOES NOT NEED to be merged. I'm just asking an opinion because currently I have two ideas:
1. Use concurrency for smoke-testing, as only the most important pushes (latest) are really important, and before changes can be "discarded" as outdated.
2. Modify smoke-testing.yml to stop running when .png (templates) are pushed. This is not really a solution, as it could happen that a task is called the name of a .png, but they are "misstyped", meaning that not running smoke-testing at all could potentially lead to undiagnosed issues, so I'm more inclined to go with `1.`

Let me know what you think.