### PR TITLE
feat: skip task once and enable on end

### DIFF
--- a/src/MaaWpfGui/Configuration/GUI.cs
+++ b/src/MaaWpfGui/Configuration/GUI.cs
@@ -25,6 +25,8 @@ namespace MaaWpfGui.Configuration
 
         public bool UseNotify { get; set; } = true;
 
+        public bool InvertNullFunction { get; set; } = false;
+
         public string Localization { get; set; } = LocalizationHelper.DefaultLanguage;
 
         public bool MinimizeToTray { get; set; } = false;

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -352,6 +352,7 @@ Please do not check it when the stage OF-1 is not unlocked.</system:String>
     <system:String x:Key="SystemNotification">System Notification</system:String>
     <system:String x:Key="HideCloseButton">Hide close button</system:String>
     <system:String x:Key="WindowTitleScrollable">Window Title Scrolling</system:String>
+    <system:String x:Key="NullFunctionality">Invert right click checkbox function</system:String>
     <system:String x:Key="TitleBarDisplayContent">Title Bar Display Content</system:String>
     <system:String x:Key="UseLogItemDateFormat">Custom log date format</system:String>
     <system:String x:Key="LogItemDateFormatString">Date format string</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -352,6 +352,7 @@
     <system:String x:Key="SystemNotification">重要な通知をポップアップする</system:String>
     <system:String x:Key="HideCloseButton">「閉じる」ボタンを隠す</system:String>
     <system:String x:Key="WindowTitleScrollable">タイトルのスクロール機能</system:String>
+    <system:String x:Key="NullFunctionality">右クリックチェックボックス機能を反転する</system:String>
     <system:String x:Key="TitleBarDisplayContent">タイトルバー表示コンテンツ</system:String>
     <system:String x:Key="UseLogItemDateFormat">カスタムログ日付形式</system:String>
     <system:String x:Key="LogItemDateFormatString">日付書式文字列</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -352,6 +352,7 @@ OF-1을 해금하지 않았다면 선택하지 말아 주세요.</system:String>
     <system:String x:Key="SystemNotification">중요 알림 팝업</system:String>
     <system:String x:Key="HideCloseButton">닫기 버튼 숨기기</system:String>
     <system:String x:Key="WindowTitleScrollable">윈도우 제목 스크롤</system:String>
+    <system:String x:Key="NullFunctionality">오른쪽 클릭 체크박스 기능 반전</system:String>
     <system:String x:Key="TitleBarDisplayContent">타이틀 바 표시 내용</system:String>
     <system:String x:Key="UseLogItemDateFormat">사용자 정의 로그 날짜 형식</system:String>
     <system:String x:Key="LogItemDateFormatString">날짜 형식 문자열</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -352,6 +352,7 @@
     <system:String x:Key="SystemNotification">重要信息弹出系统通知</system:String>
     <system:String x:Key="HideCloseButton">隐藏关闭按钮</system:String>
     <system:String x:Key="WindowTitleScrollable">窗口标题滚动</system:String>
+    <system:String x:Key="NullFunctionality">反转右键单击复选框功能</system:String>
     <system:String x:Key="TitleBarDisplayContent">标题栏显示内容</system:String>
     <system:String x:Key="UseLogItemDateFormat">自选日志日期格式</system:String>
     <system:String x:Key="LogItemDateFormatString">日期格式字符串</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -352,6 +352,7 @@
     <system:String x:Key="SystemNotification">重要訊息彈出系統通知</system:String>
     <system:String x:Key="HideCloseButton">隱藏關閉按鈕</system:String>
     <system:String x:Key="WindowTitleScrollable">窗口標題滾動</system:String>
+    <system:String x:Key="NullFunctionality">反轉右鍵點選複選框功能</system:String>
     <system:String x:Key="TitleBarDisplayContent">標題欄顯示內容</system:String>
     <system:String x:Key="UseLogItemDateFormat">自訂日誌日期格式</system:String>
     <system:String x:Key="LogItemDateFormatString">日期格式字串</system:String>

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -1057,7 +1057,7 @@ namespace MaaWpfGui.ViewModels.UI
             {
                 if (item.IsCheckedWithNull == null)
                 {
-                    item.IsChecked = false;
+                    item.IsChecked = GuiSettingsUserControlModel.Instance.InvertNullFunction;
                 }
             }
         }
@@ -1246,7 +1246,7 @@ namespace MaaWpfGui.ViewModels.UI
             int count = 0;
             foreach (var item in TaskItemViewModels)
             {
-                if (item.IsChecked == false)
+                if (item.IsChecked == false || (GuiSettingsUserControlModel.Instance.InvertNullFunction && item.IsCheckedWithNull == null))
                 {
                     continue;
                 }
@@ -1308,6 +1308,10 @@ namespace MaaWpfGui.ViewModels.UI
                 _runningState.SetIdle(true);
                 Instances.AsstProxy.AsstStop();
                 SetStopped();
+                if (GuiSettingsUserControlModel.Instance.InvertNullFunction)
+                {
+                    ResetTaskSelection();
+                }
                 return;
             }
 
@@ -1796,7 +1800,6 @@ namespace MaaWpfGui.ViewModels.UI
         private static bool AppendReclamation()
         {
             var toolToCraft = SettingsViewModel.ReclamationTask.ReclamationToolToCraft.Split(';', '；').Select(s => s.Trim());
-
 
             _ = int.TryParse(SettingsViewModel.ReclamationTask.ReclamationMode, out var mode);
 

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/GuiSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/GuiSettingsUserControlModel.cs
@@ -157,6 +157,15 @@ public class GuiSettingsUserControlModel : PropertyChangedBase
         }
     }
 
+    public bool InvertNullFunction
+    {
+        get => ConfigFactory.Root.GUI.InvertNullFunction;
+        set
+        {
+            ConfigFactory.Root.GUI.InvertNullFunction = value;
+        }
+    }
+
     public List<string> LogItemDateFormatStringList { get; } =
     [
         "HH:mm:ss",

--- a/src/MaaWpfGui/Views/UserControl/Settings/GuiSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/Settings/GuiSettingsUserControl.xaml
@@ -60,6 +60,10 @@
                     Margin="10"
                     Content="{DynamicResource WindowTitleScrollable}"
                     IsChecked="{Binding WindowTitleScrollable}" />
+                <CheckBox
+                    Margin="10"
+                    Content="{DynamicResource NullFunctionality}"
+                    IsChecked="{Binding InvertNullFunction}" />
                 <hc:CheckComboBox
                     x:Name="CheckComboBox"
                     Width="180"


### PR DESCRIPTION
Quite a lot of times I found myself manually changing the base infrastructure. This meant that I had to disable the base task and run all the other ones.

This lead to me forgetting about re enabling the base task and completely fucking the subsequent rotations (just like I did today :P )

This PR gives users the possibility to invert the right click functionality in the TaskQueueViewModel so that the task will be skipped on the first run and on Task:

![MAA](https://github.com/user-attachments/assets/974efc56-e5c8-4f82-901d-b9fd106be593)
