### PR TITLE
feat: 允许手动指定WPFGUI中干员名称显示语言

### DIFF
--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -411,6 +411,7 @@ Only supports Official(CN) and Bilibili server. Login account is not supported.<
     <system:String x:Key="OperNameLanguage">Operator display language</system:String>
     <system:String x:Key="OperNameLanguageMAA">Follow MAA</system:String>
     <system:String x:Key="OperNameLanguageClient">Follow game client</system:String>
+    <system:String x:Key="OperNameLanguageForce">Force use of specified language</system:String>
     <system:String x:Key="Light">Light</system:String>
     <system:String x:Key="Dark">Dark</system:String>
     <system:String x:Key="SyncWithOs">Sync with OS</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -410,6 +410,7 @@
     <system:String x:Key="OperNameLanguage">オペレーター名の表示言語</system:String>
     <system:String x:Key="OperNameLanguageMAA">MAAをフォローする</system:String>
     <system:String x:Key="OperNameLanguageClient">ゲームクライアントをフォローする</system:String>
+    <system:String x:Key="OperNameLanguageForce">指定された言語を強制的に使用する</system:String>
     <system:String x:Key="Light">ライトモード</system:String>
     <system:String x:Key="Dark">ダークモード</system:String>
     <system:String x:Key="SyncWithOs">OSと同期する</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -410,6 +410,7 @@ OF-1을 해금하지 않았다면 선택하지 말아 주세요.</system:String>
     <system:String x:Key="OperNameLanguage">간부 이름 표시 언어</system:String>
     <system:String x:Key="OperNameLanguageMAA">MAA 따라가기</system:String>
     <system:String x:Key="OperNameLanguageClient">게임 클라이언트 따라가기</system:String>
+    <system:String x:Key="OperNameLanguageForce">지정된 언어를 강제로 사용</system:String>
     <system:String x:Key="Light">라이트</system:String>
     <system:String x:Key="Dark">다크</system:String>
     <system:String x:Key="SyncWithOs">시스템 연동</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -411,6 +411,7 @@
     <system:String x:Key="OperNameLanguage">干员名称显示语言</system:String>
     <system:String x:Key="OperNameLanguageMAA">跟随MAA</system:String>
     <system:String x:Key="OperNameLanguageClient">跟随游戏客户端</system:String>
+    <system:String x:Key="OperNameLanguageForce">强制使用指定语言</system:String>
     <system:String x:Key="Light">亮色</system:String>
     <system:String x:Key="Dark">暗色</system:String>
     <system:String x:Key="SyncWithOs">与系统同步</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -401,6 +401,7 @@
     <system:String x:Key="OperNameLanguage">幹員名稱顯示語言</system:String>
     <system:String x:Key="OperNameLanguageMAA">跟隨MAA</system:String>
     <system:String x:Key="OperNameLanguageClient">跟隨遊戲客戶端</system:String>
+    <system:String x:Key="OperNameLanguageForce">強制使用指定語言</system:String>
     <system:String x:Key="Light">亮色</system:String>
     <system:String x:Key="Dark">暗色</system:String>
     <system:String x:Key="SyncWithOs">與系統同步</system:String>

--- a/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
@@ -409,7 +409,8 @@ namespace MaaWpfGui.ViewModels.UI
                         if (json.TryGetValue("buff", out var buffValue))
                         {
                             string buffLog = LocalizationHelper.GetString("DirectiveECTerm");
-                            AddLog(buffLog + DataHelper.GetLocalizedCharacterName((string?)buffValue), UiLogColor.Message, showTime: false);
+                            string? localizedBuffName = DataHelper.GetLocalizedCharacterName((string?)buffValue);
+                            AddLog(buffLog + (string.IsNullOrEmpty(localizedBuffName) ? (string?)buffValue : localizedBuffName), UiLogColor.Message, showTime: false);
                         }
 
                         if (json.TryGetValue("tool_men", out var toolMenValue))

--- a/src/MaaWpfGui/ViewModels/UI/RecognizerViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/RecognizerViewModel.cs
@@ -617,23 +617,49 @@ namespace MaaWpfGui.ViewModels.UI
             List<Tuple<string, int>> operHave = [];
             List<Tuple<string, int>> operNotHave = [];
 
