### PR TITLE
ci: smoke-testing cache + scope

### DIFF
--- a/.github/workflows/smoke-testing.yml
+++ b/.github/workflows/smoke-testing.yml
@@ -111,8 +111,8 @@ jobs:
         run: |
           pwsh tools/SmokeTesting/run_tests.ps1
 
-      - name: Save cache smoke-testing Sample.exe
-        if: steps.cache-exe.outputs.cache-hit != 'true'
+      - name: Save cache smoke-testing Sample.exe (only in dev)
+        if: steps.cache-exe.outputs.cache-hit != 'true' && github.ref == 'refs/heads/dev'
         uses: actions/cache/save@v4
         with:
           key: ${{ steps.cache_key.outputs.key }}

--- a/.github/workflows/smoke-testing.yml
+++ b/.github/workflows/smoke-testing.yml
@@ -36,11 +36,16 @@ jobs:
         with:
           show-progress: false
 
+      - name: Generate cache key
+        id: cache_key
+        run: |
+          Write-Output "key=Smoke-testing-sample.exe-${{ hashFiles('src/**', '3rdparty/include/**', 'include/**', 'MAA.sln') }}" >> $env:GITHUB_OUTPUT
+
       - name: Restore cache smoke-testing Sample.exe
         id: cache-exe
         uses: actions/cache/restore@v4
         with:
-          key: Smoke-testing-sample.exe-${{ hashFiles('src/**', '3rdparty/include/**', 'include/**', 'MAA.sln') }}
+          key: ${{ steps.cache_key.outputs.key }}
           path: |
             ./x64/Debug/Sample.exe
             ./x64/Debug/fastdeploy_ppocr.dll
@@ -89,18 +94,10 @@ jobs:
         with:
           msbuild-architecture: x64
 
-      - name: debug hashfiles
-        run: |
-          echo Smoke-testing-sample.exe-${{ hashFiles('src/**', '3rdparty/include/**', 'include/**', 'MAA.sln') }}
-
       - name: Build MaaSample
         if: steps.cache-exe.outputs.cache-hit != 'true'
         run: |
           MSBUILD src/Cpp/MaaSample.slnf -t:restore,build -p:Configuration="Debug" -p:Platform="x64" -m
-
-      - name: debug hashfiles
-        run: |
-          echo Smoke-testing-sample.exe-${{ hashFiles('src/**', '3rdparty/include/**', 'include/**', 'MAA.sln') }}
   
       - name: Copy resource to build directory
         if: steps.cache-exe.outputs.cache-hit == 'true'
@@ -118,7 +115,7 @@ jobs:
         if: steps.cache-exe.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
-          key: Smoke-testing-sample.exe-${{ hashFiles('src/**', '3rdparty/include/**', 'include/**', 'MAA.sln') }}
+          key: ${{ steps.cache_key.outputs.key }}
           path: |
             ./x64/Debug/Sample.exe
             ./x64/Debug/fastdeploy_ppocr.dll

--- a/.github/workflows/smoke-testing.yml
+++ b/.github/workflows/smoke-testing.yml
@@ -5,7 +5,9 @@ on:
     paths:
       - "3rdparty/include/**"
       - "include/**"
-      - "src/**"
+      - "src/Cpp/**"
+      - "src/MaaCore/**"
+      - "src/SyncRes/**"
       - "MAA.sln"
       - "resource/**"
       - "!**/*.md"
@@ -13,7 +15,9 @@ on:
     paths:
       - "3rdparty/include/**"
       - "include/**"
-      - "src/**"
+      - "src/Cpp/**"
+      - "src/MaaCore/**"
+      - "src/SyncRes/**"
       - "MAA.sln"
       - "resource/**"
       - "!**/*.md"
@@ -39,9 +43,9 @@ jobs:
       - name: Generate cache key
         id: cache_key
         run: |
-          Write-Output "key=Smoke-testing-sample.exe-${{ hashFiles('src/**', '3rdparty/include/**', 'include/**', 'MAA.sln') }}" >> $env:GITHUB_OUTPUT
+          Write-Output "key=Smoke-testing-${{ hashFiles('src/Cpp/**', 'src/MaaCore/**', 'src/SyncRes/**', '3rdparty/include/**', 'include/**', 'MAA.sln') }}" >> $env:GITHUB_OUTPUT
 
-      - name: Restore cache smoke-testing Sample.exe
+      - name: Restore cache smoke-testing
         id: cache-exe
         uses: actions/cache/restore@v4
         with:
@@ -111,7 +115,7 @@ jobs:
         run: |
           pwsh tools/SmokeTesting/run_tests.ps1
 
-      - name: Save cache smoke-testing Sample.exe (only in dev)
+      - name: Save cache smoke-testing (only in dev)
         if: steps.cache-exe.outputs.cache-hit != 'true' && github.ref == 'refs/heads/dev'
         uses: actions/cache/save@v4
         with:

--- a/.github/workflows/smoke-testing.yml
+++ b/.github/workflows/smoke-testing.yml
@@ -93,6 +93,10 @@ jobs:
         with:
           msbuild-architecture: x64
 
