### PR TITLE
fix: Attempt retry once screencap for MumuExtras

### DIFF
--- a/src/MaaCore/Controller/MumuExtras.cpp
+++ b/src/MaaCore/Controller/MumuExtras.cpp
@@ -68,9 +68,18 @@ std::optional<cv::Mat> MumuExtras::screencap()
         display_buffer_.data());
 
     if (ret) {
-        LogError << "Failed to capture display" << VAR(ret) << VAR(mumu_handle_) << VAR(display_id)
-                 << VAR(display_buffer_.size()) << VAR(display_width_) << VAR(display_height_);
-        return std::nullopt;
+        // Try reloading once before giving up.
+        if (!reload()) {
+            LogError << "Failed to capture display and failed to reload. " << VAR(ret) << VAR(mumu_handle_)
+                     << VAR(display_id) << VAR(display_buffer_.size()) << VAR(display_width_) << VAR(display_height_);
+            return std::nullopt;
+        }
+        if (ret) {
+            LogError << "Failed to capture display, but reload before retrying capture was successful. " << VAR(ret)
+                     << VAR(mumu_handle_) << VAR(display_id) << VAR(display_buffer_.size()) << VAR(display_width_)
+                     << VAR(display_height_);
+            return std::nullopt;
+        }
     }
 
     cv::Mat raw(display_height_, display_width_, CV_8UC4, display_buffer_.data());


### PR DESCRIPTION
This is an attempt to resolve the issue for MumuExtras "MuMu截图增强模式" that the screen capture functionality fails indefinitely, but some manual operation on the GUI like stop and restart "一件长草“ still works without restarting either the MAA or the emulator.

Some logs of importance with issue:
gui.log
```
[2025-01-13 22:18:23.645][INF] <1><> 开始任务: Reclamation
[2025-01-13 22:45:05.370][INF] <1><> 截图失败，如反复出现请尝试重启或更换模拟器！
[2025-01-13 22:45:06.388][INF] <1><> 截图失败，如反复出现请尝试重启或更换模拟器！
[2025-01-13 22:45:07.405][INF] <1><> 截图失败，如反复出现请尝试重启或更换模拟器！
[2025-01-13 22:45:08.420][INF] <1><> 截图失败，如反复出现请尝试重启或更换模拟器！
[2025-01-13 22:45:09.435][INF] <1><> 截图失败，如反复出现请尝试重启或更换模拟器！
[2025-01-13 22:45:10.450][INF] <1><> 截图失败，如反复出现请尝试重启或更换模拟器！
[2025-01-13 22:45:11.466][INF] <1><> 截图失败，如反复出现请尝试重启或更换模拟器！
[2025-01-13 22:45:12.484][INF] <1><> 截图失败，如反复出现请尝试重启或更换模拟器！
```

asst.bak.log
is lost. It loops after PNS-EnterNodeThenLeave and OCR does not seem to propely detect that it shows detection result of a single dot "."