### PR TITLE
fix: CheckLevelMax ocr target "-" -> digits

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -6888,7 +6888,8 @@
         "Doc": "base_task 等级界面检查是否满级",
         "algorithm": "OcrDetect",
         "roi": [1024, 20, 47, 27],
-        "text": ["-", "一"]
+        "text": ["nope"],
+        "ocrReplace": [["[0-9]", "nope"]]
     },
     "Roguelike@ChooseDifficulty": {
         "Doc": "base_task",

--- a/src/MaaCore/Task/Roguelike/RoguelikeLevelTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeLevelTaskPlugin.cpp
@@ -42,10 +42,10 @@ bool asst::RoguelikeLevelTaskPlugin::_run()
         ret = ProcessTask(*this, { "Roguelike@CheckLevelMax" }).set_retry_times(2).run();
         if (ret) {
             ProcessTask(*this, { "Return" }).run();
-            m_task_ptr->set_enable(false);
         }
         else {
             ProcessTask(*this, { "Return" }).run();
+            m_task_ptr->set_enable(false);
         }
     }
     return true;


### PR DESCRIPTION
将容易误识别的``-``换成数字，识别到数字就是没满
fix #12211
我没有jp客户端，希望原issue发布者测试一下稳定性，在CN上没有问题