### PR TITLE
fix: 禁用文档中的linkify自动链接转换功能

### DIFF
--- a/docs/.vuepress/theme.ts
+++ b/docs/.vuepress/theme.ts
@@ -68,6 +68,7 @@ export default hopeTheme({
     imgLazyload: true,
     imgMark: true,
     imgSize: true,
+    linkify: false,  // disable auto converting URL-like text to hrefs
     //mathjax: true,
     mark: true,
     //mermaid: true,


### PR DESCRIPTION
## 问题描述

在当前的文档中[开发文档-Linux编译教程](https://maa.plus/docs/zh-cn/develop/linux-tutorial.html)的开头，关于Mac的相关信息中：有指向[MaaAssistantArknights/MaaMacGui](https://github.com/MaaAssistantArknights/MaaMacGui)的 README.md 的文档。然而，`README.md`文字上出现了指向 `http://README.md` 的错误超链接。可以直接用浏览器查看或者用本地编译文件验证。

以中文文档为例，markdown 中原文为：
```
::: info
Mac 可以使用 `tools/build_macos_universal.zsh` 脚本进行编译。建议参考 [MaaAssistantArknights/MaaMacGui](https://github.com/MaaAssistantArknights/MaaMacGui) 项目的 README.md。
:::
```
https://github.com/MaaAssistantArknights/MaaAssistantArknights/blob/8e9a4089973d60d7b9ac1d6cbacf1f884a86c1de/docs/zh-cn/develop/linux-tutorial.md?plain=1#L14C1-L16C4

这里本不应该出现超链接。

错误编译结果：
```html
项目的 <a href="http://README.md" target="_blank" rel="noopener noreferrer">README.md</a>
```

## 问题影响范围

目前部署的文档中，中文和英文文档的该处编译会有这个问题。韩文编译没有问题，仍然是没有超链接的 README.md 文本。其他语言没有这处文档。

## 问题来源

`hopeTheme` 启用的 `@vuepress/plugin-markdown-ext` 扩展中默认开启的 [linkify](https://ecosystem.vuejs.press/zh/plugins/markdown/markdown-ext.html#linkify)
导致了该问题。

## 解决方案

在 theme 配置中将 linkify 禁用来避免这种问题（⚠️我没有确认有没有其他地方有相同的问题）。我本地编译确认了该行为消失：

正确编译结果：

```html
项目的 README.md。
```

修复的副作用应当不大。内部或外部引用的超链接应该已经使用专门的 markdown 语法来写而不是依赖 linkify 的这个行为。