### PR TITLE
perf: 添加自动编队选项 忽略干员属性要求

### DIFF
--- a/src/MaaCore/Task/Interface/CopilotTask.cpp
+++ b/src/MaaCore/Task/Interface/CopilotTask.cpp
@@ -84,6 +84,8 @@ bool asst::CopilotTask::set_params(const json::value& params)
     bool with_formation = params.get("formation", false);                            // 是否使用自动编队
     int select_formation = params.get("select_formation", 0);                        // 选择第几个编队，0为不选择
     bool add_trust = params.get("add_trust", false);                                 // 是否自动补信赖
+    bool skip_module_when_not_satisfied =
+        params.get("skip_module_when_not_satisfied", false);                         // 模组不满足时是否选择默认模组
     bool add_user_additional = params.contains("user_additional");                   // 是否自动补用户自定义干员
     auto support_unit_usage = static_cast<SupportUnitUsage>(
         params.get("support_unit_usage", static_cast<int>(SupportUnitUsage::None))); // 助战干员使用模式
@@ -147,6 +149,7 @@ bool asst::CopilotTask::set_params(const json::value& params)
     m_formation_task_ptr->set_enable(with_formation);
     m_formation_task_ptr->set_select_formation(select_formation);
     m_formation_task_ptr->set_add_trust(add_trust);
+    m_formation_task_ptr->set_skip_module_when_not_satisfied(skip_module_when_not_satisfied);
     m_formation_task_ptr->set_support_unit_usage(support_unit_usage);
     m_formation_task_ptr->set_specific_support_unit(support_unit_name);
 

--- a/src/MaaCore/Task/Interface/CopilotTask.cpp
+++ b/src/MaaCore/Task/Interface/CopilotTask.cpp
@@ -84,8 +84,7 @@ bool asst::CopilotTask::set_params(const json::value& params)
     bool with_formation = params.get("formation", false);                            // 是否使用自动编队
     int select_formation = params.get("select_formation", 0);                        // 选择第几个编队，0为不选择
     bool add_trust = params.get("add_trust", false);                                 // 是否自动补信赖
-    bool skip_unmet_operator_requirements =
-        params.get("skip_unmet_operator_requirements", false);                       // 跳过未满足的干员属性要求
+    bool ignore_requirements = params.get("ignore_requirements", false);             // 跳过未满足的干员属性要求
     bool add_user_additional = params.contains("user_additional");                   // 是否自动补用户自定义干员
     auto support_unit_usage = static_cast<SupportUnitUsage>(
         params.get("support_unit_usage", static_cast<int>(SupportUnitUsage::None))); // 助战干员使用模式
@@ -149,7 +148,7 @@ bool asst::CopilotTask::set_params(const json::value& params)
     m_formation_task_ptr->set_enable(with_formation);
     m_formation_task_ptr->set_select_formation(select_formation);
     m_formation_task_ptr->set_add_trust(add_trust);
-    m_formation_task_ptr->set_skip_unmet_operator_requirements(skip_unmet_operator_requirements);
+    m_formation_task_ptr->set_ignore_requirements(ignore_requirements);
     m_formation_task_ptr->set_support_unit_usage(support_unit_usage);
     m_formation_task_ptr->set_specific_support_unit(support_unit_name);
 

--- a/src/MaaCore/Task/Interface/CopilotTask.cpp
+++ b/src/MaaCore/Task/Interface/CopilotTask.cpp
@@ -84,8 +84,8 @@ bool asst::CopilotTask::set_params(const json::value& params)
     bool with_formation = params.get("formation", false);                            // 是否使用自动编队
     int select_formation = params.get("select_formation", 0);                        // 选择第几个编队，0为不选择
     bool add_trust = params.get("add_trust", false);                                 // 是否自动补信赖
-    bool skip_module_when_not_satisfied =
-        params.get("skip_module_when_not_satisfied", false);                         // 模组不满足时是否选择默认模组
+    bool skip_unmet_operator_requirements =
+        params.get("skip_unmet_operator_requirements", false);                       // 跳过未满足的干员属性要求
     bool add_user_additional = params.contains("user_additional");                   // 是否自动补用户自定义干员
     auto support_unit_usage = static_cast<SupportUnitUsage>(
         params.get("support_unit_usage", static_cast<int>(SupportUnitUsage::None))); // 助战干员使用模式
@@ -149,7 +149,7 @@ bool asst::CopilotTask::set_params(const json::value& params)
     m_formation_task_ptr->set_enable(with_formation);
     m_formation_task_ptr->set_select_formation(select_formation);
     m_formation_task_ptr->set_add_trust(add_trust);
