### PR TITLE
fix: build WpfGui for ARM architecture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,7 @@ jobs:
       - name: Publish WPF GUI
         continue-on-error: true
         run: |
-          dotnet publish src/MaaWpfGui/MaaWpfGui.csproj -c Release -o install
+          dotnet publish src/MaaWpfGui/MaaWpfGui.csproj -c Release -p:Platform=${{ matrix.arch == 'arm64' && 'ARM64' || 'x64' }} -o install
 
       - name: Upload PDB files
         uses: actions/upload-artifact@v5


### PR DESCRIPTION
或许，大概，fixes #14720 ...?

## Summary by Sourcery

Bug Fixes:
- Add Platform property to dotnet publish command to properly build for ARM64 and x64