### PR TITLE
fix: 修复 cmake copy_and_add_rpath_library 的失败逻辑

### DIFF
--- a/cmake/config.cmake
+++ b/cmake/config.cmake
@@ -43,7 +43,7 @@ if(LINUX)
             OUTPUT_STRIP_TRAILING_WHITESPACE
         )
 
-        if("${LIB_PATH}" STREQUAL "${LIBNAME}.so.1}")
+        if("${LIB_PATH}" STREQUAL "${LIBNAME}.so.1")
             message(FATAL_ERROR "Could not locate ${LIBNAME}.so.1 using compiler")
         endif()
 


### PR DESCRIPTION
由于多了一个大括号（}），导致 cmake 在找不到库时不会自动终止。