### PR TITLE
fix: Reclamation for YostarJP

### DIFF
--- a/resource/global/YoStarJP/resource/tasks.json
+++ b/resource/global/YoStarJP/resource/tasks.json
@@ -2814,7 +2814,7 @@
         "text": ["作戦", "開始"]
     },
     "Tales@RA@ConfirmToLoadSave": {
-        "text": ["確定"]
+        "text": ["確認"]
     },
     "Tales@RA@EnterNode": {
         "text": ["行動", "開始"]
@@ -2842,6 +2842,7 @@
         "text": ["開", "始"]
     },
     "Tales@RA@ResourceGained": {
-        "text": ["空白", "箇所", "タップ", "続ける"]
+        "text": ["空白", "箇所", "タップ", "続ける"],
+        "roi": [480, 444, 320, 48]
     }
 }

--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -11805,7 +11805,7 @@
         "doc": "生息点数达到上限, 点击右下角 Dots",
         "baseTask": "Tales@RA@Dots",
         "template": "Tales@RA@Dots.png",
-        "next": ["Tales@RA@PIS-ProsperityReachLimit-LoadSave"]
+        "next": ["Tales@RA@PIS-ProsperityReachLimit-LoadSave", "#self"]
     },
     "Tales@RA@PIS-ProsperityReachLimit-LoadSave": {
         "doc": "生息点数达到上限, 点击右下角读取存档图标, 选择从右往左第二个存档或仅存的存档, 点击 <点击确认> 文字位置确认读取存档",

--- a/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
@@ -2534,11 +2534,20 @@ namespace MaaWpfGui.ViewModels.UI
             }
         }
 
-        private string _reclamationToolToCraft = ConfigurationHelper.GetValue(ConfigurationKeys.ReclamationToolToCraft, "荧光棒");
+        private string _reclamationToolToCraft = ConfigurationHelper.GetValue(ConfigurationKeys.ReclamationToolToCraft, string.Empty);
 
         public string ReclamationToolToCraft
         {
-            get => _reclamationToolToCraft;
+            get
+            {
+                if (string.IsNullOrEmpty(_reclamationToolToCraft))
+                {
+                    return LocalizationHelper.GetString("ReclamationToolToCraftPlaceholder", _clientLanguageMapper[_clientType]);
+                }
+
+                return _reclamationToolToCraft;
+            }
+
             set
             {
                 SetAndNotify(ref _reclamationToolToCraft, value);


### PR DESCRIPTION
三个文件改了四个问题
 - task.json(JP) - Tales@RA@ConfirmToLoadSave
   用词错误，必须修正
- task.json(JP) - Tales@RA@ResourceGained
   roi区域较小，需要扩大，其他服务器可能也需要查看此问题
- task.json Tales@RA@PIS-ProsperityReachLimit-Dots
   如果读档日期出现特定对话，如25天的固定敌袭，可以这样跳过对话
- SettingsViewModel.cs
  当前版本代码下，必须为各个客户端输入对应语言的目标道具才能工作。此提交中的代码将导致无法置空该文本框，可能需要改进