### PR TITLE
fix: 暂时修复无法读取过去的评论的问题

### DIFF
--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -103,7 +103,7 @@ export default defineUserConfig({
       category: 'Comments',
       categoryId: 'DIC_kwDOHY7Gys4CgoVH',
       mapping: 'pathname',
-      strict: true,
+      strict: false,
       lazyLoading: true,
     },
 


### PR DESCRIPTION
通过将giscus的`strict`设置为`false`，暂时解决此问题