### PR TITLE
feat: '缺少干员时仍然追加或补充低信赖干员'功能

### DIFF
--- a/src/MaaCore/Task/Interface/CopilotTask.cpp
+++ b/src/MaaCore/Task/Interface/CopilotTask.cpp
@@ -50,7 +50,7 @@ asst::CopilotTask::CopilotTask(const AsstCallback& callback, Assistant* inst) :
     start_2_tp->set_tasks({ "BattleStartAll" }).set_retry_times(3).set_ignore_error(false);
     m_subtasks.emplace_back(start_2_tp);
 
-    // 跳过“以下干员出战后将被禁用，是否继续？”对话框
+    // 跳过"以下干员出战后将被禁用，是否继续？"对话框
     auto start_3_tp = std::make_shared<ProcessTask>(callback, inst, TaskType);
     start_3_tp->set_tasks({ "SkipForbiddenOperConfirm", "Stop" }).set_ignore_error(false);
     m_subtasks.emplace_back(start_3_tp);
@@ -85,6 +85,7 @@ bool asst::CopilotTask::set_params(const json::value& params)
     int select_formation = params.get("select_formation", 0);                        // 选择第几个编队，0为不选择
     bool add_trust = params.get("add_trust", false);                                 // 是否自动补信赖
     bool add_user_additional = params.contains("user_additional");                   // 是否自动补用户自定义干员
+    bool continue_when_missing_operators = params.get("continue_when_missing_operators", false);  // 是否在缺少干员时继续编队
     auto support_unit_usage = static_cast<SupportUnitUsage>(
         params.get("support_unit_usage", static_cast<int>(SupportUnitUsage::None))); // 助战干员使用模式
     std::string support_unit_name = params.get("support_unit_name", std::string());
@@ -149,6 +150,7 @@ bool asst::CopilotTask::set_params(const json::value& params)
     m_formation_task_ptr->set_add_trust(add_trust);
     m_formation_task_ptr->set_support_unit_usage(support_unit_usage);
     m_formation_task_ptr->set_specific_support_unit(support_unit_name);
+    m_formation_task_ptr->set_continue_when_missing_operators(continue_when_missing_operators);
 
     if (auto opt = params.find<json::array>("user_additional"); add_user_additional && opt) {
         std::vector<std::pair<std::string, int>> user_additional;

--- a/src/MaaCore/Task/Interface/CopilotTask.cpp
+++ b/src/MaaCore/Task/Interface/CopilotTask.cpp
@@ -85,7 +85,8 @@ bool asst::CopilotTask::set_params(const json::value& params)
     int select_formation = params.get("select_formation", 0);                        // 选择第几个编队，0为不选择
     bool add_trust = params.get("add_trust", false);                                 // 是否自动补信赖
     bool add_user_additional = params.contains("user_additional");                   // 是否自动补用户自定义干员
-    bool continue_when_missing_operators = params.get("continue_when_missing_operators", false);  // 是否在缺少干员时继续编队
+    bool continue_when_missing_operators =
+        params.get("continue_when_missing_operators", false);                        // 是否在缺少干员时继续编队
     auto support_unit_usage = static_cast<SupportUnitUsage>(
         params.get("support_unit_usage", static_cast<int>(SupportUnitUsage::None))); // 助战干员使用模式
     std::string support_unit_name = params.get("support_unit_name", std::string());

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -107,12 +107,15 @@ bool asst::BattleFormationTask::_run()
         Log.info(__FUNCTION__, "| Returned to quick formation scene");
     }
 
-    // 在尝试补齐编队后依然有缺失干员，自动编队失败
-    if (!missing_operators.empty()) {
-        report_missing_operators(missing_operators);
+    // 缓存缺失干员列表
+    std::vector<OperGroup> cached_missing_operators = missing_operators;
+
+    // 如果没有勾选"缺少干员时仍然追加或补充低信赖干员"，则报告缺失干员并返回失败
+    if (!m_continue_when_missing_operators) {
+        report_missing_operators(cached_missing_operators);
         return false;
     }
-
+    
     // 对于有在干员组中存在的自定干员，无法提前得知是否成功编入，故不提前加入编队
     if (!m_user_additional.empty()) {
         auto limit = 12 - m_size_of_operators_in_formation;
@@ -133,12 +136,20 @@ bool asst::BattleFormationTask::_run()
             add_formation(role, oper_groups, missing_operators);
         }
     }
-
+    
+    // 添加其他附加干员和信赖干员
     add_additional();
     if (m_add_trust) {
         add_trust_operators();
     }
     confirm_selection();
