### PR TITLE
fix(ci): fix AppImage build toolkit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,7 +308,7 @@ jobs:
           ln -sv usr/share/maa/maa Maa.AppDir/AppRun
           mkdir -pv Maa.AppDir/usr/share/metainfo/
           cp -v tools/AppImage/io.github.maaassistantarknights.maaassistantarknights.metainfo.xml Maa.AppDir/usr/share/metainfo/
-          wget "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage"
+          wget "https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-x86_64.AppImage"
           # appimagetool with embedded runtime does not support cross build, till AppImage/appimagetool 7a10b8
           wget "https://github.com/AppImage/type2-runtime/releases/download/old/runtime-fuse3-${{ matrix.arch }}"
           chmod a+x appimagetool-x86_64.AppImage


### PR DESCRIPTION
这仓库好像改位置了，每天都报build faild

https://github.com/Manicsteiner/MaaAssistantArknights/actions/runs/16410925377/job/46365553236
Build AppImage
line 155