### PR TITLE
fix: 使用匹配后偏移代替每日任务

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -3051,8 +3051,9 @@
         "maskRange": [1, 255]
     },
     "DailyTask": {
-        "action": "ClickSelf",
-        "roi": [400, 0, 880, 100],
+        "baseTask": "WeeklyTask",
+        "template": "WeeklyTask",
+        "rectMove": [-150, 0, 100, 30],
         "next": ["ReceiveAward", "WeeklyTask"]
     },
     "WeeklyTask": {


### PR DESCRIPTION
- close #10369

模板图保留以防万一