### PR TITLE
feat: 自动战斗费用击杀数缓存, 减少性能消耗

### DIFF
--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -3864,7 +3864,9 @@
         "algorithm": "OcrDetect",
         "isAscii": true,
         "text": [],
-        "roi": [50, 0, 100, 40]
+        "roi": [50, 0, 100, 40],
+        "specialParams_doc": "Kill区域变化阈值, 模板匹配, 100=1.0; 正常在 0.997-1 之间波动, 少有0.995; _5->_6 的分数最高, 可达0.94",
+        "specialParams": [98]
     },
     "BattleCostData": {
         "baseTask": "NumberOcrReplace",

--- a/src/MaaCore/Common/AsstTypes.h
+++ b/src/MaaCore/Common/AsstTypes.h
@@ -3,6 +3,7 @@
 #include <array>
 #include <climits>
 #include <cmath>
+#include <concepts>
 #include <functional>
 #include <optional>
 #include <ostream>
@@ -214,6 +215,37 @@ struct Rect
     explicit operator std::string() const { return to_string(); }
 
     Rect move(Rect move) const { return { x + move.x, y + move.y, move.width, move.height }; }
+
+    // 创建一个包含所有传入Rect的最小包围盒
+    static Rect bounding_box(const std::vector<Rect>& rects)
+    {
+        if (rects.empty()) {
+            return {};
+        }
+
+        int min_x = INT_MAX;
+        int min_y = INT_MAX;
+        int max_x = INT_MIN;
+        int max_y = INT_MIN;
+
+        for (const auto& rect : rects) {
+            min_x = std::min<int>(min_x, rect.x);
+            min_y = std::min<int>(min_y, rect.y);
+            max_x = std::max<int>(max_x, rect.x + rect.width);
+            max_y = std::max<int>(max_y, rect.y + rect.height);
+        }
+
+        return { min_x, min_y, max_x - min_x, max_y - min_y };
+    }
+
+    // 创建一个包含所有传入Rect的最小包围盒
+    template <typename... Args>
+    requires(std::same_as<std::remove_cvref_t<Args>, Rect> && ...)
+    static Rect bounding_box(const Rect& first, const Args&... args)
+    {
+        std::vector<Rect> rects = { first, args... };
+        return bounding_box(rects);
+    }
 
     int x = 0;
     int y = 0;

--- a/src/MaaCore/Task/BattleHelper.h
+++ b/src/MaaCore/Task/BattleHelper.h
@@ -53,7 +53,7 @@ protected:
         std::vector<battle::DeploymentOper>& cur_opers,
         const std::vector<battle::DeploymentOper>& old_deployment_opers,
         bool stop_on_unknown);
-    bool update_kills(const cv::Mat& reusable = cv::Mat());
+    bool update_kills(const cv::Mat& image, const cv::Mat& image_prev = cv::Mat());
     bool update_cost(const cv::Mat& image, const cv::Mat& image_prev = cv::Mat());
 
     cv::Mat get_top_view(const cv::Mat& cam_img, bool side = true);

--- a/src/MaaCore/Task/Experiment/CombatRecordRecognitionTask.cpp
+++ b/src/MaaCore/Task/Experiment/CombatRecordRecognitionTask.cpp
@@ -377,8 +377,8 @@ bool asst::CombatRecordRecognitionTask::slice_video()
         m_battle_end_frame = 0;
         not_in_battle_count = 0;
 
-        if (result_opt->kills) {
-            auto& [cur_kills, cur_total_kills] = *result_opt->kills;
+        if (result_opt->kills.status == BattlefieldMatcher::MatchStatus::Success) {
+            auto& [cur_kills, cur_total_kills] = result_opt->kills.value;
             if (cur_kills != latest_kills) {
                 m_frame_kills.emplace_back(std::make_pair(i, cur_kills));
             }

--- a/src/MaaCore/Task/Miscellaneous/BattleProcessTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleProcessTask.cpp
@@ -340,7 +340,7 @@ bool asst::BattleProcessTask::wait_condition(const Action& action)
     if (m_kills < action.kills) {
         update_image_if_empty();
         while (!need_exit() && m_kills < action.kills) {
-            update_kills(image);
+            update_kills(image, image_prev);
             if (m_kills >= action.kills) {
                 break;
             }

--- a/src/MaaCore/Vision/Battle/BattlefieldMatcher.cpp
+++ b/src/MaaCore/Vision/Battle/BattlefieldMatcher.cpp
@@ -279,7 +279,7 @@ BattlefieldMatcher::MatchResult<std::pair<int, int>> BattlefieldMatcher::kills_a
     TemplDetOCRer kills_analyzer(m_image);
     kills_analyzer.set_task_info("BattleKillsFlag", "BattleKills");
     kills_analyzer.set_replace(Task.get<OcrTaskInfo>("NumberOcrReplace")->replace_map);
-
+    kills_analyzer.set_ocr_use_raw(true);
     auto kills_opt = kills_analyzer.analyze();
     if (!kills_opt) {
         return {};

--- a/src/MaaCore/Vision/Battle/BattlefieldMatcher.h
+++ b/src/MaaCore/Vision/Battle/BattlefieldMatcher.h
@@ -37,7 +37,7 @@ public:
     {
         ObjectOfInterest object_of_interest;
         std::vector<battle::DeploymentOper> deployment;
-        std::optional<std::pair<int, int>> kills; // kills / total_kills
+        MatchResult<std::pair<int, int>> kills; // kills / total_kills
         MatchResult<int> costs;
 
         // bool in_detail = false;
@@ -67,9 +67,11 @@ protected:
     int oper_cost_analyze(const Rect& roi) const;
     bool oper_available_analyze(const Rect& roi) const;
 
-    std::optional<std::pair<int, int>> kills_analyze() const; // 识别击杀数
-    bool cost_symbol_analyze() const;                         // 识别费用左侧图标
-    MatchResult<int> costs_analyze() const;                   // 识别费用
+    MatchResult<std::pair<int, int>> kills_analyze() const; // 识别击杀数
+    // 识别是否持有费用是否命中缓存
+    bool hit_kills_cache() const;
+    bool cost_symbol_analyze() const;       // 识别费用左侧图标
+    MatchResult<int> costs_analyze() const; // 识别费用
     // 识别是否持有费用是否命中缓存
     bool hit_costs_cache() const;
     bool in_detail_analyze() const;        // 识别是否在详情页


### PR DESCRIPTION
测试条件：待部署1，无技能检测，单部署等击杀，不开GPU加速

一场`1-7`的score情况：
- 击杀数未变化
  - 1.0 (1128: 30.87%)
  - 0.99 (2519: 68.94%)
  - 0.98 (5: 0.14%)
  - 0.97 (2: 0.055%)
  - 0.95~0.96 未出现
- 击杀变化
  - 0.94 (1)
  - 0.93 (2)
  - 0.92 (1)
  - 0.86 (1)
  - ...
[asst.log](https://github.com/user-attachments/files/20582872/asst.log)

有缓存：CPU 15~17%
![image](https://github.com/user-attachments/assets/0aa62313-4418-4837-ba0d-c3768aeab04a)


无缓存：CPU 48~52%
![image](https://github.com/user-attachments/assets/b71b838d-089d-4aa0-9e78-23c7d65c52cf)
