### PR TITLE
feat: 优化技能识别模型

### DIFF
--- a/src/MaaCore/Task/Interface/DebugTask.cpp
+++ b/src/MaaCore/Task/Interface/DebugTask.cpp
@@ -47,25 +47,78 @@ void asst::DebugTask::test_skill_ready()
 {
     int total = 0;
     int correct = 0;
+
+    // 测试 y 类别（预期为 ready，即 true）
     for (const auto& entry : std::filesystem::directory_iterator(R"(../../test/skill_ready/y)")) {
         cv::Mat image = imread(entry.path().string());
         BattlefieldClassifier analyzer(image);
         analyzer.set_object_of_interest({ .skill_ready = true });
         total++;
-        if (analyzer.analyze()->skill_ready.ready) {
+        auto result = analyzer.analyze()->skill_ready;
+        // 记录日志：文件、预期结果、实际预测、得分、概率信息
+        Log.info(
+            __FUNCTION__,
+            "File: ",
+            entry.path().string(),
+            " | Expected: Y (ready: true)",
+            " | Predicted: ",
+            result.ready,
+            " | Score: ",
+            result.score,
+            " | Prob: ",
+            result.prob);
+        if (result.ready) {
             correct++;
         }
     }
+
+    // 测试 n 类别（预期为 not ready，即 false）
     for (const auto& entry : std::filesystem::directory_iterator(R"(../../test/skill_ready/n)")) {
         cv::Mat image = imread(entry.path().string());
         BattlefieldClassifier analyzer(image);
         analyzer.set_object_of_interest({ .skill_ready = true });
         total++;
-        if (!analyzer.analyze()->skill_ready.ready) {
+        auto result = analyzer.analyze()->skill_ready;
+        Log.info(
+            __FUNCTION__,
+            "File: ",
+            entry.path().string(),
+            " | Expected: N (ready: false)",
+            " | Predicted: ",
+            result.ready,
+            " | Score: ",
+            result.score,
+            " | Prob: ",
+            result.prob);
+        if (!result.ready) {
             correct++;
         }
     }
-    Log.info(__FUNCTION__, correct, "/", total, ",", double(correct) / total);
+
+    // 测试 c 类别（同样预期为 not ready）
+    for (const auto& entry : std::filesystem::directory_iterator(R"(../../test/skill_ready/c)")) {
+        cv::Mat image = imread(entry.path().string());
+        BattlefieldClassifier analyzer(image);
+        analyzer.set_object_of_interest({ .skill_ready = true });
+        total++;
+        auto result = analyzer.analyze()->skill_ready;
+        Log.info(
+            __FUNCTION__,
+            "File: ",
+            entry.path().string(),
+            " | Expected: C (ready: false)",
+            " | Predicted: ",
+            result.ready,
+            " | Score: ",
+            result.score,
+            " | Prob: ",
+            result.prob);
+        if (!result.ready) {
+            correct++;
+        }
+    }
+
+    Log.info(__FUNCTION__, "Final Accuracy: ", correct, "/", total, " (", double(correct) / total, ")");
 }
 
 void asst::DebugTask::test_battle_image()

--- a/src/MaaCore/Vision/Battle/BattlefieldClassifier.cpp
+++ b/src/MaaCore/Vision/Battle/BattlefieldClassifier.cpp
@@ -99,7 +99,7 @@ BattlefieldClassifier::SkillReadyResult BattlefieldClassifier::skill_ready_analy
     SkillReadyResult::Prob prob = softmax(raw_results);
     Log.info(__FUNCTION__, "prob:", prob);
     // 类别顺序为 c, n, y
-    size_t class_id = std::max_element(prob.begin(), prob.end()) - prob.begin();
+    size_t class_id = ranges::max_element(prob) - prob.begin();
     bool ready = (class_id == 2); // 只有当class_id为2（代表y）时，才认为是ready
     float score = prob[class_id];
 

--- a/src/MaaCore/Vision/Battle/BattlefieldClassifier.cpp
+++ b/src/MaaCore/Vision/Battle/BattlefieldClassifier.cpp
@@ -154,23 +154,27 @@ BattlefieldClassifier::SkillReadyResult BattlefieldClassifier::skill_ready_analy
     }
 
     if (need_save) {
-        std::filesystem::path relative_path;
-        // 根据不同类别保存到不同的文件夹
-        if (class_id == 2) {
-            relative_path = utils::path("debug") / utils::path("skill_ready") / utils::path("y") /
-                            (utils::get_time_filestem() + "_" + std::to_string(m_base_point.x) + "_" +
-                             std::to_string(m_base_point.y) + ".png");
+        std::string base_filename = utils::get_time_filestem() + "_" + std::to_string(m_base_point.x) + "_" +
+                                    std::to_string(m_base_point.y) + "(c" + std::to_string(prob[0]) + ")(n" +
+                                    std::to_string(prob[1]) + ")(y" + std::to_string(prob[2]) + ").png";
+        std::string subfolder;
+        switch (class_id) {
+        case 2:
+            subfolder = "y";
+            break;
+        case 1:
+            subfolder = "n";
+            break;
+        case 0:
+            subfolder = "c";
+            break;
+        default:
+            subfolder = "unknown";
+            break;
         }
-        else if (class_id == 0) {
-            relative_path = utils::path("debug") / utils::path("skill_ready") / utils::path("c") /
-                            (utils::get_time_filestem() + "_" + std::to_string(m_base_point.x) + "_" +
-                             std::to_string(m_base_point.y) + ".png");
-        }
-        else {
-            relative_path = utils::path("debug") / utils::path("skill_ready") / utils::path("n") /
-                            (utils::get_time_filestem() + "_" + std::to_string(m_base_point.x) + "_" +
-                             std::to_string(m_base_point.y) + ".png");
-        }
+
+        std::filesystem::path relative_path =
+            utils::path("debug") / utils::path("skill_ready") / utils::path(subfolder) / base_filename;
         last_base_point = m_base_point;
         last_class = static_cast<int>(class_id);
         Log.trace("Save image", relative_path);

--- a/src/MaaCore/Vision/Battle/BattlefieldClassifier.h
+++ b/src/MaaCore/Vision/Battle/BattlefieldClassifier.h
@@ -18,7 +18,7 @@ public:
 public:
     struct SkillReadyResult
     {
-        static constexpr size_t ClsSize = 2;
+        static constexpr size_t ClsSize = 3;
         using Raw = std::array<float, ClsSize>;
         using Prob = Raw;
 


### PR DESCRIPTION
- **模型训练**  
  - 使用 **MobileNetV4** 重新训练了技能识别模型。  
  - 模型由原先的二分类升级为 **三分类**，其中新增 “可取消” 技能状态。

- **代码更新**  
  - 在技能识别的 `analyze` 函数中，支持了新的模型前处理逻辑，并添加了三分类的判断逻辑。  
  - 更新了 `debugtask` 中的技能识别测试用例，以适配新的三分类模型。
