### PR TITLE
fix: 掉落识别修复

### DIFF
--- a/src/MaaCore/Vision/Miscellaneous/StageDropsImageAnalyzer.cpp
+++ b/src/MaaCore/Vision/Miscellaneous/StageDropsImageAnalyzer.cpp
@@ -491,7 +491,7 @@ std::optional<int> asst::StageDropsImageAnalyzer::merge_image(const cv::Mat& new
             "is less than or equal to the original one",
             m_image.cols);
         Log.info("Cancel the image merging");
-        return std::nullopt;
+        return offset;
     }
 
     // 创建新的 new_strip


### PR DESCRIPTION
检查 (即将创建的) new_strip 的长度, 若比 m_image 更短, 则放弃。
原先放弃 merge_images 后我选择了返回 std::nullopt，这导致 MAA 以为 append_image 失败。
现在重新返回 offset。