### PR TITLE
i18n: Translations update from MAA Weblate

### DIFF
--- a/docs/glossary/ja-jp.json
+++ b/docs/glossary/ja-jp.json
@@ -480,7 +480,7 @@
             "char_4066_highmo": "ハイモア",
             "char_4071_peper": "パプリカ",
             "char_4078_bdhkgt": "ジエユン",
-            "char_4079_haini": "",
+            "char_4079_haini": "ルシーラ",
             "char_4081_warmy": "ウォーミー",
             "char_4083_chimes": "ウィンドチャイム",
             "char_4102_threye": "ヴァラルクビン",
@@ -496,7 +496,7 @@
             "char_4125_rdoc": "Doc",
             "char_4126_fuze": "Fuze",
             "char_4131_odda": "オッダ",
-            "char_4137_udflow": "",
+            "char_4137_udflow": "アンダーフロー",
             "char_4139_papyrs": "",
             "char_4140_lasher": "",
             "char_4142_laios": "",
@@ -603,7 +603,7 @@
             "char_4134_cetsyr": "シヴィライト・エテルナ",
             "char_4138_narant": "",
             "char_4141_marcil": "",
-            "char_4145_ulpia": "",
+            "char_4145_ulpia": "ウルピアヌス",
             "char_4146_nymph": ""
         }
     }


### PR DESCRIPTION
> [!warning]
存在未确认的链接，请谨慎访问。
There are unconfirmed links, please visit with caution.

Translations update from [MAA Weblate](https://weblate.maa-org.net) for [MAA Assistant Arknights/Glossary](https://weblate.maa-org.net/projects/maa/glossary/).


It also includes following components:

* [MAA Assistant Arknights/WPF GUI](https://weblate.maa-org.net/projects/maa/wpf-gui/)



Current translation status:

![Weblate translation status](https://weblate.maa-org.net/widget/maa/glossary/horizontal-auto.svg)