### PR TITLE
fix: 尝试修复临时招募预备干员的权重过高

### DIFF
--- a/src/MaaCore/Task/Roguelike/RoguelikeRecruitTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeRecruitTaskPlugin.cpp
@@ -283,7 +283,8 @@ bool asst::RoguelikeRecruitTaskPlugin::_run()
                         oper_info.level);
                 }
 
-                if (temp_recruit_exist) { // 临时招募干员具有极高抓取优先级，但是在编队时会占用前面的位置
+                if (temp_recruit_exist && !oper_info.name.starts_with("预备干员")) {
+                    // 临时招募干员具有极高抓取优先级，但是在编队时会占用前面的位置
                     priority += 600;
                     temp_recruit_exist = false;
                 }


### PR DESCRIPTION
Fix #11412