### PR TITLE
ci: 当仅 version.json 的 last_updated 有变动时，回退对应服务器所有资源文件改动

### DIFF
--- a/.github/workflows/res-update-game.yml
+++ b/.github/workflows/res-update-game.yml
@@ -178,51 +178,14 @@ jobs:
         with:
           args: -w ${{ steps.task_sorting.outputs.gitdiff }}
 
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          check-latest: true
       - name: Check if only sorted and Templates
         id: check_sorted_templates
-        run: |
-          git status
-
-          $gitdiff = git diff --numstat HEAD 2>$null | findstr -i resource
-          if ($LASTEXITCODE -ne 0) {
-            Write-Output "no diff"
-            exit 0
-          }
-
-          Write-Output $gitdiff
-
-          $diff = $false
-          $hasPng = $false
-
-          $diffLines = $gitdiff -split "`n"
-
-          foreach ($line in $diffLines) {
-              $parts = $line -split "\s+"
-              $filePath = $parts[2]
-              $firstNumber = $parts[0]
-              $secondNumber = $parts[1]
-
-              if ($filePath -match "\.png$") {
-                $hasPng = $true
-              }
-
-              if ($firstNumber -gt 1 -or $firstNumber -ne $secondNumber) {
-                $diff = $true
-              }
-
-              if ($hasPng -and $diff) {
-                break
-              }
-          }
-
-          $changes = $hasPng -or $diff
-
-          Write-Output "diff: $diff"
-          Write-Output "hasPng: $hasPng"
-          Write-Output "changes: $changes"
-
-          Write-Output "contains_png=$hasPng" >> $env:GITHUB_OUTPUT
-          Write-Output "changes=$changes" >> $env:GITHUB_OUTPUT
+        run: node tools/ResourceUpdateValidator/index.mjs
 
       - name: Setup python
         if: steps.check_sorted_templates.outputs.contains_png == 'True'

--- a/tools/ResourceUpdateValidator/index.mjs
+++ b/tools/ResourceUpdateValidator/index.mjs
@@ -32,13 +32,13 @@ for (const [server, list] of Object.entries(listPerServer)) {
         if (path.posix.extname(pathname) === ".png") {
             localHasPngDiff = true;
             localDiff = true;
-            log(`Valid PNG changed: ${pathname}, no more check against the list.`);
-            break;
+            log(`PNG changed: ${pathname}, valid.`);
+            continue;
         }
         if (added > 1 || added !== deleted) {
-            log(`Valid file changed: ${pathname}, no more check against the list.`);
+            log(`File changed: ${pathname}, valid.`);
             localDiff = true;
-            break;
+            continue;
         }
         if (path.posix.basename(pathname) === "version.json") {
             const { stdout: versionDiff } = await exec(`git diff --unified=0 HEAD -- ${pathname}`);
@@ -49,10 +49,11 @@ for (const [server, list] of Object.entries(listPerServer)) {
                 && deletedLine.length === 1 && /^\s*"last_updated":/.test(deletedLine[0])
             ) {
                 log(`Version-only changed: ${pathname}, not valid.`);
+                continue;
             } else {
-                log(`Valid file changed: ${pathname}, no more check against the list.`);
+                log(`File changed: ${pathname}, valid.`);
                 localDiff = true;
-                break;
+                continue;
             }
         }
     }

