### PR TITLE
fix: 萨卡兹肉鸽进入新一层识别太快导致先点击思绪后驼兽归队/混沌未来中逃脱

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -9001,7 +9001,8 @@
             "Sarkaz@Roguelike@Stages#next",
             "Sarkaz@Roguelike@DropsFlag",
             "Sarkaz@Roguelike@CloseEvent",
-            "Sarkaz@Roguelike@ChooseOperFlag"
+            "Sarkaz@Roguelike@ChooseOperFlag",
+            "Sarkaz@Roguelike@DecreaseBurdenSwapUiToDefault1"
         ]
     },
     "Sarkaz@Roguelike@CloseEvent": {
@@ -9068,7 +9069,7 @@
         "templThreshold": 0.9,
         "action": "ClickRect",
         "specificRect": [1210, 120, 0, 0],
-        "next": ["Sarkaz@Roguelike@DecreaseBurdenSwapUiToDefault2", "Sarkaz@Roguelike@DecreaseBurdenSwapUiToDefault1"]
+        "next": ["Sarkaz@Roguelike@DecreaseBurdenSwapUiToDefault2", "Sarkaz@Roguelike@CloseCollection", "Sarkaz@Roguelike@DecreaseBurdenSwapUiToDefault1"]
     },
     "Sarkaz@Roguelike@DecreaseBurdenSwapUiToDefault2": {
         "roi": [1101, 51, 179, 137],

--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -9069,7 +9069,11 @@
         "templThreshold": 0.9,
         "action": "ClickRect",
         "specificRect": [1210, 120, 0, 0],
-        "next": ["Sarkaz@Roguelike@DecreaseBurdenSwapUiToDefault2", "Sarkaz@Roguelike@CloseCollection", "Sarkaz@Roguelike@DecreaseBurdenSwapUiToDefault1"]
+        "next": [
+            "Sarkaz@Roguelike@DecreaseBurdenSwapUiToDefault2",
+            "Sarkaz@Roguelike@CloseCollection",
+            "Sarkaz@Roguelike@DecreaseBurdenSwapUiToDefault1"
+        ]
     },
     "Sarkaz@Roguelike@DecreaseBurdenSwapUiToDefault2": {
         "roi": [1101, 51, 179, 137],


### PR DESCRIPTION
fix #9945 