### PR TITLE
chore: find OpenCV features2d and xfeatures2d components

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,8 @@ if (BUILD_TEST)
     target_link_libraries(test MaaCore)
 endif (BUILD_TEST)
 
-find_package(OpenCV REQUIRED COMPONENTS core imgproc imgcodecs videoio)
+find_package(OpenCV REQUIRED COMPONENTS core imgproc imgcodecs videoio features2d)
+find_package(OpenCV QUIET COMPONENTS xfeatures2d)
 find_package(ZLIB REQUIRED)
 find_package(cpr CONFIG REQUIRED)
 


### PR DESCRIPTION
最近似乎使用了 OpenCV 的 feature match 功能，但是并没有更改 OpenCV 的 COMPONENTS。虽然在 CI 能够正常编译（可能是因为不包含 xfeatures2d），但是给 homebrew 打包的时候，链接时会找不到符号，必须要 Cmake 找到 xfeatures2d 才行：

```
ld: Undefined symbols:
    cv::xfeatures2d::SURF::create(double, int, int, bool, bool), referenced from:
```

此外，加上 require features2d 也可以在CMake配置时就发现错误，而不会在编译的时候才发现少头文件。