### PR TITLE
feat: 官网友链改为按钮

### DIFF
--- a/docs/staticwebapp.config.json
+++ b/docs/staticwebapp.config.json
@@ -5,11 +5,11 @@
         }
     },
     "routes": [
-    {
-      "route": "/*.{jpg,gif,png,ico,svg,css,scss,js,webp,webmanifest}",
-      "headers": {
-        "cache-control": "public, max-age=604800, immutable"
-      }
-    }
-  ]
+        {
+            "route": "/*.{jpg,gif,png,ico,svg,css,scss,js,webp,webmanifest}",
+            "headers": {
+                "cache-control": "public, max-age=604800, immutable"
+            }
+        }
+    ]
 }

--- a/website/apps/web/src/components/foundations/GlowButton/GlowButton.tsx
+++ b/website/apps/web/src/components/foundations/GlowButton/GlowButton.tsx
@@ -14,12 +14,13 @@ type GlowButtonProps = WithChildren<{
   bordered?: boolean
   href?: string
   onClick?: MouseEventHandler<HTMLButtonElement>
+  className?: string
 }>
 
 export const GlowButton: FCC<GlowButtonProps> = forwardRef<
   HTMLButtonElement,
   GlowButtonProps
->(({ children, translucent, bordered, href, onClick }, ref) => {
+>(({ children, translucent, bordered, href, onClick, className }, ref) => {
   const { theme } = useTheme();
 
   const motionConfig: MotionProps = {
@@ -70,6 +71,7 @@ export const GlowButton: FCC<GlowButtonProps> = forwardRef<
         translucent && 'dark:bg-slate-900/90 bg-stone-100/90',
         !bordered && 'border-none',
         'flex px-6 py-3 dark:active:bg-slate-800 active:bg-stone-200 rounded-lg hover:-translate-y-[1px] active:translate-y-[1px] text-2xl dark:text-white/90 text-stone-800 whitespace-nowrap transition-colors transition-transform transition-all duration-200',
+        className
       )}
       onClick={onClick}
       {...motionConfig}

--- a/website/apps/web/src/components/home/HomeActions/HomeActions.tsx
+++ b/website/apps/web/src/components/home/HomeActions/HomeActions.tsx
@@ -20,8 +20,7 @@ interface HomeActionsProps {
 }
 
 export const HomeActions: FC<HomeActionsProps> = ({ toggleLinks, showLinks }) => {
-  // 添加调试日志，帮助我们追踪状态变化
-  console.log('HomeActions rendered, showLinks:', showLinks);
+  // console.log('HomeActions rendered, showLinks:', showLinks);
   
   return (
     <div className="absolute bottom-0 left-0 right-0 mb-24 md:mb-[7vh] flex flex-col mx-8">
@@ -82,11 +81,11 @@ export const HomeActions: FC<HomeActionsProps> = ({ toggleLinks, showLinks }) =>
           </div>
         </GlowButton>
         
-        {/* 添加友情链接按钮 */}
+        {}
         <GlowButton 
           translucent 
           onClick={() => {
-            console.log('Friend link button clicked, current state:', showLinks);
+            // console.log('Friend link button clicked, current state:', showLinks);
             if (toggleLinks) toggleLinks();
           }}
           className={`friend-link-button ${showLinks ? 'active-link-button' : ''}`}

--- a/website/apps/web/src/components/home/HomeActions/HomeActions.tsx
+++ b/website/apps/web/src/components/home/HomeActions/HomeActions.tsx
@@ -8,12 +8,21 @@ import mdiDocument from '@iconify/icons-mdi/document'
 import mdiGitHub from '@iconify/icons-mdi/github'
 import mdiQqchat from '@iconify/icons-mdi/qqchat'
 import mdiLoading from '@iconify/icons-mdi/loading'
+import mdiLink from '@iconify/icons-mdi/link-variant'
 import { Icon } from '@iconify/react'
 
 import { motion } from 'framer-motion'
 import { FC, Suspense } from 'react'
 
-export const HomeActions: FC = () => {
+interface HomeActionsProps {
+  toggleLinks?: () => void;
+  showLinks?: boolean;
+}
+
+export const HomeActions: FC<HomeActionsProps> = ({ toggleLinks, showLinks }) => {
+  // 添加调试日志，帮助我们追踪状态变化
+  console.log('HomeActions rendered, showLinks:', showLinks);
+  
   return (
     <div className="absolute bottom-0 left-0 right-0 mb-24 md:mb-[7vh] flex flex-col mx-8">
       <motion.div
@@ -70,6 +79,21 @@ export const HomeActions: FC = () => {
           <div className="flex items-center -ml-1 text-sm">
             <Icon icon={mdiGitHub} fontSize="20px" />
             <span className="ml-2">GitHub</span>
+          </div>
+        </GlowButton>
+        
+        {/* 添加友情链接按钮 */}
+        <GlowButton 
+          translucent 
+          onClick={() => {
+            console.log('Friend link button clicked, current state:', showLinks);
+            if (toggleLinks) toggleLinks();
+          }}
+          className={`friend-link-button ${showLinks ? 'active-link-button' : ''}`}
+        >
+          <div className="flex items-center -ml-1 text-sm">
+            <Icon icon={mdiLink} fontSize="20px" />
+            <span className="ml-2">友情链接</span>
           </div>
         </GlowButton>
       </div>

--- a/website/apps/web/src/components/home/HomeActions/HomeActions.tsx
+++ b/website/apps/web/src/components/home/HomeActions/HomeActions.tsx
@@ -81,7 +81,6 @@ export const HomeActions: FC<HomeActionsProps> = ({ toggleLinks, showLinks }) =>
           </div>
         </GlowButton>
         
-        {}
         <GlowButton 
           translucent 
           onClick={() => {

--- a/website/apps/web/src/components/home/HomeActions/HomeActions.tsx
+++ b/website/apps/web/src/components/home/HomeActions/HomeActions.tsx
@@ -99,7 +99,8 @@ export const HomeActions: FC<HomeActionsProps> = ({ toggleLinks, showLinks }) =>
       </div>
 
       <div className="mt-6 text-xs leading-5 text-center md:mt-8 dark:text-white/70 text-black/70 transition-colors duration-300">
-        MAA 以 AGPL-3.0 协议开源；使用即表示您同意并知悉「用户协议」的相关内容。
+        <span style={{ display: 'inline-block' }}>MAA 以 AGPL-3.0 协议开源；</span>
+        <span style={{ display: 'inline-block' }}>使用即表示您同意并知悉「用户协议」的相关内容。</span>
       </div>
     </div>
   )

--- a/website/apps/web/src/components/home/HomeActionsRelease/HomeActionsRelease.tsx
+++ b/website/apps/web/src/components/home/HomeActionsRelease/HomeActionsRelease.tsx
@@ -159,10 +159,13 @@ type DownloadDetectionStates =
       state: 'fallback'
     }
 
-const DownloadButton: FC<{
-  platform: ResolvedPlatform
-  releaseName: string | null
-}> = ({ platform, releaseName }) => {
+const DownloadButton = forwardRef<
+  HTMLDivElement,
+  {
+    platform: ResolvedPlatform
+    releaseName: string | null
+  }
+>(({ platform, releaseName }, ref) => {
   const href = platform.asset.browser_download_url
 
   const [loadState, setLoadState] = useState<DownloadDetectionStates>({
@@ -435,7 +438,7 @@ const DownloadButton: FC<{
       />
     )
   }
-}
+})
 
 export const DownloadButtons: FC<{ release: Release }> = ({ release }) => {
   const [viewAll, setViewAll] = useState(false)

--- a/website/apps/web/src/components/home/HomeHero.tsx
+++ b/website/apps/web/src/components/home/HomeHero.tsx
@@ -3,7 +3,7 @@ import { Canvas } from '@react-three/fiber'
 import { ErrorBoundary } from '@sentry/react'
 import { motion } from 'framer-motion'
 
-import { FC, forwardRef, useRef, useState } from 'react'
+import { FC, useRef, useState } from 'react'
 import { useWindowSize } from 'react-use'
 import { useTheme } from '@/contexts/ThemeContext'
 
@@ -18,6 +18,8 @@ export const HomeHero: FC = () => {
   const indicatorRef = useRef<HTMLDivElement | null>(null)
   const windowDimensions = useWindowSize()
   const { theme } = useTheme()
+  // 添加控制友情链接显示的状态
+  const [showLinks, setShowLinks] = useState(false)
 
   return (
     <div key={theme}>
@@ -47,6 +49,7 @@ export const HomeHero: FC = () => {
               <ScreenshotsCanvas
                 sidebarRef={linkRef}
                 indicatorRef={indicatorRef}
+                showLinks={showLinks}
               />
             </ErrorBoundary>
           )}
@@ -55,36 +58,25 @@ export const HomeHero: FC = () => {
       
       <HomeHeroHeader />
 
-      <HomeActions />
-      <HomeLinks ref={linkRef} />
-      <HomeIndicator ref={indicatorRef} />
+      <HomeActions toggleLinks={() => setShowLinks(!showLinks)} showLinks={showLinks} />
+      <HomeLinks 
+        ref={linkRef} 
+        showLinks={showLinks} 
+        onClose={() => setShowLinks(false)} 
+      />
+      {/* 移除指示器组件，不再需要通过鼠标触发友情链接 */}
     </div>
   )
 }
-const HomeIndicator = forwardRef<HTMLDivElement>((_props, ref) => {
-  const { theme } = useTheme()
-  
-  return (
-    <motion.div
-      initial={{ opacity: 0, y: 50, filter: 'blur(10px)' }}
-      animate={{ opacity: 1, y: 0, filter: 'blur(0px)' }}
-      transition={{ duration: 0.8, ease: 'easeOut', delay: 0.6 }}
-      className="fixed right-0 top-[50vh] pointer-events-none select-none hidden md:block"
-      ref={ref}
-    >
-      <div className={`-rotate-90 text-lg font-light transition-all duration-300 ${theme === 'dark' ? 'text-white/30 hover:text-white/50' : 'text-gray-800/30 hover:text-gray-800/60'}`}>
-        友情链接
-      </div>
-    </motion.div>
-  )
-})
 
 function ScreenshotsCanvas({
   sidebarRef,
   indicatorRef,
+  showLinks = false,
 }: {
   sidebarRef: React.MutableRefObject<HTMLDivElement | null>
   indicatorRef: React.MutableRefObject<HTMLDivElement | null>
+  showLinks?: boolean
 }) {
   const [dpr, setDpr] = useState(1.5)
   return (
@@ -96,7 +88,7 @@ function ScreenshotsCanvas({
         onFallback={() => setDpr(1)}
       />
       <ambientLight intensity={1} />
-      <Screenshots sidebarRef={sidebarRef} indicatorRef={indicatorRef} />
+      <Screenshots sidebarRef={sidebarRef} indicatorRef={indicatorRef} showLinks={showLinks} />
     </Canvas>
   )
 }

--- a/website/apps/web/src/components/home/HomeLinks/HomeLinks.tsx
+++ b/website/apps/web/src/components/home/HomeLinks/HomeLinks.tsx
@@ -8,10 +8,15 @@ import mdiGitHub from '@iconify/icons-mdi/github'
 import { Icon } from '@iconify/react'
 
 import clsx from 'clsx'
-import { FC, ReactNode, forwardRef } from 'react'
+import { FC, ReactNode, forwardRef, useEffect } from 'react'
 import { useTheme } from '@/contexts/ThemeContext'
 
 import styles from './HomeLinks.module.css'
+
+interface HomeLinksProps {
+  showLinks?: boolean;
+  onClose?: () => void; // 添加关闭回调函数
+}
 
 const HomeLink: FC<{
   href: string
@@ -96,7 +101,7 @@ const LINKS = [
     }
   />,
   <HomeLink
-    key="QQ"
+    key="status"
     href="https://status.annangela.cn/status/maa"
     title="MAA 状态监测"
     icon={
@@ -109,25 +114,156 @@ const LINKS = [
   />,
 ]
 
-export const HomeLinks = forwardRef<HTMLDivElement>((_props, ref) => {
+export const HomeLinks = forwardRef<HTMLDivElement, HomeLinksProps>(({ showLinks = false, onClose }, ref) => {
   const { theme } = useTheme()
   
+  // 添加调试日志
+  console.log('HomeLinks rendered, showLinks:', showLinks);
+  
+  // 使用 useEffect 直接响应 showLinks 状态变化
+  useEffect(() => {
+    console.log('showLinks changed to:', showLinks);
+    const panel = ref as React.MutableRefObject<HTMLDivElement | null>;
+    if (!panel.current) return;
+    
+    if (showLinks) {
+      panel.current.style.opacity = '1';
+      panel.current.style.pointerEvents = 'auto';
+    } else {
+      panel.current.style.opacity = '0';
+      panel.current.style.pointerEvents = 'none';
+    }
+  }, [showLinks, ref]);
+  
+  // 添加点击外部关闭的事件监听
+  useEffect(() => {
+    // 如果未显示链接或没有关闭回调，不需要监听点击事件
+    if (!showLinks || !onClose) return;
+    
+    const handleOutsideClick = (event: MouseEvent) => {
+      const panel = ref as React.MutableRefObject<HTMLDivElement | null>;
+      if (!panel.current) return;
+      
+      // 查找友情链接按钮
+      const linkButton = document.querySelector('.friend-link-button');
+      
+      // 如果点击的是面板内部或友情链接按钮，不关闭
+      if (panel.current.contains(event.target as Node) || 
+          (linkButton && linkButton.contains(event.target as Node))) {
+        return;
+      }
+      
+      // 点击了面板和按钮以外的区域，关闭面板
+      console.log('点击了面板外部，关闭友情链接');
+      onClose();
+    };
+    
+    // 添加点击事件监听，使用捕获阶段避免与其他点击事件冲突
+    document.addEventListener('click', handleOutsideClick, true);
+    
+    return () => {
+      document.removeEventListener('click', handleOutsideClick, true);
+    };
+  }, [ref, showLinks, onClose]);
+  
+  // 监听友情链接按钮位置变化，相应调整面板位置
+  useEffect(() => {
+    const positionLinksPanel = () => {
+      const panel = ref as React.MutableRefObject<HTMLDivElement | null>;
+      if (!panel.current) return;
+      
+      // 查找友情链接按钮
+      const linkButton = document.querySelector('.friend-link-button');
+      if (!linkButton) {
+        console.log('Friend link button not found!');
+        return;
+      }
+      
+      // 获取按钮位置信息
+      const buttonRect = linkButton.getBoundingClientRect();
+      console.log('Button position:', buttonRect);
+      
+      if (showLinks) {
+        // 计算面板位置 - 在按钮右侧显示
+        const buttonRight = buttonRect.right;
+        const buttonTop = buttonRect.top;
+        
+        // 确保面板不超出窗口范围
+        const windowHeight = window.innerHeight;
+        const windowWidth = window.innerWidth;
+        
+        // 设置初始高度，稍后再根据内容调整
+        panel.current.style.maxHeight = 'none';
+        
+        // 调整面板最终位置 - 修改为显示在按钮右侧
+        panel.current.style.position = 'fixed';
+        panel.current.style.left = `${buttonRight + 10}px`; // 距离按钮右侧10px
+        panel.current.style.top = `${buttonTop}px`;
+        
+        // 计算实际高度
+        const panelHeight = Math.min(panel.current.scrollHeight, windowHeight * 0.6);
+        
+        // 确保面板不超出窗口底部
+        if (buttonTop + panelHeight > windowHeight - 20) {
+          // 如果会超出，调整顶部位置使面板底部不超出窗口
+          const newTop = Math.max(20, windowHeight - panelHeight - 20);
+          panel.current.style.top = `${newTop}px`;
+        }
+        
+        // 确保面板不超出窗口右侧
+        const maxWidth = windowWidth - buttonRight - 30; // 距离窗口右侧至少留20px
+        panel.current.style.maxWidth = `${Math.min(400, maxWidth)}px`; // 限制最大宽度
+        panel.current.style.maxHeight = `${panelHeight}px`;
+        
+        // 确保面板可见
+        panel.current.style.opacity = '1';
+        panel.current.style.pointerEvents = 'auto';
+        panel.current.style.transform = 'translateX(0) rotateY(0)';
+        
+        console.log('Panel positioned and shown');
+      } else {
+        // 隐藏面板
+        panel.current.style.opacity = '0';
+        panel.current.style.pointerEvents = 'none';
+        panel.current.style.transform = 'translateX(-10px) rotateY(10deg)';
+        
+        console.log('Panel hidden');
+      }
+    };
+    
+    // 初始执行一次定位
+    setTimeout(positionLinksPanel, 50); // 添加小延迟确保DOM已更新
+    
+    // 监听窗口大小变化和滚动事件，重新计算位置
+    window.addEventListener('resize', positionLinksPanel);
+    window.addEventListener('scroll', positionLinksPanel);
+    
+    return () => {
+      window.removeEventListener('resize', positionLinksPanel);
+      window.removeEventListener('scroll', positionLinksPanel);
+    };
+  }, [ref, showLinks]);
+  
   return (
-  <div
-    ref={ref}
-    className={clsx(
-      'fixed right-0 top-[20vh] hidden md:flex flex-col pr-1 pl-6 pt-4 pb-6 h-[45vh] w-[15vw] min-w-[15rem] rounded-xl opacity-0 transition-all duration-200',
-      theme === 'dark' ? 'text-[#eee] bg-black/80' : 'text-gray-800 bg-white/90',
-      styles.root,
-    )}
-  >
-    <h1 className="text-2xl font-bold mb-3 px-2">
-      友情链接
-      <span className={`text-sm ml-4 font-bold opacity-80 tracking-wider ${theme === 'dark' ? '' : 'text-gray-700'}`}>
-        LINKS
-      </span>
-    </h1>
-    <div className="flex-1 overflow-y-auto flex flex-col gap-1">{LINKS}</div>
-  </div>
-)
+    <div
+      ref={ref}
+      className={clsx(
+        'fixed w-[15vw] min-w-[15rem] max-w-xs rounded-xl transition-all duration-300 z-50',
+        theme === 'dark' ? 'text-[#eee] bg-black/80' : 'text-gray-800 bg-white/90',
+        styles.root,
+        showLinks ? 'visible' : 'invisible' // 使用 CSS 类来控制可见性，作为 JS 控制的备份
+      )}
+      style={{ opacity: 0 }} // 初始状态为隐藏
+    >
+      <div className="pt-4 pb-6 px-4">
+        <h1 className="text-2xl font-bold mb-3 px-2">
+          友情链接
+          <span className={`text-sm ml-4 font-bold opacity-80 tracking-wider ${theme === 'dark' ? '' : 'text-gray-700'}`}>
+            LINKS
+          </span>
+        </h1>
+        <div className="max-h-[40vh] overflow-y-auto flex flex-col gap-1">{LINKS}</div>
+      </div>
+    </div>
+  )
 })

--- a/website/apps/web/src/components/home/HomeLinks/HomeLinks.tsx
+++ b/website/apps/web/src/components/home/HomeLinks/HomeLinks.tsx
@@ -12,6 +12,7 @@ import { FC, ReactNode, forwardRef, useEffect } from 'react'
 import { useTheme } from '@/contexts/ThemeContext'
 
 import styles from './HomeLinks.module.css'
+import React from 'react'
 
 interface HomeLinksProps {
   showLinks?: boolean;
@@ -116,6 +117,8 @@ const LINKS = [
 
 export const HomeLinks = forwardRef<HTMLDivElement, HomeLinksProps>(({ showLinks = false, onClose }, ref) => {
   const { theme } = useTheme()
+  // 添加一个引用变量来跟踪面板的定位状态
+  const isPanelCenteredRef = React.useRef(false);
   
   // console.log('HomeLinks rendered, showLinks:', showLinks);
   
@@ -143,10 +146,10 @@ export const HomeLinks = forwardRef<HTMLDivElement, HomeLinksProps>(({ showLinks
       const panel = ref as React.MutableRefObject<HTMLDivElement | null>;
       if (!panel.current) return;
       
-      // 查找友情链接按钮
+      // 查找友链按钮
       const linkButton = document.querySelector('.friend-link-button');
       
-      // 如果点击的是面板内部或友情链接按钮，不关闭
+      // 如果点击的是面板内部或友链按钮，不关闭
       if (panel.current.contains(event.target as Node) || 
           (linkButton && linkButton.contains(event.target as Node))) {
         return;
@@ -165,13 +168,13 @@ export const HomeLinks = forwardRef<HTMLDivElement, HomeLinksProps>(({ showLinks
     };
   }, [ref, showLinks, onClose]);
   
-  // 监听友情链接按钮位置变化，相应调整面板位置
+  // 监听友链按钮位置变化，相应调整面板位置
   useEffect(() => {
     const positionLinksPanel = () => {
       const panel = ref as React.MutableRefObject<HTMLDivElement | null>;
       if (!panel.current) return;
       
-      // 查找友情链接按钮
+      // 查找友链按钮
       const linkButton = document.querySelector('.friend-link-button');
       if (!linkButton) {
         console.error('Friend link button not found!');
@@ -216,6 +219,9 @@ export const HomeLinks = forwardRef<HTMLDivElement, HomeLinksProps>(({ showLinks
         // 如果右侧空间不足则居中显示
         const shouldCenterPanel = !isSufficientSpaceOnRight;
         
+        // 更新面板定位状态
+        isPanelCenteredRef.current = shouldCenterPanel;
+        
         if (shouldCenterPanel) {
           // 居中显示
           panel.current.style.position = 'fixed';
@@ -259,11 +265,10 @@ export const HomeLinks = forwardRef<HTMLDivElement, HomeLinksProps>(({ showLinks
         panel.current.style.pointerEvents = 'none';
         
         // 根据面板位置应用不同的隐藏动画
-        const isPanelCentered = panel.current.style.left === '50%';
-        if (isPanelCentered) {
-          panel.current.style.transform = 'translate(-50%, -60%)'; // 居中时向上移动一点，制造淡出效果
+        if (isPanelCenteredRef.current) {
+          panel.current.style.transform = 'translate(-50%, -60%)'; // 居中时向上移动一点，纵向淡出
         } else {
-          panel.current.style.transform = 'translateX(-10px) rotateY(10deg)'; // 在右侧时向左移动，添加旋转效果
+          panel.current.style.transform = 'translateX(-10px) rotateY(10deg)'; // 在右侧时向左移动，横向淡出
         }
       }
     };

--- a/website/apps/web/src/components/home/HomeLinks/HomeLinks.tsx
+++ b/website/apps/web/src/components/home/HomeLinks/HomeLinks.tsx
@@ -117,12 +117,11 @@ const LINKS = [
 export const HomeLinks = forwardRef<HTMLDivElement, HomeLinksProps>(({ showLinks = false, onClose }, ref) => {
   const { theme } = useTheme()
   
-  // 添加调试日志
-  console.log('HomeLinks rendered, showLinks:', showLinks);
+  // console.log('HomeLinks rendered, showLinks:', showLinks);
   
   // 使用 useEffect 直接响应 showLinks 状态变化
   useEffect(() => {
-    console.log('showLinks changed to:', showLinks);
+    // console.log('showLinks changed to:', showLinks);
     const panel = ref as React.MutableRefObject<HTMLDivElement | null>;
     if (!panel.current) return;
     
@@ -154,7 +153,7 @@ export const HomeLinks = forwardRef<HTMLDivElement, HomeLinksProps>(({ showLinks
       }
       
       // 点击了面板和按钮以外的区域，关闭面板
-      console.log('点击了面板外部，关闭友情链接');
+      // console.log('Clicked outside the panel, close the friend link');
       onClose();
     };
     
@@ -175,7 +174,7 @@ export const HomeLinks = forwardRef<HTMLDivElement, HomeLinksProps>(({ showLinks
       // 查找友情链接按钮
       const linkButton = document.querySelector('.friend-link-button');
       if (!linkButton) {
-        console.log('Friend link button not found!');
+        console.error('Friend link button not found!');
         return;
       }
       
@@ -214,7 +213,7 @@ export const HomeLinks = forwardRef<HTMLDivElement, HomeLinksProps>(({ showLinks
         // 判断是否有足够空间在按钮右侧显示
         const isSufficientSpaceOnRight = spaceOnRight >= contentWidth;
         
-        // 如果右侧空间不足或是移动设备，则居中显示
+        // 如果右侧空间不足则居中显示
         const shouldCenterPanel = !isSufficientSpaceOnRight;
         
         if (shouldCenterPanel) {


### PR DESCRIPTION
副驾驶新搞的代理模式好强 新时代摆完挂机超大杯
`GPT-4.1` `o4-mini` `Gemini 2.5 Pro` 用了一圈 还是 `Claude 3.7 Sonnet` 成功做出来了
随便糊的提示词：

```
请修改官网website中友情链接的位置。首先移除当前的友情链接触发方式和列表，之后在按钮的第二排”状态监测“右边新建一个友情链接按钮，并在点击后在屏幕右下角展示友情链接列表，按钮的样式需和其他按钮相同，列表的样式需和修改前相同。请将修改前的友情链接列表的出现和消失动画样式保留，不需要跟随鼠标，改为固定时长的动画即可。请注意屏幕中央的截图渲染。
```

感觉弹出的位置还可以再往下改改 改到角落那里 但先睡个觉先

---

浅色模式有问题 寄

---

新提示词

```
请修改官网website中友情链接的位置。首先移除当前的友情链接触发方式和列表，之后在按钮的第二排最右边”Github“右边新建一个友情链接按钮，并在点击后固定在友情链接按钮右边紧贴着展示友情链接列表，列表需尽可能与友情链接的按钮对齐，若无法对齐则让其低端固定在窗口底部以上，不要超出窗口范围，并根据内容列表长度调整窗口高度。按钮的样式需和其他按钮相同，列表的样式需和修改前相同。请将修改前的友情链接列表的出现和消失动画样式保留，不需要跟随鼠标，改为固定时长的动画即可。请注意屏幕中央的截图渲染，并注意同时修改暗色模式和亮色模式。

友情链接列表窗口出现的位置存在问题，应该在”友情链接“按钮的右边；截图的交互方式也存在问题，应不再和友情链接交互，请检查要求并继续修改

点击友情链接按钮后没有反应，请继续检查并修复

友情链接按钮问题仍未解决，请继续修复
同时，HomeActions.tsx的第86行存在(太长了复制不下)的问题，请一并修复

请为友情链接的列表添加另外的关闭方式，即点击除列表窗口以外的区域即关闭
```

以及我忘删 llm 的注释了

以及列表判断宽度有点问题 好像把截图的宽度当做窗口的宽度了 会提前换行

---

堂堂完结！
Copilot得了MVP，我是躺赢狗