### PR TITLE
fix: YostarKR missing tasks

### DIFF
--- a/resource/global/YoStarKR/resource/tasks.json
+++ b/resource/global/YoStarKR/resource/tasks.json
@@ -1457,6 +1457,9 @@
     "GachaLastOnceResult": {
         "text": ["증명서", "증표", "중복"]
     },
+    "GachaLastTenTimesResult2": {
+        "text": ["물자", "획득"]
+    },
     "GachaOncePrefix@DoGacha": {
         "text": ["1회진행"]
     },

--- a/resource/global/YoStarKR/resource/tasks.json
+++ b/resource/global/YoStarKR/resource/tasks.json
@@ -2687,11 +2687,17 @@
             "괴이한 단장"
         ]
     },
+    "Sarkaz@Roguelike@RoutingRefreshNodeConfirm": {
+        "text": ["확인"]
+    },
     "Sarkaz@Roguelike@SelectTheme": {
         "text": ["가설", "수록"]
     },
     "Sarkaz@Roguelike@StageRefresh": {
         "templThreshold": 0.7
+    },
+    "Sarkaz@Roguelike@StageSafeHouseReuse": {
+        "text": ["안전가옥활용"]
     },
     "Sarkaz@Roguelike@StrategyChange-FastInvestment": {
         "ocrReplace": [

--- a/resource/global/YoStarKR/resource/tasks.json
+++ b/resource/global/YoStarKR/resource/tasks.json
@@ -924,6 +924,10 @@
             "OfflineConfirm"
         ]
     },
