### PR TITLE
fix: 增加 Tales@RA@ResourceGained 任务的 roi

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -12998,7 +12998,7 @@
         "doc": "模板任务: 获得物资, 点击 <点击空白处继续> 文字位置",
         "algorithm": "OcrDetect",
         "text": ["点击空白处继续"],
-        "roi": [554, 445, 172, 41],
+        "roi": [500, 445, 280, 41],
         "action": "ClickSelf"
     },
     "Tales@RA@ReturnToOrigin": {


### PR DESCRIPTION
Try fix #11320.

原范围
<img width="1315" alt="image" src="https://github.com/user-attachments/assets/f5d952d0-219f-41fc-8fca-8da34a5065c6">

现范围
<img width="1309" alt="image" src="https://github.com/user-attachments/assets/5b3c6332-6315-4190-8672-b095428b849e">
