### PR TITLE
fix: 防止生息演算重置地图视图时因截图延迟卡死

### DIFF
--- a/resource/tasks/RA/Tales.json
+++ b/resource/tasks/RA/Tales.json
@@ -22,7 +22,7 @@
         "text": ["进入建造"],
         "roi": [956, 540, 304, 72],
         "action": "ClickRect",
-        "specificRect": [36, 634, 68, 76]
+        "specificRect": [120, 672, 1, 1]
     },
     "Tales@RA@ClearSquad": {
         "doc": "模板任务: 清空当前编队",
@@ -734,6 +734,7 @@
     "Tales@RA@ReturnToOrigin-CancelEnterBuildMode": {
         "doc": "在右下角存在 <进入建造> 按钮时点击左下角取消进入建造",
         "baseTask": "Tales@RA@CancelEnterBuildMode",
+        "postDelay": 500,
         "next": ["Tales@RA@Origin", "Tales@RA@ReturnToOrigin-CancelEnterBuildMode", "Tales@RA@ReturnToOrigin"]
     },
     "Tales@RA@SelectLeftSave": {


### PR DESCRIPTION
生息演算重置地图视图的方式是，点击左下角尝试进入建造模式，再点击左下角取消。
因为两个点击位置重合，所以在截图有延迟的情况下，可能会卡在这一步，甚至因为多点了一下而导致卡在下一步。
就比如下面这位用户：

<img width="1918" height="1079" alt="b3151b0d222808c7699cac55ea40a85c" src="https://github.com/user-attachments/assets/28a43706-8b49-43bf-afa4-3f2100a5092c" />

[report_11-11_21-26-28.zip](https://github.com/user-attachments/files/23483034/report_11-11_21-26-28.zip)

本 PR 尝试通过增加延迟 + 错开点击位置来修复这个问题。

## Summary by Sourcery

Bug Fixes:
- Fix freezing issue caused by rapid consecutive clicks at the same position when entering and exiting build mode for map view reset.