### PR TITLE
feat: script to update version.json

### DIFF
--- a/.github/workflows/res-update-game.yml
+++ b/.github/workflows/res-update-game.yml
@@ -303,20 +303,17 @@ jobs:
           args: -w ${{ steps.task_sorting.outputs.gitdiff }}
 
       - name: Update version.json date if necessary
+        id: update_version
         run: pwsh tools/ResourceUpdater/version.ps1
 
-      - name: Check if only sorted and Templates
-        id: check_sorted_templates
-        run: pwsh tools/ResourceUpdater/validator.ps1
-
       - name: Setup python
-        if: steps.check_sorted_templates.outputs.contains_png == 'True'
+        if: steps.update_version.outputs.contains_png == 'True'
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
       - name: Cache Python packages
-        if: always() && steps.check_sorted_templates.outputs.contains_png == 'True'
+        if: always() && steps.update_version.outputs.contains_png == 'True'
         id: cache_python
         uses: actions/cache@v4
         with:
@@ -324,23 +321,23 @@ jobs:
           key: ${{ runner.os }}-pip-optimize-templates-${{ hashFiles('./tools/OptimizeTemplates/requirements.txt') }}
 
       - name: Install dependencies
-        if: steps.cache_python.outputs.cache-hit != 'true' && steps.check_sorted_templates.outputs.contains_png == 'True'
+        if: steps.cache_python.outputs.cache-hit != 'true' && steps.update_version.outputs.contains_png == 'True'
         run: |
           pip install -r tools/OptimizeTemplates/requirements.txt
 
       - name: Setup oxipng
-        if: steps.check_sorted_templates.outputs.contains_png == 'True'
+        if: steps.update_version.outputs.contains_png == 'True'
         uses: baptiste0928/cargo-install@v3
         with:
           crate: oxipng
 
       - name: Run optimize_templates
-        if: steps.check_sorted_templates.outputs.contains_png == 'True'
+        if: steps.update_version.outputs.contains_png == 'True'
         run: |
           python3 tools/OptimizeTemplates/optimize_templates.py -p resource/template/items/ resource/template/infrast/
 
       - name: Add files to git
-        if: steps.check_sorted_templates.outputs.changes == 'True'
+        if: steps.update_version.outputs.changes == 'True'
         id: add_files
         run: |
           git config user.name "github-actions[bot]"
@@ -386,7 +383,7 @@ jobs:
       #     gh cache delete
 
       - name: Add cancelled status
-        if: steps.check_sorted_templates.outputs.changes != 'True' || steps.add_files.outputs.have_commits != 'True'
+        if: steps.update_version.outputs.changes != 'True' || steps.add_files.outputs.have_commits != 'True'
         uses: andymckay/cancel-action@0.5
 
     #   - name: Release # ref: https://docs.github.com/en/actions/using-workflows/triggering-a-workflow#triggering-a-workflow-from-a-workflow

--- a/.github/workflows/res-update-game.yml
+++ b/.github/workflows/res-update-game.yml
@@ -368,7 +368,7 @@ jobs:
           github_token: ${{ secrets.MAA_RESOURCE_SYNC }}
 
       - name: Update OTA resource
-        if: steps.add_files.outputs.update_resources == 'True'
+        if: steps.update_version.outputs.update_resources == 'True'
         env:
           GH_TOKEN: ${{ secrets.MAA_RESOURCE_SYNC }}
         run: |

--- a/.github/workflows/res-update-game.yml
+++ b/.github/workflows/res-update-game.yml
@@ -302,6 +302,9 @@ jobs:
         with:
           args: -w ${{ steps.task_sorting.outputs.gitdiff }}
 
+      - name: Update version.json date if necessary
+        run: pwsh tools/ResourceUpdater/version.ps1
+
       - name: Check if only sorted and Templates
         id: check_sorted_templates
         run: pwsh tools/ResourceUpdater/validator.ps1

--- a/tools/ResourceUpdater/main.cpp
+++ b/tools/ResourceUpdater/main.cpp
@@ -1431,8 +1431,8 @@ bool update_version_info(const fs::path& input_dir, const fs::path& output_dir)
         result["activity"]["time"] = time_var;
         result["activity"]["name"] = name;
     }
-    static auto time = asst::utils::get_format_time();
-    result["last_updated"] = time;
+    auto version_opt = json::open(output_dir / "version.json");
+    result["last_updated"] = version_opt->at("last_updated").as_string();
 
     std::ofstream ofs(output_dir / "version.json", std::ios::out);
     ofs << result.format() << '\n';

--- a/tools/ResourceUpdater/version.ps1
+++ b/tools/ResourceUpdater/version.ps1
@@ -1,0 +1,21 @@
+git add .
+
+$modifiedFiles = git diff --name-only HEAD 2>$null | Where-Object { $_ -notmatch 'tasks\.json$'}
+
+$directories = $modifiedFiles | ForEach-Object { Split-Path $_ } | Sort-Object -Unique
+
+foreach ($dir in $directories) {
+    $versionFile = Join-Path $dir "version.json"
+
+    if (Test-Path $versionFile) {
+        $json = Get-Content -Path $versionFile | ConvertFrom-Json
+        $json.last_updated = (Get-Date).ToString("yyyy-MM-dd HH:mm:ss.fff")
+        $jsonFormatted = $json | ConvertTo-Json -Depth 3
+        
+        $jsonFormatted = $jsonFormatted -replace "  ", "    "
+        $jsonFormatted | Set-Content -Path $versionFile
+        
+        Write-Output "Updated: $versionFile"
+    }
+}
+

--- a/tools/ResourceUpdater/version.ps1
+++ b/tools/ResourceUpdater/version.ps1
@@ -1,5 +1,6 @@
 $hasChanges = $false
 $hasPngChanges = $false
+$hasVersionChanges = $false
 
 git add .
 
@@ -27,6 +28,7 @@ else {
             $jsonFormatted = $jsonFormatted -replace "  ", "    "
             $jsonFormatted | Set-Content -Path $versionFile
             
+            $hasVersionChanges = $true
             Write-Output "Updated: $versionFile"
         }
     }
@@ -35,10 +37,10 @@ else {
     if ($allModifiedFiles | Where-Object { $_ -match '\.png$' }) {
         $hasPngChanges = $true
     }
-
 }
 
 Write-Output "Changes: $hasChanges"
 Write-Output "PNG Changes: $hasPngChanges"
 Write-Output "changes=$hasChanges" >> $env:GITHUB_OUTPUT
 Write-Output "contains_png=$hasPngChanges" >> $env:GITHUB_OUTPUT
+Write-Output "update_resources=$hasVersionChanges" >> $env:GITHUB_OUTPUT


### PR DESCRIPTION
@MistEO Ok, so shifting all logic to independent version.json modifications.

version.json will get modified when any file is modified except the tasks.json (follows [MaaResource files](https://github.com/MaaAssistantArknights/MaaResource))

~~Now I just need to revert and fix the logic to when we were previously checking for files differences and pngs, to correctly run the optimizations png step and then the commit and push.~~ DONE

Since I didnt completely understand the logic of when update-resources is run I will keep the bool that skips it, so for now the bool is directly connected to when version.json gets modified. If it gets modified, it will also run update-resources.

@AnnAngela After merge, do you think we delete validator.ps1 and mjs? Or do we keep them just in case?
