### PR TITLE
fix: 修复基建排班错误和加工站卡住

### DIFF
--- a/resource/infrast.json
+++ b/resource/infrast.json
@@ -2867,7 +2867,7 @@
                     {
                         "desc": "巫恋-2",
                         "efficient": {
-                            "all": 90.1
+                            "Money": 90.1
                         },
                         "skills": ["bskill_tra_wt&cost1", "bskill_tra_vodfox"]
                     }
@@ -2877,28 +2877,28 @@
                         "Doc": "这里具体效率不同攻略各执一词，写个大概的，反正别的组合也没这么高的，大差不差能第一就行_(:з」∠)_",
                         "desc": "龙舌兰-2",
                         "efficient": {
-                            "all": 80
+                            "Money": 80
                         },
                         "skills": ["bskill_tra_long2"]
                     },
                     {
                         "desc": "龙舌兰-1",
                         "efficient": {
-                            "all": 40
+                            "Money": 40
                         },
                         "skills": ["bskill_tra_long1"]
                     },
                     {
                         "desc": "柏喙-2、卡夫卡-2",
                         "efficient": {
-                            "all": 2
+                            "Money": 2
                         },
                         "skills": ["bskill_tra_wt&cost2"]
                     },
                     {
                         "desc": "柏喙-1、卡夫卡-1",
                         "efficient": {
-                            "all": 1
+                            "Money": 1
                         },
                         "skills": ["bskill_tra_wt&cost1"]
                     }

--- a/src/MaaCore/Task/Infrast/InfrastProcessingTask.cpp
+++ b/src/MaaCore/Task/Infrast/InfrastProcessingTask.cpp
@@ -11,7 +11,8 @@ bool asst::InfrastProcessingTask::_run()
 
     // 不是自定义的也换不了加工站
     if (!is_use_custom_opers()) {
-        return false;
+        Log.info("skip this room");
+        return true;
     }
     // 加工站，啥也造不了，随便写一个
     set_product("Placeholder");


### PR DESCRIPTION
语义问题，因为没有自定义配置时跳过加工站是正常的业务逻辑，不应该被当作错误来处理。避免了约 30 秒的无意义等待

返回 false时：
- 触发 `on_run_fails()`
- 执行 `InfrastBegin` 任务
- 导致重复执行 `InfrastBegin` -> `InfrastEnteredFlag` -> `Stop` 循环
- 每次循环大约需要 6-7 秒

因为加工站在 MAA 右边没有 log，容易被当作宿舍问题，如 #11415

- close #11499, close #7081