### PR TITLE
fix: remove duplicate strings

### DIFF
--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -855,9 +855,9 @@ namespace MaaWpfGui.Main
                             var logs = SettingsViewModel.ExternalNotificationSettings.ExternalNotificationEnableDetails
                                 ? Instances.TaskQueueViewModel.LogItemViewModels.Aggregate(string.Empty, (current, logItem) => current + $"[{logItem.Time}][{logItem.Color}]{logItem.Content}\n")
                                 : string.Empty;
-                            logs += allTaskCompleteMessage + Environment.NewLine + sanityReport;
+                            logs += allTaskCompleteMessage;
 
-                            ExternalNotificationService.Send(allTaskCompleteTitle, logs);
+                            ExternalNotificationService.Send(allTaskCompleteTitle, logs + Environment.NewLine + sanityReport);
 
                             if (_toastNotificationTimer is not null)
                             {

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -857,7 +857,7 @@ namespace MaaWpfGui.Main
                                 : string.Empty;
                             logs += allTaskCompleteMessage + Environment.NewLine + sanityReport;
 
-                            ExternalNotificationService.Send(allTaskCompleteTitle, logs + Environment.NewLine + sanityReport);
+                            ExternalNotificationService.Send(allTaskCompleteTitle, logs);
 
                             if (_toastNotificationTimer is not null)
                             {


### PR DESCRIPTION
This makes it crash apparentlty lol...
```py
[2025-03-01 13:33:50.490][ERR][Px3f84][Tx45dc] │││││││││ asst::TemplResource::get_templ templ not found act24side_melding_6
```

EDIT: Fixed
Before vs after
![{2DBDE30B-C5A2-4C54-8A64-39F7F1D157EA}](https://github.com/user-attachments/assets/293ee532-6789-41be-bcc3-04d0b0c05124)
