### PR TITLE
fix: 修复截图速度过快导致不能切换贸易站订单的问题

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -6018,7 +6018,8 @@
         "template": "InfrastTradeSyntheticJadeFlag.png",
         "cache": true,
         "roi": [950, 585, 207, 105],
-        "next": ["ChooseMoneyOrder"]
+        "next": ["ChooseMoneyOrder"],
+        "preDelay": 500
     },
     "ChooseMoneyOrder": {
         "action": "ClickSelf",
@@ -6037,7 +6038,8 @@
         "template": "InfrastTradeMoneyFlag.png",
         "cache": true,
         "roi": [950, 585, 207, 105],
-        "next": ["ChooseSyntheticJadeOrder"]
+        "next": ["ChooseSyntheticJadeOrder"],
+        "preDelay": 500
     },
     "ChooseSyntheticJadeOrder": {
         "action": "ClickSelf",


### PR DESCRIPTION
ChangeToMoneyOrder任务在9ms的截图速度下，点击动作在游戏中无法生效，故添加一个任务前延时。 

顺便为ChangeToSyntheicJadeFlagOrder任务也添加一个前延时。

Co-authored-by: @Alan-Charred 