### PR TITLE
ci: update DirectML to 1.15.2 for Windows

### DIFF
--- a/maadeps-download.py
+++ b/maadeps-download.py
@@ -11,9 +11,9 @@ import shutil
 import http.client
 
 TARGET_TAG = "2024-08-17"
-# FIXME: temporarily hold maadeps version for windows package
+# FIXME: update DirectML to 1.15.2 for Windows
 if platform.system() == "Windows":
-    TARGET_TAG = "2024-05-30"
+    TARGET_TAG = "2024-10-16"
 basedir = Path(__file__).parent
 
 


### PR DESCRIPTION
在 MaaFW 那边遇到了问题是部分 GPU 上 OCR 识别没有结果（甚至包括一些很主流的 N 卡），理论上对其他 onnx 模型也有影响（比如技能识别）

之前用的 DirectML 1.14.x，这个版本有问题（有什么问题呢，我不知道.jpg），微软已经撤包了

MAA 没有收到反馈我觉得可能是因为默认用的 CPU，而且界面上可选，大伙选了 GPU 发现不行又选回来了（？

但这个要更新一下 MaaDeps，流量消耗可能比较大，考虑要不要更新
