### PR TITLE
feat: RA2 multiple crafting

### DIFF
--- a/docs/en-us/protocol/integration.md
+++ b/docs/en-us/protocol/integration.md
@@ -313,7 +313,10 @@ For more details about auto-copilot JSON, please refer to [Copilot Schema](./cop
                                 // 0 - Farm badges & construction pts (exiting the stage immediately)
                                 // 1 - Fire Within the Sand: Farm Crude Gold (forging Gold at headquarter after purchasing water)
                                 //     Tales Within the Sand: Automatically craft items and load to earn currency
-    "tool_to_craft": string,    // Automatically crafted items, optional, glow stick by default 
+    "tools_to_craft": [
+        string,                 // Automatically crafted items, optional, glow stick by default
+        ...
+    ] 
                                 // Suggested fill in the substring
     "increment_mode": int,      // Click type, optional. 0 by default
                                 // 0 - Rapid Click

--- a/docs/ja-jp/protocol/integration.md
+++ b/docs/ja-jp/protocol/integration.md
@@ -318,7 +318,10 @@ TaskId ASSTAPI AsstAppendTask(AsstHandle handle, const char* type, const char* p
                                 // 0 - すぐにバトルをやめることでバッジと建設ポイントを周回
                                 // 1 - *砂中の火*：水を買ってから基地で鍛造して粗製純金を周回
                                 //     *沙洲遺聞*：アイテムを自動的に製造してロードして通貨を稼ぐ
-    "tool_to_craft": string,    // 自動的に製造されるアイテム、オプション、デフォルトは螢光棒
+    "tools_to_craft": [
+        string,                 // 自動的に製造されるアイテム、オプション、デフォルトは螢光棒
+        ...
+    ] 
                                 // サブストリングを入力することをお勧めします
     "increment_mode": int,      // クリックタイプ、オプション、デフォルトは0
                                 // 0 - 連続クリック

--- a/docs/ko-kr/protocol/integration.md
+++ b/docs/ko-kr/protocol/integration.md
@@ -306,7 +306,10 @@ TaskId ASSTAPI AsstAppendTask(AsstHandle handle, const char* type, const char* p
                                 // 0 - 점수를 획득하고 건설 점수를 얻어 전투에 진입한 후 바로 나가기
                                 // 1 - *모래 속의 불꽃*: 황금을 얻기 위해 오퍼레이터가 물을 사고 기지를 강화합니다.
                                 //     *모래 안의 이야기*: 모래 안의 이야기: 자동으로 아이템을 제작하고 로드하여 통화를 획득
-    "tool_to_craft": string,    // 자동으로 제작되는 아이템, 선택 사항, 기본값은 형광봉
+    "tools_to_craft": [
+        string,                 // 자동으로 제작되는 아이템, 선택 사항, 기본값은 형광봉
+        ...
+    ] 
                                 // 부분 문자열을 채우는 것이 좋습니다
     "increment_mode": int,      // 클릭 유형, 선택 사항. 기본값은 0
                                 // 0 - 연속 클릭

--- a/docs/zh-cn/protocol/integration.md
+++ b/docs/zh-cn/protocol/integration.md
@@ -328,7 +328,10 @@ AsstTaskId ASSTAPI AsstAppendTask(AsstHandle handle, const char* type, const cha
                                 // 0 - 刷分与建造点，进入战斗直接退出
                                 // 1 - 沙中之火：刷赤金，联络员买水后基地锻造；
                                 //     沙洲遗闻：自动制造物品并读档刷货币
-    "tool_to_craft": string,    // 自动制造的物品，可选项，默认为荧光棒
+    "tools_to_craft": [
+        string,                 // 自动制造的物品，可选项，默认为荧光棒
+        ...
+    ] 
                                 // 建议填写子串
     "increment_mode": int,      // 点击类型，可选项。默认为0
                                 // 0 - 连点

--- a/docs/zh-tw/protocol/integration.md
+++ b/docs/zh-tw/protocol/integration.md
@@ -319,7 +319,10 @@ AsstTaskId ASSTAPI AsstAppendTask(AsstHandle handle, const char* type, const cha
                                 // 0 - 刷分與建造點，進入戰鬥直接退出
                                 // 1 - 沙中之火：刷赤金，聯絡員買水後基地鍛造；
                                 //     沙洲遺聞：自動製造物品並讀檔刷貨幣
-    "tool_to_craft": string,    // 自動製造的物品，可選項，默認為荧光棒
+    "tools_to_craft": [
+        string,                 // 自動製造的物品，可選項，默認為荧光棒
+        ...
+    ] 
                                 // 建議填寫子串
     "increment_mode": int,      // 點擊類型，可選項。默認為0
                                 // 0 - 連點

--- a/src/MaaCore/Task/Reclamation/ReclamationConfig.h
+++ b/src/MaaCore/Task/Reclamation/ReclamationConfig.h
@@ -59,7 +59,7 @@ private:
 
     // 以下注释列出了插件专用参数, 以便于快速检阅。这些参数的具体声明与使用请参考各插件。
     // ———————— ReclamationCraftTaskPlugin 专用参数 ———————————————————————————————————————
-    // std::string m_tool_to_craft = "荧光棒";                 // 要组装的支援道具
+    // std::string m_tools_to_craft = "荧光棒";                 // 要组装的支援道具
     // int m_num_craft_batches = 16;                          // 支援道具组装批次数, 每批组装 99 个
     // IncrementMode m_increment_mode = IncrementMode::Click; // 点击加号按钮增加组装数量的方式
 };

--- a/src/MaaCore/Task/Reclamation/ReclamationConfig.h
+++ b/src/MaaCore/Task/Reclamation/ReclamationConfig.h
@@ -59,8 +59,8 @@ private:
 
     // 以下注释列出了插件专用参数, 以便于快速检阅。这些参数的具体声明与使用请参考各插件。
     // ———————— ReclamationCraftTaskPlugin 专用参数 ———————————————————————————————————————
-    // std::string m_tools_to_craft = "荧光棒";                 // 要组装的支援道具
-    // int m_num_craft_batches = 16;                          // 支援道具组装批次数, 每批组装 99 个
-    // IncrementMode m_increment_mode = IncrementMode::Click; // 点击加号按钮增加组装数量的方式
+    // std::vector<std::string> m_tools_to_craft = { "荧光棒" }; // 要组装的支援道具
+    // int m_num_craft_batches = 16;                            // 支援道具组装批次数, 每批组装 99 个
+    // IncrementMode m_increment_mode = IncrementMode::Click;   // 点击加号按钮增加组装数量的方式
 };
 } // namespace asst

--- a/src/MaaCore/Task/Reclamation/ReclamationCraftTaskPlugin.cpp
+++ b/src/MaaCore/Task/Reclamation/ReclamationCraftTaskPlugin.cpp
@@ -16,7 +16,12 @@ bool asst::ReclamationCraftTaskPlugin::load_params(const json::value& params)
     }
 
     // 根据 params 设置插件专用参数
-    m_tool_to_craft = params.get("tool_to_craft", "荧光棒");
+    auto m_tools_to_craft_opt = params.find<json::array>("tools_to_craft");
+    for (auto& tool : m_tools_to_craft_opt.value()) {
+        if (std::string tool_str = tool.as_string(); !tool_str.empty()) {
+            tools_to_craft.emplace_back(tool_str);
+        }
+    }
     m_num_craft_batches =
         params.get("num_craft_batches", 16); // 默认值 16 以组装 <荧光棒> 消耗至少 3000 木头为准计算得出
     const int increment_mode_int = params.get("increment_mode", static_cast<int>(IncrementMode::Click));
@@ -49,62 +54,17 @@ bool asst::ReclamationCraftTaskPlugin::_run()
     LogTraceFunction;
 
     const std::string& theme = m_config->get_theme();
+    for (auto& tool_to_craft : tools_to_craft) {
+        // 将要组装的道具设置为 tool
+        Task.get<OcrTaskInfo>(theme + "@RA@PIS-ClickTool")->text = { tool_to_craft };
 
-    // 将要组装的道具设置为 m_tool_to_craft
-    Task.get<OcrTaskInfo>(theme + "@RA@PIS-ClickTool")->text = { m_tool_to_craft };
-
-    bool insufficient_materials = false;
-    for (int batch = 0; !need_exit() && !insufficient_materials && batch < m_num_craft_batches; ++batch) {
-        // Step 1: 选择要组装的道具, 若没有找到则在组装台界面向下滑动屏幕后再次检测, 直到识别到要组装的道具后点击
-        ProcessTask(*this, { theme + "@RA@PIS-SelectTool" }).run();
-        sleep(500);
-
-        int craft_amount = 0;
-        while (!need_exit() && !insufficient_materials && craft_amount < 99) {
-            // Step 2: 识别加号按钮后点击 99 次增加组装数量
-            increase_craft_amount(99 - craft_amount);
-            sleep(500);
-
-            // Step 3: 识别组装数量
-            if (!calc_craft_amount(craft_amount)) {
-                return false;
-            }
-
-            if (craft_amount < 99) {
-                // 再次点击一次加号按钮, 确认组装数量已为最大
-                int old_craft_amount = craft_amount;
-                ProcessTask(*this, { theme + "@RA@IncreaseCraftAmount" }).run();
-                sleep(500);
-                if (!calc_craft_amount(craft_amount) || craft_amount <= old_craft_amount) {
-                    insufficient_materials = true;
-                }
-                else {
-                    Log.info("Reclamation Craft", "| craft amount: ", craft_amount);
-                }
-            }
-        }
-
-        // Step 4: 开始组装或取消组装
-        if (craft_amount <= 0) {
-            // 点击空白处取消组装
-            ProcessTask(*this, { theme + "@RA@CancelCraft" }).run();
-        }
-        else {
-            // 点击开始组装图标, 获得物资, 点击 <点击空白处继续> 文字位置
-            ProcessTask(*this, { theme + "@RA@PIS-Craft" }).run();
-        }
-        sleep(500);
-
-        // 将要组装的道具设置为 m_tool_to_craft
-        Task.get<OcrTaskInfo>(theme + "@RA@PIS-ClickTool")->text = { "Glow Stick" };
-
-        insufficient_materials = false;
-        for (batch = 0; !need_exit() && !insufficient_materials && batch < m_num_craft_batches; ++batch) {
+        bool insufficient_materials = false;
+        for (int batch = 0; !need_exit() && !insufficient_materials && batch < m_num_craft_batches; ++batch) {
             // Step 1: 选择要组装的道具, 若没有找到则在组装台界面向下滑动屏幕后再次检测, 直到识别到要组装的道具后点击
             ProcessTask(*this, { theme + "@RA@PIS-SelectTool" }).run();
             sleep(500);
 
-            craft_amount = 0;
+            int craft_amount = 0;
             while (!need_exit() && !insufficient_materials && craft_amount < 99) {
                 // Step 2: 识别加号按钮后点击 99 次增加组装数量
                 increase_craft_amount(99 - craft_amount);

--- a/src/MaaCore/Task/Reclamation/ReclamationCraftTaskPlugin.cpp
+++ b/src/MaaCore/Task/Reclamation/ReclamationCraftTaskPlugin.cpp
@@ -16,10 +16,10 @@ bool asst::ReclamationCraftTaskPlugin::load_params(const json::value& params)
     }
 
     // 根据 params 设置插件专用参数
-    auto m_tools_to_craft_opt = params.find<json::array>("tools_to_craft");
-    for (auto& tool : m_tools_to_craft_opt.value()) {
+    auto tools_to_craft_opt = params.find<json::array>("tools_to_craft");
+    for (auto& tool : tools_to_craft_opt.value()) {
         if (std::string tool_str = tool.as_string(); !tool_str.empty()) {
-            tools_to_craft.emplace_back(tool_str);
+            m_tools_to_craft.emplace_back(tool_str);
         }
     }
     m_num_craft_batches =
@@ -54,7 +54,7 @@ bool asst::ReclamationCraftTaskPlugin::_run()
     LogTraceFunction;
 
     const std::string& theme = m_config->get_theme();
-    for (auto& tool_to_craft : tools_to_craft) {
+    for (const std::string& tool_to_craft : m_tools_to_craft) {
         // 将要组装的道具设置为 tool
         Task.get<OcrTaskInfo>(theme + "@RA@PIS-ClickTool")->text = { tool_to_craft };
 

--- a/src/MaaCore/Task/Reclamation/ReclamationCraftTaskPlugin.h
+++ b/src/MaaCore/Task/Reclamation/ReclamationCraftTaskPlugin.h
@@ -26,7 +26,7 @@ private:
         Hold = 1
     };
 
-    std::string m_tool_to_craft = "荧光棒";                // 要组装的支援道具
+    std::vector<std::string> tools_to_craft;                // 要组装的支援道具
     int m_num_craft_batches = 16;                          // 支援道具组装批次数, 每批组装 99 个
     IncrementMode m_increment_mode = IncrementMode::Click; // 点击加号按钮增加组装数量的方式
 };

--- a/src/MaaCore/Task/Reclamation/ReclamationCraftTaskPlugin.h
+++ b/src/MaaCore/Task/Reclamation/ReclamationCraftTaskPlugin.h
@@ -27,7 +27,7 @@ private:
     };
 
     std::vector<std::string> m_tools_to_craft = { "荧光棒" }; // 要组装的支援道具
-    int m_num_craft_batches = 16;                            // 支援道具组装批次数, 每批组装 99 个
-    IncrementMode m_increment_mode = IncrementMode::Click;   // 点击加号按钮增加组装数量的方式
+    int m_num_craft_batches = 16;                             // 支援道具组装批次数, 每批组装 99 个
+    IncrementMode m_increment_mode = IncrementMode::Click;    // 点击加号按钮增加组装数量的方式
 };
 } // namespace asst

--- a/src/MaaCore/Task/Reclamation/ReclamationCraftTaskPlugin.h
+++ b/src/MaaCore/Task/Reclamation/ReclamationCraftTaskPlugin.h
@@ -26,8 +26,8 @@ private:
         Hold = 1
     };
 
-    std::vector<std::string> tools_to_craft;               // 要组装的支援道具
-    int m_num_craft_batches = 16;                          // 支援道具组装批次数, 每批组装 99 个
-    IncrementMode m_increment_mode = IncrementMode::Click; // 点击加号按钮增加组装数量的方式
+    std::vector<std::string> m_tools_to_craft = { "荧光棒" }; // 要组装的支援道具
+    int m_num_craft_batches = 16;                            // 支援道具组装批次数, 每批组装 99 个
+    IncrementMode m_increment_mode = IncrementMode::Click;   // 点击加号按钮增加组装数量的方式
 };
 } // namespace asst

