### PR TITLE
fix: 修改肉鸽编队滑页触底判断 (#9243, #9328)

### DIFF
--- a/src/MaaCore/Task/Roguelike/RoguelikeFormationTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeFormationTaskPlugin.cpp
@@ -95,6 +95,7 @@ void asst::RoguelikeFormationTaskPlugin::clear_and_reselect()
     // 清空并退出游戏会自动按等级重新排序
     ProcessTask(*this, { "RoguelikeQuickFormationClearAndReselect" }).run();
 
+    m_last_detected_oper_names.clear();
     oper_list.clear();
     cur_page = 1;
 
@@ -166,6 +167,12 @@ bool asst::RoguelikeFormationTaskPlugin::analyze()
         return false;
     }
 
+    auto formation_analyze_result = formation_analyzer.get_result();
+    auto oper_name_view = formation_analyze_result | views::transform([&](auto oper) { return oper.name; });;
+    std::vector<std::string> detected_oper_names(oper_name_view.begin(), oper_name_view.end());
+    const bool reach_last_column = (detected_oper_names == m_last_detected_oper_names);
+    m_last_detected_oper_names = std::move(detected_oper_names);
+
     auto unique_filter = views::filter([&](const auto& oper) {
         // TODO: 这里没考虑多个相同预备干员的情况，不过影响应该不大
         return !ranges::any_of(oper_list, [&](const auto& existing_oper) {
@@ -177,9 +184,9 @@ bool asst::RoguelikeFormationTaskPlugin::analyze()
         oper.page = cur_page;
         return oper;
     });
-    auto result_oper_list = formation_analyzer.get_result() | unique_filter | append_page_proj;
+    auto result_oper_list = formation_analyze_result | unique_filter | append_page_proj;
     ranges::move(result_oper_list, std::back_inserter(oper_list));
-    return !result_oper_list.empty(); // 希望OCR没识别错干员名，否则可能误判当前页面的干员情况
+    return reach_last_column;
 }
 
 bool asst::RoguelikeFormationTaskPlugin::select(RoguelikeFormationImageAnalyzer::FormationOper oper)

--- a/src/MaaCore/Task/Roguelike/RoguelikeFormationTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/RoguelikeFormationTaskPlugin.h
@@ -28,5 +28,6 @@ namespace asst
         int cur_page = 0;
         int max_page = 0;
         std::vector<RoguelikeFormationImageAnalyzer::FormationOper> oper_list;
+        std::vector<std::string> m_last_detected_oper_names;
     };
 }


### PR DESCRIPTION
两套方案：
方案A，判断滑动后检测到的8个干员是否有变动，对拥有12+个同名预备干员的倒霉蛋不太友好。
方案B，坐标魔法，需要对MAA那并不一直很可靠的滑动精度充满信任。

甲方爸爸选择了 A 方案。

---

**以下内容已失效**

简单说一下460这个数字是怎么来着：

肉鸽滑动基本上是滑动一整个`column offset`，在没有触底的情况下，检测到的第一个结果必然会偏左（排序已经在 RoguelikeFormationImageAnalyzer 里做了），并且画面右边会露出一点点下一列的内容。
![screenshot_20240807_014359](https://github.com/user-attachments/assets/b4848999-3e9f-42c7-8ff9-35482ae59d88)
此时检测到的坐标应该在416左右。

当触底的时候，因为没有了下一列，画面回正后检测到的结果会偏右，横坐标会在509左右。
![screenshot_20240807_014812](https://github.com/user-attachments/assets/a184cdd5-5326-405d-9681-3fde0ebc2553)

此次改动需要大家帮我测试一下，可能引发的问题有：画面没有及时回正导致检测不到触底，直接卡住在死循环。需要的话加一个100ms 的 sleep 。