### PR TITLE
ci: 修正一个cli相关的action的输入

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,7 +260,6 @@ jobs:
       - name: Setup cross compile toolchains for CLI
         uses: ./src/maa-cli/.github/actions/setup
         with:
-          os: ubuntu-latest
           target_arch: ${{ matrix.arch }}
 
       - name: Build CLI


### PR DESCRIPTION
This can reslove this warning:

https://github.com/MaaAssistantArknights/MaaAssistantArknights/actions/runs/19288272521/job/55156727537#step:9:2

## Summary by Sourcery

Remove invalid 'os' input from the CLI setup action in the CI workflow to resolve the warning

Bug Fixes:
- Remove unsupported 'os' input from the custom CLI setup action to fix CI warning

CI:
- Remove obsolete 'os' parameter from the cross compile toolchains setup step in the CI workflow