### PR TITLE
fix: 傀影肉鸽卡在商店界面

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -6070,11 +6070,11 @@
             "Roguelike@GetDrops#next",
             "Roguelike@GetDropCompleted",
             "Roguelike@GetDropLeave",
+            "Roguelike@StageTraderLeave",
             "Roguelike@Stages#next",
             "Roguelike@StageEncounterOptions#next",
             "Roguelike@StageEncounterSpecialClose",
             "Roguelike@EnterAfterRecruit",
-            "Roguelike@StageTraderLeave",
             "Roguelike@CloseEvent",
             "Roguelike@DialogSkip",
             "Roguelike@RecruitOther"


### PR DESCRIPTION
有个叫"Roguelike@StageEncounterOptionUnknown"的任务一定在离开商店的前面成功识别，故将离开商店提前