### PR TITLE
perf: 基建使用切换职业栏返回列表最左侧

### DIFF
--- a/src/MaaCore/Task/Infrast/InfrastAbstractTask.cpp
+++ b/src/MaaCore/Task/Infrast/InfrastAbstractTask.cpp
@@ -113,7 +113,7 @@ bool asst::InfrastAbstractTask::match_operator_groups()
                         Log.error("already retried");
                         break;
                     }
-                    swipe_to_the_left_of_operlist(swipe_times + 1);
+                    swipe_to_the_left_of_operlist();
                     swipe_times = 0;
                     retried = true;
                 }
@@ -130,7 +130,7 @@ bool asst::InfrastAbstractTask::match_operator_groups()
             swipe_times++;
         }
     }
-    swipe_to_the_left_of_operlist(swipe_times + 1);
+    swipe_to_the_left_of_operlist();
     swipe_times = 0;
     Log.info(__FUNCTION__, "available operators for group size:", opers.size());
     // 筛选第一个满足要求的干员组
@@ -292,7 +292,7 @@ bool asst::InfrastAbstractTask::swipe_and_select_custom_opers(bool is_dorm_order
                     Log.error("already retring");
                     break;
                 }
-                swipe_to_the_left_of_operlist(swipe_times + 1);
+                swipe_to_the_left_of_operlist();
                 swipe_times = 0;
                 retried = true;
             }
@@ -320,7 +320,7 @@ bool asst::InfrastAbstractTask::swipe_and_select_custom_opers(bool is_dorm_order
     }
 
     if (swipe_times) {
-        swipe_to_the_left_of_operlist(swipe_times + 1);
+        swipe_to_the_left_of_operlist();
         swipe_times = 0;
     }
     // 如果只选了一个人没必要排序
@@ -690,8 +690,9 @@ void asst::InfrastAbstractTask::swipe_of_operlist()
     ProcessTask(*this, { "InfrastOperListSlowlySwipeToTheRight" }).run();
 }
 
-void asst::InfrastAbstractTask::swipe_to_the_left_of_operlist(int loop_times)
+void asst::InfrastAbstractTask::swipe_to_the_left_of_operlist()
 {
+    /*
     if (loop_times < 0) {
         loop_times = operlist_swipe_times();
     }
@@ -699,6 +700,15 @@ void asst::InfrastAbstractTask::swipe_to_the_left_of_operlist(int loop_times)
         ProcessTask(*this, { "InfrastOperListSwipeToTheLeft" }).run();
     }
     ProcessTask(*this, { "SleepAfterOperListQuickSwipe" }).run();
+    */
+
+    // 通过切换职业栏来实现回正
+    ProcessTask(*this, { "BattleQuickFormationExpandRole", "BattleQuickFormationRole-All-OCR" }).run();
+    ProcessTask(*this, { "BattleQuickFormationRole-Caster" }).run();
+    ProcessTask(*this, { "BattleQuickFormationRole-All" }).run();
+    // 基建默认收起
+    ProcessTask(*this, { "InfrastCloseQuickFormationExpandRole" }).run();
+    sleep(500);
 }
 
 void asst::InfrastAbstractTask::swipe_to_the_left_of_main_ui()

--- a/src/MaaCore/Task/Infrast/InfrastAbstractTask.h
+++ b/src/MaaCore/Task/Infrast/InfrastAbstractTask.h
@@ -38,7 +38,7 @@ protected:
     virtual int operlist_swipe_times() const noexcept { return 2; }
 
     // 滑动到干员列表的最左侧
-    void swipe_to_the_left_of_operlist(int loop_times = -1);
+    void swipe_to_the_left_of_operlist();
     // 滑动基建的主界面到最左侧
     void swipe_to_the_left_of_main_ui();
     // 滑动基建的主界面到最右侧

--- a/src/MaaCore/Task/Infrast/InfrastProductionTask.cpp
+++ b/src/MaaCore/Task/Infrast/InfrastProductionTask.cpp
@@ -708,7 +708,7 @@ bool asst::InfrastProductionTask::opers_choose()
     }
 
     if (swipe_times) {
-        swipe_to_the_left_of_operlist(swipe_times + 1);
+        swipe_to_the_left_of_operlist();
     }
     // 点两次排序，让已选干员排到最前面
     ProcessTask(*this, { "InfrastOperListTabSkillUnClicked" }).run();


### PR DESCRIPTION
肉鸽用不了，没有对应职业的话是灰的，除非全部匹配一遍，反正不长，还是慢慢划吧

fix #11782