### PR TITLE
feat: 禁用弹出成就气泡

### DIFF
--- a/src/MaaWpfGui/Constants/ConfigurationKeys.cs
+++ b/src/MaaWpfGui/Constants/ConfigurationKeys.cs
@@ -322,8 +322,8 @@ namespace MaaWpfGui.Constants
 
         public const string MiniGameTaskName = "MiniGame.TaskName";
 
-        public const string AchievementBubbleAutoClose = "Achievement.BubbleAutoClose";
-        public const string DisableAchievementNotifications = "Achievement.DisableNotifications";
+        public const string AchievementPopupDisabled = "Achievement.PopupDisabled";
+        public const string AchievementPopupAutoClose = "Achievement.PopupAutoClose";
 
         // public const string AnnouncementInfo = "Announcement.AnnouncementInfo";// 已迁移
         // public const string DoNotRemindThisAnnouncementAgain = "Announcement.DoNotRemindThisAnnouncementAgain";// 已迁移

--- a/src/MaaWpfGui/Constants/ConfigurationKeys.cs
+++ b/src/MaaWpfGui/Constants/ConfigurationKeys.cs
@@ -323,12 +323,10 @@ namespace MaaWpfGui.Constants
         public const string MiniGameTaskName = "MiniGame.TaskName";
 
         public const string AchievementBubbleAutoClose = "Achievement.BubbleAutoClose";
+        public const string DisableAchievementNotifications = "Achievement.DisableNotifications";
 
         // public const string AnnouncementInfo = "Announcement.AnnouncementInfo";// 已迁移
         // public const string DoNotRemindThisAnnouncementAgain = "Announcement.DoNotRemindThisAnnouncementAgain";// 已迁移
         // public const string DoNotShowAnnouncement = "Announcement.DoNotShowAnnouncement";// 已迁移
-
-        public const string DisableAchievementNotifications = "Achievement.DisableNotifications";
-        public const string AchievementBubbleAutoClose = "Achievement.BubbleAutoClose";
     }
 }

--- a/src/MaaWpfGui/Constants/ConfigurationKeys.cs
+++ b/src/MaaWpfGui/Constants/ConfigurationKeys.cs
@@ -329,5 +329,6 @@ namespace MaaWpfGui.Constants
         // public const string DoNotShowAnnouncement = "Announcement.DoNotShowAnnouncement";// 已迁移
 
         public const string DisableAchievementNotifications = "Achievement.DisableNotifications";
+        public const string AchievementBubbleAutoClose = "Achievement.BubbleAutoClose";
     }
 }

--- a/src/MaaWpfGui/Constants/ConfigurationKeys.cs
+++ b/src/MaaWpfGui/Constants/ConfigurationKeys.cs
@@ -327,5 +327,7 @@ namespace MaaWpfGui.Constants
         // public const string AnnouncementInfo = "Announcement.AnnouncementInfo";// 已迁移
         // public const string DoNotRemindThisAnnouncementAgain = "Announcement.DoNotRemindThisAnnouncementAgain";// 已迁移
         // public const string DoNotShowAnnouncement = "Announcement.DoNotShowAnnouncement";// 已迁移
+
+        public const string DisableAchievementNotifications = "Achievement.DisableNotifications";
     }
 }