+    
+    // 在所有干员都添加完成后，再判断是否有缺失干员
+    if (!cached_missing_operators.empty()) {
+        // 然后再报告缺失干员
+        report_missing_operators(cached_missing_operators);
+        return false;
+    }
 
     if (m_support_unit_usage == SupportUnitUsage::Specific && !m_used_support_unit) { // 使用指定助战干员
         m_used_support_unit = m_use_support_unit_task_ptr->try_add_support_unit({ m_specific_support_unit }, 5, true);

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -115,7 +115,7 @@ bool asst::BattleFormationTask::_run()
         report_missing_operators(cached_missing_operators);
         return false;
     }
-    
+
     // 对于有在干员组中存在的自定干员，无法提前得知是否成功编入，故不提前加入编队
     if (!m_user_additional.empty()) {
         auto limit = 12 - m_size_of_operators_in_formation;
@@ -136,14 +136,14 @@ bool asst::BattleFormationTask::_run()
             add_formation(role, oper_groups, missing_operators);
         }
     }
-    
+
     // 添加其他附加干员和信赖干员
     add_additional();
     if (m_add_trust) {
         add_trust_operators();
     }
     confirm_selection();
-    
+
     // 在所有干员都添加完成后，再判断是否有缺失干员
     if (!cached_missing_operators.empty()) {
         // 然后再报告缺失干员

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.h
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.h
@@ -59,6 +59,9 @@ public:
 
     void set_data_resource(DataResource resource) { m_data_resource = resource; }
 
+    // 设置是否在缺少干员时继续编队
+    void set_continue_when_missing_operators(bool value) { m_continue_when_missing_operators = value; }
+
     // ————————————————————————————————
     // 助战干员选择相关
     // ————————————————————————————————
@@ -119,6 +122,7 @@ protected:
     std::string m_last_oper_name;
     int m_select_formation_index = 0;
     int m_missing_retry_times = 1; // 识别不到干员的重试次数
+    bool m_continue_when_missing_operators = false; // 是否在缺少干员时继续编队
 
     // ————————————————————————————————
     // 助战干员选择相关

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.h
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.h
@@ -121,7 +121,7 @@ protected:
     std::vector<AdditionalFormation> m_additional;
     std::string m_last_oper_name;
     int m_select_formation_index = 0;
-    int m_missing_retry_times = 1; // 识别不到干员的重试次数
+    int m_missing_retry_times = 1;                  // 识别不到干员的重试次数
     bool m_continue_when_missing_operators = false; // 是否在缺少干员时继续编队
 
     // ————————————————————————————————

--- a/src/MaaWpfGui/Constants/ConfigurationKeys.cs
+++ b/src/MaaWpfGui/Constants/ConfigurationKeys.cs
@@ -203,6 +203,7 @@ namespace MaaWpfGui.Constants
         public const string CopilotUserAdditional = "Copilot.UserAdditional";
         public const string CopilotLoopTimes = "Copilot.LoopTimes";
         public const string CopilotTaskList = "Copilot.CopilotTaskList";
+        public const string CopilotContinueWhenMissingOperators = "Copilot.ContinueWhenMissingOperators";
         public const string UpdateProxy = "VersionUpdate.Proxy";
         public const string ProxyType = "VersionUpdate.ProxyType";
         public const string VersionType = "VersionUpdate.VersionType";

--- a/src/MaaWpfGui/Models/AsstTasks/AsstCopilotTask.cs
+++ b/src/MaaWpfGui/Models/AsstTasks/AsstCopilotTask.cs
@@ -68,6 +68,11 @@ public class AsstCopilotTask : AsstBaseTask
     public bool UseSanityPotion { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether 缺少干员时仍然追加或补充低信赖干员
+    /// </summary>
+    public bool ContinueWhenMissingOperators { get; set; }
+
+    /// <summary>
     /// Gets or sets 自定干员列表
     /// </summary>
     public List<UserAdditional>? UserAdditionals { get; set; }
@@ -83,6 +88,7 @@ public class AsstCopilotTask : AsstBaseTask
             ["is_raid"] = IsRaid,
             ["loop_times"] = LoopTimes,
             ["use_sanity_potion"] = UseSanityPotion,
+            ["continue_when_missing_operators"] = ContinueWhenMissingOperators,
         };
 
         if (UserAdditionals?.Count > 0)

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -740,9 +740,11 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="ThanksForLikeWebJson">感谢评价！\n网页已经开放评论区，欢迎前往留下你的评论！</system:String>
     <system:String x:Key="AutoSquad">自动编队</system:String>
     <system:String x:Key="AutoSquadTip">自动编队可能无法识别带有 ｢特别关注｣ 标记的干员</system:String>
-    <system:String x:Key="AddTrust">补充低信赖干员</system:String>
+    <system:String x:Key="AddTrust">追加低信赖</system:String>
     <system:String x:Key="AddUserAdditional">追加自定干员</system:String>
     <system:String x:Key="AddUserAdditionalTip">以英文 ｢;｣ 为分隔符，英文 ｢,｣ 分隔干员名与技能，例: 史尔特尔,3;艾雅法拉,1</system:String>
+    <system:String x:Key="ContinueWhenMissingOperators">缺少干员时仍然追加或补充低信赖干员</system:String>
+    <system:String x:Key="ContinueWhenMissingOperatorsTip">当作业中的一些干员不在当前帐号时，仍然添加已有的干员，并追加自定义干员和低信赖干员</system:String>
     <system:String x:Key="LoopTimes">循环次数</system:String>
     <system:String x:Key="UseCopilotList">战斗列表</system:String>
     <system:String x:Key="UseCopilotListTip" xml:space="preserve">不支持跨章节导航。仅支持:

--- a/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
@@ -225,6 +225,21 @@ namespace MaaWpfGui.ViewModels.UI
             set => SetAndNotify(ref _useSanityPotion, value);
         }
 
