### PR TITLE
i18n: wpf`干员`统一使用指定字符串资源

### DIFF
--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -111,8 +111,8 @@
     <system:String x:Key="OriginStone">Originium Shards</system:String>
     <system:String x:Key="Chip">Chip Packs</system:String>
     <system:String x:Key="DormTrustEnabled">Trust farming in Dormitory</system:String>
-    <system:String x:Key="DormFilterNotStationedEnabled">Do not put stationed operators in Dormitory</system:String>
-    <system:String x:Key="DormFilterNotStationedTips">Checking this box will not remove operators like Irene from the Training Room; this will also prevent operators from the Workshop from entering the Dormitory.</system:String>
+    <system:String x:Key="DormFilterNotStationedEnabled">Do not put stationed {key=Operator}s in Dormitory</system:String>
+    <system:String x:Key="DormFilterNotStationedTips">Checking this box will not remove {key=Operator}s like Irene from the Training Room; this will also prevent {key=Operator}s from the Workshop from entering the Dormitory.</system:String>
     <system:String x:Key="OriginiumShardAutoReplenishment">Originium Shard auto replenishment</system:String>
     <system:String x:Key="InfrastReceptionMessageBoardReceive">Credit collection from message board in Reception Room</system:String>
     <system:String x:Key="ContinueTraining">After training is complete, try to continue mastering the current skill</system:String>
@@ -123,7 +123,7 @@
     <system:String x:Key="InfrastMode">Base Mode</system:String>
     <system:String x:Key="InfrastModeNormal">Normal Mode</system:String>
     <system:String x:Key="InfrastModeRotation">One-click Rotation Mode</system:String>
-    <system:String x:Key="InfrastModeRotationTip">Please manually set up operator queues in game before using One-click Rotation Mode</system:String>
+    <system:String x:Key="InfrastModeRotationTip">Please manually set up {key=Operator} queues in game before using One-click Rotation Mode</system:String>
     <system:String x:Key="InfrastModeCustom">Custom Base Mode</system:String>
     <system:String x:Key="DefaultInfrast">Default Base infrastructure</system:String>
     <system:String x:Key="UserDefined">User defined</system:String>
@@ -150,19 +150,19 @@
     <system:String x:Key="SecondResolution">2nd Resolution</system:String>
     <system:String x:Key="GeneralWithoutScreencapErr">General Mode (Blocked exception output)</system:String>
     <system:String x:Key="DormThreshold">Morale Threshold</system:String>
-    <system:String x:Key="InfrastThresholdTip">If custom shifts are enabled, this field is only valid for rooms with autofill and operator groups</system:String>
+    <system:String x:Key="InfrastThresholdTip">If custom shifts are enabled, this field is only valid for rooms with autofill and {key=Operator} groups</system:String>
     <system:String x:Key="RoguelikeStrategyExp">Gain Experience Points, clear as many nodes as possible</system:String>
     <system:String x:Key="RoguelikeStrategyGold">Invests coins, exits automatically after investment completes</system:String>
-    <system:String x:Key="RoguelikeStrategyLastReward">Grind to obtain Hot Water Kettle or Elite II operators</system:String>
+    <system:String x:Key="RoguelikeStrategyLastReward">Grind to obtain Hot Water Kettle or Elite II {key=Operator}s</system:String>
     <system:String x:Key="RoguelikeStrategyCollapse">Farm collapse paradigms, restart immediately after encountering a non-rare collapse paradigm</system:String>
     <system:String x:Key="RoguelikeCollectibleModeSquad">Squad to get collectibles</system:String>
     <system:String x:Key="RoguelikeStrategyMonthlySquad">Grind Monthly Squad, clear as far as possible</system:String>
     <system:String x:Key="RoguelikeStrategyDeepExploration">Grind Deep Investigation, clear as far as possible</system:String>
     <system:String x:Key="StartingSquad">Starting Squad</system:String>
     <system:String x:Key="StartingRoles">Starting Roles</system:String>
-    <system:String x:Key="StartingCoreChar">Starting Operator</system:String>
+    <system:String x:Key="StartingCoreChar">Starting {key=Operator}</system:String>
     <system:String x:Key="StartingCoreCharTip">If not filled out, the default policy will be used.</system:String>
-    <system:String x:Key="RoguelikeStartingCoreCharNotFound">The operator is not in battle_data.</system:String>
+    <system:String x:Key="RoguelikeStartingCoreCharNotFound">The {key=Operator} is not in battle_data.</system:String>
     <system:String x:Key="RoguelikeStartWithEliteTwo">Repeat for ｢{key=StartingCoreChar}｣ Elite 2</system:String>
     <system:String x:Key="RoguelikeOnlyStartWithEliteTwo">Only Repeat for ｢{key=StartingCoreChar}｣ Elite 2, No Battle</system:String>
     <system:String x:Key="Roguelike3FirstFloorFoldartal">Repeat for foldartal foreseed first floor, No Battle</system:String>
@@ -552,7 +552,7 @@ The primary instance is 0, and other instances are the numbers after the version
     <system:String x:Key="ReclamationIncrementModeHold">Hold</system:String>
     <system:String x:Key="ReclamationMaxCraftCountPerRound">Max Craft Count Per Round</system:String>
     <system:String x:Key="ReclamationClearStore">Clear Store after finished</system:String>
-    <system:String x:Key="OperNameLanguage">Operator display language</system:String>
+    <system:String x:Key="OperNameLanguage">{key=Operator} display language</system:String>
     <system:String x:Key="OperNameLanguageMAA">Follow MAA</system:String>
     <system:String x:Key="OperNameLanguageClient">Follow game client</system:String>
     <system:String x:Key="OperNameLanguageForce">Force use of specified language</system:String>
@@ -687,9 +687,9 @@ Do not adjust the proxy multiplier setting in the game</system:String>
     <system:String x:Key="CopiedToClipboard">Copied to Clipboard</system:String>
     <!--  !Depot Recognition  -->
     <!--  Operator Recognition  -->
-    <system:String x:Key="OperBoxRecognition">Operator</system:String>
+    <system:String x:Key="OperBoxRecognition">{key=Operator}</system:String>
     <system:String x:Key="OperBox">{key=OperBoxRecognition}</system:String>
-    <system:String x:Key="OperBoxRecognitionTip">Favourited (marked) operators can't be recognized. Please remove them from your favourites before starting.</system:String>
+    <system:String x:Key="OperBoxRecognitionTip">Favourited (marked) {key=Operator}s can't be recognized. Please remove them from your favourites before starting.</system:String>
     <system:String x:Key="OperBoxHaveList">Owned: {0}</system:String>
     <system:String x:Key="OperBoxNotHaveList">Not owned: {0}</system:String>
     <system:String x:Key="StartToOperBoxRecognition">Start to Identify</system:String>
@@ -766,11 +766,11 @@ The video aspect ratio needs to be 16:9 without interference factors such as bla
     <system:String x:Key="FailedToLikeWebJson">An error occurred, the like failed. : &lt;</system:String>
     <system:String x:Key="ThanksForLikeWebJson">Thanks for the likes!\nThe comment section is already open on the web page, please feel free to leave your comment!</system:String>
     <system:String x:Key="AutoSquad">Auto Squad</system:String>
-    <system:String x:Key="AutoSquadTip">｢Favourite｣ marked operators may not be recognized</system:String>
-    <system:String x:Key="AddTrust">Add low-trust operators</system:String>
-    <system:String x:Key="Copilot.IgnoreRequirements">Ignore {key=Operator} Module requirements</system:String>
-    <system:String x:Key="AddUserAdditional">Add custom operators</system:String>
-    <system:String x:Key="AddUserAdditionalTip">Use ｢;｣ as the separator, ｢,｣ to separate the operator name and skills, for example: W, 3; Ash, 2</system:String>
+    <system:String x:Key="AutoSquadTip">｢Favourite｣ marked {key=Operator}s may not be recognized</system:String>
+    <system:String x:Key="AddTrust">Add low-trust {key=Operator}s</system:String>
+    <system:String x:Key="Copilot.IgnoreRequirements">Ignore {key={key=Operator}} Module requirements</system:String>
+    <system:String x:Key="AddUserAdditional">Add custom {key=Operator}s</system:String>
+    <system:String x:Key="AddUserAdditionalTip">Use ｢;｣ as the separator, ｢,｣ to separate the {key=Operator} name and skills, for example: W, 3; Ash, 2</system:String>
     <system:String x:Key="LoopTimes">Loop Times</system:String>
     <system:String x:Key="UseCopilotList">Battle list</system:String>
     <system:String x:Key="UseCopilotListTip" xml:space="preserve">Does not support cross-chapter navigation. Only supports:
@@ -787,9 +787,9 @@ Right-click to clear inactive tasks</system:String>
     <system:String x:Key="CopilotSkill">Skill</system:String>
     <system:String x:Key="CopilotModule">Module</system:String>
     <system:String x:Key="CopilotWithoutModule">Without Module</system:String>
-    <system:String x:Key="TotalOperatorsCount">Total {0} Operator(s)</system:String>
+    <system:String x:Key="TotalOperatorsCount">Total {0} {key=Operator}(s)</system:String>
     <system:String x:Key="DirectiveECTerm">Directive EC unit:&#160;</system:String>
-    <system:String x:Key="OtherOperators">Other operators:&#160;</system:String>
+    <system:String x:Key="OtherOperators">Other {key=Operator}s:&#160;</system:String>
     <system:String x:Key="InitialEquipmentHorizontal">Tactical Equipment (horizontal):&#160;</system:String>
     <system:String x:Key="InitialStrategy">Initial Strategy:&#160;</system:String>
     <!--  Logs  -->
@@ -800,7 +800,7 @@ Right-click to clear inactive tasks</system:String>
         3. For SSS, there are multiple built-in files under the ｢resource/copilot｣ folder.\n
         Please start on the ｢Start Deployment｣ screen after manual formation (can be used with ｢{key=LoopTimes} )\n\n
         4. You need turn off the ｢{key=AutoSquad}｣ when using a friendly support unit, then start with your support unit selected.\n\n
-        5. Marking an operator as｢Favourite｣ may affect the operator selection in ｢{key=AutoSquad}｣ . It is recommended to turn off ｢Favourite｣ when using ｢{key=AutoSquad}｣ , or manually supplement missing operators to ensure the formation is complete.\n\n
+        5. Marking an {key=Operator} as｢Favourite｣ may affect the {key=Operator} selection in ｢{key=AutoSquad}｣ . It is recommended to turn off ｢Favourite｣ when using ｢{key=AutoSquad}｣ , or manually supplement missing {key=Operator}s to ensure the formation is complete.\n\n
         6. In the Copilot workstation, you can paste the mysterious code by clicking the paste button on the right side of the input box. Left-click to paste a single job, and right-click to paste the entire job set.\n\n
         7. Battle list:\n
         After selecting the job, check that the stage name below the list is correct (e.g.: CV-EX-1). \n
@@ -875,7 +875,7 @@ Right-click to clear inactive tasks</system:String>
     <system:String x:Key="DropRecognitionError">Drops recognition error</system:String>
     <system:String x:Key="GiveUpUploadingPenguins">Abort upload to Penguin Statistics</system:String>
     <system:String x:Key="TheEx">No bonus stage, stopped</system:String>
-    <system:String x:Key="MissingOperators">Operators of the following operator groups are missing:&#160;</system:String>
+    <system:String x:Key="MissingOperators">{key=Operator}s of the following {key=Operator} groups are missing:&#160;</system:String>
     <system:String x:Key="RecruitSupportOperator">Add support unit: {0}</system:String>
     <system:String x:Key="StageQueue">Stage Queue:&#160;</system:String>
     <system:String x:Key="UnableToAgent">Unable to use PRTS</system:String>
