### PR TITLE
fix: 为随机借助战功能添加点击确认按钮的步骤

### DIFF
--- a/resource/global/YoStarEN/resource/tasks.json
+++ b/resource/global/YoStarEN/resource/tasks.json
@@ -1973,7 +1973,7 @@
         "text": ["View all Themes", "Themes", "TODO: image of //INTEGRATED STRATEGIES"],
         "roi": [450, 480, 160, 45]
     },
-    "Roguelike@RecruitSupportConfirm": {
+    "RecruitSupportConfirm": {
         "text": ["Recruit support"]
     },
     "Roguelike@StageEncounterOcr": {

--- a/resource/global/YoStarJP/resource/tasks.json
+++ b/resource/global/YoStarJP/resource/tasks.json
@@ -2204,7 +2204,7 @@
         "text": ["全テーマ一覧", "全テ", "TODO: image of //INTEGRATED STRATEGIES"],
         "roi": [450, 480, 160, 45]
     },
-    "Roguelike@RecruitSupportConfirm": {
+    "RecruitSupportConfirm": {
         "text": ["サ.*ート", "招集", "召集"]
     },
     "Roguelike@StageEncounterOcr": {

--- a/resource/global/YoStarKR/resource/tasks.json
+++ b/resource/global/YoStarKR/resource/tasks.json
@@ -1860,7 +1860,7 @@
         "text": ["모든테마보기", "테마", "TODO: image of //INTEGRATED STRATEGIES"],
         "roi": [450, 480, 160, 45]
     },
-    "Roguelike@RecruitSupportConfirm": {
+    "RecruitSupportConfirm": {
         "text": ["지원"]
     },
     "Roguelike@StageEncounterOcr": {

--- a/resource/global/txwy/resource/tasks.json
+++ b/resource/global/txwy/resource/tasks.json
@@ -1591,7 +1591,7 @@
     "Roguelike@IntegratedStrategies": {
         "next": ["Roguelike@IntegratedStrategies", "Roguelike@SelectTheme"]
     },
-    "Roguelike@RecruitSupportConfirm": {
+    "RecruitSupportConfirm": {
         "text": ["招募助戰", "控募助戰", "招蔓訪戰"]
     },
     "Roguelike@SelectTheme": {

--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -4407,7 +4407,7 @@
     "BattleSupportUnitFormationSelect": {
         "action": "ClickSelf",
         "roi": [115, 595, 1165, 75],
-        "next": ["BattleSupportUnitFormationSelect", "Stop"]
+        "next": ["BattleSupportUnitFormationSelect", "RecruitSupportConfirm", "Stop"]
     },
     "BattleQuickFormationCheck": {
         "baseTask": "BattleQuickFormation",
@@ -6700,12 +6700,17 @@
             "Roguelike@RecruitWithoutButton"
         ]
     },
-    "Roguelike@RecruitSupportConfirm": {
+    "RecruitSupportConfirm": {
+        "doc": "招募助战干员后点击确认按钮，注意 <Roguelike@RecruitSupportConfirm> 任务的 roi 变化",
         "algorithm": "OcrDetect",
         "action": "ClickSelf",
         "text": ["招募助战"],
-        "roi": [810, 500, 200, 40],
+        "roi": [960, 740, 300, 80],
         "preDelay": 200
+    },
+    "Roguelike@RecruitSupportConfirm": {
+        "doc": "集成战略模式招募助战干员后点击确认按钮，注意 roi 变化",
+        "roi": [810, 500, 200, 40]
     },
     "Roguelike@RecruitWithoutButton": {
         "algorithm": "JustReturn",


### PR DESCRIPTION
Fixes #10752 

在明日方舟国服最新的版本中，助战功能得到了更新，主要体现在，普通作战选择助战干员后也有了和集成战略开局借助战类似的确认框，且可以选择技能和模组。

这是普通作战
![screenshot_20241010_124422](https://github.com/user-attachments/assets/23996523-e477-42f5-830c-6ece75442130)

这是集成战略
![screenshot_20241010_124635](https://github.com/user-attachments/assets/8782d072-6d7d-412d-8970-08bf43ce4adf)

目前观察到，助战干员会默认选择挂助战时选择的技能和模组。
未来 MAA 的借助战功能应当被重构，实现根据需要自动借助战，自动选择技能和模组，同时可以考虑拓展作业协议，让作业作者们选择刚需模组。
一些细节还有待讨论。

顺带：我不明白为什么要选择 OCR，模版匹配左边那个图标不好吗？