-            string localizedName = ConfigurationHelper.GetValue(ConfigurationKeys.OperNameLanguage, string.Empty) == "OperNameLanguageClient" ?
-                ConfigurationHelper.GetValue(ConfigurationKeys.ClientType, string.Empty) switch
+            string localizedName;
+            string operNameLanguage = ConfigurationHelper.GetValue(ConfigurationKeys.OperNameLanguage, string.Empty);
+
+            if (operNameLanguage == "OperNameLanguageClient")
             {
-                "Official" => "name",
-                "Bilibili" => "name",
-                "YoStarJP" => "name_jp",
-                "YoStarKR" => "name_kr",
-                "txwy" => "name_tw",
-                _ => "name_en",
-            } : ConfigurationHelper.GetValue(ConfigurationKeys.Localization, string.Empty) switch
+                localizedName = ConfigurationHelper.GetValue(ConfigurationKeys.ClientType, string.Empty) switch
+                {
+                    "Official" => "name",
+                    "Bilibili" => "name",
+                    "YoStarJP" => "name_jp",
+                    "YoStarKR" => "name_kr",
+                    "txwy" => "name_tw",
+                    _ => "name_en",
+                };
+            }
+            else
             {
-                "zh-cn" => "name",
-                "ja-jp" => "name_jp",
-                "ko-kr" => "name_kr",
-                "zh-tw" => "name_tw",
-                _ => "name_en",
-            };
+                string localization = ConfigurationHelper.GetValue(ConfigurationKeys.Localization, string.Empty);
+                if (operNameLanguage.Contains('.'))
+                {
+                    if (operNameLanguage.Split('.')[0] == "OperNameLanguageForce")
+                    {
+                        localization = operNameLanguage.Split('.')[1] switch
+                        {
+                            "zh-cn" => "zh-cn",
+                            "en-us" => "en-us",
+                            "ja-jp" => "ja-jp",
+                            "ko-kr" => "ko-kr",
+                            "zh-tw" => "zh-tw",
+                            _ => localization,
+                        };
+                    }
+                }
+
+                localizedName = localization switch
+                {
+                    "zh-cn" => "name",
+                    "ja-jp" => "name_jp",
+                    "ko-kr" => "name_kr",
+                    "zh-tw" => "name_tw",
+                    _ => "name_en",
+                };
+            }
 
             foreach (JObject operBox in operBoxes.Cast<JObject>())
             {

--- a/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
@@ -4572,9 +4572,9 @@ namespace MaaWpfGui.ViewModels.UI
         public List<CombinedData> LanguageList { get; set; }
 
         /// <summary>
-        /// Gets the list of operator name language settings
+        /// Gets or sets the list of operator name language settings
         /// </summary>
-        public List<CombinedData> OperNameLanguageModeList { get; } =
+        public List<CombinedData> OperNameLanguageModeList { get; set; } =
             [
                 new() { Display = LocalizationHelper.GetString("OperNameLanguageMAA"), Value = "OperNameLanguageMAA" },
                 new() { Display = LocalizationHelper.GetString("OperNameLanguageClient"), Value = "OperNameLanguageClient" }
@@ -4926,15 +4926,30 @@ namespace MaaWpfGui.ViewModels.UI
             { "txwy", "zh-tw" },
         };
 
+        /// <summary>
+        /// Opername display language, can set force display when it was set as "OperNameLanguageForce.en-us"
+        /// </summary>
         private string _operNameLanguage = ConfigurationHelper.GetValue(ConfigurationKeys.OperNameLanguage, "OperNameLanguageMAA");
 
         public string OperNameLanguage
         {
-            get => _operNameLanguage;
+            get
+            {
+                if (_operNameLanguage.Contains('.'))
+                {
+                    if (_operNameLanguage.Split('.')[0] == "OperNameLanguageForce" && LocalizationHelper.SupportedLanguages.ContainsKey(_operNameLanguage.Split('.')[1]))
+                    {
+                        OperNameLanguageModeList.Add(new() { Display = LocalizationHelper.GetString("OperNameLanguageForce"), Value = "OperNameLanguageForce" });
+                        return "OperNameLanguageForce";
+                    }
+                }
+
+                return _operNameLanguage;
+            }
 
             set
             {
-                if (value == _operNameLanguage)
+                if (value == _operNameLanguage.Split('.')[0])
                 {
                     return;
                 }
@@ -4982,6 +4997,14 @@ namespace MaaWpfGui.ViewModels.UI
                 if (_operNameLanguage == "OperNameLanguageClient")
                 {
                     return _clientLanguageMapper[ConfigurationHelper.GetValue(ConfigurationKeys.ClientType, string.Empty)];
+                }
+
+                if (_operNameLanguage.Contains('.'))
+                {
+                    if (_operNameLanguage.Split('.')[0] == "OperNameLanguageForce" && LocalizationHelper.SupportedLanguages.ContainsKey(_operNameLanguage.Split('.')[1]))
+                    {
+                        return _operNameLanguage.Split('.')[1];
+                    }
                 }
 
                 return _language;

--- a/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
@@ -4935,16 +4935,18 @@ namespace MaaWpfGui.ViewModels.UI
         {
             get
             {
-                if (_operNameLanguage.Contains('.'))
+                if (!_operNameLanguage.Contains('.'))
                 {
-                    if (_operNameLanguage.Split('.')[0] == "OperNameLanguageForce" && LocalizationHelper.SupportedLanguages.ContainsKey(_operNameLanguage.Split('.')[1]))
-                    {
-                        OperNameLanguageModeList.Add(new() { Display = LocalizationHelper.GetString("OperNameLanguageForce"), Value = "OperNameLanguageForce" });
-                        return "OperNameLanguageForce";
-                    }
+                    return _operNameLanguage;
                 }
 
-                return _operNameLanguage;
+                if (_operNameLanguage.Split('.')[0] != "OperNameLanguageForce" || !LocalizationHelper.SupportedLanguages.ContainsKey(_operNameLanguage.Split('.')[1]))
+                {
+                    return _operNameLanguage;
+                }
+
+                OperNameLanguageModeList.Add(new CombinedData { Display = LocalizationHelper.GetString("OperNameLanguageForce"), Value = "OperNameLanguageForce" });
+                return "OperNameLanguageForce";
             }
 
             set
@@ -4996,15 +4998,17 @@ namespace MaaWpfGui.ViewModels.UI
             {
                 if (_operNameLanguage == "OperNameLanguageClient")
                 {
-                    return _clientLanguageMapper[ConfigurationHelper.GetValue(ConfigurationKeys.ClientType, string.Empty)];
+                    return _clientLanguageMapper[_clientType];
                 }
 
-                if (_operNameLanguage.Contains('.'))
+                if (!_operNameLanguage.Contains('.'))
                 {
-                    if (_operNameLanguage.Split('.')[0] == "OperNameLanguageForce" && LocalizationHelper.SupportedLanguages.ContainsKey(_operNameLanguage.Split('.')[1]))
-                    {
-                        return _operNameLanguage.Split('.')[1];
-                    }
+                    return _language;
+                }
+
+                if (_operNameLanguage.Split('.')[0] == "OperNameLanguageForce" && LocalizationHelper.SupportedLanguages.ContainsKey(_operNameLanguage.Split('.')[1]))
+                {
+                    return _operNameLanguage.Split('.')[1];
                 }
 
                 return _language;


### PR DESCRIPTION
Function required by https://github.com/MaaAssistantArknights/MaaAssistantArknights/issues/10079#issuecomment-2298396723
允许通过手动修改 gui.json 中的 "GUI.OperNameLanguage" 字段强制干员名称显示指定语言。不正确的格式或不受支持的语言不会报错，只是会按默认处理，即跟随MAA。
```
"GUI.OperNameLanguage": "OperNameLanguageForce.en-us"
```

当前问题：小工具-干员识别，这里有单独的逻辑，并不直接使用软件设置，而是读取设置文件，自行解读其含义，相当于几乎不使用 SettingsViewModel.cs 中的方法。这是历史遗留问题吗，是否可以将其改为使用统一的方法？印象里两周前的测试中可以这样修改，但当时没有这样做。
先按原逻辑改改语法凑合用了（）

buff选项的修复针对的是 SSS_TowerMountains_SkalterEyjalterGoldenglowSilverash+Typhon.json，其中buff选项填了两个，不符合规则，按照规则只填写一个的话可以由MAA在开局时自动选取。