### PR TITLE
fix: 修复招募功能中的逻辑漏洞，并添加相应的测试函数

### DIFF
--- a/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.cpp
@@ -660,8 +660,7 @@ asst::AutoRecruitTask::calc_task_result_type asst::AutoRecruitTask::recruit_calc
         if (!is_calc_only_task()) {
             if (!(has_robot_tag || has_special_tag)) {
                 // do not confirm 3 star, force skip
-                if (!is_confirm_level_valid(3) &&  
-                    final_combination.min_level == 3 &&
+                if (!is_confirm_level_valid(3) && final_combination.min_level == 3 &&
                     is_select_level_invalid(final_combination.min_level)) {
                     calc_task_result_type result(calc_task_result::force_skip);
                     return result;
@@ -701,10 +700,8 @@ asst::AutoRecruitTask::calc_task_result_type asst::AutoRecruitTask::recruit_calc
             }
         }
         // recruit 3 star but nothing to select, leave the selection empty
-        if (is_confirm_level_valid(3) && 
-            !has_preferred_tag &&
-            final_combination.min_level == 3 &&
-            is_select_level_invalid(final_combination.min_level)){
+        if (is_confirm_level_valid(3) && !has_preferred_tag && final_combination.min_level == 3 &&
+            is_select_level_invalid(final_combination.min_level)) {
             calc_task_result_type result(calc_task_result::nothing_to_select, recruitment_time);
             return result;
         }

--- a/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.cpp
@@ -416,15 +416,24 @@ asst::AutoRecruitTask::calc_task_result_type asst::AutoRecruitTask::recruit_calc
 
 #ifdef ASST_DEBUG
         // mock_test_001: 1/5/6 Star Operators appear when first recruited.
-        static bool RunRecruitMockTest_001 = true;
+        static bool RunRecruitMockTest_001 = false;
         if (RunRecruitMockTest_001) {
-            static int skip_once = 0;
-            if (skip_once == 0) {
+            static int skip_once_001 = 0;
+            if (skip_once_001 == 0) {
                 // image_analyzer.mock_set_special(asst::RecruitImageAnalyzer::operator_type::robot);
                 // image_analyzer.mock_set_special(asst::RecruitImageAnalyzer::operator_type::senior);
                 // image_analyzer.mock_set_special(asst::RecruitImageAnalyzer::operator_type::top);
                 // image_analyzer.mock_set_special(asst::RecruitImageAnalyzer::operator_type::highvalue);
-                skip_once++;
+                skip_once_001++;
+            }
+        }
+        // mock_test_002: The high-star combination tag and the 1-star tag appear at the same time
+        static bool RunRecruitMockTest_002 = false;
+        if (RunRecruitMockTest_002) {
+            static int skip_once_002 = 0;
+            if (skip_once_002 == 0) {
+                image_analyzer.mock_set_special(asst::RecruitImageAnalyzer::operator_type::combination_tag);
+                skip_once_002++;
             }
         }
 #endif
@@ -644,18 +653,23 @@ asst::AutoRecruitTask::calc_task_result_type asst::AutoRecruitTask::recruit_calc
             return result;
         }
 
+        if (final_combination.min_level > 4) {
+            has_special_tag = true;
+        }
+
         if (!is_calc_only_task()) {
             if (!(has_robot_tag || has_special_tag)) {
-                // do not confirm, force skip
-                if (!(final_combination.min_level == 3 && has_preferred_tag) &&
-                    is_confirm_level_invalid(final_combination.min_level)) {
+                // do not confirm 3 star, force skip
+                if (!is_confirm_level_valid(3) &&  
+                    final_combination.min_level == 3 &&
+                    is_select_level_invalid(final_combination.min_level)) {
                     calc_task_result_type result(calc_task_result::force_skip);
                     return result;
                 }
             }
 
             // "Automatically recruit 5/6 Star operators" is not checked.
-            if (has_special_tag && is_confirm_level_invalid(final_combination.min_level)) {
+            if (has_special_tag && !is_confirm_level_valid(final_combination.min_level)) {
                 calc_task_result_type result(calc_task_result::special_tag_skip);
                 return result;
             }
@@ -686,10 +700,11 @@ asst::AutoRecruitTask::calc_task_result_type asst::AutoRecruitTask::recruit_calc
                 ctrler()->click(image_analyzer.get_minute_decrement_rect());
             }
         }
-
-        // nothing to select, leave the selection empty
-        if (!(final_combination.min_level == 3 && has_preferred_tag) &&
-            is_select_level_invalid(final_combination.min_level)) {
+        // recruit 3 star but nothing to select, leave the selection empty
+        if (is_confirm_level_valid(3) && 
+            !has_preferred_tag &&
+            final_combination.min_level == 3 &&
+            is_select_level_invalid(final_combination.min_level)){
             calc_task_result_type result(calc_task_result::nothing_to_select, recruitment_time);
             return result;
         }

--- a/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.h
+++ b/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.h
@@ -161,7 +161,6 @@ protected:
         return std::ranges::none_of(this->m_select_level, [&](const int& i) { return i != opr_level; });
     }
 
-
     calc_task_result_type recruit_calc_task(slot_index = 0);
 
     std::vector<int> m_select_level;

--- a/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.h
+++ b/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.h
@@ -146,10 +146,21 @@ protected:
         return std::ranges::none_of(this->m_confirm_level, [&](const int& i) { return i == opr_level; });
     }
 
+    bool is_confirm_level_valid(int opr_level)
+    {
+        return std::ranges::none_of(this->m_confirm_level, [&](const int& i) { return i != opr_level; });
+    }
+
     bool is_select_level_invalid(int opr_level)
     {
         return std::ranges::none_of(this->m_select_level, [&](const int& i) { return i == opr_level; });
     }
+
+    bool is_select_level_valid(int opr_level)
+    {
+        return std::ranges::none_of(this->m_select_level, [&](const int& i) { return i != opr_level; });
+    }
+
 
     calc_task_result_type recruit_calc_task(slot_index = 0);
 

--- a/src/MaaCore/Vision/Miscellaneous/RecruitImageAnalyzer.h
+++ b/src/MaaCore/Vision/Miscellaneous/RecruitImageAnalyzer.h
@@ -31,7 +31,8 @@ public:
         top = 6,
         senior = 5,
         robot = 1,
-        highvalue = 11
+        highvalue = 11,
+        combination_tag = 12
     };
 
     void mock_set_special(operator_type type)
@@ -48,6 +49,14 @@ public:
         if (type == highvalue) {
             m_tags_result[0].text = "资深干员";
             m_tags_result[1].text = "高级资深干员";
+        }
+        if (type == combination_tag) {
+            // 近卫+防护=星极
+            m_tags_result[0].text = "近卫干员";
+            m_tags_result[1].text = "先锋干员";
+            m_tags_result[2].text = "费用回复";
+            m_tags_result[3].text = "防护";
+            m_tags_result[4].text = "元素";
         }
     }
 #endif // ASST_DEBUG


### PR DESCRIPTION
按照执行结果来看
有问题的这个分支原本应该是为了在

有3星偏好TAG且招募最小等级是3星

的情况下，能够正常招募指定的3星tag。

但是逆否命题是

没有3星偏好tag或招募最小等级不是3星

就会导致错误地捕获5星的招募。

而且没有验证是否确认招募3星，顺便修了。

update 250214: 
有小猪（我

误操作卷回了修改 ，要重新开一个PR。

原PR#11855