### PR TITLE
feat: hide MirrorChyan token on GitHub

### DIFF
--- a/src/MaaWpfGui/Views/UserControl/Settings/VersionUpdateSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/Settings/VersionUpdateSettingsUserControl.xaml
@@ -97,7 +97,7 @@
                             HorizontalAlignment="Left"
                             VerticalAlignment="Center"
                             hc:InfoElement.Placeholder="{DynamicResource MirrorChyanCdkPlaceholder}"
-                            IsEnabled="{c:Binding 'UpdateSource == &quot;MirrorChyan&quot;'}"
+                            Visibility="{c:Binding 'UpdateSource == &quot;MirrorChyan&quot;'}"
                             IsSafeEnabled="False"
                             ShowEyeButton="True"
                             UnsafePassword="{Binding MirrorChyanCdk}">
@@ -107,7 +107,7 @@
                                 </MultiBinding>
                             </hc:TitleElement.Title>
                         </hc:PasswordBox>
-                        <controls:TextBlock HorizontalAlignment="Center" VerticalAlignment="Center">
+                        <controls:TextBlock HorizontalAlignment="Center" VerticalAlignment="Center" Visibility="{c:Binding 'UpdateSource == &quot;MirrorChyan&quot;'}">
                             <Hyperlink
                                 Cursor="Hand"
                                 NavigateUri="{Binding Source={x:Static constants:MaaUrls.MirrorChyanWebsite}}"

--- a/src/MaaWpfGui/Views/UserControl/Settings/VersionUpdateSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/Settings/VersionUpdateSettingsUserControl.xaml
@@ -63,13 +63,6 @@
                         VerticalAlignment="Center"
                         Content="{DynamicResource AutoInstallUpdatePackage}"
                         IsChecked="{Binding AutoInstallUpdatePackage}" />
-                    <CheckBox
-                        Margin="10"
-                        HorizontalAlignment="Left"
-                        VerticalAlignment="Center"
-                        Content="{DynamicResource ForceGithubGlobalSource}"
-                        IsChecked="{Binding ForceGithubGlobalSource}"
-                        Visibility="{c:Binding 'UpdateSource == &quot;Github&quot;'}" />
                     <hc:ComboBox
                         Width="150"
                         Margin="10"
@@ -116,6 +109,13 @@
                             </Hyperlink>
                         </controls:TextBlock>
                     </StackPanel>
+                    <CheckBox
+                        Margin="10"
+                        HorizontalAlignment="Left"
+                        VerticalAlignment="Center"
+                        Content="{DynamicResource ForceGithubGlobalSource}"
+                        IsChecked="{Binding ForceGithubGlobalSource}"
+                        Visibility="{c:Binding 'UpdateSource == &quot;Github&quot;'}" />
                 </StackPanel>
             </StackPanel>
             <StackPanel


### PR DESCRIPTION
Unless I'm not understanding how MirrorChyan and Github work, it's either one or the other, so we can hide one at a time to cleanup the guy:
Commit [735bc1f](https://github.com/MaaAssistantArknights/MaaAssistantArknights/pull/12196/commits/735bc1fee34f13a8cca26d7c5c340a9f90ed6d04) hides password box when github is selected.

Commit [7a8ae3d](https://github.com/MaaAssistantArknights/MaaAssistantArknights/pull/12196/commits/7a8ae3d5231f88c72d2f7337ba87c01edd7f7b04) moves down the `Force` to add consistency (looks a bit ugly let me know)

<p float="left">
  <img src="https://github.com/user-attachments/assets/66783d2f-cc13-47d4-b062-3dfa849b7392" width="30%" />
  <img src="https://github.com/user-attachments/assets/b3ad59ab-7541-4984-901f-96c4cafa812e" width="30%" />
</p>