@@ -892,7 +892,7 @@ Right-click to clear inactive tasks</system:String>
     <system:String x:Key="ActingCommandError">PRTS error</system:String>
     <system:String x:Key="LabelsRefreshed">Labels refreshed</system:String>
     <system:String x:Key="RecruitConfirm">Recruit confirm</system:String>
-    <system:String x:Key="InfrastDormDoubleConfirmed">Operator conflict</system:String>
+    <system:String x:Key="InfrastDormDoubleConfirmed">{key=Operator} conflict</system:String>
     <system:String x:Key="BegunToExplore">Exploration started</system:String>
     <system:String x:Key="ExplorationAbandoned">Abandoned this Exploration</system:String>
     <system:String x:Key="FightCompleted">Combat completed</system:String>
@@ -932,8 +932,8 @@ Right-click to clear inactive tasks</system:String>
     <system:String x:Key="FurnitureDrop">Furniture</system:String>
     <system:String x:Key="ThisFacility" xml:space="preserve">Current Facility:&#160;</system:String>
     <system:String x:Key="RoomGroupsMatch" xml:space="preserve">Match Group:&#160;</system:String>
-    <system:String x:Key="RoomGroupsMatchFailed" xml:space="preserve">Failed to match operator groups, group list:&#160;</system:String>
-    <system:String x:Key="RoomOperators" xml:space="preserve">Preferred operators:&#160;</system:String>
+    <system:String x:Key="RoomGroupsMatchFailed" xml:space="preserve">Failed to match {key=Operator} groups, group list:&#160;</system:String>
+    <system:String x:Key="RoomOperators" xml:space="preserve">Preferred {key=Operator}s:&#160;</system:String>
     <system:String x:Key="ProductIncorrect">Product does NOT match the configuration.</system:String>
     <system:String x:Key="ProductUnknown">Unknown Product</system:String>
     <system:String x:Key="ProductChanged">Product has changed</system:String>
@@ -951,7 +951,7 @@ Right-click to clear inactive tasks</system:String>
     <system:String x:Key="SelectExtraOnlyRareTags">Pick as many high-star Tags as possible</system:String>
     <system:String x:Key="AutoRecruitHighPriority">Preference for 3★ Tags</system:String>
     <system:String x:Key="AutoRecruitHighPriorityTooltip">Will select as many Tag preferences as possible</system:String>
-    <system:String x:Key="NotEnoughStaff">Insufficient operators</system:String>
+    <system:String x:Key="NotEnoughStaff">Insufficient {key=Operator}s</system:String>
     <system:String x:Key="StageInfoError">Stage recognition error</system:String>
     <system:String x:Key="UseFormation">Use formation</system:String>
     <system:String x:Key="Current">Current</system:String>
@@ -1016,14 +1016,14 @@ Right-click to clear inactive tasks</system:String>
     <system:String x:Key="Hangover">I won't drink so much next time……</system:String>
     <system:String x:Key="HelloWorld">Hello World!</system:String>
     <system:String x:Key="EasterEggsRules" xml:space="preserve">1. The official version of MAA will not have Debug mode. If you see a Debug option while running, close the software immediately, do not click it, and contact the nearest MAA developer.\n
-2. Infrastructure shift changes are automatic. If you find an operator working continuously for more than 72 hours, manually adjust the shifts and check if the system time is correct.\n
+2. Infrastructure shift changes are automatic. If you find an {key=Operator} working continuously for more than 72 hours, manually adjust the shifts and check if the system time is correct.\n
 3. Recruitment tags will not change. If you notice tags changing before the countdown ends, do not continue recruiting. Restart MAA and try again.\n
 4. MAA will not send friend requests. If you receive a friend request from ｢MAA_System｣, do not accept it and delete the account.\n
 5. Roguelike assistance only provides suggestions. If the game automatically selects a non-existent option, force quit and restart the client.\n
 6. MAA's log files should not contain garbled text. If you find logs with errors other than ｢ERROR: Data parsing failed｣, delete the logs and reinstall the software.\n
 7. Night mode is safe. However, if MAA starts automatically at 3:33 AM and runs ｢unknown tasks｣, unplug the power and wait until sunrise to use it again.\n
 8. The last rule does not exist. If you see this, forget it and use MAA as usual.\n
-9. Do not click on炒...锟斤拷拷拷拷喜报拷拷拷饭 in MAA.\n
+9. Do not click on ███████████ █████████ in MAA.\n
 10. MirrorChyan is kind. You only need to pay a small price to receive its protection.\n
 11. MAA does not support future versions. If the software updates to an unreleased version number (e.g., v10.0.0), do not run it and wait for an official announcement.\n
 12. MAA has no voice prompts. If you hear whispers, laughter, or non-program-generated voices, turn off the speakers and check for unknown scripts running.\n
@@ -1272,7 +1272,7 @@ If you want to run multiple MAA at the same time, please copy the whole MAA and 
 
     <system:String x:Key="Achievement.Irreplaceable.Title">Irreplaceable</system:String>
     <system:String x:Key="Achievement.Irreplaceable.Description">Maybe I should get different homework?</system:String>
-    <system:String x:Key="Achievement.Irreplaceable.Conditions">When using ｢{key=Copilot} - {key=AutoSquad}｣, missing at least two operators</system:String>
+    <system:String x:Key="Achievement.Irreplaceable.Conditions">When using ｢{key=Copilot} - {key=AutoSquad}｣, missing at least two {key=Operator}s</system:String>
 
     <system:String x:Key="Achievement.SnapshotChallenge1.Title">High Ping Warrior</system:String>
     <system:String x:Key="Achievement.SnapshotChallenge1.Description">"lag"</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -111,8 +111,8 @@
     <system:String x:Key="OriginStone">製造所-源石の欠片</system:String>
     <system:String x:Key="Chip">製造所-中級SoC</system:String>
     <system:String x:Key="DormTrustEnabled">宿舎の空き位置で信頼度を上げる</system:String>
-    <system:String x:Key="DormFilterNotStationedEnabled">作業中の人員を宿舎に移動しない（例:訓練所でのアイリーニなど）</system:String>
-    <system:String x:Key="DormFilterNotStationedTips">チェックした場合、アイリーニのようなオペレーターが訓練室から外れなくなり、また、加工所のオペレーターが宿舎に送られることを防止します。</system:String>
+    <system:String x:Key="DormFilterNotStationedEnabled">作業中の{key=Operator}を宿舎に移動しない（例:訓練所でのアイリーニなど）</system:String>
+    <system:String x:Key="DormFilterNotStationedTips">チェックした場合、アイリーニのような{key=Operator}が訓練室から外れなくなり、また、加工所の{key=Operator}が宿舎に送られることを防止します。</system:String>
     <system:String x:Key="OriginiumShardAutoReplenishment">源石の欠片を自動で補充</system:String>
     <system:String x:Key="InfrastReceptionMessageBoardReceive">受付室の掲示板からのクレジット収集</system:String>
     <system:String x:Key="ContinueTraining">訓練完了後に現在スキルの継続特化を試みます</system:String>
@@ -123,7 +123,7 @@
     <system:String x:Key="InfrastMode">インフラモード</system:String>
     <system:String x:Key="InfrastModeNormal">通常モード</system:String>
     <system:String x:Key="InfrastModeRotation">一括シフト休暇</system:String>
-    <system:String x:Key="InfrastModeRotationTip">一括シフト休暇を使用する前に、ゲーム内でオペレーターのキューを手動で設定してください</system:String>
+    <system:String x:Key="InfrastModeRotationTip">一括シフト休暇を使用する前に、ゲーム内で{key=Operator}のシフト編成を手動で設定してください</system:String>
     <system:String x:Key="InfrastModeCustom">カスタムされた基地構成</system:String>
     <system:String x:Key="DefaultInfrast">標準設定</system:String>
     <system:String x:Key="UserDefined">ユーザー定義</system:String>
@@ -150,19 +150,19 @@
     <system:String x:Key="SecondResolution">2番目の決議</system:String>
     <system:String x:Key="GeneralWithoutScreencapErr">一般モード（ブロックされた例外出力）</system:String>
     <system:String x:Key="DormThreshold">体力が設定した%以下になれば宿舎へ移動する</system:String>
-    <system:String x:Key="InfrastThresholdTip">カスタム シフトが有効な場合、このフィールドは自動入力とオペレーター グループのあるルームに対してのみ有効です</system:String>
+    <system:String x:Key="InfrastThresholdTip">カスタム シフトが有効な場合、このフィールドは自動入力と{key=Operator} グループのあるルームに対してのみ有効です</system:String>
     <system:String x:Key="RoguelikeStrategyExp">経験値を取得し、できるだけクリア</system:String>
     <system:String x:Key="RoguelikeStrategyGold">源石錐を収集、投資完了後に自動で終了</system:String>
-    <system:String x:Key="RoguelikeStrategyLastReward">支援選択を得るため3層到着後に終了</system:String>
+    <system:String x:Key="RoguelikeStrategyLastReward">支援選択あるいは昇進した{key=Operator}を得るため3層到着後に終了</system:String>
     <system:String x:Key="RoguelikeStrategyCollapse">パラダイムロストをファーミングして、非レアパラダイムロストに遭遇したらすぐに再起動します</system:String>
     <system:String x:Key="RoguelikeCollectibleModeSquad">支援選択を得るモードの分隊</system:String>
     <system:String x:Key="RoguelikeStrategyMonthlySquad">月間小隊をグラインドし、できるだけ多くの層をクリア</system:String>
     <system:String x:Key="RoguelikeStrategyDeepExploration">深層探索をグラインドし、できるだけ多くの層をクリア</system:String>
     <system:String x:Key="StartingSquad">最初の分隊</system:String>
     <system:String x:Key="StartingRoles">最初の職業</system:String>
-    <system:String x:Key="StartingCoreChar">最初のオペレーター</system:String>
+    <system:String x:Key="StartingCoreChar">最初の{key=Operator}</system:String>
     <system:String x:Key="StartingCoreCharTip">記入がない場合はデフォルトの方針を使用します。</system:String>
-    <system:String x:Key="RoguelikeStartingCoreCharNotFound">このオペレーターがbattle_dataにありません。</system:String>
+    <system:String x:Key="RoguelikeStartingCoreCharNotFound">この{key=Operator}がbattle_dataにありません。</system:String>
     <system:String x:Key="RoguelikeStartWithEliteTwo">｢{key=StartingCoreChar}｣ 直接昇進</system:String>
     <system:String x:Key="RoguelikeOnlyStartWithEliteTwo">｢{key=StartingCoreChar}｣の昇進招集までリセマラし、戦闘を行わない</system:String>
     <system:String x:Key="Roguelike3FirstFloorFoldartal">第一層遠見で指定された啓示板を取得し、戦闘を行わない</system:String>
@@ -553,7 +553,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="ReclamationIncrementModeHold">長押し</system:String>
     <system:String x:Key="ReclamationMaxCraftCountPerRound">1回の最大クラフト回数</system:String>
     <system:String x:Key="ReclamationClearStore">完成後、商店を空にする</system:String>
-    <system:String x:Key="OperNameLanguage">オペレーター名の表示言語</system:String>
+    <system:String x:Key="OperNameLanguage">{key=Operator}名の表示言語</system:String>
     <system:String x:Key="OperNameLanguageMAA">MAA をフォローする</system:String>
     <system:String x:Key="OperNameLanguageClient">ゲームクライアントをフォローする</system:String>
     <system:String x:Key="OperNameLanguageForce">指定された言語を強制的に使用する</system:String>
