### PR TITLE
fix: 移除多余的阻止休眠设置选项

### DIFF
--- a/src/MaaWpfGui/Views/UserControl/Settings/ConnectSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/Settings/ConnectSettingsUserControl.xaml
@@ -253,18 +253,6 @@
             HorizontalAlignment="Center"
             VerticalAlignment="Center"
             Orientation="Horizontal">
-            <CheckBox
-                Margin="10"
-                HorizontalAlignment="Center"
-                VerticalAlignment="Center"
-                Content="{DynamicResource BlockSleep}"
-                IsChecked="{Binding BlockSleep}" />
-            <CheckBox
-                Margin="10"
-                VerticalAlignment="Center"
-                Content="{DynamicResource BlockSleepWithScreenOn}"
-                IsChecked="{Binding BlockSleepWithScreenOn}"
-                Visibility="{c:Binding BlockSleep}" />
         </StackPanel>
     </Grid>
 </UserControl>


### PR DESCRIPTION
这俩选项没对应到实际设置键值 也不会保存

我觉得应该只删 UI 就行了.jpg
