### PR TITLE
feat: deprecate legacy GPUs

### DIFF
--- a/src/MaaWpfGui/Constants/ConfigurationKeys.cs
+++ b/src/MaaWpfGui/Constants/ConfigurationKeys.cs
@@ -237,6 +237,7 @@ namespace MaaWpfGui.Constants
         public const string PerformanceUseGpu = "Performance.UseGpu";
         public const string PerformancePreferredGpuDescription = "Performance.PreferredGpuDescription";
         public const string PerformancePreferredGpuInstancePath = "Performance.PreferredGpuInstancePath";
+        public const string PerformanceAllowDeprecatedGpu = "Performance.AllowDeprecatedGpu";
 
         // The following should not be modified manually
         public const string VersionName = "VersionUpdate.name";

--- a/src/MaaWpfGui/Helper/GpuOption.cs
+++ b/src/MaaWpfGui/Helper/GpuOption.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -8,6 +9,8 @@ using System.Threading.Tasks;
 using DirectN;
 using MaaWpfGui.Constants;
 using Microsoft.Win32;
+using Vanara.Extensions;
+using Vanara.PInvoke;
 
 namespace MaaWpfGui.Helper
 {
@@ -15,19 +18,103 @@ namespace MaaWpfGui.Helper
     {
         public static GpuOption Disable => DisableOption.Instance;
 
-        public static GpuOption SystemDefault => SystemDefaultOption.Instance;
-
         private static readonly List<GpuOption> _unavailableOptions = [Disable];
+
+        public static bool AllowDeprecatedGpu
+        {
+            get
+            {
+                bool.TryParse(ConfigurationHelper.GetValue(ConfigurationKeys.PerformanceAllowDeprecatedGpu, "false"), out var allowUnsupported);
+                return allowUnsupported;
+            }
+
+            set
+            {
+                ConfigurationHelper.SetValue(ConfigurationKeys.PerformanceAllowDeprecatedGpu, value.ToString());
+            }
+        }
+
+        // use string literal to efficiently store uint16 array
+        // https://github.com/torvalds/linux/blob/v6.10/drivers/gpu/drm/amd/amdgpu/amdgpu_drv.c#L1756
+        private static ReadOnlySpan<ushort> _amd_blacklist => MemoryMarshal.Cast<char, ushort>(
+            /* CHIP_TAHITI   */ "\u6780\u6784\u6788\u678A\u6790\u6791\u6792\u6798\u6799\u679A\u679B\u679E\u679F" +
+            /* CHIP_PITCAIRN */ "\u6800\u6801\u6802\u6806\u6808\u6809\u6810\u6811\u6816\u6817\u6818\u6819" +
+            /* CHIP_OLAND    */ "\u6600\u6601\u6602\u6603\u6604\u6605\u6606\u6607\u6608" +
+            "\u6610\u6611\u6613\u6617\u6620\u6621\u6623\u6631" +
+            /* CHIP_VERDE    */ "\u6820\u6821\u6822\u6823\u6824\u6825\u6826\u6827\u6828\u6829\u682A\u682B\u682C" +
+            "\u682D\u682F\u6830\u6831\u6835\u6837\u6838\u6839\u683B\u683D\u683F" +
+            /* CHIP_HAINAN   */ "\u6660\u6663\u6664\u6665\u6667\u666F" +
+            /* CHIP_KAVERI   */ "\u1304\u1305\u1306\u1307\u1309\u130A\u130B\u130C\u130D\u130E\u130F" +
+            "\u1310\u1311\u1312\u1313\u1315\u1316\u1317\u1318\u131B\u131C\u131D" +
+            /* CHIP_BONAIRE  */ "\u6640\u6641\u6646\u6647\u6649\u6650\u6651\u6658\u665c\u665d\u665f" +
+            /* CHIP_HAWAII   */ "\u67A0\u67A1\u67A2\u67A8\u67A9\u67AA\u67B0\u67B1\u67B8\u67B9\u67BA\u67BE" +
+            /* CHIP_KABINI   */ "\u9830\u9831\u9832\u9833\u9834\u9835\u9836\u9837" +
+            "\u9838\u9839\u983a\u983b\u983c\u983d\u983e\u983f" +
+            /* CHIP_MULLINS  */ "\u9850\u9851\u9852\u9853\u9854\u9855\u9856\u9857" +
+            "\u9858\u9859\u985A\u985B\u985C\u985D\u985E\u985F" +
+            /* CHIP_TOPAZ    */ "\u6900\u6901\u6902\u6903\u6907" +
+            /* CHIP_TONGA    */ "\u6920\u6921\u6928\u6929\u692B\u692F\u6930\u6938\u6939" +
+            /* CHIP_FIJI     */ "\u7300\u730F" +
+            /* CHIP_CARRIZO  */ "\u9870\u9874\u9875\u9876\u9877" +
+            /* CHIP_STONEY   */ "\u98E4");
+
+        // https://dgpu-docs.intel.com/devices/hardware-table.html#gpus-with-unsupported-drivers
+        private static ReadOnlySpan<ushort> _intel_blacklist => MemoryMarshal.Cast<char, ushort>(
+            /* Gen11 */ "\u8A70\u8A71\u8A56\u8A58\u8A5B\u8A5D\u8A54\u8A5A\u8A5C\u8A57\u8A59\u8A50\u8A51\u8A52\u8A53" +
+            /* Gen9  */ "\u3EA5\u3EA8\u3EA6\u3EA7\u3EA2\u3E90\u3E93\u3E99\u3E9C\u3EA1\u9BA5\u9BA8\u3EA4\u9B21\u9BA0" +
+            "\u9BA2\u9BA4\u9BAA\u9BAB\u9BAC\u87CA\u3EA3\u9B41\u9BC0\u9BC2\u9BC4\u9BCA\u9BCB\u9BCC\u3E91\u3E92\u3E98" +
+            "\u3E9B\u9BC5\u9BC8\u3E96\u3E9A\u3E94\u9BC6\u9BE6\u9BF6\u3EA9\u3EA0\u593B\u5923\u5926\u5927\u5917\u5912" +
+            "\u591B\u5916\u5921\u591A\u591D\u591E\u591C\u87C0\u5913\u5915\u5902\u5906\u590B\u590A\u5908\u590E\u3185" +
+            "\u3184\u1A85\u5A85\u0A84\u1A84\u5A84\u192A\u1932\u193B\u193A\u193D\u1923\u1926\u1927\u192B\u192D\u1912" +
+            "\u191B\u1913\u1915\u1917\u191A\u1916\u1921\u191D\u191E\u1902\u1906\u190B\u190A\u190E");
+
+        // https://download.nvidia.com/XFree86/Linux-x86_64/555.58/README/supportedchips.html
+        private static ReadOnlySpan<ushort> _nvidia_blacklist => MemoryMarshal.Cast<char, ushort>(
+            /* Kepler */ "\u0FC6\u0FC8\u0FC9\u0FCD\u0FCE\u0FD1\u0FD2\u0FD3\u0FD4\u0FD5\u0FD8\u0FD9\u0FDF\u0FE0\u0FE1" +
+            "\u0FE2\u0FE3\u0FE4\u0FE9\u0FEA\u0FEC\u0FED\u0FEE\u0FF6\u0FF8\u0FF9\u0FFA\u0FFB\u0FFC\u0FFD\u0FFE\u0FFF" +
+            "\u1001\u1004\u1005\u1007\u1008\u100A\u100C\u1021\u1022\u1023\u1024\u1026\u1027\u1028\u1029\u102A\u102D" +
+            "\u103A\u103C\u1180\u1183\u1184\u1185\u1185\u1187\u1188\u1189\u1189\u118A\u118E\u118F\u1193\u1194\u1195" +
+            "\u1198\u1199\u1199\u119A\u119D\u119E\u119F\u11A0\u11A1\u11A2\u11A3\u11A7\u11B4\u11B6\u11B7\u11B8\u11BA" +
+            "\u11BC\u11BD\u11BE\u11C0\u11C2\u11C3\u11C4\u11C5\u11C6\u11C8\u11CB\u11E0\u11E1\u11E2\u11E3\u11E3\u11FA" +
+            "\u11FC\u1280\u1281\u1282\u1284\u1286\u1287\u1288\u1289\u128B\u1290\u1290\u1291\u1292\u1292\u1293\u1295" +
+            "\u1295\u1296\u1298\u1299\u1299\u129A\u12B9\u12BA" +
+            /* Maxwell */ "\u1340\u1341\u1344\u1346\u1347\u1348\u1349\u134B\u134D\u134E\u134F\u137A\u137B\u1380" +
+            "\u1381\u1382\u1390\u1391\u1392\u1393\u1398\u1399\u139A\u139B\u139C\u139D\u13B0\u13B1\u13B2\u13B3\u13B4" +
+            "\u13B6\u13B9\u13BA\u13BB\u13BC\u13C0\u13C2\u13D7\u13D8\u13D9\u13DA\u13F0\u13F1\u13F2\u13F3\u13F8\u13F9" +
+            "\u13FA\u13FB\u1401\u1402\u1406\u1407\u1427\u1430\u1431\u1436\u1617\u1618\u1619\u161A\u1667\u174D\u174E" +
+            "\u179C\u17C2\u17C8\u17F0\u17F1\u17FD");
+
+        private static IDXGIFactory4? _factory;
 
         private static IDXGIFactory4? GetDxgiFactory()
         {
+            if (_factory != null)
+            {
+                try
+                {
+                    if (!_factory.IsCurrent())
+                    {
+                        _factory = null;
+                    }
+                    else
+                    {
+                        return _factory;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _factory = null;
+                }
+            }
+
             var hr = DXGIFunctions.CreateDXGIFactory2(0, typeof(IDXGIFactory4).GUID, out var comobj);
             if (!hr.IsSuccess)
             {
                 return null;
             }
 
-            return (IDXGIFactory4)comobj;
+            _factory = (IDXGIFactory4)comobj;
+            return _factory;
         }
 
         public static List<GpuOption> GetGpuOptions()
@@ -41,11 +128,7 @@ namespace MaaWpfGui.Helper
 
             uint i = 0;
 
-            var options = new List<GpuOption>()
-            {
-                Disable,
-                SystemDefault,
-            };
+            var options = new List<GpuOption>() { Disable };
 
             while (true)
             {
@@ -60,28 +143,21 @@ namespace MaaWpfGui.Helper
                 i++;
 
                 var desc = adapter.GetDesc1();
-
-                if ((desc.Flags & (uint)DXGI_ADAPTER_FLAG.DXGI_ADAPTER_FLAG_SOFTWARE) != 0)
-                {
-                    // skip software device
-                    continue;
-                }
-
-                if (!CheckD3D12Support(adapter))
-                {
-                    // skip adapters without D3D12 support
-                    continue;
-                }
-
                 var instance_path = GetAdapterInstancePath((ulong)desc.AdapterLuid.Value);
 
-                if (instance_path != null && IsIndirectDisplayAdapter(instance_path))
+                if (!CheckGpu(adapter, ref desc, instance_path, out var deprecated))
                 {
-                    // skip virtual adapters (streaming/RDP)
                     continue;
                 }
 
-                options.Add(new SpecificGpuOption(index, desc, instance_path ?? string.Empty));
+                if (index == 0)
+                {
+                    options.Add(new SystemDefaultOption(factory) { IsDeprecated = deprecated });
+                }
+
+                var opt = new SpecificGpuOption(index, desc, instance_path ?? string.Empty) { IsDeprecated = deprecated };
+
+                options.Add(opt);
             }
 
             if (i == 0)
@@ -107,29 +183,50 @@ namespace MaaWpfGui.Helper
             return options;
         }
 
-        private static bool CheckD3D12Support(IDXGIAdapter1 adapter)
+        private static bool CheckD3D12Support(IDXGIAdapter1 adapter, bool requireFL12 = false)
         {
             // using the same feature level as onnxruntime does
-            var hr = D3D12Functions.D3D12CheckDeviceCreate<ID3D12Device>(adapter, D3D_FEATURE_LEVEL.D3D_FEATURE_LEVEL_11_0);
+            var hr = D3D12Functions.D3D12CheckDeviceCreate<ID3D12Device>(adapter, requireFL12 ? D3D_FEATURE_LEVEL.D3D_FEATURE_LEVEL_12_0 : D3D_FEATURE_LEVEL.D3D_FEATURE_LEVEL_11_0);
 
             return hr == HRESULTS.S_FALSE;
         }
 
-        private static string? GetAdapterInstancePath(ulong luid)
+        private static unsafe string? GetAdapterInstancePath(ulong luid)
         {
             try
             {
-                var adpname = Vanara.PInvoke.User32.DisplayConfigGetDeviceInfo<Vanara.PInvoke.Gdi32.DISPLAYCONFIG_ADAPTER_NAME>(luid, 0, Vanara.PInvoke.Gdi32.DISPLAYCONFIG_DEVICE_INFO_TYPE.DISPLAYCONFIG_DEVICE_INFO_GET_ADAPTER_NAME);
+                var adpname = User32.DisplayConfigGetDeviceInfo<Gdi32.DISPLAYCONFIG_ADAPTER_NAME>(luid, 0, Gdi32.DISPLAYCONFIG_DEVICE_INFO_TYPE.DISPLAYCONFIG_DEVICE_INFO_GET_ADAPTER_NAME);
 
                 var interface_path = adpname.adapterDevicePath;
+                uint size = 0;
+                var err = CfgMgr32.CM_Get_Device_Interface_Property(interface_path, SetupAPI.DEVPKEY_Device_InstanceId, out var type, IntPtr.Zero, ref size, 0);
 
-                var interface_guid_pos = interface_path.LastIndexOf('#');
-                if (interface_guid_pos == -1)
+                if (err != CfgMgr32.CONFIGRET.CR_BUFFER_SMALL)
                 {
                     return null;
                 }
 
-                return interface_path[4..interface_guid_pos].Replace('#', '\\');
+                if (type != SetupAPI.DEVPROPTYPE.DEVPROP_TYPE_STRING)
+                {
+                    return null;
+                }
+
+                var buf = ArrayPool<byte>.Shared.Rent((int)size);
+                string? result = null;
+
+                fixed (byte* ptr = buf)
+                {
+                    err = CfgMgr32.CM_Get_Device_Interface_Property(interface_path, SetupAPI.DEVPKEY_Device_InstanceId, out _, (nint)ptr, ref size, 0);
+                    if (err != CfgMgr32.CONFIGRET.CR_SUCCESS)
+                    {
+                        return null;
+                    }
+
+                    var cch = (int)(size / 2) - 1;
+                    result = Marshal.PtrToStringUni((nint)ptr, cch);
+                }
+
+                return result;
             }
             catch
             {
@@ -168,6 +265,95 @@ namespace MaaWpfGui.Helper
             return false;
         }
 
+        private static unsafe DateTime? GetDriverDate(string instance_path)
+        {
+            var err = CfgMgr32.CM_Locate_DevNode(out var devinst, instance_path, CfgMgr32.CM_LOCATE_DEVNODE.CM_LOCATE_DEVNODE_NORMAL);
+
+            if (err != CfgMgr32.CONFIGRET.CR_SUCCESS)
+            {
+                return null;
+            }
+
+            System.Runtime.InteropServices.ComTypes.FILETIME ft;
+            uint size = (uint)sizeof(System.Runtime.InteropServices.ComTypes.FILETIME);
+
+            err = CfgMgr32.CM_Get_DevNode_Property(devinst, SetupAPI.DEVPKEY_Device_DriverDate, out _, (nint)(&ft), ref size, 0);
+
+            if (err != CfgMgr32.CONFIGRET.CR_SUCCESS)
+            {
+                return null;
+            }
+
+            return ft.ToDateTime();
+        }
+
+        private static bool CheckGpu(IDXGIAdapter1 adapter, ref DXGI_ADAPTER_DESC1 desc, string? instance_path, out bool deprecated)
+        {
+            deprecated = false;
+            if ((desc.Flags & (uint)DXGI_ADAPTER_FLAG.DXGI_ADAPTER_FLAG_SOFTWARE) != 0)
+            {
+                // skip software device
+                return false;
+            }
+
+            if (!CheckD3D12Support(adapter, requireFL12: false))
+            {
+                // skip adapters without D3D12 support
+                // onnxruntime uses FL 11_0 for device creation
+                return false;
+            }
+
+            if (instance_path != null && IsIndirectDisplayAdapter(instance_path))
+            {
+                // skip virtual adapters (streaming/RDP)
+                return false;
+            }
+
+            // check for deprecated GPU
+            bool IsGpuDeprecated(ref DXGI_ADAPTER_DESC1 desc)
+            {
+                // reject GPUs without native D3D12 support (FL 12_0)
+                if (!CheckD3D12Support(adapter, requireFL12: true))
+                {
+                    return true;
+                }
+
+                // reject drivers that predates DirectML (released alongside with Windows 10 1903, i.e. 2019-05-21)
+                if (instance_path != null)
+                {
+                    var devdate = GetDriverDate(instance_path);
+                    if (devdate.HasValue && devdate.Value < new DateTime(2019, 5, 21))
+                    {
+                        return true;
+                    }
+                }
+
+                // reject legacy GPUs
+                // since we filtered GPUs without FL 12_0, only a few generations will be listed here
+                // Intel: pre-Xe (Gen9, Gen11)
+                // AMD: pre-Polaris (Sea Islands, Volcanic Islands, Arctic Islands)
+                // NVIDIA: maybe pre-Pascal? (Kepler, Maxwell)
+                ReadOnlySpan<ushort> devid_blacklist = desc.VendorId switch
+                {
+                    0x8086 => _intel_blacklist,
+                    0x1002 => _amd_blacklist,
+                    0x10de => _nvidia_blacklist,
+                    _ => default,
+                };
+
+                if (devid_blacklist.Contains((ushort)desc.DeviceId))
+                {
+                    return true;
+                }
+
+                return false;
+            }
+
+            deprecated = IsGpuDeprecated(ref desc);
+
+            return true;
+        }
+
         public static GpuOption GetCurrent()
         {
             bool.TryParse(ConfigurationHelper.GetValue(ConfigurationKeys.PerformanceUseGpu, "false"), out var useGpu);
@@ -183,16 +369,16 @@ namespace MaaWpfGui.Helper
                     result = Disable;
                 }
 
-                result = SystemDefault;
+                result = options.OfType<SystemDefaultOption>().FirstOrDefault(Disable);
                 if (preferredGpuInstancePath != string.Empty)
                 {
-                    result = options.OfType<SpecificGpuOption>().FirstOrDefault(x => string.Equals(((SpecificGpuOption)x).InstancePath, preferredGpuInstancePath, StringComparison.Ordinal), SystemDefault);
+                    result = options.OfType<SpecificGpuOption>().FirstOrDefault(x => string.Equals(((SpecificGpuOption)x).InstancePath, preferredGpuInstancePath, StringComparison.Ordinal), result);
                 }
 
-                if (result == SystemDefault && preferredGpuDescription != string.Empty)
+                if (result is SystemDefaultOption && preferredGpuDescription != string.Empty)
                 {
                     // instance path lookup failed, fallback to description (name) lookup
-                    result = options.OfType<SpecificGpuOption>().FirstOrDefault(x => string.Equals(((SpecificGpuOption)x).Description, preferredGpuDescription, StringComparison.OrdinalIgnoreCase), SystemDefault);
+                    result = options.OfType<SpecificGpuOption>().FirstOrDefault(x => string.Equals(((SpecificGpuOption)x).Description, preferredGpuDescription, StringComparison.OrdinalIgnoreCase), result);
                 }
             }
             else
@@ -231,6 +417,9 @@ namespace MaaWpfGui.Helper
 
             private DisableOption() { }
 
+            // make WPF happy
+            public bool IsDeprecated => false;
+
             public override bool Equals(object? obj)
             {
                 return obj is DisableOption;
@@ -244,15 +433,27 @@ namespace MaaWpfGui.Helper
         public abstract class EnableOption : GpuOption
         {
             public abstract uint Index { get; }
+
+            public bool IsDeprecated { get; set; }
+
+            public abstract string? Description { get; }
         }
 
         public class SystemDefaultOption : EnableOption
         {
-            public static SystemDefaultOption Instance { get; } = new SystemDefaultOption();
-
-            private SystemDefaultOption() { }
 
             public override uint Index => 0;
+
+            public override string? Description { get; }
+
+            public SystemDefaultOption(IDXGIFactory1 factory)
+            {
+                if (factory.EnumAdapters1(0, out var adapter).IsSuccess)
+                {
+                    var desc = adapter.GetDesc1();
+                    Description = desc.Description;
+                }
+            }
 
             public override bool Equals(object? obj)
             {
@@ -261,7 +462,7 @@ namespace MaaWpfGui.Helper
 
             public override int GetHashCode() => typeof(SystemDefaultOption).GetHashCode();
 
-            public override string ToString() => LocalizationHelper.GetString("GpuOptionSystemDefault");
+            public override string ToString() => LocalizationHelper.GetString("GpuOptionSystemDefault") + (Description == null ? string.Empty : $" ({Description})");
         }
 
         public class SpecificGpuOption : EnableOption
@@ -281,7 +482,7 @@ namespace MaaWpfGui.Helper
 
             public override uint Index => _index;
 
-            public string Description => _description.Description;
+            public override string Description => _description.Description;
 
             public string InstancePath => _instance_path;
 

--- a/src/MaaWpfGui/MaaWpfGui.csproj
+++ b/src/MaaWpfGui/MaaWpfGui.csproj
@@ -124,6 +124,7 @@
     <PackageReference Include="Vanara.PInvoke.ComCtl32" Version="3.4.17" />
     <PackageReference Include="Vanara.PInvoke.Shared" Version="3.4.17" />
     <PackageReference Include="Vanara.PInvoke.Shell32" Version="3.4.16" />
+    <PackageReference Include="Vanara.PInvoke.CfgMgr32" Version="3.4.16" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
   </ItemGroup>
 

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -260,6 +260,11 @@ namespace MaaWpfGui.Main
         {
             if (GpuOption.GetCurrent() is GpuOption.EnableOption x)
             {
+                if (x.IsDeprecated && !GpuOption.AllowDeprecatedGpu)
+                {
+                    Instances.TaskQueueViewModel.AddLog(string.Format(LocalizationHelper.GetString("GpuDeprecatedMessage"), x.Description), UiLogColor.Warning);
+                }
+
                 AsstSetStaticOption(AsstStaticOptionKey.GpuOCR, x.Index.ToString());
             }
 

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -262,8 +262,10 @@ namespace MaaWpfGui.Main
             {
                 if (x.IsDeprecated && !GpuOption.AllowDeprecatedGpu)
                 {
-                    Instances.TaskQueueViewModel.AddLog(string.Format(LocalizationHelper.GetString("GpuDeprecatedMessage"), x.Description), UiLogColor.Warning);
+                    Instances.TaskQueueViewModel.AddLog(string.Format(LocalizationHelper.GetString("GpuDeprecatedMessage"), x.GpuInfo?.Description), UiLogColor.Warning);
                 }
+
+                _logger.Debug("Using GPU {0} (Driver {1} {2})", x.GpuInfo?.Description, x.GpuInfo?.DriverVersion, x.GpuInfo?.DriverDate?.ToString("yyyy-mm-dd"));
 
                 AsstSetStaticOption(AsstStaticOptionKey.GpuOCR, x.Index.ToString());
             }

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -265,7 +265,7 @@ namespace MaaWpfGui.Main
                     Instances.TaskQueueViewModel.AddLog(string.Format(LocalizationHelper.GetString("GpuDeprecatedMessage"), x.GpuInfo?.Description), UiLogColor.Warning);
                 }
 
-                _logger.Debug("Using GPU {0} (Driver {1} {2})", x.GpuInfo?.Description, x.GpuInfo?.DriverVersion, x.GpuInfo?.DriverDate?.ToString("yyyy-mm-dd"));
+                _logger.Debug("Using GPU {0} (Driver {1} {2})", x.GpuInfo?.Description, x.GpuInfo?.DriverVersion, x.GpuInfo?.DriverDate?.ToString("yyyy-MM-dd"));
 
                 AsstSetStaticOption(AsstStaticOptionKey.GpuOCR, x.Index.ToString());
             }

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -48,6 +48,8 @@
     <system:String x:Key="UseGpuForInference">Use GPU for inference acceleration</system:String>
     <system:String x:Key="GpuOptionDisable">Don’t use</system:String>
     <system:String x:Key="GpuOptionSystemDefault">System default GPU</system:String>
+    <system:String x:Key="GpuDeprecatedMessage">The current selected GPU ({0}) for inference acceleration is not recommended.\n\nYou can choose another GPU or suppress this message in “Settings - Performance”.</system:String>
+    <system:String x:Key="GpuAllowDeprecated">Allow deprecated GPU</system:String>
     <!--  Settings Guide  -->
     <system:String x:Key="TaskSettings">Task Settings</system:String>
     <system:String x:Key="SettingsGuide">Settings Guide</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -51,6 +51,8 @@
     <system:String x:Key="UseGpuForInference">使用 GPU 加速推理</system:String>
     <system:String x:Key="GpuOptionDisable">不使用</system:String>
     <system:String x:Key="GpuOptionSystemDefault">系统默认 GPU</system:String>
+    <system:String x:Key="GpuDeprecatedMessage">不推荐使用当前选择的推理加速 GPU（{0}）。\n\n您可以前往「设置 - 性能设置」选择其他 GPU 或禁用此消息。</system:String>
+    <system:String x:Key="GpuAllowDeprecated">允许使用不推荐的 GPU</system:String>
     <!--  设置指引  -->
     <system:String x:Key="TaskSettings">任务设置</system:String>
     <system:String x:Key="SettingsGuide">设置指引</system:String>

--- a/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
@@ -51,6 +51,7 @@ using MaaWpfGui.WineCompat;
 using Microsoft.Win32;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using PropertyChanged;
 using Serilog;
 using Stylet;
 using ComboBox = System.Windows.Controls.ComboBox;
@@ -643,6 +644,15 @@ namespace MaaWpfGui.ViewModels.UI
             {
                 GpuOption.SetCurrent(value);
                 AskRestartToApplySettings();
+            }
+        }
+
+        public bool AllowDeprecatedGpu
+        {
+            get => GpuOption.AllowDeprecatedGpu;
+            set {
+                GpuOption.AllowDeprecatedGpu = value;
+                NotifyOfPropertyChange();
             }
         }
 

--- a/src/MaaWpfGui/Views/UserControl/PerformanceUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/PerformanceUserControl.xaml
@@ -1,5 +1,6 @@
 <UserControl
     x:Class="MaaWpfGui.Views.UserControl.PerformanceUserControl"
+    x:Name="performanceUserControl"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:c="clr-namespace:CalcBinding;assembly=CalcBinding"
@@ -25,30 +26,41 @@
         <Grid.RowDefinitions>
             <RowDefinition/>
             <RowDefinition/>
+            <RowDefinition/>
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
             <ColumnDefinition/>
             <ColumnDefinition/>
         </Grid.ColumnDefinitions>
-        <StackPanel
-            Grid.Row="0"
-            Grid.Column="0"
-            Grid.ColumnSpan="2"
-            HorizontalAlignment="Center"
-            VerticalAlignment="Center"
-            Orientation="Horizontal">
-                <controls:TextBlock Margin="24, 0, 0, 0"
+
+        <controls:TextBlock Margin="24, 0, 0, 0"
                                     Text="{DynamicResource UseGpuForInference}"/>
-                <hc:ComboBox
+        <hc:ComboBox
+                Grid.Column="1"
                     Width="240"
                     Margin="10"
                     HorizontalAlignment="Center"
                     VerticalAlignment="Center"
                     ItemsSource="{Binding GpuOptions}"
-                    SelectedValue="{Binding ActiveGpuOption}"/>
-            </StackPanel>
+                    SelectedValue="{Binding ActiveGpuOption}"
+                    >
+            <hc:ComboBox.ItemContainerStyle>
+                <Style TargetType="ComboBoxItem" BasedOn="{StaticResource ComboBoxItemBaseStyle}">
+                    <Style.Triggers>
+                        <MultiDataTrigger >
+                            <MultiDataTrigger.Conditions>
+                                <Condition Binding="{Binding IsDeprecated}" Value="True"/>
+                                <Condition Binding="{Binding DataContext.AllowDeprecatedGpu, RelativeSource={RelativeSource AncestorType=hc:ComboBox}}" Value="False"/>
+                            </MultiDataTrigger.Conditions>
+                            <Setter Property="Visibility" Value="Collapsed"/>
+                        </MultiDataTrigger>
+                    </Style.Triggers>
+                </Style>
+            </hc:ComboBox.ItemContainerStyle>
+        </hc:ComboBox>
+        <CheckBox Grid.Row="1" Grid.Column="1" Margin="10" Content="{DynamicResource GpuAllowDeprecated}" IsChecked="{Binding AllowDeprecatedGpu}"/>
         <controls:TextBlock
-            Grid.Row="1"
+            Grid.Row="2"
             Grid.ColumnSpan="2"
             HorizontalAlignment="Center"
             Text="{c:Binding ScreencapCost}"/>

--- a/src/MaaWpfGui/Views/UserControl/PerformanceUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/PerformanceUserControl.xaml
@@ -38,7 +38,7 @@
         <hc:ComboBox
                 Grid.Column="1"
                     Width="240"
-                    Margin="10"
+                    Margin="10, 5"
                     HorizontalAlignment="Center"
                     VerticalAlignment="Center"
                     ItemsSource="{Binding GpuOptions}"
@@ -58,11 +58,12 @@
                 </Style>
             </hc:ComboBox.ItemContainerStyle>
         </hc:ComboBox>
-        <CheckBox Grid.Row="1" Grid.Column="1" Margin="10" Content="{DynamicResource GpuAllowDeprecated}" IsChecked="{Binding AllowDeprecatedGpu}"/>
+        <CheckBox Grid.Row="1" Grid.Column="1" Margin="10, 5" Content="{DynamicResource GpuAllowDeprecated}" IsChecked="{Binding AllowDeprecatedGpu}"/>
         <controls:TextBlock
             Grid.Row="2"
             Grid.ColumnSpan="2"
             HorizontalAlignment="Center"
+            Margin="10"
             Text="{c:Binding ScreencapCost}"/>
     </Grid>
 </UserControl>


### PR DESCRIPTION
blacklist GPU if:
* no FL 12_0
* driver predates DirectML GA
* Intel: pre-Xe (Gen9, Gen11)
* AMD: pre-Polaris (Sea Islands, Volcanic Islands, Arctic Islands)
* NVIDIA: pre-Pascal (Kepler, Maxwell)