### PR TITLE
fix: 修复开发者帮助文档内的 Typo

### DIFF
--- a/docs/zh-cn/develop/development.md
+++ b/docs/zh-cn/develop/development.md
@@ -65,7 +65,7 @@ icon: iconoir:developer
     git push origin dev
     ```
 
-11. 打开 [MAA 主仓库](https://github.com/MaaAssistantArknights/MaaAssistantArknights)。提交一个 Rull Request，等待管理员通过。别忘了你是在 dev 分支上修改，别提交到 master 分支去了
+11. 打开 [MAA 主仓库](https://github.com/MaaAssistantArknights/MaaAssistantArknights)。提交一个 Pull Request，等待管理员通过。别忘了你是在 dev 分支上修改，别提交到 master 分支去了
 12. 当 MAA 原仓库出现更改（别人做的），你可能需要把这些更改同步到你的分支
 
     1. 关联 MAA 原仓库

--- a/docs/zh-tw/develop/development.md
+++ b/docs/zh-tw/develop/development.md
@@ -61,7 +61,7 @@ icon: iconoir:developer
     git push origin dev
     ```
 
-11. 打開 [MAA 主倉庫](https://github.com/MaaAssistantArknights/MaaAssistantArknights)。提交一個 Rull Request，等待管理員通過。別忘了你是在 dev 分支上修改，別提交到 master 分支去了
+11. 打開 [MAA 主倉庫](https://github.com/MaaAssistantArknights/MaaAssistantArknights)。提交一個 Pull Request，等待管理員通過。別忘了你是在 dev 分支上修改，別提交到 master 分支去了
 12. 當 MAA 原倉庫出現更改（別人做的），你可能需要把這些更改同步到你的分支
 
     1. 關聯 MAA 原倉庫


### PR DESCRIPTION
Typo 位置在[文档此小节](https://maa.plus/docs/zh-cn/develop/development.html#%E6%88%91%E4%BC%9A%E7%BC%96%E7%A8%8B-%E4%BD%86%E6%B2%A1%E6%8E%A5%E8%A7%A6%E8%BF%87-github-c-%E8%A6%81%E6%80%8E%E4%B9%88%E6%93%8D%E4%BD%9C)的第 11 条。

简体中文：![image](https://github.com/user-attachments/assets/bd4ca1c7-96f9-4127-bea5-8608612d79cf)
繁体中文：![image](https://github.com/user-attachments/assets/26bc029c-a0e5-42ab-bb36-4d1a09cf1112)

很明显 `Rull Request` 应为 -> `Pull Request`。经检查，只有简中和繁中语言出现问题，其他语言包括英语都是正确的 `Pull Request`。

> 小声说：心血来潮看 MAA 文档的时候看到的，这是本人第一次给 MAA 提 PR，逃~
