### PR TITLE
fix: log rotate

### DIFF
--- a/src/MaaCore/Task/Roguelike/RoguelikeResetTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeResetTaskPlugin.cpp
@@ -34,6 +34,5 @@ bool asst::RoguelikeResetTaskPlugin::_run()
         }
     }
     m_config->clear();
-    Log.flush();
     return true;
 }

--- a/src/MaaCore/Utils/Logger.hpp
+++ b/src/MaaCore/Utils/Logger.hpp
@@ -412,16 +412,15 @@ public:
         template <typename T>
         LogStream& operator<<(T&& arg)
         {
-            std::size_t byte_count = 0;
             if constexpr (std::same_as<separator, remove_cvref_t<T>>) {
                 m_sep = std::forward<T>(arg);
             }
             else {
                 // 如果是 level，则不输出 separator
                 if constexpr (!std::same_as<Logger::level, remove_cvref_t<T>>) {
-                    stream_put(m_ofs, m_sep.str, byte_count);
+                    stream_put(m_ofs, m_sep.str, m_bytes_written);
                 }
-                stream_put(m_ofs, std::forward<T>(arg), byte_count);
+                stream_put(m_ofs, std::forward<T>(arg), m_bytes_written);
             }
             return *this;
         }

--- a/src/MaaCore/Utils/Logger.hpp
+++ b/src/MaaCore/Utils/Logger.hpp
@@ -5,7 +5,7 @@
 #include <functional>
 #include <iostream>
 #include <mutex>
-#include <string>
+#include <cstring>
 #include <thread>
 #include <type_traits>
 #include <utility>

--- a/src/MaaCore/Utils/Logger.hpp
+++ b/src/MaaCore/Utils/Logger.hpp
@@ -5,10 +5,10 @@
 #include <functional>
 #include <iostream>
 #include <mutex>
+#include <string>
 #include <thread>
 #include <type_traits>
 #include <utility>
-#include <string>
 
 #include "Common/AsstTypes.h"
 #include "Common/AsstVersion.h"

--- a/src/MaaCore/Utils/Logger.hpp
+++ b/src/MaaCore/Utils/Logger.hpp
@@ -561,9 +561,7 @@ public:
     {
     public:
         LogStreambuf(std::filebuf* dest_buf) :
-            ch(0),
-            dest(dest_buf),
-            count(0)
+            dest(dest_buf)
         {
         }
 
@@ -611,9 +609,9 @@ public:
 #else
         const static std::size_t NewLineSize = 1; // \n;
 #endif
-        char ch;
+        char ch = 0;
         std::filebuf* dest;
-        std::streamsize count;
+        std::streamsize count = 0;
     };
 
 public:

--- a/src/MaaCore/Utils/Logger.hpp
+++ b/src/MaaCore/Utils/Logger.hpp
@@ -818,7 +818,7 @@ private:
     std::ofstream m_ofs;
     std::size_t m_bytes_written = 0;
     std::function<void(const std::unique_lock<std::mutex>&, std::size_t)> m_callback = nullptr;
-    const std::size_t MaxLogSize = 24 * 1024LL; //   64LL *1024 * 1024;
+    const std::size_t MaxLogSize = 64LL *1024 * 1024;
 };
 
 inline constexpr Logger::separator Logger::separator::none;

--- a/src/MaaCore/Utils/Logger.hpp
+++ b/src/MaaCore/Utils/Logger.hpp
@@ -744,7 +744,7 @@ private:
         log_init_info();
     }
 
-    void rotate([[maybe_unused]] std::unique_lock<std::mutex>& m_lock)
+    void rotate([[maybe_unused]] const std::unique_lock<std::mutex>& m_lock)
     {
         if (!m_ofs || !m_ofs.is_open() || m_bytes_written <= MaxLogSize) {
             return;
@@ -785,7 +785,7 @@ private:
     std::ofstream m_ofs;
     std::size_t m_bytes_written = 0;
     std::function<void(const std::unique_lock<std::mutex>&, std::size_t)> m_add_bytes_callback = nullptr;
-    const uintmax_t MaxLogSize = 64LL * 1024 * 1024;
+    const std::size_t MaxLogSize = 64LL * 1024 * 1024;
 };
 
 inline constexpr Logger::separator Logger::separator::none;

--- a/src/MaaCore/Utils/Logger.hpp
+++ b/src/MaaCore/Utils/Logger.hpp
@@ -788,7 +788,7 @@ private:
         m_ofs = std::ofstream(m_log_path, std::ios::out | std::ios::app);
         m_file_size = std::filesystem::file_size(m_log_path);
         m_buff = LogStreambuf(m_ofs.rdbuf());
-        m_of.set_rdbuf(&m_buff);
+        m_of.rdbuf(&m_buff);
     }
 
     void log_init_info()

--- a/src/MaaCore/Utils/Logger.hpp
+++ b/src/MaaCore/Utils/Logger.hpp
@@ -740,7 +740,14 @@ private:
         m_directory(UserDir.get()),
         m_add_bytes_callback([&](const auto& lock, size_t count) { add_byte_count(lock, count); })
     {
-        std::filesystem::create_directories(m_log_path.parent_path());
+        try {
+            std::filesystem::create_directories(m_log_path.parent_path());
+        }
+        catch (std::filesystem::filesystem_error& e) {
+            std::cerr << e.what() << std::endl;
+        }
+        catch (...) {
+        }
         log_init_info();
     }
 

--- a/src/MaaCore/Utils/Logger.hpp
+++ b/src/MaaCore/Utils/Logger.hpp
@@ -818,7 +818,7 @@ private:
     std::ofstream m_ofs;
     std::size_t m_bytes_written = 0;
     std::function<void(const std::unique_lock<std::mutex>&, std::size_t)> m_callback = nullptr;
-    const std::size_t MaxLogSize = 64LL *1024 * 1024;
+    const std::size_t MaxLogSize = 64LL * 1024 * 1024;
 };
 
 inline constexpr Logger::separator Logger::separator::none;

--- a/src/MaaCore/Utils/Logger.hpp
+++ b/src/MaaCore/Utils/Logger.hpp
@@ -1,11 +1,11 @@
 #pragma once
 
+#include <cstring>
 #include <filesystem>
 #include <fstream>
 #include <functional>
 #include <iostream>
 #include <mutex>
-#include <cstring>
 #include <thread>
 #include <type_traits>
 #include <utility>

--- a/src/MaaCore/Utils/Logger.hpp
+++ b/src/MaaCore/Utils/Logger.hpp
@@ -643,7 +643,7 @@ public:
             m_ofs.seekp(0, std::ios::end);
             m_bytes_written = m_ofs.tellp();
         }
-        rotate(lock);
+        rotate();
         if constexpr (std::same_as<level, remove_cvref_t<T>>) {
 #ifdef ASST_DEBUG
             return LogStream(std::move(lock), m_callback, ostreams { console_ostream(std::cout), m_ofs }, arg);
@@ -738,7 +738,7 @@ public:
             m_ofs.seekp(0, std::ios::end);
             m_bytes_written = m_ofs.tellp();
         }
-        rotate(lock);
+        rotate();
         (LogStream(
              std::move(lock),
              m_callback,
@@ -777,7 +777,7 @@ private:
         log_init_info();
     }
 
-    void rotate([[maybe_unused]] const std::unique_lock<std::mutex>& m_lock)
+    void rotate()
     {
         if (!m_ofs || !m_ofs.is_open() || m_bytes_written <= MaxLogSize) {
             return;


### PR DESCRIPTION
- close #11893 

分离日志翻转和业务逻辑，对日志流中字符计数，避免关闭时产生空日志文件