### PR TITLE
feat(style): Colored logs for I.S.

### DIFF
--- a/src/MaaWpfGui/Constants/UILogColor.cs
+++ b/src/MaaWpfGui/Constants/UILogColor.cs
@@ -69,6 +69,48 @@ namespace MaaWpfGui.Constants
         /// </summary>
         public const string LdSpecialScreenshot = "LdSpecialScreenshot";
 
+        // I.S. Colors
+
+        /// <summary>
+        /// The recommended color for success fights.
+        /// </summary>
+        public const string SuccessIS = "SuccessIS";
+
+        /// <summary>
+        /// The recommended color for Safe House events.
+        /// </summary>
+        public const string SafehouseIS = "SafehouseIS";
+
+        /// <summary>
+        /// The recommended color for Trader events.
+        /// </summary>
+        public const string TraderIS = "TraderIS";
+
+        /// <summary>
+        /// The recommended color for standard events.
+        /// </summary>
+        public const string EventIS = "EventIS";
+
+        /// <summary>
+        /// The recommended color for truth events.
+        /// </summary>
+        public const string TruthIS = "TruthIS";
+
+        /// <summary>
+        /// The recommended color for standard fights.
+        /// </summary>
+        public const string CombatIS = "CombatIS";
+
+        /// <summary>
+        /// The recommended color for emergency fights.
+        /// </summary>
+        public const string EmergencyIS = "EmergencyIS";
+
+        /// <summary>
+        /// The recommended color for boss fights.
+        /// </summary>
+        public const string BossIS = "BossIS";
+
         // 颜色在MaaWpfGui\Res\Themes中定义
         // Brush are defined in MaaWpfGui\Res\Themes
     }

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -1134,46 +1134,46 @@ namespace MaaWpfGui.Main
 
                             /* 肉鸽相关 */
                             case "ExitThenAbandon":
-                                Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("ExplorationAbandoned"));
+                                Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("ExplorationAbandoned"), UiLogColor.Error);
                                 break;
 
                             // case "StartAction":
                             //    Instances.TaskQueueViewModel.AddLog("开始战斗");
                             //    break;
                             case "MissionCompletedFlag":
-                                Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("FightCompleted"));
+                                Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("FightCompleted"), UiLogColor.SuccessIS);
                                 break;
 
                             case "MissionFailedFlag":
-                                Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("FightFailed"));
+                                Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("FightFailed"), UiLogColor.Error);
                                 break;
 
                             case "StageTraderEnter":
-                                Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("Trader"));
+                                Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("Trader"), UiLogColor.TraderIS);
                                 break;
 
                             case "StageSafeHouseEnter":
-                                Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("SafeHouse"));
+                                Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("SafeHouse"), UiLogColor.SafehouseIS);
                                 break;
 
                             case "StageFilterTruthEnter":
-                                Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("FilterTruth"));
+                                Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("FilterTruth"), UiLogColor.TruthIS);
                                 break;
 
                             // case "StageBoonsEnter":
                             //    Instances.TaskQueueViewModel.AddLog("古堡馈赠");
                             //    break;
                             case "StageCombatDpsEnter":
-                                Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("CombatDps"));
+                                Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("CombatDps"), UiLogColor.CombatIS);
                                 break;
 
                             case "StageEmergencyDps":
-                                Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("EmergencyDps"));
+                                Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("EmergencyDps"), UiLogColor.EmergencyIS);
                                 break;
 
                             case "StageDreadfulFoe":
                             case "StageDreadfulFoe-5Enter":
-                                Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("DreadfulFoe"));
+                                Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("DreadfulFoe"), UiLogColor.BossIS);
                                 break;
 
                             case "StageTraderInvestSystemFull":
@@ -1487,7 +1487,7 @@ namespace MaaWpfGui.Main
                     break;
 
                 case "RoguelikeEvent":
-                    Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("RoguelikeEvent") + $" {subTaskDetails!["name"]}");
+                    Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("RoguelikeEvent") + $" {subTaskDetails!["name"]}", UiLogColor.EventIS);
                     break;
 
                 case "FoldartalGainOcrNextLevel":

--- a/src/MaaWpfGui/Res/Themes/Dark.xaml
+++ b/src/MaaWpfGui/Res/Themes/Dark.xaml
@@ -45,4 +45,15 @@
     <SolidColorBrush x:Key="DownloadLogBrush" Color="Violet" />
     <SolidColorBrush x:Key="MuMuSpecialScreenshot" Color="#02BFFF" />
     <SolidColorBrush x:Key="LdSpecialScreenshot" Color="#6666FF" />
+
+    <!--  UiLogColor - I.S. -->
+    <SolidColorBrush x:Key="SuccessIS" Color="LimeGreen" />
+    <SolidColorBrush x:Key="SafehouseIS" Color="DodgerBlue" />
+    <SolidColorBrush x:Key="TraderIS" Color="MediumSeaGreen" />
+    <SolidColorBrush x:Key="EventIS" Color="LightSkyBlue" />
+    <SolidColorBrush x:Key="TrustIS" Color="SlateGray"/>
+    <SolidColorBrush x:Key="CombatIS" Color="DarkOrange" />
+    <SolidColorBrush x:Key="EmergencyIS" Color="MediumVioletRed" />
+    <SolidColorBrush x:Key="BossIS" Color="Firebrick " />
+
 </ResourceDictionary>

--- a/src/MaaWpfGui/Res/Themes/Light.xaml
+++ b/src/MaaWpfGui/Res/Themes/Light.xaml
@@ -27,4 +27,15 @@
     <SolidColorBrush x:Key="DownloadLogBrush" Color="BlueViolet" />
     <SolidColorBrush x:Key="MuMuSpecialScreenshot" Color="#02BFFF" />
     <SolidColorBrush x:Key="LdSpecialScreenshot" Color="#6666FF" />
+
+    <!--  UiLogColor - I.S. -->
+    <SolidColorBrush x:Key="SuccessIS" Color="LimeGreen" />
+    <SolidColorBrush x:Key="SafehouseIS" Color="DodgerBlue" />
+    <SolidColorBrush x:Key="TraderIS" Color="MediumSeaGreen" />
+    <SolidColorBrush x:Key="EventIS" Color="LightSkyBlue" />
+    <SolidColorBrush x:Key="TrustIS" Color="SlateGray"/>
+    <SolidColorBrush x:Key="CombatIS" Color="DarkOrange" />
+    <SolidColorBrush x:Key="EmergencyIS" Color="MediumVioletRed" />
+    <SolidColorBrush x:Key="BossIS" Color="Firebrick " />
+
 </ResourceDictionary>


### PR DESCRIPTION
| ![image](https://github.com/user-attachments/assets/035b64d7-99e6-4ef1-9ae9-7a149e682c4c) | ![image](https://github.com/user-attachments/assets/7ffd223d-b45c-4a83-8b14-917667d60a0a) |
| -------- | ------- |

Missing log text stays as already defined previously (e.g. Trader investing, stage names, ...)