### PR TITLE
fix: 对掉落信息进行排序 与ToolTip保持一致

### DIFF
--- a/src/MaaCore/Task/Fight/StageDropsTaskPlugin.cpp
+++ b/src/MaaCore/Task/Fight/StageDropsTaskPlugin.cpp
@@ -243,18 +243,6 @@ void asst::StageDropsTaskPlugin::drop_info_callback()
         stats_vec.emplace_back(std::move(info));
     }
 
-    // 先按新增数量降序，再按总数量降序
-    std::sort(stats_vec.begin(), stats_vec.end(), [](const json::value& lhs, const json::value& rhs) -> bool {
-        int lhs_add = lhs.get("addQuantity", 0);
-        int rhs_add = rhs.get("addQuantity", 0);
-        if (lhs_add != rhs_add) {
-            return lhs_add > rhs_add;
-        }
-        int lhs_total = lhs.get("quantity", 0);
-        int rhs_total = rhs.get("quantity", 0);
-        return lhs_total > rhs_total;
-    });
-
     json::value info = basic_info_with_what("StageDrops");
     json::value& details = info["details"];
     details["stars"] = m_stars;

--- a/src/MaaWpfGui/Helper/ToolTipHelper.cs
+++ b/src/MaaWpfGui/Helper/ToolTipHelper.cs
@@ -129,7 +129,7 @@ namespace MaaWpfGui.Helper
         /// </summary>
         /// <param name="drops">掉落物列表</param>
         /// <returns>ToolTip</returns>
-        public static ToolTip CreateMaterialDropTooltip(this IEnumerable<(string ItemId, int Total, int Add)> drops)
+        public static ToolTip CreateMaterialDropTooltip(this IEnumerable<(string ItemId, string ItemName, int Total, int Add)> drops)
         {
             var row = new WrapPanel
             {
@@ -140,9 +140,7 @@ namespace MaaWpfGui.Helper
                 MaxWidth = (64 * 5) + (4 * 10),
             };
 
-            foreach (var (itemId, total, add) in drops
-                         .OrderByDescending(x => x.Add)
-                         .ThenByDescending(x => x.Total))
+            foreach (var (itemId, _, total, add) in drops)
             {
                 var image = new Image
                 {


### PR DESCRIPTION
## 修改前

<img width="341" height="310" alt="屏幕截图 2025-07-29 154339" src="https://github.com/user-attachments/assets/e977d747-a8d2-4894-a7b1-270a1a841222" />

## 修改后

<img width="309" height="333" alt="屏幕截图 2025-07-29 155807" src="https://github.com/user-attachments/assets/03858dbf-cf3f-4744-bea3-800e8718da1a" />
