### PR TITLE
feat: 萨卡兹肉鸽卫士不语功战斗策略调整

### DIFF
--- a/resource/roguelike/Sarkaz/autopilot/卫士不语功.json
+++ b/resource/roguelike/Sarkaz/autopilot/卫士不语功.json
@@ -23,17 +23,17 @@
         },
         {
             "groups": ["单奶", "群奶", "高台输出"],
-            "location": [9, 3],
+            "location": [9, 2],
             "direction": "left"
         },
         {
             "groups": ["单奶", "群奶", "高台输出"],
-            "location": [3, 4],
+            "location": [3, 5],
             "direction": "up"
         },
         {
             "groups": ["单奶", "群奶", "高台输出"],
-            "location": [2, 4],
+            "location": [2, 5],
             "direction": "up"
         },
         {


### PR DESCRIPTION
卫士不语功关卡的[9, 3]、[3, 4]、[2, 4]均为“启动！”装置，不可部署。
故修改为对应边上的高台。
![image](https://github.com/user-attachments/assets/f07f3c88-5efb-42ca-8c00-0307ec6b9a6e)