@@ -688,9 +688,9 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="CopiedToClipboard">クリップボードへコピー</system:String>
     <!--  !倉庫アイテム認識  -->
     <!--  Operator Recognition  -->
-    <system:String x:Key="OperBoxRecognition">オペレーター</system:String>
+    <system:String x:Key="OperBoxRecognition">{key=Operator}</system:String>
     <system:String x:Key="OperBox">{key=OperBoxRecognition}</system:String>
-    <system:String x:Key="OperBoxRecognitionTip">｢戦術要員｣ は、オペレーター識別の正確性に影響します。戦術要員のオペレーターの識別が誤っている場合は、自己判断してください。</system:String>
+    <system:String x:Key="OperBoxRecognitionTip">｢戦術要員｣ は、{key=Operator}識別の正確性に影響します。戦術要員の{key=Operator}の識別が誤っている場合は、自己判断してください。</system:String>
     <system:String x:Key="OperBoxHaveList">所有している: {0}</system:String>
     <system:String x:Key="OperBoxNotHaveList">所有していない: {0}</system:String>
     <system:String x:Key="StartToOperBoxRecognition">認識開始</system:String>
@@ -766,11 +766,11 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="FailedToLikeWebJson">エラーが発生しました、いいねに失敗しました。 : &lt;</system:String>
     <system:String x:Key="ThanksForLikeWebJson">感謝と評価！\nウェブページには既にコメント欄が開放されており、あなたのコメントを心待ちにしています！</system:String>
     <system:String x:Key="AutoSquad">自動編成</system:String>
-    <system:String x:Key="AutoSquadTip">自動編成では、一時的に ｢戦術要員｣ オペレーターを認識できません</system:String>
-    <system:String x:Key="AddTrust">信頼度が低いオペレーターを追加する</system:String>
+    <system:String x:Key="AutoSquadTip">自動編成では、一時的に ｢戦術要員｣ {key=Operator}を認識できません</system:String>
+    <system:String x:Key="AddTrust">信頼度が低い{key=Operator}を追加する</system:String>
     <system:String x:Key="Copilot.IgnoreRequirements">{key=Operator}属性の要件を無視</system:String>
-    <system:String x:Key="AddUserAdditional">カスタムで指定したオペレーターを追加する</system:String>
-    <system:String x:Key="AddUserAdditionalTip">｢;｣ はセパレータ、｢,｣ でオペレーターの名前とスキルを区切ります。例: Surtr, 3; Eyjafjalla,1</system:String>
+    <system:String x:Key="AddUserAdditional">カスタムで指定した{key=Operator}を追加する</system:String>
+    <system:String x:Key="AddUserAdditionalTip">｢;｣ はセパレータ、｢,｣ で{key=Operator}の名前とスキルを区切ります。例: Surtr, 3; Eyjafjalla,1</system:String>
     <system:String x:Key="UseCopilotList">バトルリスト</system:String>
     <system:String x:Key="UseCopilotListTip" xml:space="preserve">チャプター間の移動はサポートされていません。サポートのみです:
   1. メインストーリー：同一章内でのナビゲーション
@@ -787,9 +787,9 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="CopilotSkill">スキル</system:String>
     <system:String x:Key="CopilotModule">モジュール</system:String>
     <system:String x:Key="CopilotWithoutModule">モジュールなし</system:String>
-    <system:String x:Key="TotalOperatorsCount">合計 {0} 名のオペレーター</system:String>
+    <system:String x:Key="TotalOperatorsCount">合計 {0} 名の{key=Operator}</system:String>
     <system:String x:Key="DirectiveECTerm">拡張式戦術ユニット：</system:String>
-    <system:String x:Key="OtherOperators">その他のオペレーター：</system:String>
+    <system:String x:Key="OtherOperators">その他の{key=Operator}：</system:String>
     <system:String x:Key="InitialEquipmentHorizontal">初期戦術装備（横）：</system:String>
     <system:String x:Key="InitialStrategy">初期戦略：</system:String>
     <!--  Logs  -->
@@ -799,8 +799,8 @@ C:\\leidian\\LDPlayer9
         2. 逆理演算の場合は、｢{key=AutoSquad}｣ をオフにする必要があり、スキルを選択した後、｢演算開始｣ ボタンのインターフェースから開始する必要があります；\n\n
         3. SSSには、resource/copilot フォルダー内に複数の組み込みファイルがあります。\n
         手動形成後、｢開始デプロイメント｣ 画面から開始してください（｢{key=LoopTimes} で使用可能）。\n\n
-        4. サポートを使うときは、｢{key=AutoSquad}｣ をオフにし、手動でオペレーターを選択してから始めましょう；\n\n
-        5. ｢戦術要員｣ 機能を有効にすると、｢{key=AutoSquad}｣ のオペレーター選択に影響を与える可能性があります。｢{key=AutoSquad}｣ を 使用する際は ｢戦術要員｣ をオフにするか、不足しているオペレーターを手動で補充して編成を完成させることをお勧めします。\n\n
+        4. サポートを使うときは、｢{key=AutoSquad}｣ をオフにし、手動で{key=Operator}を選択してから始めましょう；\n\n
+        5. ｢戦術要員｣ 機能を有効にすると、｢{key=AutoSquad}｣ の{key=Operator}選択に影響を与える可能性があります。｢{key=AutoSquad}｣ を 使用する際は ｢戦術要員｣ をオフにするか、不足している{key=Operator}を手動で補充して編成を完成させることをお勧めします。\n\n
         6. Copilot作業ステーションでは、入力欄の右側にある貼り付けボタンをクリックして、謎のコードを貼り付けることができます。左クリックで単一のジョブを貼り付け、右クリックでジョブセット全体を貼り付けます。\n\n
         7. バトルリスト:\n
         ジョブを選択した後、リストの下のステージ名が正しいことを確認してください (例: CV-EX-1)。 \n
@@ -875,7 +875,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="DropRecognitionError">ドロップ認識エラー</system:String>
     <system:String x:Key="GiveUpUploadingPenguins">Penguin-Statsへのアップロードをあきらめました</system:String>
     <system:String x:Key="TheEx">ステージ報酬がないため停止します</system:String>
-    <system:String x:Key="MissingOperators">次のオペレーターがオペレーターグループにありません：</system:String>
+    <system:String x:Key="MissingOperators">次の{key=Operator}が{key=Operator}グループにありません：</system:String>
     <system:String x:Key="RecruitSupportOperator">サポートユニットを追加：{0}</system:String>
     <system:String x:Key="StageQueue">ステージキュー:</system:String>
     <system:String x:Key="UnableToAgent">自動指揮利用不可</system:String>
@@ -892,7 +892,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="ActingCommandError">自動指揮のミスが生じました</system:String>
     <system:String x:Key="LabelsRefreshed">タグが更新されました</system:String>
     <system:String x:Key="RecruitConfirm">募集を行いました</system:String>
-    <system:String x:Key="InfrastDormDoubleConfirmed">オペレーターが競合しました</system:String>
+    <system:String x:Key="InfrastDormDoubleConfirmed">{key=Operator}が競合しました</system:String>
     <system:String x:Key="BegunToExplore">探索を開始しました</system:String>
     <system:String x:Key="ExplorationAbandoned">この探索を放棄しました</system:String>
     <system:String x:Key="FightCompleted">戦闘完了</system:String>
@@ -932,8 +932,8 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="FurnitureDrop">家具</system:String>
     <system:String x:Key="ThisFacility" xml:space="preserve">現在の施設: </system:String>
     <system:String x:Key="RoomGroupsMatch" xml:space="preserve">グループに合わせる: </system:String>
-    <system:String x:Key="RoomGroupsMatchFailed" xml:space="preserve">オペレータ グループ、グループ リストの一致に失敗しました: </system:String>
-    <system:String x:Key="RoomOperators" xml:space="preserve">優先オペレーター: </system:String>
+    <system:String x:Key="RoomGroupsMatchFailed" xml:space="preserve">{key=Operator} グループ、グループ リストの一致に失敗しました: </system:String>
+    <system:String x:Key="RoomOperators" xml:space="preserve">優先{key=Operator}: </system:String>
     <system:String x:Key="ProductIncorrect">製産物が構成と一致しません。</system:String>
     <system:String x:Key="ProductUnknown">認識不能な製産物</system:String>
     <system:String x:Key="ProductChanged">製産物が切り替わった</system:String>
@@ -951,13 +951,13 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="SelectExtraOnlyRareTags">可能な限りタグを選択し、かつ高い星のタグのみを選択する</system:String>
     <system:String x:Key="AutoRecruitHighPriority">優先タグ</system:String>
     <system:String x:Key="AutoRecruitHighPriorityTooltip">できるだけ多くのタグの傾向を選択します</system:String>
-    <system:String x:Key="NotEnoughStaff">利用可能なオペレーターが不足しています</system:String>
+    <system:String x:Key="NotEnoughStaff">利用可能な{key=Operator}が不足しています</system:String>
     <system:String x:Key="StageInfoError">ステージ認識エラー</system:String>
     <system:String x:Key="UseFormation">使用編成</system:String>
     <system:String x:Key="Current">現在</system:String>
     <system:String x:Key="BattleFormation">編成開始</system:String>
-    <system:String x:Key="BattleFormationSelected" xml:space="preserve">オペレーターを選択: </system:String>
-    <system:String x:Key="BattleFormationOperUnavailable" xml:space="preserve">オペレーターを利用不可: {0}、制限: {1}</system:String>
+    <system:String x:Key="BattleFormationSelected" xml:space="preserve">{key=Operator}を選択: </system:String>
+    <system:String x:Key="BattleFormationOperUnavailable" xml:space="preserve">{key=Operator}を利用不可: {0}、制限: {1}</system:String>
     <system:String x:Key="CurrentSteps">現在の手順: {0} {1}</system:String>
     <system:String x:Key="UnsupportedLevel">サポートされていないステージです。ステージ名を確認するか、｢{key=Settings} - {key=UpdateSettings} - {key=ResourceUpdate}｣ に移動してリソースバージョンを更新してみてください！</system:String>
     <system:String x:Key="RecruitTagsDetected" xml:space="preserve">認識結果: </system:String>
@@ -1016,7 +1016,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="Hangover">つ、次は飲みすぎないようにしないと……</system:String>
     <system:String x:Key="HelloWorld">Hello World!</system:String>
     <system:String x:Key="EasterEggsRules" xml:space="preserve">1. MAA の正式版にはデバッグモードはありません。実行中にデバッグオプションが表示された場合は、すぐにソフトウェアを閉じ、それをクリックせず、最寄りの MAA 開発者に連絡してください。\n
-2. インフラのシフト変更は自動です。オペレーターが 72 時間以上連続して働いている場合は、手動でシフトを調整し、システム時間が正しいか確認してください。\n
+2. インフラのシフト変更は自動です。{key=Operator}が 72 時間以上連続して働いている場合は、手動でシフトを調整し、システム時間が正しいか確認してください。\n
 3. 公開募集のタグは変更されません。カウントダウンが終了する前にタグが変更された場合は、募集を続けず、MAA を再起動してから操作してください。\n
 4. MAA はフレンドリクエストを送信しません。｢MAA_System｣ からフレンドリクエストを受け取った場合は、承認せず、そのアカウントを削除してください。\n
 5. ローグライクの支援は提案のみを提供します。ゲームが存在しないオプションを自動的に選択した場合は、強制終了してクライアントを再起動してください。\n
@@ -1088,7 +1088,7 @@ C:\\leidian\\LDPlayer9
  初期設定でポイントを稼ぐ：（既存のセーブデータが削除されることに注意してください）
   0.ポイントがいっぱいになると ｢タスク完了｣ が出力され、タスクは自動的に停止します
   1. 理論的には、タスクは、セーブデータの有無に関係なく、ポイント獲得のためのどの時点からでもタスクを開始できる。
