### PR TITLE
fix: 为 PVChapterToPV 添加 1 秒的 postDelay

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -604,6 +604,7 @@
         "text": ["四幕汇演"],
         "preDelay": 3000,
         "roi": [69, 594, 123, 40],
+        "postDelay": 1000,
         "next": ["#self", "ChapterSwipeToTheRight"]
     },
     "PV-10@SideStoryStage": {


### PR DESCRIPTION
总得有人来当这个坏人，增加 postDelay 以防截图太快的用户。
Try fix #11051.