### PR TITLE
fix: 部分情况下信用购物因过度动画购买错误

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -3463,10 +3463,15 @@
         "next": ["CreditShop-Bought", "CreditShop-BuyIt@LoadingText", "CreditShop-NoMoney"]
     },
     "CreditShop-Bought": {
+        "doc": [
+            "在信用商店购买物品后，识别屏幕中 <获得物资> 文字上方的 Icon，并点击屏幕下方按钮靠下位置",
+            "考虑到淡入淡出动画，本任务不宜使用 ClickSelf，若识别上方 Icon 则可能点到其他商店页面，若识别下方按钮则容易点到其他商品"
+        ],
         "templThreshold": 0.7,
-        "action": "ClickSelf",
         "roi": [544, 0, 210, 201],
         "maskRange": [1, 255],
+        "action": "ClickRect",
+        "specificRect": [645, 665],
         "postDelay": 1500,
         "next": ["CreditShop-Bought", "Stop"]
     },

--- a/src/MaaCore/Task/Miscellaneous/CreditShoppingTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/CreditShoppingTask.cpp
@@ -147,11 +147,14 @@ bool asst::CreditShoppingTask::credit_shopping(bool white_list_enabled, bool cre
             }
         }
 
-        auto clickCount = 0;
-        do {
+        // 因动画过渡等原因，ctrler()->click(commodity) 点击商品时可能失败，共可尝试 4 次
+        // 若点击商品成功，则 CreditShop-BuyIt 的 ProcessTask 应顺利执行并返回 true
+        for (int clickCount = 0; clickCount <= 3; ++clickCount) {
             ctrler()->click(commodity);
-            clickCount++;
-        } while (ProcessTask(*this, { "CreditShop-BuyIt" }).run() || clickCount > 3);
+            if (ProcessTask(*this, { "CreditShop-BuyIt" }).run()) {
+                break;
+            }
+        }
 
         if (ProcessTask(*this, { "CreditShop-NoMoney" }).set_task_delay(0).set_retry_times(0).run()) {
             break;


### PR DESCRIPTION
Try fix #10888.

分析 Log 得知用户点击右下角 <加急许可> 时失败，未能识别到购买按钮，疑似因动画过渡导致点击未能失效。
现可重试 3 次（共尝试 4 次）。学姐之前写的 while 循环也没问题，只是条件里在`ProcessTask`前应该加一个`!`取反。

```
[2024-10-21 08:48:36.562][TRC][Px49d0][Tx1fa0] Click with scaled coordinates (916, 530) 1.5
[2024-10-21 08:48:36.562][TRC][Px49d0][Tx1fa0] minitouch click: (1374, 795)
[2024-10-21 08:48:36.663][TRC][Px49d0][Tx1fa0] asst::ProcessTask::run | enter
[2024-10-21 08:48:36.663][INF][Px49d0][Tx1fa0] {"class":"asst::ProcessTask","details":{"cur_retry":0,"retry_times":1,"to_be_recognized":["CreditShop-BuyIt"]},"first":["CreditShop-BuyIt"],"pre_task":"","subtask":"ProcessTask","taskchain":"Mall","taskid":5}
[2024-10-21 08:48:36.693][INF][Px49d0][Tx1fa0] {"class":"asst::ProcessTask","details":{"cur_retry":1,"retry_times":1,"to_be_recognized":["CreditShop-BuyIt"]},"first":["CreditShop-BuyIt"],"pre_task":"","subtask":"ProcessTask","taskchain":"Mall","taskid":5}
[2024-10-21 08:48:36.693][TRC][Px49d0][Tx1fa0] ready to sleep 500
[2024-10-21 08:48:37.195][TRC][Px49d0][Tx1fa0] end of sleep 500
[2024-10-21 08:48:37.228][INF][Px49d0][Tx1fa0] Assistant::append_callback | SubTaskError {"class":"asst::ProcessTask","details":{},"first":["CreditShop-BuyIt"],"pre_task":"","subtask":"ProcessTask","taskchain":"Mall","taskid":5,"uuid":"6f6d44078c775828"}
[2024-10-21 08:48:37.229][TRC][Px49d0][Tx1fa0] asst::ProcessTask::run | leave, 566 ms
```

另外，注意到`CreditShop-Bought`任务点击位置比较危险，如果时机“恰当”可能会错误地进入其他商店页面，故修改点击位置。具体点击位置见下图。

<img width="940" alt="image" src="https://github.com/user-attachments/assets/73d911b2-0e19-4e18-8fdb-aa87b4704c6f">

<img width="1349" alt="image" src="https://github.com/user-attachments/assets/dd7cfee9-cca1-4393-9541-f5bf561ac477">