### PR TITLE
ci: disable ccache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,9 +234,6 @@ jobs:
           sudo apt-get update
           sudo apt-get install g++-12-aarch64-linux-gnu g++-12-aarch64-linux-gnu
 
-      # - name: Setup ccache
-      #   uses: Chocobo1/setup-ccache-action@v1
-
       # Caching not necessary on ubuntu runner
       - name: Bootstrap MaaDeps
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,8 +234,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install g++-12-aarch64-linux-gnu g++-12-aarch64-linux-gnu
 
-      - name: Setup ccache
-        uses: Chocobo1/setup-ccache-action@v1
+      # - name: Setup ccache
+      #   uses: Chocobo1/setup-ccache-action@v1
 
       # Caching not necessary on ubuntu runner
       - name: Bootstrap MaaDeps
@@ -259,8 +259,8 @@ jobs:
           mkdir -p install
           cmake --install build --prefix install
         env:
-          CC: ${{ matrix.arch == 'x86_64' && 'ccache gcc-12' || 'ccache aarch64-linux-gnu-gcc-12' }}
-          CXX: ${{ matrix.arch == 'x86_64' && 'ccache g++-12' || 'ccache aarch64-linux-gnu-g++-12' }}
+          CC: ${{ matrix.arch == 'x86_64' && 'gcc-12' || 'aarch64-linux-gnu-gcc-12' }}
+          CXX: ${{ matrix.arch == 'x86_64' && 'g++-12' || 'aarch64-linux-gnu-g++-12' }}
           CMAKE_COLOR_DIAGNOSTICS: ON
           CLICOLOR_FORCE: 1
           CXXFLAGS: | # workaround for gcc bugs


### PR DESCRIPTION
ccache completely pollutes the action cache.
- It's not easily manageable (keys, restore-keys etc)
- Every commit creates a new cache and older ones don't seem to get removed
- From 640MB we now have 800MB cache sizes
- And most importantly the build time reduction is minimal. We are talking at best 1 minute off the build time (When we are gate locked by the Windows build time anyway)

Without:
![{AFFD0FC1-5A64-4A63-9A15-CEADF3A15107}](https://github.com/user-attachments/assets/622dfe70-ddaf-4c2a-82b9-63469a8f575f)
With:
![{29FD1667-DA46-4BFA-9A23-B2E3D2D11C39}](https://github.com/user-attachments/assets/3616942f-536f-4dee-8061-69d4b087d4db)

But at least we don't go over by 15GB in the cache total (removing important cargo oxipng caches)