### PR TITLE
fix: 降低萨米肉鸽进入 “诡秘的预感” 所需模版匹配分数阈值

### DIFF
--- a/resource/tasks/Roguelike/Sami.json
+++ b/resource/tasks/Roguelike/Sami.json
@@ -767,7 +767,7 @@
     },
     "Sami@Roguelike@StageMysteriousPresageEnter": {
         "baseTask": "Sami@Roguelike@StageEnter",
-        "templThreshold": 0.9,
+        "templThreshold": 0.85,
         "postDelay": 1000,
         "next": ["Sami@Roguelike@TraderCheck", "Sami@Roguelike@StageEncounterJudgeClick"]
     },


### PR DESCRIPTION
Try fix #14512.