### PR TITLE
fix: 尝试修复生息演算任务识别并删除编队时卡住的问题

### DIFF
--- a/resource/tasks/RA/Tales.json
+++ b/resource/tasks/RA/Tales.json
@@ -28,7 +28,7 @@
         "doc": "模板任务: 清空当前编队",
         "roi": [1150, 12, 47, 46],
         "action": "ClickSelf",
-        "next": ["Tales@RA@DialogConfirmRed"]
+        "next": ["Tales@RA@DialogConfirmRed", "Tales@RA@ClearSquad"]
     },
     "Tales@RA@ClickGatheringOfFeathers": {
         "doc": "模板任务: 点击 <捕猎区: 聚羽之地>",
@@ -447,6 +447,7 @@
             "Step 4: 在行动结束界面点击左下角 <物资将送往仓库> 图标返回"
         ],
         "baseTask": "Tales@RA@EnterNode",
+        "postDelay": 800,
         "sub": ["Tales@RA@PNS-ClearSquadIfSizeGE7", "Tales@RA@PNS-ConfirmSquad"],
         "next": [
             "Tales@RA@PNS-LeaveNode",

--- a/resource/tasks/RA/Tales.json
+++ b/resource/tasks/RA/Tales.json
@@ -28,7 +28,7 @@
         "doc": "模板任务: 清空当前编队",
         "roi": [1150, 12, 47, 46],
         "action": "ClickSelf",
-        "next": ["Tales@RA@DialogConfirmRed", "Tales@RA@ClearSquad"]
+        "next": ["Tales@RA@DialogConfirmRed", "#self"]
     },
     "Tales@RA@ClickGatheringOfFeathers": {
         "doc": "模板任务: 点击 <捕猎区: 聚羽之地>",


### PR DESCRIPTION
有用户反映，会随机在进入节点时卡住而导致任务失败。
怀疑进入任务后 MAA 识别过快导致在动画过渡阶段错误地以为编队人数超过 6 人，并尝试删除编队。
然后因为点击太快未能生效，于是卡在了点击确认这一步。
现尝试予以修复。