### PR TITLE
feat: 新增是否进行线索交流选项

### DIFF
--- a/docs/zh-cn/protocol/integration.md
+++ b/docs/zh-cn/protocol/integration.md
@@ -174,6 +174,7 @@ AsstTaskId ASSTAPI AsstAppendTask(AsstHandle handle, const char* type, const cha
     "dorm_notstationed_enabled": bool, // 是否启用宿舍“未进驻”选项，可选，默认 false
     "dorm_trust_enabled": bool, // 是否将宿舍剩余位置填入信赖未满干员，可选，默认 false
     "reception_message_board": bool, // 是否领取会客室信息板信用，可选，默认 true
+    "reception_clue_exchange": bool, // 是否进行线索交流，可选，默认 true
 
     /* 以下参数仅在 mode = 10000 时生效，否则会被忽略 */
     "filename": string,     // 自定义配置路径，必选。不支持运行中设置

--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -3114,8 +3114,7 @@
         "algorithm": "OcrDetect",
         "text": ["已达线索上限", "无法获取新的线索", "上限", "无法"],
         "reduceOtherTimes": ["SelectClue*3"],
-        "roi": [286, 550, 366, 130],
-        "next": ["CloseCluePageThenSendClue"]
+        "roi": [286, 550, 366, 130]
     },
     "BackToReceptionMain": {
         "algorithm": "JustReturn",
@@ -3158,13 +3157,7 @@
     "CloseCluePage": {
         "action": "ClickSelf",
         "roi": [930, 50, 120, 120],
-        "next": ["CloseCluePage", "SendClueFlag", "InfrastClueFriendNew", "ReceptionFlag"]
-    },
-    "SendClueFlag": {
-        "Doc": "这里识别的是自己的线索的new：如果获取完自己的线索、再获取完好友送的线索，自己的线索new还亮着，则说明自己的线索没获取成功，即线索满了",
-        "next": ["SendClues"],
-        "roi": [1150, 100, 130, 80],
-        "template": "ClueNew.png"
+        "next": ["CloseCluePage", "InfrastClueFriendNew", "ReceptionFlag"]
     },
     "UnlockClues": {
         "action": "ClickSelf",

--- a/src/MaaCore/Task/Infrast/InfrastReceptionTask.cpp
+++ b/src/MaaCore/Task/Infrast/InfrastReceptionTask.cpp
@@ -88,17 +88,17 @@ bool asst::InfrastReceptionTask::get_self_clue()
         task.set_retry_times(ProcessTask::RetryTimesDefault);
         return task.run();
     };
-    
-    run_with_retries({ "InfrastClueSelfNew", "InfrastClueSelfMaybeFull" , "ReceptionFlag"});
-    
-    if (!ProcessTask(*this, {"InfrastClueSelfFull"}).set_retry_times(0).run()) {
-        return run_with_retries({"CloseCluePage", "ReceptionFlag"});
+
+    run_with_retries({ "InfrastClueSelfNew", "InfrastClueSelfMaybeFull", "ReceptionFlag" });
+
+    if (!ProcessTask(*this, { "InfrastClueSelfFull" }).set_retry_times(0).run()) {
+        return run_with_retries({ "CloseCluePage", "ReceptionFlag" });
     }
     if (m_enable_clue_exchange) {
-        return run_with_retries({"CloseCluePageThenSendClue"});
+        return run_with_retries({ "CloseCluePageThenSendClue" });
     }
-    
-    return run_with_retries({"CloseCluePage", "ReceptionFlag"});
+
+    return run_with_retries({ "CloseCluePage", "ReceptionFlag" });
 }
 
 bool asst::InfrastReceptionTask::use_clue()

--- a/src/MaaCore/Task/Infrast/InfrastReceptionTask.h
+++ b/src/MaaCore/Task/Infrast/InfrastReceptionTask.h
@@ -13,6 +13,8 @@ public:
 
     void set_receive_message_board(bool value) noexcept { m_receive_message_board = value; }
 
+    void set_enable_clue_exchange(bool value) noexcept { m_enable_clue_exchange = value; }
+
 protected:
     virtual bool _run() override;
 
@@ -32,5 +34,6 @@ private:
     bool shift();
 
     bool m_receive_message_board = true;
+    bool m_enable_clue_exchange = true;
 };
 }

--- a/src/MaaCore/Task/Interface/InfrastTask.cpp
+++ b/src/MaaCore/Task/Interface/InfrastTask.cpp
@@ -167,6 +167,9 @@ bool asst::InfrastTask::set_params(const json::value& params)
     bool reception_message_board = params.get("reception_message_board", true);
     m_reception_task_ptr->set_receive_message_board(reception_message_board);
 
