### PR TITLE
fix: Server酱通知推送无法正常推送到微信服务号

### DIFF
--- a/src/MaaWpfGui/Services/Notification/ServerChanNotificationProvider.cs
+++ b/src/MaaWpfGui/Services/Notification/ServerChanNotificationProvider.cs
@@ -37,6 +37,13 @@ namespace MaaWpfGui.Services.Notification
 
         public async Task<bool> SendAsync(string title, string content)
         {
+            title = title.Replace("\n", string.Empty);  //去掉 title 中的换行符
+            // 确保 title 的长度不超过 32 个字符
+            if (title.Length > 32)
+            {
+                title = title.Substring(0, 32); // 截取前 32 个字符
+            }
+            
             var sendKey = ConfigurationHelper.GetValue(ConfigurationKeys.ExternalNotificationServerChanSendKey, string.Empty);
 
             try


### PR DESCRIPTION
#10640
Server酱的title参数服务号通道不支持换行"\n"，在推送前删掉"\n"，并加入title的长度限制。
title: 消息标题，必填。最大长度为 32 。 
