### PR TITLE
ci: delete stale cache for codeql

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -76,3 +76,14 @@
           uses: github/codeql-action/analyze@v3
           with:
             category: "/language:multi-manual"
+
+        - name: Delete old caches
+          shell: pwsh
+          run: |
+            $oldCaches = gh cache list --key codeql --order asc --json key | ConvertFrom-Json | Select-Object -SkipLast 1
+              foreach ($cache in $oldCaches) {
+                if ($cache.key) {
+                  Write-Host "Deleting cache: $($cache.key)"
+                  gh cache delete $cache.key
+                }
+              }


### PR DESCRIPTION
I had to manually delete 6 caches 810 MB each that were just polluting are cache that's "reserved" for the ResourceUpdater, SmokeTester, lyche and pip template optimizer. 

We definitely have space for codeql cache, just not that much. 

This just leaves the latest cache alive.