### PR TITLE
fix: 要求每次进入基建宿舍后都重新选择一遍筛选条件

### DIFF
--- a/src/MaaCore/Task/Infrast/InfrastDormTask.cpp
+++ b/src/MaaCore/Task/Infrast/InfrastDormTask.cpp
@@ -50,10 +50,15 @@ bool asst::InfrastDormTask::_run()
         }
 
         Log.trace("m_dorm_notstationed_enabled:", m_dorm_notstationed_enabled);
-        if (m_dorm_notstationed_enabled && !m_if_filter_notstationed_haspressed) {
+        if (m_dorm_notstationed_enabled) {
             Log.trace("click_filter_menu_not_stationed_button");
-            click_filter_menu_not_stationed_button();
-            m_if_filter_notstationed_haspressed = true;
+            // 在此处不进行 m_if_filter_notstationed_haspressed 的判断，即必须重新选择一次筛选条件
+            // 使用循环强制要求成功点击按钮
+            while(!need_exit()) {
+                if (click_filter_menu_not_stationed_button()) {
+                    m_if_filter_notstationed_haspressed = true;
+                }
+            }
         }
 
         if (!m_is_custom || current_room_config().autofill) {

--- a/src/MaaCore/Task/Infrast/InfrastDormTask.cpp
+++ b/src/MaaCore/Task/Infrast/InfrastDormTask.cpp
@@ -54,6 +54,7 @@ bool asst::InfrastDormTask::_run()
             Log.trace("click_filter_menu_not_stationed_button");
             // 在此处不进行 m_if_filter_notstationed_haspressed 的判断，即必须重新选择一次筛选条件
             if (click_filter_menu_not_stationed_button()) {
+                Log.info("successfully set filter to [Not Assigned]");
                 m_if_filter_notstationed_haspressed = true;
             }
         }

--- a/src/MaaCore/Task/Infrast/InfrastDormTask.cpp
+++ b/src/MaaCore/Task/Infrast/InfrastDormTask.cpp
@@ -54,7 +54,7 @@ bool asst::InfrastDormTask::_run()
             Log.trace("click_filter_menu_not_stationed_button");
             // 在此处不进行 m_if_filter_notstationed_haspressed 的判断，即必须重新选择一次筛选条件
             // 使用循环强制要求成功点击按钮
-            while(!need_exit()) {
+            while (!need_exit()) {
                 if (click_filter_menu_not_stationed_button()) {
                     m_if_filter_notstationed_haspressed = true;
                 }

--- a/src/MaaCore/Task/Infrast/InfrastDormTask.cpp
+++ b/src/MaaCore/Task/Infrast/InfrastDormTask.cpp
@@ -53,11 +53,8 @@ bool asst::InfrastDormTask::_run()
         if (m_dorm_notstationed_enabled) {
             Log.trace("click_filter_menu_not_stationed_button");
             // 在此处不进行 m_if_filter_notstationed_haspressed 的判断，即必须重新选择一次筛选条件
-            // 使用循环强制要求成功点击按钮
-            while (!need_exit()) {
-                if (click_filter_menu_not_stationed_button()) {
-                    m_if_filter_notstationed_haspressed = true;
-                }
+            if (click_filter_menu_not_stationed_button()) {
+                m_if_filter_notstationed_haspressed = true;
             }
         }
 


### PR DESCRIPTION
Try fix #10682.

基建【不撤离进驻干员】功能是通过将宿舍的干员筛选条件设置为【未进驻】实现的。有专门的变量 `m_if_filter_notstationed_haspressed` 记录此筛选条件是否已经被设置。

由于基建插件的 on_run_fails 中的特殊设置，在【基建子任务】运行期间，无论因为什么原因退出基建系统，都能再次进入并继续该子任务。此时基建各设施的干员筛选条件将被重置，而 `m_if_filter_notstationed_haspressed` 变量却不会被重置。
学姐分析 Bug 极有可能因此产生。
此处修改逻辑，在每次进入宿舍后都会重新设置一遍筛选条件。
感谢学姐的指导。