### PR TITLE
fix: 通过新增 tasks.json 中task 解决pv-10导航关卡时有概率点进其他ui的问题

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -453,7 +453,7 @@
     "SwipeToStageToTheRight": {
         "Doc": "活动导航右滑找关",
         "baseTask": "ChapterSlowlySwipeToTheRight",
-        "specialParams": [ 150, 1 ]
+        "specialParams": [150, 1]
     },
     "SwipeLeftToStage1-7": {
         "algorithm": "OcrDetect",

--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -450,6 +450,11 @@
         "baseTask": "ChapterSlowlySwipeToTheLeft",
         "specialParams": [150, 1]
     },
+    "SwipeToStageToTheRight": {
+        "Doc": "活动导航右滑找关",
+        "baseTask": "ChapterSlowlySwipeToTheRight",
+        "specialParams": [ 150, 1 ]
+    },
     "SwipeLeftToStage1-7": {
         "algorithm": "OcrDetect",
         "baseTask": "ChapterSlowlySwipeToTheLeft",
@@ -567,22 +572,22 @@
     "PV-10": {
         "algorithm": "JustReturn",
         "sub": ["PV-OpenOpt"],
-        "next": ["PV-10@SideStoryStage", "PV-10@SwipeToStage"]
+        "next": ["PV-10@SideStoryStage", "PV-10@SwipeToStageToTheRight"]
     },
     "PV-9": {
         "algorithm": "JustReturn",
         "sub": ["PV-OpenOpt"],
-        "next": ["PV-9@SideStoryStage", "PV-9@SwipeToStage"]
+        "next": ["PV-9@SideStoryStage", "PV-9@SwipeToStageToTheRight"]
     },
     "PV-8": {
         "algorithm": "JustReturn",
         "sub": ["PV-OpenOpt"],
-        "next": ["PV-8@SideStoryStage", "PV-8@SwipeToStage"]
+        "next": ["PV-8@SideStoryStage", "PV-8@SwipeToStageToTheRight"]
     },
     "PV-5": {
         "algorithm": "JustReturn",
         "sub": ["PV-OpenOpt"],
-        "next": ["PV-5@SideStoryStage", "PV-5@SwipeToStage"]
+        "next": ["PV-5@SideStoryStage", "PV-5@SwipeToStageToTheRight"]
     },
     "PV-OpenOpt": {
         "algorithm": "JustReturn",
@@ -604,7 +609,7 @@
         "text": ["四幕汇演"],
         "preDelay": 3000,
         "roi": [69, 594, 123, 40],
-        "next": ["#self", "ChapterSwipeToTheRight"]
+        "next": ["#self", "ChapterSwipeToTheLeft"]
     },
     "PV-10@SideStoryStage": {
         "doc": "<PV-10> 文字与 <装配工坊> 位置靠近，容易误点，向右偏移一些",


### PR DESCRIPTION
bug描述：这是issues#11042的修复版本
修复过程：由于原task只有先向右滑到底再左滑找关的操作流程,导致了本次活动在托管刷理智的时候ui和关卡会重叠,但是能正常识别出来关卡,但是执行action的时候有概率点进"烟花装配"导致卡死。
由于本人能力有限，只修改了tasks.json
新增了一个"SwipeToStageToTheRight"。用来在活动中右滑找关
修改了用来在本次异拉活动中用来找关的逻辑。修改为先向左滑到底再右滑找关，这样找出来的pv-10会在正中间不会与ui重叠。同理pv-9，pv-8，pv-5也可以使用这套找关逻辑

因为本人水平有限,在尽可能不修改其他代码的情况下试图修复这个bug。