### PR TITLE
feat: 萨卡兹肉鸽刷开局 2 构想

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -9723,12 +9723,12 @@
     },
     "Sarkaz@Roguelike@CloseCollection": {
         "next": [
+            "Sarkaz@Roguelike@LastReward5",
             "Sarkaz@Roguelike@LastReward",
             "Sarkaz@Roguelike@LastReward4",
             "Sarkaz@Roguelike@LastReward2",
             "Sarkaz@Roguelike@LastReward3",
             "Sarkaz@Roguelike@LastRewardRand",
-            "Sarkaz@Roguelike@LastReward5",
             "Sarkaz@Roguelike@RolesDefault"
         ]
     },

--- a/src/MaaCore/Task/Roguelike/RoguelikeConfig.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeConfig.cpp
@@ -99,6 +99,15 @@ bool asst::RoguelikeConfig::verify_and_load_params(const json::value& params)
         m_first_floor_foldartal = params.contains("first_floor_foldartal");
     }
 
+    // ------------------ 萨卡兹主题专用参数 ------------------
+    if (m_theme == RoguelikeTheme::Sarkaz) {
+        m_start_with_two_ideas = params.get("start_with_two_ideas", false);
+        if (m_mode != RoguelikeMode::Collectible && m_start_with_two_ideas) {
+            Log.error(__FUNCTION__, "| Invalid mode for start_with_two_ideas", static_cast<int>(mode));
+            return false;
+        }
+    }
+
     return true;
 }
 

--- a/src/MaaCore/Task/Roguelike/RoguelikeConfig.h
+++ b/src/MaaCore/Task/Roguelike/RoguelikeConfig.h
@@ -118,7 +118,19 @@ private:
     // ------------------ 密文板 ------------------
     bool m_first_floor_foldartal = false; // 凹远见密文板
 
-    /* 以下为局内数据，每次重置 */
+    // =========================== 萨卡兹主题专用参数 ===========================
+
+public:
+    void set_start_with_two_ideas(bool value) { m_start_with_two_ideas = value; }
+
+    bool get_start_with_two_ideas() const { return m_start_with_two_ideas; }
+
+private:
+    bool m_start_with_two_ideas = false; // 在刷开局模式下凹开局 2 构想
+
+    // ================================================================================
+    // 以下为局内数据，每次重置
+    // ================================================================================
 public:
     // ------------------ 招募 ------------------
     void set_team_full_without_rookie(bool value) { m_team_full_without_rookie = value; }
@@ -185,7 +197,7 @@ private:
     // ------------------ 密文板 ------------------
     std::vector<std::string> m_foldartal; // 所有已获得密文板
 
-    // ------------------ 萨卡兹主题专用参数 ------------------
+    // =========================== 萨卡兹主题专用参数 ===========================
 public:
     void set_idea_count(int idea_count) { m_idea_count = idea_count; }
 

--- a/src/MaaCore/Task/Roguelike/RoguelikeLastRewardTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeLastRewardTaskPlugin.cpp
@@ -70,6 +70,9 @@ bool asst::RoguelikeLastRewardTaskPlugin::_run()
             Task.set_task_base("Roguelike@LastReward3", "Roguelike@LastReward_restart");
             Task.set_task_base("Roguelike@LastReward4", last_reward_stop_or_continue);
             Task.set_task_base("Roguelike@LastRewardRand", "Roguelike@LastReward_restart");
+            if (m_config->get_theme() == RoguelikeTheme::Sarkaz && m_config->get_start_with_two_ideas()) {
+                Task.set_task_base("Sarkaz@Roguelike@LastReward5", last_reward_stop_or_continue);
+            }
         }
         else if (!m_config->get_only_start_with_elite_two()) {
             // 开启烧开水 Flag，将难度设置为 0
@@ -80,6 +83,9 @@ bool asst::RoguelikeLastRewardTaskPlugin::_run()
             Task.set_task_base("Roguelike@LastReward3", "Roguelike@LastReward_default");
             Task.set_task_base("Roguelike@LastReward4", "Roguelike@LastReward_default");
             Task.set_task_base("Roguelike@LastRewardRand", "Roguelike@LastReward_default");
+            if (m_config->get_theme() == RoguelikeTheme::Sarkaz) {
+                Task.set_task_base("Sarkaz@Roguelike@LastReward5", "Sarkaz@Roguelike@LastReward_default");
+            }
         }
     }
     return true;

