### PR TITLE
fix: CheckLevelMax too fast without delay

### DIFF
--- a/resource/tasks/Roguelike/base.json
+++ b/resource/tasks/Roguelike/base.json
@@ -406,6 +406,7 @@
     "Roguelike@CheckLevelMax": {
         "Doc": "base_task 等级界面检查是否满级",
         "algorithm": "OcrDetect",
+        "postDelay": 500,
         "roi": [1024, 20, 47, 27],
         "text": ["nope"],
         "ocrReplace": [["[0-9]", "nope"]]


### PR DESCRIPTION
For whatever reason current dev complains about ```Duplicate key in json file: MaaAssistantArknights\x64\Debug\resource\tasks\Stages\SS.json SS-Open``` on my environment, so I'm unable to test this myself. Shouldn't really be a problem as a one-liner tho.