+        private bool _continueWhenMissingOperators = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.CopilotContinueWhenMissingOperators, bool.FalseString));
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to continue adding operators when missing required operators.
+        /// </summary>
+        public bool ContinueWhenMissingOperators
+        {
+            get => _continueWhenMissingOperators;
+            set
+            {
+                SetAndNotify(ref _continueWhenMissingOperators, value);
+                ConfigurationHelper.SetValue(ConfigurationKeys.CopilotContinueWhenMissingOperators, value.ToString());
+            }
+        }
+
         private bool _addUserAdditional = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.CopilotAddUserAdditional, bool.FalseString));
 
         /// <summary>
@@ -1192,6 +1207,7 @@ namespace MaaWpfGui.ViewModels.UI
                          IsRaid = model.IsRaid,
                          LoopTimes = Loop ? LoopTimes : 1,
                          UseSanityPotion = _useSanityPotion,
+                         ContinueWhenMissingOperators = _continueWhenMissingOperators,
                      };
                      var (type, param) = task.Serialize();
                      return Instances.AsstProxy.AsstAppendTaskWithEncoding(AsstProxy.TaskType.Copilot, type, param);
@@ -1232,6 +1248,7 @@ namespace MaaWpfGui.ViewModels.UI
                     NeedNavigate = false,
                     LoopTimes = Loop ? LoopTimes : 1,
                     UseSanityPotion = _useSanityPotion,
+                    ContinueWhenMissingOperators = _continueWhenMissingOperators,
                 };
                 ret = Instances.AsstProxy.AsstAppendTaskWithEncoding(AsstProxy.TaskType.Copilot, _taskType, task.Serialize().Params);
                 ret &= Instances.AsstProxy.AsstStart();

--- a/src/MaaWpfGui/Views/UI/CopilotView.xaml
+++ b/src/MaaWpfGui/Views/UI/CopilotView.xaml
@@ -166,6 +166,20 @@
                         Visibility="{c:Binding UseCopilotList}" />
                 </StackPanel>
                 <StackPanel
+                    HorizontalAlignment="Center"
+                    IsEnabled="{Binding Idle}"
+                    Orientation="Horizontal">
+                    <CheckBox
+                        Height="30"
+                        Margin="10,0"
+                        HorizontalAlignment="Center"
+                        Content="{DynamicResource ContinueWhenMissingOperators}"
+                        IsChecked="{Binding ContinueWhenMissingOperators}"
+                        ToolTip="{DynamicResource ContinueWhenMissingOperatorsTip}"
+                        IsEnabled="{Binding Idle}"
+                        Visibility="{c:Binding Form}" />
+                </StackPanel>
+                <StackPanel
                     Height="30"
                     Margin="0,7"
                     HorizontalAlignment="Center"


### PR DESCRIPTION
   ## 功能描述
   添加了新的UI选项："缺少干员时仍然追加或补充低信赖干员"，允许在自动编队时即使缺少必要干员也能继续完成编队。

   ## 解决的问题
   之前当自动编队缺少干员时会直接报错并终止编队，导致无法自动编入自定义干员和追加低信赖干员。现在用户可以选择继续编队流程。

   ## 实现方式
   1. 在UI中添加选项控制此功能
   2. 修改BattleFormationTask类增加对应标志位
   3. 修改编队逻辑，在缺少干员时先判断是否勾选了选项，再决定是否终止编队
   
   ## 测试情况
   已在本地测试，功能正常工作。