### PR TITLE
ci: disable cache for pnpm

### DIFF
--- a/.github/workflows/website-workflow.yml
+++ b/.github/workflows/website-workflow.yml
@@ -42,8 +42,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: pnpm
-          cache-dependency-path: "./website/pnpm-lock.yaml"
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
Build times are identical. Just wasted 100MB of cache for every "different" instance.