### PR TITLE
fix: 从主页进入终端点过头后返回

### DIFF
--- a/resource/tasks/RA/base.json
+++ b/resource/tasks/RA/base.json
@@ -40,7 +40,12 @@
         "maskRange": [1, 255],
         "action": "ClickSelf",
         "roi": [844, 58, 268, 272],
-        "next": ["RA@Navigation-FromTodoList", "RA@Navigation-LongTermExploration", "RA@Navigation-FromMainInterface", "RA@ReturnButtons#next"],
+        "next": [
+            "RA@Navigation-FromTodoList",
+            "RA@Navigation-LongTermExploration",
+            "RA@Navigation-FromMainInterface",
+            "RA@ReturnButtons#next"
+        ],
         "postDelay": 3000
     },
     "RA@Navigation-LongTermExploration": {

--- a/resource/tasks/Roguelike/base.json
+++ b/resource/tasks/Roguelike/base.json
@@ -19,7 +19,13 @@
         "maskRange": [1, 255],
         "action": "ClickSelf",
         "roi": [844, 58, 268, 272],
-        "next": ["Roguelike", "Roguelike@CloseAnnos#next", "Roguelike@TodoEnter", "Roguelike@IntegratedStrategies", "Roguelike@ReturnButtons#next"],
+        "next": [
+            "Roguelike",
+            "Roguelike@CloseAnnos#next",
+            "Roguelike@TodoEnter",
+            "Roguelike@IntegratedStrategies",
+            "Roguelike@ReturnButtons#next"
+        ],
         "postDelay": 3000
     },
     "RoguelikeBattleAbandon": {

--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -1772,7 +1772,13 @@
         "action": "ClickSelf",
         "roi": [844, 58, 268, 272],
         "exceededNext": ["Fight@TodaysSupplies", "Fight@CloseAnnos#next", "Stop"],
-        "next": ["Fight@GoLastBattle", "Fight", "Fight@CloseAnnos#next", "Fight@GoTerminalStopflag", "Fight@ReturnButtons#next"],
+        "next": [
+            "Fight@GoLastBattle",
+            "Fight",
+            "Fight@CloseAnnos#next",
+            "Fight@GoTerminalStopflag",
+            "Fight@ReturnButtons#next"
+        ],
         "postDelay": 3000
     },
     "GoTerminalStopflag": {


### PR DESCRIPTION
不改延迟了，换种方式改这个问题

## Summary by Sourcery

Bug Fixes:
- Prevent overscrolling after navigating from the homepage to a terminal endpoint and back