### PR TITLE
fix: JP paradox

### DIFF
--- a/resource/global/YoStarJP/resource/tasks/tasks.json
+++ b/resource/global/YoStarJP/resource/tasks/tasks.json
@@ -1323,6 +1323,7 @@
         "text": ["職分"]
     },
     "BattleStartPre": {
+        "ocrReplace": [["算.*", ""]],
         "text": ["行動開始", "開始", "試練", "挑戦", "作戦", "推論"]
     },
     "BattleStartOCR": {

--- a/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
@@ -1547,7 +1547,7 @@ public partial class CopilotViewModel : Screen
         bool ret = true;
         foreach (var task in CopilotItemViewModels.Where(i => i.IsChecked))
         {
-            if (!DataHelper.Operators.Any(op => op.Value.Name == task.Name))
+            if (!DataHelper.Operators.Any(op => op.Value.Name == DataHelper.GetLocalizedCharacterName(task.Name, "zh-cn")))
             {
                 AddLog("illegal oper name: " + task.Name, UiLogColor.Error);
                 ret = false;


### PR DESCRIPTION
json(JP only): 尝试修复一个很久以前遗留的问题，“开始模拟”的按钮会被BattleStartPre识别到然后卡住
C#(global): 在设置里选择使用其他语言显示干员名后，无法通过此处的检验

## Summary by Sourcery

Fix paradox task detection by updating Japanese tasks JSON and supporting localized operator names in verification

Bug Fixes:
- Prevent the 'start simulation' button from being misidentified as a paradox task in the Japanese tasks JSON
- Fix VerifyParadoxTasks to correctly recognize operator names when using non-default display languages