### PR TITLE
chore: training room styled output depending on language

### DIFF
--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -1475,7 +1475,7 @@ namespace MaaWpfGui.Main
                         var operatorName = DataHelper.GetLocalizedCharacterName(subTaskDetails!["operator"]?.ToString()) ?? "UnKnown";
                         var skillName = subTaskDetails["skill"]?.ToString() ?? "UnKnown";
                         Instances.TaskQueueViewModel.AddLog(
-                            $"[{operatorName}]{skillName}\n" +
+                            string.Format(LocalizationHelper.GetString("TrainingNameFormat"), operatorName, skillName) + "\n" +
                             $"{LocalizationHelper.GetString("TrainingLevel")}: {(int)(subTaskDetails["level"] ?? -1)} {LocalizationHelper.GetString("TrainingCompleted")}",
                             UiLogColor.Info);
                         break;
@@ -1486,7 +1486,7 @@ namespace MaaWpfGui.Main
                         var operatorName = DataHelper.GetLocalizedCharacterName(subTaskDetails!["operator"]?.ToString()) ?? "UnKnown";
                         var skillName = subTaskDetails["skill"]?.ToString() ?? "UnKnown";
                         Instances.TaskQueueViewModel.AddLog(
-                            $"[{operatorName}]{skillName}\n" +
+                            string.Format(LocalizationHelper.GetString("TrainingNameFormat"), operatorName, skillName) + "\n" +
                             $"{LocalizationHelper.GetString("TrainingLevel")}: {(int)(subTaskDetails["level"] ?? -1)}\n" +
                             $"{LocalizationHelper.GetString("TrainingTimeLeft")}: {subTaskDetails["hh"]:D2}:{subTaskDetails["mm"]:D2}:{subTaskDetails["ss"]:D2}",
                             UiLogColor.Info);

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -85,6 +85,7 @@
     <system:String x:Key="ContinueTraining">After training is complete, try to continue mastering the current skill</system:String>
     <system:String x:Key="TrainingIdle">Training room is vacant</system:String>
     <system:String x:Key="TrainingCompleted">Training completed</system:String>
+    <system:String x:Key="TrainingNameFormat">[{0}] {1}</system:String>
     <system:String x:Key="TrainingLevel">Skill Rank</system:String>
     <system:String x:Key="TrainingTimeLeft">Remaining Time</system:String>
     <system:String x:Key="CustomInfrastEnabled">Enable Custom Base (beta)</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -83,6 +83,7 @@
     <system:String x:Key="ContinueTraining">訓練完了後、現在のスキルを特化する試みを続けます</system:String>
     <system:String x:Key="TrainingIdle">訓練室は空いています</system:String>
     <system:String x:Key="TrainingCompleted">訓練が完了しました</system:String>
+    <system:String x:Key="TrainingNameFormat">[{0}]{1}</system:String>
     <system:String x:Key="TrainingLevel">スキルランク</system:String>
     <system:String x:Key="TrainingTimeLeft">残り時間</system:String>
     <system:String x:Key="CustomInfrastEnabled">カスタムされた基地構成を有効にする（ベータ）</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -86,6 +86,7 @@
     <system:String x:Key="ContinueTraining">훈련 완료 시 스킬 마스터리를 훈련</system:String>
     <system:String x:Key="TrainingIdle">훈련실이 비어 있습니다</system:String>
     <system:String x:Key="TrainingCompleted">훈련 완료</system:String>
+    <system:String x:Key="TrainingNameFormat">[{0}]{1}</system:String>
     <system:String x:Key="TrainingLevel">스킬 랭크</system:String>
     <system:String x:Key="TrainingTimeLeft">남은 시간</system:String>
     <system:String x:Key="CustomInfrastEnabled">커스텀 기반시설 (베타)</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -88,6 +88,7 @@
     <system:String x:Key="ContinueTraining">训练完成后继续尝试专精当前技能</system:String>
     <system:String x:Key="TrainingIdle">训练室空闲中</system:String>
     <system:String x:Key="TrainingCompleted">训练完成</system:String>
+    <system:String x:Key="TrainingNameFormat">[{0}]{1}</system:String>
     <system:String x:Key="TrainingLevel">专精等级</system:String>
     <system:String x:Key="TrainingTimeLeft">剩余时间</system:String>
     <system:String x:Key="CustomInfrastEnabled">启用自定义基建配置（beta）</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -79,6 +79,7 @@
     <system:String x:Key="ContinueTraining">訓練完成後繼續嘗試專精當前技能</system:String>
     <system:String x:Key="TrainingIdle">訓練室空閒中</system:String>
     <system:String x:Key="TrainingCompleted">訓練完成</system:String>
+    <system:String x:Key="TrainingNameFormat">[{0}]{1}</system:String>
     <system:String x:Key="TrainingLevel">專精等級</system:String>
     <system:String x:Key="TrainingTimeLeft">剩餘時間</system:String>
     <system:String x:Key="CustomInfrastEnabled">啟用自定義基建配置（beta）</system:String>


### PR DESCRIPTION
This is the more complicated solution to https://github.com/MaaAssistantArknights/MaaAssistantArknights/pull/10023#issuecomment-2265033067.

This way the change is only for EN. In case the change is liked on all clients, I can just 
```cpp
$"[{operatorName}] {skillName}\n" +
```