### PR TITLE
fix: 给 `MiniGame@ALL@GreenGrass@DuelChannel@End` 加点延迟

### DIFF
--- a/resource/tasks/MiniGame/ALL.json
+++ b/resource/tasks/MiniGame/ALL.json
@@ -68,6 +68,7 @@
         "action": "ClickSelf",
         "roi": [1010, 611, 212, 109],
         "text": ["返回主页"],
+        "postDelay": 5000,
         "next": ["MiniGame@ALL@GreenGrass@DuelChannel@Begin", "MiniGame@ALL@GreenGrass@DuelChannel@End"]
     }
 }


### PR DESCRIPTION
{"class":"asst::ProcessTask","details":{"cur_retry":20,"retry_times":20,"to_be_recognized":["MiniGame@ALL@GreenGrass@DuelChannel@Begin","MiniGame@ALL@GreenGrass@DuelChannel@End"]},"first":["MiniGame@ALL@GreenGrass@DuelChannel@Begin"],"pre_task":"MiniGame@ALL@GreenGrass@DuelChannel@End","subtask":"ProcessTask","taskchain":"Custom","taskid":1}

这里容易超时。