### PR TITLE
refactor(config) : reorganize settings loading

### DIFF
--- a/src/MaaWpfGui/Helper/ConfigurationHelper.cs
+++ b/src/MaaWpfGui/Helper/ConfigurationHelper.cs
@@ -188,6 +188,7 @@ namespace MaaWpfGui.Helper
             parsed = ParseJsonFile(_configurationFile);
             if (parsed is null && File.Exists(_configurationBakFile))
             {
+                _logger.Warning("Failed to load configuration file, trying to use backup file");
                 parsed = ParseJsonFile(_configurationFile);
                 if (parsed is not null)
                 {
@@ -197,7 +198,7 @@ namespace MaaWpfGui.Helper
 
             if (parsed is null)
             {
-                _logger.Information("Failed to load configuration file, creating a new one");
+                _logger.Warning("Failed to load configuration file and/or backup file, using default settings");
 
                 _kvsMap = new Dictionary<string, Dictionary<string, string>>();
                 _current = ConfigurationKeys.DefaultConfiguration;

--- a/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
@@ -4345,13 +4345,13 @@ namespace MaaWpfGui.ViewModels.UI
         {
             if (string.IsNullOrEmpty(_bluestacksConfig))
             {
-                return null;
+                return string.Empty;
             }
 
             if (!File.Exists(_bluestacksConfig))
             {
                 ConfigurationHelper.SetValue(ConfigurationKeys.BluestacksConfigError, "File not exists");
-                return null;
+                return string.Empty;
             }
 
             var allLines = File.ReadAllLines(_bluestacksConfig);


### PR DESCRIPTION
重新组织配置读取的函数。虽然还是没找到 #2535 的根因。

ConfigHelper 使用.bak前应该先检查一下.bak是否可以被有效解析，可能会出现两者同时解析失败的情况 

AsstConnect 勾选自动检测的逻辑处理感觉有些乱，也一并重写了一下。  