### PR TITLE
fix: mac下选择难度 999 导致卡死

### DIFF
--- a/src/MaaCore/Task/Roguelike/RoguelikeDifficultySelectionTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeDifficultySelectionTaskPlugin.cpp
@@ -71,7 +71,7 @@ bool asst::RoguelikeDifficultySelectionTaskPlugin::select_difficulty(const int d
 {
     LogTraceFunction;
 
-    if (difficulty == INT_MAX) {
+    if (difficulty >= MAX_DIFFICULTY) {
         ProcessTask(*this, { m_config->get_theme() + "@Roguelike@ChooseDifficulty_Hardest" }).run();
     }
     else if (difficulty == 0) {

--- a/src/MaaCore/Task/Roguelike/RoguelikeDifficultySelectionTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeDifficultySelectionTaskPlugin.cpp
@@ -81,7 +81,7 @@ bool asst::RoguelikeDifficultySelectionTaskPlugin::select_difficulty(const int d
         // 从最高难度依次点下来
         ProcessTask(*this, { m_config->get_theme() + "@Roguelike@ChooseDifficulty_Hardest" }).run();
         std::vector<std::string> difficulty_list;
-        for (int i = 20; i >= difficulty; --i) { // 难度识别内容为 20 ~ difficulty
+        for (int i = MAX_DIFFICULTY; i >= difficulty; --i) { // 难度识别内容为 MAX_DIFFICULTY ~ difficulty
             difficulty_list.push_back(std::to_string(i));
         }
         Task.get<OcrTaskInfo>(m_config->get_theme() + "@Roguelike@ChooseDifficulty_Specified")->text = difficulty_list;

--- a/src/MaaCore/Task/Roguelike/RoguelikeDifficultySelectionTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/RoguelikeDifficultySelectionTaskPlugin.h
@@ -18,5 +18,6 @@ private:
     bool select_difficulty(const int difficulty = 0);
 
     int m_current_difficulty = -1;
+    static constexpr int MAX_DIFFICULTY = 20;
 };
 }


### PR DESCRIPTION
提问：当 OcrDetect 任务的 text 为空数组时，这个任务能被成功执行吗？
答案：只要检测任何文字就会被成功执行。
所以当 difficulty 为 999 时，maa 设置 Roguelike@ChooseDifficulty_Specified 任务的 text 为空，会出现大大大大大问题。