### PR TITLE
perf: 肉鸽临时招募和极端情况下不招募问题优化

### DIFF
--- a/src/MaaCore/Task/Roguelike/RoguelikeRecruitTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeRecruitTaskPlugin.cpp
@@ -308,7 +308,7 @@ bool asst::RoguelikeRecruitTaskPlugin::_run()
                 }
             }
 
-            // 优先级为0，且非临时招募干员，可能练度不够被忽略（加这个非临时招募条件是因为很多五星干员默认不写优先级会被直接忽略）
+            // 优先级为0，可能练度不够或未适配被忽略
             if (priority <= 0) {
                 continue;
             }

--- a/src/MaaCore/Task/Roguelike/RoguelikeRecruitTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeRecruitTaskPlugin.cpp
@@ -302,6 +302,7 @@ bool asst::RoguelikeRecruitTaskPlugin::_run()
                     }
                     else if (!m_team_complete) {
                         if (!recruit_info.is_key  && !is_temp_recruit) priority -= 1000;
+                        is_temp_recruit = false;
 }
                         //极大幅降低阵容未完备且非临时招募干员的招募优先级
                     }

--- a/src/MaaCore/Task/Roguelike/RoguelikeRecruitTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/RoguelikeRecruitTaskPlugin.h
@@ -11,6 +11,7 @@ struct RoguelikeRecruitInfo
     int priority = 0;   // 招募优先级 (0-1000)
     int page_index = 0; // 所在页码 (用于判断翻页方向)
     bool is_alternate = false; // 是否后备干员 (允许重复招募、划到后备干员时不再往右划动)
+    bool is_temp_recruit = false;   //临时招募干员标记，在阵容未完备时启用
 };
 
 class RoguelikeRecruitTaskPlugin : public AbstractRoguelikeTaskPlugin


### PR DESCRIPTION
给临时招募干员加了个标记，在阵容未完备时启用，现在只有阵容不完备且非临时招募条件招募的优先级才会被大幅降低
优化了部分注释