### PR TITLE
docs: 肉鸽文档增加低练版链接

### DIFF
--- a/docs/zh-cn/protocol/integrated-strategy-schema.md
+++ b/docs/zh-cn/protocol/integrated-strategy-schema.md
@@ -28,10 +28,11 @@ icon: ri:game-fill
   - `encounter/collapse.json` 刷坍缩范式模式不期而遇逻辑
 
 ## 衍生开源项目：自动肉鸽的低练适配
+
 - 如果你的练度较低，或是肉鸽的buff树点得很少，或是想用MAA自动肉鸽打低难度刷等级，或是觉得MAA现有的招募逻辑不适合自己的账号，可以尝试使用低练版的文件代替原有文件。
 - 在使用此版本的文件前，请确保您已经详细阅读该项目下的文档和MAA的文档，并充分知晓由此可能带来的安全、资源版本、bug、代码算法漏洞风险。由于低练版的文件和原版不能共存，若使用低练版，请自觉做好数据备份。
 - 该项目的链接如下：
--  [低练版肉鸽（衍生开源项目）](https://github.com/shikakihuso/MAARoguelikeforGreeners) 
+- [低练版肉鸽（衍生开源项目）](https://github.com/shikakihuso/MAARoguelikeforGreeners)
 
 ## 肉鸽第一步——干员招募
 

--- a/docs/zh-cn/protocol/integrated-strategy-schema.md
+++ b/docs/zh-cn/protocol/integrated-strategy-schema.md
@@ -27,6 +27,12 @@ icon: ri:game-fill
   - `autopilot/关卡名_collapse.json` 关卡的作战逻辑（刷坍缩范式模式）
   - `encounter/collapse.json` 刷坍缩范式模式不期而遇逻辑
 
+## 衍生开源项目：自动肉鸽的低练适配
+- 如果你的练度较低，或是肉鸽的buff树点得很少，或是想用MAA自动肉鸽打低难度刷等级，或是觉得MAA现有的招募逻辑不适合自己的账号，可以尝试使用低练版的文件代替原有文件。
+- 在使用此版本的文件前，请确保您已经详细阅读该项目下的文档和MAA的文档，并充分知晓由此可能带来的安全、资源版本、bug、代码算法漏洞风险。由于低练版的文件和原版不能共存，若使用低练版，请自觉做好数据备份。
+- 该项目的链接如下：
+-  [低练版肉鸽（衍生开源项目）](https://github.com/shikakihuso/MAARoguelikeforGreeners) 
+
 ## 肉鸽第一步——干员招募
 
 `resource/roguelike/主题名/recruitment.json` 描述了干员招募的逻辑


### PR DESCRIPTION
本人针对肉鸽写的低练版适配因为针对低练重写了全部招募参数，改动太大并不进主仓库，已经作为一个独立的衍生开源项目按AGPL 3.0协议发布。希望能在MAA肉鸽文档写出给用户一个选择。用户可以选择到低练版的仓库自行下载和替换文件使用。