--- a/src/MaaWpfGui/Helper/AchievementTrackerHelper.cs
+++ b/src/MaaWpfGui/Helper/AchievementTrackerHelper.cs
@@ -189,7 +189,7 @@ namespace MaaWpfGui.Helper
             {
                 IsCustom = true,
                 Message = $"{LocalizationHelper.GetString("AchievementCelebrate")}: {achievement.Title}\n{achievement.Description}",
-                StaysOpen = staysOpen && !SettingsViewModel.AchievementSettings.AchievementBubbleAutoClose,
+                StaysOpen = staysOpen && !SettingsViewModel.AchievementSettings.AchievementPopupAutoClose,
                 WaitTime = 15,
                 IconKey = "HangoverGeometry",
                 IconBrushKey = achievement.MedalBrushKey,
@@ -202,7 +202,7 @@ namespace MaaWpfGui.Helper
             _allowSave = false; // 禁止保存，避免重复触发 Save
             foreach (var achievement in _achievements.Values.Where(a => !a.IsUnlocked))
             {
-                if (!SettingsViewModel.AchievementSettings.DisableAchievementNotifications)
+                if (!SettingsViewModel.AchievementSettings.AchievementPopupDisabled)
                 {
                     await Task.Delay(100);
                 }
@@ -252,7 +252,7 @@ namespace MaaWpfGui.Helper
         public static void ShowInfo(GrowlInfo info)
         {
             // 检查是否禁用了成就通知
-            if (SettingsViewModel.AchievementSettings.DisableAchievementNotifications)
+            if (SettingsViewModel.AchievementSettings.AchievementPopupDisabled)
             {
                 return;
             }

--- a/src/MaaWpfGui/Helper/AchievementTrackerHelper.cs
+++ b/src/MaaWpfGui/Helper/AchievementTrackerHelper.cs
@@ -247,6 +247,12 @@ namespace MaaWpfGui.Helper
 
         public static void ShowInfo(GrowlInfo info)
         {
+            // 检查是否禁用了成就通知
+            if (SettingsViewModel.AchievementSettings.DisableAchievementNotifications)
+            {
+                return;
+            }
+
             Execute.OnUIThread(() =>
             {
                 var win = Instances.MainWindowManager.GetWindowIfVisible();

--- a/src/MaaWpfGui/Helper/AchievementTrackerHelper.cs
+++ b/src/MaaWpfGui/Helper/AchievementTrackerHelper.cs
@@ -185,9 +185,6 @@ namespace MaaWpfGui.Helper
             achievement.IsNewUnlock = true;
             Save();
 
-            // Check if user wants auto-close bubbles
-            bool shouldStayOpen = staysOpen && !SettingsViewModel.AchievementSettings.AchievementBubbleAutoClose;
-
             var growlInfo = new GrowlInfo
             {
                 IsCustom = true,

--- a/src/MaaWpfGui/Helper/AchievementTrackerHelper.cs
+++ b/src/MaaWpfGui/Helper/AchievementTrackerHelper.cs
@@ -202,7 +202,11 @@ namespace MaaWpfGui.Helper
             _allowSave = false; // 禁止保存，避免重复触发 Save
             foreach (var achievement in _achievements.Values.Where(a => !a.IsUnlocked))
             {
-                await Task.Delay(100);
+                if (!SettingsViewModel.AchievementSettings.DisableAchievementNotifications)
+                {
+                    await Task.Delay(100);
+                }
+
                 Unlock(achievement.Id, false);
             }
 

--- a/src/MaaWpfGui/Helper/AchievementTrackerHelper.cs
+++ b/src/MaaWpfGui/Helper/AchievementTrackerHelper.cs
@@ -185,6 +185,9 @@ namespace MaaWpfGui.Helper
             achievement.IsNewUnlock = true;
             Save();
 
+            // Check if user wants auto-close bubbles
+            bool shouldStayOpen = staysOpen && !SettingsViewModel.AchievementSettings.AchievementBubbleAutoClose;
+
             var growlInfo = new GrowlInfo
             {
                 IsCustom = true,

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -1134,7 +1134,7 @@ If you want to run multiple MAA at the same time, please copy the whole MAA and 
     <system:String x:Key="AchievementRestoreSuccess">Achievement progress restored</system:String>
     <system:String x:Key="AchievementRestoreFailed">Restore failed, invalid file format</system:String>
     <system:String x:Key="AchievementBubbleAutoClose">Achievement bubble will disappear after a short time</system:String>
-    <system:String x:Key="DisableAchievementNotifications">Disable achievement auto-popup notifications</system:String>
+    <system:String x:Key="DisableAchievementNotifications">Disable Achievement auto-popup notifications</system:String>
 
     <system:String x:Key="Achievement.SanitySpender1.Title">Tactical Practice</system:String>
     <system:String x:Key="Achievement.SanitySpender1.Description">You've got the hang of it</system:String>

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -1134,7 +1134,7 @@ If you want to run multiple MAA at the same time, please copy the whole MAA and 
     <system:String x:Key="AchievementRestoreSuccess">Achievement progress restored</system:String>
     <system:String x:Key="AchievementRestoreFailed">Restore failed, invalid file format</system:String>
     <system:String x:Key="AchievementBubbleAutoClose">Achievement bubble will disappear after a short time</system:String>
-
+    <system:String x:Key="DisableAchievementNotifications">Disable auto-popup achievement notifications</system:String>
     <system:String x:Key="Achievement.SanitySpender1.Title">Tactical Practice</system:String>
     <system:String x:Key="Achievement.SanitySpender1.Description">You've got the hang of it</system:String>
     <system:String x:Key="Achievement.SanitySpender1.Conditions">Complete 10 auto-battle operations</system:String>

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -1134,7 +1134,8 @@ If you want to run multiple MAA at the same time, please copy the whole MAA and 
     <system:String x:Key="AchievementRestoreSuccess">Achievement progress restored</system:String>
     <system:String x:Key="AchievementRestoreFailed">Restore failed, invalid file format</system:String>
     <system:String x:Key="AchievementBubbleAutoClose">Achievement bubble will disappear after a short time</system:String>
-    <system:String x:Key="DisableAchievementNotifications">Disable auto-popup achievement notifications</system:String>
+    <system:String x:Key="DisableAchievementNotifications">Disable achievement auto-popup notifications</system:String>
+
     <system:String x:Key="Achievement.SanitySpender1.Title">Tactical Practice</system:String>
     <system:String x:Key="Achievement.SanitySpender1.Description">You've got the hang of it</system:String>
     <system:String x:Key="Achievement.SanitySpender1.Conditions">Complete 10 auto-battle operations</system:String>

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -1133,8 +1133,8 @@ If you want to run multiple MAA at the same time, please copy the whole MAA and 
     <system:String x:Key="AchievementBackupSuccess">Backed up to</system:String>
     <system:String x:Key="AchievementRestoreSuccess">Achievement progress restored</system:String>
     <system:String x:Key="AchievementRestoreFailed">Restore failed, invalid file format</system:String>
-    <system:String x:Key="AchievementBubbleAutoClose">Achievement bubble will disappear after a short time</system:String>
-    <system:String x:Key="DisableAchievementNotifications">Disable Achievement auto-popup notifications</system:String>
+    <system:String x:Key="AchievementPopupAutoClose">Achievement bubble will disappear after a short time</system:String>
+    <system:String x:Key="AchievementPopupDisabled">Disable Achievement auto-popup notifications</system:String>
 
     <system:String x:Key="Achievement.SanitySpender1.Title">Tactical Practice</system:String>
     <system:String x:Key="Achievement.SanitySpender1.Description">You've got the hang of it</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -1133,8 +1133,8 @@ MAA を複数開くには、新しい MAA を他のフォルダにコピーし�
     <system:String x:Key="AchievementBackupSuccess">バックアップした</system:String>
     <system:String x:Key="AchievementRestoreSuccess">実績の進捗が復元されました</system:String>
     <system:String x:Key="AchievementRestoreFailed">復元に失敗しました、ファイル形式が無効です</system:String>
-    <system:String x:Key="AchievementBubbleAutoClose">実績バブルはしばらくすると自動的に消えます</system:String>
-    <system:String x:Key="DisableAchievementNotifications">実績通知の自動ポップアップを無効にする</system:String>
+    <system:String x:Key="AchievementPopupAutoClose">実績バブルはしばらくすると自動的に消えます</system:String>
+    <system:String x:Key="AchievementPopupDisabled">実績通知の自動ポップアップを無効にする</system:String>
 
     <system:String x:Key="Achievement.SanitySpender1.Title">戦術実戦</system:String>
     <system:String x:Key="Achievement.SanitySpender1.Description">あなたはすでに始めました。</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -1134,6 +1134,7 @@ MAA を複数開くには、新しい MAA を他のフォルダにコピーし�
     <system:String x:Key="AchievementRestoreSuccess">実績の進捗が復元されました</system:String>
     <system:String x:Key="AchievementRestoreFailed">復元に失敗しました、ファイル形式が無効です</system:String>
     <system:String x:Key="AchievementBubbleAutoClose">実績バブルはしばらくすると自動的に消えます</system:String>
+    <system:String x:Key="DisableAchievementNotifications">実績通知の自動ポップアップを無効にする</system:String>
 
     <system:String x:Key="Achievement.SanitySpender1.Title">戦術実戦</system:String>
     <system:String x:Key="Achievement.SanitySpender1.Description">あなたはすでに始めました。</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -1131,6 +1131,7 @@ Microsoft Visual C++ redistributable 2015-2022(x64) 가 설치되지 않았거�
     <system:String x:Key="AchievementRestoreSuccess">도전과제 진행도 복원 완료</system:String>
     <system:String x:Key="AchievementRestoreFailed">복원 실패, 파일 형식이 유효하지 않음</system:String>
     <system:String x:Key="AchievementBubbleAutoClose">업적 알림이 잠시 후 자동으로 사라집니다</system:String>
+    <system:String x:Key="DisableAchievementNotifications">도전과제 달성 알림 자동 팝업 비활성화</system:String>
 
     <system:String x:Key="Achievement.SanitySpender1.Title">뉴비</system:String>
     <system:String x:Key="Achievement.SanitySpender1.Description">이제 감이 잡혔네요</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -1130,8 +1130,8 @@ Microsoft Visual C++ redistributable 2015-2022(x64) 가 설치되지 않았거�
     <system:String x:Key="AchievementBackupSuccess">백업 완료</system:String>
     <system:String x:Key="AchievementRestoreSuccess">도전과제 진행도 복원 완료</system:String>
     <system:String x:Key="AchievementRestoreFailed">복원 실패, 파일 형식이 유효하지 않음</system:String>
-    <system:String x:Key="AchievementBubbleAutoClose">업적 알림이 잠시 후 자동으로 사라집니다</system:String>
-    <system:String x:Key="DisableAchievementNotifications">도전과제 달성 알림 자동 팝업 비활성화</system:String>
+    <system:String x:Key="AchievementPopupAutoClose">업적 알림이 잠시 후 자동으로 사라집니다</system:String>
+    <system:String x:Key="AchievementPopupDisabled">도전과제 달성 알림 자동 팝업 비활성화</system:String>
 
     <system:String x:Key="Achievement.SanitySpender1.Title">뉴비</system:String>
     <system:String x:Key="Achievement.SanitySpender1.Description">이제 감이 잡혔네요</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -1133,8 +1133,8 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="AchievementBackupSuccess">已备份到</system:String>
     <system:String x:Key="AchievementRestoreSuccess">已恢复成就进度</system:String>
     <system:String x:Key="AchievementRestoreFailed">恢复失败，文件格式无效</system:String>
-    <system:String x:Key="AchievementBubbleAutoClose">成就气泡弹出后一段时间消失</system:String>
-    <system:String x:Key="DisableAchievementNotifications">禁用自动弹出成就气泡</system:String>
+    <system:String x:Key="AchievementPopupAutoClose">成就提示气泡自动关闭</system:String>
+    <system:String x:Key="AchievementPopupDisabled">禁用成就提示气泡</system:String>
 
     <system:String x:Key="Achievement.SanitySpender1.Title">战术实战</system:String>
     <system:String x:Key="Achievement.SanitySpender1.Description">你已经上手了。</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -1134,7 +1134,7 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="AchievementRestoreSuccess">已恢复成就进度</system:String>
     <system:String x:Key="AchievementRestoreFailed">恢复失败，文件格式无效</system:String>
     <system:String x:Key="AchievementBubbleAutoClose">成就气泡弹出后一段时间消失</system:String>
-
+    <system:String x:Key="DisableAchievementNotifications">禁用自动弹出成就气泡</system:String>
     <system:String x:Key="Achievement.SanitySpender1.Title">战术实战</system:String>
     <system:String x:Key="Achievement.SanitySpender1.Description">你已经上手了。</system:String>
     <system:String x:Key="Achievement.SanitySpender1.Conditions">完成 10 次代理通关</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -1135,6 +1135,7 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="AchievementRestoreFailed">恢复失败，文件格式无效</system:String>
     <system:String x:Key="AchievementBubbleAutoClose">成就气泡弹出后一段时间消失</system:String>
     <system:String x:Key="DisableAchievementNotifications">禁用自动弹出成就气泡</system:String>
+
     <system:String x:Key="Achievement.SanitySpender1.Title">战术实战</system:String>
     <system:String x:Key="Achievement.SanitySpender1.Description">你已经上手了。</system:String>
     <system:String x:Key="Achievement.SanitySpender1.Conditions">完成 10 次代理通关</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -1133,6 +1133,7 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="AchievementRestoreSuccess">已恢復成就進度</system:String>
     <system:String x:Key="AchievementRestoreFailed">恢復失敗，檔格式無效</system:String>
     <system:String x:Key="AchievementBubbleAutoClose">成就氣泡彈出後一段時間消失</system:String>
+    <system:String x:Key="DisableAchievementNotifications">禁用自動彈出成就氣泡</system:String>
 
     <system:String x:Key="Achievement.SanitySpender1.Title">戰術實戰</system:String>
     <system:String x:Key="Achievement.SanitySpender1.Description">你已經上手了。</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -1132,8 +1132,8 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="AchievementBackupSuccess">已備份到</system:String>
     <system:String x:Key="AchievementRestoreSuccess">已恢復成就進度</system:String>
     <system:String x:Key="AchievementRestoreFailed">恢復失敗，檔格式無效</system:String>
-    <system:String x:Key="AchievementBubbleAutoClose">成就氣泡彈出後一段時間消失</system:String>
-    <system:String x:Key="DisableAchievementNotifications">禁用自動彈出成就氣泡</system:String>
+    <system:String x:Key="AchievementPopupAutoClose">成就氣泡彈出後一段時間消失</system:String>
+    <system:String x:Key="AchievementPopupDisabled">禁用自動彈出成就氣泡</system:String>
 
     <system:String x:Key="Achievement.SanitySpender1.Title">戰術實戰</system:String>
     <system:String x:Key="Achievement.SanitySpender1.Description">你已經上手了。</system:String>

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/AchievementSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/AchievementSettingsUserControlModel.cs
@@ -222,4 +222,19 @@ public class AchievementSettingsUserControlModel : PropertyChangedBase
             ConfigurationHelper.SetValue(ConfigurationKeys.AchievementBubbleAutoClose, value.ToString());
         }
     }
+
+    private bool _disableAchievementNotifications = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.DisableAchievementNotifications, bool.FalseString));
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to disable achievement notifications.
+    /// </summary>
+    public bool DisableAchievementNotifications
+    {
+        get => _disableAchievementNotifications;
+        set
+        {
+            SetAndNotify(ref _disableAchievementNotifications, value);
+            ConfigurationHelper.SetValue(ConfigurationKeys.DisableAchievementNotifications, value.ToString());
+        }
+    }
 }

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/AchievementSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/AchievementSettingsUserControlModel.cs
@@ -237,19 +237,4 @@ public class AchievementSettingsUserControlModel : PropertyChangedBase
             ConfigurationHelper.SetValue(ConfigurationKeys.DisableAchievementNotifications, value.ToString());
         }
     }
-
-    private bool _achievementBubbleAutoClose = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.AchievementBubbleAutoClose, bool.FalseString));
-
-    /// <summary>
-    /// Gets or sets a value indicating whether achievement bubbles should auto-close after some time.
-    /// </summary>
-    public bool AchievementBubbleAutoClose
-    {
-        get => _achievementBubbleAutoClose;
-        set
-        {
-            SetAndNotify(ref _achievementBubbleAutoClose, value);
-            ConfigurationHelper.SetValue(ConfigurationKeys.AchievementBubbleAutoClose, value.ToString());
-        }
-    }
 }

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/AchievementSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/AchievementSettingsUserControlModel.cs
@@ -208,33 +208,33 @@ public class AchievementSettingsUserControlModel : PropertyChangedBase
         AchievementTrackerHelper.Instance.LockAll();
     }
 