-  2. 生息演算の編成にオペレーターを入れることができるが、テストしていないのでお勧めしない。
+  2. 生息演算の編成に{key=Operator}を入れることができるが、テストしていないのでお勧めしない。
   3. ナビゲーションがまだ書かれていないので、生息演算の画面以外の場所からタスクを開始することはできない。
   4. タスク中にエラーが出たり、ポイントが満杯なかたでタスクが完了した場合は、GitHubにissueを提出してください。
 
@@ -1272,7 +1272,7 @@ MAA を複数開くには、新しい MAA を他のフォルダにコピーし�
 
     <system:String x:Key="Achievement.Irreplaceable.Title">替代不可</system:String>
     <system:String x:Key="Achievement.Irreplaceable.Description">たぶん、別の作業を変更すべきですか？</system:String>
-    <system:String x:Key="Achievement.Irreplaceable.Conditions">｢{key=Copilot} - {key=AutoSquad}｣ 使用時、少なくとも2名のオペレーターが不足している。</system:String>
+    <system:String x:Key="Achievement.Irreplaceable.Conditions">｢{key=Copilot} - {key=AutoSquad}｣ 使用時、少なくとも2名の{key=Operator}が不足している。</system:String>
 
     <system:String x:Key="Achievement.SnapshotChallenge1.Title">高遅延危機</system:String>
     <system:String x:Key="Achievement.SnapshotChallenge1.Description">「kale」</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -111,8 +111,8 @@
     <system:String x:Key="OriginStone">제조소-오리지늄 조각</system:String>
     <system:String x:Key="Chip">제조소-칩</system:String>
     <system:String x:Key="DormTrustEnabled">숙소의 남은 자리로 신뢰도 증가</system:String>
-    <system:String x:Key="DormFilterNotStationedEnabled">업무중인 오퍼레이터 숙소 배치 제한</system:String>
-    <system:String x:Key="DormFilterNotStationedTips">체크할 경우 아이린과 같은 오퍼레이터를 훈련실에서 제거하지 않고, 가공소의 오퍼레이터가 숙소에 배치되는 것을 방지합니다.</system:String>
+    <system:String x:Key="DormFilterNotStationedEnabled">업무중인 {key=Operator} 숙소 배치 제한</system:String>
+    <system:String x:Key="DormFilterNotStationedTips">체크할 경우 아이린과 같은 {key=Operator}를 훈련실에서 제거하지 않고, 가공소의 {key=Operator}가 숙소에 배치되는 것을 방지합니다.</system:String>
     <system:String x:Key="OriginiumShardAutoReplenishment">오리지늄 조각 자동 보충</system:String>
     <system:String x:Key="InfrastReceptionMessageBoardReceive">응접실 게시판에서 크레딧 수집</system:String>
     <system:String x:Key="ContinueTraining">스킬 훈련 완료 시 이어서 훈련 시도</system:String>
@@ -123,7 +123,7 @@
     <system:String x:Key="InfrastMode">인프라 모드</system:String>
     <system:String x:Key="InfrastModeNormal">표준 모드</system:String>
     <system:String x:Key="InfrastModeRotation">일괄 쉬프트</system:String>
-    <system:String x:Key="InfrastModeRotationTip">일괄 쉬프트 사용 전에 게임 내에서 오퍼레이터 대열을 수동으로 설정해 주세요</system:String>
+    <system:String x:Key="InfrastModeRotationTip">일괄 쉬프트 사용 전에 게임 내에서 {key=Operator} 대열을 수동으로 설정해 주세요</system:String>
     <system:String x:Key="InfrastModeCustom">커스텀 기반시설</system:String>
     <system:String x:Key="DefaultInfrast">기본 구성</system:String>
     <system:String x:Key="UserDefined">사용자 설정</system:String>
@@ -149,20 +149,20 @@
     <system:String x:Key="Compatible">호환 모드</system:String>
     <system:String x:Key="SecondResolution">분할 화면</system:String>
     <system:String x:Key="GeneralWithoutScreencapErr">일반 모드 (예외 출력 차단)</system:String>
-    <system:String x:Key="DormThreshold">오퍼레이터 컨디션 한계점</system:String>
-    <system:String x:Key="InfrastThresholdTip">사용자 지정 교대 근무 변경이 활성화된 경우 이 필드는 자동 채우기 및 오퍼레이터 교체를 사용하는 회의실에만 유효합니다</system:String>
+    <system:String x:Key="DormThreshold">{key=Operator} 컨디션 한계점</system:String>
+    <system:String x:Key="InfrastThresholdTip">사용자 지정 교대 근무 변경이 활성화된 경우 이 필드는 자동 채우기 및 {key=Operator} 교체를 사용하는 회의실에만 유효합니다</system:String>
     <system:String x:Key="RoguelikeStrategyExp">레벨 우선, 최대한 많은 구역 클리어</system:String>
     <system:String x:Key="RoguelikeStrategyGold">각뿔 수집, 투자 완료 시 자동 종료</system:String>
-    <system:String x:Key="RoguelikeStrategyLastReward">2정 오퍼레이터 또는 전기주전자 획득까지 반복</system:String>
+    <system:String x:Key="RoguelikeStrategyLastReward">2정 {key=Operator} 또는 전기주전자 획득까지 반복</system:String>
     <system:String x:Key="RoguelikeStrategyCollapse">희귀 붕괴 패러다임 파밍, 일반 붕괴 패러다임 획득 시 재시작</system:String>
     <system:String x:Key="RoguelikeCollectibleModeSquad">전기주전자 획득 분대</system:String>
     <system:String x:Key="RoguelikeStrategyMonthlySquad">월간 분대 파밍, 최대한 많은 구역 클리어</system:String>
     <system:String x:Key="RoguelikeStrategyDeepExploration">심층 조사 파밍, 최대한 많은 구역 클리어</system:String>
     <system:String x:Key="StartingSquad">시작 분대</system:String>
     <system:String x:Key="StartingRoles">모집 조합</system:String>
-    <system:String x:Key="StartingCoreChar">시작 오퍼레이터</system:String>
+    <system:String x:Key="StartingCoreChar">시작 {key=Operator}</system:String>
     <system:String x:Key="StartingCoreCharTip">작성하지 않으면 기본 설정이 사용됩니다.</system:String>
-    <system:String x:Key="RoguelikeStartingCoreCharNotFound">해당 오퍼레이터는 battle_data에 없습니다</system:String>
+    <system:String x:Key="RoguelikeStartingCoreCharNotFound">해당 {key=Operator}는 battle_data에 없습니다</system:String>
     <system:String x:Key="RoguelikeStartWithEliteTwo">｢{key=StartingCoreChar}｣ 2정까지 반복</system:String>
     <system:String x:Key="RoguelikeOnlyStartWithEliteTwo">｢{key=StartingCoreChar}｣ 2정까지 반복, 전투 X</system:String>
     <system:String x:Key="Roguelike3FirstFloorFoldartal">1층 암호판 획득 반복, 전투 X</system:String>
@@ -552,7 +552,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="ReclamationIncrementModeHold">길게 누르기</system:String>
     <system:String x:Key="ReclamationMaxCraftCountPerRound">한 번의 최대 제작 횟수</system:String>
     <system:String x:Key="ReclamationClearStore">Clear Store after finished</system:String>
-    <system:String x:Key="OperNameLanguage">오퍼레이터 이름 표시 언어</system:String>
+    <system:String x:Key="OperNameLanguage">{key=Operator} 이름 표시 언어</system:String>
     <system:String x:Key="OperNameLanguageMAA">MAA 언어 따라가기</system:String>
     <system:String x:Key="OperNameLanguageClient">게임 클라이언트 따라가기</system:String>
     <system:String x:Key="OperNameLanguageForce">지정된 언어를 강제로 사용</system:String>
@@ -670,7 +670,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="RecruitmentRecognitionTip">시작 화면의 공개모집 기능과는 별도로 독립된 기능입니다\n게임 내 공개모집 태그 화면에 진입한 뒤 인식 시작 버튼을 누르세요~</system:String>
     <system:String x:Key="AutoSettingTime">자동 시간 설정</system:String>
     <system:String x:Key="RecruitmentShowPotential">잠재능력 확인 (★4 이상)</system:String>
-    <system:String x:Key="RecruitmentShowPotentialTips">오퍼레이터 정보를 불러오려면 ｢{key=OperBoxRecognition}｣ 기능을 사용하세요.</system:String>
+    <system:String x:Key="RecruitmentShowPotentialTips">{key=Operator} 정보를 불러오려면 ｢{key=OperBoxRecognition}｣ 기능을 사용하세요.</system:String>
     <system:String x:Key="AutoSelectLevel3Tags">★3 태그를 자동 선택</system:String>
     <system:String x:Key="AutoSelectLevel4Tags">★4 태그를 자동 선택</system:String>
     <system:String x:Key="AutoSelectLevel5Tags">★5 태그를 자동 선택</system:String>
@@ -687,9 +687,9 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="CopiedToClipboard">클립보드에 복사됨</system:String>
     <!--  !창고 인식  -->
     <!--  오퍼레이터 인식  -->
-    <system:String x:Key="OperBoxRecognition">오퍼레이터 인식</system:String>
+    <system:String x:Key="OperBoxRecognition">{key=Operator} 인식</system:String>
     <system:String x:Key="OperBox">{key=OperBoxRecognition}</system:String>
-    <system:String x:Key="OperBoxRecognitionTip">시작하기 전에 등록된 ｢선호｣ 오퍼레이터를 등록 해제하세요.</system:String>
+    <system:String x:Key="OperBoxRecognitionTip">시작하기 전에 등록된 ｢선호｣ {key=Operator}를 등록 해제하세요.</system:String>
     <system:String x:Key="OperBoxHaveList">보유: {0}</system:String>
     <system:String x:Key="OperBoxNotHaveList">미보유: {0}</system:String>
     <system:String x:Key="StartToOperBoxRecognition">인식 시작</system:String>
@@ -765,11 +765,11 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="FailedToLikeWebJson">오류로 인해 평가에 실패했습니다: &lt;</system:String>
     <system:String x:Key="ThanksForLikeWebJson">감사합니다!\n웹사이트에 댓글을 남길 수도 있으니 의견을 남겨 주세요!</system:String>
     <system:String x:Key="AutoSquad">자동 편성</system:String>
-    <system:String x:Key="AutoSquadTip">자동 편성은 ｢선호｣ 설정 된 오퍼레이터를 인식할 수 없습니다</system:String>
-    <system:String x:Key="AddTrust">신뢰도가 낮은 오퍼레이터 추가</system:String>
+    <system:String x:Key="AutoSquadTip">자동 편성은 ｢선호｣ 설정 된 {key=Operator}를 인식할 수 없습니다</system:String>
+    <system:String x:Key="AddTrust">신뢰도가 낮은 {key=Operator} 추가</system:String>
     <system:String x:Key="Copilot.IgnoreRequirements">{key=Operator} 모듈 요구 사항 무시</system:String>
-    <system:String x:Key="AddUserAdditional">커스텀 오퍼레이터 추가</system:String>
-    <system:String x:Key="AddUserAdditionalTip">｢;｣ 로 오퍼레이터를 구분하고, ｢,｣ 로 스킬을 구분합니다. 예시: W, 3; Ash, 2</system:String>
+    <system:String x:Key="AddUserAdditional">커스텀 {key=Operator} 추가</system:String>
+    <system:String x:Key="AddUserAdditionalTip">｢;｣ 로 {key=Operator}를 구분하고, ｢,｣ 로 스킬을 구분합니다. 예시: W, 3; Ash, 2</system:String>
     <system:String x:Key="UseCopilotList">전투 목록</system:String>
     <system:String x:Key="UseCopilotListTip" xml:space="preserve">챕터 간 이동은 지원하지 않습니다. 지원:
   1. 메인 스토리: 동일 챕터 내 네비게이션
