### PR TITLE
ci: create macOS runtime files in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,7 +382,7 @@ jobs:
           ln -vs libopencv_world4*.dylib libopencv_world4.dylib
           cp -vr ../../resource .
           cd .. || exit 1
-          zip -r "$name.zip" "$name"
+          zip -yrX9 "$name.zip" "$name"
 
       - name: Upload MAA runtime to Github
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -372,6 +372,24 @@ jobs:
             lipo -create install-arm64/$LIB_NAME install-x86_64/$LIB_NAME -output build/$LIB_NAME
           done
 
+      - name: Archive Runtime Files
+        run: |
+          mkdir runtime && cd runtime
+          name='MAA-${{ needs.meta.outputs.tag }}-macos-runtime-universal'
+          mkdir "$name" && cd "$name"
+          cp -v ../../build/*.dylib .
+          ln -vs libonnxruntime*.dylib libonnxruntime.dylib
+          ln -vs libopencv_world4*.dylib libopencv_world4.dylib
+          cp -vr ../../resource .
+          cd .. || exit 1
+          zip -r "$name.zip" "$name"
+
+      - name: Upload MAA runtime to Github
+        uses: actions/upload-artifact@v4
+        with:
+          name: MAA-macos-runtime-universal
+          path: runtime/MAA-${{ needs.meta.outputs.tag }}-macos-runtime-universal.zip
+
       - name: Build XCFramework
         run: |
           xcodebuild -create-xcframework -library libMaaCore.dylib -headers ../include -output MaaCore.xcframework

--- a/.github/workflows/release-ota.yml
+++ b/.github/workflows/release-ota.yml
@@ -166,31 +166,6 @@ jobs:
         run: |
           find ./packages -type f ! \( -name 'MAA-${{ needs.create-tag.outputs.release_tag }}-macos-universal.dmg' -o -name '*.delta' -o -name '*.xml' \) -print -delete
 
-      - name: Unpack the .dmg files for .dylib
-        run: |
-          cd ${{ runner.temp }}
-          mkdir -p macos-runtime-temp
-          echo ::group::Attaching release package...
-          hdiutil attach ${{ github.workspace }}/packages/MAA-${{ needs.create-tag.outputs.release_tag }}-macos-universal.dmg
-          echo ::endgroup::
-          echo ::group::Copying files...
-          cp -v /Volumes/MAA/MAA.app/Contents/Frameworks/*.dylib macos-runtime-temp/
-          cp -vr /Volumes/MAA/MAA.app/Contents/Resources/resource macos-runtime-temp/resource
-          echo ::endgroup::
-          echo ::group::Linking files...
-          libonnxruntime_file=$(basename macos-runtime-temp/libonnxruntime*.dylib)
-          ln -vs $libonnxruntime_file macos-runtime-temp/libonnxruntime.dylib
-          libopencv_world_file=$(basename macos-runtime-temp/libopencv_world*.dylib)
-          ln -vs $libopencv_world_file macos-runtime-temp/libopencv_world4.dylib
-          echo ::endgroup::
-          cd macos-runtime-temp
-          echo ::group::Compressing files...
-          zip -yrX9 ${{ github.workspace }}/packages/MAA-${{ needs.create-tag.outputs.release_tag }}-macos-runtime-universal.zip *
-          echo ::endgroup::
-          echo ::group::Detaching release package...
-          hdiutil detach /Volumes/MAA
-          echo ::endgroup::
-
       - name: Upload to MaaRelease
         uses: svenstaro/upload-release-action@v2
         with:


### PR DESCRIPTION
相比在 OTA workflow 里面靠解包 dmg 来生成 macOS 的 runtime 文件，在 CI 里面直接生成会更好一点。