-    private bool _achievementBubbleAutoClose = ConfigurationHelper.GetValue(ConfigurationKeys.AchievementBubbleAutoClose, false);
-
-    /// <summary>
-    /// Gets or sets a value indicating whether achievement bubbles should auto-close after some time.
-    /// </summary>
-    public bool AchievementBubbleAutoClose
-    {
-        get => _achievementBubbleAutoClose;
-        set
-        {
-            SetAndNotify(ref _achievementBubbleAutoClose, value);
-            ConfigurationHelper.SetValue(ConfigurationKeys.AchievementBubbleAutoClose, value.ToString());
-        }
-    }
-
-    private bool _disableAchievementNotifications = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.DisableAchievementNotifications, bool.FalseString));
+    private bool _achievementPopupDisabled = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.AchievementPopupDisabled, bool.FalseString));
 
     /// <summary>
     /// Gets or sets a value indicating whether to disable achievement notifications.
     /// </summary>
-    public bool DisableAchievementNotifications
+    public bool AchievementPopupDisabled
     {
-        get => _disableAchievementNotifications;
+        get => _achievementPopupDisabled;
         set
         {
-            SetAndNotify(ref _disableAchievementNotifications, value);
-            ConfigurationHelper.SetValue(ConfigurationKeys.DisableAchievementNotifications, value.ToString());
+            SetAndNotify(ref _achievementPopupDisabled, value);
+            ConfigurationHelper.SetValue(ConfigurationKeys.AchievementPopupDisabled, value.ToString());
+        }
+    }
+
+    private bool _achievementPopupAutoClose = ConfigurationHelper.GetValue(ConfigurationKeys.AchievementPopupAutoClose, false);
+
+    /// <summary>
+    /// Gets or sets a value indicating whether achievement bubbles should auto-close after some time.
+    /// </summary>
+    public bool AchievementPopupAutoClose
+    {
+        get => _achievementPopupAutoClose;
+        set
+        {
+            SetAndNotify(ref _achievementPopupAutoClose, value);
+            ConfigurationHelper.SetValue(ConfigurationKeys.AchievementPopupAutoClose, value.ToString());
         }
     }
 }

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/AchievementSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/AchievementSettingsUserControlModel.cs
@@ -237,4 +237,19 @@ public class AchievementSettingsUserControlModel : PropertyChangedBase
             ConfigurationHelper.SetValue(ConfigurationKeys.DisableAchievementNotifications, value.ToString());
         }
     }
