### PR TITLE
fix: 简化萨米肉鸽 "诡秘的预感" 相关任务链

### DIFF
--- a/resource/tasks/Roguelike/Sami.json
+++ b/resource/tasks/Roguelike/Sami.json
@@ -765,7 +765,7 @@
         "Doc": "诡秘的预感",
         "baseTask": "Sami@Roguelike@Stage",
         "templThreshold": 0.9,
-        "next": ["Sami@Roguelike@StageMysteriousPresageEnter", "Sami@Roguelike@Stages#next"]
+        "next": ["Sami@Roguelike@StageMysteriousPresageEnter", "#self"]
     },
     "Sami@Roguelike@StageMysteriousPresageEnter": {
         "baseTask": "Sami@Roguelike@StageEnter",


### PR DESCRIPTION
我不知道那个 `Stages#next` 有什么用，建议未来都改掉。

---

有多位用户在卡在萨米肉鸽 “诡秘的预感”，原因是点击后未能第一时间识别 `Sami@Roguelike@StageMysteriousPresageEnter`，之后兜兜转转沿着 `Stages#next` 去了别处，稀里糊涂撞进了 `Sami@Roguelike@StageEmergencyDpsEnter`。我提议别绕路了。

另一种改法是给每一个 StageEnter 任务加上数色，工作量不小，而且我私下认为任务链那么杂才是根本问题。