### PR TITLE
style: tweak unsupported level logging

### DIFF
--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -1034,7 +1034,7 @@ namespace MaaWpfGui.Main
                         Instances.TaskQueueViewModel.AddLog(why + "，" + LocalizationHelper.GetString("GiveUpUploadingPenguins"), UiLogColor.Error);
                         if (why == "UnknownStage")
                         {
-                            Instances.TaskQueueViewModel.AddLog(details["details"]?["stage_code"] + LocalizationHelper.GetString("UnsupportedLevel"), UiLogColor.Error);
+                            Instances.TaskQueueViewModel.AddLog(details["details"]?["stage_code"]+ ": " + LocalizationHelper.GetString("UnsupportedLevel"), UiLogColor.Error);
                         }
 
                         break;

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -1020,7 +1020,7 @@ namespace MaaWpfGui.Main
                 case "AutoRecruitTask":
                     {
                         var whyStr = details.TryGetValue("why", out var why) ? why.ToString() : LocalizationHelper.GetString("ErrorOccurred");
-                        Instances.TaskQueueViewModel.AddLog(whyStr + "，" + LocalizationHelper.GetString("HasReturned"), UiLogColor.Error);
+                        Instances.TaskQueueViewModel.AddLog(whyStr + ", " + LocalizationHelper.GetString("HasReturned"), UiLogColor.Error);
                         break;
                     }
 
@@ -1031,7 +1031,7 @@ namespace MaaWpfGui.Main
                 case "ReportToPenguinStats":
                     {
                         var why = details["why"]!.ToString();
-                        Instances.TaskQueueViewModel.AddLog(why + "，" + LocalizationHelper.GetString("GiveUpUploadingPenguins"), UiLogColor.Error);
+                        Instances.TaskQueueViewModel.AddLog(why + ", " + LocalizationHelper.GetString("GiveUpUploadingPenguins"), UiLogColor.Error);
                         if (why == "UnknownStage")
                         {
                             Instances.TaskQueueViewModel.AddLog(details["details"]?["stage_code"]+ ": " + LocalizationHelper.GetString("UnsupportedLevel"), UiLogColor.Error);


### PR DESCRIPTION
![{46DDD7F1-1694-49CF-A03A-334F35239110}](https://github.com/user-attachments/assets/af1fd247-3d66-49df-9229-10b271e9b2ff)

Since the stage comes first for all languages it looks good.