### PR TITLE
perf: 公招三星优先tag 改为复选框

### DIFF
--- a/src/MaaWpfGui/Helper/ItemListHelper.cs
+++ b/src/MaaWpfGui/Helper/ItemListHelper.cs
@@ -28,14 +28,6 @@ namespace MaaWpfGui.Helper
 
         private static readonly ILogger _logger = Log.ForContext("SourceContext", "ItemListHelper");
 
-        private static readonly Dictionary<string, string> _clientDirectoryMapper = new Dictionary<string, string>
-        {
-            { "zh-tw", "txwy" },
-            { "en-us", "YoStarEN" },
-            { "ja-jp", "YoStarJP" },
-            { "ko-kr", "YoStarKR" },
-        };
-
         static ItemListHelper()
         {
             var language = ConfigurationHelper.GetValue(ConfigurationKeys.Localization, LocalizationHelper.DefaultLanguage);
@@ -50,7 +42,7 @@ namespace MaaWpfGui.Helper
                     break;
 
                 default:
-                    filename = Path.Combine(Directory.GetCurrentDirectory(), "resource", "global", _clientDirectoryMapper[language], "resource", "item_index.json");
+                    filename = Path.Combine(Directory.GetCurrentDirectory(), "resource", "global", DataHelper.ClientDirectoryMapper[language], "resource", "item_index.json");
                     break;
             }
 

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -793,8 +793,8 @@ The video aspect ratio needs to be 16:9 without interference factors such as bla
     <system:String x:Key="DefaultNoExtraTags">Additional Tags are not selected by default</system:String>
     <system:String x:Key="SelectExtraTags">If higher ★ tags appear, always select 3 tags</system:String>
     <system:String x:Key="SelectExtraOnlyRareTags">Pick as many high-star Tags as possible</system:String>
-    <system:String x:Key="AutoRecruitHighPriority">Preference for 3★ Tags (split by semicolon)</system:String>
-    <system:String x:Key="AutoRecruitHighPriorityTooltip">Substring is sufficient, will select as many Tag preferences as possible</system:String>
+    <system:String x:Key="AutoRecruitHighPriority">Preference for 3★ Tags</system:String>
+    <system:String x:Key="AutoRecruitHighPriorityTooltip">Will select as many Tag preferences as possible</system:String>
     <system:String x:Key="NotEnoughStaff">Insufficient operators</system:String>
     <system:String x:Key="StageInfoError">Stage recognition error</system:String>
     <system:String x:Key="UseFormation">Use formation</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -796,8 +796,8 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="DefaultNoExtraTags">追加のタグを選択しない</system:String>
     <system:String x:Key="SelectExtraTags">常に 3 つのタグを選択する</system:String>
     <system:String x:Key="SelectExtraOnlyRareTags">可能な限りタグを選択し、かつ高い星のタグのみを選択する</system:String>
-    <system:String x:Key="AutoRecruitHighPriority">優先タグ（セミコロンで区切）</system:String>
-    <system:String x:Key="AutoRecruitHighPriorityTooltip">サブストリングで十分です、できるだけ多くのタグの傾向を選択します</system:String>
+    <system:String x:Key="AutoRecruitHighPriority">優先タグ</system:String>
+    <system:String x:Key="AutoRecruitHighPriorityTooltip">できるだけ多くのタグの傾向を選択します</system:String>
     <system:String x:Key="NotEnoughStaff">利用可能なオペレーターが不足しています</system:String>
     <system:String x:Key="StageInfoError">ステージ認識エラー</system:String>
     <system:String x:Key="UseFormation">使用編成</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -796,8 +796,8 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="DefaultNoExtraTags">기본값: 추가 태그 없음</system:String>
     <system:String x:Key="SelectExtraTags">항상 3개의 태그를 선택</system:String>
     <system:String x:Key="SelectExtraOnlyRareTags">가능한 한 많은 태그를 선택하고 높은 등급의 태그만 선택</system:String>
