### PR TITLE
ci: try to fix pre commit using an updated fork

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,6 @@ repos:
     rev: v3.5.1
     hooks:
       - id: prettier
-        verbose: true
         files: ^((\.github/ISSUE_TEMPLATE|docs|resource|src|tools|website)/.*|\.pre-commit-config\.yaml|package-definition\.json)
         types_or:
           - yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,15 +14,15 @@ repos:
       - id: clang-format
         files: ^src/MaaCore/.*
         args: ["--assume-filename", ".clang-format"]
-  # - repo: https://github.com/pre-commit/mirrors-prettier
-  #   rev: v4.0.0-alpha.8
-  #   hooks:
-  #     - id: prettier
-  #       verbose: true
-  #       files: ^((\.github/ISSUE_TEMPLATE|docs|resource|src|tools|website)/.*|\.pre-commit-config\.yaml|package-definition\.json)
-  #       types_or:
-  #         - yaml
-  #         - json
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: v3.5.1
+    hooks:
+      - id: prettier
+        verbose: true
+        files: ^((\.github/ISSUE_TEMPLATE|docs|resource|src|tools|website)/.*|\.pre-commit-config\.yaml|package-definition\.json)
+        types_or:
+          - yaml
+          - json
   - repo: https://github.com/DavidAnson/markdownlint-cli2
     rev: v0.13.0
     hooks:


### PR DESCRIPTION
Why were we even using an alpha version of prettier? Especially when the mirror repo has been archived. (Especially when https://github.com/prettier/prettier/releases/tag/4.0.0-alpha.10 exists)