### PR TITLE
ci: exclude link in cli docs

### DIFF
--- a/.github/workflows/markdown-checker.yml
+++ b/.github/workflows/markdown-checker.yml
@@ -55,7 +55,7 @@ jobs:
             --include 'https?://user-images\.githubusercontent\.com/.*'
             --exclude-path 'docs/zh-tw/manual/introduction/introduction_old.md'
             --exclude-path 'docs/ja-jp/manual/introduction/introduction_old.md'
-            --exclude-path 'docs/*/manual/cli/*.md'
+            --exclude-path 'docs/[\w-]*/manual/cli/.*\.md'
             --exclude 'files/MAA_Runtime_Fix_Pwsh.ps1$'
             -- './docs/**/*.md' './README.md'
 

--- a/.github/workflows/markdown-checker.yml
+++ b/.github/workflows/markdown-checker.yml
@@ -55,6 +55,7 @@ jobs:
             --include 'https?://user-images\.githubusercontent\.com/.*'
             --exclude-path 'docs/zh-tw/manual/introduction/introduction_old.md'
             --exclude-path 'docs/ja-jp/manual/introduction/introduction_old.md'
+            --exclude-path 'docs/*/manual/cli/*.md'
             --exclude 'files/MAA_Runtime_Fix_Pwsh.ps1$'
             -- './docs/**/*.md' './README.md'
 


### PR DESCRIPTION
cli 的文档都是单向同步过来的，在 cli 那边已经有进行了检查，所以在这边可以排除来减少需要检查的链接的数量，来一定程度上防止GitHub 的速率限制的影响。