### PR TITLE
fix: 肉鸽探索失败后执行ClickToStartPointAfterFailed点进讲述者

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -5998,7 +5998,7 @@
     "Roguelike@ClickToStartPoint": {
         "algorithm": "JustReturn",
         "action": "ClickRect",
-        "specificRect": [600, 600, 50, 50],
+        "specificRect": [600, 600, 50, 10],
         "postDelay_Doc": "这个延迟保证不会识别到 StartExplore 之后又弹出 每月委托/解锁收藏品 等。 #7033",
         "postDelay": 800,
         "next": [


### PR DESCRIPTION
用justReturn点击，是因为认为点击空白区域不会有影响吗
fix #10176 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能更新**
	- 调整了可点击区域的尺寸，具体为将高度从50减少到10，这可能影响用户交互体验。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->