@@ -786,9 +786,9 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="CopilotSkill">스킬</system:String>
     <system:String x:Key="CopilotModule">모듈</system:String>
     <system:String x:Key="CopilotWithoutModule">모듈 없이 시작</system:String>
-    <system:String x:Key="TotalOperatorsCount">총 {0}명의 오퍼레이터</system:String>
+    <system:String x:Key="TotalOperatorsCount">총 {0}명의 {key=Operator}</system:String>
     <system:String x:Key="DirectiveECTerm">에너지 기어:</system:String>
-    <system:String x:Key="OtherOperators">기타 오퍼레이터:</system:String>
+    <system:String x:Key="OtherOperators">기타 {key=Operator}:</system:String>
     <system:String x:Key="InitialEquipmentHorizontal">전술 장비 (가로):</system:String>
     <system:String x:Key="InitialStrategy">초기 전략:</system:String>
     <!--  Logs  -->
@@ -799,7 +799,7 @@ C:\\leidian\\LDPlayer9
         3. 보안파견의 Copilot 파일의 경우 MAA 내의 ｢resource/copilot｣ 폴더에 있습니다 \n
         수동 편성 후 ｢작전 개시｣ 버튼이 있는 화면에서 시작하세요. (｢{key=LoopTimes} 와 함께 사용 가능)\n\n
         4. 지원 유닛을 사용할 때에는 반드시 ｢{key=AutoSquad}｣ 을 끄고, 지원 유닛을 선택한 후에 시작해야 합니다\n\n
-        5. ｢선호｣ 기능을 활성화하면 ｢{key=AutoSquad}｣ 의 오퍼레이터 선택에 영향을 미칠 수 있습니다. ｢{key=AutoSquad}｣ 을 사용할 때 ｢선호｣ 을 끄거나, 누락된 오퍼레이터를 수동으로 추가하여 편성을 완료하는 것을 권장합니다.\n\n
+        5. ｢선호｣ 기능을 활성화하면 ｢{key=AutoSquad}｣ 의 {key=Operator} 선택에 영향을 미칠 수 있습니다. ｢{key=AutoSquad}｣ 을 사용할 때 ｢선호｣ 을 끄거나, 누락된 {key=Operator}를 수동으로 추가하여 편성을 완료하는 것을 권장합니다.\n\n
         6. Copilot 작업 스테이션에서 입력란 오른쪽의 붙여넣기 버튼을 클릭하여 신비한 코드를 붙여넣을 수 있습니다. 왼쪽 클릭으로 단일 작업을 붙여넣고, 오른쪽 클릭으로 작업 세트 전체를 붙여넣습니다.\n\n
         7. 전투 목록:\n
         작업을 선택한 후 목록 아래의 스테이지 이름이 올바른지 확인하세요 (예: CV-EX-1).\n
@@ -874,7 +874,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="DropRecognitionError">드롭 인식 오류</system:String>
     <system:String x:Key="GiveUpUploadingPenguins">펭귄 물류에 업로드 불가</system:String>
     <system:String x:Key="TheEx">EX 스테이지가 없어 중단되었습니다</system:String>
-    <system:String x:Key="MissingOperators">다음 오퍼레이터들이 누락되었습니다:</system:String>
+    <system:String x:Key="MissingOperators">다음 {key=Operator}들이 누락되었습니다:</system:String>
     <system:String x:Key="RecruitSupportOperator">지원 유닛 추가: {0}</system:String>
     <system:String x:Key="StageQueue">스테이지 대기열:</system:String>
     <system:String x:Key="UnableToAgent">프록시 명령을 사용할 수 없습니다</system:String>
@@ -891,7 +891,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="ActingCommandError">PRTS 오류</system:String>
     <system:String x:Key="LabelsRefreshed">태그를 새로 고쳤습니다</system:String>
     <system:String x:Key="RecruitConfirm">모집 확정</system:String>
-    <system:String x:Key="InfrastDormDoubleConfirmed">요구 오퍼레이터 충돌</system:String>
+    <system:String x:Key="InfrastDormDoubleConfirmed">요구 {key=Operator} 충돌</system:String>
     <system:String x:Key="BegunToExplore" xml:space="preserve">탐험 시작됨</system:String>
     <system:String x:Key="ExplorationAbandoned">탐사 중단</system:String>
     <system:String x:Key="FightCompleted">작전 완료</system:String>
@@ -931,14 +931,14 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="FurnitureDrop">가구</system:String>
     <system:String x:Key="ThisFacility" xml:space="preserve">현재 시설: </system:String>
     <system:String x:Key="RoomGroupsMatch" xml:space="preserve">그룹에 일치: </system:String>
-    <system:String x:Key="RoomGroupsMatchFailed" xml:space="preserve">오퍼레이터 그룹, 그룹 목록을 일치시키지 못했습니다: </system:String>
-    <system:String x:Key="RoomOperators" xml:space="preserve">선호하는 오퍼레이터: </system:String>
+    <system:String x:Key="RoomGroupsMatchFailed" xml:space="preserve">{key=Operator} 그룹, 그룹 목록을 일치시키지 못했습니다: </system:String>
+    <system:String x:Key="RoomOperators" xml:space="preserve">선호하는 {key=Operator}: </system:String>
     <system:String x:Key="ProductIncorrect">생산품이 구성과 맞지 않습니다.</system:String>
     <system:String x:Key="ProductUnknown">인식할 수 없는 생산품</system:String>
     <system:String x:Key="ProductChanged">생산품이 변경됨</system:String>
     <system:String x:Key="RecruitingResults" xml:space="preserve">공개모집 인식 결과: </system:String>
     <system:String x:Key="RecruitingTips">공개모집 팁</system:String>
-    <system:String x:Key="RecruitmentOfStar">★{0} 오퍼레이터를 모집했습니다!</system:String>
+    <system:String x:Key="RecruitmentOfStar">★{0} {key=Operator}를 모집했습니다!</system:String>
     <system:String x:Key="RecruitmentOfBot">로봇을 모집했습니다!</system:String>
     <system:String x:Key="Choose">선택</system:String>
     <system:String x:Key="Refreshed">새로고침됨</system:String>
@@ -950,12 +950,12 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="SelectExtraOnlyRareTags">가능한 한 많은 태그를 선택하고 높은 등급의 태그만 선택</system:String>
     <system:String x:Key="AutoRecruitHighPriority">선호 태그</system:String>
     <system:String x:Key="AutoRecruitHighPriorityTooltip">가능한 한 많은 태그 기본 설정을 선택합니다</system:String>
-    <system:String x:Key="NotEnoughStaff">오퍼레이터 부족</system:String>
+    <system:String x:Key="NotEnoughStaff">{key=Operator} 부족</system:String>
     <system:String x:Key="StageInfoError">스테이지 인식 오류</system:String>
     <system:String x:Key="UseFormation">편성 사용</system:String>
     <system:String x:Key="Current">현재</system:String>
     <system:String x:Key="BattleFormation">편성 시작</system:String>
-    <system:String x:Key="BattleFormationSelected" xml:space="preserve">오퍼레이터를 선택: </system:String>
+    <system:String x:Key="BattleFormationSelected" xml:space="preserve">{key=Operator}를 선택: </system:String>
     <system:String x:Key="BattleFormationOperUnavailable" xml:space="preserve">사용할 수 없는 운영자: {0}, 제한: {1}</system:String>
     <system:String x:Key="CurrentSteps">현재 단계: {0} {1}</system:String>
     <system:String x:Key="UnsupportedLevel">지원되지 않는 스테이지입니다. 스테이지 이름을 확인하거나 ｢{key=Settings} - {key=UpdateSettings} - {key=ResourceUpdate}｣ 로 이동하여 리소스 버전을 업데이트해 보세요!</system:String>
@@ -1269,7 +1269,7 @@ Microsoft Visual C++ redistributable 2015-2022(x64) 가 설치되지 않았거�
 
     <system:String x:Key="Achievement.Irreplaceable.Title">대체 불가능</system:String>
     <system:String x:Key="Achievement.Irreplaceable.Description">다른 작업을 사용해야 할까요?</system:String>
-    <system:String x:Key="Achievement.Irreplaceable.Conditions">｢{key=Copilot} - {key=AutoSquad}｣ 사용 시 최소 2명의 오퍼레이터가 부족</system:String>
+    <system:String x:Key="Achievement.Irreplaceable.Conditions">｢{key=Copilot} - {key=AutoSquad}｣ 사용 시 최소 2명의 {key=Operator}가 부족</system:String>
 
     <system:String x:Key="Achievement.SnapshotChallenge1.Title">Hight Ping 전사</system:String>
     <system:String x:Key="Achievement.SnapshotChallenge1.Description">"Disconnect"</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -111,8 +111,8 @@
     <system:String x:Key="OriginStone">制造站-源石碎片</system:String>
     <system:String x:Key="Chip">制造站-芯片组</system:String>
     <system:String x:Key="DormTrustEnabled">宿舍空余位置蹭信赖</system:String>
-    <system:String x:Key="DormFilterNotStationedEnabled">不将已进驻的干员放入宿舍</system:String>
-    <system:String x:Key="DormFilterNotStationedTips">勾选则不会将艾丽妮等干员从训练室移除，但也会导致加工站干员不能进入宿舍。</system:String>
+    <system:String x:Key="DormFilterNotStationedEnabled">不将已进驻的{key=Operator}放入宿舍</system:String>
+    <system:String x:Key="DormFilterNotStationedTips">勾选则不会将艾丽妮等{key=Operator}从训练室移除，但也会导致加工站{key=Operator}不能进入宿舍。</system:String>
     <system:String x:Key="OriginiumShardAutoReplenishment">源石碎片自动补货</system:String>
     <system:String x:Key="InfrastReceptionMessageBoardReceive">会客室信息板收取信用</system:String>
     <system:String x:Key="ContinueTraining">训练完成后继续尝试专精当前技能</system:String>
@@ -150,19 +150,19 @@
     <system:String x:Key="SecondResolution">第二分辨率</system:String>
     <system:String x:Key="GeneralWithoutScreencapErr">通用模式（屏蔽异常输出）</system:String>
     <system:String x:Key="DormThreshold">基建工作心情阈值</system:String>
-    <system:String x:Key="InfrastThresholdTip">若启用自定义换班，该字段仅针对 autofill 和使用干员编组的房间有效</system:String>
+    <system:String x:Key="InfrastThresholdTip">若启用自定义换班，该字段仅针对 autofill 和使用{key=Operator}编组的房间有效</system:String>
     <system:String x:Key="RoguelikeStrategyExp">刷等级，尽可能稳定地打更多层数</system:String>
     <system:String x:Key="RoguelikeStrategyGold">刷源石锭，投资完成后自动退出</system:String>
-    <system:String x:Key="RoguelikeStrategyLastReward">刷开局，刷取热水壶或精二干员开局</system:String>
+    <system:String x:Key="RoguelikeStrategyLastReward">刷开局，刷取热水壶或精二{key=Operator}开局</system:String>
     <system:String x:Key="RoguelikeStrategyCollapse">刷坍缩范式，遇到非稀有坍缩范式后直接重开</system:String>
     <system:String x:Key="RoguelikeCollectibleModeSquad">烧水使用分队</system:String>
     <system:String x:Key="RoguelikeStrategyMonthlySquad">刷月度小队，尽可能稳定地打更多层数</system:String>
     <system:String x:Key="RoguelikeStrategyDeepExploration">刷深入调查，尽可能稳定地打更多层数</system:String>
     <system:String x:Key="StartingSquad">开局分队</system:String>
     <system:String x:Key="StartingRoles">开局职业组</system:String>
