### PR TITLE
fix: Log Rotate 临时性检查措施

### DIFF
--- a/src/MaaCore/Assistant.cpp
+++ b/src/MaaCore/Assistant.cpp
@@ -423,7 +423,6 @@ void Assistant::working_proc()
         }
 
         m_running = true;
-        Log.flush();
         const auto [id, task_ptr] = m_tasks_list.front();
         lock.unlock();
         // only one instance of working_proc running, unlock here to allow set_task_param to the running task

--- a/src/MaaCore/Assistant.cpp
+++ b/src/MaaCore/Assistant.cpp
@@ -423,6 +423,7 @@ void Assistant::working_proc()
         }
 
         m_running = true;
+        Log.flush();
         const auto [id, task_ptr] = m_tasks_list.front();
         lock.unlock();
         // only one instance of working_proc running, unlock here to allow set_task_param to the running task

--- a/src/MaaCore/Task/Roguelike/RoguelikeResetTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeResetTaskPlugin.cpp
@@ -34,5 +34,6 @@ bool asst::RoguelikeResetTaskPlugin::_run()
         }
     }
     m_config->clear();
+    Log.flush();
     return true;
 }


### PR DESCRIPTION
- 结合#11834 实施，分离PR仅用于后日revert

@ABA2396 