+      - name: debug hashfiles
+        run: |
+          echo Smoke-testing-sample.exe-${{ hashFiles('src/**', 'CMakeLists.txt', '3rdparty/include/**', 'include/**', 'cmake/**', 'MAA.sln') }}
+
       - name: Build MaaSample
         if: steps.cache-exe.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/smoke-testing.yml
+++ b/.github/workflows/smoke-testing.yml
@@ -6,8 +6,6 @@ on:
       - "3rdparty/include/**"
       - "include/**"
       - "src/**"
-      - "cmake/**"
-      - "CMakeLists.txt"
       - "MAA.sln"
       - "resource/**"
       - "!**/*.md"
@@ -16,8 +14,6 @@ on:
       - "3rdparty/include/**"
       - "include/**"
       - "src/**"
-      - "cmake/**"
-      - "CMakeLists.txt"
       - "MAA.sln"
       - "resource/**"
       - "!**/*.md"
@@ -44,7 +40,7 @@ jobs:
         id: cache-exe
         uses: actions/cache/restore@v4
         with:
-          key: Smoke-testing-sample.exe-${{ hashFiles('src/**', 'CMakeLists.txt', '3rdparty/include/**', 'include/**', 'cmake/**', 'MAA.sln') }}
+          key: Smoke-testing-sample.exe-${{ hashFiles('src/**', '3rdparty/include/**', 'include/**', 'MAA.sln') }}
           path: |
             ./x64/Debug/Sample.exe
             ./x64/Debug/fastdeploy_ppocr.dll
@@ -95,7 +91,7 @@ jobs:
 
       - name: debug hashfiles
         run: |
-          echo Smoke-testing-sample.exe-${{ hashFiles('src/**', 'CMakeLists.txt', '3rdparty/include/**', 'include/**', 'cmake/**', 'MAA.sln') }}
+          echo Smoke-testing-sample.exe-${{ hashFiles('src/**', '3rdparty/include/**', 'include/**', 'MAA.sln') }}
 
       - name: Build MaaSample
         if: steps.cache-exe.outputs.cache-hit != 'true'
@@ -104,7 +100,7 @@ jobs:
 
       - name: debug hashfiles
         run: |
-          echo Smoke-testing-sample.exe-${{ hashFiles('src/**', 'CMakeLists.txt', '3rdparty/include/**', 'include/**', 'cmake/**', 'MAA.sln') }}
+          echo Smoke-testing-sample.exe-${{ hashFiles('src/**', '3rdparty/include/**', 'include/**', 'MAA.sln') }}
   
       - name: Copy resource to build directory
         if: steps.cache-exe.outputs.cache-hit == 'true'
@@ -122,7 +118,7 @@ jobs:
         if: steps.cache-exe.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
-          key: Smoke-testing-sample.exe-${{ hashFiles('src/**', 'CMakeLists.txt', '3rdparty/include/**', 'include/**', 'cmake/**', 'MAA.sln') }}
+          key: Smoke-testing-sample.exe-${{ hashFiles('src/**', '3rdparty/include/**', 'include/**', 'MAA.sln') }}
           path: |
             ./x64/Debug/Sample.exe
             ./x64/Debug/fastdeploy_ppocr.dll

--- a/.github/workflows/smoke-testing.yml
+++ b/.github/workflows/smoke-testing.yml
@@ -102,7 +102,7 @@ jobs:
         if: steps.cache-exe.outputs.cache-hit != 'true'
         run: |
           MSBUILD src/Cpp/MaaSample.slnf -t:restore,build -p:Configuration="Debug" -p:Platform="x64" -m
-  
+
       - name: Copy resource to build directory
         if: steps.cache-exe.outputs.cache-hit == 'true'
         run: |

--- a/.github/workflows/smoke-testing.yml
+++ b/.github/workflows/smoke-testing.yml
@@ -102,6 +102,10 @@ jobs:
         run: |
           MSBUILD src/Cpp/MaaSample.slnf -t:restore,build -p:Configuration="Debug" -p:Platform="x64" -m
 
+      - name: debug hashfiles
+        run: |
+          echo Smoke-testing-sample.exe-${{ hashFiles('src/**', 'CMakeLists.txt', '3rdparty/include/**', 'include/**', 'cmake/**', 'MAA.sln') }}
+  
       - name: Copy resource to build directory
         if: steps.cache-exe.outputs.cache-hit == 'true'
         run: |
@@ -114,8 +118,8 @@ jobs:
         run: |
           pwsh tools/SmokeTesting/run_tests.ps1
 
-      - name: Save cache smoke-testing Sample.exe (only in dev)
-        if: steps.cache-exe.outputs.cache-hit != 'true' && github.ref == 'refs/heads/dev'
+      - name: Save cache smoke-testing Sample.exe
+        if: steps.cache-exe.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
           key: Smoke-testing-sample.exe-${{ hashFiles('src/**', 'CMakeLists.txt', '3rdparty/include/**', 'include/**', 'cmake/**', 'MAA.sln') }}


### PR DESCRIPTION
Reduce path scoping for smoke-testing run requirements and implement global caching for all branches.
Save new cache only in dev.