### PR TITLE
feat: Increase the adaptive size of the depot recognize view

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,9 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          python3 -m venv venv
+          venv\Scripts\activate
+          pip install -r requirements.txt
           python3 maadeps-download.py ${{ matrix.lowercase_target }}-windows
 
       - name: Create fake event file
@@ -239,7 +242,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          python3 maadeps-download.py ${{ matrix.arch == 'x86_64' && 'x64' || 'arm64' }}-linux
+          python -m venv venv
+          source venv/bin/activate
+          pip install -r requirements.txt
+          python maadeps-download.py ${{ matrix.arch == 'x86_64' && 'x64' || 'arm64' }}-linux
 
       - name: Build MAA
         run: |
@@ -352,6 +358,9 @@ jobs:
       # Caching not necessary on macOS runner
       - name: Bootstrap MaaDeps
         run: |
+          python -m venv venv
+          source venv/bin/activate
+          pip install -r requirements.txt
           [[ ${{ matrix.arch }} = "arm64" ]] && triplet="arm64-osx" || triplet="x64-osx"
           python3 maadeps-download.py ${triplet}
         env:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+Requests

--- a/src/MaaWpfGui/Views/UI/RecognizerView.xaml
+++ b/src/MaaWpfGui/Views/UI/RecognizerView.xaml
@@ -314,21 +314,27 @@
                 </StackPanel>
                 <DataGrid
                     Grid.Row="1"
-                    Width="680"
-                    HorizontalAlignment="Center"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Stretch"
                     AutoGenerateColumns="False"
                     HeadersVisibility="None"
                     IsReadOnly="True"
                     ItemsSource="{Binding DepotResult}"
-                    ScrollViewer.CanContentScroll="True"
+                    ScrollViewer.CanContentScroll="False"
                     ScrollViewer.HorizontalScrollBarVisibility="Disabled">
                     <DataGrid.ItemsPanel>
                         <ItemsPanelTemplate>
-                            <WrapPanel HorizontalAlignment="Center" />
+                            <!--<WrapPanel
+                                HorizontalAlignment="Center"
+                                ItemHeight="80"
+                                ItemWidth="300"
+                                Orientation="Horizontal" />-->
+                            <WrapPanel HorizontalAlignment="Center" Orientation="Horizontal" />
                         </ItemsPanelTemplate>
                     </DataGrid.ItemsPanel>
                     <DataGrid.Columns>
-                        <DataGridTemplateColumn>
+                        <DataGridTemplateColumn Width="100">
+
                             <DataGridTemplateColumn.CellTemplate>
                                 <DataTemplate>
                                     <Image
@@ -338,8 +344,16 @@
                                 </DataTemplate>
                             </DataGridTemplateColumn.CellTemplate>
                         </DataGridTemplateColumn>
-                        <DataGridTextColumn Binding="{Binding Name}" Header="Name" />
-                        <DataGridTextColumn Binding="{Binding Count}" Header="Count" />
+                        <DataGridTextColumn
+                            Width="100"
+                            Binding="{Binding Name}"
+                            Header="Name" />
+
+                        <DataGridTextColumn
+                            Width="60"
+                            Binding="{Binding Count}"
+                            Header="Count" />
+
                     </DataGrid.Columns>
                 </DataGrid>
                 <StackPanel


### PR DESCRIPTION
### Increase the adaptive size of the warehouse detection window

- Target

  - Enlarge the display window to see more repository content at once

- Add content

  - DataGrid adaptively resizes the window view and dynamically adjusts the number of item columns



### Screenshot example

- Old：

![20250405-132225](https://github.com/user-attachments/assets/4001c5b7-f1f8-4333-9b59-9e357e4c82ae)

- New：

![20250405-131606](https://github.com/user-attachments/assets/2320e251-b55b-4e68-b8e7-1bc5c5d35312)