### PR TITLE
chore(style): strings instead of ints for training room time output

### DIFF
--- a/src/MaaCore/Task/Infrast/InfrastTrainingTask.cpp
+++ b/src/MaaCore/Task/Infrast/InfrastTrainingTask.cpp
@@ -153,10 +153,13 @@ bool asst::InfrastTrainingTask::time_left_analyze(cv::Mat image)
         }
         std::string str_time = match.str();
 
-        if (!utils::chars_to_number(str_time, time_left[i])) {
-            Log.error(__FUNCTION__, "chars_to_number failed");
-            return false;
+        // Ensure the time string has two characters
+        if (str_time.length() == 1) {
+            str_time = "0" + str_time;
         }
+
+        // Store the time as a string with leading zeros
+        time_left[i] = str_time;
     }
 
     return true;

--- a/src/MaaCore/Task/Infrast/InfrastTrainingTask.h
+++ b/src/MaaCore/Task/Infrast/InfrastTrainingTask.h
@@ -25,7 +25,7 @@ namespace asst
         static int skill_index_from_rect(const Rect& r);
 
         int m_level;
-        int time_left[3];
+        std::string time_left[3];
         std::string m_operator_name;
         std::string m_skill_name;
         // asst::battle::Role m_operator_role;


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/9237e9d3-733f-4901-8f9a-6c72c1030538)


After:
![image](https://github.com/user-attachments/assets/c5a3c5fb-80af-4b34-85b6-47dfa87a0f1c)

Reading times as x:x:x gives me a stroke.

(Why no space between `[Name] Skill` 😭 )

@HX3N no more stroke when reading