### PR TITLE
fix: 肉鸽不期而遇闪退

### DIFF
--- a/src/MaaCore/Task/Roguelike/RoguelikeStageEncounterTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeStageEncounterTaskPlugin.cpp
@@ -89,6 +89,11 @@ bool asst::RoguelikeStageEncounterTaskPlugin::_run()
     callback(AsstMsg::SubTaskExtraInfo, info);
 
     const auto click_option_task_name = [&](const int item, const int total) {
+        if (item > total) {
+            Log.warn("Event:", event.name, "Total:", total, "Choice", item, "out of range, switch to choice", total);
+            return m_config->get_theme() + "@Roguelike@OptionChoose" + std::to_string(total) + "-" +
+                   std::to_string(total);
+        }
         return m_config->get_theme() + "@Roguelike@OptionChoose" + std::to_string(total) + "-" + std::to_string(item);
     };
 


### PR DESCRIPTION
Fix #10967 
闪退的触发原因是 process task 了一个不存在的任务
正在重构，不修 json 了，代码加点