+
+    private bool _achievementBubbleAutoClose = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.AchievementBubbleAutoClose, bool.FalseString));
+
+    /// <summary>
+    /// Gets or sets a value indicating whether achievement bubbles should auto-close after some time.
+    /// </summary>
+    public bool AchievementBubbleAutoClose
+    {
+        get => _achievementBubbleAutoClose;
+        set
+        {
+            SetAndNotify(ref _achievementBubbleAutoClose, value);
+            ConfigurationHelper.SetValue(ConfigurationKeys.AchievementBubbleAutoClose, value.ToString());
+        }
+    }
 }

--- a/src/MaaWpfGui/Views/UserControl/Settings/AchievementSettings.xaml
+++ b/src/MaaWpfGui/Views/UserControl/Settings/AchievementSettings.xaml
@@ -23,20 +23,6 @@
             Margin="5"
             Command="{s:Action OnShowAchievementsClick}"
             Content="{DynamicResource AchievementView}" />
-        
-        <!-- 成就通知设置 -->
-        <CheckBox
-            Margin="5"
-            HorizontalAlignment="Center"
-            Content="{DynamicResource DisableAchievementNotifications}"
-            IsChecked="{Binding DisableAchievementNotifications}" />
-        
-        <CheckBox
-            Margin="5"
-            HorizontalAlignment="Center"
-            Content="{DynamicResource AchievementBubbleAutoClose}"
-            IsChecked="{Binding AchievementBubbleAutoClose}" />
-        
         <StackPanel HorizontalAlignment="Center" Orientation="Horizontal">
             <Button
                 Margin="5"
