### PR TITLE
chore: reduce smoke-testing path scope

### DIFF
--- a/.github/workflows/smoke-testing.yml
+++ b/.github/workflows/smoke-testing.yml
@@ -5,23 +5,25 @@ on:
     paths:
       - "3rdparty/include/**"
       - "include/**"
-      - "src/**"
+      - "src/Cpp/**"
+      - "src/MaaCore/**"
+      - "src/SyncRes/**"
       - "cmake/**"
       - "CMakeLists.txt"
       - "MAA.sln"
       - "resource/**"
-      - "MaaDeps/**"
       - "!**/*.md"
   pull_request:
     paths:
       - "3rdparty/include/**"
       - "include/**"
-      - "src/**"
+      - "src/Cpp/**"
+      - "src/MaaCore/**"
+      - "src/SyncRes/**"
       - "cmake/**"
       - "CMakeLists.txt"
       - "MAA.sln"
       - "resource/**"
-      - "MaaDeps/**"
       - "!**/*.md"
   workflow_dispatch:
 
@@ -46,7 +48,7 @@ jobs:
         id: cache-exe
         uses: actions/cache@v4
         with:
-          key: Smoke-testing-sample.exe-${{ github.ref }}-${{ hashFiles('src/**', 'CMakeLists.txt', '3rdparty/include/**', 'include/**', 'cmake/**', 'MAA.sln', 'MaaDeps/**') }}
+          key: Smoke-testing-sample.exe-${{ github.ref }}-${{ hashFiles('src/Cpp/**', 'src/MaaCore/**', 'src/SyncRes/**', 'CMakeLists.txt', '3rdparty/include/**', 'include/**', 'cmake/**', 'MAA.sln') }}
           path: |
             ./x64/Debug/Sample.exe
             ./x64/Debug/fastdeploy_ppocr.dll


### PR DESCRIPTION
After doing some changes to the workflows. I noticed that smoke-testing was being run more times then it was necessary. E.G:
- f95f1b8cc61d5c406b8c8a8809ee5dc3e7dac301
- 3a01a7f50ca806ebef2120ea1e517dea7b5332cd

Were changes only to wpf (C#) but smoke-testing was requested.

The MSBUILD requires only MaaCore (Cpp)