### PR TITLE
fix: convert a Symbol value to a string

### DIFF
--- a/tools/ResourceUpdateValidator/index.mjs
+++ b/tools/ResourceUpdateValidator/index.mjs
@@ -64,7 +64,7 @@ for (const [server, list] of [...Object.entries(listPerServer), ...Object.getOwn
     if (localDiff) {
         diff = true;
     } else {
-        log(serverName, `No valid changes found in server: ${server}`);
+        log(serverName, `No valid changes found in server: ${typeof server === "symbol" ? server.description : server}`);
         log(serverName, "Revert the file changes...");
         for (const [, , pathname] of list) {
             await exec(`git checkout HEAD -- ${pathname}`);


### PR DESCRIPTION
https://github.com/MaaAssistantArknights/MaaAssistantArknights/commit/9d96081f47ea2a10be08f745f9d80baec16b95b4#commitcomment-146287940

This is just a patch fix, why is mainlandChina a Symbol anyway when the others don't seem to be one?
```
[2024/9/5 14:03:03] Parsed diff: {
  YoStarEN: [ [ '1', '1', 'resource/global/YoStarEN/resource/version.json' ] ],
  YoStarJP: [ [ '1', '1', 'resource/global/YoStarJP/resource/version.json' ] ],
  YoStarKR: [ [ '1', '1', 'resource/global/YoStarKR/resource/version.json' ] ],
  txwy: [ [ '1', '1', 'resource/global/txwy/resource/version.json' ] ],
  [Symbol(mainlandChina)]: [ [ '1', '1', 'resource/version.json' ] ]
}
```