### PR TITLE
fix: 修复debug模式在intel mac系统下无法通过编译的问题

### DIFF
--- a/src/MaaCore/Task/BattleHelper.cpp
+++ b/src/MaaCore/Task/BattleHelper.cpp
@@ -577,7 +577,7 @@ bool asst::BattleHelper::use_all_ready_skill(const cv::Mat& reusable)
             Log.debug(
                 name,
                 "use skill too fast, interval time:",
-                std::chrono::duration_cast<std::chrono::milliseconds>(interval));
+                std::to_string(std::chrono::duration_cast<std::chrono::milliseconds>(interval).count()) + " ms");
             continue;
         }
 


### PR DESCRIPTION
疑似是因为无法自动将 std::chrono::milliseconds 转换为 std::string。