### PR TITLE
fix: macOS build script

### DIFF
--- a/tools/build_macos_universal.zsh
+++ b/tools/build_macos_universal.zsh
@@ -1,6 +1,6 @@
 #!/usr/bin/env zsh
 
-arch=$(arch)
+[[ "$(arch)" == "arm64" ]] && arch="arm64" || arch="x86_64"
 basedir=$(dirname "$0")/..
 pushd ${basedir}
 


### PR DESCRIPTION
修复对于 x86_64 CPU 的识别

[skip changelog]