### PR TITLE
perf: 开始任务自动关闭雷电模拟器 Google 套件窗口

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -2446,11 +2446,11 @@
     "LeidianGoogleFrameworkConfirm": {
         "algorithm": "OcrDetect",
         "action": "ClickSelf",
-        "text": [ "不安装" ],
-        "roi": [ 480, 410, 200, 50 ],
+        "text": ["不安装"],
+        "roi": [480, 410, 200, 50],
         "maxTimes": 5,
         "Doc": "用以关闭雷电模拟器启动外服明日方舟时弹出的未安装谷歌套件的提示",
-        "next": [ "StartUpThemes#next" ]
+        "next": ["StartUpThemes#next"]
     },
     "GameStart": {
         "action": "ClickSelf",

--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -2431,6 +2431,7 @@
     "StartUpThemes": {
         "algorithm": "JustReturn",
         "next": [
+            "LeidianGoogleFrameworkConfirm",
             "GameStart",
             "StartToWakeUp",
             "StartToWakeUpOCR",
@@ -2442,14 +2443,14 @@
             "GameStartUpdateOCR"
         ]
     },
-    "StartUpBegin": {
-        "algorithm": "JustReturn",
-        "next": [
-            "StartUp@StartUpThemes#next",
-            "StartUpBegin@LoadingIcon",
-            "StartUp@ReturnButtons#next",
-            "StartUp@EndOfAction"
-        ]
+    "LeidianGoogleFrameworkConfirm": {
+        "algorithm": "OcrDetect",
+        "action": "ClickSelf",
+        "text": [ "不安装" ],
+        "roi": [ 480, 410, 200, 50 ],
+        "maxTimes": 5,
+        "Doc": "用以关闭雷电模拟器启动外服明日方舟时弹出的未安装谷歌套件的提示",
+        "next": [ "StartUpThemes#next" ]
     },
     "GameStart": {
         "action": "ClickSelf",

--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -2460,7 +2460,7 @@
             "StartUp@ReturnButtons#next",
             "StartUp@EndOfAction"
         ]
-    }，
+    },
     "GameStart": {
         "action": "ClickSelf",
         "roi": [550, 600, 200, 120],

--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -2452,6 +2452,15 @@
         "Doc": "用以关闭雷电模拟器启动外服明日方舟时弹出的未安装谷歌套件的提示",
         "next": ["StartUpThemes#next"]
     },
+    "StartUpBegin": {
+        "algorithm": "JustReturn",
+        "next": [
+            "StartUp@StartUpThemes#next",
+            "StartUpBegin@LoadingIcon",
+            "StartUp@ReturnButtons#next",
+            "StartUp@EndOfAction"
+        ]
+    }，
     "GameStart": {
         "action": "ClickSelf",
         "roi": [550, 600, 200, 120],


### PR DESCRIPTION
### 本Pull Request是为了增加配置文件内容，用以实现开始任务时自动关闭雷电模拟器 Google 套件窗口
![Screenshot_20250204-205140](https://github.com/user-attachments/assets/4f661c4f-64ce-4dea-b8d0-3b7921ca5877)
该弹窗在雷电模拟器的设置中无法关闭,但可以借助adb模拟点击关闭
配置文件已经经过测试，可以稳定使用
``` 
    "StartUpThemes": {
    "algorithm": "JustReturn",
    "next": [
      "LeidianGoogleFrameworkConfirm",
      "GameStart",
      "StartToWakeUp",
      "StartToWakeUpOCR",
      "StartLoginBServer",
      "StartUpConnectingFlag",
      "MainThemes#next",
      "CloseAnnos#next",
      "OfflineConfirm",
      "GameStartUpdateOCR"
    ]
  },
"LeidianGoogleFrameworkConfirm": {
  "algorithm": "OcrDetect",
  "action": "ClickSelf",
  "text": [ "不安装" ],
  "roi": [ 480, 410, 200, 50 ],
  "maxTimes": 5,
  "Doc": "用以关闭雷电模拟器启动外服明日方舟时弹出的未安装谷歌套件的提示",
  "next": [ "StartUpThemes#next" ]
},
```
将`LeidianGoogleFrameworkConfirm`摆在`GameStart`之前是因为这个窗口在打开游戏的时候就会出现，不将其关闭将会导致GameStart卡住，从而导致StartUp失败

如果需要补充我可以提供