### PR TITLE
perf: limit codeql run only to source code

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,6 +3,15 @@ name: "CodeQL Advanced"
 on:
   pull_request:
     branches: ["dev"]
+    paths:
+      - "3rdparty/include/**"
+      - "include/**"
+      - "src/**"
+      - "cmake/**"
+      - "CMakeLists.txt"
+      - "MAA.sln"
+      - ".github/workflows/ci.yml"
+      - "!**/*.md"
   schedule:
     - cron: "45 11 * * *"
   workflow_dispatch:


### PR DESCRIPTION
Currently codeql runs on ANY change that is a PR and points to `dev`, which is super excessive.

This PR will limit it to run "together" with the current `ci.yml` so only for source code / build changes

EDIT:
On another note. We separate the jobs between CI and website / MAAcore and MAAWpf, but that makes no sense... Shouldn't they need to be completely different workflows altogether? If I only change source code, CI website shouldn't run.