+    bool reception_clue_exchange = params.get("reception_clue_exchange", true);
+    m_reception_task_ptr->set_enable_clue_exchange(reception_clue_exchange);
+
     bool replenish = params.get("replenish", false);
     m_replenish_task_ptr->set_enable(replenish);
 

--- a/src/MaaWpfGui/Constants/ConfigurationKeys.cs
+++ b/src/MaaWpfGui/Constants/ConfigurationKeys.cs
@@ -115,6 +115,7 @@ namespace MaaWpfGui.Constants
         public const string DormThreshold = "Infrast.DormThreshold";
         public const string UsesOfDrones = "Infrast.UsesOfDrones";
         public const string InfrastReceptionMessageBoardReceive = "Infrast.ReceptionMessageBoardReceive";
+        public const string InfrastReceptionClueExchange = "Infrast.ReceptionClueExchange";
         public const string ContinueTraining = "Infrast.ContinueTraining";
         public const string DefaultInfrast = "Infrast.DefaultInfrast";
         public const string IsCustomInfrastFileReadOnly = "Infrast.IsCustomInfrastFileReadOnly"; // 已废弃

--- a/src/MaaWpfGui/Models/AsstTasks/AsstInfrastTask.cs
+++ b/src/MaaWpfGui/Models/AsstTasks/AsstInfrastTask.cs
@@ -81,6 +81,11 @@ public class AsstInfrastTask : AsstBaseTask
     public bool ReceptionMessageBoard { get; set; } = true;
 
     /// <summary>
+    /// Gets or sets a value indicating whether 启用线索交流
+    /// </summary>
+    public bool ReceptionClueExchange { get; set; } = true;
+
+    /// <summary>
     /// Gets or sets 自定义配置文件路径
     /// </summary>
     public string Filename { get; set; } = string.Empty;
@@ -102,6 +107,7 @@ public class AsstInfrastTask : AsstBaseTask
             ["dorm_trust_enabled"] = DormTrustEnabled,
             ["replenish"] = OriginiumShardAutoReplenishment,
             ["reception_message_board"] = ReceptionMessageBoard,
+            ["reception_clue_exchange"] = ReceptionClueExchange,
             ["mode"] = (int)Mode,
         };
 

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -115,6 +115,7 @@
     <system:String x:Key="DormFilterNotStationedTips">Checking this box will not remove {key=Operator}s like Irene from the Training Room; this will also prevent {key=Operator}s from the Workshop from entering the Dormitory.</system:String>
     <system:String x:Key="OriginiumShardAutoReplenishment">Originium Shard auto replenishment</system:String>
     <system:String x:Key="InfrastReceptionMessageBoardReceive">Credit collection from message board in Reception Room</system:String>
+    <system:String x:Key="InfrastReceptionClueExchange">Conduct Clue Exchange</system:String>
     <system:String x:Key="ContinueTraining">After training is complete, try to continue mastering the current skill</system:String>
     <system:String x:Key="TrainingIdle">Training room is vacant</system:String>
     <system:String x:Key="TrainingCompleted">Training completed</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -115,6 +115,7 @@
     <system:String x:Key="DormFilterNotStationedTips">チェックした場合、アイリーニのような{key=Operator}が訓練室から外れなくなり、また、加工所の{key=Operator}が宿舎に送られることを防止します。</system:String>
     <system:String x:Key="OriginiumShardAutoReplenishment">源石の欠片を自動で補充</system:String>
     <system:String x:Key="InfrastReceptionMessageBoardReceive">受付室の掲示板からのクレジット収集</system:String>
+    <system:String x:Key="InfrastReceptionClueExchange">手がかり交換を実施</system:String>
     <system:String x:Key="ContinueTraining">訓練完了後に現在スキルの継続特化を試みます</system:String>
     <system:String x:Key="TrainingIdle">訓練室は空いています</system:String>
     <system:String x:Key="TrainingCompleted">訓練が完了しました</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -115,6 +115,7 @@
     <system:String x:Key="DormFilterNotStationedTips">체크할 경우 아이린과 같은 {key=Operator}를 훈련실에서 제거하지 않고, 가공소의 {key=Operator}가 숙소에 배치되는 것을 방지합니다.</system:String>
     <system:String x:Key="OriginiumShardAutoReplenishment">오리지늄 조각 자동 보충</system:String>
     <system:String x:Key="InfrastReceptionMessageBoardReceive">응접실 게시판에서 크레딧 수집</system:String>
