### PR TITLE
fix: clang编译警告

### DIFF
--- a/src/MaaCore/Common/AsstBattleDef.h
+++ b/src/MaaCore/Common/AsstBattleDef.h
@@ -39,7 +39,7 @@ struct OperUsage // 干员用法
     int skill = 0;       // 技能序号，取值范围 [0, 3]，0时使用默认技能 或 上次编队时使用的技能
     SkillUsage skill_usage = SkillUsage::NotUse;
     int skill_times = 1; // 使用技能的次数，默认为 1，兼容曾经的作业
-    asst::battle::OperatorRequirements requirements; // 练度需求
+    asst::battle::OperatorRequirements requirements = {}; // 练度需求
 };
 
 enum class DeployDirection

--- a/src/MaaCore/Task/Roguelike/RoguelikeConfig.h
+++ b/src/MaaCore/Task/Roguelike/RoguelikeConfig.h
@@ -48,6 +48,7 @@ struct RoguelikeStatus
 public:
     RoguelikeStatus() = default;
     RoguelikeStatus(const RoguelikeStatus&) = delete;
+    RoguelikeStatus& operator=(const RoguelikeStatus&) = default;
 
 public:
     int hope = 0;                                         // 当前希望


### PR DESCRIPTION
修复了两处warning：
- missing field 'requirements' initializer 
- definition of implicit copy assignment operator for 'RoguelikeStatus' is deprecated because it has a user-declared copy constructor.

（其实并没有改变代码行为）