### PR TITLE
fix: YostarKR HS rerun navigation

### DIFF
--- a/resource/global/YoStarKR/resource/tasks/Stages/HS.json
+++ b/resource/global/YoStarKR/resource/tasks/Stages/HS.json
@@ -1,21 +1,15 @@
 {
+    "HS-OpenOpt": {
+        "algorithm": "JustReturn",
+        "next": ["HS-OpenOcr", "HS-Open"]
+    },
     "HS-Open": {
-        "baseTask": "SS-Open"
-    },
-    "HS-9": {
-        "sub": ["HS-Open", "HSChapterToHS"]
-    },
-    "HS-8": {
-        "sub": ["HS-Open", "HSChapterToHS"]
-    },
-    "HS-7": {
-        "sub": ["HS-Open", "HSChapterToHS"]
-    },
-    "HS-5": {
-        "sub": ["HS-Open", "HSChapterToHS"]
+        "baseTask": "SS-Open",
+        "template": ["StageSideStory.png", "StageActivity.png"],
+        "next": ["HSChapterToHS"]
     },
     "HS-OpenOcr": {
-        "text": ["회서리", "이벤트", "개방중"]
+        "text": ["회서리"]
     },
     "HSChapterToHS": {
         "text": ["경작지"]

--- a/resource/global/YoStarKR/resource/tasks/Stages/HS.json
+++ b/resource/global/YoStarKR/resource/tasks/Stages/HS.json
@@ -1,4 +1,16 @@
 {
+    "HS-9": {
+        "sub": ["HS-OpenOpt"]
+    },
+    "HS-8": {
+        "sub": ["HS-OpenOpt"]
+    },
+    "HS-7": {
+        "sub": ["HS-OpenOpt"]
+    },
+    "HS-5": {
+        "sub": ["HS-OpenOpt"]
+    },
     "HS-OpenOpt": {
         "algorithm": "JustReturn",
         "next": ["HS-OpenOcr", "HS-Open"]


### PR DESCRIPTION
iirc, SSReopen-HS required HS-OpenOpt. It could be the same for other global server.


log
``` python
[2025-07-03 22:44:14.211][TRC][Px4300][Tx6428] asst::ProcessTask::run | enter
[2025-07-03 22:44:14.211][INF][Px4300][Tx6428] {"class":"asst::ProcessTask","details":{"cur_retry":0,"retry_times":0,"to_be_recognized":["HS-OpenOpt"]},"first":["HS-OpenOpt"],"pre_task":"","subtask":"ProcessTask","taskchain":"Fight","taskid":4}
[2025-07-03 22:44:14.211][ERR][Px4300][Tx6428] Unknown task: HS-OpenOpt
[2025-07-03 22:44:14.211][ERR][Px4300][Tx6428] Task HS-OpenOpt not found
```