### PR TITLE
fix: OTA打包时对跳过的版本做删除处理

### DIFF
--- a/tools/OTAPacker/build.sh
+++ b/tools/OTAPacker/build.sh
@@ -21,7 +21,7 @@ while read tag; do
         echo "Downloading $tag"
         gh release download "$tag" --repo $source_repo --pattern "MAA-$tag-win-$arch.zip" --clobber \
             || gh release download "$tag" --repo $source_repo_fallback --pattern "MAA-$tag-win-$arch.zip" --clobber \
-            || { echo "::warning:: win $arch not found in release $tag skipping."; echo "::endgroup::"; continue; }
+            || { echo "::warning:: win $arch not found in release $tag, skipping."; rm -vf MAA-$tag-win-$arch.zip ; echo "::endgroup::"; continue; }
         mv MAA-$tag-win-$arch.zip $tag
     else
         echo "$tag"/MAA-$tag-win-$arch.zip already exists


### PR DESCRIPTION
## 问题起因

在 [v5.5.1-alpha.1.d084.g5f5eccda7](https://github.com/MaaAssistantArknights/MaaRelease/releases/tag/v5.5.1-alpha.1.d084.g5f5eccda7) 版本的 OTA 包中意外出现了先前版本的完整包

![09d43b16e02be7204464027ef10dd490](https://github.com/user-attachments/assets/65c2100e-7921-4223-ba6e-5656cb94a548)

分析 [CI 日志](https://github.com/MaaAssistantArknights/MaaAssistantArknights/actions/runs/10199520807/job/28217514723) 发现如下几行

```
2024-08-01T14:00:51.2065910Z ##[group]v5.5.0-beta.1.d241.gbc3ad67a0
2024-08-01T14:00:51.2080265Z mkdir: created directory 'v5.5.0-beta.1.d241.gbc3ad67a0'
2024-08-01T14:00:51.2082057Z Downloading v5.5.0-beta.1.d241.gbc3ad67a0
2024-08-01T14:00:51.7285658Z release not found
2024-08-01T14:00:56.0414161Z stream error: stream ID 1; PROTOCOL_ERROR; received from peer
2024-08-01T14:00:56.0460379Z ##[warning] win x64 not found in release v5.5.0-beta.1.d241.gbc3ad67a0 skipping.
2024-08-01T14:00:56.0468909Z ##[endgroup]
```

应该是偶发的网络问题导致这个包下载错误，只下了一半。但由于压缩文件已经存在于 OTA 目录中，故被后续上传至 Release 附件中，导致存在出现了多个完整包的情况