### PR TITLE
fix: YostarKR add ocrReplace on RecruitSupportConfirm

### DIFF
--- a/resource/global/YoStarKR/resource/tasks.json
+++ b/resource/global/YoStarKR/resource/tasks.json
@@ -1273,7 +1273,8 @@
         "text": ["생존", "연산"]
     },
     "RecruitSupportConfirm": {
-        "text": ["지원"]
+        "ocrReplace": [[".?(원|운)유.?", "지원유닛"]],
+        "text": ["지원", "유닛"]
     },
     "RoguelikeChooseSupportBtnOcr": {
         "text": ["지원"]


### PR DESCRIPTION
``` python
[2024-10-20 11:57:32.113][TRC][Px311c][Tx87ac] asst::WordOcr [{ 지운유닛모집: [ 5, 10, 128, 25 ], score: 0.654263 }] by OCR Pipeline , cost 76 ms
[2024-10-20 11:57:32.114][INF][Px311c][Tx87ac] Assistant::append_callback | SubTaskError {"class":"asst::ProcessTask","details":{},"first":["Roguelike@RecruitSupportConfirm"],"pre_task":"","subtask":"ProcessTask","taskchain":"Roguelike","taskid":1,"uuid":""}
[2024-10-20 11:57:32.114][TRC][Px311c][Tx87ac] asst::ProcessTask::run | leave, 1694 ms
```