### PR TITLE
fix: 公告窗口触控板滚动异常

### DIFF
--- a/src/MaaWpfGui/Views/UI/AnnouncementView.xaml
+++ b/src/MaaWpfGui/Views/UI/AnnouncementView.xaml
@@ -17,7 +17,7 @@
     Icon="../../newlogo.ico"
     ShowCloseButton="False"
     mc:Ignorable="d">
-    <ScrollViewer Background="{DynamicResource VersionUpdateViewBackgroundBrush}">
+    <hc:ScrollViewer Background="{DynamicResource VersionUpdateViewBackgroundBrush}" IsInertiaEnabled="True">
         <StackPanel>
             <mdxam:MarkdownScrollViewer
                 Margin="10,0,10,0"
@@ -47,5 +47,5 @@
                 Command="{s:Action Close}"
                 Content="{DynamicResource Confirm}" />
         </StackPanel>
-    </ScrollViewer>
+    </hc:ScrollViewer>
 </hc:Window>


### PR DESCRIPTION
fix #11673 

有点没搞明白  
加上允许惯性滚动的属性就和其他页面一样了 把其他页面的惯性滚动去掉也会变得像公告一样超快  
感觉像handycontrol的实现有点问题 还是其他什么

但是这个惯性的速度曲线好奇怪啊