-    m_formation_task_ptr->set_skip_module_when_not_satisfied(skip_module_when_not_satisfied);
+    m_formation_task_ptr->set_skip_unmet_operator_requirements(skip_unmet_operator_requirements);
     m_formation_task_ptr->set_support_unit_usage(support_unit_usage);
     m_formation_task_ptr->set_specific_support_unit(support_unit_name);
 

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -488,7 +488,7 @@ bool asst::BattleFormationTask::select_opers_in_cur_page(std::vector<OperGroup>&
                 info["details"]["oper_name"] = name;
                 info["details"]["requirement_type"] = "module";
                 callback(AsstMsg::SubTaskExtraInfo, info);
-                if (m_skip_module_when_not_satisfied) {
+                if (m_skip_unmet_operator_requirements) {
                     // 模组不满足时选择默认模组
                     LogInfo << __FUNCTION__ << "| Module " << std::to_string(module)
                             << " not satisfied, skip module selection";

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -488,7 +488,7 @@ bool asst::BattleFormationTask::select_opers_in_cur_page(std::vector<OperGroup>&
                 info["details"]["oper_name"] = name;
                 info["details"]["requirement_type"] = "module";
                 callback(AsstMsg::SubTaskExtraInfo, info);
-                if (m_skip_unmet_operator_requirements) {
+                if (m_ignore_requirements) {
                     // 模组不满足时选择默认模组
                     LogInfo << __FUNCTION__ << "| Module " << std::to_string(module)
                             << " not satisfied, skip module selection";

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -488,10 +488,17 @@ bool asst::BattleFormationTask::select_opers_in_cur_page(std::vector<OperGroup>&
                 info["details"]["oper_name"] = name;
                 info["details"]["requirement_type"] = "module";
                 callback(AsstMsg::SubTaskExtraInfo, info);
-                ctrler()->click(res.flag_rect); // 选择模组失败时反选干员
-                sleep(delay);
-                // 继续检查同组其他干员
-                continue;
+                if (m_skip_module_when_not_satisfied) {
+                    // 模组不满足时选择默认模组
+                    LogInfo << __FUNCTION__ << "| Module " << std::to_string(module)
+                            << " not satisfied, skip module selection";
+                }
+                else {
+                    ctrler()->click(res.flag_rect); // 选择模组失败时反选干员
+                    sleep(delay);
+                    // 继续检查同组其他干员
+                    continue;
+                }
             }
             sleep(delay);
         }

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.h
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.h
@@ -44,7 +44,7 @@ public:
     void set_add_trust(bool add_trust) { m_add_trust = add_trust; }
 
     // 设置是否跳过未满足的干员属性要求
-    void set_skip_unmet_operator_requirements(bool skip) { m_skip_unmet_operator_requirements = skip; }
+    void set_ignore_requirements(bool value) { m_ignore_requirements = value; }
 
     // 设置对指定编队自动编队
     void set_select_formation(int index) { m_select_formation_index = index; }
@@ -116,7 +116,7 @@ protected:
     std::shared_ptr<std::unordered_map<std::string, std::string>> m_opers_in_formation =
         std::make_shared<std::unordered_map<std::string, std::string>>(); // 编队中的干员名称-所属组名
     bool m_add_trust = false;                                             // 是否需要追加信赖干员
-    bool m_skip_unmet_operator_requirements = false;                      // 是否跳过未满足的干员属性要求
+    bool m_ignore_requirements = false;                                   // 是否跳过未满足的干员属性要求
     std::vector<std::pair<std::string, int>> m_user_additional;           // 追加干员表，从头往后加
     DataResource m_data_resource = DataResource::Copilot;
     std::vector<AdditionalFormation> m_additional;

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.h
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.h
@@ -43,6 +43,9 @@ public:
     // 是否追加低信赖干员
     void set_add_trust(bool add_trust) { m_add_trust = add_trust; }
 
+    // 设置模组不满足时是否选择默认模组
+    void set_skip_module_when_not_satisfied(bool skip) { m_skip_module_when_not_satisfied = skip; }
+
     // 设置对指定编队自动编队
     void set_select_formation(int index) { m_select_formation_index = index; }
 
@@ -113,6 +116,7 @@ protected:
     std::shared_ptr<std::unordered_map<std::string, std::string>> m_opers_in_formation =
         std::make_shared<std::unordered_map<std::string, std::string>>(); // 编队中的干员名称-所属组名
     bool m_add_trust = false;                                             // 是否需要追加信赖干员
+    bool m_skip_module_when_not_satisfied = false;                        // 是否在模组不满足要求时选择默认模组
     std::vector<std::pair<std::string, int>> m_user_additional;           // 追加干员表，从头往后加
     DataResource m_data_resource = DataResource::Copilot;
     std::vector<AdditionalFormation> m_additional;

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.h
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.h
@@ -43,8 +43,8 @@ public:
     // 是否追加低信赖干员
     void set_add_trust(bool add_trust) { m_add_trust = add_trust; }
 
-    // 设置模组不满足时是否选择默认模组
-    void set_skip_module_when_not_satisfied(bool skip) { m_skip_module_when_not_satisfied = skip; }
+    // 设置是否跳过未满足的干员属性要求
+    void set_skip_unmet_operator_requirements(bool skip) { m_skip_unmet_operator_requirements = skip; }
 
     // 设置对指定编队自动编队
     void set_select_formation(int index) { m_select_formation_index = index; }
@@ -116,7 +116,7 @@ protected:
     std::shared_ptr<std::unordered_map<std::string, std::string>> m_opers_in_formation =
         std::make_shared<std::unordered_map<std::string, std::string>>(); // 编队中的干员名称-所属组名
     bool m_add_trust = false;                                             // 是否需要追加信赖干员
-    bool m_skip_module_when_not_satisfied = false;                        // 是否在模组不满足要求时选择默认模组
+    bool m_skip_unmet_operator_requirements = false;                      // 是否跳过未满足的干员属性要求
     std::vector<std::pair<std::string, int>> m_user_additional;           // 追加干员表，从头往后加
     DataResource m_data_resource = DataResource::Copilot;
     std::vector<AdditionalFormation> m_additional;

--- a/src/MaaWpfGui/Models/AsstTasks/AsstCopilotTask.cs
+++ b/src/MaaWpfGui/Models/AsstTasks/AsstCopilotTask.cs
@@ -43,9 +43,9 @@ public class AsstCopilotTask : AsstBaseTask
     public bool AddTrust { get; set; }
 
     /// <summary>
-    /// 跳过未满足的干员属性要求
+    /// Gets or sets a value indicating whether 跳过未满足的干员属性要求
     /// </summary>
-    public bool SkipUnmetOperatorRequirements { get; set; }
+    public bool IgnoreRequirements { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether 导航至关卡（启用自动战斗序列、取消代理）
@@ -84,7 +84,7 @@ public class AsstCopilotTask : AsstBaseTask
             ["filename"] = FileName,
             ["formation"] = Formation,
             ["add_trust"] = AddTrust,
-            ["skip_unmet_operator_requirements"] = SkipUnmetOperatorRequirements,
+            ["ignore_requirements"] = IgnoreRequirements,
             ["need_navigate"] = NeedNavigate,
             ["is_raid"] = IsRaid,
             ["loop_times"] = LoopTimes,

--- a/src/MaaWpfGui/Models/AsstTasks/AsstCopilotTask.cs
+++ b/src/MaaWpfGui/Models/AsstTasks/AsstCopilotTask.cs
@@ -43,9 +43,9 @@ public class AsstCopilotTask : AsstBaseTask
     public bool AddTrust { get; set; }
 
     /// <summary>
-    /// 模组不满足要求时选择默认模组
+    /// 跳过未满足的干员属性要求
     /// </summary>
-    public bool SkipModuleWhenNotSatisfied { get; set; }
+    public bool SkipUnmetOperatorRequirements { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether 导航至关卡（启用自动战斗序列、取消代理）
@@ -84,7 +84,7 @@ public class AsstCopilotTask : AsstBaseTask
             ["filename"] = FileName,
             ["formation"] = Formation,
             ["add_trust"] = AddTrust,
-            ["skip_module_when_not_satisfied"] = SkipModuleWhenNotSatisfied,
+            ["skip_unmet_operator_requirements"] = SkipUnmetOperatorRequirements,
             ["need_navigate"] = NeedNavigate,
             ["is_raid"] = IsRaid,
             ["loop_times"] = LoopTimes,

--- a/src/MaaWpfGui/Models/AsstTasks/AsstCopilotTask.cs
+++ b/src/MaaWpfGui/Models/AsstTasks/AsstCopilotTask.cs
@@ -43,6 +43,11 @@ public class AsstCopilotTask : AsstBaseTask
     public bool AddTrust { get; set; }
 
     /// <summary>
+    /// 模组不满足要求时选择默认模组
+    /// </summary>
+    public bool SkipModuleWhenNotSatisfied { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether 导航至关卡（启用自动战斗序列、取消代理）
     /// </summary>
     public bool NeedNavigate { get; set; }
@@ -79,6 +84,7 @@ public class AsstCopilotTask : AsstBaseTask
             ["filename"] = FileName,
             ["formation"] = Formation,
             ["add_trust"] = AddTrust,
+            ["skip_module_when_not_satisfied"] = SkipModuleWhenNotSatisfied,
             ["need_navigate"] = NeedNavigate,
             ["is_raid"] = IsRaid,
             ["loop_times"] = LoopTimes,

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -747,6 +747,7 @@ The video aspect ratio needs to be 16:9 without interference factors such as bla
     <system:String x:Key="IdentificationCompleted">Identification completed</system:String>
     <!--  !Logs  -->
     <!--  Copilot  -->
+    <system:String x:Key="Operator">Operator</system:String>
     <system:String x:Key="Copilot">Copilot</system:String>
     <system:String x:Key="CopilotLocation">Task file / URL</system:String>
     <system:String x:Key="CopilotTaskName">Stage Code</system:String>
@@ -761,7 +762,7 @@ The video aspect ratio needs to be 16:9 without interference factors such as bla
     <system:String x:Key="AutoSquad">Auto Squad</system:String>
     <system:String x:Key="AutoSquadTip">｢Favourite｣ marked operators may not be recognized</system:String>
     <system:String x:Key="AddTrust">Add low-trust operators</system:String>
-    <system:String x:Key="SkipUnmetOperatorRequirements">Skip unmet operator requirements</system:String>
+    <system:String x:Key="Copilot.IgnoreRequirements">Ignore {key=Operator} attribute requirements</system:String>
     <system:String x:Key="AddUserAdditional">Add custom operators</system:String>
     <system:String x:Key="AddUserAdditionalTip">Use ｢;｣ as the separator, ｢,｣ to separate the operator name and skills, for example: W, 3; Ash, 2</system:String>
     <system:String x:Key="UseCopilotList">Battle list</system:String>

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -761,6 +761,7 @@ The video aspect ratio needs to be 16:9 without interference factors such as bla
     <system:String x:Key="AutoSquad">Auto Squad</system:String>
     <system:String x:Key="AutoSquadTip">｢Favourite｣ marked operators may not be recognized</system:String>
     <system:String x:Key="AddTrust">Add low-trust operators</system:String>
+    <system:String x:Key="SkipModuleWhenNotSatisfied">Choose the default module when the current module fails to meet the requirements</system:String>
     <system:String x:Key="AddUserAdditional">Add custom operators</system:String>
     <system:String x:Key="AddUserAdditionalTip">Use ｢;｣ as the separator, ｢,｣ to separate the operator name and skills, for example: W, 3; Ash, 2</system:String>
     <system:String x:Key="UseCopilotList">Battle list</system:String>

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -761,7 +761,7 @@ The video aspect ratio needs to be 16:9 without interference factors such as bla
     <system:String x:Key="AutoSquad">Auto Squad</system:String>
     <system:String x:Key="AutoSquadTip">｢Favourite｣ marked operators may not be recognized</system:String>
     <system:String x:Key="AddTrust">Add low-trust operators</system:String>
-    <system:String x:Key="SkipModuleWhenNotSatisfied">Choose the default module when the current module fails to meet the requirements</system:String>
+    <system:String x:Key="SkipUnmetOperatorRequirements">Skip unmet operator requirements</system:String>
     <system:String x:Key="AddUserAdditional">Add custom operators</system:String>
     <system:String x:Key="AddUserAdditionalTip">Use ｢;｣ as the separator, ｢,｣ to separate the operator name and skills, for example: W, 3; Ash, 2</system:String>
     <system:String x:Key="UseCopilotList">Battle list</system:String>

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -762,7 +762,7 @@ The video aspect ratio needs to be 16:9 without interference factors such as bla
     <system:String x:Key="AutoSquad">Auto Squad</system:String>
     <system:String x:Key="AutoSquadTip">｢Favourite｣ marked operators may not be recognized</system:String>
     <system:String x:Key="AddTrust">Add low-trust operators</system:String>
-    <system:String x:Key="Copilot.IgnoreRequirements">Ignore {key=Operator} attribute requirements</system:String>
+    <system:String x:Key="Copilot.IgnoreRequirements">Ignore {key=Operator} Module requirements</system:String>
     <system:String x:Key="AddUserAdditional">Add custom operators</system:String>
     <system:String x:Key="AddUserAdditionalTip">Use ｢;｣ as the separator, ｢,｣ to separate the operator name and skills, for example: W, 3; Ash, 2</system:String>
     <system:String x:Key="UseCopilotList">Battle list</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -765,6 +765,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="AutoSquad">自動編成</system:String>
     <system:String x:Key="AutoSquadTip">自動編成では、一時的に ｢戦術要員｣ オペレーターを認識できません</system:String>
     <system:String x:Key="AddTrust">信頼度が低いオペレーターを追加する</system:String>
+    <system:String x:Key="SkipModuleWhenNotSatisfied">モジュールが要件を満たさない場合、デフォルトモジュールを選択する</system:String>
     <system:String x:Key="AddUserAdditional">カスタムで指定したオペレーターを追加する</system:String>
     <system:String x:Key="AddUserAdditionalTip">｢;｣ はセパレータ、｢,｣ でオペレーターの名前とスキルを区切ります。例: Surtr, 3; Eyjafjalla,1</system:String>
     <system:String x:Key="UseCopilotList">バトルリスト</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -765,7 +765,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="AutoSquad">自動編成</system:String>
     <system:String x:Key="AutoSquadTip">自動編成では、一時的に ｢戦術要員｣ オペレーターを認識できません</system:String>
     <system:String x:Key="AddTrust">信頼度が低いオペレーターを追加する</system:String>
-    <system:String x:Key="SkipModuleWhenNotSatisfied">モジュールが要件を満たさない場合、デフォルトモジュールを選択する</system:String>
+    <system:String x:Key="SkipUnmetOperatorRequirements">未満足のオペレーター属性要件をスキップ</system:String>
     <system:String x:Key="AddUserAdditional">カスタムで指定したオペレーターを追加する</system:String>
     <system:String x:Key="AddUserAdditionalTip">｢;｣ はセパレータ、｢,｣ でオペレーターの名前とスキルを区切ります。例: Surtr, 3; Eyjafjalla,1</system:String>
     <system:String x:Key="UseCopilotList">バトルリスト</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -751,6 +751,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="IdentificationCompleted">認識完了</system:String>
     <!--  !Logs  -->
     <!--  Copilot  -->
+    <system:String x:Key="Operator">オペレーター</system:String>
     <system:String x:Key="Copilot">自動戦闘</system:String>
     <system:String x:Key="CopilotLocation">攻略ファイルパス/ミステリーコード</system:String>
     <system:String x:Key="CopilotTaskName">ステージコード</system:String>
@@ -765,7 +766,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="AutoSquad">自動編成</system:String>
     <system:String x:Key="AutoSquadTip">自動編成では、一時的に ｢戦術要員｣ オペレーターを認識できません</system:String>
     <system:String x:Key="AddTrust">信頼度が低いオペレーターを追加する</system:String>
-    <system:String x:Key="SkipUnmetOperatorRequirements">未満足のオペレーター属性要件をスキップ</system:String>
+    <system:String x:Key="Copilot.IgnoreRequirements">{key=Operator}属性の要件を無視</system:String>
     <system:String x:Key="AddUserAdditional">カスタムで指定したオペレーターを追加する</system:String>
     <system:String x:Key="AddUserAdditionalTip">｢;｣ はセパレータ、｢,｣ でオペレーターの名前とスキルを区切ります。例: Surtr, 3; Eyjafjalla,1</system:String>
     <system:String x:Key="UseCopilotList">バトルリスト</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -764,7 +764,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="AutoSquad">자동 편성</system:String>
     <system:String x:Key="AutoSquadTip">자동 편성은 ｢선호｣ 설정 된 오퍼레이터를 인식할 수 없습니다</system:String>
     <system:String x:Key="AddTrust">신뢰도가 낮은 오퍼레이터 추가</system:String>
-    <system:String x:Key="SkipModuleWhenNotSatisfied">모듈이 요구 사항을 충족하지 않을 때 기본 모듈을 선택합니다.</system:String>
+    <system:String x:Key="SkipUnmetOperatorRequirements">미충족 오퍼레이터 속성 요구사항 건너뛰기</system:String>
     <system:String x:Key="AddUserAdditional">커스텀 오퍼레이터 추가</system:String>
     <system:String x:Key="AddUserAdditionalTip">｢;｣ 로 오퍼레이터를 구분하고, ｢,｣ 로 스킬을 구분합니다. 예시: W, 3; Ash, 2</system:String>
     <system:String x:Key="UseCopilotList">전투 목록</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -765,7 +765,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="AutoSquad">자동 편성</system:String>
     <system:String x:Key="AutoSquadTip">자동 편성은 ｢선호｣ 설정 된 오퍼레이터를 인식할 수 없습니다</system:String>
     <system:String x:Key="AddTrust">신뢰도가 낮은 오퍼레이터 추가</system:String>
-    <system:String x:Key="Copilot.IgnoreRequirements">{key=Operator} 속성 요구 사항 무시</system:String>
+    <system:String x:Key="Copilot.IgnoreRequirements">{key=Operator} 모듈 요구 사항 무시</system:String>
     <system:String x:Key="AddUserAdditional">커스텀 오퍼레이터 추가</system:String>
     <system:String x:Key="AddUserAdditionalTip">｢;｣ 로 오퍼레이터를 구분하고, ｢,｣ 로 스킬을 구분합니다. 예시: W, 3; Ash, 2</system:String>
     <system:String x:Key="UseCopilotList">전투 목록</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -764,6 +764,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="AutoSquad">자동 편성</system:String>
     <system:String x:Key="AutoSquadTip">자동 편성은 ｢선호｣ 설정 된 오퍼레이터를 인식할 수 없습니다</system:String>
     <system:String x:Key="AddTrust">신뢰도가 낮은 오퍼레이터 추가</system:String>
+    <system:String x:Key="SkipModuleWhenNotSatisfied">모듈이 요구 사항을 충족하지 않을 때 기본 모듈을 선택합니다.</system:String>
     <system:String x:Key="AddUserAdditional">커스텀 오퍼레이터 추가</system:String>
     <system:String x:Key="AddUserAdditionalTip">｢;｣ 로 오퍼레이터를 구분하고, ｢,｣ 로 스킬을 구분합니다. 예시: W, 3; Ash, 2</system:String>
     <system:String x:Key="UseCopilotList">전투 목록</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -750,6 +750,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="IdentificationCompleted">인식 완료</system:String>
     <!--  !로그  -->
     <!--  Copilot  -->
+    <system:String x:Key="Operator">오퍼레이터</system:String>
     <system:String x:Key="Copilot">자동지휘</system:String>
     <system:String x:Key="CopilotLocation">작업 파일 경로/코드</system:String>
     <system:String x:Key="CopilotTaskName">스테이지 코드</system:String>
@@ -764,7 +765,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="AutoSquad">자동 편성</system:String>
     <system:String x:Key="AutoSquadTip">자동 편성은 ｢선호｣ 설정 된 오퍼레이터를 인식할 수 없습니다</system:String>
     <system:String x:Key="AddTrust">신뢰도가 낮은 오퍼레이터 추가</system:String>
-    <system:String x:Key="SkipUnmetOperatorRequirements">미충족 오퍼레이터 속성 요구사항 건너뛰기</system:String>
+    <system:String x:Key="Copilot.IgnoreRequirements">{key=Operator} 속성 요구 사항 무시</system:String>
     <system:String x:Key="AddUserAdditional">커스텀 오퍼레이터 추가</system:String>
     <system:String x:Key="AddUserAdditionalTip">｢;｣ 로 오퍼레이터를 구분하고, ｢,｣ 로 스킬을 구분합니다. 예시: W, 3; Ash, 2</system:String>
     <system:String x:Key="UseCopilotList">전투 목록</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -765,7 +765,7 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="AutoSquad">自动编队</system:String>
     <system:String x:Key="AutoSquadTip">自动编队可能无法识别带有 ｢特别关注｣ 标记的干员</system:String>
     <system:String x:Key="AddTrust">补充低信赖干员</system:String>
-    <system:String x:Key="SkipModuleWhenNotSatisfied">模组不满足要求时选择默认模组</system:String>
+    <system:String x:Key="SkipUnmetOperatorRequirements">跳过未满足的干员属性要求</system:String>
     <system:String x:Key="AddUserAdditional">追加自定干员</system:String>
     <system:String x:Key="AddUserAdditionalTip">以英文 ｢;｣ 为分隔符，英文 ｢,｣ 分隔干员名与技能，例: 史尔特尔,3;艾雅法拉,1</system:String>
     <system:String x:Key="LoopTimes">循环次数</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -750,6 +750,7 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="IdentificationCompleted">识别完成</system:String>
     <!--  !日志  -->
     <!--  自动战斗  -->
+    <system:String x:Key="Operator">干员</system:String>
     <system:String x:Key="Copilot">自动战斗</system:String>
     <system:String x:Key="SSSCopilot">SSS {key=Copilot}</system:String>
     <system:String x:Key="CopilotLocation">作业路径/神秘代码</system:String>
@@ -765,7 +766,7 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="AutoSquad">自动编队</system:String>
     <system:String x:Key="AutoSquadTip">自动编队可能无法识别带有 ｢特别关注｣ 标记的干员</system:String>
     <system:String x:Key="AddTrust">补充低信赖干员</system:String>
-    <system:String x:Key="SkipUnmetOperatorRequirements">跳过未满足的干员属性要求</system:String>
+    <system:String x:Key="Copilot.IgnoreRequirements">忽略{key=Operator}属性要求</system:String>
     <system:String x:Key="AddUserAdditional">追加自定干员</system:String>
     <system:String x:Key="AddUserAdditionalTip">以英文 ｢;｣ 为分隔符，英文 ｢,｣ 分隔干员名与技能，例: 史尔特尔,3;艾雅法拉,1</system:String>
     <system:String x:Key="LoopTimes">循环次数</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -765,6 +765,7 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="AutoSquad">自动编队</system:String>
     <system:String x:Key="AutoSquadTip">自动编队可能无法识别带有 ｢特别关注｣ 标记的干员</system:String>
     <system:String x:Key="AddTrust">补充低信赖干员</system:String>
+    <system:String x:Key="SkipModuleWhenNotSatisfied">模组不满足要求时选择默认模组</system:String>
     <system:String x:Key="AddUserAdditional">追加自定干员</system:String>
     <system:String x:Key="AddUserAdditionalTip">以英文 ｢;｣ 为分隔符，英文 ｢,｣ 分隔干员名与技能，例: 史尔特尔,3;艾雅法拉,1</system:String>
     <system:String x:Key="LoopTimes">循环次数</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -762,7 +762,7 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="AutoSquad">自動編隊</system:String>
     <system:String x:Key="AutoSquadTip">自動編隊可能無法辨識 ｢特別關注｣ 的幹員</system:String>
     <system:String x:Key="AddTrust">補充低信賴幹員</system:String>
-    <system:String x:Key="SkipModuleWhenNotSatisfied">模組不滿足要求時選擇默認模組</system:String>
+    <system:String x:Key="SkipUnmetOperatorRequirements">跳過未滿足的幹員屬性要求</system:String>
     <system:String x:Key="AddUserAdditional">追加自定幹員</system:String>
     <system:String x:Key="AddUserAdditionalTip">使用 ｢;｣ 作為分隔符，用 ｢,｣ 分隔操作員姓名和技能，例：史尔特尔,3;艾雅法拉,1</system:String>
     <system:String x:Key="UseCopilotList">戰鬥列表</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -762,6 +762,7 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="AutoSquad">自動編隊</system:String>
     <system:String x:Key="AutoSquadTip">自動編隊可能無法辨識 ｢特別關注｣ 的幹員</system:String>
     <system:String x:Key="AddTrust">補充低信賴幹員</system:String>
+    <system:String x:Key="SkipModuleWhenNotSatisfied">模組不滿足要求時選擇默認模組</system:String>
     <system:String x:Key="AddUserAdditional">追加自定幹員</system:String>
     <system:String x:Key="AddUserAdditionalTip">使用 ｢;｣ 作為分隔符，用 ｢,｣ 分隔操作員姓名和技能，例：史尔特尔,3;艾雅法拉,1</system:String>
     <system:String x:Key="UseCopilotList">戰鬥列表</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -748,6 +748,7 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="IdentificationCompleted">辨識完成</system:String>
     <!--  !日誌  -->
     <!--  Copilot  -->
+    <system:String x:Key="Operator">幹員</system:String>
     <system:String x:Key="Copilot">自動戰鬥</system:String>
     <system:String x:Key="CopilotLocation">作業路徑 / 神秘代碼</system:String>
     <system:String x:Key="CopilotTaskName">關卡名</system:String>
@@ -762,7 +763,7 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="AutoSquad">自動編隊</system:String>
     <system:String x:Key="AutoSquadTip">自動編隊可能無法辨識 ｢特別關注｣ 的幹員</system:String>
     <system:String x:Key="AddTrust">補充低信賴幹員</system:String>
-    <system:String x:Key="SkipUnmetOperatorRequirements">跳過未滿足的幹員屬性要求</system:String>
+    <system:String x:Key="Copilot.IgnoreRequirements">忽略{key=Operator}屬性要求</system:String>
     <system:String x:Key="AddUserAdditional">追加自定幹員</system:String>
     <system:String x:Key="AddUserAdditionalTip">使用 ｢;｣ 作為分隔符，用 ｢,｣ 分隔操作員姓名和技能，例：史尔特尔,3;艾雅法拉,1</system:String>
     <system:String x:Key="UseCopilotList">戰鬥列表</system:String>

--- a/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
@@ -218,6 +218,17 @@ namespace MaaWpfGui.ViewModels.UI
             set => SetAndNotify(ref _addTrust, value);
         }
 
+        private bool _skipModuleWhenNotSatisfied;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to use auto-formation.
+        /// </summary>
+        public bool SkipModuleWhenNotSatisfied
+        {
+            get => _skipModuleWhenNotSatisfied;
+            set => SetAndNotify(ref _skipModuleWhenNotSatisfied, value);
+        }
+
         private bool _useSanityPotion;
 
         public bool UseSanityPotion
@@ -1194,6 +1205,7 @@ namespace MaaWpfGui.ViewModels.UI
                          FileName = model.FilePath,
                          Formation = _form,
                          AddTrust = _addTrust,
+                         SkipModuleWhenNotSatisfied = _skipModuleWhenNotSatisfied,
                          UserAdditionals = AddUserAdditional ? userAdditional.ToList() : [],
                          NeedNavigate = UseCopilotList,
                          StageName = model.Name,
@@ -1236,6 +1248,7 @@ namespace MaaWpfGui.ViewModels.UI
                     FileName = IsDataFromWeb ? TempCopilotFile : Filename,
                     Formation = _form,
                     AddTrust = _addTrust,
+                    SkipModuleWhenNotSatisfied = _skipModuleWhenNotSatisfied,
                     UserAdditionals = AddUserAdditional ? userAdditional.ToList() : [],
                     NeedNavigate = false,
                     LoopTimes = Loop ? LoopTimes : 1,

--- a/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
@@ -218,15 +218,15 @@ namespace MaaWpfGui.ViewModels.UI
             set => SetAndNotify(ref _addTrust, value);
         }
 
-        private bool _skipModuleWhenNotSatisfied;
+        private bool _skipUnmetOperatorRequirements;
 
         /// <summary>
         /// Gets or sets a value indicating whether to use auto-formation.
         /// </summary>
-        public bool SkipModuleWhenNotSatisfied
+        public bool SkipUnmetOperatorRequirements
         {
-            get => _skipModuleWhenNotSatisfied;
-            set => SetAndNotify(ref _skipModuleWhenNotSatisfied, value);
+            get => _skipUnmetOperatorRequirements;
+            set => SetAndNotify(ref _skipUnmetOperatorRequirements, value);
         }
 
         private bool _useSanityPotion;
@@ -1205,7 +1205,7 @@ namespace MaaWpfGui.ViewModels.UI
                          FileName = model.FilePath,
                          Formation = _form,
                          AddTrust = _addTrust,
-                         SkipModuleWhenNotSatisfied = _skipModuleWhenNotSatisfied,
+                         SkipUnmetOperatorRequirements = _skipUnmetOperatorRequirements,
                          UserAdditionals = AddUserAdditional ? userAdditional.ToList() : [],
                          NeedNavigate = UseCopilotList,
                          StageName = model.Name,
@@ -1248,7 +1248,7 @@ namespace MaaWpfGui.ViewModels.UI
                     FileName = IsDataFromWeb ? TempCopilotFile : Filename,
                     Formation = _form,
                     AddTrust = _addTrust,
-                    SkipModuleWhenNotSatisfied = _skipModuleWhenNotSatisfied,
+                    SkipUnmetOperatorRequirements = _skipUnmetOperatorRequirements,
                     UserAdditionals = AddUserAdditional ? userAdditional.ToList() : [],
                     NeedNavigate = false,
                     LoopTimes = Loop ? LoopTimes : 1,

--- a/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
@@ -218,15 +218,15 @@ namespace MaaWpfGui.ViewModels.UI
             set => SetAndNotify(ref _addTrust, value);
         }
 
-        private bool _skipUnmetOperatorRequirements;
+        private bool _ignoreRequirements;
 
         /// <summary>
         /// Gets or sets a value indicating whether to use auto-formation.
         /// </summary>
-        public bool SkipUnmetOperatorRequirements
+        public bool IgnoreRequirements
         {
-            get => _skipUnmetOperatorRequirements;
-            set => SetAndNotify(ref _skipUnmetOperatorRequirements, value);
+            get => _ignoreRequirements;
+            set => SetAndNotify(ref _ignoreRequirements, value);
         }
 
         private bool _useSanityPotion;
@@ -1205,7 +1205,7 @@ namespace MaaWpfGui.ViewModels.UI
                          FileName = model.FilePath,
                          Formation = _form,
                          AddTrust = _addTrust,
-                         SkipUnmetOperatorRequirements = _skipUnmetOperatorRequirements,
+                         IgnoreRequirements = _ignoreRequirements,
                          UserAdditionals = AddUserAdditional ? userAdditional.ToList() : [],
                          NeedNavigate = UseCopilotList,
                          StageName = model.Name,
@@ -1248,7 +1248,7 @@ namespace MaaWpfGui.ViewModels.UI
                     FileName = IsDataFromWeb ? TempCopilotFile : Filename,
                     Formation = _form,
                     AddTrust = _addTrust,
-                    SkipUnmetOperatorRequirements = _skipUnmetOperatorRequirements,
+                    IgnoreRequirements = _ignoreRequirements,
                     UserAdditionals = AddUserAdditional ? userAdditional.ToList() : [],
                     NeedNavigate = false,
                     LoopTimes = Loop ? LoopTimes : 1,

--- a/src/MaaWpfGui/Views/UI/CopilotView.xaml
+++ b/src/MaaWpfGui/Views/UI/CopilotView.xaml
@@ -143,6 +143,21 @@
                         ToolTipService.InitialShowDelay="0"
                         Visibility="{c:Binding AddUserAdditional}" />
                 </StackPanel>
+                
+                <StackPanel
+                    Height="30"
+                    HorizontalAlignment="Center"
+                    Orientation="Horizontal"
+                    Visibility="{c:Binding Form}">
+                        <CheckBox
+                        Height="30"
+                        Margin="10,0"
+                        HorizontalAlignment="Center"
+                        Content="{DynamicResource SkipModuleWhenNotSatisfied}"
+                        IsChecked="{Binding SkipModuleWhenNotSatisfied}"
+                        IsEnabled="{Binding Idle}"
+                        Visibility="{c:Binding Form}" />
+                </StackPanel>
 
                 <StackPanel
                     HorizontalAlignment="Center"

--- a/src/MaaWpfGui/Views/UI/CopilotView.xaml
+++ b/src/MaaWpfGui/Views/UI/CopilotView.xaml
@@ -153,8 +153,8 @@
                         Height="30"
                         Margin="10,0"
                         HorizontalAlignment="Center"
-                        Content="{DynamicResource SkipModuleWhenNotSatisfied}"
-                        IsChecked="{Binding SkipModuleWhenNotSatisfied}"
+                        Content="{DynamicResource SkipUnmetOperatorRequirements}"
+                        IsChecked="{Binding SkipUnmetOperatorRequirements}"
                         IsEnabled="{Binding Idle}"
                         Visibility="{c:Binding Form}" />
                 </StackPanel>

--- a/src/MaaWpfGui/Views/UI/CopilotView.xaml
+++ b/src/MaaWpfGui/Views/UI/CopilotView.xaml
@@ -143,18 +143,18 @@
                         ToolTipService.InitialShowDelay="0"
                         Visibility="{c:Binding AddUserAdditional}" />
                 </StackPanel>
-                
+
                 <StackPanel
                     Height="30"
                     HorizontalAlignment="Center"
                     Orientation="Horizontal"
                     Visibility="{c:Binding Form}">
-                        <CheckBox
+                    <CheckBox
                         Height="30"
                         Margin="10,0"
                         HorizontalAlignment="Center"
-                        Content="{DynamicResource SkipUnmetOperatorRequirements}"
-                        IsChecked="{Binding SkipUnmetOperatorRequirements}"
+                        Content="{DynamicResource Copilot.IgnoreRequirements}"
+                        IsChecked="{Binding IgnoreRequirements}"
                         IsEnabled="{Binding Idle}"
                         Visibility="{c:Binding Form}" />
                 </StackPanel>


### PR DESCRIPTION
给自动编队加了个选项，用来控制当模组不满足要求时是否忽略模组要求

<img width="800" height="600" alt="image" src="https://github.com/user-attachments/assets/b6c719c2-b741-44f7-943c-78bed2816924" />

checklist:
- [x] cn
- [x] EN
- [x] JP
- [x] KR