### PR TITLE
feat: Skip recruited count when skipping senior/top operator recruitment.#11346

### DIFF
--- a/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.h
+++ b/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.h
@@ -66,12 +66,62 @@ protected:
 
     using slot_index = size_t;
 
+    enum calc_task_result
+    {
+        init = 0,
+        no_permit = 1,
+        force_skip = 2,
+        special_skip=3,
+        nothing_to_select = 4,
+        success = 5
+    };
     struct calc_task_result_type
     {
+        
         bool success = false;
         bool force_skip = false;
+        bool for_special_tags_skip = false;        // Get the definition by searching for "SpecialTags".
         int recruitment_time = 60;
         [[maybe_unused]] int tags_selected = 0;
+
+        calc_task_result_type(calc_task_result res, const int _recruitment_time = 60, const int _tag_selected=0) 
+        {
+            switch (res) {
+            case calc_task_result::init:
+                success = false;
+                force_skip = false;
+                for_special_tags_skip = false; 
+                recruitment_time = _recruitment_time;
+                tags_selected = _tag_selected;
+                break;
+            case calc_task_result::special_skip:
+                success = true;
+                force_skip = true;
+                for_special_tags_skip = true;
+                recruitment_time = _recruitment_time;
+                tags_selected = _tag_selected;
+                break;
+            case calc_task_result::no_permit:
+            case calc_task_result::force_skip:
+                success = true;
+                force_skip = true;
+                for_special_tags_skip = false;
+                recruitment_time = _recruitment_time;
+                tags_selected = _tag_selected;
+                break;
+            case calc_task_result::nothing_to_select:
+            case calc_task_result::success:
+                success = true;
+                force_skip = false;
+                for_special_tags_skip = false;
+                recruitment_time = _recruitment_time;
+                tags_selected = _tag_selected;
+                break;
+            }
+        };
+
+        calc_task_result_type() :
+            calc_task_result_type(init) {};
     };
 
     calc_task_result_type recruit_calc_task(slot_index = 0);

--- a/src/MaaCore/Vision/Miscellaneous/RecruitImageAnalyzer.h
+++ b/src/MaaCore/Vision/Miscellaneous/RecruitImageAnalyzer.h
@@ -24,6 +24,25 @@ public:
 
     Rect get_permit_rect() const noexcept { return m_permit_rect; }
 
+#ifdef ASST_DEBUG
+    // mock function
+    enum special_type
+    {
+        top_operator = 6,
+        senior_operator = 5
+    };
+   
+    void mock_set_special(special_type type)
+    {
+        if (type == top_operator) {
+            m_tags_result[0].text = "高级资深干员";
+        }
+        if (type == senior_operator) {
+            m_tags_result[0].text = "资深干员";
+        }
+    }
+#endif                                                          // ASST_DEBUG
+
 private:
     // 该分析器不支持外部设置ROI
     using VisionHelper::set_roi;


### PR DESCRIPTION
feat: Skip recruited count when skipping senior/top operator recruitment.#11346
test: Add test function for this feature.
fix: Modify the construction and usage of calc_task_result_type structure.