### PR TITLE
fix: ocrReplace for EN

### DIFF
--- a/resource/global/YoStarEN/resource/tasks/Roguelike/base.json
+++ b/resource/global/YoStarEN/resource/tasks/Roguelike/base.json
@@ -955,7 +955,7 @@
             ["QuackingMad", "气打鸭处来"],
             ["ThePiousWorshiper", "敬虔之人"],
             ["EmployeeofBabel", "巴别塔雇员"],
-            ["SoulExperiences.*TwinGargoyles", "魂灵见闻：石心双子"],
+            ["SoulExperiences.*TwinGargoyles?", "魂灵见闻：石心双子"],
             ["FinalPage", "尾页"],
             ["TheDissident'sSound", "扣响异音"],
             ["DecipheringEvolution", "解读变迁"],


### PR DESCRIPTION
@Constrat 
A user reports an OCR result of "Soul Experiences:Twin Gargoyle".

```
[2025-11-13 09:36:36.780][TRC][Px4196][Tx64593] asst::WordOcr [{ : [ 393, 21, 127, 62 ], score: 0.000000 }, { S: [ 355, 21, 42, 42 ], score: 0.074356 }, { Soul Experiences:Twin Gargoyle: [ 318, 94, 283, 23 ], score: 0.943213 }, { Y: [ 632, 100, 16, 16 ], score: 0.117858 }, { The Tin Man has gathered some scattered: [ 321, 130, 285, 16 ], score: 0.949519 }, { NETTU: [ 612, 136, 43, 7 ], score: 0.342415 }, { and: [ 678, 132, 36, 11 ], score: 0.998217 }] by OCR Pipeline , cost 153 ms
[2025-11-13 09:36:36.782][ERR][Px4196][Tx64593] Unknown Event
```

Could you please help doublecheck whether this is a proper fix?

I first ended up with `Soul ?Experiences.*Twin ?Gargoyles?`，thanks to @Saratoga-Official who reminds me that the spaces are already handled somewhere else.

Please merge this PR if it looks good to you.

Cheers,

## Summary by Sourcery

Bug Fixes:
- Correct the OCR replacement rule for the 'Soul Experiences: Twin Gargoyle' event in the English Roguelike task base