-    <system:String x:Key="StartingCoreChar">开局干员</system:String>
+    <system:String x:Key="StartingCoreChar">开局{key=Operator}</system:String>
     <system:String x:Key="StartingCoreCharTip">不填写则使用默认策略。</system:String>
-    <system:String x:Key="RoguelikeStartingCoreCharNotFound">输入的干员未在 battle_data 中。</system:String>
+    <system:String x:Key="RoguelikeStartingCoreCharNotFound">输入的{key=Operator}未在 battle_data 中。</system:String>
     <system:String x:Key="RoguelikeStartWithEliteTwo">凹 ｢{key=StartingCoreChar}｣ 直升精二</system:String>
     <system:String x:Key="RoguelikeOnlyStartWithEliteTwo">只凹 ｢{key=StartingCoreChar}｣ 直升精二，不进行作战</system:String>
     <system:String x:Key="Roguelike3FirstFloorFoldartal">凹第一层远见密文板，不进行作战</system:String>
@@ -552,7 +552,7 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="ReclamationIncrementModeHold">长按</system:String>
     <system:String x:Key="ReclamationMaxCraftCountPerRound">单次最大组装轮数</system:String>
     <system:String x:Key="ReclamationClearStore">任务完成后购买商店</system:String>
-    <system:String x:Key="OperNameLanguage">干员名称显示语言</system:String>
+    <system:String x:Key="OperNameLanguage">{key=Operator}名称显示语言</system:String>
     <system:String x:Key="OperNameLanguageMAA">跟随 MAA</system:String>
     <system:String x:Key="OperNameLanguageClient">跟随游戏客户端</system:String>
     <system:String x:Key="OperNameLanguageForce">强制使用指定语言</system:String>
@@ -669,8 +669,8 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="RecruitmentRecognition">公招识别</system:String>
     <system:String x:Key="RecruitmentRecognitionTip">小提示: 和主界面的自动公招是两个独立的功能，请手动打开游戏公招 Tags 界面后使用~</system:String>
     <system:String x:Key="AutoSettingTime">自动设置时间</system:String>
-    <system:String x:Key="RecruitmentShowPotential">显示干员潜能（四星及以上）</system:String>
-    <system:String x:Key="RecruitmentShowPotentialTips">请使用 ｢{key=OperBoxRecognition}｣ 获取干员信息。</system:String>
+    <system:String x:Key="RecruitmentShowPotential">显示{key=Operator}潜能（四星及以上）</system:String>
+    <system:String x:Key="RecruitmentShowPotentialTips">请使用 ｢{key=OperBoxRecognition}｣ 获取{key=Operator}信息。</system:String>
     <system:String x:Key="AutoSelectLevel3Tags">自动选择 3 星 Tags</system:String>
     <system:String x:Key="AutoSelectLevel4Tags">自动选择 4 星 Tags</system:String>
     <system:String x:Key="AutoSelectLevel5Tags">自动选择 5 星 Tags</system:String>
@@ -687,9 +687,9 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="CopiedToClipboard">已复制到剪切板</system:String>
     <!--  !仓库识别  -->
     <!--  干员识别  -->
-    <system:String x:Key="OperBoxRecognition">干员识别</system:String>
+    <system:String x:Key="OperBoxRecognition">{key=Operator}识别</system:String>
     <system:String x:Key="OperBox">{key=OperBoxRecognition}</system:String>
-    <system:String x:Key="OperBoxRecognitionTip">特别关注会影响干员识别准确率，如有特别关注干员识别错误请自行判断。</system:String>
+    <system:String x:Key="OperBoxRecognitionTip">特别关注会影响{key=Operator}识别准确率，如有特别关注{key=Operator}识别错误请自行判断。</system:String>
     <system:String x:Key="OperBoxHaveList">已拥有: {0} 名</system:String>
     <system:String x:Key="OperBoxNotHaveList">未拥有: {0} 名</system:String>
     <system:String x:Key="StartToOperBoxRecognition">开始识别</system:String>
@@ -766,11 +766,11 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="FailedToLikeWebJson">出现错误，评价失败 : &lt;</system:String>
     <system:String x:Key="ThanksForLikeWebJson">感谢评价！\n网页已经开放评论区，欢迎前往留下你的评论！</system:String>
     <system:String x:Key="AutoSquad">自动编队</system:String>
-    <system:String x:Key="AutoSquadTip">自动编队可能无法识别带有 ｢特别关注｣ 标记的干员</system:String>
-    <system:String x:Key="AddTrust">补充低信赖干员</system:String>
+    <system:String x:Key="AutoSquadTip">自动编队可能无法识别带有 ｢特别关注｣ 标记的{key=Operator}</system:String>
+    <system:String x:Key="AddTrust">补充低信赖{key=Operator}</system:String>
     <system:String x:Key="Copilot.IgnoreRequirements">忽略{key=Operator}属性要求</system:String>
-    <system:String x:Key="AddUserAdditional">追加自定干员</system:String>
-    <system:String x:Key="AddUserAdditionalTip">以英文 ｢;｣ 为分隔符，英文 ｢,｣ 分隔干员名与技能，例: 史尔特尔,3;艾雅法拉,1</system:String>
+    <system:String x:Key="AddUserAdditional">追加自定{key=Operator}</system:String>
+    <system:String x:Key="AddUserAdditionalTip">以英文 ｢;｣ 为分隔符，英文 ｢,｣ 分隔{key=Operator}名与技能，例: 史尔特尔,3;艾雅法拉,1</system:String>
     <system:String x:Key="LoopTimes">循环次数</system:String>
     <system:String x:Key="UseCopilotList">战斗列表</system:String>
     <system:String x:Key="UseCopilotListTip" xml:space="preserve">不支持跨章节导航。仅支持:
@@ -787,7 +787,7 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="CopilotSkill">技能</system:String>
     <system:String x:Key="CopilotModule">模组</system:String>
     <system:String x:Key="CopilotWithoutModule">不使用模组</system:String>
-    <system:String x:Key="TotalOperatorsCount">共 {0} 名干员</system:String>
+    <system:String x:Key="TotalOperatorsCount">共 {0} 名{key=Operator}</system:String>
     <system:String x:Key="DirectiveECTerm">导能原件：</system:String>
     <system:String x:Key="OtherOperators">编队工具人：</system:String>
     <system:String x:Key="InitialEquipmentHorizontal">开局装备（横向）：</system:String>
@@ -799,8 +799,8 @@ C:\\leidian\\LDPlayer9。\n
         2. 模拟悖论需要关闭 ｢{key=AutoSquad}｣，并选好技能后处于 ｢开始模拟｣ 按钮的界面再开始。\n\n
         3. 保全派驻 在 resource/copilot 文件夹下内置了多份作业。\n
         请手动编队后在 ｢开始部署｣ 界面开始（可配合 ｢{key=LoopTimes}｣ 使用）。\n\n
-        4. 使用好友助战可以关闭 ｢{key=AutoSquad}｣，手动选择干员后开始。\n\n
-        5. 将干员标为 ｢特别关注｣ 可能会影响 ｢{key=AutoSquad}｣ 时的识别与选择。建议在使用 ｢{key=AutoSquad}｣ 时考虑移除 ｢特别关注｣ 标记，或手动补充缺失的干员以确保编队完整。\n\n
+        4. 使用好友助战可以关闭 ｢{key=AutoSquad}｣，手动选择{key=Operator}后开始。\n\n
+        5. 将{key=Operator}标为 ｢特别关注｣ 可能会影响 ｢{key=AutoSquad}｣ 时的识别与选择。建议在使用 ｢{key=AutoSquad}｣ 时考虑移除 ｢特别关注｣ 标记，或手动补充缺失的{key=Operator}以确保编队完整。\n\n
         6. Copilot 作业站的神秘代码可点击输入框右侧的粘贴按钮粘贴。左键单击可粘贴单个作业，右键单击则可粘贴整个作业集。\n\n
         7. 战斗列表:\n
         选择作业后，检查列表下方的关卡名是否正确 (如: CV-EX-1)。\n
@@ -875,8 +875,8 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="DropRecognitionError">掉落识别错误</system:String>
     <system:String x:Key="GiveUpUploadingPenguins">放弃上传企鹅物流</system:String>
     <system:String x:Key="TheEx">无奖励关卡，已停止</system:String>
-    <system:String x:Key="MissingOperators">缺少以下干员组中的干员：</system:String>
-    <system:String x:Key="RecruitSupportOperator">编入助战干员：{0}</system:String>
+    <system:String x:Key="MissingOperators">缺少以下{key=Operator}组中的{key=Operator}：</system:String>
+    <system:String x:Key="RecruitSupportOperator">编入助战{key=Operator}：{0}</system:String>
     <system:String x:Key="StageQueue">关卡队列:</system:String>
     <system:String x:Key="UnableToAgent">无法使用代理指挥</system:String>
     <system:String x:Key="MissionStart">已开始行动</system:String>
@@ -892,7 +892,7 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="ActingCommandError">代理指挥失误</system:String>
     <system:String x:Key="LabelsRefreshed">已刷新标签</system:String>
     <system:String x:Key="RecruitConfirm">已确认招募</system:String>
-    <system:String x:Key="InfrastDormDoubleConfirmed">干员冲突</system:String>
+    <system:String x:Key="InfrastDormDoubleConfirmed">{key=Operator}冲突</system:String>
     <system:String x:Key="BegunToExplore">已开始探索</system:String>
     <system:String x:Key="ExplorationAbandoned">已放弃本次探索</system:String>
     <system:String x:Key="FightCompleted">战斗完成</system:String>
@@ -932,8 +932,8 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="FurnitureDrop">家具</system:String>
     <system:String x:Key="ThisFacility" xml:space="preserve">当前设施: </system:String>
     <system:String x:Key="RoomGroupsMatch" xml:space="preserve">匹配编组: </system:String>
-    <system:String x:Key="RoomGroupsMatchFailed" xml:space="preserve">匹配干员编组失败，编组列表: </system:String>
-    <system:String x:Key="RoomOperators" xml:space="preserve">首选干员: </system:String>
+    <system:String x:Key="RoomGroupsMatchFailed" xml:space="preserve">匹配{key=Operator}编组失败，编组列表: </system:String>
+    <system:String x:Key="RoomOperators" xml:space="preserve">首选{key=Operator}: </system:String>
     <system:String x:Key="ProductIncorrect">产物与配置不相符。</system:String>
     <system:String x:Key="ProductUnknown">无法识别的产物</system:String>
     <system:String x:Key="ProductChanged">产物已切换</system:String>
@@ -951,13 +951,13 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="SelectExtraOnlyRareTags">尽可能多地选且只选高星 Tag</system:String>
     <system:String x:Key="AutoRecruitHighPriority">3 星 Tag 时的 Tag 倾向</system:String>
     <system:String x:Key="AutoRecruitHighPriorityTooltip">会尽可能多的选择倾向的 Tag</system:String>
-    <system:String x:Key="NotEnoughStaff">可用干员不足</system:String>
+    <system:String x:Key="NotEnoughStaff">可用{key=Operator}不足</system:String>
     <system:String x:Key="StageInfoError">关卡识别错误</system:String>
     <system:String x:Key="UseFormation">使用编队</system:String>
     <system:String x:Key="Current">当前</system:String>
     <system:String x:Key="BattleFormation">开始编队</system:String>
