### PR TITLE
chore: 再度調整繁中服「崔林特爾梅之金·復刻」活動導航

### DIFF
--- a/resource/global/txwy/resource/tasks/Stages/ZT.json
+++ b/resource/global/txwy/resource/tasks/Stages/ZT.json
@@ -1,8 +1,48 @@
 {
+    "ZT-9": {
+        "algorithm": "JustReturn",
+        "sub": ["ZT-9@ZT-OpenOpt"],
+        "next": ["ZT-9@SideStoryStage", "ZT-9@SwipeToStage"]
+    },
+    "ZT-9@SideStoryStage": {
+        "text": ["ZT-9"]
+    },
+    "ZT-8": {
+        "algorithm": "JustReturn",
+        "sub": ["ZT-8@ZT-OpenOpt"],
+        "next": ["ZT-8@SideStoryStage", "ZT-8@SwipeToStage"]
+    },
+    "ZT-8@SideStoryStage": {
+        "text": ["ZT-8"]
+    },
+    "ZT-7": {
+        "algorithm": "JustReturn",
+        "sub": ["ZT-7@ZT-OpenOpt"],
+        "next": ["ZT-7@SideStoryStage", "ZT-7@SwipeToStage"]
+    },
+    "ZT-7@SideStoryStage": {
+        "text": ["ZT-7"]
+    },
+    "ZT-OpenOpt": {
+        "algorithm": "JustReturn",
+        "next": ["ZT-OpenOcr", "ZT-Open"]
+    },
+    "ZT-Open": {
+        "baseTask": "SS-Open",
+        "template": ["StageActivity.png"],
+        "next": ["ZTChapterToZT"]
+    },
     "ZT-OpenOcr": {
-        "text": ["崔林", "之金", "恩典", "無情"]
+        "baseTask": "SS-OpenOcr",
+        "text": ["崔林", "之金", "恩典", "無情"],
+        "next": ["ZTChapterToZT"]
     },
     "ZTChapterToZT": {
-        "text": ["朝見", "雙塔"]
+        "algorithm": "OcrDetect",
+        "action": "ClickSelf",
+        "text": ["朝見", "雙塔"],
+        "preDelay": 1000,
+        "roi": [1059, 367, 206, 129],
+        "next": ["ChapterSwipeToTheRight"]
     }
 }


### PR DESCRIPTION
close #13514

不確定到底是不是這樣改，但反正現在能跑 (x

又因為中間現在長下面這樣，所以 "ZT-Open" 的 "template" 就只留了 "StageActivity.png"
<img width="1280" height="720" alt="Screenshot_20250805-001719" src="https://github.com/user-attachments/assets/85409d07-2bfd-4145-99d6-dc8400613024" />