--- a/src/MaaCore/Task/Roguelike/RoguelikeLastRewardTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeLastRewardTaskPlugin.cpp
@@ -71,6 +71,8 @@ bool asst::RoguelikeLastRewardTaskPlugin::_run()
             Task.set_task_base("Roguelike@LastReward4", last_reward_stop_or_continue);
             Task.set_task_base("Roguelike@LastRewardRand", "Roguelike@LastReward_restart");
             if (m_config->get_theme() == RoguelikeTheme::Sarkaz && m_config->get_start_with_two_ideas()) {
+                Task.set_task_base("Roguelike@LastReward", "Roguelike@LastReward_restart");
+                Task.set_task_base("Roguelike@LastReward4", "Roguelike@LastReward_restart");
                 Task.set_task_base("Sarkaz@Roguelike@LastReward5", last_reward_stop_or_continue);
             }
         }

--- a/src/MaaWpfGui/Constants/ConfigurationKeys.cs
+++ b/src/MaaWpfGui/Constants/ConfigurationKeys.cs
@@ -125,6 +125,7 @@ namespace MaaWpfGui.Constants
         public const string RoguelikeCoreChar = "Roguelike.CoreChar";
         public const string RoguelikeStartWithEliteTwo = "Roguelike.RoguelikeStartWithEliteTwo";
         public const string RoguelikeOnlyStartWithEliteTwo = "Roguelike.RoguelikeOnlyStartWithEliteTwo";
+        public const string RoguelikeStartWithTwoIdeas = "Roguelike.RoguelikeStartWithTwoIdeas";
         public const string Roguelike3FirstFloorFoldartal = "Roguelike.Roguelike3FirstFloorFoldartal";
         public const string Roguelike3StartFloorFoldartal = "Roguelike.Roguelike3StartFloorFoldartal";
         public const string Roguelike3NewSquad2StartingFoldartal = "Roguelike.Roguelike3NewSquad2StartingFoldartal";

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -2417,6 +2417,7 @@ namespace MaaWpfGui.Main
         /// <param name="coreChar">开局干员名</param>
         /// <param name="startWithEliteTwo">是否凹开局直升</param>
         /// <param name="onlyStartWithEliteTwo">是否只凹开局直升，不进行作战</param>
+        /// <param name="startWithTwoIdeas">是否凹 2 构想</param>
         /// <param name="roguelike3FirstFloorFoldartal">凹第一层远见板子</param>
         /// <param name="roguelike3StartFloorFoldartal">需要凹的板子</param>
         /// <param name="roguelike3NewSquad2StartingFoldartal">是否在萨米肉鸽生活队凹开局板子</param>
@@ -2441,6 +2442,7 @@ namespace MaaWpfGui.Main
             string coreChar,
             bool startWithEliteTwo,
             bool onlyStartWithEliteTwo,
+            bool startWithTwoIdeas,
             bool roguelike3FirstFloorFoldartal,
             string roguelike3StartFloorFoldartal,
             bool roguelike3NewSquad2StartingFoldartal,
@@ -2490,6 +2492,7 @@ namespace MaaWpfGui.Main
 
             taskParams["start_with_elite_two"] = startWithEliteTwo;
             taskParams["only_start_with_elite_two"] = onlyStartWithEliteTwo;
