### PR TITLE
feat: 自动战斗费用识别缓存, 减少性能消耗

### DIFF
--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -3861,7 +3861,7 @@
     "BattleCostData": {
         "baseTask": "NumberOcrReplace",
         "roi": [1199, 494, 80, 44],
-        "specialParams_doc": "Cost数字变化阈值, 模板匹配, 100=1.0",
+        "specialParams_doc": "Cost数字变化阈值, 模板匹配, 100=1.0; 正常在 0.997-1 之间波动, 少有0.995; _5->_6 的分数最高, 0.85上下",
         "specialParams": [98]
     },
     "BattleSkillReady": {

--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -3859,10 +3859,10 @@
         "roi": [50, 0, 100, 40]
     },
     "BattleCostData": {
-        "algorithm": "OcrDetect",
-        "isAscii": true,
-        "text": [],
-        "roi": [1199, 494, 80, 44]
+        "baseTask": "NumberOcrReplace",
+        "roi": [1199, 494, 80, 44],
+        "specialParams_doc": "Cost数字变化阈值, 模板匹配, 100=1.0",
+        "specialParams": [98]
     },
     "BattleSkillReady": {
         "rectMove": [-28, -140, 64, 64]

--- a/src/MaaCore/Task/BattleHelper.cpp
+++ b/src/MaaCore/Task/BattleHelper.cpp
@@ -352,20 +352,11 @@ bool asst::BattleHelper::update_cost(const cv::Mat& image, const cv::Mat& image_
     analyzer.set_object_of_interest({ .costs = true });
     analyzer.set_image_cache(image_prev);
     auto result_opt = analyzer.analyze();
-    if (!result_opt) {
+    if (!result_opt || result_opt->costs.status == BattlefieldMatcher::MatchStatus::Invalid) {
         return false;
     }
-    else if (std::holds_alternative<int>(result_opt->costs)) {
-        m_cost = std::get<int>(result_opt->costs);
-    }
-    else if (std::holds_alternative<BattlefieldMatcher::MatchStatus>(result_opt->costs)) {
-        auto status = std::get<BattlefieldMatcher::MatchStatus>(result_opt->costs);
-        if (status == BattlefieldMatcher::MatchStatus::Invalid) {
-            return false;
-        }
-        else {
-            Log.debug("costs hit cache:", m_cost);
-        }
+    else if (result_opt->costs.status == BattlefieldMatcher::MatchStatus::Match) {
+        m_cost = result_opt->costs.value;
     }
     return true;
 }

--- a/src/MaaCore/Task/BattleHelper.cpp
+++ b/src/MaaCore/Task/BattleHelper.cpp
@@ -355,7 +355,7 @@ bool asst::BattleHelper::update_cost(const cv::Mat& image, const cv::Mat& image_
     if (!result_opt || result_opt->costs.status == BattlefieldMatcher::MatchStatus::Invalid) {
         return false;
     }
-    else if (result_opt->costs.status == BattlefieldMatcher::MatchStatus::Match) {
+    else if (result_opt->costs.status == BattlefieldMatcher::MatchStatus::Success) {
         m_cost = result_opt->costs.value;
     }
     return true;

--- a/src/MaaCore/Task/BattleHelper.cpp
+++ b/src/MaaCore/Task/BattleHelper.cpp
@@ -350,7 +350,7 @@ bool asst::BattleHelper::update_cost(const cv::Mat& image, const cv::Mat& image_
 {
     BattlefieldMatcher analyzer(image);
     analyzer.set_object_of_interest({ .costs = true });
-    analyzer.set_image_cache(image_prev);
+    analyzer.set_image_prev(image_prev);
     auto result_opt = analyzer.analyze();
     if (!result_opt || result_opt->costs.status == BattlefieldMatcher::MatchStatus::Invalid) {
         return false;

--- a/src/MaaCore/Task/BattleHelper.h
+++ b/src/MaaCore/Task/BattleHelper.h
@@ -54,7 +54,7 @@ protected:
         const std::vector<battle::DeploymentOper>& old_deployment_opers,
         bool stop_on_unknown);
     bool update_kills(const cv::Mat& reusable = cv::Mat());
-    bool update_cost(const cv::Mat& reusable = cv::Mat());
+    bool update_cost(const cv::Mat& image, const cv::Mat& image_prev = cv::Mat());
 
     cv::Mat get_top_view(const cv::Mat& cam_img, bool side = true);
 

--- a/src/MaaCore/Task/Experiment/CombatRecordRecognitionTask.cpp
+++ b/src/MaaCore/Task/Experiment/CombatRecordRecognitionTask.cpp
@@ -848,11 +848,11 @@ json::object asst::CombatRecordRecognitionTask::analyze_action_condition(ClipInf
     BattlefieldMatcher analyzer(pre_clip_ptr->end_frame); // 开始执行这次操作的画面
     analyzer.set_object_of_interest({ .costs = true });
     auto end_result_opt = analyzer.analyze();
-    if (!end_result_opt || !std::holds_alternative<int>(end_result_opt->costs)) {
+    if (!end_result_opt || end_result_opt->costs.status != BattlefieldMatcher::MatchStatus::Match) {
         m_pre_action_costs = -1;
         return condition;
     }
-    int start_costs = std::get<int>(end_result_opt->costs);
+    int start_costs = end_result_opt->costs.value;
     int cost_changes = start_costs - m_pre_action_costs;
     if (m_pre_action_costs >= 0 && cost_changes > 0) {
         condition.emplace("cost_changes", cost_changes);
@@ -860,8 +860,8 @@ json::object asst::CombatRecordRecognitionTask::analyze_action_condition(ClipInf
 
     analyzer.set_image(clip.start_frame); // 这次操作执行完了的画面
     auto start_result_opt = analyzer.analyze();
-    m_pre_action_costs = (start_result_opt && std::holds_alternative<int>(end_result_opt->costs))
-                             ? std::get<int>(end_result_opt->costs)
+    m_pre_action_costs = (start_result_opt && end_result_opt->costs.status == BattlefieldMatcher::MatchStatus::Match)
+                             ? end_result_opt->costs.value
                              : start_costs;
 
     return condition;

--- a/src/MaaCore/Task/Experiment/CombatRecordRecognitionTask.cpp
+++ b/src/MaaCore/Task/Experiment/CombatRecordRecognitionTask.cpp
@@ -848,11 +848,11 @@ json::object asst::CombatRecordRecognitionTask::analyze_action_condition(ClipInf
     BattlefieldMatcher analyzer(pre_clip_ptr->end_frame); // 开始执行这次操作的画面
     analyzer.set_object_of_interest({ .costs = true });
     auto end_result_opt = analyzer.analyze();
-    if (!end_result_opt || !end_result_opt->costs) {
+    if (!end_result_opt || !std::holds_alternative<int>(end_result_opt->costs)) {
         m_pre_action_costs = -1;
         return condition;
     }
-    int start_costs = end_result_opt->costs.value();
+    int start_costs = std::get<int>(end_result_opt->costs);
     int cost_changes = start_costs - m_pre_action_costs;
     if (m_pre_action_costs >= 0 && cost_changes > 0) {
         condition.emplace("cost_changes", cost_changes);
@@ -860,7 +860,9 @@ json::object asst::CombatRecordRecognitionTask::analyze_action_condition(ClipInf
 
     analyzer.set_image(clip.start_frame); // 这次操作执行完了的画面
     auto start_result_opt = analyzer.analyze();
-    m_pre_action_costs = (start_result_opt && start_result_opt->costs) ? start_result_opt->costs.value() : start_costs;
+    m_pre_action_costs = (start_result_opt && std::holds_alternative<int>(end_result_opt->costs))
+                             ? std::get<int>(end_result_opt->costs)
+                             : start_costs;
 
     return condition;
 }

--- a/src/MaaCore/Task/Experiment/CombatRecordRecognitionTask.cpp
+++ b/src/MaaCore/Task/Experiment/CombatRecordRecognitionTask.cpp
@@ -848,7 +848,7 @@ json::object asst::CombatRecordRecognitionTask::analyze_action_condition(ClipInf
     BattlefieldMatcher analyzer(pre_clip_ptr->end_frame); // 开始执行这次操作的画面
     analyzer.set_object_of_interest({ .costs = true });
     auto end_result_opt = analyzer.analyze();
-    if (!end_result_opt || end_result_opt->costs.status != BattlefieldMatcher::MatchStatus::Match) {
+    if (!end_result_opt || end_result_opt->costs.status != BattlefieldMatcher::MatchStatus::Success) {
         m_pre_action_costs = -1;
         return condition;
     }
@@ -860,7 +860,7 @@ json::object asst::CombatRecordRecognitionTask::analyze_action_condition(ClipInf
 
     analyzer.set_image(clip.start_frame); // 这次操作执行完了的画面
     auto start_result_opt = analyzer.analyze();
-    m_pre_action_costs = (start_result_opt && end_result_opt->costs.status == BattlefieldMatcher::MatchStatus::Match)
+    m_pre_action_costs = (start_result_opt && end_result_opt->costs.status == BattlefieldMatcher::MatchStatus::Success)
                              ? end_result_opt->costs.value
                              : start_costs;
 

--- a/src/MaaCore/Vision/Battle/BattlefieldMatcher.cpp
+++ b/src/MaaCore/Vision/Battle/BattlefieldMatcher.cpp
@@ -355,7 +355,7 @@ BattlefieldMatcher::MatchResult<int> BattlefieldMatcher::costs_analyze() const
         // _5->_6 的分数最高, 0.85上下
         const double threshold = static_cast<double>(task->special_params[0]) / 100;
         if (mark > threshold) {
-            return BattlefieldMatcher::MatchResult<int> { .status = MatchStatus::HitCache };
+            return { .status = MatchStatus::HitCache };
         }
     }
 
@@ -363,14 +363,14 @@ BattlefieldMatcher::MatchResult<int> BattlefieldMatcher::costs_analyze() const
     cost_analyzer.set_task_info(task);
     auto cost_opt = cost_analyzer.analyze();
     if (!cost_opt) {
-        return BattlefieldMatcher::MatchResult<int> {};
+        return {};
     }
 
     int cost = 0;
     if (utils::chars_to_number(cost_opt->text, cost)) {
-        return BattlefieldMatcher::MatchResult { .value = cost, .status = MatchStatus::Success };
+        return { .value = cost, .status = MatchStatus::Success };
     }
-    return BattlefieldMatcher::MatchResult<int> {};
+    return {};
 }
 
 bool BattlefieldMatcher::pause_button_analyze() const

--- a/src/MaaCore/Vision/Battle/BattlefieldMatcher.cpp
+++ b/src/MaaCore/Vision/Battle/BattlefieldMatcher.cpp
@@ -56,7 +56,7 @@ BattlefieldMatcher::ResultOpt BattlefieldMatcher::analyze() const
 
     if (m_object_of_interest.costs) {
         result.costs = costs_analyze();
-        if (result.costs.status == MatchStatus::Success) {
+        if (result.costs.status == MatchStatus::Invalid) {
             return std::nullopt;
         }
     }

--- a/src/MaaCore/Vision/Battle/BattlefieldMatcher.cpp
+++ b/src/MaaCore/Vision/Battle/BattlefieldMatcher.cpp
@@ -26,6 +26,11 @@ void BattlefieldMatcher::set_total_kills_prompt(int prompt)
     m_total_kills_prompt = prompt;
 }
 
+void asst::BattlefieldMatcher::set_image_prev(const cv::Mat& image)
+{
+    m_image_prev = image;
+}
+
 BattlefieldMatcher::ResultOpt BattlefieldMatcher::analyze() const
 {
     Result result;
@@ -70,8 +75,8 @@ BattlefieldMatcher::ResultOpt BattlefieldMatcher::analyze() const
 
 std::vector<battle::DeploymentOper> BattlefieldMatcher::deployment_analyze() const
 {
-    MultiMatcher flags_analyzer(m_image);
     const auto& flag_task_ptr = Task.get("BattleOpersFlag");
+    MultiMatcher flags_analyzer(m_image);
     flags_analyzer.set_task_info(flag_task_ptr);
 
 #ifndef ASST_DEBUG
@@ -335,8 +340,8 @@ bool BattlefieldMatcher::cost_symbol_analyze() const
 BattlefieldMatcher::MatchResult<int> BattlefieldMatcher::costs_analyze() const
 {
     const auto& task = Task.get("BattleCostData");
-    if (!m_image_cache.empty() && m_image.cols == m_image_cache.cols && m_image.rows == m_image_cache.rows) {
-        cv::Mat cost_image_cache = make_roi(m_image_cache, task->roi);
+    if (!m_image_prev.empty() && m_image.cols == m_image_prev.cols && m_image.rows == m_image_prev.rows) {
+        cv::Mat cost_image_cache = make_roi(m_image_prev, task->roi);
         cv::Mat cost_image = make_roi(m_image, task->roi);
         cv::cvtColor(cost_image_cache, cost_image_cache, cv::COLOR_BGR2GRAY);
         cv::cvtColor(cost_image, cost_image, cv::COLOR_BGR2GRAY);

--- a/src/MaaCore/Vision/Battle/BattlefieldMatcher.cpp
+++ b/src/MaaCore/Vision/Battle/BattlefieldMatcher.cpp
@@ -51,7 +51,7 @@ BattlefieldMatcher::ResultOpt BattlefieldMatcher::analyze() const
 
     if (m_object_of_interest.costs) {
         result.costs = costs_analyze();
-        if (result.costs.status == MatchStatus::Match) {
+        if (result.costs.status == MatchStatus::Success) {
             return std::nullopt;
         }
     }
@@ -346,10 +346,10 @@ BattlefieldMatcher::MatchResult<int> BattlefieldMatcher::costs_analyze() const
         cv::matchTemplate(cost_image, cost_image_cache, match, cv::TM_CCOEFF_NORMED);
         double mark;
         cv::minMaxLoc(match, nullptr, &mark);
-
+        // 正常在 0.997-1 之间波动, 少有0.995
+        // _5->_6 的分数最高, 0.85上下
         const double threshold = static_cast<double>(task->special_params[0]) / 100;
-        if (mark > threshold) { // 正常在 0.997-1 之间波动, 少有0.995
-            // _5->_6 的分数最高, 0.85上下
+        if (mark > threshold) {
             return BattlefieldMatcher::MatchResult<int> { .status = MatchStatus::HitCache };
         }
     }
@@ -363,7 +363,7 @@ BattlefieldMatcher::MatchResult<int> BattlefieldMatcher::costs_analyze() const
 
     int cost = 0;
     if (utils::chars_to_number(cost_opt->text, cost)) {
-        return BattlefieldMatcher::MatchResult<int> { .value = cost, .status = MatchStatus::Match };
+        return BattlefieldMatcher::MatchResult<int> { .value = cost, .status = MatchStatus::Success };
     }
     return BattlefieldMatcher::MatchResult<int> {};
 }

--- a/src/MaaCore/Vision/Battle/BattlefieldMatcher.cpp
+++ b/src/MaaCore/Vision/Battle/BattlefieldMatcher.cpp
@@ -355,7 +355,7 @@ BattlefieldMatcher::MatchResult<int> BattlefieldMatcher::costs_analyze() const
         // _5->_6 的分数最高, 0.85上下
         const double threshold = static_cast<double>(task->special_params[0]) / 100;
         if (mark > threshold) {
-            return MatchResult<int> { .status = MatchStatus::HitCache };
+            return BattlefieldMatcher::MatchResult<int> { .status = MatchStatus::HitCache };
         }
     }
 
@@ -363,14 +363,14 @@ BattlefieldMatcher::MatchResult<int> BattlefieldMatcher::costs_analyze() const
     cost_analyzer.set_task_info(task);
     auto cost_opt = cost_analyzer.analyze();
     if (!cost_opt) {
-        return MatchResult<int> {};
+        return BattlefieldMatcher::MatchResult<int> {};
     }
 
     int cost = 0;
     if (utils::chars_to_number(cost_opt->text, cost)) {
-        return MatchResult { .value = cost, .status = MatchStatus::Success };
+        return BattlefieldMatcher::MatchResult { .value = cost, .status = MatchStatus::Success };
     }
-    return MatchResult<int> {};
+    return BattlefieldMatcher::MatchResult<int> {};
 }
 
 bool BattlefieldMatcher::pause_button_analyze() const

--- a/src/MaaCore/Vision/Battle/BattlefieldMatcher.cpp
+++ b/src/MaaCore/Vision/Battle/BattlefieldMatcher.cpp
@@ -355,7 +355,7 @@ BattlefieldMatcher::MatchResult<int> BattlefieldMatcher::costs_analyze() const
         // _5->_6 的分数最高, 0.85上下
         const double threshold = static_cast<double>(task->special_params[0]) / 100;
         if (mark > threshold) {
-            return BattlefieldMatcher::MatchResult<int> { .status = MatchStatus::HitCache };
+            return MatchResult<int> { .status = MatchStatus::HitCache };
         }
     }
 
@@ -363,14 +363,14 @@ BattlefieldMatcher::MatchResult<int> BattlefieldMatcher::costs_analyze() const
     cost_analyzer.set_task_info(task);
     auto cost_opt = cost_analyzer.analyze();
     if (!cost_opt) {
-        return BattlefieldMatcher::MatchResult<int> {};
+        return MatchResult<int> {};
     }
 
     int cost = 0;
     if (utils::chars_to_number(cost_opt->text, cost)) {
-        return BattlefieldMatcher::MatchResult<int> { .value = cost, .status = MatchStatus::Success };
+        return MatchResult { .value = cost, .status = MatchStatus::Success };
     }
-    return BattlefieldMatcher::MatchResult<int> {};
+    return MatchResult<int> {};
 }
 
 bool BattlefieldMatcher::pause_button_analyze() const

--- a/src/MaaCore/Vision/Battle/BattlefieldMatcher.h
+++ b/src/MaaCore/Vision/Battle/BattlefieldMatcher.h
@@ -21,8 +21,8 @@ public:
 
     enum MatchStatus
     {
-        Invalid = 0,  // 匹配错误
-        Match = 1,  // 匹配成功
+        Invalid = 0,  // 识别失败
+        Success = 1,  // 识别成功
         HitCache = 2, // 图像命中缓存, 不进行识别
     };
 
@@ -30,16 +30,14 @@ public:
     struct MatchResult
     {
         T value;
-        MatchStatus status;
+        MatchStatus status = MatchStatus::Invalid;
     };
 
     struct Result
     {
         ObjectOfInterest object_of_interest;
-
         std::vector<battle::DeploymentOper> deployment;
-        // kills / total_kills
-        std::optional<std::pair<int, int>> kills;
+        std::optional<std::pair<int, int>> kills; // kills / total_kills
         MatchResult<int> costs;
 
         // bool in_detail = false;

--- a/src/MaaCore/Vision/Battle/BattlefieldMatcher.h
+++ b/src/MaaCore/Vision/Battle/BattlefieldMatcher.h
@@ -21,9 +21,16 @@ public:
 
     enum MatchStatus
     {
-        Invalid = 0, // 匹配错误
-        // Match = 1,    // 匹配成功
+        Invalid = 0,  // 匹配错误
+        Match = 1,  // 匹配成功
         HitCache = 2, // 图像命中缓存, 不进行识别
+    };
+
+    template <typename T>
+    struct MatchResult
+    {
+        T value;
+        MatchStatus status;
     };
 
     struct Result
@@ -33,7 +40,7 @@ public:
         std::vector<battle::DeploymentOper> deployment;
         // kills / total_kills
         std::optional<std::pair<int, int>> kills;
-        std::variant<int, MatchStatus> costs;
+        MatchResult<int> costs;
 
         // bool in_detail = false;
         bool speed_button = false;
@@ -64,14 +71,14 @@ protected:
     int oper_cost_analyze(const Rect& roi) const;
     bool oper_available_analyze(const Rect& roi) const;
 
-    std::optional<std::pair<int, int>> kills_analyze() const;                       // 识别击杀数
-    bool cost_symbol_analyze() const;                                               // 识别费用左侧图标
-    std::variant<int, asst::BattlefieldMatcher::MatchStatus> costs_analyze() const; // 识别费用
-    bool in_detail_analyze() const;                                                 // 识别是否在详情页
-    bool speed_button_analyze() const;     // 识别是否有加速按钮（在详情页就没有）
+    std::optional<std::pair<int, int>> kills_analyze() const; // 识别击杀数
+    bool cost_symbol_analyze() const;                         // 识别费用左侧图标
+    MatchResult<int> costs_analyze() const;                   // 识别费用
+    bool in_detail_analyze() const;                           // 识别是否在详情页
+    bool speed_button_analyze() const;                        // 识别是否有加速按钮（在详情页就没有）
 
-    ObjectOfInterest m_object_of_interest; // 待识别的目标
-    int m_total_kills_prompt = 0;          // 之前的击杀总数，因为击杀数经常识别不准所以依赖外部传入作为参考
-    cv::Mat m_image_cache;                 // 缓存图像, 用于判断费用, 击杀数是否变化. 无变化则不重新识别
+    ObjectOfInterest m_object_of_interest;                    // 待识别的目标
+    int m_total_kills_prompt = 0; // 之前的击杀总数，因为击杀数经常识别不准所以依赖外部传入作为参考
+    cv::Mat m_image_cache;        // 缓存图像, 用于判断费用, 击杀数是否变化. 无变化则不重新识别
 };
 } // namespace asst

--- a/src/MaaCore/Vision/Battle/BattlefieldMatcher.h
+++ b/src/MaaCore/Vision/Battle/BattlefieldMatcher.h
@@ -53,9 +53,7 @@ public:
 
     void set_object_of_interest(ObjectOfInterest obj);
     void set_total_kills_prompt(int prompt);
-
-    void set_image_cache(const cv::Mat& image) { m_image_cache = image; }
-
+    void set_image_prev(const cv::Mat& image);
     ResultOpt analyze() const;
 
 protected:
@@ -77,6 +75,6 @@ protected:
 
     ObjectOfInterest m_object_of_interest;                    // 待识别的目标
     int m_total_kills_prompt = 0; // 之前的击杀总数，因为击杀数经常识别不准所以依赖外部传入作为参考
-    cv::Mat m_image_cache;        // 缓存图像, 用于判断费用, 击杀数是否变化. 无变化则不重新识别
+    cv::Mat m_image_prev;         // 缓存图像, 用于判断费用, 击杀数是否变化. 无变化则不重新识别
 };
 } // namespace asst

--- a/src/MaaCore/Vision/Battle/BattlefieldMatcher.h
+++ b/src/MaaCore/Vision/Battle/BattlefieldMatcher.h
@@ -29,7 +29,7 @@ public:
     template <typename T>
     struct MatchResult
     {
-        T value;
+        T value {};
         MatchStatus status = MatchStatus::Invalid;
     };
 


### PR DESCRIPTION
理想环境测试：待部署1，无技能检测，单步骤等费用

没上费用缓存
没开GPU加速
![G9M5J Y20PW9(9UX0A@Y9GE](https://github.com/user-attachments/assets/fbb7a6de-d732-48fd-a5c6-6d064e9c1f3b)

开了GPU加速
![P4$~`M~I977FH5%S7D0W1@V](https://github.com/user-attachments/assets/ec26a793-9490-41db-b15f-4f0f8f8297b8)


上费用ocr缓存
不开GPU加速
![43UTTI0G%GUN`_OJ2R)ZYP](https://github.com/user-attachments/assets/62617ca3-0009-457d-9b3b-9f31bb7b4999)

 
开GPU加速
![MRCIHH VMOUM({K0%A8@Q(F](https://github.com/user-attachments/assets/27caf93d-ade8-4d11-b978-c726533ecfbd)