-    <system:String x:Key="BattleFormationSelected" xml:space="preserve">选择干员: </system:String>
-    <system:String x:Key="BattleFormationOperUnavailable" xml:space="preserve">干员不可用: {0}, 限制: {1}</system:String>
+    <system:String x:Key="BattleFormationSelected" xml:space="preserve">选择{key=Operator}: </system:String>
+    <system:String x:Key="BattleFormationOperUnavailable" xml:space="preserve">{key=Operator}不可用: {0}, 限制: {1}</system:String>
     <system:String x:Key="CurrentSteps">当前步骤: {0} {1}</system:String>
     <system:String x:Key="UnsupportedLevel">不支持的关卡，请检查关卡名或前往 ｢{key=Settings} - {key=UpdateSettings} - {key=ResourceUpdate}｣ 尝试更新资源版本！</system:String>
     <system:String x:Key="RecruitTagsDetected" xml:space="preserve">识别结果: </system:String>
@@ -1016,7 +1016,7 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="Hangover">下次不能喝、喝这么多了……</system:String>
     <system:String x:Key="HelloWorld">Hello World!</system:String>
     <system:String x:Key="EasterEggsRules" xml:space="preserve">1. MAA 正式版不会出现 Debug 模式。如果你在运行时看到 Debug 选项，请立即关闭软件，不要点击它，并联系最近的 MAA 开发者。\n
-2. 基建换班是自动的。如果你发现某个干员连续工作了 72 小时以上，请手动调整班次，并检查系统时间是否正常。\n
+2. 基建换班是自动的。如果你发现某个{key=Operator}连续工作了 72 小时以上，请手动调整班次，并检查系统时间是否正常。\n
 3. 公开招募的标签不会改变。如果发现标签在倒计时结束前自行更换，不要继续招募，重启 MAA 后再操作。\n
 4. MAA 不会主动发送好友申请。如果收到来自 ｢MAA_System｣ 的好友请求，不要接受，并删除该账号。\n
 5. 肉鸽辅助仅提供建议。若游戏自动选择了 不存在的选项，强制退出并重新启动客户端。\n
@@ -1087,7 +1087,7 @@ C:\\leidian\\LDPlayer9。\n
 
  通过开局刷点数：(小心已有存档被删除)
   1. 点数刷满后会输出 ｢任务完成｣，自动停止任务
-  2. 不要在生息演算的编队中有干员的情况下使用
+  2. 不要在生息演算的编队中有{key=Operator}的情况下使用
   3. 手动确认存档情况并删除，以免 MAA 删除你的珍贵存档
   4. 导航还没写，不能从生息演算以外的位置开始任务
   5. 如果任务过程中报错、点数没刷满就任务完成，请前往 GitHub 提交 issue
@@ -1272,7 +1272,7 @@ C:\\leidian\\LDPlayer9。\n
 
     <system:String x:Key="Achievement.Irreplaceable.Title">无可替代</system:String>
     <system:String x:Key="Achievement.Irreplaceable.Description">或许我应该换一份作业？</system:String>
-    <system:String x:Key="Achievement.Irreplaceable.Conditions">使用 ｢{key=Copilot} - {key=AutoSquad}｣ 时，缺少至少两名干员</system:String>
+    <system:String x:Key="Achievement.Irreplaceable.Conditions">使用 ｢{key=Copilot} - {key=AutoSquad}｣ 时，缺少至少两名{key=Operator}</system:String>
 
     <system:String x:Key="Achievement.SnapshotChallenge1.Title">高 ping 战士</system:String>
     <system:String x:Key="Achievement.SnapshotChallenge1.Description">“kale”</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -110,8 +110,8 @@
     <system:String x:Key="OriginStone">製造站-源石碎片</system:String>
     <system:String x:Key="Chip">製造站-晶片組</system:String>
     <system:String x:Key="DormTrustEnabled">宿舍空餘位置蹭信賴</system:String>
-    <system:String x:Key="DormFilterNotStationedEnabled">不將已進駐的幹員放入宿舍</system:String>
-    <system:String x:Key="DormFilterNotStationedTips">勾選則不會將艾麗妮等幹員從訓練室移除，但也會導致加工站幹員不能進入宿舍。</system:String>
+    <system:String x:Key="DormFilterNotStationedEnabled">不將已進駐的{key=Operator}放入宿舍</system:String>
+    <system:String x:Key="DormFilterNotStationedTips">勾選則不會將艾麗妮等{key=Operator}從訓練室移除，但也會導致加工站{key=Operator}不能進入宿舍。</system:String>
     <system:String x:Key="OriginiumShardAutoReplenishment">源石碎片自動補貨</system:String>
     <system:String x:Key="InfrastReceptionMessageBoardReceive">會客室資訊板收取信用</system:String>
     <system:String x:Key="ContinueTraining">訓練完成後繼續嘗試專精當前技能</system:String>
@@ -149,19 +149,19 @@
     <system:String x:Key="SecondResolution">第二解析度</system:String>
     <system:String x:Key="GeneralWithoutScreencapErr">通用模式（阻擋異常輸出）</system:String>
     <system:String x:Key="DormThreshold">基建工作心情閾值</system:String>
-    <system:String x:Key="InfrastThresholdTip">若啟用自定義換班，該欄位僅針對 autofill 和 幹員編組 的房間有效</system:String>
+    <system:String x:Key="InfrastThresholdTip">若啟用自定義換班，該欄位僅針對 autofill 和 {key=Operator}編組 的房間有效</system:String>
     <system:String x:Key="RoguelikeStrategyExp">刷等級，盡可能穩定地打更多層數</system:String>
     <system:String x:Key="RoguelikeStrategyGold">刷源石錠，投資完成後自動退出</system:String>
-    <system:String x:Key="RoguelikeStrategyLastReward">刷開局，刷取熱水壺或精二幹員開局</system:String>
+    <system:String x:Key="RoguelikeStrategyLastReward">刷開局，刷取熱水壺或精二{key=Operator}開局</system:String>
     <system:String x:Key="RoguelikeStrategyCollapse">刷坍縮範式，遇到非稀有坍縮範式後直接重開</system:String>
     <system:String x:Key="RoguelikeCollectibleModeSquad">燒水分隊</system:String>
     <system:String x:Key="RoguelikeStrategyMonthlySquad">刷月度小隊，盡可能穩定地打更多層數</system:String>
     <system:String x:Key="RoguelikeStrategyDeepExploration">刷深入調查，盡可能穩定地打更多層數</system:String>
     <system:String x:Key="StartingSquad">開局分隊</system:String>
     <system:String x:Key="StartingRoles">開局職業組</system:String>
-    <system:String x:Key="StartingCoreChar">開局幹員</system:String>
+    <system:String x:Key="StartingCoreChar">開局{key=Operator}</system:String>
     <system:String x:Key="StartingCoreCharTip">不填寫則使用預設策略。</system:String>
-    <system:String x:Key="RoguelikeStartingCoreCharNotFound">輸入的幹員未在 battle_data 中。</system:String>
+    <system:String x:Key="RoguelikeStartingCoreCharNotFound">輸入的{key=Operator}未在 battle_data 中。</system:String>
     <system:String x:Key="RoguelikeStartWithEliteTwo">凹 ｢{key=StartingCoreChar}｣ 直升精二</system:String>
     <system:String x:Key="RoguelikeOnlyStartWithEliteTwo">只凹 ｢{key=StartingCoreChar}｣ 直升精二，不進行作戰</system:String>
     <system:String x:Key="Roguelike3FirstFloorFoldartal">凹第一層遠見密文板，不進行作戰</system:String>
@@ -178,7 +178,7 @@
     <system:String x:Key="RoguelikeMonthlySquadAutoIterate">月度小隊自動切換</system:String>
     <system:String x:Key="RoguelikeMonthlySquadCheckComms">月度小隊通訊</system:String>
     <system:String x:Key="RoguelikeDeepExplorationAutoIterate">深入調查自動切換</system:String>
-    <system:String x:Key="DeploymentWithPause">暫停下幹員（自動戰鬥相關）（不穩定, 暫不推薦開啟）</system:String>
+    <system:String x:Key="DeploymentWithPause">暫停下{key=Operator}（自動戰鬥相關）（不穩定, 暫不推薦開啟）</system:String>
     <system:String x:Key="AdbLiteEnabled">使用 ADB Lite（實驗性功能）</system:String>
     <system:String x:Key="KillAdbOnExit">退出時釋放 ADB</system:String>
     <system:String x:Key="DefaultSquad">默認分隊</system:String>
@@ -550,7 +550,7 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="ReclamationIncrementModeHold">長按</system:String>
     <system:String x:Key="ReclamationMaxCraftCountPerRound">單次最大組裝輪數</system:String>
     <system:String x:Key="ReclamationClearStore">任务完成后购买商店</system:String>
-    <system:String x:Key="OperNameLanguage">幹員名稱顯示語言</system:String>
+    <system:String x:Key="OperNameLanguage">{key=Operator}名稱顯示語言</system:String>
     <system:String x:Key="OperNameLanguageMAA">跟隨 MAA</system:String>
     <system:String x:Key="OperNameLanguageClient">跟隨遊戲客戶端</system:String>
     <system:String x:Key="OperNameLanguageForce">強制使用指定語言</system:String>
@@ -667,8 +667,8 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="RecruitmentRecognition">公招辨識</system:String>
     <system:String x:Key="RecruitmentRecognitionTip">小提示: 和主介面的自動公招是兩個獨立的功能，請手動打開遊戲公招 Tags 介面後使用 ~</system:String>
     <system:String x:Key="AutoSettingTime">自動設定時間</system:String>
-    <system:String x:Key="RecruitmentShowPotential">顯示幹員潛能（四星及以上）</system:String>
-    <system:String x:Key="RecruitmentShowPotentialTips">請使用 ｢{key=OperBoxRecognition}｣ 獲得幹員資訊。</system:String>
+    <system:String x:Key="RecruitmentShowPotential">顯示{key=Operator}潛能（四星及以上）</system:String>
+    <system:String x:Key="RecruitmentShowPotentialTips">請使用 ｢{key=OperBoxRecognition}｣ 獲得{key=Operator}資訊。</system:String>
     <system:String x:Key="AutoSelectLevel3Tags">自動選擇 3 星 Tags</system:String>
     <system:String x:Key="AutoSelectLevel4Tags">自動選擇 4 星 Tags</system:String>
     <system:String x:Key="AutoSelectLevel5Tags">自動選擇 5 星 Tags</system:String>
@@ -685,9 +685,9 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="CopiedToClipboard">已複製到剪貼簿</system:String>
     <!--  !倉庫辨識  -->
     <!--  日誌  -->
-    <system:String x:Key="OperBoxRecognition">幹員辨識</system:String>
+    <system:String x:Key="OperBoxRecognition">{key=Operator}辨識</system:String>
     <system:String x:Key="OperBox">{key=OperBoxRecognition}</system:String>
-    <system:String x:Key="OperBoxRecognitionTip">特別關注會影響幹員識別準確率，如有特別關注幹員識別錯誤請自行判斷。</system:String>
+    <system:String x:Key="OperBoxRecognitionTip">特別關注會影響{key=Operator}識別準確率，如有特別關注{key=Operator}識別錯誤請自行判斷。</system:String>
     <system:String x:Key="OperBoxHaveList">已擁有: {0} 名</system:String>
     <system:String x:Key="OperBoxNotHaveList">未擁有: {0} 名</system:String>
     <system:String x:Key="StartToOperBoxRecognition">開始辨識</system:String>