--- a/tools/ResourceUpdateValidator/index.mjs
+++ b/tools/ResourceUpdateValidator/index.mjs
@@ -1,0 +1,75 @@
+import fs from "node:fs";
+import path from "node:path";
+import { exec as child_process_exec } from "node:child_process";
+import { promisify } from "node:util";
+
+const exec = promisify(child_process_exec);
+const log = (...args) => console.info(new Date().toLocaleString("zh-Hans-CN"), ...args);
+
+log("Check git status...");
+log(`git status:\n${(await exec("git status")).stdout}`);
+log("Start to diff the file changes...");
+const { stdout } = await exec("git diff --numstat HEAD");
+log(`Diff:\n${stdout}`);
+let diff = false;
+let hasPngDiff = false;
+const listPerServer = {};
+const mainlandChina = Symbol("mainlandChina");
+for (const line of stdout.split(/\r*\n+/)) {
+    const [added, deleted, pathname] = line.split(/\s+/);
+    const server = pathname.startsWith("resource/global/") ? pathname.split("/")[2] : mainlandChina;
+    if (!Reflect.has(listPerServer, server)) {
+        listPerServer[server] = [];
+    }
+    listPerServer[server].push([added, deleted, pathname]);
+}
+log("Parsed diff:", listPerServer);
+for (const [server, list] of Object.entries(listPerServer)) {
+    log(`Server: ${server}`);
+    let localDiff = false;
+    let localHasPngDiff = false;
+    for (const [added, deleted, pathname] of list) {
+        if (path.extname(pathname) === ".png") {
+            localHasPngDiff = true;
+            localDiff = true;
+            log(`Valid PNG changed: ${pathname}, no more check against the list.`);
+            break;
+        }
+        if (added > 1 || added !== deleted) {
+            log(`Valid file changed: ${pathname}, no more check against the list.`);
+            localDiff = true;
+            break;
+        }
+        if (path.basename(pathname) === "version.json") {
+            const { stdout: versionDiff } = await exec(`git diff --unified=0 HEAD -- ${pathname}`);
+            const addedLine = versionDiff.split(/\r*\n+/).filter((line) => line.startsWith("+") && !line.startsWith("+++ "));
+            const deletedLine = versionDiff.split(/\r*\n+/).filter((line) => line.startsWith("-") && !line.startsWith("--- "));
+            if (
+                addedLine.length === 1 && /^\s*"last_updated":/.test(addedLine[0])
+                && deletedLine.length === 1 && /^\s*"last_updated":/.test(deletedLine[0])
+            ) {
+                log(`Version-only changed: ${pathname}, not valid.`);
+            } else {
+                log(`Valid file changed: ${pathname}, no more check against the list.`);
+                localDiff = true;
+                break;
+            }
+        }
+    }
+    if (localHasPngDiff) {
+        hasPngDiff = true;
+    }
+    if (localDiff) {
+        diff = true;
+    } else {
+        log(`No valid changes found in server: ${server}`);
+        log("Revert the file changes...");
+        for (const [, , pathname] of list) {
+            await exec(`git checkout HEAD -- ${pathname}`);
+        }
+    }
+    log("Server check result:", { localHasPngDiff, localDiff });
+}
+log("Diff check result:", { hasPngDiff, diff });
+await fs.promises.appendFile(process.env.GITHUB_OUTPUT, `contains_png=${hasPngDiff}\nchanges=${diff}\n`, { encoding: "utf-8" });
+log(`GITHUB_OUTPUT:\n${await fs.promises.readFile(process.env.GITHUB_OUTPUT, { encoding: "utf-8" })}`);

--- a/tools/ResourceUpdateValidator/index.mjs
+++ b/tools/ResourceUpdateValidator/index.mjs
@@ -29,7 +29,7 @@ for (const [server, list] of Object.entries(listPerServer)) {
     let localDiff = false;
     let localHasPngDiff = false;
     for (const [added, deleted, pathname] of list) {
-        if (path.extname(pathname) === ".png") {
+        if (path.posix.extname(pathname) === ".png") {
             localHasPngDiff = true;
             localDiff = true;
             log(`Valid PNG changed: ${pathname}, no more check against the list.`);
@@ -40,7 +40,7 @@ for (const [server, list] of Object.entries(listPerServer)) {
             localDiff = true;
             break;
         }
-        if (path.basename(pathname) === "version.json") {
+        if (path.posix.basename(pathname) === "version.json") {
             const { stdout: versionDiff } = await exec(`git diff --unified=0 HEAD -- ${pathname}`);
             const addedLine = versionDiff.split(/\r*\n+/).filter((line) => line.startsWith("+") && !line.startsWith("+++ "));
             const deletedLine = versionDiff.split(/\r*\n+/).filter((line) => line.startsWith("-") && !line.startsWith("--- "));


### PR DESCRIPTION
这个.mjs文件是一个用于自动化代码审查和版本控制的脚本。

脚本的核心功能是分析Git的差异输出，识别出哪些文件发生了变化，并根据变化类型（如是否为PNG文件或仅 version.json 的 last_updated 有变动的更新）来决定是否保留这些变更。对于不符合特定条件的变更，脚本会自动恢复到变更前的状态，确保代码库的一致性和规范性。

此外，脚本还使用了环境变量`GITHUB_OUTPUT`来记录分析结果，包括是否包含PNG文件的变更和是否有有效的文件变更。这些信息可以用于后续的自动化流程，如CI/CD管道中的决策步骤。

总体而言，这个脚本通过自动化和规范化的方式，提高了代码审查的效率和准确性，确保了代码库的健康和稳定。