### PR TITLE
fix: 进入去伪存真后识别太快导致错过 close collection 识别

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -10493,6 +10493,7 @@
                 [25, 230, 150]
             ]
         ],
+        "postDelay": 1500,
         "next": [
             "Sarkaz@Roguelike@StageFilterTruthCloseCollection",
             "Sarkaz@Roguelike@StageFilterTruthTryCombine1",


### PR DESCRIPTION
Fix #11331