### PR TITLE
chore: fix issue-checker macGui regex

### DIFF
--- a/.github/issue-checker.yml
+++ b/.github/issue-checker.yml
@@ -335,7 +335,7 @@ labels:
   # `MacGui`
   - name: MacGui
     content: "client: MacGui"
-    regexes: '(?i)mac(?:book|os|\s*(?:操作系统|系统|电脑|版))|playcover'
+    regexes: '/mac(?:book|os|\s*(?:操作系统|系统|电脑|版))|playcover/i'
     skip-if:
       - skip all
       - skip client


### PR DESCRIPTION
issue-checker uses typescript, or whatever, and does not support mode modifiers.
Luckily, we should be able to do this.

https://github.com/MaaAssistantArknights/issue-checker/blob/08d909e163099974c55f9dda40e45ac668bf91dc/src/main.ts#L942C5-L945C26