### PR TITLE
fix: start plugin task not enough delay

### DIFF
--- a/src/MaaCore/Task/Miscellaneous/StartGameTaskPlugin.cpp
+++ b/src/MaaCore/Task/Miscellaneous/StartGameTaskPlugin.cpp
@@ -18,8 +18,7 @@ bool StartGameTaskPlugin::start_game_with_retries(size_t pipe_data_size_limit, b
             }
         }
 
-        int delay = std::min(1500, 300 + i * 50);
-        sleep(delay);
+        sleep(1500);
     }
 
     return false;


### PR DESCRIPTION
https://github.com/MaaAssistantArknights/MaaAssistantArknights/commit/4a68fac63975ec01f20b1292531f711365c4063e#r163749694

> This completely breaks the algorithm. 300 ms is too little to detect a crash. I remember during the "studies". 1500 is the minimum possible delay. Anything less and the game will not crash in time as it's still "booting up" or "running" right before the crash.