### PR TITLE
build: bump MaaDeps to v2.10.1-maa.1

### DIFF
--- a/.devcontainer/1/Dockerfile
+++ b/.devcontainer/1/Dockerfile
@@ -13,9 +13,7 @@ ARG NODEJS_VERSION=24
 RUN sudo apt update \
     && sudo apt upgrade -y \
     && sudo apt install -y \
-    cmake clangd-${CLANGD_VERSION}
-
-RUN sudo update-alternatives --install /usr/bin/clangd clangd /usr/bin/clangd-${CLANGD_VERSION} 100
+    cmake
 
 # Install Miniconda
 RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh \

--- a/.devcontainer/1/post-create.sh
+++ b/.devcontainer/1/post-create.sh
@@ -44,4 +44,4 @@ echo "Installing MaaDeps..."
 python tools/maadeps-download.py
 # Link clang-format & clangd to /usr/local/bin for easy access
 sudo ln -s $WORKSPACE/src/MaaUtils/MaaDeps/x-tools/llvm/bin/clang-format /usr/local/bin/clang-format
-# sudo ln -s $WORKSPACE/src/MaaUtils/MaaDeps/x-tools/llvm/bin/clangd /usr/local/bin/clangd
+sudo ln -s $WORKSPACE/src/MaaUtils/MaaDeps/x-tools/llvm/bin/clangd /usr/local/bin/clangd

--- a/tools/maadeps-download.py
+++ b/tools/maadeps-download.py
@@ -9,7 +9,7 @@ from maadeps_download import detect_host_triplet
 from maadeps_download import main as download_main
 
 REPO = "MaaAssistantArknights/MaaDeps"
-VERSION = "v2.10.0-maa.1"
+VERSION = "v2.10.1-maa.1"
 
 if __name__ == "__main__":
     if len(sys.argv) == 2:


### PR DESCRIPTION
1. 更新 MaaDeps 到 [`v2.10.1-maa.1`](https://github.com/MaaAssistantArknights/MaaDeps/releases/tag/v2.10.1-maa.1)
2. 新版本的 MaaDeps 自带 `clangd`，于是 devcontainer 中可以直接引用，无需额外安装