### PR TITLE
fix: 肉鸽构想不足过高阈值导致 mac 版无法识别

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -10490,7 +10490,7 @@
     },
     "Sarkaz@Roguelike@StageRefreshNoThought": {
         "action": "ClickRect",
-        "templThreshold": 0.9,
+        "templThreshold": 0.85,
         "roi": [902, 24, 327, 179],
         "specificRect": [1100, 558, 111, 50],
         "next": ["Sarkaz@Roguelike@QuickFormation"]


### PR DESCRIPTION
Fix #11225