### PR TITLE
fix: 肉鸽允许跳过招募组合直接开始初始招募

### DIFF
--- a/resource/tasks/Roguelike/JieGarden.json
+++ b/resource/tasks/Roguelike/JieGarden.json
@@ -456,10 +456,12 @@
         "roi": [848, 686, 46, 26]
     },
     "JieGarden@Roguelike@SquadConfirm": {
+        "doc": "注意：在部分深入调查条目（如傀影主题的 <地面推进>）中有可能跳过招募组合直接开始初始招募",
         "template": "JieGarden@Roguelike@LastRewardConfirm.png",
         "next": [
             "JieGarden@Roguelike@LastReward-EnterPoint",
             "JieGarden@Roguelike@RolesDefault",
+            "JieGarden@Roguelike@RecruitMain",
             "JieGarden@Roguelike@CloseCollection",
             "JieGarden@Roguelike@MapObject"
         ]

--- a/resource/tasks/Roguelike/Mizuki.json
+++ b/resource/tasks/Roguelike/Mizuki.json
@@ -307,10 +307,12 @@
         "text": ["生态谱系"]
     },
     "Mizuki@Roguelike@SquadConfirm": {
+        "doc": "注意：在部分深入调查条目（如傀影主题的 <地面推进>）中有可能跳过招募组合直接开始初始招募",
         "template": "Mizuki@Roguelike@LastRewardConfirm.png",
         "next": [
             "Mizuki@Roguelike@LastReward-EnterPoint",
             "Mizuki@Roguelike@RolesDefault",
+            "Mizuki@Roguelike@RecruitMain",
             "Mizuki@Roguelike@CloseCollection",
             "Mizuki@Roguelike@MapObject"
         ]

--- a/resource/tasks/Roguelike/Phantom.json
+++ b/resource/tasks/Roguelike/Phantom.json
@@ -188,10 +188,12 @@
         "text": ["古堡笔记"]
     },
     "Phantom@Roguelike@SquadConfirm": {
+        "doc": "注意：在部分深入调查条目（如 <地面推进>）中有可能跳过招募组合直接开始初始招募",
         "template": "Phantom@Roguelike@LastRewardConfirm.png",
         "next": [
             "Phantom@Roguelike@LastReward-EnterPoint",
             "Phantom@Roguelike@RolesDefault",
+            "Phantom@Roguelike@RecruitMain",
             "Phantom@Roguelike@CloseCollection",
             "Phantom@Roguelike@NextLevel",
             "Phantom@Roguelike@NextLevel#next"

--- a/resource/tasks/Roguelike/Sami.json
+++ b/resource/tasks/Roguelike/Sami.json
@@ -607,11 +607,13 @@
         "text": []
     },
     "Sami@Roguelike@SquadConfirm": {
+        "doc": "注意：在部分深入调查条目（如傀影主题的 <地面推进>）中有可能跳过招募组合直接开始初始招募",
         "template": "Sami@Roguelike@LastRewardConfirm.png",
         "next": [
             "Sami@Roguelike@LastReward-EnterPoint",
             "Sami@Roguelike@GetLUD",
             "Sami@Roguelike@RolesDefault",
+            "Sami@Roguelike@RecruitMain",
             "Sami@Roguelike@CloseCollection",
             "Sami@Roguelike@MapObject",
             "Sami@Roguelike@FoldartalGain"

--- a/resource/tasks/Roguelike/Sarkaz.json
+++ b/resource/tasks/Roguelike/Sarkaz.json
@@ -468,10 +468,12 @@
         "roi": [848, 686, 46, 26]
     },
     "Sarkaz@Roguelike@SquadConfirm": {
+        "doc": "注意：在部分深入调查条目（如傀影主题的 <地面推进>）中有可能跳过招募组合直接开始初始招募",
         "template": "Sarkaz@Roguelike@LastRewardConfirm.png",
         "next": [
             "Sarkaz@Roguelike@LastReward-EnterPoint",
             "Sarkaz@Roguelike@RolesDefault",
+            "Sarkaz@Roguelike@RecruitMain",
             "Sarkaz@Roguelike@CloseCollection",
             "Sarkaz@Roguelike@MapObject"
         ]


### PR DESCRIPTION
Try fix #13956.
正常的集成战略流程是：领取奖励 -> 选择分队 -> 选择招募组合 -> 进行初始招募。
部分深入调查条目没有选择招募组合这一步，所以卡住了。
我给其他的主题也加上了。

@status102 请您看一下这样写对不对。我留意到了您之前写的 StartExplore@Roguelike 任务系列和 MapObject 任务，但是那个似乎是给月度小队用的，所以我应该没改错？顺带，傀影肉鸽没有用 MapObject 任务，是有什么原因吗？

## Summary by Sourcery

Add the recruitment combination selection step to missing Roguelike tasks so that initial recruitment can proceed without blocking

Bug Fixes:
- Prevent certain Roguelike exploration tasks from getting stuck by adding the missing recruitment combination step

Enhancements:
- Extend the standard recruitment flow to additional Roguelike themes to align with the integration strategy process