### PR TITLE
i18n: wpf CN 修改描述`连战次数` -> `代理倍率`

### DIFF
--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -440,7 +440,7 @@
     <system:String x:Key="UseRemainingSanityStageTip">在完成主任务后刷取指定关卡，不使用理智药/碎石</system:String>
     <system:String x:Key="UseExpiringMedicine">无限吃48小时内过期的理智药</system:String>
     <system:String x:Key="HideUnavailableStage">隐藏当日不开放关卡</system:String>
-    <system:String x:Key="HideSeries">隐藏连战次数</system:String>
+    <system:String x:Key="HideSeries">隐藏代理倍率</system:String>
     <system:String x:Key="CustomInfrastPlanShowInFightSettings">显示基建计划</system:String>
     <system:String x:Key="MainViewButtonFeature">主界面可选择按钮功能</system:String>
     <system:String x:Key="CustomStageCode">手动输入关卡名</system:String>
@@ -560,7 +560,7 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="PerformBattles">指定次数</system:String>
     <system:String x:Key="AssignedMaterial">指定材料</system:String>
     <system:String x:Key="Quantity">刷取数量</system:String>
-    <system:String x:Key="Series">连战次数</system:String>
+    <system:String x:Key="Series">代理倍率</system:String>
     <system:String x:Key="StageSelect">关卡选择</system:String>
     <system:String x:Key="StageSelect2">备选</system:String>
     <system:String x:Key="RemainingSanityStage">剩余理智</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -439,7 +439,7 @@
     <system:String x:Key="UseRemainingSanityStageTip">在完成主任務後刷取指定關卡，不使用理智藥 / 碎石</system:String>
     <system:String x:Key="UseExpiringMedicine">無限吃 48 小時內過期的理智藥</system:String>
     <system:String x:Key="HideUnavailableStage">隱藏當日不開放關卡</system:String>
-    <system:String x:Key="HideSeries">隱藏連戰次數</system:String>
+    <system:String x:Key="HideSeries">隱藏代理倍率</system:String>
     <system:String x:Key="CustomInfrastPlanShowInFightSettings">顯示基建計劃</system:String>
     <system:String x:Key="MainViewButtonFeature">主介面可選擇按鈕功能</system:String>
     <system:String x:Key="CustomStageCode">手動輸入關卡名</system:String>
@@ -558,7 +558,7 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="PerformBattles">指定次數</system:String>
     <system:String x:Key="AssignedMaterial">指定材料</system:String>
     <system:String x:Key="Quantity">刷取數量</system:String>
-    <system:String x:Key="Series">連戰次數</system:String>
+    <system:String x:Key="Series">代理倍率</system:String>
     <system:String x:Key="StageSelect">關卡選擇</system:String>
     <system:String x:Key="StageSelect2">備選</system:String>
     <system:String x:Key="RemainingSanityStage">剩餘理智</system:String>


### PR DESCRIPTION
由于在`连战次数(Series)`与`指定次数`联动后，存在以 `指定次数`=2，`连战次数`=3 运行MAA的情况，修改`连战次数`的中文描述以贴近游戏描述

@Constrat Need I modify EN's?

![367f878a-074f-493d-a23c-1d2856d60403](https://github.com/user-attachments/assets/664a25f2-d883-485a-93e5-ebe872ae91ca)
![f80962b5-6db7-4671-be69-c08196fc5074](https://github.com/user-attachments/assets/7a0bf918-6d17-4612-8b2b-f0117c61151e)
