### PR TITLE
chore: 肉鸽丰川祥子招募策略

### DIFF
--- a/resource/roguelike/JieGarden/recruitment.json
+++ b/resource/roguelike/JieGarden/recruitment.json
@@ -344,7 +344,7 @@
                     "name": "佩佩",
                     "skill": 2,
                     "is_start": true,
-                    "recruit_priority": 809,
+                    "recruit_priority": 800,
                     "promote_priority": 801,
                     "recruit_priority_offsets": [
                         {
@@ -362,11 +362,10 @@
                 },
                 {
                     "name": "乌尔比安",
-                    "skill": 3,
-                    "alternate_skill": 2,
+                    "skill": 2,
                     "is_key": true,
                     "is_start": true,
-                    "recruit_priority": 520,
+                    "recruit_priority": 801,
                     "promote_priority": 801,
                     "recruit_priority_offsets": [
                         {
@@ -413,7 +412,8 @@
                     "skill": 2,
                     "skill_usage": 0,
                     "is_start": true,
-                    "recruit_priority": 810,
+                    "is_key": true,
+                    "recruit_priority": 821,
                     "promote_priority": 960,
                     "recruit_priority_offsets": [
                         {

--- a/resource/roguelike/Mizuki/recruitment.json
+++ b/resource/roguelike/Mizuki/recruitment.json
@@ -562,7 +562,8 @@
                     "skill": 2,
                     "skill_usage": 0,
                     "is_start": true,
-                    "recruit_priority": 810,
+                    "is_key": true,
+                    "recruit_priority": 821,
                     "promote_priority": 980,
                     "recruit_priority_offsets": [
                         {
@@ -2252,7 +2253,7 @@
                     "name": "佩佩",
                     "skill": 2,
                     "is_start": true,
-                    "recruit_priority": 809,
+                    "recruit_priority": 800,
                     "promote_priority": 801,
                     "recruit_priority_offsets": [
                         {
@@ -2264,11 +2265,10 @@
                 },
                 {
                     "name": "乌尔比安",
-                    "skill": 3,
-                    "alternate_skill": 2,
+                    "skill": 2,
                     "is_key": true,
                     "is_start": true,
-                    "recruit_priority": 520,
+                    "recruit_priority": 801,
                     "promote_priority": 801,
                     "recruit_priority_offsets": [
                         {

--- a/resource/roguelike/Phantom/recruitment.json
+++ b/resource/roguelike/Phantom/recruitment.json
@@ -24,7 +24,7 @@
                     "skill_usage": 0,
                     "is_key": true,
                     "is_start": true,
-                    "recruit_priority": 811,
+                    "recruit_priority": 821,
                     "promote_priority": 1001,
                     "promote_priority_when_team_full": 1200,
                     "recruit_priority_offsets": [
@@ -324,7 +324,7 @@
                     "skill_usage": 0,
                     "is_key": true,
                     "is_start": true,
-                    "recruit_priority": 821,
+                    "recruit_priority": 801,
                     "promote_priority": 801,
                     "recruit_priority_offsets": [
                         {
@@ -366,7 +366,7 @@
                     "name": "佩佩",
                     "skill": 2,
                     "is_start": true,
-                    "recruit_priority": 809,
+                    "recruit_priority": 800,
                     "promote_priority": 801,
                     "recruit_priority_offsets": [
                         {

--- a/resource/roguelike/Sami/recruitment.json
+++ b/resource/roguelike/Sami/recruitment.json
@@ -355,7 +355,7 @@
                     "name": "佩佩",
                     "skill": 2,
                     "is_start": true,
-                    "recruit_priority": 809,
+                    "recruit_priority": 800,
                     "promote_priority": 801,
                     "recruit_priority_offsets": [
                         {
@@ -370,7 +370,8 @@
                     "skill": 2,
                     "skill_usage": 0,
                     "is_start": true,
-                    "recruit_priority": 810,
+                    "is_key": true,
+                    "recruit_priority": 821,
                     "promote_priority": 960,
                     "recruit_priority_offsets": [
                         {

--- a/resource/roguelike/Sarkaz/recruitment.json
+++ b/resource/roguelike/Sarkaz/recruitment.json
@@ -344,7 +344,7 @@
                     "name": "佩佩",
                     "skill": 2,
                     "is_start": true,
-                    "recruit_priority": 809,
+                    "recruit_priority": 800,
                     "promote_priority": 801,
                     "recruit_priority_offsets": [
                         {
@@ -362,11 +362,10 @@
                 },
                 {
                     "name": "乌尔比安",
-                    "skill": 3,
-                    "alternate_skill": 2,
+                    "skill": 2,
                     "is_key": true,
                     "is_start": true,
-                    "recruit_priority": 520,
+                    "recruit_priority": 801,
                     "promote_priority": 801,
                     "recruit_priority_offsets": [
                         {
@@ -412,8 +411,9 @@
                     "name": "丰川祥子",
                     "skill": 2,
                     "skill_usage": 0,
+                    "is_key": true,
                     "is_start": true,
-                    "recruit_priority": 810,
+                    "recruit_priority": 821,
                     "promote_priority": 960,
                     "recruit_priority_offsets": [
                         {


### PR DESCRIPTION
调整了佩佩的优先级，我觉得祥子应该大于佩佩
测测祥子在傀影的发挥，如果能完全替掉棘刺就改下推荐开局干员