### PR TITLE
rft: Splitting IS Encounter OCR by themes

### DIFF
--- a/src/MaaCore/Task/Roguelike/RoguelikeStageEncounterTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeStageEncounterTaskPlugin.cpp
@@ -39,7 +39,7 @@ bool asst::RoguelikeStageEncounterTaskPlugin::_run()
     std::unordered_map<std::string, Config::RoguelikeEvent> event_map = RoguelikeStageEncounter.get_events(theme, mode);
     std::vector<std::string> event_names = RoguelikeStageEncounter.get_event_names(theme);
 
-    const auto event_name_task_ptr = Task.get("Roguelike@StageEncounterOcr");
+    const auto event_name_task_ptr = Task.get(theme + "@" + "Roguelike@StageEncounterOcr");
     sleep(event_name_task_ptr->pre_delay);
 
     if (need_exit()) {


### PR DESCRIPTION
https://github.com/MaaAssistantArknights/MaaAssistantArknights/pull/11921#issuecomment-2662243345

EDIT: TODO
- [ ] Adapt ResourceUpdater to split the data in the 4 I.S. (technically Phantom, Mizuki and Sami are dead so we could ignore them (same thing for all the other roguelike gamedata, but that's another problem)
- [ ] After getting the new baseline from ResourceUpdater, check all tasks (again) and reapply the necessary regexes