### PR TITLE
feat: core 崩溃后下次启动时 ui 输出提示

### DIFF
--- a/src/MaaCore/Utils/Logger.hpp
+++ b/src/MaaCore/Utils/Logger.hpp
@@ -862,6 +862,31 @@ private:
     }
 
 #ifndef ASST_DEBUG
+
+    inline static std::atomic<const char*> g_last_signal_reason { nullptr };
+
+#pragma warning(push)
+#pragma warning(disable: 4996)
+
+    static void write_crash_file(const char* reason, const char* detail = nullptr) noexcept
+    {
+        FILE* f = fopen("crash.log", "a");
+        if (!f) {
+            return;
+        }
+        fprintf(f, "=== FATAL ERROR ===\n");
+        if (reason) {
+            fprintf(f, "Reason: %s\n", reason);
+        }
+        if (detail) {
+            fprintf(f, "Detail: %s\n", detail);
+        }
+        fprintf(f, "===================\n\n");
+        fclose(f);
+    }
+
+#pragma warning(pop)
+
     static void custom_terminate_handler() noexcept
     {
         static bool in_handler = false;
@@ -872,24 +897,35 @@ private:
 
         try {
             auto& logger = Logger::get_instance();
-            std::string exception_info = "Unknown exception";
 
-            try {
-                if (auto eptr = std::current_exception()) {
+            // 先写信号信息
+            if (auto sig_reason = g_last_signal_reason.load()) {
+                logger.error("=== FATAL ERROR ===");
+                logger.error("Signal caught:", sig_reason);
+                logger.flush();
+                write_crash_file("Fatal Signal", sig_reason);
+            }
+
+            // 再处理 C++ 异常
+            std::string exception_info = "Unknown exception";
+            if (auto eptr = std::current_exception()) {
+                try {
                     std::rethrow_exception(eptr);
                 }
+                catch (const std::exception& e) {
+                    exception_info = std::string("std::exception: ") + e.what() + " (type: " + typeid(e).name() + ")";
+                }
+                catch (...) {
+                    exception_info = "Unknown exception type";
+                }
             }
-            catch (const std::exception& e) {
-                exception_info = std::string("std::exception: ") + e.what() + " (type: " + typeid(e).name() + ")";
-            }
-            catch (...) {
-                exception_info = "Unknown exception type";
-            }
+
             logger.error("=== FATAL ERROR ===");
             logger.error("Unhandled exception caught:", exception_info);
             logger.error("Program terminating...");
             logger.error("===================");
             logger.flush();
+            write_crash_file("Unhandled exception", exception_info.c_str());
         }
         catch (...) {
             std::cerr << "=== FATAL ERROR ===" << std::endl;
@@ -901,8 +937,6 @@ private:
 
     static void signal_handler(int sig)
     {
-        auto& logger = Logger::get_instance();
-
         std::string sig_name;
         switch (sig) {
         case SIGSEGV:
@@ -921,20 +955,7 @@ private:
             sig_name = "Signal " + std::to_string(sig);
             break;
         }
-
-        try {
-            logger.error("=== FATAL ERROR ===");
-            logger.error("Signal caught:", sig_name);
-            logger.error("Signal number:", std::to_string(sig));
-            logger.error("Program terminating...");
-            logger.error("===================");
-        }
-        catch (...) {
-            std::cerr << "=== FATAL ERROR ===" << std::endl;
-            std::cerr << "Signal caught: " << sig_name << " (" << sig << ")" << std::endl;
-            std::cerr << "===================" << std::endl;
-        }
-
+        g_last_signal_reason.store(sig_name.c_str());
         custom_terminate_handler();
         std::_Exit(EXIT_FAILURE);
     }

--- a/src/MaaWpfGui/Main/Bootstrapper.cs
+++ b/src/MaaWpfGui/Main/Bootstrapper.cs
@@ -20,6 +20,7 @@ using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using System.Security.Principal;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
@@ -135,6 +136,82 @@ namespace MaaWpfGui.Main
             catch
             {
                 return false;
+            }
+        }
+
+        public static void ParseCrashLog()
+        {
+            var crashFile = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "crash.log");
+            if (!File.Exists(crashFile))
+            {
+                return;
+            }
+
+            try
+            {
+                string[] lines = File.ReadAllLines(crashFile, Encoding.UTF8);
+
+                StringBuilder message = new StringBuilder();
+                string currentReason = null;
+                string currentDetail = null;
+
+                foreach (var line in lines)
+                {
+                    if (line.StartsWith("Reason: "))
+                    {
+                        currentReason = line[7..].Trim();
+                    }
+                    else if (line.StartsWith("Detail: "))
+                    {
+                        currentDetail = line[8..].Trim();
+                    }
+                    else if (line.StartsWith("==================="))
+                    {
+                        if (!string.IsNullOrEmpty(currentReason))
+                        {
+                            message.AppendLine($"Reason: {currentReason}");
+                            if (!string.IsNullOrEmpty(currentDetail))
+                            {
+                                message.AppendLine($"Detail: {currentDetail}");
+                            }
+
+                            message.AppendLine();
+                        }
+
+                        currentReason = null;
+                        currentDetail = null;
+                    }
+                }
+
+                if (message.Length > 0)
+                {
+                    message.AppendLine(LocalizationHelper.GetString("ErrorCrashMessageHeader"));
+                    message.AppendLine();
+                    message.AppendLine(LocalizationHelper.GetString("ErrorCrashMessageOpenLog"));
+                    message.AppendLine(LocalizationHelper.GetString("ErrorCrashMessageGenerateReport"));
+                    message.AppendLine();
+                    message.AppendLine(LocalizationHelper.GetString("ErrorCrashMessageHelpTip"));
+
+                    MessageBoxHelper.Show(
+                        message.ToString(),
+                        LocalizationHelper.GetString("ErrorCrashDialogTitle"),
+                        MessageBoxButton.OK,
+                        MessageBoxImage.Error
+                    );
+
+                    try
+                    {
+                        File.Delete(crashFile);
+                    }
+                    catch
+                    {
+                        // ignored
+                    }
+                }
+            }
+            catch
+            {
+                // ignored
             }
         }
 
@@ -278,6 +355,8 @@ namespace MaaWpfGui.Main
             {
                 Task.Run(() => MessageBoxHelper.Show(LocalizationHelper.GetString("SoftwareLocationWarning"), LocalizationHelper.GetString("Error"), MessageBoxButton.OK, MessageBoxImage.Error));
             }
+
+            Task.Run(ParseCrashLog);
 
             base.OnStart();
             _hasMutex = true;

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -896,6 +896,11 @@ Right-click to clear inactive tasks</system:String>
     <system:String x:Key="ErrorSolutionSelectDefaultBrowser">Open link failure, please go to ｢Windows Settings｣ and select the default browser.</system:String>
     <system:String x:Key="ErrorFeedbackLinkText">Create a GitHub issue</system:String>
     <system:String x:Key="ErrorQqGroupLinkText">Join QQ Group</system:String>
+    <system:String x:Key="ErrorCrashMessageHeader">The above issue caused the program to crash.</system:String>
+    <system:String x:Key="ErrorCrashMessageOpenLog">You can go to “{key=Settings} - {key=Issue} - {key=OpenDebugFolder}” to view the logs and check the specific cause of the error.</system:String>
+    <system:String x:Key="ErrorCrashMessageGenerateReport">Please use “{key=Settings} - {key=Issue} - {key=GenerateSupportPayload}” to generate an error report, and click the blue ｢{key=Issue}｣ link to submit feedback.</system:String>
+    <system:String x:Key="ErrorCrashMessageHelpTip">If you need help from others, please send the generated error report file instead of sending a screenshot or photo of this window.</system:String>
+    <system:String x:Key="ErrorCrashDialogTitle">Reason for the last crash</system:String>
     <system:String x:Key="CopyErrorMessage">Copy error message</system:String>
     <!--  !ErrorView  -->
     <!--  AsstProxy  -->

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -896,6 +896,12 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="ErrorSolutionSelectDefaultBrowser">リンクを開けませんでした。Windows 設定に移動してデフォルトのブラウザを選択してください。</system:String>
     <system:String x:Key="ErrorFeedbackLinkText">GitHub issueを作成する</system:String>
     <system:String x:Key="ErrorQqGroupLinkText">QQグループに入ります</system:String>
+    <system:String x:Key="ErrorCrashMessageHeader">上記の問題により、プログラムが異常終了しました。</system:String>
+    <system:String x:Key="ErrorCrashMessageOpenLog">「{key=Settings} - {key=Issue} - {key=OpenDebugFolder}」に移動してログを確認し、エラーが発生した具体的な原因を確認できます。</system:String>
+    <system:String x:Key="ErrorCrashMessageGenerateReport">「{key=Settings} - {key=Issue} - {key=GenerateSupportPayload}」を使用してエラーレポートを生成し、青色の ｢{key=Issue}｣ リンクをクリックしてフィードバックを送信してください。</system:String>
+    <system:String x:Key="ErrorCrashMessageHelpTip">他人に助けを求める場合は、このウィンドウのスクリーンショットや写真ではなく、生成されたエラーレポートファイルを送信してください。</system:String>
+    <system:String x:Key="ErrorCrashDialogTitle">前回のクラッシュ原因</system:String>
+
     <system:String x:Key="CopyErrorMessage">エラー情報をコピーする</system:String>
     <!--  !ErrorView  -->
     <!--  AsstProxy  -->

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -896,6 +896,12 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="ErrorSolutionSelectDefaultBrowser">링크 열기 실패. ｢Windows 설정｣ 으로 이동하여 기본 브라우저를 선택하세요.</system:String>
     <system:String x:Key="ErrorFeedbackLinkText">GitHub에 issue 생성</system:String>
     <system:String x:Key="ErrorQqGroupLinkText">QQ 그룹 가입</system:String>
+    <system:String x:Key="ErrorCrashMessageHeader">위의 문제로 인해 프로그램이 비정상 종료되었습니다.</system:String>
+    <system:String x:Key="ErrorCrashMessageOpenLog">「{key=Settings} - {key=Issue} - {key=OpenDebugFolder}」로 이동하여 로그를 확인하고 오류가 발생한 구체적인 원인을 확인할 수 있습니다.</system:String>
+    <system:String x:Key="ErrorCrashMessageGenerateReport">「{key=Settings} - {key=Issue} - {key=GenerateSupportPayload}」을(를) 사용하여 오류 보고서를 생성한 후, 파란색 ｢{key=Issue}｣ 링크를 클릭하여 피드백을 제출해 주세요.</system:String>
+    <system:String x:Key="ErrorCrashMessageHelpTip">다른 사람에게 도움을 요청할 경우, 이 창의 스크린샷이나 사진이 아니라 생성된 오류 보고서 파일을 보내 주세요.</system:String>
+    <system:String x:Key="ErrorCrashDialogTitle">마지막 충돌 원인</system:String>
+
     <system:String x:Key="CopyErrorMessage">오류 메시지 복사</system:String>
     <!--  !ErrorView  -->
     <!--  AsstProxy  -->

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -896,6 +896,11 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="ErrorSolutionSelectDefaultBrowser">打开链接失败，请前往 ｢Windows 设置｣ 选择默认浏览器。</system:String>
     <system:String x:Key="ErrorFeedbackLinkText">创建 GitHub issue</system:String>
     <system:String x:Key="ErrorQqGroupLinkText">加入 QQ 群</system:String>
+    <system:String x:Key="ErrorCrashMessageHeader">以上问题导致程序异常退出。</system:String>
+    <system:String x:Key="ErrorCrashMessageOpenLog">您可以前往「{key=Settings} - {key=Issue} - {key=OpenDebugFolder}」查看日志，了解错误发生的具体原因。</system:String>
+    <system:String x:Key="ErrorCrashMessageGenerateReport">请使用「{key=Settings} - {key=Issue} - {key=GenerateSupportPayload}」生成错误报告，并点击蓝色的 ｢{key=Issue}｣ 链接提交反馈。</system:String>
+    <system:String x:Key="ErrorCrashMessageHelpTip">如果向他人寻求帮助，请发送生成的错误报告文件，而不是发送这个窗口的截图或照片。</system:String>
+    <system:String x:Key="ErrorCrashDialogTitle">上次程序崩溃原因</system:String>
     <system:String x:Key="CopyErrorMessage">复制错误信息</system:String>
     <!--  !ErrorView  -->
     <!--  AsstProxy  -->

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -894,6 +894,11 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="ErrorSolutionSelectDefaultBrowser">打開連結失敗，請前往 ｢Windows 設定｣ 選擇預設瀏覽器。</system:String>
     <system:String x:Key="ErrorFeedbackLinkText">建立 GitHub issue</system:String>
     <system:String x:Key="ErrorQqGroupLinkText">加入 QQ 群</system:String>
+    <system:String x:Key="ErrorCrashMessageHeader">以上問題導致程式異常退出。</system:String>
+    <system:String x:Key="ErrorCrashMessageOpenLog">您可以前往「{key=Settings} - {key=Issue} - {key=OpenDebugFolder}」查看日誌，了解錯誤發生的具體原因。</system:String>
+    <system:String x:Key="ErrorCrashMessageGenerateReport">請使用「{key=Settings} - {key=Issue} - {key=GenerateSupportPayload}」生成錯誤報告，並點擊藍色的 ｢{key=Issue}｣ 鏈接提交反饋。</system:String>
+    <system:String x:Key="ErrorCrashMessageHelpTip">如果向他人尋求幫助，請傳送生成的錯誤報告檔案，而不是傳送這個視窗的截圖或照片。</system:String>
+    <system:String x:Key="ErrorCrashDialogTitle">上次程式崩潰原因</system:String>
     <system:String x:Key="CopyErrorMessage">複製錯誤資訊</system:String>
     <!--  !ErrorView  -->
     <!--  AsstProxy  -->

--- a/src/MaaWpfGui/Views/UI/ErrorView.xaml.cs
+++ b/src/MaaWpfGui/Views/UI/ErrorView.xaml.cs
@@ -142,7 +142,10 @@ namespace MaaWpfGui.Views.UI
 
             AchievementTrackerHelper.Instance.Unlock(AchievementIds.UnexpectedCrash);
 
-            return LocalizationHelper.GetString("UnknownErrorOccurs");
+            return $"{LocalizationHelper.GetString("UnknownErrorOccurs")}\n" +
+                   $"{LocalizationHelper.GetString("ErrorCrashMessageOpenLog")}\n" +
+                   $"{LocalizationHelper.GetString("ErrorCrashMessageGenerateReport")}\n" +
+                   $"{LocalizationHelper.GetString("ErrorCrashMessageHelpTip")}";
         }
 
         protected override void OnClosed(EventArgs e)


### PR DESCRIPTION
cc @MaaAssistantArknights/global-support-team 

[crash.log](https://github.com/user-attachments/files/22193905/crash.log)
Set this as readonly and place it in the root directory of maa