@@ -65,6 +51,12 @@
                 Fill="{Binding MedalBrush}"
                 Stretch="Uniform" />
         </Border>
+        <!--  成就通知设置  -->
+        <CheckBox
+            Margin="5"
+            HorizontalAlignment="Center"
+            Content="{DynamicResource DisableAchievementNotifications}"
+            IsChecked="{Binding DisableAchievementNotifications}" />
         <CheckBox
             Margin="5"
             HorizontalAlignment="Center"

--- a/src/MaaWpfGui/Views/UserControl/Settings/AchievementSettings.xaml
+++ b/src/MaaWpfGui/Views/UserControl/Settings/AchievementSettings.xaml
@@ -31,6 +31,12 @@
             Content="{DynamicResource DisableAchievementNotifications}"
             IsChecked="{Binding DisableAchievementNotifications}" />
         
+        <CheckBox
+            Margin="5"
+            HorizontalAlignment="Center"
+            Content="{DynamicResource AchievementBubbleAutoClose}"
+            IsChecked="{Binding AchievementBubbleAutoClose}" />
+        
         <StackPanel HorizontalAlignment="Center" Orientation="Horizontal">
             <Button
                 Margin="5"

--- a/src/MaaWpfGui/Views/UserControl/Settings/AchievementSettings.xaml
+++ b/src/MaaWpfGui/Views/UserControl/Settings/AchievementSettings.xaml
@@ -51,17 +51,6 @@
                 Fill="{Binding MedalBrush}"
                 Stretch="Uniform" />
         </Border>
