### PR TITLE
chore: fix build warning

### DIFF
--- a/src/MaaWpfGui/States/RunningState.cs
+++ b/src/MaaWpfGui/States/RunningState.cs
@@ -20,7 +20,6 @@ using MaaWpfGui.Helper;
 using MaaWpfGui.Utilities;
 using MaaWpfGui.ViewModels.UI;
 using Serilog;
-using Serilog.Core;
 
 namespace MaaWpfGui.States
 {
@@ -35,7 +34,7 @@ namespace MaaWpfGui.States
             public bool Stopping { get; } = stopping;
         }
 
-        private static RunningState _instance;
+        private static RunningState? _instance;
         private static readonly ILogger _logger = Log.Logger.ForContext<RunningState>();
 
         private RunningState()
@@ -83,7 +82,7 @@ namespace MaaWpfGui.States
         }
 
         // 超时事件
-        public event EventHandler<string> TimeoutOccurred;
+        public event EventHandler<string>? TimeoutOccurred;
 
         public void StartTimeoutTimer()
         {
@@ -103,7 +102,7 @@ namespace MaaWpfGui.States
         }
 
         // 超时计时器回调
-        private void TimeoutReminderTimer_Elapsed(object sender, System.Timers.ElapsedEventArgs e)
+        private void TimeoutReminderTimer_Elapsed(object? sender, System.Timers.ElapsedEventArgs? e)
         {
             if (!_taskStartTime.HasValue || _idle)
             {


### PR DESCRIPTION
0>RunningState.cs(49,46): Warning CS8622 : “void RunningState.TimeoutReminderTimer_Elapsed(object sender, ElapsedEventArgs e)”的参数“sender”类型中引用类型的为 Null 性与目标委托“ElapsedEventHandler”不匹配(可能是由于为 Null 性特性)。
0>RunningState.cs(41,17): Warning CS8618 : 在退出构造函数时，不可为 null 的 事件 "TimeoutOccurred" 必须包含非 null 值。请考虑添加 "required" 修饰符或将该 事件 声明为可为 null。
0>RunningState.cs(80,46): Warning CS8625 : 无法将 null 字面量转换为非 null 的引用类型。
0>RunningState.cs(80,52): Warning CS8625 : 无法将 null 字面量转换为非 null 的引用类型。
0>RunningState.cs(38,37): Warning CS8618 : 在退出构造函数时，不可为 null 的 字段 "_instance" 必须包含非 null 值。请考虑添加 "required" 修饰符或将该 字段 声明为可为 null。