### PR TITLE
chore: bump maa-cli to 0.5.2

### DIFF
--- a/docs/en-us/manual/cli/install.md
+++ b/docs/en-us/manual/cli/install.md
@@ -59,6 +59,7 @@ If package managers are not available on your system or you prefer not to use th
 - [Linux x86_64 (x64, amd64)](https://github.com/MaaAssistantArknights/maa-cli/releases/latest/download/maa_cli-x86_64-unknown-linux-gnu.tar.gz)
 - [Linux aarch64 (arm64)](https://github.com/MaaAssistantArknights/maa-cli/releases/latest/download/maa_cli-aarch64-unknown-linux-gnu.tar.gz)
 - [Windows x86_64 (x64, amd64)](https://github.com/MaaAssistantArknights/maa-cli/releases/latest/download/maa_cli-x86_64-pc-windows-msvc.zip)
+- [Windows aarch64 (arm64)](https://github.com/MaaAssistantArknights/maa-cli/releases/latest/download/maa_cli-aarch64-pc-windows-msvc.zip)
 
 If your platform is not listed above, you can try to compile and install it yourself (see below).
 

--- a/docs/ja-jp/manual/cli/install.md
+++ b/docs/ja-jp/manual/cli/install.md
@@ -63,6 +63,7 @@ Homebrew 用户可以通过非官方的 [tap](https://github.com/MaaAssistantArk
 - [Linux x86_64 (x64, amd64)](https://github.com/MaaAssistantArknights/maa-cli/releases/latest/download/maa_cli-x86_64-unknown-linux-gnu.tar.gz)
 - [Linux aarch64 (arm64)](https://github.com/MaaAssistantArknights/maa-cli/releases/latest/download/maa_cli-aarch64-unknown-linux-gnu.tar.gz)
 - [Windows x86_64 (x64, amd64)](https://github.com/MaaAssistantArknights/maa-cli/releases/latest/download/maa_cli-x86_64-pc-windows-msvc.zip)
+- [Windows aarch64 (arm64)](https://github.com/MaaAssistantArknights/maa-cli/releases/latest/download/maa_cli-aarch64-pc-windows-msvc.zip)
 
 如果你的平台不在上述列表中，可以尝试自行编译安装（参见下文）。
 

--- a/docs/ko-kr/manual/cli/install.md
+++ b/docs/ko-kr/manual/cli/install.md
@@ -59,6 +59,7 @@ Homebrew 사용자는 비공식 [tap](https://github.com/MaaAssistantArknights/h
 - [Linux x86_64 (x64, amd64)](https://github.com/MaaAssistantArknights/maa-cli/releases/latest/download/maa_cli-x86_64-unknown-linux-gnu.tar.gz)
 - [Linux aarch64 (arm64)](https://github.com/MaaAssistantArknights/maa-cli/releases/latest/download/maa_cli-aarch64-unknown-linux-gnu.tar.gz)
 - [Windows x86_64 (x64, amd64)](https://github.com/MaaAssistantArknights/maa-cli/releases/latest/download/maa_cli-x86_64-pc-windows-msvc.zip)
+- [Windows aarch64 (arm64)](https://github.com/MaaAssistantArknights/maa-cli/releases/latest/download/maa_cli-aarch64-pc-windows-msvc.zip)
 
 위의 목록에 없는 플랫폼의 경우, 직접 컴파일하여 설치할 수 있습니다(아래 참조).
 

--- a/docs/zh-cn/manual/cli/install.md
+++ b/docs/zh-cn/manual/cli/install.md
@@ -59,6 +59,7 @@ Homebrew 用户可以通过非官方的 [tap](https://github.com/MaaAssistantArk
 - [Linux x86_64 (x64, amd64)](https://github.com/MaaAssistantArknights/maa-cli/releases/latest/download/maa_cli-x86_64-unknown-linux-gnu.tar.gz)
 - [Linux aarch64 (arm64)](https://github.com/MaaAssistantArknights/maa-cli/releases/latest/download/maa_cli-aarch64-unknown-linux-gnu.tar.gz)
 - [Windows x86_64 (x64, amd64)](https://github.com/MaaAssistantArknights/maa-cli/releases/latest/download/maa_cli-x86_64-pc-windows-msvc.zip)
+- [Windows aarch64 (arm64)](https://github.com/MaaAssistantArknights/maa-cli/releases/latest/download/maa_cli-aarch64-pc-windows-msvc.zip)
 
 如果你的平台不在上述列表中，可以尝试自行编译安装（参见下文）。
 

--- a/docs/zh-tw/manual/cli/install.md
+++ b/docs/zh-tw/manual/cli/install.md
@@ -63,6 +63,7 @@ Homebrew 用户可以通过非官方的 [tap](https://github.com/MaaAssistantArk
 - [Linux x86_64 (x64, amd64)](https://github.com/MaaAssistantArknights/maa-cli/releases/latest/download/maa_cli-x86_64-unknown-linux-gnu.tar.gz)
 - [Linux aarch64 (arm64)](https://github.com/MaaAssistantArknights/maa-cli/releases/latest/download/maa_cli-aarch64-unknown-linux-gnu.tar.gz)
 - [Windows x86_64 (x64, amd64)](https://github.com/MaaAssistantArknights/maa-cli/releases/latest/download/maa_cli-x86_64-pc-windows-msvc.zip)
+- [Windows aarch64 (arm64)](https://github.com/MaaAssistantArknights/maa-cli/releases/latest/download/maa_cli-aarch64-pc-windows-msvc.zip)
 
 如果你的平台不在上述列表中，可以尝试自行编译安装（参见下文）。
 


### PR DESCRIPTION
Bump maa-cli to 0.5.2.

See [maa-cli changelog](https://github.com/MaaAssistantArknights/maa-cli/releases/tag/v0.5.2) for more details.