### PR TITLE
chore: 优化依赖下载脚本，避免重复下载

### DIFF
--- a/maadeps-download.py
+++ b/maadeps-download.py
@@ -186,6 +186,10 @@ def main():
         download_dir = Path(maadeps_dir, "tarball")
         download_dir.mkdir(parents=True, exist_ok=True)
         try:
+            shutil.rmtree(maadeps_dir / "runtime" / f"maa-{target_triplet}",
+                          ignore_errors=True)
+            shutil.rmtree(maadeps_dir / "vcpkg" / "installed" /
+                          f"maa-{target_triplet}", ignore_errors=True)
             for asset in [devel_asset, runtime_asset]:
                 url = asset['browser_download_url']
                 print("downloading from", url)

--- a/maadeps-download.py
+++ b/maadeps-download.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import argparse
 import os
 import sys
 import urllib.request
@@ -110,20 +111,27 @@ def retry_urlopen(*args, **kwargs):
 
 
 def main():
-    if len(sys.argv) >= 2:
-        target_triplet = sys.argv[1]
+    parser = argparse.ArgumentParser()
+    parser.add_argument("target_triplet", nargs="?", default=None)
+    parser.add_argument("tag", nargs="?", default=None)
+    parser.add_argument("-f", "--force", action="store_true",
+                        help="force download even if already exists")
+    args = parser.parse_args()
+
+    if args.target_triplet is not None:
+        target_triplet = args.target_triplet
     else:
         target_triplet = detect_host_triplet()
 
-    if len(sys.argv) >= 3:
-        target_tag = sys.argv[2]
+    if args.tag is not None:
+        target_tag = args.tag
     else:
         target_tag = TARGET_TAG
     print(
         "about to download prebuilt dependency libraries for ",
         f"{target_triplet} of {target_tag}"
     )
-    if len(sys.argv) == 1:
+    if args.target_triplet is None:
         print(
             "to specify another triplet [and tag], ",
             f"run `{sys.argv[0]} <target triplet> [tag]`"
@@ -140,12 +148,12 @@ def main():
             versions = json.load(f)
     except:
         versions = {}
-    if versions.get(target_triplet) == target_tag:
+    if not args.force and versions.get(target_triplet) == target_tag:
         print(
             f"prebuilt dependencies for {target_triplet} of {target_tag} ",
             "already exist, skipping download"
         )
-        print(f"to force download, delete {maadeps_version_file}")
+        print(f"to force download, run `{sys.argv[0]} -f`")
         return
 
     req = urllib.request.Request(

--- a/tools/build_macos_universal.zsh
+++ b/tools/build_macos_universal.zsh
@@ -1,5 +1,7 @@
 #!/usr/bin/env zsh
 
+set -eu -o pipefail
+
 [[ "$(arch)" == "arm64" ]] && arch="arm64" || arch="x86_64"
 basedir=$(dirname "$0")/..
 pushd ${basedir}
@@ -7,9 +9,7 @@ pushd ${basedir}
 build_arch() {
     [[ $1 = "arm64" ]] && triplet="arm64-osx" || triplet="x64-osx"
 
-    if [ ! -d ${basedir}/MaaDeps/runtime/maa-${triplet} ]; then
-        python3 maadeps-download.py ${triplet}
-    fi
+    python3 maadeps-download.py ${triplet}
 
     if [[ -n $(which ccache) ]]; then
         ccache_arg="-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache"
@@ -17,7 +17,7 @@ build_arch() {
         ccache_arg=""
     fi
 
-    cmake -B build-$1 -GNinja -DCMAKE_BUILD_TYPE=$2 -DCMAKE_OSX_ARCHITECTURES=$1 "${ccache_arg}"
+    cmake -B build-$1 -GNinja -DCMAKE_BUILD_TYPE=$2 -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_OSX_ARCHITECTURES=$1 "${ccache_arg}"
     cmake --build build-$1
     cmake --install build-$1 --prefix install-$1
 }


### PR DESCRIPTION
本地开发的时候偶尔要更新 maadeps，添加一个已下载的记录提高效率。
~这下每次 pull 后都无脑跑一遍 maadeps-download.py 也不成问题了~