### PR TITLE
fix: 肉鸽结算难度报错

### DIFF
--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/RoguelikeSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/RoguelikeSettingsUserControlModel.cs
@@ -921,7 +921,30 @@ public class RoguelikeSettingsUserControlModel : TaskViewModel
                 {// 肉鸽结算
                     var report = subTaskDetails;
                     var pass = (bool)report!["game_pass"]!;
-                    var difficulty = (int)(report["difficulty"] ?? -1);
+
+                    int difficulty = -1;
+                    var difficultyStr = (string?)(report["difficulty"] ?? string.Empty);
+                    if (!string.IsNullOrEmpty(difficultyStr))
+                    {
+                        string numericString = string.Empty;
+                        foreach (char c in difficultyStr)
+                        {
+                            if ((c >= '0' && c <= '9') || c == ' ')
+                            {
+                                numericString = string.Concat(numericString, c);
+                            }
+                            else
+                            {
+                                numericString = string.Empty;
+                            }
+                        }
+
+                        if (Int32.TryParse(numericString, out int temp))
+                        {
+                            difficulty = temp;
+                        }
+                    }
+
                     var roguelikeInfo = string.Format(
                         LocalizationHelper.GetString("RoguelikeSettlement"),
                         pass ? "✓" : "✗",
@@ -932,7 +955,7 @@ public class RoguelikeSettingsUserControlModel : TaskViewModel
                         report["boss"],
                         report["recruit"],
                         report["collection"],
-                        difficulty,
+                        report["difficulty"],
                         report["score"],
                         report["exp"],
                         report["skill"]);


### PR DESCRIPTION
`report["difficulty"]` 内容实际为 "波瀾万丈3" 形式，执行强制转换会报错，所以改成了一种非常脱裤子放屁的转换方式。
附件为discord群内的错误报告
[report_06-20_14-40-38.zip](https://github.com/user-attachments/files/20851412/report_06-20_14-40-38.zip)
