### PR TITLE
fix: Roguelike InitialDrop: SquadDefault -> Squad-EnterPoint

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -7142,7 +7142,7 @@
         "template": "empty.png",
         "action": "ClickSelf",
         "roi": [569, 583, 141, 137],
-        "next": ["Roguelike@SquadDefault", "Roguelike@InitialDrop"]
+        "next": ["Roguelike@Squad-EnterPoint", "Roguelike@InitialDrop"]
     },
     "Roguelike@IntegratedStrategies": {
         "action": "ClickSelf",


### PR DESCRIPTION
修discord回报的无法选择干员，没能复现反而发现了这个
没能复现的问题大概nightly修好了，大概