### PR TITLE
fix: ClickStageName pattern extraction for EX stages

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -298,7 +298,10 @@
         "isAscii": true,
         "text": [],
         "next": ["ClickedCorrectStageOrSwipe", "#self"],
-        "ocrReplace": [["-\\]", "-1"]]
+        "ocrReplace": [
+            ["-\\]", "-1"],
+            ["^.*([A-Z]{2}-EX-\\d+)", "$1"]
+        ]
     },
     "StageNavigationSlowlySwipeLeft": {
         "baseTask": "ChapterSlowlySwipeToTheLeft",
@@ -10257,7 +10260,7 @@
     "Reclamation2ExAssemblyStation": {
         "Doc": "进入组装台",
         "action": "ClickSelf",
-        "roi": [109, 642, 1111, 63],
+        "roi": [564, 596, 155, 124],
         "next": ["Reclamation2ExAssemblyStationOcr", "#self"]
     },
     "Reclamation2ExAssemblyStationBack": {
@@ -10383,19 +10386,6 @@
         "roi": [871, 407, 238, 146],
         "next": ["#back"]
     },
-    "Reclamation2QuitToMainPage": {
-        "algorithm": "OcrDetect",
-        "action": "ClickSelf",
-        "text": ["返回"],
-        "preDelay": 2000,
-        "roi": [33, 0, 97, 63],
-        "next": ["Stop"]
-    },
-    "Reclamation2RightMax": {
-        "roi": [789, 475, 154, 122],
-        "preDelay": 1000,
-        "next": ["Reclamation2SkipDaysAwardEndTask"]
-    },
     "Reclamation2SkipDays": {
         "algorithm": "JustReturn",
         "postDelay": 1000,
@@ -10434,7 +10424,7 @@
     "Reclamation2SkipDaysAward": {
         "algorithm": "JustReturn",
         "postDelay": 5000,
-        "next": ["Reclamation2RightMax", "Reclamation2SkipDaysAward2", "Reclamation2SkipDaysAward1"]
+        "next": ["Reclamation2SkipDaysAward2", "Reclamation2SkipDaysAward1"]
     },
     "Reclamation2SkipDaysAward1": {
         "algorithm": "JustReturn",
@@ -10450,29 +10440,12 @@
         "text": ["点击", "任意处", "继续"],
         "next": ["Reclamation2SkipDaysBeginNewDay"]
     },
-    "Reclamation2SkipDaysAwardEndTask": {
-        "algorithm": "OcrDetect",
-        "action": "ClickSelf",
-        "roi": [506, 609, 272, 111],
-        "preDelay": 1000,
-        "postDelay": 4000,
-        "text": ["点击", "任意处", "继续"],
-        "next": ["Reclamation2SkipDaysBeginNewDayEndTask"]
-    },
     "Reclamation2SkipDaysBeginNewDay": {
         "algorithm": "OcrDetect",
         "action": "ClickSelf",
         "text": ["开", "启", "今", "日"],
         "preDelay": 1000,
         "roi": [519, 525, 261, 144]
-    },
-    "Reclamation2SkipDaysBeginNewDayEndTask": {
-        "algorithm": "OcrDetect",
-        "action": "ClickSelf",
-        "text": ["开", "启", "今", "日"],
-        "preDelay": 1000,
-        "roi": [519, 525, 261, 144],
-        "next": ["Reclamation2QuitToMainPage", "Stop"]
     },
     "Reclamation@AtCmdCenterFlag": {
         "algorithm": "OcrDetect",


### PR DESCRIPTION
In many cases, after first clearing a stage with a normal and challenge mode, the OCR will pickup a `I` or `J` from the "completion" logo,  which prevents the task from continuing and results in a task error.
![image](https://github.com/user-attachments/assets/4b1878ee-7bee-4275-8454-adb23e77cd64)

```py
[2024-08-11 17:51:37.271][TRC][Px41a4][Tx0104] asst::CharOcr [...... { JHS-EX-2: [ 117, 316, 109, 32 ], score: 0.906266 } ...... { IHS-EX-3: [ 124, 513, 101, 32 ], score: 0.963113 }
```

This regex resolves the issue, but currently only for EX stages, as the problem hasn't been identified in other stages yet. This is primarily because only EX stages feature both a normal and a challenge mode.

The change is fairly simple. It utilizes` std::regex_replace` ability to use backreference substitution. (I didn't know it was possible directly in the JSON, but after checking how the values are passed from JSON to MaaCore and they remain simple strings it stupid easy to implement)