### PR TITLE
fix: 修改邮件通知中特殊字符的处理方式

### DIFF
--- a/src/MaaWpfGui/Services/Notification/SmtpNotificationProvider.cs
+++ b/src/MaaWpfGui/Services/Notification/SmtpNotificationProvider.cs
@@ -59,8 +59,8 @@ namespace MaaWpfGui.Services.Notification
             var emailFrom = ConfigurationHelper.GetValue(ConfigurationKeys.ExternalNotificationSmtpFrom, string.Empty);
             var emailTo = ConfigurationHelper.GetValue(ConfigurationKeys.ExternalNotificationSmtpTo, string.Empty);
 
-            title = title.Replace("\r", "").Replace("\n", "");
-            content = content.Replace("\r", "").Replace("\n", "");
+            title = title.Replace("\r", string.Empty).Replace("\n", string.Empty);
+            content = content.Replace("\r", string.Empty).Replace("\n", string.Empty);
 
             var email = Email
                 .From(emailFrom)

--- a/src/MaaWpfGui/Services/Notification/SmtpNotificationProvider.cs
+++ b/src/MaaWpfGui/Services/Notification/SmtpNotificationProvider.cs
@@ -59,8 +59,8 @@ namespace MaaWpfGui.Services.Notification
             var emailFrom = ConfigurationHelper.GetValue(ConfigurationKeys.ExternalNotificationSmtpFrom, string.Empty);
             var emailTo = ConfigurationHelper.GetValue(ConfigurationKeys.ExternalNotificationSmtpTo, string.Empty);
 
-            title = Regex.Replace(title, "\r(?!\n)", "\r\n");
-            content = Regex.Replace(content, "\r(?!\n)", "\r\n");
+            title = title.Replace("\r", "").Replace("\n", "");
+            content = content.Replace("\r", "").Replace("\n", "");
 
             var email = Email
                 .From(emailFrom)


### PR DESCRIPTION
上一个修复中 （#11110） 的正则写错了，后来想了下 HTML 模板本来就不支持换行符，直接移除就行