### PR TITLE
fix: EN RoutingRefreshNodeConfirm roi too small

### DIFF
--- a/resource/global/YoStarEN/resource/tasks/Roguelike/Sarkaz.json
+++ b/resource/global/YoStarEN/resource/tasks/Roguelike/Sarkaz.json
@@ -27,6 +27,7 @@
         "roi": [513, 564, 248, 63]
     },
     "Sarkaz@Roguelike@RoutingRefreshNodeConfirm": {
+        "roi": [993, 472, 90, 34],
         "text": ["Confirm"]
     },
     "Sarkaz@Roguelike@SelectTheme": {


### PR DESCRIPTION
issue reported from discord, current roi would cause a cutoff at ```Confi```, and only for EN since all other languages have their confirm in two wide characters