-    <system:String x:Key="AutoRecruitHighPriority">선호 태그 (「;」로 구분)</system:String>
-    <system:String x:Key="AutoRecruitHighPriorityTooltip">하위 문자열이면 충분하며 가능한 한 많은 태그 기본 설정을 선택합니다</system:String>
+    <system:String x:Key="AutoRecruitHighPriority">선호 태그</system:String>
+    <system:String x:Key="AutoRecruitHighPriorityTooltip">가능한 한 많은 태그 기본 설정을 선택합니다</system:String>
     <system:String x:Key="NotEnoughStaff">오퍼레이터 부족</system:String>
     <system:String x:Key="StageInfoError">스테이지 인식 오류</system:String>
     <system:String x:Key="UseFormation">편성 사용</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -796,7 +796,7 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="SelectExtraTags">选择高星时总是选择三个 Tag</system:String>
     <system:String x:Key="SelectExtraOnlyRareTags">尽可能多地选且只选高星 Tag</system:String>
     <system:String x:Key="AutoRecruitHighPriority">3 星 Tag 时的 Tag 倾向</system:String>
-    <system:String x:Key="AutoRecruitHighPriorityTooltip">尽可能多的选择倾向的 Tag</system:String>
+    <system:String x:Key="AutoRecruitHighPriorityTooltip">会尽可能多的选择倾向的 Tag</system:String>
     <system:String x:Key="NotEnoughStaff">可用干员不足</system:String>
     <system:String x:Key="StageInfoError">关卡识别错误</system:String>
     <system:String x:Key="UseFormation">使用编队</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -795,8 +795,8 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="DefaultNoExtraTags">默认不选择额外 Tag</system:String>
     <system:String x:Key="SelectExtraTags">选择高星时总是选择三个 Tag</system:String>
     <system:String x:Key="SelectExtraOnlyRareTags">尽可能多地选且只选高星 Tag</system:String>
-    <system:String x:Key="AutoRecruitHighPriority">3 星 Tag 时的 Tag 倾向，分号分隔</system:String>
-    <system:String x:Key="AutoRecruitHighPriorityTooltip">子串即可，会尽可能多的选择倾向的 Tag</system:String>
+    <system:String x:Key="AutoRecruitHighPriority">3 星 Tag 时的 Tag 倾向</system:String>
+    <system:String x:Key="AutoRecruitHighPriorityTooltip">尽可能多的选择倾向的 Tag</system:String>
     <system:String x:Key="NotEnoughStaff">可用干员不足</system:String>
     <system:String x:Key="StageInfoError">关卡识别错误</system:String>
     <system:String x:Key="UseFormation">使用编队</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -796,8 +796,8 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="DefaultNoExtraTags">默認不選擇額外的 Tags</system:String>
     <system:String x:Key="SelectExtraTags">選擇高星時總是選擇三個 Tag</system:String>
     <system:String x:Key="SelectExtraOnlyRareTags">盡可能多地選且只選高星 Tags</system:String>
-    <system:String x:Key="AutoRecruitHighPriority">3 星 Tags 時的 Tags 傾向，分號分隔</system:String>
-    <system:String x:Key="AutoRecruitHighPriorityTooltip">子串即可，會盡可能多的選擇傾向的 Tags</system:String>
+    <system:String x:Key="AutoRecruitHighPriority">3 星 Tags 時的 Tags 傾向</system:String>
+    <system:String x:Key="AutoRecruitHighPriorityTooltip">會盡可能多的選擇傾向的 Tags</system:String>
     <system:String x:Key="StageInfoError">關卡辨識錯誤</system:String>
     <system:String x:Key="UseFormation">使用編隊</system:String>
     <system:String x:Key="Current">當前</system:String>

--- a/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
@@ -3445,7 +3445,7 @@ namespace MaaWpfGui.ViewModels.UI
         }
 
         private object[] _autoRecruitFirstList = ConfigurationHelper
-            .GetValue(ConfigurationKeys.AutoRecruitFirstList, "A B C")
+            .GetValue(ConfigurationKeys.AutoRecruitFirstList, string.Empty)
             .Split(';')
             .Where(s => _autoRecruitOptionsDict.ContainsValue(s.ToString()))
             .Select(s => _autoRecruitOptionsDict.FirstOrDefault(pair => pair.Value == s).Key)

--- a/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
@@ -3416,18 +3416,49 @@ namespace MaaWpfGui.ViewModels.UI
                 new() { Display = LocalizationHelper.GetString("SelectExtraOnlyRareTags"), Value = "2" },
             ];
 
