### PR TITLE
feat: detour ssl certificate

### DIFF
--- a/maadeps-download.py
+++ b/maadeps-download.py
@@ -9,6 +9,9 @@ import platform
 from pathlib import Path
 import shutil
 import http.client
+import ssl
+
+ssl._create_default_https_context = ssl._create_unverified_context
 
 TARGET_TAG = "2024-08-17"
 # FIXME: temporarily hold maadeps version for windows package


### PR DESCRIPTION
> [!warning]
存在未确认的链接，请谨慎访问。
There are unconfirmed links, please visit with caution.

When first time ```MAA_DEBUG=1 ./tools/build_macos_universal.zsh```, I got this kind of error message.

```
➜  MaaAssistantArknights git:(dev) MAA_DEBUG=1 ./tools/build_macos_universal.zsh
about to download prebuilt dependency libraries for  arm64-osx of 2024-08-17
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/urllib/request.py", line 1348, in do_open
    h.request(req.get_method(), req.selector, req.data, headers,
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/http/client.py", line 1282, in request
    self._send_request(method, url, body, headers, encode_chunked)
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/http/client.py", line 1328, in _send_request
    self.endheaders(body, encode_chunked=encode_chunked)
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/http/client.py", line 1277, in endheaders
    self._send_output(message_body, encode_chunked=encode_chunked)
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/http/client.py", line 1037, in _send_output
    self.send(msg)
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/http/client.py", line 975, in send
    self.connect()
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/http/client.py", line 1454, in connect
    self.sock = self._context.wrap_socket(self.sock,
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/ssl.py", line 513, in wrap_socket
    return self.sslsocket_class._create(
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/ssl.py", line 1071, in _create
    self.do_handshake()
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/ssl.py", line 1342, in do_handshake
    self._sslobj.do_handshake()
ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:997)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/yangjin.cho/Desktop/workspace/MaaAssistantArknights/maadeps-download.py", line 186, in <module>
    main()
  File "/Users/yangjin.cho/Desktop/workspace/MaaAssistantArknights/maadeps-download.py", line 141, in main
    resp = retry_urlopen(req).read()
  File "/Users/yangjin.cho/Desktop/workspace/MaaAssistantArknights/maadeps-download.py", line 89, in retry_urlopen
    resp: http.client.HTTPResponse = urllib.request.urlopen(*args,
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/urllib/request.py", line 216, in urlopen
    return opener.open(url, data, timeout)
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/urllib/request.py", line 519, in open
    response = self._open(req, data)
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/urllib/request.py", line 536, in _open
    result = self._call_chain(self.handle_open, protocol, protocol +
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/urllib/request.py", line 496, in _call_chain
    result = func(*args)
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/urllib/request.py", line 1391, in https_open
    return self.do_open(http.client.HTTPSConnection, req,
  File "/Library/Frameworks/Python.framework/Versions/3.10/lib/python3.10/urllib/request.py", line 1351, in do_open
    raise URLError(err)
urllib.error.URLError: <urlopen error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:997)>
CMake Error at CMakeLists.txt:28 (include):
  include could not find requested file:

    /Users/yangjin.cho/Desktop/workspace/MaaAssistantArknights/MaaDeps/maadeps.cmake


CMake Error at CMakeLists.txt:87 (find_package):
  By not providing "FindOpenCV.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "OpenCV", but
  CMake did not find one.

  Could not find a package configuration file provided by "OpenCV" with any
  of the following names:

    OpenCVConfig.cmake
    opencv-config.cmake

  Add the installation prefix of "OpenCV" to CMAKE_PREFIX_PATH or set
  "OpenCV_DIR" to a directory containing one of the above files.  If "OpenCV"
  provides a separate development package or SDK, be sure it has been
  installed.


-- Configuring incomplete, errors occurred!
ninja: error: loading 'build.ninja': No such file or directory
CMake Error: Not a file: /Users/yangjin.cho/Desktop/workspace/MaaAssistantArknights/build-arm64/cmake_install.cmake
CMake Error: Error processing file: /Users/yangjin.cho/Desktop/workspace/MaaAssistantArknights/build-arm64/cmake_install.cmake
ls: install-arm64: No such file or directory
cp: build-arm64/compile_commands.json: No such file or directory
error: the path does not point to a valid library: /Users/yangjin.cho/Desktop/workspace/MaaAssistantArknights/build/libMaaCore.dylib
error: the path does not point to a valid library: /Users/yangjin.cho/Desktop/workspace/MaaAssistantArknights/build/libfastdeploy_ppocr.dylib
./tools/build_macos_universal.zsh:46: no matches found: libonnxruntime.*.dylib
./tools/build_macos_universal.zsh:47: no matches found: libopencv*.dylib
./tools/build_macos_universal.zsh:48: no matches found: *.dylib
```

