### PR TITLE
perf: 调整关卡选择更新逻辑

### DIFF
--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -697,12 +697,7 @@ namespace MaaWpfGui.Main
                         // 对剿灭的特殊处理，如果刷完了剿灭还选了剿灭会因为找不到入口报错
                         if (taskChain == "Fight" && (Instances.TaskQueueViewModel.Stage == "Annihilation"))
                         {
-                            if (new[]
-                                {
-                                    Instances.TaskQueueViewModel.Stage1,
-                                    Instances.TaskQueueViewModel.Stage2,
-                                    Instances.TaskQueueViewModel.Stage3,
-                                }.Any(stage => Instances.TaskQueueViewModel.IsStageOpen(stage) && (stage != "Annihilation")))
+                            if (Instances.TaskQueueViewModel.Stages.Any(stage => Instances.TaskQueueViewModel.IsStageOpen(stage) && (stage != "Annihilation")))
                             {
                                 Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("AnnihilationTaskFailed"), UiLogColor.Warning);
                             }

--- a/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
@@ -1507,7 +1507,7 @@ namespace MaaWpfGui.ViewModels.UI
                 ResourceVersion = _resourceInfo.VersionName;
                 ResourceDateTime = _resourceInfo.DateTime;
                 UpdateWindowTitle(); // 每次修改客户端时更新WindowTitle
-                Instances.TaskQueueViewModel.UpdateStageList(true);
+                Instances.TaskQueueViewModel.UpdateStageList();
                 Instances.TaskQueueViewModel.UpdateDatePrompt();
                 Instances.AsstProxy.LoadResource();
                 AskRestartToApplySettings(_clientType is "YoStarEN");
@@ -3367,7 +3367,7 @@ namespace MaaWpfGui.ViewModels.UI
                     UseAlternateStage = false;
                 }
 
-                Instances.TaskQueueViewModel.UpdateStageList(true);
+                Instances.TaskQueueViewModel.UpdateStageList();
             }
         }
 


### PR DESCRIPTION
Linkstart 按钮现在替换成了更新关卡列表，可以通过改本地时间后点击来测试更新

使用`手动输入`时，只更新`关卡列表`，不更新`关卡选择`
使用`隐藏当日不开放`时，更新`关卡列表`，`关卡选择`为`未开放的关卡`时清空
使用`备选关卡`时，更新`关卡列表`，`关卡选择`为`未开放的关卡`时在`关卡列表`中添加对应`未开放关卡`，避免清空导致进入`当前/上次`
啥都不选时，更新`关卡列表`，`关卡选择`为`未开放的关卡`时在`关卡列表`中添加对应`未开放关卡`，避免清空导致进入`当前/上次`
除`手动输入`外所有情况下，如果`剩余理智`为`未开放的关卡`，会被清空