### PR TITLE
fix: 繁中服_生息演算組裝道具後卡住

### DIFF
--- a/resource/global/txwy/resource/tasks.json
+++ b/resource/global/txwy/resource/tasks.json
@@ -2203,7 +2203,7 @@
         "text": ["開始組裝", "組裝"]
     },
     "Reclamation2ExManufactureConfirmClickToContinue": {
-        "text": ["點擊", "空白", "繼續"]
+        "text": ["點擊", "空白", "繼續", "空百"]
     },
     "Reclamation2ExReadArchiveConfirm": {
         "text": ["確認"]
@@ -2383,6 +2383,6 @@
         "text": ["演算", "開始"]
     },
     "Tales@RA@ResourceGained": {
-        "text": ["點擊空白處繼續", "空白"]
+        "text": ["點擊空白處繼續", "空白", "空百"]
     }
 }

--- a/resource/global/txwy/resource/tasks.json
+++ b/resource/global/txwy/resource/tasks.json
@@ -2203,7 +2203,8 @@
         "text": ["開始組裝", "組裝"]
     },
     "Reclamation2ExManufactureConfirmClickToContinue": {
-        "text": ["點擊", "空白", "繼續", "空百"]
+        "text": ["點擊", "空白", "繼續"],
+        "ocrReplace": [["空百", "空白"]]
     },
     "Reclamation2ExReadArchiveConfirm": {
         "text": ["確認"]
@@ -2383,6 +2384,7 @@
         "text": ["演算", "開始"]
     },
     "Tales@RA@ResourceGained": {
-        "text": ["點擊空白處繼續", "空白", "空百"]
+        "text": ["點擊空白處繼續", "空白"],
+        "ocrReplace": [["空百", "空白"]]
     }
 }


### PR DESCRIPTION
fix: #12181 

神秘的 OCR 把 "空白" 認成 "空百" 了