### PR TITLE
chore: move `push tag` later in the workflow in case or errors

### DIFF
--- a/.github/workflows/release-nightly-ota.yml
+++ b/.github/workflows/release-nightly-ota.yml
@@ -136,17 +136,6 @@ jobs:
 
           gh run watch ${{ github.run_id }}
 
-      - name: Push tag to main repo
-        id: push_main_tag
-        run: |
-          git config user.name 'github-actions[bot]'
-          git config user.email 'github-actions[bot]@users.noreply.github.com'
-
-          $main_tag_name=$(echo "alpha/${{ steps.set_tag.outputs.tag }}")
-          git tag $main_tag_name -f
-          git push --tags origin HEAD:refs/tags/$main_tag_name -f
-          echo "main_tag_name=$main_tag_name" >> $env:GITHUB_OUTPUT
-
       - name: Generate Changelog
         id: generate_changelog
         run: |
@@ -241,6 +230,17 @@ jobs:
         with:
           name: MAA-win-${{ matrix.msbuild_target }}
           path: artifacts
+
+      - name: Push tag to main repo
+        id: push_main_tag
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+
+          $main_tag_name=$(echo "alpha/${{ steps.set_tag.outputs.tag }}")
+          git tag $main_tag_name -f
+          git push --tags origin HEAD:refs/tags/$main_tag_name -f
+          echo "main_tag_name=$main_tag_name" >> $env:GITHUB_OUTPUT
 
   push-tag:
     needs: build-win-nightly


### PR DESCRIPTION
Had some troubles while testing a week ago, since the push tag step is done very early. 

In case of exceptions or weird errors in the workflow (build errors, actions breaking), the tag should be the last thing to push, since we would be creating "empty tags" with no referred nightly.

TL;DR
Push tag later = good.
I can't think of any bad side effect, since we use `steps.set_tag.outputs.tag' around the workflow to mention to TO-BE tag (and not `git describe --tags --match "v*"`)