+    <system:String x:Key="InfrastReceptionClueExchange">단서 교환 수행</system:String>
     <system:String x:Key="ContinueTraining">스킬 훈련 완료 시 이어서 훈련 시도</system:String>
     <system:String x:Key="TrainingIdle">훈련실이 비어 있습니다</system:String>
     <system:String x:Key="TrainingCompleted">훈련 완료</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -115,6 +115,7 @@
     <system:String x:Key="DormFilterNotStationedTips">勾选则不会将艾丽妮等{key=Operator}从训练室移除，但也会导致加工站{key=Operator}不能进入宿舍。</system:String>
     <system:String x:Key="OriginiumShardAutoReplenishment">源石碎片自动补货</system:String>
     <system:String x:Key="InfrastReceptionMessageBoardReceive">会客室信息板收取信用</system:String>
+    <system:String x:Key="InfrastReceptionClueExchange">进行线索交流</system:String>
     <system:String x:Key="ContinueTraining">训练完成后继续尝试专精当前技能</system:String>
     <system:String x:Key="TrainingIdle">训练室空闲中</system:String>
     <system:String x:Key="TrainingCompleted">训练完成</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -114,6 +114,7 @@
     <system:String x:Key="DormFilterNotStationedTips">勾選則不會將艾麗妮等{key=Operator}從訓練室移除，但也會導致加工站{key=Operator}不能進入宿舍。</system:String>
     <system:String x:Key="OriginiumShardAutoReplenishment">源石碎片自動補貨</system:String>
     <system:String x:Key="InfrastReceptionMessageBoardReceive">會客室資訊板收取信用</system:String>
+    <system:String x:Key="InfrastReceptionClueExchange">進行線索交流</system:String>
     <system:String x:Key="ContinueTraining">訓練完成後繼續嘗試專精當前技能</system:String>
     <system:String x:Key="TrainingIdle">訓練室空閒中</system:String>
     <system:String x:Key="TrainingCompleted">訓練完成</system:String>

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/InfrastSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/InfrastSettingsUserControlModel.cs
@@ -273,6 +273,18 @@ public class InfrastSettingsUserControlModel : TaskViewModel
         }
     }
 
+    private bool _receptionClueExchange = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.InfrastReceptionClueExchange, bool.TrueString));
+
+    public bool ReceptionClueExchange
+    {
+        get => _receptionClueExchange;
+        set
+        {
+            SetAndNotify(ref _receptionClueExchange, value);
+            ConfigurationHelper.SetValue(ConfigurationKeys.InfrastReceptionClueExchange, value.ToString());
+        }
+    }
+
     private bool _continueTraining = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.ContinueTraining, bool.FalseString));
 
     /// <summary>
@@ -656,6 +668,7 @@ public class InfrastSettingsUserControlModel : TaskViewModel
             DormTrustEnabled = DormTrustEnabled,
             OriginiumShardAutoReplenishment = OriginiumShardAutoReplenishment,
             ReceptionMessageBoard = ReceptionMessageBoardReceive,
+            ReceptionClueExchange = ReceptionClueExchange,
             Filename = CustomInfrastFile,
             PlanIndex = CustomInfrastPlanIndex,
         }.Serialize();

--- a/src/MaaWpfGui/Views/UserControl/TaskQueue/InfrastSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/TaskQueue/InfrastSettingsUserControl.xaml
@@ -185,6 +185,9 @@
             <CheckBox Margin="0,10" IsChecked="{Binding ReceptionMessageBoardReceive}">
                 <controls:TextBlock Text="{DynamicResource InfrastReceptionMessageBoardReceive}" TextWrapping="Wrap" />
             </CheckBox>
+            <CheckBox Margin="0,10" IsChecked="{Binding ReceptionClueExchange}">
+                <controls:TextBlock Text="{DynamicResource InfrastReceptionClueExchange}" TextWrapping="Wrap" />
+            </CheckBox>
             <CheckBox Margin="0,10" IsChecked="{Binding ContinueTraining}">
                 <controls:TextBlock Text="{DynamicResource ContinueTraining}" TextWrapping="Wrap" />
             </CheckBox>


### PR DESCRIPTION
close #6210.
解耦线索赠送逻辑 默认启用线索交流时与之前的行为一致
关闭线索交流时不再赠送线索 仅尝试在线索未满时收取线索 若已满则跳过该步骤 以便用户手动处理线索