### PR TITLE
fix: stuck on StageEnterBattleAgain while in team selection screen

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -7466,6 +7466,7 @@
         "templThreshold": 0.7,
         "action": "ClickSelf",
         "roi": [0, 0, 180, 80],
+        "preDelay": 500,
         "next": ["Roguelike@StageEnterBattleAgain"]
     },
     "Roguelike@RolesConfirm": {


### PR DESCRIPTION
Someone on discord had their MAA hung on team selection screen while MAA was in ```StageEnterBattleAgain```. We may also add ```Roguelike@ReturnToMap``` to ```StageEnterBattleAgain#next``` if need be, but I feel a simple preDelay is enough.


Discord那边有个报告MAA在选人界面（点进加号以后选择干员那个界面）挂起的，提供的log节选表明MAA卡在```StageEnterBattleAgain```里转了3w多圈，难以复现，先当成是没有足够的delay卡住了