### PR TITLE
fix: 修复掉落上报消息类型没有在 Python 层定义导致外部脚本报错的问题

### DIFF
--- a/src/Python/asst/utils.py
+++ b/src/Python/asst/utils.py
@@ -56,6 +56,8 @@ class Message(Enum):
 
     SubTaskStopped = auto()
 
+    ReportRequest = 30000
+
 
 @unique
 class Version(Enum):


### PR DESCRIPTION
修正 8.9 将上报逻辑转给 UI 层后 Python 接口未同步定义导致外部脚本执行时报错的问题