### PR TITLE
fix: 增强playtools关闭连接时的异常处理，确保套接字安全关闭

### DIFF
--- a/src/MaaCore/Controller/PlayToolsController.cpp
+++ b/src/MaaCore/Controller/PlayToolsController.cpp
@@ -230,15 +230,17 @@ void asst::PlayToolsController::close()
 
     if (m_socket.is_open()) {
         try {
-            m_socket.shutdown(tcp::socket::shutdown_both); 
-        } catch (const std::exception& e) {
-            Log.warn("Error during socket shutdown in close():", e.what()); 
+            m_socket.shutdown(tcp::socket::shutdown_both);
         }
-        
+        catch (const std::exception& e) {
+            Log.warn("Error during socket shutdown in close():", e.what());
+        }
+
         try {
             m_socket.close();
-        } catch (const std::exception& e) {
-            Log.warn("Error during socket close() cleanup:", e.what()); 
+        }
+        catch (const std::exception& e) {
+            Log.warn("Error during socket close() cleanup:", e.what());
         }
     }
 }

--- a/src/MaaCore/Controller/PlayToolsController.cpp
+++ b/src/MaaCore/Controller/PlayToolsController.cpp
@@ -229,8 +229,17 @@ void asst::PlayToolsController::close()
     m_screen_size = { 0, 0 };
 
     if (m_socket.is_open()) {
-        m_socket.shutdown(tcp::socket::shutdown_both);
-        m_socket.close();
+        try {
+            m_socket.shutdown(tcp::socket::shutdown_both); 
+        } catch (const std::exception& e) {
+            Log.warn("Error during socket shutdown in close():", e.what()); 
+        }
+        
+        try {
+            m_socket.close();
+        } catch (const std::exception& e) {
+            Log.warn("Error during socket close() cleanup:", e.what()); 
+        }
     }
 }
 


### PR DESCRIPTION
本次 PR 修复了在Mac端开始任务时明日方舟意外退出或连接断开由PlayToolsController 导致的程序崩溃问题

问题根源在于：~PlayToolsController() 调用 close()，而 close() 内部的 m_socket.shutdown() 和 m_socket.close() 在连接已经断开的情况下会抛出 boost::system::system_error。

在 C++ 析构函数中未捕获的异常会导致程序立即调用 std::terminate() 并退出。

修复措施： 在 close() 函数中，为 m_socket.shutdown() 和 m_socket.close() 操作添加了独立的 try-catch 块，确保在清理资源时，即使网络操作失败，也不会导致程序崩溃。