### PR TITLE
fix: 生息演算无存档刷点模式，允许在确认离开当前区块后没有 Loading Text 的情况下等待

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -12757,13 +12757,14 @@
         ]
     },
     "Tales@RA@PNS-ConfirmToLeaveNode": {
-        "doc": "确认离开当前区块",
+        "doc": "确认离开当前区块，注意，可能会在没有 <正在提交反馈至神经> 文字的情况下卡住一小会儿",
         "baseTask": "Tales@RA@DialogConfirmYellow",
         "template": "Tales@RA@DialogConfirmYellow.png",
         "next": [
             "Tales@RA@PNS-MissionResults",
             "Tales@RA@PNS-ConfirmToLeaveNode@NextAfterLoadingText",
-            "Tales@RA@PNS-ConfirmToLeaveNode"
+            "Tales@RA@PNS-ConfirmToLeaveNode",
+            "Tales@RA@PNS-ConfirmToLeaveNode@NextAfterMerelyWaiting"
         ]
     },
     "Tales@RA@PNS-EnterBaseCamp": {


### PR DESCRIPTION
有用户反映生息演算确认离开当前区块后，会卡在战斗界面一小会儿，而 MAA 需要识别到“正在提交反馈至神经”这样的加载文字时才能一直等待，否则会在 20 次 retry 后停止任务。

这个 PR 通过在 `Tales@RA@PNS-ConfirmToLeaveNode` 任务的 `next` 中添加 `NextAfterMerelyWaiting` 项来允许无条件等待。