-        private string _autoRecruitFirstList = ConfigurationHelper.GetValue(ConfigurationKeys.AutoRecruitFirstList, string.Empty);
+        private static readonly Dictionary<string, string> _autoRecruitOptionsDict = new()
+        {
+            { "近战位", "近战位" },
+            { "远程位", "远程位" },
+            { "先锋干员", "先锋干员" },
+            { "近卫干员", "近卫干员" },
+            { "狙击干员", "狙击干员" },
+            { "重装干员", "重装干员" },
+            { "医疗干员", "医疗干员" },
+            { "辅助干员", "辅助干员" },
+            { "术师干员", "术师干员" },
+            { "治疗", "治疗" },
+            { "费用回复", "费用回复" },
+            { "输出", "输出" },
+            { "生存", "生存" },
+            { "群攻", "群攻" },
+            { "防护", "防护" },
+            { "减速", "减速" },
+        };
 
-        /// <summary>
-        /// Gets or sets the priority tag list of level-3 tags.
-        /// </summary>
-        public string AutoRecruitFirstList
+        private List<string> _autoRecruitFirstAllList = new(_autoRecruitOptionsDict.Keys);
+
+        public List<string> AutoRecruitTagList
+        {
+            get => _autoRecruitFirstAllList;
+            set => SetAndNotify(ref _autoRecruitFirstAllList, value);
+        }
+
+        private object[] _autoRecruitFirstList = ConfigurationHelper
+            .GetValue(ConfigurationKeys.AutoRecruitFirstList, "A B C")
+            .Split(';')
+            .Where(s => _autoRecruitOptionsDict.ContainsValue(s.ToString()))
+            .Select(s => _autoRecruitOptionsDict.FirstOrDefault(pair => pair.Value == s).Key)
+            .ToArray();
+
+        public object[] AutoRecruitFirstList
         {
             get => _autoRecruitFirstList;
             set
             {
                 SetAndNotify(ref _autoRecruitFirstList, value);
-                ConfigurationHelper.SetValue(ConfigurationKeys.AutoRecruitFirstList, value);
+                var config = string.Join(';', _autoRecruitFirstList.Cast<string>().Select(s => _autoRecruitOptionsDict[s]));
+                ConfigurationHelper.SetValue(ConfigurationKeys.AutoRecruitFirstList, config);
             }
         }
 

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -1728,7 +1728,7 @@ namespace MaaWpfGui.ViewModels.UI
 
             return Instances.AsstProxy.AsstAppendRecruit(
                 maxTimes,
-                firstList.Cast<string>().ToArray(),
+                firstList.Cast<CombinedData>().Select(i => i.Value).ToArray(),
                 [.. reqList],
                 [.. cfmList],
                 Instances.SettingsViewModel.RefreshLevel3,

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -1701,8 +1701,7 @@ namespace MaaWpfGui.ViewModels.UI
                 maxTimes = 0;
             }
 
-            var firstList = Instances.SettingsViewModel.AutoRecruitFirstList.Split(';', '；')
-                .Select(s => s.Trim());
+            var firstList = Instances.SettingsViewModel.AutoRecruitFirstList;
 
             var reqList = new List<int>();
             var cfmList = new List<int>();