+            taskParams["start_with_two_ideas"] = startWithTwoIdeas;
             if (roguelike3FirstFloorFoldartal && roguelike3StartFloorFoldartal.Length > 0)
             {
                 taskParams["first_floor_foldartal"] = roguelike3StartFloorFoldartal;

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -133,6 +133,7 @@
     <system:String x:Key="RoguelikeStartingCoreCharNotFound">The operator is not in battle_data.</system:String>
     <system:String x:Key="RoguelikeStartWithEliteTwo">Repeat for「Starting Operator」Elite 2</system:String>
     <system:String x:Key="RoguelikeOnlyStartWithEliteTwo">Only Repeat for「Starting Operator」Elite 2, No Battle</system:String>
+    <system:String x:Key="RoguelikeStartWithTwoIdeas">Repeat for a start with 2 ideas</system:String>
     <system:String x:Key="Roguelike3FirstFloorFoldartal">Repeat for foldartal foreseed first floor，No Battle</system:String>
     <system:String x:Key="Roguelike3NewSquad2StartingFoldartal">Start with "Life Prioritizing Squad" and acquire the cypherboard</system:String>
     <system:String x:Key="Roguelike3NewSquad2StartingFoldartalTip">Write up to three and separate with ";"</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -133,6 +133,7 @@
     <system:String x:Key="RoguelikeStartingCoreCharNotFound">このオペレーターがbattle_dataにありません。</system:String>
     <system:String x:Key="RoguelikeStartWithEliteTwo">「最初のオペレーター」直接昇進</system:String>
     <system:String x:Key="RoguelikeOnlyStartWithEliteTwo">指定オペレーターの昇進招集までリセマラし、戦闘を行わない</system:String>
+    <system:String x:Key="RoguelikeStartWithTwoIdeas">Repeat for a start with 2 ideas</system:String>
     <system:String x:Key="Roguelike3FirstFloorFoldartal">第一層遠見で指定された啓示板を取得し、戦闘を行わない</system:String>
     <system:String x:Key="Roguelike3NewSquad2StartingFoldartal">生活重視分隊で開始、指定された啓示板を取得する</system:String>
     <system:String x:Key="Roguelike3NewSquad2StartingFoldartalTip">最大3つ書き込み、半角セミコロン;で区切る</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -133,6 +133,7 @@
     <system:String x:Key="RoguelikeStartingCoreCharNotFound">오퍼레이터 는 battle_data에 없습니다.</system:String>
     <system:String x:Key="RoguelikeStartWithEliteTwo">시작 오퍼레이터 2정예화까지 반복</system:String>
     <system:String x:Key="RoguelikeOnlyStartWithEliteTwo">시작 오퍼레이터 2정예화까지 반복(전투 X)</system:String>
+    <system:String x:Key="RoguelikeStartWithTwoIdeas">Repeat for a start with 2 ideas</system:String>
     <system:String x:Key="Roguelike3FirstFloorFoldartal">1층 암호판 획득 반복(전투 X)</system:String>
     <system:String x:Key="Roguelike3NewSquad2StartingFoldartal">생존지상 분대 목표 암호판 설정</system:String>
     <system:String x:Key="Roguelike3NewSquad2StartingFoldartalTip">최대 3개까지 지원하며「;」로 구분합니다</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -133,6 +133,7 @@
     <system:String x:Key="RoguelikeStartingCoreCharNotFound">输入的干员未在 battle_data 中。</system:String>
     <system:String x:Key="RoguelikeStartWithEliteTwo">凹「开局干员」直升精二</system:String>
     <system:String x:Key="RoguelikeOnlyStartWithEliteTwo">只凹「开局干员」直升精二，不进行作战</system:String>
+    <system:String x:Key="RoguelikeStartWithTwoIdeas">凹双构想开局</system:String>
     <system:String x:Key="Roguelike3FirstFloorFoldartal">凹第一层远见密文板，不进行作战</system:String>
     <system:String x:Key="Roguelike3NewSquad2StartingFoldartal">生活队凹开局密文板</system:String>
     <system:String x:Key="Roguelike3NewSquad2StartingFoldartalTip">最多写三个，并用英文分号「;」隔开</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -133,6 +133,7 @@
     <system:String x:Key="RoguelikeStartingCoreCharNotFound">輸入的幹員未在 battle_data 中。</system:String>
     <system:String x:Key="RoguelikeStartWithEliteTwo">凹「開局幹員」直升精二</system:String>
     <system:String x:Key="RoguelikeOnlyStartWithEliteTwo">只凹「開局幹員」直升精二，不進行作戰</system:String>
+    <system:String x:Key="RoguelikeStartWithTwoIdeas">Repeat for a start with 2 ideas</system:String>
     <system:String x:Key="Roguelike3FirstFloorFoldartal">凹第一層遠見密文板，不進行作戰</system:String>
     <system:String x:Key="Roguelike3NewSquad2StartingFoldartal">生活隊凹開局密文板</system:String>
     <system:String x:Key="Roguelike3NewSquad2StartingFoldartalTip">最多寫三個，並用英文分號;隔開</system:String>

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -1780,6 +1780,7 @@ namespace MaaWpfGui.ViewModels.UI
                 DataHelper.GetCharacterByNameOrAlias(SettingsViewModel.RoguelikeTask.RoguelikeCoreChar)?.Name ?? SettingsViewModel.RoguelikeTask.RoguelikeCoreChar,
                 SettingsViewModel.RoguelikeTask.RoguelikeStartWithEliteTwo,
                 SettingsViewModel.RoguelikeTask.RoguelikeOnlyStartWithEliteTwo,
+                SettingsViewModel.RoguelikeTask.RoguelikeStartWithTwoIdeas,
                 SettingsViewModel.RoguelikeTask.Roguelike3FirstFloorFoldartal,
                 SettingsViewModel.RoguelikeTask.Roguelike3StartFloorFoldartal,
                 SettingsViewModel.RoguelikeTask.Roguelike3NewSquad2StartingFoldartal,

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/RoguelikeSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/RoguelikeSettingsUserControlModel.cs
@@ -453,6 +453,21 @@ public class RoguelikeSettingsUserControlModel : PropertyChangedBase
     /// </summary>
     public bool RoguelikeOnlyStartWithEliteTwo => _roguelikeOnlyStartWithEliteTwo && RoguelikeStartWithEliteTwo;
 
+    private bool _roguelikeStartWithTwoIdeas = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.RoguelikeStartWithTwoIdeas, bool.FalseString));
+
+    /// <summary>
+    /// Gets or sets a value indicating whether we need to start with two ideas.
+    /// </summary>
+    public bool RoguelikeStartWithTwoIdeas
+    {
+        get => _roguelikeStartWithTwoIdeas;
+        set
+        {
+            SetAndNotify(ref _roguelikeStartWithTwoIdeas, value);
+            ConfigurationHelper.SetValue(ConfigurationKeys.RoguelikeStartWithTwoIdeas, value.ToString());
+        }
+    }
+
     private bool _roguelike3FirstFloorFoldartal = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.Roguelike3FirstFloorFoldartal, bool.FalseString));
 
     /// <summary>

