### PR TITLE
fix: EN Babel OCR ROI

### DIFF
--- a/resource/global/YoStarEN/resource/tasks.json
+++ b/resource/global/YoStarEN/resource/tasks.json
@@ -36,7 +36,8 @@
         "text": ["Babel", "open", "event"]
     },
     "BBChapterToBB": {
-        "text": ["Future", "FUTURE", "Gifts", "Gifts"]
+        "text": ["Future", "FUTURE", "Gifts", "Gifts"],
+        "roi": [1000, 589, 209, 131]
     },
     "OD-8": {
         "sub": ["OD-Open"]


### PR DESCRIPTION
This change modifies the OCR bounding box for the EN Babel Event

![image](https://github.com/user-attachments/assets/f4d67305-0756-4648-9d99-891f64087851)
