### PR TITLE
fix: 调整肉鸽 StageTraderRefreshWithDice 任务的 roi 参数

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -7071,7 +7071,7 @@
     "Roguelike@StageTraderRefreshWithDice": {
         "template": "Roguelike@StageTraderRefresh.png",
         "action": "ClickSelf",
-        "roi": [230, 47, 211, 139],
+        "roi": [230, 47, 211, 182],
         "next": [
             "Roguelike@StageTraderRefreshWithDiceConfirm",
             "Roguelike@StageTraderRefreshWithDiceNotAvaiable",


### PR DESCRIPTION
商店页面部分 UI 位置下移后未及时适配，现修复。

原 roi 位置
<img width="824" alt="image" src="https://github.com/user-attachments/assets/9d6503dc-4d79-4884-8280-e733cb3699c0">

修复后 roi 位置
<img width="822" alt="image" src="https://github.com/user-attachments/assets/bbac4409-9bd5-4697-9fe3-7b2a9ed55094">
