### PR TITLE
fix: 因模组约束取消干员时删除编队信息

### DIFF
--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -495,6 +495,8 @@ bool asst::BattleFormationTask::select_opers_in_cur_page(std::vector<OperGroup>&
                             << " not satisfied, skip module selection";
                 }
                 else {
+                    m_opers_in_formation->erase(name);
+                    m_size_of_operators_in_formation--;
                     ctrler()->click(res.flag_rect); // 选择模组失败时反选干员
                     sleep(delay);
                     // 继续检查同组其他干员


### PR DESCRIPTION
之前模组不满足时仅取消干员，没有删除对应的编队信息，导致在部署时尝试部署编队内不存在的干员

fix #13722