@@ -763,11 +763,11 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="FailedToLikeWebJson">出現錯誤，評價失敗 : &lt;</system:String>
     <system:String x:Key="ThanksForLikeWebJson">感謝評價！\n網頁已經開放評論區，歡迎前往留下你的評論！</system:String>
     <system:String x:Key="AutoSquad">自動編隊</system:String>
-    <system:String x:Key="AutoSquadTip">自動編隊可能無法辨識 ｢特別關注｣ 的幹員</system:String>
-    <system:String x:Key="AddTrust">補充低信賴幹員</system:String>
+    <system:String x:Key="AutoSquadTip">自動編隊可能無法辨識 ｢特別關注｣ 的{key=Operator}</system:String>
+    <system:String x:Key="AddTrust">補充低信賴{key=Operator}</system:String>
     <system:String x:Key="Copilot.IgnoreRequirements">忽略{key=Operator}屬性要求</system:String>
-    <system:String x:Key="AddUserAdditional">追加自定幹員</system:String>
-    <system:String x:Key="AddUserAdditionalTip">使用 ｢;｣ 作為分隔符，用 ｢,｣ 分隔操作員姓名和技能，例：史尔特尔,3;艾雅法拉,1</system:String>
+    <system:String x:Key="AddUserAdditional">追加自定{key=Operator}</system:String>
+    <system:String x:Key="AddUserAdditionalTip">使用 ｢;｣ 作為分隔符，用 ｢,｣ 分隔{key=Operator}姓名和技能，例：史尔特尔,3;艾雅法拉,1</system:String>
     <system:String x:Key="UseCopilotList">戰鬥列表</system:String>
     <system:String x:Key="UseCopilotListTip" xml:space="preserve">不支援跨章節導航。僅支援:
   1. 主線關卡：同一章節內導航
@@ -784,9 +784,9 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="CopilotSkill">技能</system:String>
     <system:String x:Key="CopilotModule">模組</system:String>
     <system:String x:Key="CopilotWithoutModule">不使用模組</system:String>
-    <system:String x:Key="TotalOperatorsCount">共 {0} 名幹員</system:String>
+    <system:String x:Key="TotalOperatorsCount">共 {0} 名{key=Operator}</system:String>
     <system:String x:Key="DirectiveECTerm">導能組件：</system:String>
-    <system:String x:Key="OtherOperators">其他幹員：</system:String>
+    <system:String x:Key="OtherOperators">其他{key=Operator}：</system:String>
     <system:String x:Key="InitialEquipmentHorizontal">開局裝備（橫向）：</system:String>
     <system:String x:Key="InitialStrategy">開局策略：</system:String>
     <!--  日誌  -->
@@ -796,8 +796,8 @@ C:\\leidian\\LDPlayer9。\n
         2. 模擬悖論需要關閉 ｢{key=AutoSquad}｣，選好技能後在｢開始模擬｣按鈕的介面再開始。\n\n
         3. 保全派駐 在 resource/copilot 文件夾下內建了多份作業。\n
         請手動編隊後在 ｢開始部署｣ 介面開始（可配合 ｢{key=LoopTimes} 使用）。\n\n
-        4. 使用好友助戰可以關閉｢{key=AutoSquad}｣，手動選擇幹員後開始。\n\n
-        5. 將幹員標為 ｢特別關注｣ 可能會影響 ｢{key=AutoSquad}｣ 時的識別與選擇。建議在使用 ｢{key=AutoSquad}｣ 時考慮移除 ｢特別注意｣ 標記，或手動補充缺少的幹員以確保編隊完整。\n\n
+        4. 使用好友助戰可以關閉｢{key=AutoSquad}｣，手動選擇{key=Operator}後開始。\n\n
+        5. 將{key=Operator}標為 ｢特別關注｣ 可能會影響 ｢{key=AutoSquad}｣ 時的識別與選擇。建議在使用 ｢{key=AutoSquad}｣ 時考慮移除 ｢特別注意｣ 標記，或手動補充缺少的{key=Operator}以確保編隊完整。\n\n
         6. Copilot 作業站的神秘代碼可點擊輸入框右側的貼上按鈕貼上。左鍵單擊可貼上單個作業，右鍵單擊則可貼上整個作業集。\n\n
         7. 戰鬥列表:\n
         選擇作業後，檢查列表下方的關卡名是否正確 (如: CV-EX-1)。\n
@@ -872,8 +872,8 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="DropRecognitionError">掉落辨識錯誤</system:String>
     <system:String x:Key="GiveUpUploadingPenguins">放棄上傳企鵝物流</system:String>
     <system:String x:Key="TheEx">無獎勵關卡，已停止</system:String>
-    <system:String x:Key="MissingOperators">缺少以下幹員組的幹員：</system:String>
-    <system:String x:Key="RecruitSupportOperator">編入助戰幹員：{0}</system:String>
+    <system:String x:Key="MissingOperators">缺少以下{key=Operator}組的{key=Operator}：</system:String>
+    <system:String x:Key="RecruitSupportOperator">編入助戰{key=Operator}：{0}</system:String>
     <system:String x:Key="StageQueue">關卡隊列:</system:String>
     <system:String x:Key="UnableToAgent">無法使用代理指揮</system:String>
     <system:String x:Key="MissionStart">已開始行動</system:String>
@@ -889,7 +889,7 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="ActingCommandError">代理指揮失誤</system:String>
     <system:String x:Key="LabelsRefreshed">已刷新標籤</system:String>
     <system:String x:Key="RecruitConfirm">已確認招募</system:String>
-    <system:String x:Key="InfrastDormDoubleConfirmed">幹員衝突</system:String>
+    <system:String x:Key="InfrastDormDoubleConfirmed">{key=Operator}衝突</system:String>
     <system:String x:Key="BegunToExplore">已開始探索</system:String>
     <system:String x:Key="ExplorationAbandoned">已放棄本次探索</system:String>
     <system:String x:Key="FightCompleted">戰鬥完成</system:String>
@@ -929,8 +929,8 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="FurnitureDrop">家具</system:String>
     <system:String x:Key="ThisFacility" xml:space="preserve">當前設施: </system:String>
     <system:String x:Key="RoomGroupsMatch" xml:space="preserve">匹配編組: </system:String>
-    <system:String x:Key="RoomGroupsMatchFailed" xml:space="preserve">匹配幹員編組失敗，編組列表: </system:String>
-    <system:String x:Key="RoomOperators" xml:space="preserve">首選幹員: </system:String>
+    <system:String x:Key="RoomGroupsMatchFailed" xml:space="preserve">匹配{key=Operator}編組失敗，編組列表: </system:String>
+    <system:String x:Key="RoomOperators" xml:space="preserve">首選{key=Operator}: </system:String>
     <system:String x:Key="ProductIncorrect">產物與配置不相符。</system:String>
     <system:String x:Key="ProductUnknown">無法辨識的產物</system:String>
     <system:String x:Key="ProductChanged">產物已切換</system:String>
@@ -942,7 +942,7 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="Refreshed">當前欄位已刷新</system:String>
     <system:String x:Key="ContinueRefresh">無招聘許可，繼續嘗試刷新 Tags</system:String>
     <system:String x:Key="NoRecruitmentPermit">無招聘許可，已返回</system:String>
-    <system:String x:Key="NotEnoughStaff">可用幹員不足</system:String>
+    <system:String x:Key="NotEnoughStaff">可用{key=Operator}不足</system:String>
     <system:String x:Key="AutoRecruitSelectStrategy">公招多選 Tags 的策略</system:String>
     <system:String x:Key="DefaultNoExtraTags">默認不選擇額外的 Tags</system:String>
     <system:String x:Key="SelectExtraTags">選擇高星時總是選擇三個 Tag</system:String>
@@ -953,8 +953,8 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="UseFormation">使用編隊</system:String>
     <system:String x:Key="Current">當前</system:String>
     <system:String x:Key="BattleFormation">開始編隊</system:String>
-    <system:String x:Key="BattleFormationSelected" xml:space="preserve">選擇幹員: </system:String>
-    <system:String x:Key="BattleFormationOperUnavailable" xml:space="preserve">幹員不可用: {0}, 限制: {1}</system:String>
+    <system:String x:Key="BattleFormationSelected" xml:space="preserve">選擇{key=Operator}: </system:String>
+    <system:String x:Key="BattleFormationOperUnavailable" xml:space="preserve">{key=Operator}不可用: {0}, 限制: {1}</system:String>
     <system:String x:Key="CurrentSteps">當前步驟: {0} {1}</system:String>
     <system:String x:Key="UnsupportedLevel">不支援的關卡，請檢查關卡名稱或前往 ｢{key=Settings} - {key=UpdateSettings} - {key=ResourceUpdate}｣，嘗試更新資源版本！</system:String>
     <system:String x:Key="RecruitTagsDetected" xml:space="preserve">辨識結果: </system:String>
@@ -1013,7 +1013,7 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="Hangover">下次不能喝、喝這麼多了……</system:String>
     <system:String x:Key="HelloWorld">Hello World!</system:String>
     <system:String x:Key="EasterEggsRules" xml:space="preserve">1. MAA 正式版不會出現 Debug 模式。如果你在運行時看到 Debug 選項，請立即關閉軟件，不要點擊它，並聯繫最近的 MAA 開發者。\n
-2. 基建換班是自動的。如果你發現某個幹員連續工作了 72 小時以上，請手動調整班次，並檢查系統時間是否正常。\n
+2. 基建換班是自動的。如果你發現某個{key=Operator}連續工作了 72 小時以上，請手動調整班次，並檢查系統時間是否正常。\n
 3. 公開招募的標籤不會改變。如果發現標籤在倒計時結束前自行更換，不要繼續招募，重啟 MAA 後再操作。\n
 4. MAA 不會主動發送好友申請。如果收到來自 ｢MAA_System｣ 的好友請求，不要接受，並刪除該賬號。\n
 5. 肉鴿輔助僅提供建議。若遊戲自動選擇了 不存在的選項，強制退出並重新啟動客戶端。\n
@@ -1084,7 +1084,7 @@ C:\\leidian\\LDPlayer9。\n
 
  透過開局刷點數：(小心已有存檔被刪除)
   1. 點數刷滿後會輸出 ｢任務完成｣，自動停止任務
-  2. 不要在生息演算的編隊中有幹員的情況下使用
+  2. 不要在生息演算的編隊中有{key=Operator}的情況下使用
   3. 手動確認存檔情況並刪除，以免 MAA 刪除你的珍貴存檔
   4. 導航還沒寫，不能從生息演算以外的位置開始任務
   5. 如果任務過程中報錯、點數沒刷滿就任務完成，請前往 GitHub 提交 issue
@@ -1271,7 +1271,7 @@ C:\\leidian\\LDPlayer9。\n
 
     <system:String x:Key="Achievement.Irreplaceable.Title">無可替代</system:String>
     <system:String x:Key="Achievement.Irreplaceable.Description">或許我應該換一份作業？</system:String>
-    <system:String x:Key="Achievement.Irreplaceable.Conditions">使用 ｢{key=Copilot} - {key=AutoSquad}｣ 時，缺少至少兩名幹員</system:String>
+    <system:String x:Key="Achievement.Irreplaceable.Conditions">使用 ｢{key=Copilot} - {key=AutoSquad}｣ 時，缺少至少兩名{key=Operator}</system:String>
 
     <system:String x:Key="Achievement.SnapshotChallenge1.Title">高 ping 戰士</system:String>
     <system:String x:Key="Achievement.SnapshotChallenge1.Description">“kale”</system:String>


### PR DESCRIPTION
I'm not sure if it seems well if doing same thing in overseas resource. like uppercase and plural forms
@HX3N @Manicsteiner 

checklist:
- [x] cn
- [x] EN
- [x] JP
- [x] KR