### PR TITLE
fix: 公开招募检测 Tag 失败时尝试识别 <继续招募> 按钮

### DIFF
--- a/resource/global/YoStarEN/resource/tasks.json
+++ b/resource/global/YoStarEN/resource/tasks.json
@@ -914,6 +914,9 @@
     "StartRecruit": {
         "text": ["Recruit Now"]
     },
+    "RecruitContinue": {
+        "text": ["Continue", "Recruitment"]
+    },
     "RecruitFlag": {
         "text": ["Recruit"]
     },

--- a/resource/global/YoStarJP/resource/tasks.json
+++ b/resource/global/YoStarJP/resource/tasks.json
@@ -1046,6 +1046,9 @@
     "StartRecruit": {
         "text": ["求人開始"]
     },
+    "RecruitContinue": {
+        "text": ["継続する"]
+    },
     "RecruitFlag": {
         "text": ["公開求人"]
     },

--- a/resource/global/YoStarKR/resource/tasks.json
+++ b/resource/global/YoStarKR/resource/tasks.json
@@ -868,6 +868,9 @@
     "StartRecruit": {
         "text": ["개시"]
     },
+    "RecruitContinue": {
+        "text": ["계속", "모집"]
+    },
     "RecruitFlag": {
         "text": ["공개모집"]
     },

--- a/resource/global/txwy/resource/tasks.json
+++ b/resource/global/txwy/resource/tasks.json
@@ -677,6 +677,9 @@
     "StartRecruit": {
         "text": ["開始招"]
     },
+    "RecruitContinue": {
+        "text": ["繼續招募"]
+    },
     "RecruitFlag": {
         "text": ["公開招募"]
     },

--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -3558,6 +3558,14 @@
         "postDelay_Doc": "招募结束后有一瞬间还是原来的界面，有可能会点到放弃招募然后卡死",
         "next": ["RecruitConfirm@LoadingText", "Recruit@OfflineConfirm", "RecruitFlag"]
     },
+    "RecruitContinue": {
+        "doc": "检测 <继续招募> 按钮并点击",
+        "algorithm": "OcrDetect",
+        "text": ["继续招"],
+        "roi": [675, 470, 450, 50],
+        "action": "ClickSelf",
+        "postDelay": 500
+    },
     "InfrastBegin": {
         "algorithm": "JustReturn",
         "next": [

--- a/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.cpp
@@ -299,6 +299,11 @@ bool asst::AutoRecruitTask::_run()
     return true;
 }
 
+void asst::AutoRecruitTask::click_return_button()
+{
+    ProcessTask(*this, { "RecruitContinue", "Return" }).run();
+}
+
 std::vector<asst::TextRect> asst::AutoRecruitTask::start_recruit_analyze(const cv::Mat& image)
 {
     OCRer start_analyzer(image);

--- a/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.cpp
@@ -355,8 +355,9 @@ bool asst::AutoRecruitTask::recruit_one(const Rect& button)
             info["why"] = "识别错误";
             callback(AsstMsg::SubTaskError, info);
         }
-        m_force_skipped.emplace(slot_index_from_rect(button));
-        ProcessTask(*this, { "RecruitContinue", "Return" }).run();
+        if (!ProcessTask(*this, { "RecruitContinue", "Return" }).run()) {
+            m_force_skipped.emplace(slot_index_from_rect(button));
+        }
         return false;
     }
 

--- a/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.cpp
@@ -351,7 +351,7 @@ bool asst::AutoRecruitTask::recruit_one(const Rect& button)
             callback(AsstMsg::SubTaskError, info);
         }
         m_force_skipped.emplace(slot_index_from_rect(button));
-        click_return_button();
+        ProcessTask(*this, { "RecruitContinue", "Return" }).run();
         return false;
     }
 

--- a/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.h
+++ b/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.h
@@ -36,6 +36,7 @@ namespace asst
 
     protected:
         virtual bool _run() override;
+        virtual void click_return_button() override;
 
         bool is_calc_only_task() { return m_max_times <= 0 && m_confirm_level.empty(); }
         std::optional<Rect> try_get_start_button(const cv::Mat&);


### PR DESCRIPTION
Fixes #10749

不太懂是不是应该这么改，等学姐看看。
我的理解是如果 MAA 因为什么延迟抽风的原因，点格子的时候点进了 <停止招募> 就退出来。

实际上开始招募按钮的 Task 后面已经有 500ms 的 postDelay 了，所以可能并不是这个问题。
<img width="894" alt="image" src="https://github.com/user-attachments/assets/ff2f94d9-e45e-4562-abc0-2438912e6294">

roi 设置如下。
<img width="667" alt="image" src="https://github.com/user-attachments/assets/e8d9b6f3-b7d8-4c03-bf71-9fe72f6312dd">

等学姐确认之后再考虑适配国际服。