-        <!--  成就通知设置  -->
-        <CheckBox
-            Margin="5"
-            HorizontalAlignment="Center"
-            Content="{DynamicResource DisableAchievementNotifications}"
-            IsChecked="{Binding DisableAchievementNotifications}" />
-        <CheckBox
-            Margin="5"
-            HorizontalAlignment="Center"
-            Content="{DynamicResource AchievementBubbleAutoClose}"
-            IsChecked="{Binding AchievementBubbleAutoClose}" />
         <StackPanel HorizontalAlignment="Center" Visibility="{c:Binding IsDebugVersion}">
             <StackPanel HorizontalAlignment="Center" Orientation="Horizontal">
                 <Button
@@ -74,5 +63,17 @@
                     Content="Lock All" />
             </StackPanel>
         </StackPanel>
+        <!--  成就通知设置  -->
+        <CheckBox
+            Margin="5"
+            HorizontalAlignment="Center"
+            Content="{DynamicResource AchievementPopupDisabled}"
+            IsChecked="{Binding AchievementPopupDisabled}" />
+        <CheckBox
+            Margin="5"
+            HorizontalAlignment="Center"
+            Content="{DynamicResource AchievementPopupAutoClose}"
+            IsChecked="{Binding AchievementPopupAutoClose}"
+            Visibility="{c:Binding !AchievementPopupDisabled}" />
     </StackPanel>
 </UserControl>

