### PR TITLE
chore: bump maa-cli to 0.5.4

### DIFF
--- a/docs/en-us/manual/cli/config.md
+++ b/docs/en-us/manual/cli/config.md
@@ -418,6 +418,7 @@ binary = true # whether install maa-cli binary
 # hot update resource configurations
 [resource]
 auto_update = true # whether auto update resource before running task
+warn_on_update_failure = true # Whether to warn on update failure instead of panic
 backend = "libgit2" # the backend of resource, can be "libgit2" or "git"
 
 # the remote of resource

--- a/docs/en-us/manual/cli/install.md
+++ b/docs/en-us/manual/cli/install.md
@@ -96,7 +96,7 @@ maa-cli only provides an interface for MaaCore, it needs MaaCore and resources t
 maa install
 ```
 
-For users who installed via package managers, MaaCore can be installed via package managers:
+For users who installed via package managers, MaaCore can also be installed via package managers:
 
 - Homebrew：
 
@@ -112,8 +112,6 @@ For users who installed via package managers, MaaCore can be installed via packa
 
 - Nix：
 
-  ```bash
-  nix-env -iA nixpkgs.maa-assistant-arknights
-  ```
+  maa-cli on Nix depends on the MaaCore package, so no additional installation is required.
 
-**NOTE**: Only users who installed maa-cli via package managers can install MaaCore via package managers. Otherwise, please use the `maa install` command to install. In addition, the `maa install` downloads the official precompiled MaaCore, while the MaaCore installed by package managers has different compilation options and dependency versions from the official precompiled version. This does not affect the use of maa-cli but may cause differences in the functionality and performance of MaaCore. For example, the MaaCore installed by package managers uses a newer version of `fastdeploy`, while the official precompiled MaaCore uses an older version of `fastdeploy`. In the new version of `fastdeploy`, logs can be hidden, which can eliminate some unnecessary log output.
+**NOTE**: Only users who installed maa-cli via package managers can install MaaCore via package managers. Otherwise, please use the `maa install` command to install. In addition, the `maa install` downloads the official precompiled MaaCore, while the MaaCore installed by package managers has different compilation options and dependency versions from the official precompiled version, potentially causing variations in behavior and performance.

--- a/docs/ja-jp/manual/cli/config.md
+++ b/docs/ja-jp/manual/cli/config.md
@@ -408,6 +408,7 @@ binary = true # 是否安装 maa-cli 的二进制文件，默认为 true
 # 资源热更新相关配置
 [resource]
 auto_update = true  # 是否在每次运行任务时自动更新资源，默认为 false
+warn_on_update_failure = true # 是否在更新失败时发出警告而不是直接报错
 backend = "libgit2" # 资源热更新后端，可选值为 "git" 或者 "libgit2"，默认为 "git"
 
 # 资源热更新远程仓库相关配置

--- a/docs/ja-jp/manual/cli/install.md
+++ b/docs/ja-jp/manual/cli/install.md
@@ -116,8 +116,6 @@ maa install
 
 - Nix：
 
-  ```bash
-  nix-env -iA nixpkgs.maa-assistant-arknights
-  ```
+  Nix 上的 maa-cli 强制依赖 MaaCore。 因此，Nix 用户无需，也不应该手动安装 MaaCore。
 
-**注意**：只有使用包管理器安装 maa-cli 的用户才能使用包管理器安装 MaaCore，否则请使用 `maa install` 命令安装。此外，`maa install` 通过下载官方预编译的 MaaCore，而包管理器安装的 MaaCore 的编译选项和依赖版本与官方预编译的版本不同。这不会影响 maa-cli 的使用，但可能会导致 MaaCore 的功能和性能有所不同。比如，包管理器安装的 MaaCore 使用较新版本的 `fastdeploy`，而官方预编译的 MaaCore 使用较旧版本的 `fastdeploy`。而在新版本的 `fastdeploy` 中，日志可以被隐藏，这可以消除了一些不必要的日志输出。
+**注意**：只有使用包管理器安装 maa-cli 的用户才能使用包管理器安装 MaaCore，否则请使用 `maa install` 命令安装。此外，`maa install` 通过下载官方预编译的 MaaCore，而包管理器安装的 MaaCore 可能使用的编译选项和依赖版本与官方预编译的版本不同，这可能导致性能和功能上存在略微差异。

--- a/docs/ko-kr/manual/cli/config.md
+++ b/docs/ko-kr/manual/cli/config.md
@@ -401,6 +401,7 @@ binary = true # maa-cli 바이너리 파일을 설치할지 여부, 기본값은
 # 리소스 핫 업데이트 관련 설정
 [resource]
 auto_update = true  # 각 작업 실행 시 리소스를 자동 업데이트할지 여부, 기본값은 false
+warn_on_update_failure = true # 업데이트 실패 시 오류를 바로 보고하지 않고 경고를 발행할지 여부
 backend = "libgit2" # 리소스 핫 업데이트 백엔드, 가능한 값은 "git" 또는 "libgit2", 기본값은 "git"
 
 [resource.remote]

--- a/docs/ko-kr/manual/cli/install.md
+++ b/docs/ko-kr/manual/cli/install.md
@@ -112,8 +112,6 @@ maa install
 
 - Nix：
 
-  ```bash
-  nix-env -iA nixpkgs.maa-assistant-arknights
-  ```
+  Nix의 maa-cli는 MaaCore에 대한 필수 종속성이 있습니다. 따라서 Nix 사용자는 MaaCore를 수동으로 설치할 필요가 없으며, 설치해서도 안 됩니다.
 
-**주의**: 패키지 관리자를 통해 maa-cli를 설치한 경우에만 패키지 관리자를 통해 MaaCore를 설치할 수 있습니다. 그렇지 않으면 `maa install` 명령어를 사용해야 합니다. 또한, `maa install` 명령어는 공식적으로 사전 컴파일된 MaaCore를 다운로드합니다. 패키지 관리자를 통해 설치된 MaaCore는 컴파일 옵션과 종속성 버전이 공식 사전 컴파일 버전과 다를 수 있습니다. 이는 maa-cli의 사용에 영향을 미치지 않지만, MaaCore의 기능과 성능에 차이가 있을 수 있습니다. 예를 들어, 패키지 관리자를 통해 설치된 MaaCore는 최신 버전의 `fastdeploy`를 사용하고, 공식 사전 컴파일된 MaaCore는 구버전의 `fastdeploy`를 사용합니다. 최신 버전의 `fastdeploy`에서는 로그를 숨길 수 있어 불필요한 로그 출력을 줄일 수 있습니다.
+**주의**: 패키지 관리자를 통해 maa-cli를 설치한 경우에만 패키지 관리자를 통해 MaaCore를 설치할 수 있습니다. 그렇지 않으면 `maa install` 명령어를 사용해야 합니다. 또한, `maa install` 명령어는 공식적으로 사전 컴파일된 MaaCore를 다운로드합니다. 패키지 관리자를 통해 설치된 MaaCore는 컴파일 옵션과 종속성 버전이 공식 사전 컴파일 버전과 다를 수 있습니다. 이는 maa-cli의 사용에 영향을 미치지 않지만, MaaCore의 기능과 성능에 차이가 있을 수 있습니다.

--- a/docs/zh-cn/manual/cli/config.md
+++ b/docs/zh-cn/manual/cli/config.md
@@ -404,6 +404,7 @@ binary = true # 是否安装 maa-cli 的二进制文件，默认为 true
 # 资源热更新相关配置
 [resource]
 auto_update = true  # 是否在每次运行任务时自动更新资源，默认为 false
+warn_on_update_failure = true # 是否在更新失败时发出警告而不是直接报错
 backend = "libgit2" # 资源热更新后端，可选值为 "git" 或者 "libgit2"，默认为 "git"
 
 # 资源热更新远程仓库相关配置

--- a/docs/zh-cn/manual/cli/install.md
+++ b/docs/zh-cn/manual/cli/install.md
@@ -112,8 +112,6 @@ maa install
 
 - Nix：
 
-  ```bash
-  nix-env -iA nixpkgs.maa-assistant-arknights
-  ```
+  Nix 上的 maa-cli 强制依赖 MaaCore。 因此，Nix 用户无需，也不应该手动安装 MaaCore。
 
-**注意**：只有使用包管理器安装 maa-cli 的用户才能使用包管理器安装 MaaCore，否则请使用 `maa install` 命令安装。此外，`maa install` 通过下载官方预编译的 MaaCore，而包管理器安装的 MaaCore 的编译选项和依赖版本与官方预编译的版本不同。这不会影响 maa-cli 的使用，但可能会导致 MaaCore 的功能和性能有所不同。比如，包管理器安装的 MaaCore 使用较新版本的 `fastdeploy`，而官方预编译的 MaaCore 使用较旧版本的 `fastdeploy`。而在新版本的 `fastdeploy` 中，日志可以被隐藏，这可以消除了一些不必要的日志输出。
+**注意**：只有使用包管理器安装 maa-cli 的用户才能使用包管理器安装 MaaCore，否则请使用 `maa install` 命令安装。此外，`maa install` 通过下载官方预编译的 MaaCore，而包管理器安装的 MaaCore 可能使用的编译选项和依赖版本与官方预编译的版本不同，这可能导致性能和功能上存在略微差异。

--- a/docs/zh-tw/manual/cli/config.md
+++ b/docs/zh-tw/manual/cli/config.md
@@ -408,6 +408,7 @@ binary = true # 是否安装 maa-cli 的二进制文件，默认为 true
 # 资源热更新相关配置
 [resource]
 auto_update = true  # 是否在每次运行任务时自动更新资源，默认为 false
+warn_on_update_failure = true # 是否在更新失败时发出警告而不是直接报错
 backend = "libgit2" # 资源热更新后端，可选值为 "git" 或者 "libgit2"，默认为 "git"
 
 # 资源热更新远程仓库相关配置

--- a/docs/zh-tw/manual/cli/install.md
+++ b/docs/zh-tw/manual/cli/install.md
@@ -116,8 +116,6 @@ maa install
 
 - Nix：
 
-  ```bash
-  nix-env -iA nixpkgs.maa-assistant-arknights
-  ```
+  Nix 上的 maa-cli 强制依赖 MaaCore。 因此，Nix 用户无需，也不应该手动安装 MaaCore。
 
-**注意**：只有使用包管理器安装 maa-cli 的用户才能使用包管理器安装 MaaCore，否则请使用 `maa install` 命令安装。此外，`maa install` 通过下载官方预编译的 MaaCore，而包管理器安装的 MaaCore 的编译选项和依赖版本与官方预编译的版本不同。这不会影响 maa-cli 的使用，但可能会导致 MaaCore 的功能和性能有所不同。比如，包管理器安装的 MaaCore 使用较新版本的 `fastdeploy`，而官方预编译的 MaaCore 使用较旧版本的 `fastdeploy`。而在新版本的 `fastdeploy` 中，日志可以被隐藏，这可以消除了一些不必要的日志输出。
+**注意**：只有使用包管理器安装 maa-cli 的用户才能使用包管理器安装 MaaCore，否则请使用 `maa install` 命令安装。此外，`maa install` 通过下载官方预编译的 MaaCore，而包管理器安装的 MaaCore 可能使用的编译选项和依赖版本与官方预编译的版本不同，这可能导致性能和功能上存在略微差异。


### PR DESCRIPTION
Bump maa-cli to 0.5.4.

See [maa-cli changelog](https://github.com/MaaAssistantArknights/maa-cli/releases/tag/v0.5.4) for more details.