+    "GameStartUpdateOCR": {
+        "text": ["신경", "전달물질", "MB"],
+        "roi": [280, 650, 720, 60]
+    },
     "StartToWakeUp": {
         "Doc": "CN서버보다 ROI를 크게 조절하세요",
         "roi": [540, 480, 192, 56]

--- a/resource/global/YoStarKR/resource/tasks.json
+++ b/resource/global/YoStarKR/resource/tasks.json
@@ -2508,6 +2508,9 @@
     "Sami@Roguelike@Collapsal": {
         "text": ["선택적", "선택적무시", "이미지", "이미지에러"]
     },
+    "Sami@Roguelike@CollapsalParadigmTaskBannerCheckConfig": {
+        "ocrReplace": [["붕괴패러다임심화", "坍缩范式加深"]]
+    },
     "Sami@Roguelike@ContinueClick": {
         "ocrReplace": [
             ["여명의.+", "여명의툰드라"],

--- a/resource/global/YoStarKR/resource/tasks.json
+++ b/resource/global/YoStarKR/resource/tasks.json
@@ -2187,6 +2187,9 @@
     "Roguelike@IntegratedStrategies": {
         "templThreshold": 0.75
     },
+    "Roguelike@NoneSelected": {
+        "text": ["편성하지", "않은상태"]
+    },
     "Roguelike@PreSelectTheme": {
         "text": ["모든테마보기", "테마", "TODO: image of //INTEGRATED STRATEGIES"],
         "roi": [450, 480, 160, 45]

--- a/resource/global/YoStarKR/resource/tasks.json
+++ b/resource/global/YoStarKR/resource/tasks.json
@@ -2397,6 +2397,10 @@
     "Roguelike@StageTraderSpecialShoppingAfterRefresh": {
         "text": ["패스파인더", "패스파인더 핀"]
     },
+    "Roguelike@StartExploreCD": {
+        "doc": "로그라이크 재시작 딜레이",
+        "text": ["복귀", "재정비", "정리", "중"]
+    },
     "Phantom@Roguelike@CheckLevel": {
         "roi": [1106, 32, 117, 36],
         "text": ["고성", "노트"]

--- a/resource/global/YoStarKR/resource/tasks.json
+++ b/resource/global/YoStarKR/resource/tasks.json
@@ -1390,6 +1390,9 @@
     "BattleStartSimulationForTwo": {
         "text": ["시작", "시뮬레이션"]
     },
+    "StageDrops-TimesCheck": {
+        "text": ["연속", "대리", "지휘"]
+    },
     "StageDrops-Quantity": {
         "maskRange": [200, 255],
         "template": "empty.png",

--- a/resource/global/YoStarKR/resource/tasks.json
+++ b/resource/global/YoStarKR/resource/tasks.json
@@ -2431,6 +2431,26 @@
             ["욕망의로비", "_exit"]
         ]
     },
+    "Phantom@Roguelike@StrategyChange_mode6": {
+        "ocrReplace": [
+            ["안개의기로", "_aggressive"],
+            ["석양의정원", "_aggressive"],
+            ["고향의잔.+$", "_aggressive"],
+            ["악몽의시작", "_pragmatic"],
+            ["붉은달회랑", "_pragmatic"],
+            ["욕망의로비", "_default"]
+        ]
+    },
+    "Phantom@Roguelike@StrategyChange_mode7": {
+        "ocrReplace": [
+            ["안개의기로", "_aggressive"],
+            ["석양의정원", "_aggressive"],
+            ["고향의잔.+$", "_aggressive"],
+            ["악몽의시작", "_pragmatic"],
+            ["붉은달회랑", "_pragmatic"],
+            ["욕망의로비", "_default"]
+        ]
+    },
     "Mizuki@Roguelike@CheckLevel": {
         "roi": [1114, 36, 91, 28],
         "text": ["생태", "계보"]
@@ -2469,6 +2489,28 @@
             ["신성한동굴", "_exit"],
             ["심해의숲", "_exit"],
             ["짙푸른요람", "_exit"]
+        ]
+    },
+    "Mizuki@Roguelike@StrategyChange_mode6": {
+        "ocrReplace": [
+            ["하늘빛해안", "_aggressive"],
+            ["연안외딴섬", "_aggressive"],
+            ["맹렬한파도", "_pragmatic"],
+            ["은밀한온상", "_pragmatic"],
+            ["신성한동굴", "_default"],
+            ["심해의숲", "_default"],
+            ["짙푸른요람", "_SKIP_"]
+        ]
+    },
+    "Mizuki@Roguelike@StrategyChange_mode7": {
+        "ocrReplace": [
+            ["하늘빛해안", "_aggressive"],
+            ["연안외딴섬", "_aggressive"],
+            ["맹렬한파도", "_pragmatic"],
+            ["은밀한온상", "_pragmatic"],
+            ["신성한동굴", "_default"],
+            ["심해의숲", "_default"],
+            ["짙푸른요람", "_SKIP_"]
         ]
     },
     "Sami@Roguelike@CheckCollapsalParadigms": {
@@ -2673,6 +2715,28 @@
             [".*얼어붙은바위", "_SKIP_"],
             [".*무결점의정원", "_SKIP_"],
             [".*예견의구상", "_SKIP_"],
+            [".*숨겨진비경", "_SKIP_"]
+        ]
+    },
+    "Sami@Roguelike@StrategyChange_mode6": {
+        "ocrReplace": [
+            [".*은빛의호.+", "_aggressive"],
+            [".*고요한숲", "_aggressive"],
+            [".*여명의.+", "_pragmatic"],
+            [".*얼어붙은바위", "_pragmatic"],
+            [".*무결점의정원", "_default"],
+            [".*예견의구상", "_default"],
+            [".*숨겨진비경", "_SKIP_"]
+        ]
+    },
+    "Sami@Roguelike@StrategyChange_mode7": {
+        "ocrReplace": [
+            [".*은빛의호.+", "_aggressive"],
+            [".*고요한숲", "_aggressive"],
+            [".*여명의.+", "_pragmatic"],
+            [".*얼어붙은바위", "_pragmatic"],
+            [".*무결점의정원", "_default"],
+            [".*예견의구상", "_default"],
             [".*숨겨진비경", "_SKIP_"]
         ]
     },


### PR DESCRIPTION
```
StageDrops-TimesCheck: 连续, 成功, 代理, 作战
StageDrops-StageCF-FoodBonusFlag: 用, 餐, 加, 成
StageDrops-Stage12-TripleFlag: 后勤, 急派
GachaLastTenTimesResult2: 获得物资
Roguelike@NoneSelected: 不编入
```

Some items remain, but I don't know what they are :|