--- a/src/MaaWpfGui/Views/UserControl/Settings/AchievementSettings.xaml
+++ b/src/MaaWpfGui/Views/UserControl/Settings/AchievementSettings.xaml
@@ -25,8 +25,6 @@
             Content="{DynamicResource AchievementView}" />
         
         <!-- 成就通知设置 -->
-        <hc:Divider Content="{DynamicResource AchievementNotificationSettings}" 
-                    Margin="0,10,0,5"/>
         <CheckBox
             Margin="5"
             HorizontalAlignment="Center"

--- a/src/MaaWpfGui/Views/UserControl/Settings/AchievementSettings.xaml
+++ b/src/MaaWpfGui/Views/UserControl/Settings/AchievementSettings.xaml
@@ -23,6 +23,16 @@
             Margin="5"
             Command="{s:Action OnShowAchievementsClick}"
             Content="{DynamicResource AchievementView}" />
+        
+        <!-- 成就通知设置 -->
+        <hc:Divider Content="{DynamicResource AchievementNotificationSettings}" 
+                    Margin="0,10,0,5"/>
+        <CheckBox
+            Margin="5"
+            HorizontalAlignment="Center"
+            Content="{DynamicResource DisableAchievementNotifications}"
+            IsChecked="{Binding DisableAchievementNotifications}" />
+        
         <StackPanel HorizontalAlignment="Center" Orientation="Horizontal">
             <Button
                 Margin="5"


### PR DESCRIPTION
在设置-成就设置中，添加设置勾选框选项：“禁用自动弹出成就气泡”

fix #13315 

<img width="521" height="316" alt="image" src="https://github.com/user-attachments/assets/26f926f5-8238-44b8-99a0-98361c413d01" />

 “成就气泡弹出后一段时间关闭”（已摘到dev）

 · 如果勾选了“成就气泡弹出后一段时间消失”：成就气泡弹出后 经过15s后消失