--- a/src/MaaWpfGui/Views/UserControl/TaskQueue/RoguelikeSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/TaskQueue/RoguelikeSettingsUserControl.xaml
@@ -149,6 +149,15 @@
             </CheckBox>
             <CheckBox
                 Margin="0,10"
+                IsChecked="{Binding RoguelikeStartWithTwoIdeas}"
+                Visibility="{c:Binding 'RoguelikeMode == &quot;4&quot; and RoguelikeTheme == &quot;Sarkaz&quot;'}">
+                <TextBlock
+                    Block.TextAlignment="Left"
+                    Text="{DynamicResource RoguelikeStartWithTwoIdeas}"
+                    TextWrapping="Wrap" />
+            </CheckBox>
+            <CheckBox
+                Margin="0,10"
                 IsChecked="{Binding Roguelike3FirstFloorFoldartalRaw}"
                 Visibility="{c:Binding 'RoguelikeMode == &quot;4&quot; and RoguelikeTheme == &quot;Sami&quot; '}">
                 <TextBlock


### PR DESCRIPTION
#11091 #11213

纯瞎搞。
目前的逻辑是，如果不选 `start_with_two_ideas`，那么刷的是 2 希望、热水壶、2 构想，3 选 1；反之则仅刷 2 构想。
要将每种奖励独立开来处理的话，得改写整个插件，目前精力不在这一块儿，先放放。