### PR TITLE
feat: Increase the adaptive size of the depot recognize view

### DIFF
--- a/resource/tasks.json
+++ b/resource/tasks.json
@@ -2120,7 +2120,7 @@
         "action": "ClickSelf",
         "Doc": "进入资源关卡",
         "templThreshold": 0.77,
-        "roi": [0, 600, 1280, 110]
+        "roi": [600, 600, 250, 110]
     },
     "Stage": {
         "Doc": "base_task",
@@ -7295,7 +7295,7 @@
     },
     "Roguelike@IntegratedStrategies": {
         "action": "ClickSelf",
-        "roi": [0, 600, 1280, 110],
+        "roi": [963, 599, 148, 121],
         "next": ["Roguelike@IntegratedStrategies", "Roguelike@PreSelectTheme"]
     },
     "Roguelike@LastReward": {

--- a/src/MaaWpfGui/Views/UI/RecognizerView.xaml
+++ b/src/MaaWpfGui/Views/UI/RecognizerView.xaml
@@ -314,21 +314,27 @@
                 </StackPanel>
                 <DataGrid
                     Grid.Row="1"
-                    Width="680"
-                    HorizontalAlignment="Center"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Stretch"
                     AutoGenerateColumns="False"
                     HeadersVisibility="None"
                     IsReadOnly="True"
                     ItemsSource="{Binding DepotResult}"
-                    ScrollViewer.CanContentScroll="True"
+                    ScrollViewer.CanContentScroll="False"
                     ScrollViewer.HorizontalScrollBarVisibility="Disabled">
                     <DataGrid.ItemsPanel>
                         <ItemsPanelTemplate>
-                            <WrapPanel HorizontalAlignment="Center" />
+                            <!--<WrapPanel
+                                HorizontalAlignment="Center"
+                                ItemHeight="80"
+                                ItemWidth="300"
+                                Orientation="Horizontal" />-->
+                            <WrapPanel HorizontalAlignment="Center" Orientation="Horizontal" />
                         </ItemsPanelTemplate>
                     </DataGrid.ItemsPanel>
                     <DataGrid.Columns>
-                        <DataGridTemplateColumn>
+                        <DataGridTemplateColumn Width="100">
+
                             <DataGridTemplateColumn.CellTemplate>
                                 <DataTemplate>
                                     <Image
@@ -338,8 +344,16 @@
                                 </DataTemplate>
                             </DataGridTemplateColumn.CellTemplate>
                         </DataGridTemplateColumn>
-                        <DataGridTextColumn Binding="{Binding Name}" Header="Name" />
-                        <DataGridTextColumn Binding="{Binding Count}" Header="Count" />
+                        <DataGridTextColumn
+                            Width="100"
+                            Binding="{Binding Name}"
+                            Header="Name" />
+
+                        <DataGridTextColumn
+                            Width="60"
+                            Binding="{Binding Count}"
+                            Header="Count" />
+
                     </DataGrid.Columns>
                 </DataGrid>
                 <StackPanel


### PR DESCRIPTION
Increase the adaptive size of the warehouse detection window
- Target
  - Enlarge the display window to see more repository content at once
- Add content
  - DataGrid adaptively resizes the window view and dynamically adjusts the number of item columns
Screenshot example
- New
![image](https://github.com/user-attachments/assets/61496bf0-5fc3-4f10-a4b2-63283002a188)

- Old
![image](https://github.com/user-attachments/assets/3b31a725-c206-400a-b690-6a24c09ffc9a)
