### PR TITLE
chore: bump maa-cli to 0.4.12

### DIFF
--- a/docs/en-us/manual/cli/faq.md
+++ b/docs/en-us/manual/cli/faq.md
@@ -13,13 +13,3 @@ Due to the limitation of [Directories](https://github.com/dirs-dev/directories-r
 mkdir -p "$HOME/.config/maa"
 ln -s "$HOME/.config/maa" "$(maa dir config)"
 ```
-
-## 2. Strange logs appear during running, how to disable them?
-
-When running the maa-cli task, you may see some logs that look like this:
-
-```plaintext
-[INFO] ... /fastdeploy/runtime.cc(544)::Init Runtime initialized with Backend::ORT in Device::CPU.
-```
-
-This log is output by `fastdeploy`, which is a dependency of MaaCore. For the officially compiled MaaCore, this log cannot be closed. However, if you are using a package manager to install maa-cli, you can try installing the package manager's version of MaaCore which uses a newer version of `fastdeploy` without logs enabled by default.

--- a/docs/ja-jp/manual/cli/faq.md
+++ b/docs/ja-jp/manual/cli/faq.md
@@ -17,17 +17,3 @@ This page is outdated and maybe still in Simplified Chinese. Translation is need
 mkdir -p "$HOME/.config/maa"
 ln -s "$HOME/.config/maa" "$(maa dir config)"
 ```
-
-## 2. 运行过程中出现奇怪日志，如何关闭？
-
-MaaCore 的依赖 `fastdeploy` 会输出一些日志，因此你在运行 maa-cli 时可能会看到类似于下面的日志：
-
-```plaintext
-[INFO] ... /fastdeploy/runtime.cc(544)::Init Runtime initialized with Backend::ORT in Device::CPU.`
-```
-
-这个日志是由 `fastdeploy` 输出的，对于官方预编译的 MaaCore，这个日志无法关闭。但是如果你是使用包管理器安装的 maa-cli，你可以尝试安装包管理器提供的 MaaCore。包管理器提供的 MaaCore 使用了较新版本的 `fastdeploy`，其日志默认是关闭的。
-
-## 3. 在 macOS 下使用 maa-cli 启动的 PlayCover 游戏客户端，无法代理作战且肉鸽无法结算
-
-由于未知原因，通过终端启动的 PlayCover 游戏客户端无法代理作战，且肉鸽无法结算。但是该状况仅限于通过终端运行的 maa-cli。因此如果你是在终端交互使用，那么你可能需要手动启动游戏。如果你是通过 cron 等方式运行 maa-cli，那么该问题不会影响你的使用。

--- a/docs/ko-kr/manual/cli/faq.md
+++ b/docs/ko-kr/manual/cli/faq.md
@@ -13,17 +13,3 @@ Rust 라이브러리 [Directories](https://github.com/dirs-dev/directories-rs/)�
 mkdir -p "$HOME/.config/maa"
 ln -s "$HOME/.config/maa" "$(maa dir config)"
 ```
-
-## 2. 실행 중 이상한 로그가 나타납니다. 이걸 어떻게 끌 수 있나요?
-
-MaaCore의 종속성인 `fastdeploy`가 일부 로그를 출력합니다. 따라서 maa-cli를 실행할 때 다음과 같은 로그를 볼 수 있습니다:
-
-```plaintext
-[INFO] ... /fastdeploy/runtime.cc(544)::Init Runtime initialized with Backend::ORT in Device::CPU.`
-```
-
-이 로그는 `fastdeploy`에서 출력하는 것으로, 공식적으로 사전 컴파일된 MaaCore에서는 이 로그를 끌 수 없습니다. 그러나 패키지 관리자를 통해 설치된 maa-cli를 사용하는 경우, 패키지 관리자가 제공하는 MaaCore를 설치해보세요. 패키지 관리자가 제공하는 MaaCore는 최신 버전의 `fastdeploy`를 사용하며, 기본적으로 로그가 비활성화되어 있습니다.
-
-## 3. macOS에서 maa-cli로 실행한 PlayCover 게임 클라이언트가 전투를 대리할 수 없고 로그라이크 모드를 완료할 수 없습니다
-
-알 수 없는 이유로, 터미널을 통해 실행한 PlayCover 게임 클라이언트는 전투를 대리할 수 없고 로그라이크 모드를 완료할 수 없습니다. 하지만 이 문제는 터미널에서 실행한 maa-cli에만 해당됩니다. 터미널에서 상호작용할 때는 게임을 수동으로 실행해야 할 수도 있습니다. cron 등의 방법으로 maa-cli를 실행하는 경우, 이 문제는 영향을 미치지 않습니다.

--- a/docs/zh-cn/manual/cli/faq.md
+++ b/docs/zh-cn/manual/cli/faq.md
@@ -13,17 +13,3 @@ icon: ph:question-fill
 mkdir -p "$HOME/.config/maa"
 ln -s "$HOME/.config/maa" "$(maa dir config)"
 ```
-
-## 2. 运行过程中出现奇怪日志，如何关闭？
-
-MaaCore 的依赖 `fastdeploy` 会输出一些日志，因此你在运行 maa-cli 时可能会看到类似于下面的日志：
-
-```plaintext
-[INFO] ... /fastdeploy/runtime.cc(544)::Init Runtime initialized with Backend::ORT in Device::CPU.`
-```
-
-这个日志是由 `fastdeploy` 输出的，对于官方预编译的 MaaCore，这个日志无法关闭。但是如果你是使用包管理器安装的 maa-cli，你可以尝试安装包管理器提供的 MaaCore。包管理器提供的 MaaCore 使用了较新版本的 `fastdeploy`，其日志默认是关闭的。
-
-## 3. 在 macOS 下使用 maa-cli 启动的 PlayCover 游戏客户端，无法代理作战且肉鸽无法结算
-
-由于未知原因，通过终端启动的 PlayCover 游戏客户端无法代理作战，且肉鸽无法结算。但是该状况仅限于通过终端运行的 maa-cli。因此如果你是在终端交互使用，那么你可能需要手动启动游戏。如果你是通过 cron 等方式运行 maa-cli，那么该问题不会影响你的使用。

--- a/docs/zh-tw/manual/cli/faq.md
+++ b/docs/zh-tw/manual/cli/faq.md
@@ -17,17 +17,3 @@ This page is outdated and maybe still in Simplified Chinese. Translation is need
 mkdir -p "$HOME/.config/maa"
 ln -s "$HOME/.config/maa" "$(maa dir config)"
 ```
-
-## 2. 运行过程中出现奇怪日志，如何关闭？
-
-MaaCore 的依赖 `fastdeploy` 会输出一些日志，因此你在运行 maa-cli 时可能会看到类似于下面的日志：
-
-```plaintext
-[INFO] ... /fastdeploy/runtime.cc(544)::Init Runtime initialized with Backend::ORT in Device::CPU.`
-```
-
-这个日志是由 `fastdeploy` 输出的，对于官方预编译的 MaaCore，这个日志无法关闭。但是如果你是使用包管理器安装的 maa-cli，你可以尝试安装包管理器提供的 MaaCore。包管理器提供的 MaaCore 使用了较新版本的 `fastdeploy`，其日志默认是关闭的。
-
-## 3. 在 macOS 下使用 maa-cli 启动的 PlayCover 游戏客户端，无法代理作战且肉鸽无法结算
-
-由于未知原因，通过终端启动的 PlayCover 游戏客户端无法代理作战，且肉鸽无法结算。但是该状况仅限于通过终端运行的 maa-cli。因此如果你是在终端交互使用，那么你可能需要手动启动游戏。如果你是通过 cron 等方式运行 maa-cli，那么该问题不会影响你的使用。


### PR DESCRIPTION
Bump maa-cli to 0.4.12.

See [maa-cli changelog](https://github.com/MaaAssistantArknights/maa-cli/releases/tag/v0.4.12) for more details.