### PR TITLE
fix: YostarKR lower StartToVisit templThreshold

### DIFF
--- a/resource/global/YoStarKR/resource/tasks.json
+++ b/resource/global/YoStarKR/resource/tasks.json
@@ -1073,6 +1073,9 @@
     "NoFriends": {
         "text": ["등록된", "없습니다"]
     },
+    "StartToVisit": {
+        "templThreshold": 0.7
+    },
     "VisitNextOcr": {
         "text": ["다음", "방문"]
     },


### PR DESCRIPTION
log
``` python
[2025-03-16 15:57:49.944][TRC][Px6824][Tx470c] match_templ | StartToVisit.png score: 0.732708 rect: [ 1057, 148, 59, 34 ] roi: [ 952, 105, 267, 601 ]
```