### PR TITLE
fix: 肉鸽重新编队应在首页执行

### DIFF
--- a/src/MaaCore/Task/Roguelike/RoguelikeFormationTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeFormationTaskPlugin.cpp
@@ -95,19 +95,13 @@ void asst::RoguelikeFormationTaskPlugin::clear_and_reselect()
     // 清空并退出游戏会自动按等级重新排序
     ProcessTask(*this, { "RoguelikeQuickFormationClearAndReselect" }).run();
 
-    m_last_detected_oper_names.clear();
-    oper_list.clear();
-
-    if (cur_page > 1) {
-        swipe_to_first_page(); 
+    scan_oper();
+    // 如果新识别出的干员页数没有之前的多，说明没在最左侧开始识别
+    if (max_page > cur_page) {
+        cur_page = max_page;
+        swipe_to_first_page();
+        scan_oper();
     }
-
-    while (analyze()) { // 返回true说明新增了干员，可能还有下一页
-        ProcessTask(*this, { "RoguelikeRecruitOperListSlowlySwipeToTheRight" }).run();
-        cur_page++;
-    }
-
-    cur_page--; // 最后多划了一下，退回最后一页的页码
     max_page = cur_page;
 
     // 将oper_list的每个干员重置为未选择
@@ -226,4 +220,18 @@ void asst::RoguelikeFormationTaskPlugin::swipe_to_first_page()
     }
     ProcessTask(*this, { "SleepAfterOperListQuickSwipe" }).run();
     cur_page = 1;
+}
+
+void asst::RoguelikeFormationTaskPlugin::scan_oper()
+{
+    m_last_detected_oper_names.clear();
+    oper_list.clear();
+    cur_page = 1;
+
+    while (analyze()) { // 返回true说明新增了干员，可能还有下一页
+        ProcessTask(*this, { "RoguelikeRecruitOperListSlowlySwipeToTheRight" }).run();
+        cur_page++;
+    }
+
+    cur_page--; // 最后多划了一下，退回最后一页的页码
 }

--- a/src/MaaCore/Task/Roguelike/RoguelikeFormationTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeFormationTaskPlugin.cpp
@@ -97,7 +97,7 @@ void asst::RoguelikeFormationTaskPlugin::clear_and_reselect()
 
     m_last_detected_oper_names.clear();
     oper_list.clear();
-    cur_page = 1;
+    swipe_to_first_page();
 
     while (analyze()) { // 返回true说明新增了干员，可能还有下一页
         ProcessTask(*this, { "RoguelikeRecruitOperListSlowlySwipeToTheRight" }).run();
@@ -199,11 +199,7 @@ bool asst::RoguelikeFormationTaskPlugin::select(RoguelikeFormationImageAnalyzer:
         Log.info(__FUNCTION__, "swipe from page", cur_page, "to page", oper.page);
         // 在最大页码时（当总页数>=2），从右往左划可能会有对不齐的问题，直接划动到底
         if ((cur_page > oper.page && max_page >= 2 && cur_page == max_page) || max_page == 1) {
-            for (; cur_page > 0; --cur_page) { // 多划一次到不存在的第0页
-                ProcessTask(*this, { "RoguelikeRecruitOperListSwipeToTheLeft" }).run();
-            }
-            ProcessTask(*this, { "SleepAfterOperListQuickSwipe" }).run();
-            cur_page = 1;
+            swipe_to_first_page();
         }
         // 中间页面划动姑且当成是相对准确的
         while (cur_page > oper.page) {
@@ -218,4 +214,13 @@ bool asst::RoguelikeFormationTaskPlugin::select(RoguelikeFormationImageAnalyzer:
     Log.info(__FUNCTION__, "select oper", oper.name, "on page", cur_page);
     ctrler()->click(oper.rect);
     return true;
+}
+
+void asst::RoguelikeFormationTaskPlugin::swipe_to_first_page()
+{
+    for (; cur_page > 0; --cur_page) { // 多划一次到不存在的第0页
+        ProcessTask(*this, { "RoguelikeRecruitOperListSwipeToTheLeft" }).run();
+    }
+    ProcessTask(*this, { "SleepAfterOperListQuickSwipe" }).run();
+    cur_page = 1;
 }

--- a/src/MaaCore/Task/Roguelike/RoguelikeFormationTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeFormationTaskPlugin.cpp
@@ -97,7 +97,10 @@ void asst::RoguelikeFormationTaskPlugin::clear_and_reselect()
 
     m_last_detected_oper_names.clear();
     oper_list.clear();
-    swipe_to_first_page();
+
+    if (cur_page > 1) {
+        swipe_to_first_page(); 
+    }
 
     while (analyze()) { // 返回true说明新增了干员，可能还有下一页
         ProcessTask(*this, { "RoguelikeRecruitOperListSlowlySwipeToTheRight" }).run();

--- a/src/MaaCore/Task/Roguelike/RoguelikeFormationTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/RoguelikeFormationTaskPlugin.h
@@ -23,6 +23,7 @@ namespace asst
         void clear_and_reselect();
         bool analyze();
         bool select(RoguelikeFormationImageAnalyzer::FormationOper oper);
+        void swipe_to_first_page();
 
     private:
         int cur_page = 0;

--- a/src/MaaCore/Task/Roguelike/RoguelikeFormationTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/RoguelikeFormationTaskPlugin.h
@@ -24,10 +24,11 @@ namespace asst
         bool analyze();
         bool select(RoguelikeFormationImageAnalyzer::FormationOper oper);
         void swipe_to_first_page();
+        void scan_oper();
 
     private:
         int cur_page = 1;
-        int max_page = 0;
+        int max_page = 1;
         std::vector<RoguelikeFormationImageAnalyzer::FormationOper> oper_list;
         std::vector<std::string> m_last_detected_oper_names; // 上一页识别到的干员
     };

--- a/src/MaaCore/Task/Roguelike/RoguelikeFormationTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/RoguelikeFormationTaskPlugin.h
@@ -26,7 +26,7 @@ namespace asst
         void swipe_to_first_page();
 
     private:
-        int cur_page = 0;
+        int cur_page = 1;
         int max_page = 0;
         std::vector<RoguelikeFormationImageAnalyzer::FormationOper> oper_list;
         std::vector<std::string> m_last_detected_oper_names; // 上一页识别到的干员


### PR DESCRIPTION
#9510
正常来说 cur_page 变量都是正确的，可以作为判断依据，既不用每次都划几下也不用识别左侧是否还有干员。