### PR TITLE
Try to fix the compilation failure on aarch64

### DIFF
--- a/src/MaaCore/Config/TaskData.cpp
+++ b/src/MaaCore/Config/TaskData.cpp
@@ -857,8 +857,8 @@ asst::MatchTaskConstPtr asst::TaskData::_default_match_task_info()
 {
     auto match_task_info_ptr = std::make_shared<MatchTaskInfo>();
     match_task_info_ptr->templ_names = { "__INVALID__" };
-    match_task_info_ptr->templ_thresholds = { TemplThresholdDefault };
-    match_task_info_ptr->methods = { MatchMethod::Ccoeff };
+    match_task_info_ptr->templ_thresholds = std::vector<double> { TemplThresholdDefault };
+    match_task_info_ptr->methods = std::vector<MatchMethod> { MatchMethod::Ccoeff };
     match_task_info_ptr->mask_ranges = {};
     match_task_info_ptr->color_scales = {};
     match_task_info_ptr->color_close = true;


### PR DESCRIPTION
隐式声明导致以最小长度创建该vector，会存在一个时点是有越界风险的。
aarch64的严格检查会警告这一点。
尝试改为显式声明，就会直接创建合适长度的vector，从而回避这一点。