### PR TITLE
fix: 移除了邮件通知中可能的非法字符

### DIFF
--- a/src/MaaWpfGui/Services/Notification/SmtpNotificationProvider.cs
+++ b/src/MaaWpfGui/Services/Notification/SmtpNotificationProvider.cs
@@ -11,6 +11,7 @@
 // but WITHOUT ANY WARRANTY
 // </copyright>
 
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using FluentEmail.Core;
 using FluentEmail.Liquid;
@@ -56,6 +57,9 @@ namespace MaaWpfGui.Services.Notification
 
             var emailFrom = ConfigurationHelper.GetValue(ConfigurationKeys.ExternalNotificationSmtpFrom, string.Empty);
             var emailTo = ConfigurationHelper.GetValue(ConfigurationKeys.ExternalNotificationSmtpTo, string.Empty);
+
+            title = Regex.Replace(title, "\r(?!\n)", "\r\n");
+            content = Regex.Replace(content, "\r(?!\n)", "\r\n");
 
             var email = Email
                 .From(emailFrom)


### PR DESCRIPTION
> [!warning]
存在未确认的链接，请谨慎访问。
There are unconfirmed links, please visit with caution.

部分邮件服务器不支持裸换行符 (https://learn.microsoft.com/en-us/exchange/troubleshoot/email-delivery/ndr/fix-error-code-550-5-6-11-in-exchange-online)