@@ -1729,7 +1728,7 @@ namespace MaaWpfGui.ViewModels.UI
 
             return Instances.AsstProxy.AsstAppendRecruit(
                 maxTimes,
-                firstList.ToArray(),
+                firstList.Cast<string>().ToArray(),
                 [.. reqList],
                 [.. cfmList],
                 Instances.SettingsViewModel.RefreshLevel3,

--- a/src/MaaWpfGui/Views/UserControl/AutoRecruitSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/AutoRecruitSettingsUserControl.xaml
@@ -41,19 +41,14 @@
                 SelectedValue="{Binding SelectExtraTags}"
                 SelectedValuePath="Value"
                 Style="{StaticResource ComboBoxExtend}" />
-            <controls:TextBlock 
-                Text="{DynamicResource AutoRecruitHighPriority}" 
-                TextWrapping="Wrap" 
-                HorizontalAlignment="Left"
-                Margin="10,0,0,0" />
             <hc:CheckComboBox
                 Margin="0,10"
                 hc:InfoElement.Title="{DynamicResource AutoRecruitHighPriority}"
-                ItemsSource="{Binding AutoRecruitTagList}"
                 hc:ListBoxAttach.SelectedItems="{Binding AutoRecruitFirstList}"
-                ToolTip="{DynamicResource AutoRecruitHighPriorityTooltip}"
+                ItemsSource="{Binding AutoRecruitTagList}"
                 SelectionMode="Multiple"
-                ScrollViewer.VerticalScrollBarVisibility="Visible" />
+                Style="{StaticResource CheckComboBoxExtend}"
+                ToolTip="{DynamicResource AutoRecruitHighPriorityTooltip}" />
             <CheckBox
                 Margin="0,10"
                 Content="{DynamicResource AutoRefresh}"

--- a/src/MaaWpfGui/Views/UserControl/AutoRecruitSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/AutoRecruitSettingsUserControl.xaml
@@ -41,12 +41,19 @@
                 SelectedValue="{Binding SelectExtraTags}"
                 SelectedValuePath="Value"
                 Style="{StaticResource ComboBoxExtend}" />
-            <TextBox
+            <controls:TextBlock 
+                Text="{DynamicResource AutoRecruitHighPriority}" 
+                TextWrapping="Wrap" 
+                HorizontalAlignment="Left"
+                Margin="10,0,0,0" />
+            <hc:CheckComboBox
                 Margin="0,10"
                 hc:InfoElement.Title="{DynamicResource AutoRecruitHighPriority}"
-                Style="{StaticResource TextBoxExtend}"
-                Text="{Binding AutoRecruitFirstList}"
-                ToolTip="{DynamicResource AutoRecruitHighPriorityTooltip}" />
+                ItemsSource="{Binding AutoRecruitTagList}"
+                hc:ListBoxAttach.SelectedItems="{Binding AutoRecruitFirstList}"
+                ToolTip="{DynamicResource AutoRecruitHighPriorityTooltip}"
+                SelectionMode="Multiple"
+                ScrollViewer.VerticalScrollBarVisibility="Visible" />
             <CheckBox
                 Margin="0,10"
                 Content="{DynamicResource AutoRefresh}"

--- a/src/MaaWpfGui/Views/UserControl/AutoRecruitSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/AutoRecruitSettingsUserControl.xaml
@@ -45,7 +45,8 @@
                 Margin="0,10"
                 hc:InfoElement.Title="{DynamicResource AutoRecruitHighPriority}"
                 hc:ListBoxAttach.SelectedItems="{Binding AutoRecruitFirstList}"
-                ItemsSource="{Binding AutoRecruitTagList}"
+                DisplayMemberPath="Display"
+                ItemsSource="{Binding AutoRecruitTagShowList}"
                 SelectionMode="Multiple"
                 Style="{StaticResource CheckComboBoxExtend}"
                 ToolTip="{DynamicResource AutoRecruitHighPriorityTooltip}" />


### PR DESCRIPTION
## Description

This PR replaces the existing `AutoRecruitHighPriority (公招三星优先tag)` textbox with a combination of `CheckComboBox` and `ListBox` for improved user interaction and better tag selection functionality.

### Changes:
- Replaced the `AutoRecruitHighPriority` textbox with a `CheckComboBox` to allow multi-tag selection.
- Implemented a `ListBox` to display the selected tags.
- Updated the data binding to ensure proper handling of selected tags.
- Refactored related event handling logic to integrate with the new components.
- Reword the tips and title for `AutoRecruitHighPriority`.

## Motivation

The previous implementation used a simple `TextBox` for selecting priority tags, which was not user-friendly, especially for selecting multiple tags. **Nobody wants to type those tags in string with no typo at all. 太不人性化了:(** 
This update improves usability by introducing a `CheckComboBox` for better tag selection and a `ListBox` to display selected tags, enhancing overall functionality.

## How Has This Been Tested?

- Manually tested the `CheckComboBox` and `ListBox` functionalities to ensure proper tag selection and display.
- Verified data binding for the selected tags in the UI.
- Functionality is good by manual testing.
- Other functionalities are unchanged and testing in Visual Studio **does not give any error**.

## Screenshots for Tested Functionality
<p align="center">
  <img src="https://github.com/user-attachments/assets/2849146d-b5ce-4876-b0c6-1ffa2502055e" alt="Tag selection" width="400"/>
  <img src="https://github.com/user-attachments/assets/5ba986fd-2b75-4f9b-8045-83d251f60e7e" alt="Tag selected in Game" width="400"/>
</p>

## Screenshots for Changes

| Before | After |
|-------|-------|
<p align="center">
  <img src="https://github.com/user-attachments/assets/86c5bb5b-0e5f-4e86-8e7f-97d050487437" alt="Before" width="400"/>
  <img src="https://github.com/user-attachments/assets/366302a0-4f21-4fe6-9d6e-957159f1657f" alt="After" width="400"/>
</p>
