### PR TITLE
fix: add delay before InfrastEnteredFlag

### DIFF
--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -2461,10 +2461,10 @@
         "next": [
             "Infrast",
             "InfrastNotification",
-            "InfrastPreEnteredFlag",
             "Infrast@ReturnButtons#next",
             "Infrast@CloseAnnos#next",
-            "Infrast@OfflineConfirm"
+            "Infrast@OfflineConfirm",
+            "InfrastPreEnteredFlag"
         ]
     },
     "Infrast@MainThemes": {
@@ -2491,7 +2491,7 @@
         "maskRange": [1, 255],
         "roi": [930, 540, 230, 180],
         "action": "ClickSelf",
-        "next": ["InfrastPreEnteredFlag", "Infrast", "Infrast@CloseAnnos#next", "Infrast@OfflineConfirm"],
+        "next": ["Infrast", "Infrast@CloseAnnos#next", "Infrast@OfflineConfirm", "InfrastPreEnteredFlag"],
         "postDelay": 5000,
         "crop_doc": {
             "roi": [935, 570, 85, 75],
@@ -2501,7 +2501,7 @@
     "InfrastPreEnteredFlag": {
         "algorithm": "JustReturn",
         "postDelay": 1000,
-        "next": ["InfrastEnteredFlag"]
+        "next": ["InfrastEnteredFlag", "Infrast#next"]
     },
     "InfrastEnteredFlag": {
         "template": "InfrastOverview.png",

--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -2461,7 +2461,7 @@
         "next": [
             "Infrast",
             "InfrastNotification",
-            "InfrastEnteredFlag",
+            "InfrastPreEnteredFlag",
             "Infrast@ReturnButtons#next",
             "Infrast@CloseAnnos#next",
             "Infrast@OfflineConfirm"
@@ -2491,12 +2491,17 @@
         "maskRange": [1, 255],
         "roi": [930, 540, 230, 180],
         "action": "ClickSelf",
-        "next": ["InfrastEnteredFlag", "Infrast", "Infrast@CloseAnnos#next", "Infrast@OfflineConfirm"],
+        "next": ["InfrastPreEnteredDelay", "Infrast", "Infrast@CloseAnnos#next", "Infrast@OfflineConfirm"],
         "postDelay": 5000,
         "crop_doc": {
             "roi": [935, 570, 85, 75],
             "mask": []
         }
+    },
+    "InfrastPreEnteredDelay": {
+        "algorithm": "JustReturn",
+        "postDelay": 1000,
+        "next": ["InfrastEnteredFlag"]
     },
     "InfrastEnteredFlag": {
         "template": "InfrastOverview.png",

--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -2491,14 +2491,14 @@
         "maskRange": [1, 255],
         "roi": [930, 540, 230, 180],
         "action": "ClickSelf",
-        "next": ["InfrastPreEnteredDelay", "Infrast", "Infrast@CloseAnnos#next", "Infrast@OfflineConfirm"],
+        "next": ["InfrastPreEnteredFlag", "Infrast", "Infrast@CloseAnnos#next", "Infrast@OfflineConfirm"],
         "postDelay": 5000,
         "crop_doc": {
             "roi": [935, 570, 85, 75],
             "mask": []
         }
     },
-    "InfrastPreEnteredDelay": {
+    "InfrastPreEnteredFlag": {
         "algorithm": "JustReturn",
         "postDelay": 1000,
         "next": ["InfrastEnteredFlag"]


### PR DESCRIPTION
**UNTESTED** 
###### will check in the morning. 4AM currently.

I've noticed on my other machine that MAA keeps going back to the main interface because the score of the InfrastEnteredFlag is 0.82~0.86, when it's usually 0.96 (when correctly detected). This is likely because when going back from the trading post / power plant / dormitory there can be a bit of lag rerendering the base leading to a slight stutter, reducing the score. Just lowering could be a solution since before d65cde757482cd69e7090fccb5da4734ee1d73c7 there was the default 0.8 score. 

If for some reason the 0.86 score is still uninteractibile there shouldn't be big issues since we have a postDelay of 5000 anyway.