--- a/src/MaaCore/Task/Reclamation/ReclamationCraftTaskPlugin.h
+++ b/src/MaaCore/Task/Reclamation/ReclamationCraftTaskPlugin.h
@@ -26,7 +26,7 @@ private:
         Hold = 1
     };
 
-    std::vector<std::string> tools_to_craft;                // 要组装的支援道具
+    std::vector<std::string> tools_to_craft;               // 要组装的支援道具
     int m_num_craft_batches = 16;                          // 支援道具组装批次数, 每批组装 99 个
     IncrementMode m_increment_mode = IncrementMode::Click; // 点击加号按钮增加组装数量的方式
 };

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -2542,13 +2542,13 @@ namespace MaaWpfGui.Main
         /// <param name="incrementMode">点击类型：0 连点；1 长按</param>
         /// <param name="numCraftBatches">单次最大制造轮数</param>
         /// <returns>是否成功。</returns>
-        public bool AsstAppendReclamation(string theme = "Tales", int mode = 1, string toolToCraft = "", int incrementMode = 0, int numCraftBatches = 16)
+        public bool AsstAppendReclamation(string[] toolToCraft, string theme = "Tales", int mode = 1, int incrementMode = 0, int numCraftBatches = 16)
         {
             var taskParams = new JObject
             {
+                ["tools_to_craft"] = new JArray(toolToCraft),
                 ["theme"] = theme,
                 ["mode"] = mode,
-                ["tool_to_craft"] = toolToCraft,
                 ["increment_mode"] = incrementMode,
                 ["num_craft_batches"] = numCraftBatches,
             };

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -1794,12 +1794,15 @@ namespace MaaWpfGui.ViewModels.UI
 
         private static bool AppendReclamation()
         {
+            var toolToCraft = SettingsViewModel.ReclamationTask.ReclamationToolToCraft.Split(';', '；').Select(s => s.Trim());
+
+
             _ = int.TryParse(SettingsViewModel.ReclamationTask.ReclamationMode, out var mode);
 
             return Instances.AsstProxy.AsstAppendReclamation(
+                toolToCraft.ToArray(),
                 SettingsViewModel.ReclamationTask.ReclamationTheme,
                 mode,
-                SettingsViewModel.ReclamationTask.ReclamationToolToCraft,
                 SettingsViewModel.ReclamationTask.ReclamationIncrementMode,
                 SettingsViewModel.ReclamationTask.ReclamationMaxCraftCountPerRound);
         }


### PR DESCRIPTION
@Alan-Charred I started farming RA as I was very behind and this is my result in just about 1 hour:
![image](https://github.com/user-attachments/assets/086cbcba-bb7d-48ff-b938-f28169a86dd3)
Pretty good right?

But then I thought. What are the most efficient crafting recipes? And so I started crafting just the net hunter launcher thing. But I was leaving the run with 300 wood never to be used.
And so I thought about just copying the logic like a retard to use both rocks and wood (for very advanced players you could even use more crafting with metal)

Obviously my implementation is super bad and just an idea. But have we ever considered adding more crafting recipes / option to craft more stuff?