### PR TITLE
feat(界园autopilot): 增加电弧站位配置

### DIFF
--- a/resource/roguelike/JieGarden/autopilot/不成烟火.json
+++ b/resource/roguelike/JieGarden/autopilot/不成烟火.json
@@ -6,8 +6,45 @@
             "direction": "up"
         }
     ],
+    "retreat_plan": [
+        {
+            "location": [5, 1],
+            "condition": [0, 12]
+        }
+    ],
     "blacklist_location": [],
     "deploy_plan": [
+        {
+            "groups": ["新约能天使"],
+            "location": [2, 2],
+            "direction": "down"
+        },
+        {
+            "groups": ["投锋"],
+            "location": [5, 1],
+            "direction": "left",
+            "condition": [0, 12]
+        },
+        {
+            "groups": ["电弧"],
+            "location": [7, 4],
+            "direction": "down"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [7, 6],
+            "direction": "left"
+        },
+        {
+            "groups": ["奶盾"],
+            "location": [2, 1],
+            "direction": "left"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [6, 6],
+            "direction": "left"
+        },
         {
             "groups": [
                 "奶盾",
@@ -36,6 +73,11 @@
             "direction": "Left"
         },
         {
+            "groups": ["高台输出","单奶", "群奶"],
+            "location": [3, 2],
+            "direction": "Left"
+        },
+        {
             "groups": ["高台输出"],
             "location": [8, 5],
             "direction": "Left"
@@ -44,6 +86,16 @@
             "groups": ["玛恩纳", "地面远程", "重装", "地面阻挡", "回费", "处决者", "其他地面"],
             "location": [7, 6],
             "direction": "Left"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [8, 6],
+            "direction": "left"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [9, 6],
+            "direction": "left"
         },
         {
             "groups": ["高台输出"],

--- a/resource/roguelike/JieGarden/autopilot/仁·义·武.json
+++ b/resource/roguelike/JieGarden/autopilot/仁·义·武.json
@@ -10,6 +10,16 @@
             "direction": "Left"
         }
     ],
+    "retreat_plan": [
+        {
+            "location": [9, 4],
+            "condition": [8, 8]
+        },
+        {
+            "location": [8, 4],
+            "condition": [8, 8]
+        }
+    ],
     "blacklist_location": [],
     "deploy_plan": [
         {
@@ -18,9 +28,52 @@
             "direction": "up"
         },
         {
+            "groups": ["新约能天使"],
+            "location": [9, 4],
+            "direction": "down",
+            "condition": [0, 8]
+        },
+        {
+            "groups": ["回费"],
+            "location": [8, 4],
+            "direction": "down",
+            "condition": [0, 8]
+        },
+        {
             "groups": ["高台输出"],
             "location": [1, 4],
             "direction": "down"
+        },
+        {
+            "groups": ["电弧"],
+            "location": [9, 4],
+            "direction": "left",
+            "condition": [8, 35]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [7, 2],
+            "direction": "left"
+        },
+        {
+            "groups": ["奶盾","重装","地面阻挡","其他地面"],
+            "location": [6, 3],
+            "direction": "left"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [7, 3],
+            "direction": "left"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [7, 1],
+            "direction": "left"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [6, 3],
+            "direction": "left"
         },
         {
             "groups": [

--- a/resource/roguelike/JieGarden/autopilot/剑·刀·矛.json
+++ b/resource/roguelike/JieGarden/autopilot/剑·刀·矛.json
@@ -6,12 +6,70 @@
             "direction": "left"
         }
     ],
+    "retreat_plan": [
+        {
+            "location": [5, 4],
+            "condition": [16, 16]
+        },
+        {
+            "location": [9, 2],
+            "condition": [13, 15]
+        }
+    ],
     "blacklist_location": [],
     "deploy_plan": [
+        {
+            "groups": ["投锋"],
+            "location": [9, 2],
+            "direction": "up",
+            "condition": [0, 11]
+        },
+        {
+            "groups": ["电弧"],
+            "location": [5, 3],
+            "direction": "down"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [7, 4],
+            "direction": "left"
+        },
+        {
+            "groups": ["新约能天使"],
+            "location": [5, 2],
+            "direction": "down"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [4, 4],
+            "direction": "right"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [5, 4],
+            "direction": "left",
+            "condition": [0, 15]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [4, 2],
+            "direction": "down"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [6, 1],
+            "direction": "down"
+        },
         {
             "groups": ["奶盾", "回费", "地面远程", "锏", "重装", "情报官", "地面阻挡", "处决者", "其他地面"],
             "location": [8, 4],
             "direction": "left"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [8, 4],
+            "direction": "left",
+            "condition": [0, 6]
         },
         {
             "groups": ["益达", "提丰"],

--- a/resource/roguelike/JieGarden/autopilot/去晦.json
+++ b/resource/roguelike/JieGarden/autopilot/去晦.json
@@ -6,8 +6,78 @@
             "direction": "left"
         }
     ],
+    "retreat_plan": [
+        {
+            "location": [5, 4],
+            "condition": [3, 4]
+        },
+        {
+            "location": [5, 3],
+            "condition": [14, 14]
+        },
+        {
+            "location": [4, 4],
+            "condition": [24, 24]
+        },
+        {
+            "location": [4, 4],
+            "condition": [25, 26]
+        }
+    ],
     "blacklist_location": [],
     "deploy_plan": [
+        {
+            "groups": ["电弧"],
+            "location": [8, 2],
+            "direction": "left"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [5, 4],
+            "direction": "up",
+            "condition": [1, 3]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [4, 4],
+            "direction": "left",
+            "condition": [0, 22]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [8, 3],
+            "direction": "up"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [5, 2],
+            "direction": "up",
+            "condition": [1, 1]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [5, 4],
+            "direction": "up",
+            "condition": [9, 23]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [6, 3],
+            "direction": "left",
+            "condition": [10, 23]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [5, 3],
+            "direction": "up",
+            "condition": [10, 23]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [4, 4],
+            "direction": "right",
+            "condition": [23, 23]
+        },
         {
             "groups": ["益达", "提丰", "焰苇", "水陈", "高台输出"],
             "location": [3, 5],
@@ -17,6 +87,43 @@
             "groups": ["地面远程", "锏", "地刺", "重装", "玛恩纳", "情报官", "地面阻挡", "处决者", "回费", "其他地面"],
             "location": [7, 5],
             "direction": "left"
+        },
+
+        {
+            "groups": ["赛柯"],
+            "location": [7, 5],
+            "direction": "left",
+            "condition": [23, 24]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [6, 5],
+            "direction": "up",
+            "condition": [23, 28]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [4, 4],
+            "direction": "left",
+            "condition": [26, 38]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [5, 4],
+            "direction": "up",
+            "condition": [24, 38]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [6, 3],
+            "direction": "left",
+            "condition": [29, 38]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [6, 4],
+            "direction": "left",
+            "condition": [32, 38]
         },
         {
             "groups": ["高台输出"],

--- a/resource/roguelike/JieGarden/autopilot/啖之以利.json
+++ b/resource/roguelike/JieGarden/autopilot/啖之以利.json
@@ -67,7 +67,7 @@
         {
             "groups": ["赛柯"],
             "location": [1, 6],
-            "direction": "up"
+            "direction": "right"
         },
         {
             "groups": ["益达", "提丰", "焰苇", "水陈", "高台输出"],

--- a/resource/roguelike/JieGarden/autopilot/啖之以利.json
+++ b/resource/roguelike/JieGarden/autopilot/啖之以利.json
@@ -11,7 +11,64 @@
         [4, 6],
         [5, 6]
     ],
+    "retreat_plan": [
+        {
+            "location": [2, 6],
+            "condition": [15, 18]
+        },
+        {
+            "location": [2, 1],
+            "condition": [34, 46]
+        }
+    ],
     "deploy_plan": [
+        {
+            "groups": ["投锋"],
+            "location": [2, 6],
+            "direction": "right",
+            "condition": [0, 13]
+        },
+        {
+            "groups": ["电弧"],
+            "location": [6, 2],
+            "direction": "left"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [4, 5],
+            "direction": "up"
+        },
+        {
+            "groups": ["新约能天使"],
+            "location": [2, 2],
+            "direction": "left"
+        },
+        {
+            "groups": ["地面阻挡"],
+            "location": [2, 1],
+            "direction": "right",
+            "condition": [0, 31]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [5, 5],
+            "direction": "up"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [3, 5],
+            "direction": "up"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [1, 1],
+            "direction": "right"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [1, 6],
+            "direction": "up"
+        },
         {
             "groups": ["益达", "提丰", "焰苇", "水陈", "高台输出"],
             "location": [2, 5],

--- a/resource/roguelike/JieGarden/autopilot/夕娥忆.json
+++ b/resource/roguelike/JieGarden/autopilot/夕娥忆.json
@@ -9,6 +9,11 @@
     "blacklist_location": [],
     "deploy_plan": [
         {
+            "groups": ["奶盾"],
+            "location": [5, 4],
+            "direction": "down"
+        },
+        {
             "groups": [
                 "奶盾",
                 "地面远程",
@@ -24,6 +29,39 @@
             ],
             "location": [5, 4],
             "direction": "down"
+        },
+        
+        {
+            "groups": ["益达"],
+            "location": [6, 3],
+            "direction": "down"
+        },
+        {
+            "groups": ["回费"],
+            "location": [3, 3],
+            "direction": "up",
+            "condition": [0, 7]
+        },
+        {
+            "groups": ["电弧"],
+            "location": [4, 3],
+            "direction": "down"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [4, 3],
+            "direction": "up"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [2, 3],
+            "direction": "left",
+            "condition": [0, 7]
+        },
+        {
+            "groups": ["新约能天使"],
+            "location": [4, 4],
+            "direction": "up"
         },
         {
             "groups": ["益达", "提丰"],
@@ -44,6 +82,22 @@
             "groups": ["单奶", "群奶"],
             "location": [7, 4],
             "direction": "Left"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [1, 6],
+            "direction": "up"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [3, 4],
+            "direction": "up"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [7, 5],
+            "direction": "up",
+            "condition": [12, 19]
         },
         {
             "groups": ["玛恩纳", "地面远程", "重装", "地面阻挡", "回费", "处决者", "其他地面"],

--- a/resource/roguelike/JieGarden/autopilot/山海必争.json
+++ b/resource/roguelike/JieGarden/autopilot/山海必争.json
@@ -26,6 +26,31 @@
             "direction": "left"
         },
         {
+            "groups": ["电弧"],
+            "location": [5, 3],
+            "direction": "up"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [4, 2],
+            "direction": "right" 
+        },
+        {
+            "groups": ["新约能天使"],
+            "location": [5, 5],
+            "direction": "left" 
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [4, 1],
+            "direction": "left" 
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [2, 4],
+            "direction": "up" 
+        },
+        {
             "groups": ["益达", "提丰", "水陈", "焰苇", "高台输出"],
             "location": [5, 5],
             "direction": "left"
@@ -44,6 +69,11 @@
             "groups": ["单奶", "群奶"],
             "location": [5, 3],
             "direction": "right"
+        },
+        {
+            "groups": ["单奶", "群奶"],
+            "location": [4, 5],
+            "direction": "up"
         },
         {
             "groups": ["玛恩纳", "地面远程", "重装", "地面阻挡", "回费", "处决者", "其他地面"],

--- a/resource/roguelike/JieGarden/autopilot/峥嵘战功.json
+++ b/resource/roguelike/JieGarden/autopilot/峥嵘战功.json
@@ -10,8 +10,82 @@
             "direction": "left"
         }
     ],
+    "retreat_plan": [
+        {
+            "location": [3, 2],
+            "condition": [5, 6]
+        },
+        {
+            "location": [3, 5],
+            "condition": [5, 6]
+        }
+    ],
     "blacklist_location": [],
     "deploy_plan": [
+        {
+            "groups": ["投锋"],
+            "location": [3, 3],
+            "direction": "left"
+        },
+        {
+            "groups": ["电弧"],
+            "location": [9, 3],
+            "direction": "left"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [3, 2],
+            "direction": "left",
+            "condition": [0, 4]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [3, 5],
+            "direction": "left",
+            "condition": [0, 4]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [7, 3],
+            "direction": "left" 
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [7, 4],
+            "direction": "left" 
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [8, 3],
+            "direction": "left" 
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [8, 4],
+            "direction": "left" 
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [3, 4],
+            "direction": "up",
+            "condition": [6, 8]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [4, 4],
+            "direction": "up",
+            "condition": [6, 8]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [8, 1],
+            "direction": "left" 
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [7, 2],
+            "direction": "left" 
+        },
         {
             "groups": ["益达", "提丰", "水陈", "焰苇", "高台输出"],
             "location": [9, 3],

--- a/resource/roguelike/JieGarden/autopilot/往事暗哑.json
+++ b/resource/roguelike/JieGarden/autopilot/往事暗哑.json
@@ -9,6 +9,31 @@
     "blacklist_location": [],
     "deploy_plan": [
         {
+            "groups": ["新约能天使"],
+            "location": [9, 5],
+            "direction": "left"
+        },
+        {
+            "groups": ["电弧"],
+            "location": [8, 5],
+            "direction": "left"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [8, 4],
+            "direction": "up"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [6, 3],
+            "direction": "down"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [6, 5],
+            "direction": "up"
+        },
+        {
             "groups": ["益达", "提丰", "水陈", "焰苇", "高台输出"],
             "location": [5, 2],
             "direction": "down"
@@ -43,6 +68,11 @@
         {
             "groups": ["高台输出"],
             "location": [8, 5],
+            "direction": "up"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [6, 6],
             "direction": "up"
         },
         {

--- a/resource/roguelike/JieGarden/autopilot/所守者，义.json
+++ b/resource/roguelike/JieGarden/autopilot/所守者，义.json
@@ -6,8 +6,68 @@
             "direction": "left"
         }
     ],
+    "retreat_plan": [
+        {
+            "location": [8, 3],
+            "condition": [15, 20]
+        },
+        {
+            "location": [2, 5],
+            "condition": [15, 20]
+        }
+    ],
     "blacklist_location": [],
     "deploy_plan": [
+        {
+            "groups": ["回费"],
+            "location": [8, 3],
+            "direction": "left"
+        },
+        {
+            "groups": ["电弧"],
+            "location": [8, 1],
+            "direction": "down"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [3, 2],
+            "direction": "right",
+            "condition": [0, 7]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [6, 4],
+            "direction": "left",
+            "condition": [0, 14]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [5, 3],
+            "direction": "left"
+        },
+        {
+            "groups": ["荒芜拉普兰德", "新约能天使"],
+            "location": [7, 1],
+            "direction": "down"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [2, 5],
+            "direction": "left",
+            "condition": [0, 13]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [3, 3],
+            "direction": "left",
+            "condition": [9, 21]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [4, 3],
+            "direction": "left",
+            "condition": [12, 20]
+        },
         {
             "groups": ["益达", "提丰", "焰苇", "水陈", "高台输出"],
             "location": [5, 5],

--- a/resource/roguelike/JieGarden/autopilot/明抢暗偷.json
+++ b/resource/roguelike/JieGarden/autopilot/明抢暗偷.json
@@ -9,6 +9,58 @@
     "blacklist_location": [],
     "deploy_plan": [
         {
+            "groups": ["回费"],
+            "location": [7, 5],
+            "direction": "left"
+        },
+        {
+            "groups": ["电弧"],
+            "location": [6, 4],
+            "direction": "left"
+        },
+        {
+            "groups": ["益达", "焰苇", "水陈", "高台输出"],
+            "location": [7, 4],
+            "direction": "left"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [5, 3],
+            "direction": "left",
+            "condition": [0, 2]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [3, 5],
+            "direction": "up"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [3, 3],
+            "direction": "right"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [2, 1],
+            "direction": "left"
+        },
+        {
+            "groups": ["地面远程"],
+            "location": [3, 1],
+            "direction": "left",
+            "condition": [4, 12]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [5, 5],
+            "direction": "up"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [5, 1],
+            "direction": "down"
+        },
+        {
             "groups": ["益达", "焰苇", "水陈", "高台输出"],
             "location": [6, 4],
             "direction": "left"

--- a/resource/roguelike/JieGarden/autopilot/易易鸭鸭.json
+++ b/resource/roguelike/JieGarden/autopilot/易易鸭鸭.json
@@ -17,14 +17,55 @@
     "blacklist_location": [],
     "deploy_plan": [
         {
+            "groups": ["投锋"],
+            "location": [7, 3],
+            "direction": "down"
+        },
+        {
             "groups": ["益达", "提丰", "水陈", "焰苇", "高台输出"],
             "location": [8, 4],
             "direction": "Left"
         },
         {
+            "groups": ["新约能天使"],
+            "location": [6, 6],
+            "direction": "up"
+        },
+        {
             "groups": ["高台输出"],
             "location": [6, 6],
             "direction": "up"
+        },
+        {
+            "groups": ["电弧"],
+            "location": [10, 2],
+            "direction": "left"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [6, 4],
+            "direction": "left"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [7, 5],
+            "direction": "left"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [5, 6],
+            "direction": "up"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [8, 5],
+            "direction": "left"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [5, 4],
+            "direction": "left",
+            "condition": [23, 32]
         },
         {
             "groups": [

--- a/resource/roguelike/JieGarden/autopilot/暗箭难防.json
+++ b/resource/roguelike/JieGarden/autopilot/暗箭难防.json
@@ -18,9 +18,44 @@
             "direction": "down"
         },
         {
+            "groups": ["投锋"],
+            "location": [1, 1],
+            "direction": "right"
+        },
+        {
             "groups": ["高台输出"],
             "location": [7, 3],
             "direction": "right"
+        },
+        {
+            "groups": ["电弧"],
+            "location": [3, 3],
+            "direction": "right"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [2, 2],
+            "direction": "down"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [2, 3],
+            "direction": "down"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [9, 3],
+            "direction": "down"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [9, 2],
+            "direction": "left"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [9, 4],
+            "direction": "left"
         },
         {
             "groups": ["地面远程", "锏", "地刺", "重装", "玛恩纳", "情报官", "地面阻挡", "处决者", "回费", "其他地面"],

--- a/resource/roguelike/JieGarden/autopilot/月华寒.json
+++ b/resource/roguelike/JieGarden/autopilot/月华寒.json
@@ -6,17 +6,62 @@
             "direction": "Right"
         }
     ],
+    "retreat_plan": [
+        {
+            "location": [4, 5],
+            "condition": [12, 12]
+        },
+        {
+            "location": [3, 3],
+            "condition": [12, 12]
+        },
+        {
+            "location": [4, 5],
+            "condition": [29, 31]
+        },
+        {
+            "location": [7, 5],
+            "condition": [29, 31]
+        }
+    ],
     "blacklist_location": [],
     "deploy_plan": [
+        {
+            "groups": ["投锋"],
+            "location": [4, 5],
+            "direction": "right",
+            "condition": [0, 5]
+        },
         {
             "groups": ["奶盾"],
             "location": [3, 5],
             "direction": "Right"
         },
         {
+            "groups": ["电弧"],
+            "location": [4, 4],
+            "direction": "left"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [2, 5],
+            "direction": "right"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [4, 5],
+            "direction": "right",
+            "condition": [0, 28]
+        },
+        {
             "groups": ["益达", "焰苇", "高台输出"],
             "location": [4, 4],
             "direction": "left"
+        },
+        {
+            "groups": ["单奶", "群奶"],
+            "location": [2, 4],
+            "direction": "right"
         },
         {
             "groups": ["地面远程", "锏", "地刺", "重装", "玛恩纳", "情报官", "地面阻挡", "处决者", "回费", "其他地面"],
@@ -42,6 +87,22 @@
             "groups": ["玛恩纳", "地面远程", "重装", "地面阻挡", "回费", "处决者", "其他地面"],
             "location": [1, 5],
             "direction": "Up"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [7, 5],
+            "direction": "Up",
+            "condition": [29, 31]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [1, 4],
+            "direction": "Up"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [1, 5],
+            "direction": "right"
         },
         {
             "groups": ["处决者"],

--- a/resource/roguelike/JieGarden/autopilot/有教无类.json
+++ b/resource/roguelike/JieGarden/autopilot/有教无类.json
@@ -9,6 +9,41 @@
     "blacklist_location": [],
     "deploy_plan": [
         {
+            "groups": ["挡人先锋"],
+            "location": [1, 5],
+            "direction": "down"
+        },
+        {
+            "groups": ["电弧"],
+            "location": [7, 5],
+            "direction": "up"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [7, 3],
+            "direction": "up"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [8, 4],
+            "direction": "up"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [2, 3],
+            "direction": "left"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [8, 2],
+            "direction": "up"
+        },
+        {
+            "groups": ["新约能天使"],
+            "location": [2, 4],
+            "direction": "down"
+        },
+        {
             "groups": ["益达", "提丰", "焰苇", "水陈", "高台输出"],
             "location": [7, 5],
             "direction": "up"

--- a/resource/roguelike/JieGarden/autopilot/正经生意.json
+++ b/resource/roguelike/JieGarden/autopilot/正经生意.json
@@ -6,8 +6,44 @@
             "direction": "down"
         }
     ],
+    "retreat_plan": [
+        {
+            "location": [3, 2],
+            "condition": [17, 19]
+        }
+    ],
     "blacklist_location": [],
     "deploy_plan": [
+        {
+            "groups": ["回费"],
+            "location": [6, 4],
+            "direction": "left"
+        },
+        {
+            "groups": ["电弧"],
+            "location": [6, 3],
+            "direction": "left"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [5, 4],
+            "direction": "left"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [3, 2],
+            "direction": "up"
+        },
+        {
+            "groups": ["新约能天使", "高台输出"],
+            "location": [2, 2],
+            "direction": "down"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [3, 4],
+            "direction": "left"
+        },
         {
             "groups": ["益达", "焰苇", "水陈", "高台输出"],
             "location": [6, 3],

--- a/resource/roguelike/JieGarden/autopilot/求道.json
+++ b/resource/roguelike/JieGarden/autopilot/求道.json
@@ -6,12 +6,51 @@
             "direction": "Right"
         }
     ],
+    "retreat_plan": [
+        {
+            "location": [6, 5],
+            "condition": [7, 11]
+            
+        },
+        {
+            "location": [2, 4],
+            "condition": [14, 17]
+        }
+    ],
     "blacklist_location": [],
     "deploy_plan": [
+        {
+            "groups": ["新约能天使"],
+            "location": [6, 3],
+            "direction": "left"
+        },
+        {
+            "groups": ["投锋"],
+            "location": [5, 4],
+            "direction": "up",
+            "condition": [0, 7]
+        },
         {
             "groups": ["益达", "提丰", "水陈", "焰苇", "高台输出"],
             "location": [5, 5],
             "direction": "up"
+        },
+        {
+            "groups": ["电弧"],
+            "location": [4, 3],
+            "direction": "right"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [8, 4],
+            "direction": "up",
+            "condition": [0, 7]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [5, 2],
+            "direction": "up",
+            "condition": [0, 7]
         },
         {
             "groups": ["高台输出"],
@@ -51,9 +90,27 @@
             "direction": "up"
         },
         {
+            "groups": ["赛柯"],
+            "location": [2, 4],
+            "direction": "left",
+            "condition": [0,14]
+        },
+        {
             "groups": ["玛恩纳", "地面远程", "重装", "地面阻挡", "回费", "处决者", "其他地面"],
             "location": [3, 6],
             "direction": "Right"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [4, 6],
+            "direction": "right",
+            "condition": [7, 21]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [5, 6],
+            "direction": "right",
+            "condition": [7, 21]
         },
         {
             "groups": ["处决者"],

--- a/resource/roguelike/JieGarden/autopilot/点化.json
+++ b/resource/roguelike/JieGarden/autopilot/点化.json
@@ -6,12 +6,72 @@
             "direction": "left"
         }
     ],
+    "retreat_plan": [
+        {
+            "location": [4, 2],
+            "condition": [12, 12]
+        },
+        {
+            "location": [3, 3],
+            "condition": [21, 23]
+        }
+    ],
     "blacklist_location": [],
     "deploy_plan": [
         {
             "groups": ["回费", "地面远程", "锏", "地刺", "重装", "情报官", "地面阻挡", "处决者", "其他地面"],
             "location": [10, 2],
             "direction": "up"
+        },
+        {
+            "groups": ["电弧"],
+            "location": [8, 2],
+            "direction": "left"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [8, 1],
+            "direction": "left"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [7, 5],
+            "direction": "left" 
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [4, 2],
+            "direction": "down",
+            "condition": [0, 11]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [3, 3],
+            "direction": "Right",
+            "condition": [0, 20]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [5, 1],
+            "direction": "left",
+            "condition": [12, 39]
+        },
+        {
+            "groups": ["新约能天使"],
+            "location": [3, 4],
+            "direction": "left"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [4, 2],
+            "direction": "left",
+            "condition": [11, 39]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [5, 5],
+            "direction": "right",
+            "condition": [13, 39]
         },
         {
             "groups": ["益达", "提丰"],

--- a/resource/roguelike/JieGarden/autopilot/点化.json
+++ b/resource/roguelike/JieGarden/autopilot/点化.json
@@ -30,13 +30,9 @@
         },
         {
             "groups": ["赛柯"],
-            "location": [8, 1],
-            "direction": "left"
-        },
-        {
-            "groups": ["赛柯"],
-            "location": [7, 5],
-            "direction": "left" 
+            "location": [3, 3],
+            "direction": "Right",
+            "condition": [0, 20]
         },
         {
             "groups": ["赛柯"],
@@ -46,9 +42,13 @@
         },
         {
             "groups": ["赛柯"],
-            "location": [3, 3],
-            "direction": "Right",
-            "condition": [0, 20]
+            "location": [8, 1],
+            "direction": "left"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [8, 5],
+            "direction": "left" 
         },
         {
             "groups": ["赛柯"],

--- a/resource/roguelike/JieGarden/autopilot/狡鼷三窟.json
+++ b/resource/roguelike/JieGarden/autopilot/狡鼷三窟.json
@@ -6,8 +6,85 @@
             "direction": "right"
         }
     ],
+    "retreat_plan": [
+        {
+        "location": [3, 2],
+        "condition": [19, 40]
+        },
+        {
+        "location": [6, 6],
+        "condition": [17, 18]    
+        },
+        {
+        "location": [6, 6],
+        "condition": [27, 40]    
+        }
+    ],
     "blacklist_location": [],
     "deploy_plan": [
+        {
+            "groups": ["投锋"],
+            "location": [6, 6],
+            "direction": "up",
+            "condition": [0, 17]
+        },
+        {
+            "groups": ["电弧"],
+            "location": [3, 5],
+            "direction": "right"
+        },
+        {
+            "groups": ["新约能天使", "高台输出"],
+            "location": [3, 2],
+            "direction": "left",
+            "condition": [0, 19]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [4, 6],
+            "direction": "right",
+            "condition": [0, 19]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [4, 4],
+            "direction": "up"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [5, 3],
+            "direction": "down",
+            "condition": [27, 40]
+        },
+        {
+            "groups": ["单奶", "群奶"],
+            "location": [6, 5],
+            "direction": "left"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [6, 6],
+            "direction": "up",
+            "condition": [19, 27]
+        },
+        {
+            "groups": ["地面阻挡"],
+            "location": [3, 6],
+            "direction": "right",
+            "condition": [30, 40]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [4, 6],
+            "direction": "right",
+            "condition": [30, 40]
+        },
+        {
+            "groups": ["新约能天使", "高台输出"],
+            "location": [7, 3],
+            "direction": "left",
+            "condition": [30, 40]
+        },
         {
             "groups": ["益达", "提丰", "焰苇", "水陈", "高台输出"],
             "location": [2, 3],

--- a/resource/roguelike/JieGarden/autopilot/生百相.json
+++ b/resource/roguelike/JieGarden/autopilot/生百相.json
@@ -6,8 +6,85 @@
             "direction": "left"
         }
     ],
+    "retreat_plan": [
+        {
+            "location": [4, 2],
+            "condition": [11, 12]
+        },
+        {
+            "location": [4, 4],
+            "condition": [11, 12]
+        },
+        {
+            "location": [2, 4],
+            "condition": [11, 12]
+        },
+        {
+            "location": [6, 2],
+            "condition": [11, 12]
+        },
+        {
+            "location": [6, 4],
+            "condition": [9, 9]
+        },
+        {
+            "location": [2, 2],
+            "condition": [25, 26]
+        }
+    ],
     "blacklist_location": [],
     "deploy_plan": [
+        {
+            "groups": ["投锋"],
+            "location": [6, 4],
+            "direction": "down",
+            "condition": [0, 9]
+        },
+        {
+            "groups": ["新约能天使"],
+            "location": [7, 2],
+            "direction": "left"
+        },
+        {
+            "groups": ["电弧"],
+            "location": [7, 4],
+            "direction": "left"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [6, 2],
+            "direction": "up",
+            "condition": [0, 9]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [4, 2],
+            "direction": "up",
+            "condition": [0, 9]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [4, 4],
+            "direction": "down",
+            "condition": [0, 9]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [2, 4],
+            "direction": "down",
+            "condition": [0, 9]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [2, 2],
+            "direction": "up",
+            "condition": [0, 25]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [6, 4],
+            "direction": "down"
+        },
         {
             "groups": ["益达", "焰苇", "水陈", "高台输出"],
             "location": [7, 2],
@@ -16,6 +93,21 @@
         {
             "groups": ["地面远程", "锏", "地刺", "重装", "玛恩纳", "情报官", "地面阻挡", "处决者", "回费", "其他地面"],
             "location": [8, 3],
+            "direction": "left"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [7, 3],
+            "direction": "left"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [3, 3],
+            "direction": "left"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [6, 3],
             "direction": "left"
         },
         {

--- a/resource/roguelike/JieGarden/autopilot/破岁阵祀.json
+++ b/resource/roguelike/JieGarden/autopilot/破岁阵祀.json
@@ -6,8 +6,19 @@
             "direction": "Left"
         }
     ],
+    "retreat_plan": [
+        {
+            "location": [1, 6],
+            "condition": [13, 15]
+        }
+    ],
     "blacklist_location": [],
     "deploy_plan": [
+        {
+            "groups": ["投锋"],
+            "location": [1, 6],
+            "direction": "up"
+        },
         {
             "groups": [
                 "奶盾",
@@ -26,9 +37,64 @@
             "direction": "Left"
         },
         {
+            "groups": ["新约能天使"],
+            "location": [4, 4],
+            "direction": "Right"
+        },
+        {
+            "groups": ["电弧"],
+            "location": [3, 4],
+            "direction": "left"
+        },
+        {
+            "groups": ["辅助","其他高台"],
+            "location": [2, 4],
+            "direction": "right"
+        },
+        {
             "groups": ["益达", "提丰", "水陈", "焰苇", "高台输出"],
             "location": [4, 6],
             "direction": "up"
+        },
+        {
+            "groups": ["单奶", "群奶"],
+            "location": [4, 5],
+            "direction": "Left"
+        },
+        {
+            "groups": ["高台输出"],
+            "location": [2, 4],
+            "direction": "right"
+        },
+        {
+            "groups": ["奶盾"],
+            "location": [5, 4],
+            "direction": "right"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [5, 4],
+            "direction": "right"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [1, 4],
+            "direction": "left"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [7, 4],
+            "direction": "right"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [7, 5],
+            "direction": "right"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [6, 5],
+            "direction": "right"
         },
         {
             "groups": ["玛恩纳", "地面远程", "重装", "地面阻挡", "回费", "处决者", "其他地面"],
@@ -39,6 +105,11 @@
             "groups": ["单奶", "群奶"],
             "location": [8, 5],
             "direction": "Left"
+        },
+        {
+            "groups": ["单奶", "群奶"],
+            "location": [4, 6],
+            "direction": "up"
         },
         {
             "groups": ["高台输出"],

--- a/resource/roguelike/JieGarden/autopilot/离域检查.json
+++ b/resource/roguelike/JieGarden/autopilot/离域检查.json
@@ -13,6 +13,36 @@
     "blacklist_location": [],
     "deploy_plan": [
         {
+            "groups": ["电弧"],
+            "location": [4, 1],
+            "direction": "down"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [5, 2],
+            "direction": "down"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [6, 6],
+            "direction": "right"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [6, 2],
+            "direction": "down"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [5, 3],
+            "direction": "up"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [6, 3],
+            "direction": "up"
+        },
+        {
             "groups": ["益达", "提丰", "水陈", "焰苇", "高台输出"],
             "location": [4, 2],
             "direction": "down"

--- a/resource/roguelike/JieGarden/autopilot/老戏骨.json
+++ b/resource/roguelike/JieGarden/autopilot/老戏骨.json
@@ -9,6 +9,41 @@
     "blacklist_location": [],
     "deploy_plan": [
         {
+            "groups": ["投锋"],
+            "location": [5, 5],
+            "direction": "up"
+        },
+        {
+            "groups": ["电弧"],
+            "location": [5, 4],
+            "direction": "left"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [2, 5],
+            "direction": "up" 
+        },
+        {
+            "groups": ["高台输出"],
+            "location": [4, 2],
+            "direction": "right"
+        },
+        {
+            "groups": ["新约能天使,高台输出"],
+            "location": [3, 3],
+            "direction": "up"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [7, 1],
+            "direction": "left" 
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [3, 1],
+            "direction": "left" 
+        },
+        {
             "groups": ["地面远程", "锏", "地刺", "重装", "玛恩纳", "情报官", "地面阻挡", "处决者", "回费", "其他地面"],
             "location": [2, 5],
             "direction": "up"

--- a/resource/roguelike/JieGarden/autopilot/背山面水.json
+++ b/resource/roguelike/JieGarden/autopilot/背山面水.json
@@ -29,9 +29,49 @@
             "direction": "down"
         },
         {
+            "groups": ["电弧"],
+            "location": [9, 3],
+            "direction": "up"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [10, 5],
+            "direction": "up"
+        },
+        {
+            "groups": ["投锋"],
+            "location": [9, 5],
+            "direction": "right"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [10, 4],
+            "direction": "up"
+        },
+        {
             "groups": ["地面远程", "锏", "地刺", "重装", "玛恩纳", "情报官", "地面阻挡", "处决者", "回费", "其他地面"],
             "location": [10, 3],
             "direction": "down"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [10, 3],
+            "direction": "up"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [10, 1],
+            "direction": "down"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [2, 3],
+            "direction": "right"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [10, 2],
+            "direction": "up"
         },
         {
             "groups": ["高台输出"],

--- a/resource/roguelike/JieGarden/autopilot/落叶归根.json
+++ b/resource/roguelike/JieGarden/autopilot/落叶归根.json
@@ -6,8 +6,70 @@
             "direction": "down"
         }
     ],
+    "retreat_plan": [
+        {
+            "location": [3, 5],
+            "condition": [10, 10]
+        },
+        {
+            "location": [2, 2],
+            "condition": [10, 10]
+        }
+    ],
     "blacklist_location": [],
     "deploy_plan": [
+        {
+            "groups": ["投锋"],
+            "location": [2, 2],
+            "direction": "left",
+            "condition": [0, 9]
+        },
+        {
+            "groups": ["电弧"],
+            "location": [2, 1],
+            "direction": "down"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [1, 2],
+            "direction": "down"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [3, 2],
+            "direction": "down"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [3, 6],
+            "direction": "right"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [8, 6],
+            "direction": "left"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [3, 5],
+            "direction": "up",
+            "condition": [4, 9]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [7, 5],
+            "direction": "down"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [8, 1],
+            "direction": "right"
+        },
+        {
+            "groups": ["新约能天使"],
+            "location": [3, 3],
+            "direction": "down"
+        },
         {
             "groups": ["益达", "焰苇", "高台输出"],
             "location": [3, 3],

--- a/resource/roguelike/JieGarden/autopilot/落叶归根.json
+++ b/resource/roguelike/JieGarden/autopilot/落叶归根.json
@@ -66,6 +66,11 @@
             "direction": "right"
         },
         {
+            "groups": ["赛柯"],
+            "location": [5, 1],
+            "direction": "right"
+        },
+        {
             "groups": ["新约能天使"],
             "location": [3, 3],
             "direction": "down"

--- a/resource/roguelike/JieGarden/autopilot/薄礼一份.json
+++ b/resource/roguelike/JieGarden/autopilot/薄礼一份.json
@@ -6,8 +6,35 @@
             "direction": "Right"
         }
     ],
+    "retreat_plan": [
+        {
+            "location": [1, 3],
+            "condition": [16, 18]
+        }
+    ],
     "blacklist_location": [],
     "deploy_plan": [
+        {
+            "groups": ["投锋"],
+            "location": [1, 3],
+            "direction": "right",
+            "condition": [0, 16]
+        },
+        {
+            "groups": ["电弧"],
+            "location": [2, 2],
+            "direction": "right"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [4, 1],
+            "direction": "left"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [4, 5],
+            "direction": "left"
+        },
         {
             "groups": ["益达", "提丰", "水陈", "焰苇", "高台输出"],
             "location": [1, 2],
@@ -22,6 +49,21 @@
             "groups": ["高台输出"],
             "location": [6, 4],
             "direction": "Right"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [3, 1],
+            "direction": "left"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [3, 5],
+            "direction": "left"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [1, 3],
+            "direction": "right"
         },
         {
             "groups": [

--- a/resource/roguelike/JieGarden/autopilot/识文.json
+++ b/resource/roguelike/JieGarden/autopilot/识文.json
@@ -9,9 +9,44 @@
     "blacklist_location": [],
     "deploy_plan": [
         {
-            "groups": ["益达", "提丰", "水陈", "焰苇", "高台输出"],
+            "groups": ["投锋"],
+            "location": [6, 4],
+            "direction": "right"
+        },
+        {
+            "groups": ["电弧"],
+            "location": [4, 6],
+            "direction": "up"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [4, 5],
+            "direction": "left" 
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [4, 4],
+            "direction": "left" 
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [4, 3],
+            "direction": "left" 
+        },
+        {
+            "groups": ["益达", "提丰", "水陈", "焰苇", "高台输出", "酒神"],
             "location": [4, 2],
             "direction": "right"
+        },
+        {
+            "groups": ["新约能天使"],
+            "location": [5, 3],
+            "direction": "right" 
+        },
+        {
+            "groups": ["益达", "提丰", "水陈", "焰苇", "高台输出"],
+            "location": [5, 3],
+            "direction": "right" 
         },
         {
             "groups": [

--- a/resource/roguelike/JieGarden/autopilot/贪饵.json
+++ b/resource/roguelike/JieGarden/autopilot/贪饵.json
@@ -9,6 +9,11 @@
     "blacklist_location": [],
     "deploy_plan": [
         {
+            "groups": ["投锋"],
+            "location": [10, 5],
+            "direction": "left" 
+        },
+        {
             "groups": ["益达", "提丰", "水陈", "焰苇", "高台输出"],
             "location": [9, 3],
             "direction": "left"
@@ -17,6 +22,36 @@
             "groups": ["单奶", "群奶"],
             "location": [6, 4],
             "direction": "right"
+        },
+        {
+            "groups": ["电弧"],
+            "location": [9, 2],
+            "direction": "left"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [4, 1],
+            "direction": "left" 
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [3, 5],
+            "direction": "left" 
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [4, 4],
+            "direction": "left" 
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [2, 4],
+            "direction": "up" 
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [7, 1],
+            "direction": "right" 
         },
         {
             "groups": ["地面远程", "锏", "地刺", "重装", "玛恩纳", "情报官", "地面阻挡", "处决者", "回费", "其他地面"],

--- a/resource/roguelike/JieGarden/autopilot/赶场戏班.json
+++ b/resource/roguelike/JieGarden/autopilot/赶场戏班.json
@@ -10,8 +10,45 @@
             "direction": "right"
         }
     ],
+    "retreat_plan": [
+        {
+            "location": [8, 4],
+            "condition": [18,20]
+        },
+        {
+            "location": [8, 6],
+            "condition": [18,20]
+        }
+    ],
     "blacklist_location": [],
     "deploy_plan": [
+        {
+            "groups": ["投锋"],
+            "location": [1, 5],
+            "direction": "right"
+        },
+        {
+            "groups": ["电弧"],
+            "location": [1, 4],
+            "direction": "right"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [8, 4],
+            "direction": "up",
+            "condition": [0,16]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [8, 6],
+            "direction": "down",
+            "condition": [0,16]
+        },
+        {
+            "groups": ["新约能天使"],
+            "location": [5, 6],
+            "direction": "left"
+        },
         {
             "groups": ["益达", "提丰", "水陈", "焰苇", "高台输出"],
             "location": [4, 6],
@@ -53,6 +90,11 @@
             "groups": ["玛恩纳", "地面远程", "重装", "地面阻挡", "回费", "处决者", "其他地面"],
             "location": [2, 5],
             "direction": "right"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [3, 5],
+            "direction": "up"
         },
         {
             "groups": ["高台输出"],

--- a/resource/roguelike/JieGarden/autopilot/赶集.json
+++ b/resource/roguelike/JieGarden/autopilot/赶集.json
@@ -6,8 +6,95 @@
             "direction": "left"
         }
     ],
+    "retreat_plan": [
+        {
+            "location": [2, 3],
+            "condition": [10, 40]
+        },
+        {
+            "location": [4, 3],
+            "condition": [16, 40]
+        },
+        {
+            "location": [3, 3],
+            "condition": [28, 40]
+        },
+        {
+            "location": [2, 1],
+            "condition": [28, 40]
+        }
+    ],
     "blacklist_location": [],
     "deploy_plan": [
+        {
+            "groups": ["投锋"],
+            "location": [2, 5],
+            "direction": "left"
+        },
+        {
+            "groups": ["电弧"],
+            "location": [2, 4],
+            "direction": "up"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [1, 4],
+            "direction": "up",
+            "condition": [0, 10]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [2, 1],
+            "direction": "right",
+            "condition": [0, 27]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [2, 3],
+            "direction": "right",
+            "condition": [0, 10]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [4, 5],
+            "direction": "left",
+            "condition": [10, 14]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [5, 5],
+            "direction": "left",
+            "condition": [10, 30]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [4, 3],
+            "direction": "up",
+            "condition": [15, 20]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [3, 3],
+            "direction": "up",
+            "condition": [16, 20]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [4, 5],
+            "direction": "left",
+            "condition": [27, 30]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [5, 5],
+            "direction": "left",
+            "condition": [27, 30]
+        },
+        {
+            "groups": ["新约能天使"],
+            "location": [3, 4],
+            "direction": "right"
+        },
         {
             "groups": ["地面远程", "锏", "地刺", "重装", "玛恩纳", "情报官", "地面阻挡", "处决者", "回费", "其他地面"],
             "location": [1, 5],

--- a/resource/roguelike/JieGarden/autopilot/邙山镇地方志.json
+++ b/resource/roguelike/JieGarden/autopilot/邙山镇地方志.json
@@ -13,6 +13,26 @@
     "blacklist_location": [],
     "deploy_plan": [
         {
+            "groups": ["投锋"],
+            "location": [8, 5],
+            "direction": "up"
+        },
+        {
+            "groups": ["电弧"],
+            "location": [6, 4],
+            "direction": "left"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [3, 4],
+            "direction": "right"
+        },
+        {
+            "groups": ["新约能天使"],
+            "location": [6, 3],
+            "direction": "left"
+        },
+        {
             "groups": ["益达", "提丰", "水陈", "焰苇", "高台输出"],
             "location": [9, 6],
             "direction": "up"
@@ -55,9 +75,30 @@
             "direction": "down"
         },
         {
+            "groups": ["单奶", "群奶"],
+            "location": [6, 2],
+            "direction": "down"
+        },
+        {
             "groups": ["补给站"],
             "location": [5, 5],
             "direction": "Right"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [4, 4],
+            "direction": "up"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [9, 1],
+            "direction": "right",
+            "condition": [0, 18]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [5, 6],
+            "direction": "left"
         },
         {
             "groups": ["处决者"],

--- a/resource/roguelike/JieGarden/autopilot/长驱不复.json
+++ b/resource/roguelike/JieGarden/autopilot/长驱不复.json
@@ -6,8 +6,60 @@
             "direction": "down"
         }
     ],
+    "retreat_plan": [
+        {
+            "location": [6, 5],
+            "condition": [6, 22]
+        },
+        {
+            "location": [4, 5],
+            "condition": [7, 10]
+        },
+        {
+            "location": [8, 5],
+            "condition": [4, 8]
+        }
+    ],
     "blacklist_location": [],
     "deploy_plan": [
+        {
+            "groups": ["投锋"],
+            "location": [9, 5],
+            "direction": "left"
+        },
+        {
+            "groups": ["电弧"],
+            "location": [2, 2],
+            "direction": "right"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [8, 5],
+            "direction": "up",
+            "condition": [0, 3]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [3, 5],
+            "direction": "left"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [4, 5],
+            "direction": "up",
+            "condition": [0, 6]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [6, 5],
+            "direction": "up",
+            "condition": [0, 6]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [5, 5],
+            "direction": "left"
+        },
         {
             "groups": ["益达", "提丰", "焰苇", "水陈", "高台输出"],
             "location": [2, 2],
@@ -17,6 +69,27 @@
             "groups": ["地面远程", "锏", "地刺", "重装", "玛恩纳", "情报官", "地面阻挡", "处决者", "回费", "其他地面"],
             "location": [9, 3],
             "direction": "left"
+        },
+        {
+            "groups": ["奶盾"],
+            "location": [3, 1],
+            "direction": "left"
+        },
+        {
+            "groups": ["新约能天使"],
+            "location": [4, 2],
+            "direction": "left"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [4, 1],
+            "direction": "left"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [4, 5],
+            "direction": "left",
+            "condition": [11, 22]
         },
         {
             "groups": ["高台输出"],

--- a/resource/roguelike/JieGarden/autopilot/青山不语.json
+++ b/resource/roguelike/JieGarden/autopilot/青山不语.json
@@ -13,6 +13,46 @@
     "blacklist_location": [],
     "deploy_plan": [
         {
+            "groups": ["回费"],
+            "location": [9, 5],
+            "direction": "left"
+        },
+        {
+            "groups": ["新约能天使"],
+            "location": [9, 4],
+            "direction": "left"
+        },
+        {
+            "groups": ["电弧"],
+            "location": [10, 1],
+            "direction": "left"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [1, 6],
+            "direction": "right"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [4, 1],
+            "direction": "left"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [8, 5],
+            "direction": "left"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [2, 6],
+            "direction": "right"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [10, 5],
+            "direction": "left"
+        },
+        {
             "groups": ["益达", "提丰", "水陈", "焰苇", "高台输出"],
             "location": [9, 3],
             "direction": "Left"
@@ -38,6 +78,11 @@
             "groups": ["单奶", "群奶"],
             "location": [10, 1],
             "direction": "down"
+        },
+        {
+            "groups": ["单奶", "群奶"],
+            "location": [7, 4],
+            "direction": "right"
         },
         {
             "groups": ["高台输出"],

--- a/resource/roguelike/JieGarden/autopilot/飞来横祸.json
+++ b/resource/roguelike/JieGarden/autopilot/飞来横祸.json
@@ -6,12 +6,50 @@
             "direction": "left"
         }
     ],
+    "retreat_plan": [
+        {
+            "location": [5, 2],
+            "condition": [10, 12]
+        },
+        {
+            "location": [5, 5],
+            "condition": [6, 7]
+        }
+    ],
     "blacklist_location": [],
     "deploy_plan": [
         {
             "groups": ["挡人先锋", "回费"],
-            "location": [6, 1],
+            "location": [5, 2],
+            "direction": "left",
+            "condition": [0, 9]
+        },
+        {
+            "groups": ["电弧"],
+            "location": [5, 1],
             "direction": "down"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [5, 5],
+            "direction": "left",
+            "condition": [0, 5]
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [6, 2],
+            "direction": "left"
+        },
+        {
+            "groups": ["赛柯"],
+            "location": [5, 5],
+            "direction": "up",
+            "condition": [8, 15]
+        },
+        {
+            "groups": ["新约能天使"],
+            "location": [6, 3],
+            "direction": "left"
         },
         {
             "groups": ["益达", "提丰", "焰苇", "水陈", "高台输出"],


### PR DESCRIPTION
感谢大佬查看，辛苦了
尝试在界园战斗json中增加电弧和其召唤物赛柯的位置配置

修改文件路径：\resource\roguelike\JieGarden\autopilot

个人测试情况：
- 测试环境：n3
- 个人较好阵容：特勤开局，灵活部署（先锋，辅助，特种），抓新约能天使
- 遗憾的是破岁阵祀还没能通过

recruitment未上传
本地recruitment配置：
电弧：
<img width="742" height="613" alt="image" src="https://github.com/user-attachments/assets/b92dea7e-c698-45a8-81b7-0b9d296b477f" />

赛柯：
<img width="368" height="396" alt="image" src="https://github.com/user-attachments/assets/f417f65d-aaf0-4fab-9d53-9ccec48974cc" />

如有不当之处，还请大佬指正，感谢审阅！
