### PR TITLE
feat: 更新 243 极限效率一天四换排班表（20250507 修订）

### DIFF
--- a/resource/custom_infrast/old/153_layout_3_times_a_day_20231103.json
+++ b/resource/custom_infrast/old/153_layout_3_times_a_day_20231103.json
@@ -1,0 +1,345 @@
+{
+    "plans": [
+        {
+            "rooms": {
+                "trading": [
+                    {
+                        "product": "LMD",
+                        "operators": ["伺夜", "黑键", "但书"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "product": "Pure Gold",
+                        "operators": ["苍苔", "砾", "斑点"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "product": "Battle Record",
+                        "operators": ["至简", "槐琥", "断罪者"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "product": "Battle Record",
+                        "operators": ["野鬃", "远牙", "灰毫"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "product": "Battle Record",
+                        "operators": ["淬羽赫默", "多萝西", "迷迭香"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "product": "Battle Record",
+                        "operators": ["温蒂", "异客", "掠风"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "hire": [
+                    {
+                        "operators": ["絮雨"],
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "operators": ["爱丽丝", "车尔尼", "塑心", "菲亚梅塔"],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "control": [
+                    {
+                        "operators": ["森蚺", "焰尾", "薇薇安娜", "琴柳", "夕"]
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": true
+                    }
+                ],
+                "power": [
+                    {
+                        "operators": ["承曦格雷伊"],
+                        "autofill": false
+                    },
+                    {
+                        "operators": ["Lancet-2"],
+                        "autofill": false
+                    },
+                    {
+                        "operators": ["格雷伊"],
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "operators": ["陈", "伊内丝"],
+                        "autofill": false
+                    }
+                ]
+            },
+            "Fiammetta": {
+                "enable": true,
+                "target": "但书",
+                "order": "pre"
+            },
+            "drones": {
+                "enable": true,
+                "index": 1,
+                "room": "manufacture",
+                "order": "pre"
+            },
+            "name": "A+B 16H",
+            "description": "最高效率长班，下次换班请在约16小时后进行"
+        },
+        {
+            "rooms": {
+                "trading": [
+                    {
+                        "product": "LMD",
+                        "operators": ["推进之王", "摩根", "但书"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "product": "Pure Gold",
+                        "operators": ["苍苔", "砾", "斑点"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "product": "Battle Record",
+                        "operators": ["至简", "槐琥", "断罪者"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "product": "Battle Record",
+                        "operators": ["野鬃", "远牙", "灰毫"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "product": "Battle Record",
+                        "operators": ["水月", "香草", "杰西卡"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "product": "Battle Record",
+                        "operators": ["红云", "稀音", "帕拉斯"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "hire": [
+                    {
+                        "operators": ["斥罪"],
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "operators": ["爱丽丝", "车尔尼", "塑心"],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "control": [
+                    {
+                        "operators": ["戴菲恩", "凯尔希", "焰尾", "薇薇安娜", "涤火杰西卡"]
+                    }
+                ],
+                "processing": [
+                    {
+                        "operators": ["Lancet-2"]
+                    }
+                ],
+                "power": [
+                    {
+                        "operators": ["格雷伊"],
+                        "autofill": false
+                    },
+                    {
+                        "operators": ["雷蛇"],
+                        "autofill": false
+                    },
+                    {
+                        "operators": ["澄闪"],
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "operators": ["见行者", "陈"],
+                        "autofill": false
+                    }
+                ]
+            },
+            "drones": {
+                "enable": true,
+                "index": 1,
+                "room": "manufacture",
+                "order": "pre"
+            },
+            "name": "A+C 4H",
+            "description": "下次换班请在约4小时后进行"
+        },
+        {
+            "rooms": {
+                "trading": [
+                    {
+                        "product": "LMD",
+                        "operators": ["伺夜", "黑键", "但书"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "product": "Pure Gold",
+                        "operators": ["泡泡", "火神", "杏仁"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "product": "Battle Record",
+                        "operators": ["淬羽赫默", "多萝西", "迷迭香"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "product": "Battle Record",
+                        "operators": ["温蒂", "异客", "掠风"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "product": "Battle Record",
+                        "operators": ["水月", "香草", "杰西卡"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "product": "Battle Record",
+                        "operators": ["红云", "稀音", "帕拉斯"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "hire": [
+                    {
+                        "operators": ["絮雨"],
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "control": [
+                    {
+                        "operators": ["森蚺", "涤火杰西卡", "凯尔希", "琴柳", "令"]
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": true
+                    }
+                ],
+                "power": [
+                    {
+                        "operators": ["承曦格雷伊"],
+                        "autofill": false
+                    },
+                    {
+                        "operators": ["Lancet-2"],
+                        "autofill": false
+                    },
+                    {
+                        "operators": ["澄闪"],
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "operators": ["见行者", "伊内丝"],
+                        "autofill": false
+                    }
+                ]
+            },
+            "drones": {
+                "enable": true,
+                "index": 1,
+                "room": "manufacture",
+                "order": "pre"
+            },
+            "name": "B+C 4H",
+            "description": "下次换班请在约4小时后进行"
+        }
+    ],
+    "author": "uye、lhh",
+    "description": "23/11/03修订\n干员配置要求极高，请留意\n若缺少干员请自行拷贝文件并修改（请勿直接修改，以免更新后被覆盖）\n请保证L2为红脸\n第一个制造站为赤金，其余为记录\n\n作业作者：uye、lhh\n\n感谢公孙长乐大佬提供数据及方案支持！",
+    "id": 1699014867506993,
+    "title": "153 极限效率，一天三换",
+    "buildingType": "153",
+    "planTimes": "3班"
+}

--- a/resource/custom_infrast/old/153_layout_4_times_a_day_20241106.json
+++ b/resource/custom_infrast/old/153_layout_4_times_a_day_20241106.json
@@ -1,22 +1,23 @@
 {
-    "author": "公孙长乐, bodayw",
-    "description": "干员配置要求极高，若缺少干员请自行调整\n默认每八小时使用无人机加速制造作战记录，请按实际需求修改\n首次使用前将令的心情消耗至 12\n请在一图流排班表生成器上导入本文件，修改后下载导出（请勿直接修改本文件，以免 MAA 更新时被覆盖）\n\n[20250507 修订] 视频地址: https://www.bilibili.com/video/BV1vbVsz2EWj/?t=156",
-    "id": 1746615586785171,
-    "title": "243 极限效率，一天四换",
+    "author": "uye",
+    "description": "干员配置要求极高，请留意\\n若缺少干员请自行拷贝文件并修改（请勿直接修改，以免更新后被覆盖）\\n第一个制造站为赤金，其余为记录\\n\\n作业作者：uye\\n\\n感谢公孙长乐大佬提供数据及方案支持！",
+    "id": 1731223360113755,
+    "title": "153 极限效率，一天四换",
     "buildingType": 243,
     "planTimes": "3班",
     "plans": [
         {
-            "name": "A+B 高效长班 1",
-            "description_post": "请在八小时后换班",
+            "name": "1",
+            "description": "7h",
+            "description_post": "7小时后换班",
             "Fiammetta": {
                 "enable": true,
-                "target": "巫恋",
+                "target": "但书",
                 "order": "pre"
             },
             "drones": {
-                "room": "manufacture",
-                "index": 3,
+                "room": "trading",
+                "index": 1,
                 "enable": true,
                 "order": "pre"
             },
@@ -25,26 +26,12 @@
                     {
                         "skip": false,
                         "product": "LMD",
-                        "operators": ["巫恋", "卡夫卡", "龙舌兰"],
-                        "sort": true,
-                        "autofill": false
-                    },
-                    {
-                        "skip": false,
-                        "product": "LMD",
                         "operators": ["空弦", "黑键", "但书"],
-                        "sort": false,
+                        "sort": true,
                         "autofill": false
                     }
                 ],
                 "manufacture": [
-                    {
-                        "skip": false,
-                        "product": "Pure Gold",
-                        "operators": ["清流", "温蒂", "森蚺"],
-                        "sort": false,
-                        "autofill": false
-                    },
                     {
                         "skip": false,
                         "product": "Pure Gold",
@@ -55,15 +42,29 @@
                     {
                         "skip": false,
                         "product": "Battle Record",
-                        "operators": ["野鬃", "远牙", "灰毫"],
-                        "sort": false,
+                        "operators": ["温蒂", "异客", "掠风"],
+                        "sort": true,
                         "autofill": false
                     },
                     {
                         "skip": false,
                         "product": "Battle Record",
-                        "operators": ["迷迭香", "至简", "断罪者"],
-                        "sort": false,
+                        "operators": ["野鬃", "远牙", "灰毫"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["迷迭香", "乌尔比安", "安哲拉"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["幽灵鲨", "斯卡蒂", "至简"],
+                        "sort": true,
                         "autofill": false
                     }
                 ],
@@ -76,7 +77,7 @@
                     },
                     {
                         "skip": false,
-                        "operators": ["缪尔赛思"],
+                        "operators": ["Lancet-2"],
                         "sort": false,
                         "autofill": false
                     },
@@ -90,25 +91,25 @@
                 "dormitory": [
                     {
                         "skip": false,
-                        "operators": ["菲亚梅塔", "雷蛇", "戴菲恩", "推进之王", "摩根"],
+                        "operators": ["菲亚梅塔", "爱丽丝", "车尔尼", "塑心", "年"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["杏仁", "红云", "稀音", "帕拉斯", "多萝西"],
                         "sort": false,
                         "autofill": false
                     },
                     {
                         "skip": false,
-                        "operators": ["歌蕾蒂娅", "乌尔比安", "安哲拉", "幽灵鲨", "斯卡蒂"],
+                        "operators": ["淬羽赫默", "断罪者", "食铁兽", "水月", "香草"],
                         "sort": false,
                         "autofill": false
                     },
                     {
                         "skip": false,
-                        "operators": ["爱丽丝", "车尔尼", "塑心", "伊内丝", "苍苔"],
-                        "sort": false,
-                        "autofill": false
-                    },
-                    {
-                        "skip": false,
-                        "operators": ["赫默", "伊芙利特", "塞雷娅", "白面鸮", "梅尔"],
+                        "operators": ["杰西卡", "格雷伊", "忍冬", "铃兰", "九色鹿"],
                         "sort": false,
                         "autofill": false
                     }
@@ -116,16 +117,16 @@
                 "control": [
                     {
                         "skip": false,
-                        "operators": ["阿米娅", "琴柳", "令", "薇薇安娜", "焰尾"],
-                        "sort": false,
+                        "operators": ["薇薇安娜", "焰尾", "森蚺", "琴柳", "歌蕾蒂娅"],
+                        "sort": true,
                         "autofill": false
                     }
                 ],
                 "meeting": [
                     {
                         "skip": false,
-                        "operators": ["信仰搅拌机", "见行者"],
-                        "sort": false,
+                        "operators": ["伊内丝", "陈"],
+                        "sort": true,
                         "autofill": false
                     }
                 ],
@@ -148,16 +149,17 @@
             }
         },
         {
-            "name": "A+B 高效长班 2",
-            "description_post": "请在八小时后换班",
+            "name": "2",
+            "description": "5h",
+            "description_post": "5小时后换班",
             "Fiammetta": {
-                "enable": true,
-                "target": "龙舌兰",
+                "enable": false,
+                "target": "",
                 "order": "pre"
             },
             "drones": {
-                "room": "manufacture",
-                "index": 3,
+                "room": "trading",
+                "index": 1,
                 "enable": true,
                 "order": "pre"
             },
@@ -166,58 +168,58 @@
                     {
                         "skip": false,
                         "product": "LMD",
-                        "operators": ["巫恋", "卡夫卡", "龙舌兰"],
+                        "operators": ["巫恋", "龙舌兰", "但书"],
                         "sort": true,
-                        "autofill": false
-                    },
-                    {
-                        "skip": true,
-                        "product": "LMD",
-                        "operators": ["空弦", "黑键", "但书"],
-                        "sort": false,
                         "autofill": false
                     }
                 ],
                 "manufacture": [
                     {
-                        "skip": true,
+                        "skip": false,
                         "product": "Pure Gold",
-                        "operators": ["清流", "温蒂", "森蚺"],
-                        "sort": false,
-                        "autofill": false
-                    },
-                    {
-                        "skip": true,
-                        "product": "Pure Gold",
-                        "operators": ["槐琥", "阿罗玛", "砾"],
+                        "operators": ["苍苔", "砾", "杏仁"],
                         "sort": true,
                         "autofill": false
                     },
                     {
-                        "skip": true,
+                        "skip": false,
                         "product": "Battle Record",
-                        "operators": ["野鬃", "远牙", "灰毫"],
-                        "sort": false,
+                        "operators": ["温蒂", "异客", "掠风"],
+                        "sort": true,
                         "autofill": false
                     },
                     {
-                        "skip": true,
+                        "skip": false,
                         "product": "Battle Record",
-                        "operators": ["迷迭香", "至简", "断罪者"],
-                        "sort": false,
+                        "operators": ["野鬃", "远牙", "灰毫"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["多萝西", "淬羽赫默", "断罪者"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["水月", "香草", "杰西卡"],
+                        "sort": true,
                         "autofill": false
                     }
                 ],
                 "power": [
                     {
-                        "skip": true,
+                        "skip": false,
                         "operators": ["承曦格雷伊"],
                         "sort": false,
                         "autofill": false
                     },
                     {
-                        "skip": true,
-                        "operators": ["缪尔赛思"],
+                        "skip": false,
+                        "operators": ["Lancet-2"],
                         "sort": false,
                         "autofill": false
                     },
@@ -231,166 +233,25 @@
                 "dormitory": [
                     {
                         "skip": false,
-                        "operators": ["菲亚梅塔", "澄闪", "格雷伊", "柏喙", "斥罪"],
-                        "sort": false,
-                        "autofill": false
-                    },
-                    {
-                        "skip": false,
-                        "operators": ["诗怀雅", "Mon3tr", "夕", "引星棘刺", "见行者"],
-                        "sort": false,
-                        "autofill": false
-                    },
-                    {
-                        "skip": false,
-                        "operators": ["爱丽丝", "车尔尼", "塑心"],
-                        "sort": false,
-                        "autofill": true
-                    },
-                    {
-                        "skip": true,
-                        "operators": ["赫默", "伊芙利特", "塞雷娅", "白面鸮", "梅尔"],
-                        "sort": false,
-                        "autofill": false
-                    }
-                ],
-                "control": [
-                    {
-                        "skip": true,
-                        "operators": ["阿米娅", "琴柳", "令", "薇薇安娜", "焰尾"],
-                        "sort": false,
-                        "autofill": false
-                    }
-                ],
-                "meeting": [
-                    {
-                        "skip": false,
-                        "operators": ["信仰搅拌机", "伊内丝"],
-                        "sort": true,
-                        "autofill": false
-                    }
-                ],
-                "hire": [
-                    {
-                        "skip": true,
-                        "operators": ["絮雨"],
-                        "sort": false,
-                        "autofill": false
-                    }
-                ],
-                "processing": [
-                    {
-                        "skip": true,
-                        "operators": [],
-                        "sort": false,
-                        "autofill": false
-                    }
-                ]
-            }
-        },
-        {
-            "name": "B+C 替补短班 1",
-            "description_post": "请在四小时后换班（三小时后把回满 12 心情的令移出宿舍）",
-            "Fiammetta": {
-                "enable": true,
-                "target": "但书",
-                "order": "pre"
-            },
-            "drones": {
-                "room": "manufacture",
-                "index": 3,
-                "enable": true,
-                "order": "pre"
-            },
-            "rooms": {
-                "trading": [
-                    {
-                        "skip": false,
-                        "product": "LMD",
-                        "operators": ["巫恋", "柏喙", "龙舌兰"],
+                        "operators": ["菲亚梅塔", "夕", "琴柳", "令", "年"],
                         "sort": true,
                         "autofill": false
                     },
                     {
                         "skip": false,
-                        "product": "LMD",
-                        "operators": ["推进之王", "摩根", "但书"],
-                        "sort": false,
-                        "autofill": false
-                    }
-                ],
-                "manufacture": [
-                    {
-                        "skip": false,
-                        "product": "Pure Gold",
-                        "operators": ["苍苔", "砾", "引星棘刺"],
+                        "operators": ["阿罗玛", "迷迭香", "歌蕾蒂娅", "闪灵", "流明"],
                         "sort": false,
                         "autofill": false
                     },
                     {
                         "skip": false,
-                        "product": "Pure Gold",
-                        "operators": ["槐琥", "阿罗玛", "乌尔比安"],
-                        "sort": true,
-                        "autofill": false
-                    },
-                    {
-                        "skip": false,
-                        "product": "Battle Record",
-                        "operators": ["野鬃", "远牙", "安哲拉"],
+                        "operators": ["至简", "澄闪", "絮雨", "黑键", "槐琥"],
                         "sort": false,
                         "autofill": false
                     },
                     {
                         "skip": false,
-                        "product": "Battle Record",
-                        "operators": ["幽灵鲨", "斯卡蒂", "灰毫"],
-                        "sort": false,
-                        "autofill": false
-                    }
-                ],
-                "power": [
-                    {
-                        "skip": false,
-                        "operators": ["格雷伊"],
-                        "sort": false,
-                        "autofill": false
-                    },
-                    {
-                        "skip": true,
-                        "operators": ["缪尔赛思"],
-                        "sort": false,
-                        "autofill": false
-                    },
-                    {
-                        "skip": true,
-                        "operators": ["雷蛇"],
-                        "sort": false,
-                        "autofill": false
-                    }
-                ],
-                "dormitory": [
-                    {
-                        "skip": false,
-                        "operators": ["菲亚梅塔", "令", "卡夫卡", "空弦", "黑键"],
-                        "sort": false,
-                        "autofill": false
-                    },
-                    {
-                        "skip": false,
-                        "operators": ["清流", "温蒂", "森蚺", "迷迭香", "至简"],
-                        "sort": false,
-                        "autofill": false
-                    },
-                    {
-                        "skip": false,
-                        "operators": ["断罪者", "承曦格雷伊", "信仰搅拌机", "絮雨", "琴柳"],
-                        "sort": false,
-                        "autofill": false
-                    },
-                    {
-                        "skip": true,
-                        "operators": ["赫默", "伊芙利特", "塞雷娅", "白面鸮", "梅尔"],
+                        "operators": ["伊内丝", "陈", "空弦", "杜林", "九色鹿"],
                         "sort": false,
                         "autofill": false
                     }
@@ -398,15 +259,15 @@
                 "control": [
                     {
                         "skip": false,
-                        "operators": ["阿米娅", "戴菲恩", "歌蕾蒂娅", "薇薇安娜", "焰尾"],
-                        "sort": false,
+                        "operators": ["薇薇安娜", "焰尾", "森蚺", "涤火杰西卡", "凯尔希"],
+                        "sort": true,
                         "autofill": false
                     }
                 ],
                 "meeting": [
                     {
                         "skip": false,
-                        "operators": ["见行者", "伊内丝"],
+                        "operators": ["忍冬", "铃兰"],
                         "sort": true,
                         "autofill": false
                     }
@@ -421,7 +282,7 @@
                 ],
                 "processing": [
                     {
-                        "skip": true,
+                        "skip": false,
                         "operators": [],
                         "sort": false,
                         "autofill": false
@@ -430,17 +291,18 @@
             }
         },
         {
-            "name": "A+C 替补短班 2",
-            "description_post": "请在四小时后换班",
+            "name": "3",
+            "description": "7h",
+            "description_post": "7小时后换班",
             "Fiammetta": {
                 "enable": false,
                 "target": "",
                 "order": "pre"
             },
             "drones": {
-                "room": "manufacture",
-                "index": 3,
-                "enable": false,
+                "room": "trading",
+                "index": 1,
+                "enable": true,
                 "order": "pre"
             },
             "rooms": {
@@ -448,15 +310,8 @@
                     {
                         "skip": false,
                         "product": "LMD",
-                        "operators": ["巫恋", "卡夫卡", "龙舌兰"],
-                        "sort": true,
-                        "autofill": false
-                    },
-                    {
-                        "skip": false,
-                        "product": "LMD",
                         "operators": ["空弦", "黑键", "但书"],
-                        "sort": false,
+                        "sort": true,
                         "autofill": false
                     }
                 ],
@@ -464,29 +319,36 @@
                     {
                         "skip": false,
                         "product": "Pure Gold",
-                        "operators": ["清流", "温蒂", "森蚺"],
-                        "sort": false,
-                        "autofill": false
-                    },
-                    {
-                        "skip": false,
-                        "product": "Pure Gold",
-                        "operators": ["苍苔", "引星棘刺", "迷迭香"],
-                        "sort": false,
+                        "operators": ["槐琥", "阿罗玛", "砾"],
+                        "sort": true,
                         "autofill": false
                     },
                     {
                         "skip": false,
                         "product": "Battle Record",
-                        "operators": ["断罪者", "乌尔比安", "安哲拉"],
-                        "sort": false,
+                        "operators": ["温蒂", "异客", "掠风"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["野鬃", "远牙", "灰毫"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["迷迭香", "乌尔比安", "安哲拉"],
+                        "sort": true,
                         "autofill": false
                     },
                     {
                         "skip": false,
                         "product": "Battle Record",
                         "operators": ["幽灵鲨", "斯卡蒂", "至简"],
-                        "sort": false,
+                        "sort": true,
                         "autofill": false
                     }
                 ],
@@ -499,13 +361,13 @@
                     },
                     {
                         "skip": false,
-                        "operators": ["澄闪"],
+                        "operators": ["Lancet-2"],
                         "sort": false,
                         "autofill": false
                     },
                     {
-                        "skip": true,
-                        "operators": ["雷蛇"],
+                        "skip": false,
+                        "operators": ["澄闪"],
                         "sort": false,
                         "autofill": false
                     }
@@ -513,25 +375,25 @@
                 "dormitory": [
                     {
                         "skip": false,
-                        "operators": ["菲亚梅塔", "阿米娅", "薇薇安娜", "焰尾", "砾"],
+                        "operators": ["菲亚梅塔", "爱丽丝", "车尔尼", "塑心", "年"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["巫恋", "龙舌兰", "苍苔", "杏仁", "多萝西"],
                         "sort": false,
                         "autofill": false
                     },
                     {
                         "skip": false,
-                        "operators": ["槐琥", "阿罗玛", "野鬃", "远牙", "灰毫"],
+                        "operators": ["淬羽赫默", "断罪者", "水月", "香草", "杰西卡"],
                         "sort": false,
                         "autofill": false
                     },
                     {
                         "skip": false,
-                        "operators": ["爱丽丝", "车尔尼", "塑心", "缪尔赛思", "见行者"],
-                        "sort": false,
-                        "autofill": false
-                    },
-                    {
-                        "skip": true,
-                        "operators": ["赫默", "伊芙利特", "塞雷娅", "白面鸮", "梅尔"],
+                        "operators": ["雷蛇", "斥罪", "涤火杰西卡", "凯尔希", "九色鹿"],
                         "sort": false,
                         "autofill": false
                     }
@@ -539,15 +401,15 @@
                 "control": [
                     {
                         "skip": false,
-                        "operators": ["诗怀雅", "歌蕾蒂娅", "Mon3tr", "夕", "琴柳"],
-                        "sort": false,
+                        "operators": ["薇薇安娜", "焰尾", "森蚺", "琴柳", "歌蕾蒂娅"],
+                        "sort": true,
                         "autofill": false
                     }
                 ],
                 "meeting": [
                     {
                         "skip": false,
-                        "operators": ["信仰搅拌机", "伊内丝"],
+                        "operators": ["伊内丝", "陈"],
                         "sort": true,
                         "autofill": false
                     }
@@ -562,7 +424,149 @@
                 ],
                 "processing": [
                     {
-                        "skip": true,
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        },
+        {
+            "name": "4",
+            "description": "5h",
+            "description_post": "5小时后换班",
+            "Fiammetta": {
+                "enable": false,
+                "target": "",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "trading",
+                "index": 1,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["空弦", "黑键", "但书"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["槐琥", "阿罗玛", "杏仁"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["红云", "稀音", "帕拉斯"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["至简", "多萝西", "淬羽赫默"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["迷迭香", "断罪者", "食铁兽"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["水月", "香草", "杰西卡"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["雷蛇"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["澄闪"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["菲亚梅塔", "爱丽丝", "车尔尼", "塑心", "年"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["砾", "温蒂", "异客", "掠风", "野鬃"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["远牙", "灰毫", "歌蕾蒂娅", "流明", "闪灵"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["承曦格雷伊", "森蚺", "焰尾", "薇薇安娜", "九色鹿"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["凯尔希", "涤火杰西卡", "令", "琴柳", "夕"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": ["伊内丝", "陈"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
                         "operators": [],
                         "sort": false,
                         "autofill": false
@@ -573,8 +577,8 @@
     ],
     "scheduleType": {
         "planTimes": 4,
-        "trading": 2,
-        "manufacture": 4,
+        "trading": 1,
+        "manufacture": 5,
         "power": 3,
         "dormitory": 4
     }

--- a/resource/custom_infrast/old/243_layout_4_times_a_day_20240608.json
+++ b/resource/custom_infrast/old/243_layout_4_times_a_day_20240608.json
@@ -1,7 +1,6 @@
 {
-    "author": "公孙长乐, bodayw",
-    "description": "干员配置要求极高，若缺少干员请自行调整\n默认每八小时使用无人机加速制造作战记录，请按实际需求修改\n首次使用前将令的心情消耗至 12\n请在一图流排班表生成器上导入本文件，修改后下载导出（请勿直接修改本文件，以免 MAA 更新时被覆盖）\n\n[20250507 修订] 视频地址: https://www.bilibili.com/video/BV1vbVsz2EWj/?t=156",
-    "id": 1746615586785171,
+    "author": "公孙长乐",
+    "description": "干员配置要求极高，若缺少干员请自行调整\n默认每八小时使用无人机加速制造作战记录，请按实际需求修改\n首次使用前将令的心情消耗至 12\n请在一图流排班表生成器上导入本文件，修改后下载导出（请勿直接修改本文件，以免 MAA 更新时被覆盖）\n\n[20240608 修订] 视频地址: https://www.bilibili.com/video/BV1yy411B7S7/?t=209",
     "title": "243 极限效率，一天四换",
     "buildingType": 243,
     "planTimes": "3班",
@@ -102,7 +101,7 @@
                     },
                     {
                         "skip": false,
-                        "operators": ["爱丽丝", "车尔尼", "塑心", "伊内丝", "苍苔"],
+                        "operators": ["爱丽丝", "车尔尼", "塑心", "伺夜", "苍苔"],
                         "sort": false,
                         "autofill": false
                     },
@@ -124,8 +123,8 @@
                 "meeting": [
                     {
                         "skip": false,
-                        "operators": ["信仰搅拌机", "见行者"],
-                        "sort": false,
+                        "operators": ["伊内丝", "陈"],
+                        "sort": true,
                         "autofill": false
                     }
                 ],
@@ -237,13 +236,13 @@
                     },
                     {
                         "skip": false,
-                        "operators": ["诗怀雅", "Mon3tr", "夕", "引星棘刺", "见行者"],
+                        "operators": ["诗怀雅", "凯尔希", "夕", "斑点", "食铁兽"],
                         "sort": false,
                         "autofill": false
                     },
                     {
                         "skip": false,
-                        "operators": ["爱丽丝", "车尔尼", "塑心"],
+                        "operators": ["爱丽丝", "车尔尼", "塑心", "陈"],
                         "sort": false,
                         "autofill": true
                     },
@@ -265,7 +264,7 @@
                 "meeting": [
                     {
                         "skip": false,
-                        "operators": ["信仰搅拌机", "伊内丝"],
+                        "operators": ["伊内丝", "伺夜"],
                         "sort": true,
                         "autofill": false
                     }
@@ -323,15 +322,15 @@
                     {
                         "skip": false,
                         "product": "Pure Gold",
-                        "operators": ["苍苔", "砾", "引星棘刺"],
+                        "operators": ["苍苔", "砾", "乌尔比安"],
                         "sort": false,
                         "autofill": false
                     },
                     {
                         "skip": false,
                         "product": "Pure Gold",
-                        "operators": ["槐琥", "阿罗玛", "乌尔比安"],
-                        "sort": true,
+                        "operators": ["清流", "温蒂", "森蚺"],
+                        "sort": false,
                         "autofill": false
                     },
                     {
@@ -351,14 +350,14 @@
                 ],
                 "power": [
                     {
-                        "skip": false,
-                        "operators": ["格雷伊"],
+                        "skip": true,
+                        "operators": ["承曦格雷伊"],
                         "sort": false,
                         "autofill": false
                     },
                     {
-                        "skip": true,
-                        "operators": ["缪尔赛思"],
+                        "skip": false,
+                        "operators": ["澄闪"],
                         "sort": false,
                         "autofill": false
                     },
@@ -378,15 +377,15 @@
                     },
                     {
                         "skip": false,
-                        "operators": ["清流", "温蒂", "森蚺", "迷迭香", "至简"],
+                        "operators": ["槐琥", "阿罗玛", "迷迭香", "至简", "断罪者"],
                         "sort": false,
                         "autofill": false
                     },
                     {
                         "skip": false,
-                        "operators": ["断罪者", "承曦格雷伊", "信仰搅拌机", "絮雨", "琴柳"],
+                        "operators": ["缪尔赛思", "伊内丝", "絮雨", "琴柳"],
                         "sort": false,
-                        "autofill": false
+                        "autofill": true
                     },
                     {
                         "skip": true,
@@ -406,8 +405,8 @@
                 "meeting": [
                     {
                         "skip": false,
-                        "operators": ["见行者", "伊内丝"],
-                        "sort": true,
+                        "operators": ["陈", "伺夜"],
+                        "sort": false,
                         "autofill": false
                     }
                 ],
@@ -464,21 +463,21 @@
                     {
                         "skip": false,
                         "product": "Pure Gold",
-                        "operators": ["清流", "温蒂", "森蚺"],
+                        "operators": ["苍苔", "斑点", "乌尔比安"],
                         "sort": false,
                         "autofill": false
                     },
                     {
                         "skip": false,
                         "product": "Pure Gold",
-                        "operators": ["苍苔", "引星棘刺", "迷迭香"],
-                        "sort": false,
+                        "operators": ["槐琥", "阿罗玛", "迷迭香"],
+                        "sort": true,
                         "autofill": false
                     },
                     {
                         "skip": false,
                         "product": "Battle Record",
-                        "operators": ["断罪者", "乌尔比安", "安哲拉"],
+                        "operators": ["断罪者", "食铁兽", "安哲拉"],
                         "sort": false,
                         "autofill": false
                     },
@@ -493,13 +492,13 @@
                 "power": [
                     {
                         "skip": false,
-                        "operators": ["承曦格雷伊"],
+                        "operators": ["格雷伊"],
                         "sort": false,
                         "autofill": false
                     },
                     {
                         "skip": false,
-                        "operators": ["澄闪"],
+                        "operators": ["缪尔赛思"],
                         "sort": false,
                         "autofill": false
                     },
@@ -519,13 +518,13 @@
                     },
                     {
                         "skip": false,
-                        "operators": ["槐琥", "阿罗玛", "野鬃", "远牙", "灰毫"],
+                        "operators": ["温蒂", "森蚺", "野鬃", "远牙", "灰毫"],
                         "sort": false,
                         "autofill": false
                     },
                     {
                         "skip": false,
-                        "operators": ["爱丽丝", "车尔尼", "塑心", "缪尔赛思", "见行者"],
+                        "operators": ["爱丽丝", "车尔尼", "塑心", "承曦格雷伊", "清流"],
                         "sort": false,
                         "autofill": false
                     },
@@ -539,7 +538,7 @@
                 "control": [
                     {
                         "skip": false,
-                        "operators": ["诗怀雅", "歌蕾蒂娅", "Mon3tr", "夕", "琴柳"],
+                        "operators": ["诗怀雅", "歌蕾蒂娅", "凯尔希", "夕", "琴柳"],
                         "sort": false,
                         "autofill": false
                     }
@@ -547,7 +546,7 @@
                 "meeting": [
                     {
                         "skip": false,
-                        "operators": ["信仰搅拌机", "伊内丝"],
+                        "operators": ["伊内丝", "陈"],
                         "sort": true,
                         "autofill": false
                     }

--- a/resource/custom_infrast/old/243_layout_4_times_a_day_20241216.json
+++ b/resource/custom_infrast/old/243_layout_4_times_a_day_20241216.json
@@ -1,7 +1,7 @@
 {
-    "author": "公孙长乐, bodayw",
-    "description": "干员配置要求极高，若缺少干员请自行调整\n默认每八小时使用无人机加速制造作战记录，请按实际需求修改\n首次使用前将令的心情消耗至 12\n请在一图流排班表生成器上导入本文件，修改后下载导出（请勿直接修改本文件，以免 MAA 更新时被覆盖）\n\n[20250507 修订] 视频地址: https://www.bilibili.com/video/BV1vbVsz2EWj/?t=156",
-    "id": 1746615586785171,
+    "author": "公孙长乐",
+    "description": "干员配置要求极高，若缺少干员请自行调整\n默认每八小时使用无人机加速制造作战记录，请按实际需求修改\n首次使用前将令的心情消耗至 12\n请在一图流排班表生成器上导入本文件，修改后下载导出（请勿直接修改本文件，以免 MAA 更新时被覆盖）\n\n[20241216 修订] 视频地址: https://www.bilibili.com/video/BV13gBwYbEG5/?t=158",
+    "id": 1734336875111339,
     "title": "243 极限效率，一天四换",
     "buildingType": 243,
     "planTimes": "3班",
@@ -102,7 +102,7 @@
                     },
                     {
                         "skip": false,
-                        "operators": ["爱丽丝", "车尔尼", "塑心", "伊内丝", "苍苔"],
+                        "operators": ["爱丽丝", "车尔尼", "塑心", "伺夜", "苍苔"],
                         "sort": false,
                         "autofill": false
                     },
@@ -124,8 +124,8 @@
                 "meeting": [
                     {
                         "skip": false,
-                        "operators": ["信仰搅拌机", "见行者"],
-                        "sort": false,
+                        "operators": ["伊内丝", "陈"],
+                        "sort": true,
                         "autofill": false
                     }
                 ],
@@ -237,13 +237,13 @@
                     },
                     {
                         "skip": false,
-                        "operators": ["诗怀雅", "Mon3tr", "夕", "引星棘刺", "见行者"],
+                        "operators": ["诗怀雅", "凯尔希", "夕", "引星棘刺", "食铁兽"],
                         "sort": false,
                         "autofill": false
                     },
                     {
                         "skip": false,
-                        "operators": ["爱丽丝", "车尔尼", "塑心"],
+                        "operators": ["爱丽丝", "车尔尼", "塑心", "陈"],
                         "sort": false,
                         "autofill": true
                     },
@@ -265,7 +265,7 @@
                 "meeting": [
                     {
                         "skip": false,
-                        "operators": ["信仰搅拌机", "伊内丝"],
+                        "operators": ["伊内丝", "伺夜"],
                         "sort": true,
                         "autofill": false
                     }
@@ -323,15 +323,15 @@
                     {
                         "skip": false,
                         "product": "Pure Gold",
-                        "operators": ["苍苔", "砾", "引星棘刺"],
+                        "operators": ["苍苔", "砾", "乌尔比安"],
                         "sort": false,
                         "autofill": false
                     },
                     {
                         "skip": false,
                         "product": "Pure Gold",
-                        "operators": ["槐琥", "阿罗玛", "乌尔比安"],
-                        "sort": true,
+                        "operators": ["清流", "温蒂", "森蚺"],
+                        "sort": false,
                         "autofill": false
                     },
                     {
@@ -351,14 +351,14 @@
                 ],
                 "power": [
                     {
-                        "skip": false,
-                        "operators": ["格雷伊"],
+                        "skip": true,
+                        "operators": ["承曦格雷伊"],
                         "sort": false,
                         "autofill": false
                     },
                     {
-                        "skip": true,
-                        "operators": ["缪尔赛思"],
+                        "skip": false,
+                        "operators": ["澄闪"],
                         "sort": false,
                         "autofill": false
                     },
@@ -378,15 +378,15 @@
                     },
                     {
                         "skip": false,
-                        "operators": ["清流", "温蒂", "森蚺", "迷迭香", "至简"],
+                        "operators": ["槐琥", "阿罗玛", "迷迭香", "至简", "断罪者"],
                         "sort": false,
                         "autofill": false
                     },
                     {
                         "skip": false,
-                        "operators": ["断罪者", "承曦格雷伊", "信仰搅拌机", "絮雨", "琴柳"],
+                        "operators": ["缪尔赛思", "伊内丝", "絮雨", "琴柳"],
                         "sort": false,
-                        "autofill": false
+                        "autofill": true
                     },
                     {
                         "skip": true,
@@ -406,8 +406,8 @@
                 "meeting": [
                     {
                         "skip": false,
-                        "operators": ["见行者", "伊内丝"],
-                        "sort": true,
+                        "operators": ["陈", "伺夜"],
+                        "sort": false,
                         "autofill": false
                     }
                 ],
@@ -464,21 +464,21 @@
                     {
                         "skip": false,
                         "product": "Pure Gold",
-                        "operators": ["清流", "温蒂", "森蚺"],
+                        "operators": ["苍苔", "引星棘刺", "乌尔比安"],
                         "sort": false,
                         "autofill": false
                     },
                     {
                         "skip": false,
                         "product": "Pure Gold",
-                        "operators": ["苍苔", "引星棘刺", "迷迭香"],
-                        "sort": false,
+                        "operators": ["槐琥", "阿罗玛", "迷迭香"],
+                        "sort": true,
                         "autofill": false
                     },
                     {
                         "skip": false,
                         "product": "Battle Record",
-                        "operators": ["断罪者", "乌尔比安", "安哲拉"],
+                        "operators": ["断罪者", "食铁兽", "安哲拉"],
                         "sort": false,
                         "autofill": false
                     },
@@ -493,13 +493,13 @@
                 "power": [
                     {
                         "skip": false,
-                        "operators": ["承曦格雷伊"],
+                        "operators": ["格雷伊"],
                         "sort": false,
                         "autofill": false
                     },
                     {
                         "skip": false,
-                        "operators": ["澄闪"],
+                        "operators": ["缪尔赛思"],
                         "sort": false,
                         "autofill": false
                     },
@@ -519,13 +519,13 @@
                     },
                     {
                         "skip": false,
-                        "operators": ["槐琥", "阿罗玛", "野鬃", "远牙", "灰毫"],
+                        "operators": ["温蒂", "森蚺", "野鬃", "远牙", "灰毫"],
                         "sort": false,
                         "autofill": false
                     },
                     {
                         "skip": false,
-                        "operators": ["爱丽丝", "车尔尼", "塑心", "缪尔赛思", "见行者"],
+                        "operators": ["爱丽丝", "车尔尼", "塑心", "承曦格雷伊", "清流"],
                         "sort": false,
                         "autofill": false
                     },
@@ -539,7 +539,7 @@
                 "control": [
                     {
                         "skip": false,
-                        "operators": ["诗怀雅", "歌蕾蒂娅", "Mon3tr", "夕", "琴柳"],
+                        "operators": ["诗怀雅", "歌蕾蒂娅", "凯尔希", "夕", "琴柳"],
                         "sort": false,
                         "autofill": false
                     }
@@ -547,7 +547,7 @@
                 "meeting": [
                     {
                         "skip": false,
-                        "operators": ["信仰搅拌机", "伊内丝"],
+                        "operators": ["伊内丝", "陈"],
                         "sort": true,
                         "autofill": false
                     }

--- a/resource/custom_infrast/old/243_layout_4_times_a_day_20250310.json
+++ b/resource/custom_infrast/old/243_layout_4_times_a_day_20250310.json
@@ -1,7 +1,7 @@
 {
-    "author": "公孙长乐, bodayw",
-    "description": "干员配置要求极高，若缺少干员请自行调整\n默认每八小时使用无人机加速制造作战记录，请按实际需求修改\n首次使用前将令的心情消耗至 12\n请在一图流排班表生成器上导入本文件，修改后下载导出（请勿直接修改本文件，以免 MAA 更新时被覆盖）\n\n[20250507 修订] 视频地址: https://www.bilibili.com/video/BV1vbVsz2EWj/?t=156",
-    "id": 1746615586785171,
+    "author": "公孙长乐",
+    "description": "干员配置要求极高，若缺少干员请自行调整\n默认每八小时使用无人机加速制造作战记录，请按实际需求修改\n首次使用前将令的心情消耗至 12\n请在一图流排班表生成器上导入本文件，修改后下载导出（请勿直接修改本文件，以免 MAA 更新时被覆盖）\n\n[20250310 修订] 视频地址: https://www.bilibili.com/video/BV1QARvYFEWi/?t=87",
+    "id": 1741865853371304,
     "title": "243 极限效率，一天四换",
     "buildingType": 243,
     "planTimes": "3班",
@@ -102,7 +102,7 @@
                     },
                     {
                         "skip": false,
-                        "operators": ["爱丽丝", "车尔尼", "塑心", "伊内丝", "苍苔"],
+                        "operators": ["爱丽丝", "车尔尼", "塑心", "伺夜", "苍苔"],
                         "sort": false,
                         "autofill": false
                     },
@@ -124,8 +124,8 @@
                 "meeting": [
                     {
                         "skip": false,
-                        "operators": ["信仰搅拌机", "见行者"],
-                        "sort": false,
+                        "operators": ["伊内丝", "陈"],
+                        "sort": true,
                         "autofill": false
                     }
                 ],
@@ -237,7 +237,7 @@
                     },
                     {
                         "skip": false,
-                        "operators": ["诗怀雅", "Mon3tr", "夕", "引星棘刺", "见行者"],
+                        "operators": ["诗怀雅", "凯尔希", "夕", "引星棘刺", "陈"],
                         "sort": false,
                         "autofill": false
                     },
@@ -265,7 +265,7 @@
                 "meeting": [
                     {
                         "skip": false,
-                        "operators": ["信仰搅拌机", "伊内丝"],
+                        "operators": ["伊内丝", "伺夜"],
                         "sort": true,
                         "autofill": false
                     }
@@ -384,7 +384,7 @@
                     },
                     {
                         "skip": false,
-                        "operators": ["断罪者", "承曦格雷伊", "信仰搅拌机", "絮雨", "琴柳"],
+                        "operators": ["断罪者", "承曦格雷伊", "伊内丝", "絮雨", "琴柳"],
                         "sort": false,
                         "autofill": false
                     },
@@ -406,8 +406,8 @@
                 "meeting": [
                     {
                         "skip": false,
-                        "operators": ["见行者", "伊内丝"],
-                        "sort": true,
+                        "operators": ["陈", "伺夜"],
+                        "sort": false,
                         "autofill": false
                     }
                 ],
@@ -525,7 +525,7 @@
                     },
                     {
                         "skip": false,
-                        "operators": ["爱丽丝", "车尔尼", "塑心", "缪尔赛思", "见行者"],
+                        "operators": ["爱丽丝", "车尔尼", "塑心", "缪尔赛思", "杜林"],
                         "sort": false,
                         "autofill": false
                     },
@@ -539,7 +539,7 @@
                 "control": [
                     {
                         "skip": false,
-                        "operators": ["诗怀雅", "歌蕾蒂娅", "Mon3tr", "夕", "琴柳"],
+                        "operators": ["诗怀雅", "歌蕾蒂娅", "凯尔希", "夕", "琴柳"],
                         "sort": false,
                         "autofill": false
                     }
@@ -547,7 +547,7 @@
                 "meeting": [
                     {
                         "skip": false,
-                        "operators": ["信仰搅拌机", "伊内丝"],
+                        "operators": ["伊内丝", "陈"],
                         "sort": true,
                         "autofill": false
                     }

--- a/resource/custom_infrast/old/243_layout_4_times_a_day_20250412.json
+++ b/resource/custom_infrast/old/243_layout_4_times_a_day_20250412.json
@@ -1,7 +1,7 @@
 {
-    "author": "公孙长乐, bodayw",
-    "description": "干员配置要求极高，若缺少干员请自行调整\n默认每八小时使用无人机加速制造作战记录，请按实际需求修改\n首次使用前将令的心情消耗至 12\n请在一图流排班表生成器上导入本文件，修改后下载导出（请勿直接修改本文件，以免 MAA 更新时被覆盖）\n\n[20250507 修订] 视频地址: https://www.bilibili.com/video/BV1vbVsz2EWj/?t=156",
-    "id": 1746615586785171,
+    "author": "公孙长乐",
+    "description": "干员配置要求极高，若缺少干员请自行调整\n默认每八小时使用无人机加速制造作战记录，请按实际需求修改\n首次使用前将令的心情消耗至 12\n请在一图流排班表生成器上导入本文件，修改后下载导出（请勿直接修改本文件，以免 MAA 更新时被覆盖）\n\n[20250412 修订] 视频地址: https://www.bilibili.com/video/BV14XdXYCEqh/?t=127",
+    "id": 1744447000657408,
     "title": "243 极限效率，一天四换",
     "buildingType": 243,
     "planTimes": "3班",
@@ -102,7 +102,7 @@
                     },
                     {
                         "skip": false,
-                        "operators": ["爱丽丝", "车尔尼", "塑心", "伊内丝", "苍苔"],
+                        "operators": ["爱丽丝", "车尔尼", "塑心", "伺夜", "苍苔"],
                         "sort": false,
                         "autofill": false
                     },
@@ -124,8 +124,8 @@
                 "meeting": [
                     {
                         "skip": false,
-                        "operators": ["信仰搅拌机", "见行者"],
-                        "sort": false,
+                        "operators": ["伊内丝", "陈"],
+                        "sort": true,
                         "autofill": false
                     }
                 ],
@@ -237,7 +237,7 @@
                     },
                     {
                         "skip": false,
-                        "operators": ["诗怀雅", "Mon3tr", "夕", "引星棘刺", "见行者"],
+                        "operators": ["诗怀雅", "Mon3tr", "夕", "引星棘刺", "陈"],
                         "sort": false,
                         "autofill": false
                     },
@@ -265,7 +265,7 @@
                 "meeting": [
                     {
                         "skip": false,
-                        "operators": ["信仰搅拌机", "伊内丝"],
+                        "operators": ["伊内丝", "伺夜"],
                         "sort": true,
                         "autofill": false
                     }
@@ -384,7 +384,7 @@
                     },
                     {
                         "skip": false,
-                        "operators": ["断罪者", "承曦格雷伊", "信仰搅拌机", "絮雨", "琴柳"],
+                        "operators": ["断罪者", "承曦格雷伊", "伊内丝", "絮雨", "琴柳"],
                         "sort": false,
                         "autofill": false
                     },
@@ -406,8 +406,8 @@
                 "meeting": [
                     {
                         "skip": false,
-                        "operators": ["见行者", "伊内丝"],
-                        "sort": true,
+                        "operators": ["陈", "伺夜"],
+                        "sort": false,
                         "autofill": false
                     }
                 ],
@@ -525,7 +525,7 @@
                     },
                     {
                         "skip": false,
-                        "operators": ["爱丽丝", "车尔尼", "塑心", "缪尔赛思", "见行者"],
+                        "operators": ["爱丽丝", "车尔尼", "塑心", "缪尔赛思", "杜林"],
                         "sort": false,
                         "autofill": false
                     },
@@ -547,7 +547,7 @@
                 "meeting": [
                     {
                         "skip": false,
-                        "operators": ["信仰搅拌机", "伊内丝"],
+                        "operators": ["伊内丝", "陈"],
                         "sort": true,
                         "autofill": false
                     }


### PR DESCRIPTION
让见行者和信仰搅拌机到会客室上班 / Let Enforcer and Sankta Miksaparato work in the reception room

顺便补上了之前忘记备份到 old 子目录下的旧排班表（取 custom_infrast 目录内自 commit 3f858de 之后所有 feat 类改动的前一个版本，fix/chore 就不要了）

PS. 这次是我自己做的调整，公孙长乐的排班表并没有变化（他的视频不排会客室），不过还是把视频链接也更新了一下，另外考虑到用到了最新实装的干员，所以本 commit 也还是标记为 feat 吧