### PR TITLE
fix: 更新cli的AUR包说明

### DIFF
--- a/docs/en-us/manual/cli/install.md
+++ b/docs/en-us/manual/cli/install.md
@@ -29,10 +29,16 @@ Homebrew users can install maa-cli via the unofficial [tap](https://github.com/M
 
 ### Linux
 
-- Arch Linux users can install the [AUR package](https://aur.archlinux.org/packages/maa-cli/):
+- Arch Linux users can install the [AUR package](https://aur.archlinux.org/packages/maa-assistant-arknights):
 
   ```bash
-  yay -S maa-cli
+  yay -S maa-assistant-arknights
+  ```
+  
+  Or use the precompiled version [AUR package](https://aur.archlinux.org/packages/maa-assistant-arknights-bin):
+
+  ```bash
+  yay -S maa-assistant-arknights-bin
   ```
 
 - ❄️ Nix users can run directly:

--- a/docs/ja-jp/manual/cli/install.md
+++ b/docs/ja-jp/manual/cli/install.md
@@ -33,10 +33,16 @@ Homebrew 用户可以通过非官方的 [tap](https://github.com/MaaAssistantArk
 
 ### Linux
 
-- Arch Linux 用户可以安装 [AUR 包](https://aur.archlinux.org/packages/maa-cli/)：
+- Arch Linux 用户可以安装 [AUR 包](https://aur.archlinux.org/packages/maa-assistant-arknights)：
 
   ```bash
-  yay -S maa-cli
+  yay -S maa-assistant-arknights
+  ```
+
+  或者使用预编译版本 [AUR 包](https://aur.archlinux.org/packages/maa-assistant-arknights-bin)：
+
+  ```bash
+  yay -S maa-assistant-arknights-bin
   ```
 
 - ❄️ Nix 用户可以直接运行:

--- a/docs/ko-kr/manual/cli/install.md
+++ b/docs/ko-kr/manual/cli/install.md
@@ -29,10 +29,16 @@ Homebrew 사용자는 비공식 [tap](https://github.com/MaaAssistantArknights/h
 
 ### Linux
 
-- Arch Linux 사용자는 [AUR 패캐지](https://aur.archlinux.org/packages/maa-cli/)를 설치할 수 있습니다:
+- Arch Linux 사용자는 [AUR 패캐지](https://aur.archlinux.org/packages/maa-assistant-arknights)를 설치할 수 있습니다:
 
   ```bash
-  yay -S maa-cli
+  yay -S maa-assistant-arknights
+  ```
+
+  또는 사전 컴파일된 버전 [AUR 패캐지](https://aur.archlinux.org/packages/maa-assistant-arknights-bin)를 사용할 수 있습니다:
+
+  ```bash
+  yay -S maa-assistant-arknights-bin
   ```
 
 - ❄️ Nix 사용자는 다음 명령어를 실행할 수 있습니다:

--- a/docs/zh-cn/manual/cli/install.md
+++ b/docs/zh-cn/manual/cli/install.md
@@ -29,10 +29,16 @@ Homebrew 用户可以通过非官方的 [tap](https://github.com/MaaAssistantArk
 
 ### Linux
 
-- Arch Linux 用户可以安装 [AUR 包](https://aur.archlinux.org/packages/maa-cli/)：
+- Arch Linux 用户可以安装 [AUR 包](https://aur.archlinux.org/packages/maa-assistant-arknights)：
 
   ```bash
-  yay -S maa-cli
+  yay -S maa-assistant-arknights
+  ```
+
+  或者使用预编译版本 [AUR 包](https://aur.archlinux.org/packages/maa-assistant-arknights-bin)：
+
+  ```bash
+  yay -S maa-assistant-arknights-bin
   ```
 
 - ❄️ Nix 用户可以直接运行:

--- a/docs/zh-tw/manual/cli/install.md
+++ b/docs/zh-tw/manual/cli/install.md
@@ -33,10 +33,16 @@ Homebrew 用户可以通过非官方的 [tap](https://github.com/MaaAssistantArk
 
 ### Linux
 
-- Arch Linux 用户可以安装 [AUR 包](https://aur.archlinux.org/packages/maa-cli/)：
+- Arch Linux 用户可以安装 [AUR 包](https://aur.archlinux.org/packages/maa-assistant-arknights)：
 
   ```bash
-  yay -S maa-cli
+  yay -S maa-assistant-arknights
+  ```
+
+  或者使用预编译版本 [AUR 包](https://aur.archlinux.org/packages/maa-assistant-arknights-bin)：
+
+  ```bash
+  yay -S maa-assistant-arknights-bin
   ```
 
 - ❄️ Nix 用户可以直接运行:


### PR DESCRIPTION
AUR中的maa-cli长期停留在0.5.4-1未更新, 目前AUR中较新的AUR包为maa-assistant-arknights和maa-assistant-arknights-bin