### PR TITLE
fix: 基建高级设置中部分元素未正确隐藏

### DIFF
--- a/src/MaaWpfGui/Views/UserControl/TaskQueue/InfrastSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/TaskQueue/InfrastSettingsUserControl.xaml
@@ -161,13 +161,15 @@
                 IsChecked="{Binding DormTrustEnabled}"
                 Visibility="{c:Binding 'InfrastMode != task:InfrastMode.Rotation',
                                        Source={x:Static setting:TaskQueueViewModel.InfrastTask}}" />
-            <StackPanel Margin="0,10" Orientation="Horizontal">
+            <StackPanel 
+                Margin="0,10"
+                Orientation="Horizontal"
+                Visibility="{c:Binding 'InfrastMode != task:InfrastMode.Rotation',
+                                       Source={x:Static setting:TaskQueueViewModel.InfrastTask}}">
                 <CheckBox
                     MaxWidth="{c:Binding '220 - ActualWidth',
                                          ElementName=DormFilterNotStationedTipsTooltipBlock}"
-                    IsChecked="{c:Binding DormFilterNotStationedEnabled}"
-                    Visibility="{c:Binding 'InfrastMode != task:InfrastMode.Rotation',
-                                           Source={x:Static setting:TaskQueueViewModel.InfrastTask}}">
+                    IsChecked="{c:Binding DormFilterNotStationedEnabled}">
                     <controls:TextBlock Text="{DynamicResource DormFilterNotStationedEnabled}" TextWrapping="Wrap" />
                 </CheckBox>
                 <controls:TooltipBlock x:Name="DormFilterNotStationedTipsTooltipBlock" TooltipText="{DynamicResource DormFilterNotStationedTips}" />


### PR DESCRIPTION
当基建模式设置为“队列轮换”时，高级设置中的“不将已进驻的干员放入宿舍”项旁的提示图标未正确隐藏

Resolves #12981 