### PR TITLE
fix: add postDelay to roguelike end-related tasks

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -6901,8 +6901,10 @@
         "roi": [715, 282, 171, 155]
     },
     "Roguelike@GamePassSkip2": {
+        "doc": "在 Skip2 与 TheEndConfirm 之间有空窗期，通过 postDelay 度过",
         "action": "ClickSelf",
         "roi": [1109, 0, 171, 138],
+        "postDelay": 5000,
         "next": ["Roguelike@GamePassTheEndConfirm", "Roguelike@GamePass", "Roguelike@ClickToStartPoint"]
     },
     "Roguelike@GamePassTheEndConfirm": {
@@ -7927,6 +7929,8 @@
     "Phantom@Roguelike@GamePass": {},
     "Phantom@Roguelike@GamePassSkip1": {},
     "Phantom@Roguelike@GamePassSkip1Confirm": {
+        "doc": "在 Skip1Confirm 与 Skip2 之间有空窗期，通过 postDelay 度过",
+        "postDelay": 5000,
         "next": [
             "Phantom@Roguelike@GamePassSkip2",
             "Phantom@Roguelike@GamePassTheEndConfirm",


### PR DESCRIPTION
有用户反馈在 Skip1Confirm 后未能成功识别到 Skip2，导致 MAA 卡在此处长达 5 个小时。推测是空窗期导致。加个 postDelay 试试。

日志文件部分摘录如下：

```
[2025-01-21 00:28:34.724][TRC][Pxc0c][Tx1380] match_templ | Phantom@Roguelike@GamePassSkip1.png score: 0.997288 rect: [ 1140, 31, 90, 44 ] roi: [ 1090, 0, 190, 144 ]
[2025-01-21 00:28:34.724][TRC][Pxc0c][Tx1380] asst::PipelineAnalyzer::analyze | MatchTemplate Phantom@Roguelike@GamePassSkip1
[2025-01-21 00:28:34.725][INF][Pxc0c][Tx1380] Assistant::append_callback | SubTaskStart {"class":"asst::ProcessTask","details":{"action":"ClickSelf","algorithm":"MatchTemplate","exec_times":1,"max_times":2147483647,"result":{"score":0.997288},"task":"GamePassSkip1"},"first":["Phantom@Roguelike@Begin"],"pre_task":"Phantom@Roguelike@StartAction@LoadingIcon","subtask":"ProcessTask","taskchain":"Roguelike","taskid":9,"uuid":"11e48b39dc76a2e7"}
[2025-01-21 00:28:34.725][TRC][Pxc0c][Tx1380] Click with scaled coordinates (1183, 54) 1.5
[2025-01-21 00:28:34.725][TRC][Pxc0c][Tx1380] minitouch click: (1774, 81)
[2025-01-21 00:28:34.826][TRC][Pxc0c][Tx1380] ready to sleep 1000
[2025-01-21 00:28:35.826][TRC][Pxc0c][Tx1380] end of sleep 1000
[2025-01-21 00:28:35.826][INF][Pxc0c][Tx1380] Assistant::append_callback | SubTaskCompleted {"class":"asst::ProcessTask","details":{"action":"ClickSelf","algorithm":"MatchTemplate","exec_times":1,"max_times":2147483647,"result":{"score":0.997288},"task":"GamePassSkip1"},"first":["Phantom@Roguelike@Begin"],"pre_task":"Phantom@Roguelike@StartAction@LoadingIcon","subtask":"ProcessTask","taskchain":"Roguelike","taskid":9,"uuid":"11e48b39dc76a2e7"}
[2025-01-21 00:28:35.826][TRC][Pxc0c][Tx1380] ready to sleep 500
[2025-01-21 00:28:36.327][TRC][Pxc0c][Tx1380] end of sleep 500
[2025-01-21 00:28:36.327][INF][Pxc0c][Tx1380] {"class":"asst::ProcessTask","details":{"cur_retry":0,"retry_times":20,"to_be_recognized":["Phantom@Roguelike@GamePassSkip1Confirm","Phantom@Roguelike@GamePassSkip1"]},"first":["Phantom@Roguelike@Begin"],"pre_task":"Phantom@Roguelike@GamePassSkip1","subtask":"ProcessTask","taskchain":"Roguelike","taskid":9}
[2025-01-21 00:28:36.377][TRC][Pxc0c][Tx1380] match_templ | Phantom@Roguelike@GamePassSkip1Confirm.png score: 0.91365 rect: [ 765, 332, 71, 55 ] roi: [ 715, 282, 171, 155 ]
[2025-01-21 00:28:36.377][TRC][Pxc0c][Tx1380] asst::PipelineAnalyzer::analyze | MatchTemplate Phantom@Roguelike@GamePassSkip1Confirm
[2025-01-21 00:28:36.378][INF][Pxc0c][Tx1380] Assistant::append_callback | SubTaskStart {"class":"asst::ProcessTask","details":{"action":"ClickSelf","algorithm":"MatchTemplate","exec_times":1,"max_times":2147483647,"result":{"score":0.913650},"task":"GamePassSkip1Confirm"},"first":["Phantom@Roguelike@Begin"],"pre_task":"Phantom@Roguelike@GamePassSkip1","subtask":"ProcessTask","taskchain":"Roguelike","taskid":9,"uuid":"11e48b39dc76a2e7"}
[2025-01-21 00:28:36.378][TRC][Pxc0c][Tx1380] Click with scaled coordinates (797, 360) 1.5
[2025-01-21 00:28:36.378][TRC][Pxc0c][Tx1380] minitouch click: (1195, 540)
[2025-01-21 00:28:36.479][INF][Pxc0c][Tx1380] Assistant::append_callback | SubTaskCompleted {"class":"asst::ProcessTask","details":{"action":"ClickSelf","algorithm":"MatchTemplate","exec_times":1,"max_times":2147483647,"result":{"score":0.913650},"task":"GamePassSkip1Confirm"},"first":["Phantom@Roguelike@Begin"],"pre_task":"Phantom@Roguelike@GamePassSkip1","subtask":"ProcessTask","taskchain":"Roguelike","taskid":9,"uuid":"11e48b39dc76a2e7"}
[2025-01-21 00:28:36.479][TRC][Pxc0c][Tx1380] ready to sleep 500
[2025-01-21 00:28:36.980][TRC][Pxc0c][Tx1380] end of sleep 500
[2025-01-21 00:28:36.980][INF][Pxc0c][Tx1380] {"class":"asst::ProcessTask","details":{"cur_retry":0,"retry_times":20,"to_be_recognized":["Phantom@Roguelike@GamePassSkip2","Phantom@Roguelike@GamePassTheEndConfirm","Phantom@Roguelike@GamePass"]},"first":["Phantom@Roguelike@Begin"],"pre_task":"Phantom@Roguelike@GamePassSkip1Confirm","subtask":"ProcessTask","taskchain":"Roguelike","taskid":9}
[2025-01-21 00:28:37.042][TRC][Pxc0c][Tx1380] match_templ | Roguelike@GamePassSkip2.png score: 0.757547 rect: [ 1142, 32, 89, 38 ] roi: [ 1109, 0, 171, 138 ]
[2025-01-21 00:28:37.083][INF][Pxc0c][Tx1380] {"class":"asst::ProcessTask","details":{"cur_retry":1,"retry_times":20,"to_be_recognized":["Phantom@Roguelike@GamePassSkip2","Phantom@Roguelike@GamePassTheEndConfirm","Phantom@Roguelike@GamePass"]},"first":["Phantom@Roguelike@Begin"],"pre_task":"Phantom@Roguelike@GamePassSkip1Confirm","subtask":"ProcessTask","taskchain":"Roguelike","taskid":9}
[2025-01-21 00:28:37.083][TRC][Pxc0c][Tx1380] ready to sleep 500
[2025-01-21 00:28:37.584][TRC][Pxc0c][Tx1380] end of sleep 500
[2025-01-21 00:28:37.652][INF][Pxc0c][Tx1380] {"class":"asst::ProcessTask","details":{"cur_retry":2,"retry_times":20,"to_be_recognized":["Phantom@Roguelike@GamePassSkip2","Phantom@Roguelike@GamePassTheEndConfirm","Phantom@Roguelike@GamePass"]},"first":["Phantom@Roguelike@Begin"],"pre_task":"Phantom@Roguelike@GamePassSkip1Confirm","subtask":"ProcessTask","taskchain":"Roguelike","taskid":9}
[2025-01-21 00:28:37.652][TRC][Pxc0c][Tx1380] ready to sleep 500
[2025-01-21 00:28:38.153][TRC][Pxc0c][Tx1380] end of sleep 500
[2025-01-21 00:28:38.224][INF][Pxc0c][Tx1380] {"class":"asst::ProcessTask","details":{"cur_retry":3,"retry_times":20,"to_be_recognized":["Phantom@Roguelike@GamePassSkip2","Phantom@Roguelike@GamePassTheEndConfirm","Phantom@Roguelike@GamePass"]},"first":["Phantom@Roguelike@Begin"],"pre_task":"Phantom@Roguelike@GamePassSkip1Confirm","subtask":"ProcessTask","taskchain":"Roguelike","taskid":9}
[2025-01-21 00:28:38.224][TRC][Pxc0c][Tx1380] ready to sleep 500
[2025-01-21 00:28:38.727][TRC][Pxc0c][Tx1380] end of sleep 500
```

完整日志文件：
[logFiles.zip](https://github.com/user-attachments/files/18483709/logFiles.zip)

下图为可获取的最早的截图 `2025-01-21_03-01-05-433_raw`
![2025-01-21_03-01-05-433_raw](https://github.com/user-attachments/assets/f446bb97-91d1-4a62-acb7-23f978b40a70)

---

鉴于没有进一步 Issue 反馈，现决定暂时关闭这个 PR。
我错误的使用了自己的 dev 分支来提交这个 PR，这让我很难受。
为了防止之后我修改自己的 dev 分支导致任何问题，以下为文件修改记录截图。

I would like to reuse my dev branch for other use. Just in case, a screenshot of "Files changed" is attached below.

<img width="662" alt="image" src="https://github.com/user-attachments/assets/125f1ce6-1be9-4bbb-93b3-1d3d53030bff" />