So I've tracked down this error, find out that `maadeps-download.py` is making error with ssl certificate i guess.

My env: macbook pro 2020 13inch, macOS 14.5, M1 
I've already made discussion with this problem earlier (https://github.com/orgs/MaaAssistantArknights/discussions/8771), so if you guys don't mind, please consider this pull request.

+ after adding this line the script worked well.

```
➜  MaaAssistantArknights git:(dev) MAA_DEBUG=1 ./tools/build_macos_universal.zsh
about to download prebuilt dependency libraries for  arm64-osx of 2024-08-17
found assets:
    MaaDeps-arm64-osx-devel.tar.xz
    MaaDeps-arm64-osx-runtime.tar.xz
downloading from https://github.com/MaaAssistantArknights/MaaDeps/releases/download/2024-08-17/MaaDeps-arm64-osx-devel.tar.xz
extracting MaaDeps-arm64-osx-devel.tar.xz
downloading from https://github.com/MaaAssistantArknights/MaaDeps/releases/download/2024-08-17/MaaDeps-arm64-osx-runtime.tar.xz
extracting MaaDeps-arm64-osx-runtime.tar.xz
maadeps_triplet_system: osx
maadeps_triplet_arch: arm64
-- Use autodetected MAADEPS_TRIPLET: maa-arm64-osx, override it if not correct.
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE
-- Found TIFF: /Users/yangjin.cho/Desktop/workspace/MaaAssistantArknights/MaaDeps/vcpkg/installed/maa-arm64-osx/lib/libtiff.a (found version "4.6.0")
-- Found OpenCV: /Users/yangjin.cho/Desktop/workspace/MaaAssistantArknights/MaaDeps/vcpkg/installed/maa-arm64-osx (found version "4.8.0") found components: core imgproc imgcodecs videoio
-- Found ZLIB: /Users/yangjin.cho/Desktop/workspace/MaaAssistantArknights/MaaDeps/vcpkg/installed/maa-arm64-osx/lib/libz.a (found version "1.3.1")
-- Found CURL: /Users/yangjin.cho/Desktop/workspace/MaaAssistantArknights/MaaDeps/vcpkg/installed/maa-arm64-osx/share/curl/CURLConfig.cmake (found version "8.8.0-DEV")
-- Found Git: /usr/bin/git (found version "2.39.3 (Apple Git-146)")
-- MAA_VERSION=a99c9006584ab29a79e8f7670805cff60e96a942
-- Configuring done (0.8s)
-- Generating done (0.0s)
-- Build files have been written to: /Users/yangjin.cho/Desktop/workspace/MaaAssistantArknights/build-arm64
[164/164] Linking CXX shared library libMaaCore.dylib
ld: warning: ignoring duplicate libraries: '/Users/yangjin.cho/Desktop/workspace/MaaAssistantArknights/MaaDeps/vcpkg/installed/maa-arm64-osx/lib/libz.a'
-- Install configuration: "Debug"
-- Installing: /Users/yangjin.cho/Desktop/workspace/MaaAssistantArknights/install-arm64/./libMaaCore.dylib
-- Installing: /Users/yangjin.cho/Desktop/workspace/MaaAssistantArknights/install-arm64/./AsstCaller.h
-- Installing: /Users/yangjin.cho/Desktop/workspace/MaaAssistantArknights/install-arm64/./AsstPort.h
-- Up-to-date: /Users/yangjin.cho/Desktop/workspace/MaaAssistantArknights/install-arm64/.
-- Installing: /Users/yangjin.cho/Desktop/workspace/MaaAssistantArknights/install-arm64/./libfastdeploy_ppocr.dylib
-- Installing: /Users/yangjin.cho/Desktop/workspace/MaaAssistantArknights/install-arm64/./libopencv_world4.408.dylib
-- Installing: /Users/yangjin.cho/Desktop/workspace/MaaAssistantArknights/install-arm64/./png
-- Installing: /Users/yangjin.cho/Desktop/workspace/MaaAssistantArknights/install-arm64/./libonnxruntime.1.18.0.dylib
cp: build-arm64/compile_commands.json: No such file or directory
xcframework successfully written out to: /Users/yangjin.cho/Desktop/workspace/MaaAssistantArknights/build/MaaCore.xcframework
xcframework successfully written out to: /Users/yangjin.cho/Desktop/workspace/MaaAssistantArknights/build/fastdeploy_ppocr.xcframework
xcframework successfully written out to: /Users/yangjin.cho/Desktop/workspace/MaaAssistantArknights/build/ONNXRuntime.xcframework
xcframework successfully written out to: /Users/yangjin.cho/Desktop/workspace/MaaAssistantArknights/build/OpenCV.xcframework
```

Thank you. 