### PR TITLE
docs: 替换.NET8 桌面运行时下载链接为直链

### DIFF
--- a/docs/en-us/manual/faq.md
+++ b/docs/en-us/manual/faq.md
@@ -21,7 +21,7 @@ winget install "Microsoft.VCRedist.2015+.x64" --override "/repair /passive /nore
 or manually download and install the following <u>**two**</u> runtime libraries to resolve the issue.
 
 - [Visual C++ Redistributable x64](https://aka.ms/vs/17/release/vc_redist.x64.exe)
-- [.NET Desktop Runtime 8](https://dotnet.microsoft.com/en-us/download/dotnet/8.0#:~:text=Binaries-,Windows,-x64)
+- [.NET Desktop Runtime 8](https://aka.ms/dotnet/8.0/windowsdesktop-runtime-win-x64.exe)
 
 :::
 

--- a/docs/ja-jp/manual/faq.md
+++ b/docs/ja-jp/manual/faq.md
@@ -21,7 +21,7 @@ winget install "Microsoft.VCRedist.2015+.x64" --override "/repair /passive /nore
 以下の<u>**2つ**</u>のランタイムライブラリを手動でダウンロードしてインストールして問題を解決してください。
 
 - [Visual C++ 再頒布可能パッケージ](https://aka.ms/vs/17/release/vc_redist.x64.exe)
-- [.NET デスクトップランタイム 8](https://dotnet.microsoft.com/en-us/download/dotnet/8.0#:~:text=Binaries-,Windows,-x64)
+- [.NET デスクトップランタイム 8](https://aka.ms/dotnet/8.0/windowsdesktop-runtime-win-x64.exe)
 
 :::
 

--- a/docs/ko-kr/manual/faq.md
+++ b/docs/ko-kr/manual/faq.md
@@ -21,7 +21,7 @@ winget install "Microsoft.VCRedist.2015+.x64" --override "/repair /passive /nore
 아래<u>**두 개**</u>의 실행 라이브러리를 수동으로 다운로드하여 설치하여 문제를 해결하세요.
 
 - [Visual C++ 재배포 가능 패키지](https://aka.ms/vs/17/release/vc_redist.x64.exe)
-- [.NET 데스크톱 런타임 8](https://dotnet.microsoft.com/en-us/download/dotnet/8.0#:~:text=Binaries-,Windows,-x64)
+- [.NET 데스크톱 런타임 8](https://aka.ms/dotnet/8.0/windowsdesktop-runtime-win-x64.exe)
 
 :::
 

--- a/docs/zh-cn/manual/faq.md
+++ b/docs/zh-cn/manual/faq.md
@@ -21,7 +21,7 @@ winget install "Microsoft.VCRedist.2015+.x64" --override "/repair /passive /nore
 或手动下载并安装以下<u>**两个**</u>运行库来解决问题。
 
 - [Visual C++ 可再发行程序包](https://aka.ms/vs/17/release/vc_redist.x64.exe)
-- [.NET 桌面运行时 8](https://dotnet.microsoft.com/en-us/download/dotnet/8.0#:~:text=Binaries-,Windows,-x64)
+- [.NET 桌面运行时 8](https://aka.ms/dotnet/8.0/windowsdesktop-runtime-win-x64.exe)
 :::
 
 ## 软件无法运行/闪退/报错

--- a/docs/zh-tw/manual/faq.md
+++ b/docs/zh-tw/manual/faq.md
@@ -21,7 +21,7 @@ winget install "Microsoft.VCRedist.2015+.x64" --override "/repair /passive /nore
 或者手動下載並安裝以下<u>**兩個**</u>運行庫來解決問題。
 
 - [Visual C++ 可再發行程序包](https://aka.ms/vs/17/release/vc_redist.x64.exe)
-- [.NET 桌面運行時 8](https://dotnet.microsoft.com/en-us/download/dotnet/8.0#:~:text=Binaries-,Windows,-x64)
+- [.NET 桌面運行時 8](https://aka.ms/dotnet/8.0/windowsdesktop-runtime-win-x64.exe)
 
 :::
 


### PR DESCRIPTION
替换.NET8 桌面运行时下载链接为直链
https://aka.ms/dotnet/8.0/windowsdesktop-runtime-win-x64.exe

方法来源https://github.com/dotnet/installer/issues/11040#issuecomment-874654711
因为纯网页端PR没整明白，所以clone下来改了其他语言，然后重新提了一个PR。之前的PR：https://github.com/MaaAssistantArknights/MaaAssistantArknights/pull/11690