### PR TITLE
chore: 修改部分与服务器相关的字段的初始化

### DIFF
--- a/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
@@ -2639,7 +2639,7 @@ namespace MaaWpfGui.ViewModels.UI
             }
         }
 
-        private string _reclamationToolToCraft = ConfigurationHelper.GetValue(ConfigurationKeys.ReclamationToolToCraft, string.Empty);
+        private string _reclamationToolToCraft = ConfigurationHelper.GetValue(ConfigurationKeys.ReclamationToolToCraft, LocalizationHelper.GetString("ReclamationToolToCraftPlaceholder", _clientLanguageMapper[ConfigurationHelper.GetValue(ConfigurationKeys.ClientType, string.Empty)]));
 
         public string ReclamationToolToCraft
         {
@@ -2870,7 +2870,7 @@ namespace MaaWpfGui.ViewModels.UI
             }
         }
 
-        private string _creditFirstList = ConfigurationHelper.GetValue(ConfigurationKeys.CreditFirstListNew, LocalizationHelper.GetString("HighPriorityDefault"));
+        private string _creditFirstList = ConfigurationHelper.GetValue(ConfigurationKeys.CreditFirstListNew, LocalizationHelper.GetString("HighPriorityDefault", _clientLanguageMapper[ConfigurationHelper.GetValue(ConfigurationKeys.ClientType, string.Empty)]));
 
         /// <summary>
         /// Gets or sets the priority item list of credit shop.
@@ -2885,7 +2885,7 @@ namespace MaaWpfGui.ViewModels.UI
             }
         }
 
-        private string _creditBlackList = ConfigurationHelper.GetValue(ConfigurationKeys.CreditBlackListNew, LocalizationHelper.GetString("BlacklistDefault"));
+        private string _creditBlackList = ConfigurationHelper.GetValue(ConfigurationKeys.CreditBlackListNew, LocalizationHelper.GetString("BlacklistDefault", _clientLanguageMapper[ConfigurationHelper.GetValue(ConfigurationKeys.ClientType, string.Empty)]));
 
         /// <summary>
         /// Gets or sets the blacklist of credit shop.

--- a/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
@@ -1501,6 +1501,22 @@ namespace MaaWpfGui.ViewModels.UI
             get => _clientType;
             set
             {
+                // Related to _clientRelatedFields, search it
+                if (_creditFirstList == LocalizationHelper.GetString("HighPriorityDefault", _clientLanguageMapper[_clientType]))
+                {
+                    ConfigurationHelper.SetValue(ConfigurationKeys.CreditFirstListNew, LocalizationHelper.GetString("HighPriorityDefault", _clientLanguageMapper[value]));
+                }
+
+                if (_creditBlackList == LocalizationHelper.GetString("BlacklistDefault", _clientLanguageMapper[_clientType]))
+                {
+                    ConfigurationHelper.SetValue(ConfigurationKeys.CreditBlackListNew, LocalizationHelper.GetString("BlacklistDefault", _clientLanguageMapper[value]));
+                }
+
+                if (_reclamationToolToCraft == LocalizationHelper.GetString("ReclamationToolToCraftPlaceholder", _clientLanguageMapper[_clientType]))
+                {
+                    ConfigurationHelper.SetValue(ConfigurationKeys.ReclamationToolToCraft, LocalizationHelper.GetString("ReclamationToolToCraftPlaceholder", _clientLanguageMapper[value]));
+                }
+
                 SetAndNotify(ref _clientType, value);
                 ConfigurationHelper.SetValue(ConfigurationKeys.ClientType, value);
                 _resourceInfo = GetResourceVersionByClientType(_clientType);
@@ -5378,6 +5394,10 @@ namespace MaaWpfGui.ViewModels.UI
             }
         }
 
+        // 没办法使用的列表，用于提醒和 client 相关的需要修改的内容
+        // private static readonly List<string> _clientRelatedFields = new() { nameof(_reclamationToolToCraft), nameof(_creditFirstList), nameof(_creditBlackList) };
+
+        // Map of client and language
         private static readonly Dictionary<string, string> _clientLanguageMapper = new()
         {
             { string.Empty, "zh-cn" },

--- a/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
@@ -1501,18 +1501,20 @@ namespace MaaWpfGui.ViewModels.UI
             get => _clientType;
             set
             {
-                // Related to _clientRelatedFields, search it
-                if (_creditFirstList == LocalizationHelper.GetString("HighPriorityDefault", _clientLanguageMapper[_clientType]))
+                // 以下是一些与服务器选项相关的字段，更改 ClientType 后需要一并更改
+                // 此处检测它们是否为默认值，如为默认值则改为对应服务器的内容
+                // 全部字段暂时放在 _clientRelatedFields 中，但这个变量本身并没有用
+                if (_creditFirstList == LocalizationHelper.GetString("HighPriorityDefault", _clientLanguageMapper[_clientType]) || _creditFirstList == LocalizationHelper.GetString("HighPriorityDefault"))
                 {
                     ConfigurationHelper.SetValue(ConfigurationKeys.CreditFirstListNew, LocalizationHelper.GetString("HighPriorityDefault", _clientLanguageMapper[value]));
                 }
 
-                if (_creditBlackList == LocalizationHelper.GetString("BlacklistDefault", _clientLanguageMapper[_clientType]))
+                if (_creditBlackList == LocalizationHelper.GetString("BlacklistDefault", _clientLanguageMapper[_clientType]) || _creditBlackList == LocalizationHelper.GetString("BlacklistDefault"))
                 {
                     ConfigurationHelper.SetValue(ConfigurationKeys.CreditBlackListNew, LocalizationHelper.GetString("BlacklistDefault", _clientLanguageMapper[value]));
                 }
 
-                if (_reclamationToolToCraft == LocalizationHelper.GetString("ReclamationToolToCraftPlaceholder", _clientLanguageMapper[_clientType]))
+                if (_reclamationToolToCraft == LocalizationHelper.GetString("ReclamationToolToCraftPlaceholder", _clientLanguageMapper[_clientType]) || _reclamationToolToCraft == LocalizationHelper.GetString("ReclamationToolToCraftPlaceholder"))
                 {
                     ConfigurationHelper.SetValue(ConfigurationKeys.ReclamationToolToCraft, LocalizationHelper.GetString("ReclamationToolToCraftPlaceholder", _clientLanguageMapper[value]));
                 }


### PR DESCRIPTION
以下三个设置字段需要根据服务器语言选择语言，而非根据MAA程序的语言选择。
现在对于 config.json 中没有对应字段的情况下，可以正常初始化。

~TODO：初次启动的设置引导流程会在选择客户端类型前初始化这些字段，需要进一步修改逻辑~
用一种丑陋的方式实现了，修改客户端选项时，如果这些字段仍保持默认，则一并更改。但愿新用户能先走完配置说明吧。

- 已经在正常使用、平时不会修改客户端选项的用户，不会被更改
- 已经在正常使用、喜欢一套配置改客户端选项的用户，在客户端和语言一致时，下次更改客户端选项时会受到更改
- 新用户跟随配置说明，先设置客户端再启动任务，可以直接得到正确的内容（先设置语言似乎并不影响）