### PR TITLE
chore: bump maa-cli to 0.5.5

### DIFF
--- a/docs/zh-cn/manual/cli/config.md
+++ b/docs/zh-cn/manual/cli/config.md
@@ -333,7 +333,13 @@ address = "127.0.0.1:7777" # 如果你需要的话，你可以覆盖预设的地
 
 目前只有 `MuMuPro` 一个模拟器的预设，如果有其他常用模拟器的预设，欢迎提交 issue 或者 PR。
 
-此处有一个特殊的预设 `PlayCover`，其用于在 macOS 上连接直接通过 `PlayCover` 原生运行的游戏客户端。这种情况下不需要指定 `adb_path` 且 `address` 不是 `adb` l连接的地址而是 `PlayTools` 的地址，具体使用参见 [PlayCover 支持文档][playcover-doc].
+#### 特殊预设
+
+目前预配置了两种预设，为 `PlayCover (MacOS)`, `Waydroid (Linux)`
+
+- `PlayCover`用于在 macOS 上连接直接通过 `PlayCover` 原生运行的游戏客户端。这种情况下不需要指定 `adb_path` 且 `address` 不是 `adb` 连接的地址而是 `PlayTools` 的地址，具体使用参见 [PlayCover 支持文档][playcover-doc].
+
+- `Waydroid`用于在 Linux 上连接直接通过 `Waydroid` 原生运行的游戏客户端。这种情况下仍需要指定 `adb_path`，具体使用参见 [Waydroid 支持文档][waydroid-doc].
 
 ### 资源配置
 
@@ -463,6 +469,7 @@ passphrase = "password"       # ssh 密钥的密码
 [task-types]: ../../protocol/integration.md#任务类型一览
 [emulator-ports]: ../../manual/connection.md#获取端口号
 [playcover-doc]: ../../manual/device/macos.md#✅-playcover-原生运行最流畅-🚀
+[waydroid-doc]: ../../manual/device/linux.md#✅-waydroid
 [example-config]: https://github.com/MaaAssistantArknights/maa-cli/blob/main/crates/maa-cli/config_examples
 [wangl-cc-dotfiles]: https://github.com/wangl-cc/dotfiles/tree/master/.config/maa
 [schema-dir]: https://github.com/MaaAssistantArknights/maa-cli/blob/main/crates/maa-cli/schemas/

--- a/docs/zh-cn/manual/cli/install.md
+++ b/docs/zh-cn/manual/cli/install.md
@@ -96,6 +96,14 @@ maa-cli 只提供了一个命令行界面，它需要 MaaCore 和资源来运行
 maa install
 ```
 
+对于 Windows 平台用户，在运行 `maa install` 命令前，请以管理员身份在命令提示符或PowerShell中运行以下命令，以安装必要工具组VC++
+
+- Windows:
+
+  ```bat
+  winget install "Microsoft.VCRedist.2015+.x64" --override "/repair /passive /norestart" --uninstall-previous --accept-package-agreements --force
+  ```
+
 对于使用包管理器安装的用户，可以通过包管理器安装 MaaCore：
 
 - Homebrew：


### PR DESCRIPTION
Bump maa-cli to 0.5.5.

See [maa-cli changelog](https://github.com/MaaAssistantArknights/maa-cli/releases/tag/v0.5.5) for more details.

主要就是加了个 Waydriod 支持以及适配了一下新版倍战。