### PR TITLE
fix: 支持肉鸽特定模式下跳过选队直接选人

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -7182,7 +7182,7 @@
         "action": "ClickSelf",
         "template": "empty.png",
         "roi": [171, 474, 935, 205],
-        "next": ["Roguelike@RolesDefault", "Roguelike@CloseCollection"]
+        "next": ["Roguelike@RolesDefault", "Roguelike@CloseCollection", "Roguelike@RecruitMain"]
     },
     "Roguelike@LastRewardRand": {
         "Doc": "你的上一次探索突破了至少两层困难，这一次可以获得更多支援—— 问号",


### PR DESCRIPTION
已知存在于萨米深入调查8

问题来自discord