### PR TITLE
fix: 修复集成战略萨米主题下凹密闻板相关功能

### DIFF
--- a/src/MaaCore/Task/Roguelike/RoguelikeCustomStartTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeCustomStartTaskPlugin.cpp
@@ -179,7 +179,8 @@ bool asst::RoguelikeCustomStartTaskPlugin::hijack_reward()
         m_config->set_run_for_collectible(true);
         m_control_ptr->exit_then_stop(true);
     }
-    else if (m_config->get_start_with_elite_two()) {
+    else if (m_config->get_start_with_elite_two() || m_config->get_first_floor_foldartal()) {
+        // 之后还要凹开局精二或第一层密文板，不停止任务，继续探索
         ctrler()->click(ret->rect);
         sleep(Config.get_options().task_delay);
     }

--- a/src/MaaCore/Task/Roguelike/RoguelikeRecruitTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeRecruitTaskPlugin.cpp
@@ -555,9 +555,16 @@ bool asst::RoguelikeRecruitTaskPlugin::recruit_appointed_char(const std::string&
             if (it != chars.cend()) {
                 // !get_run_for_collectible() 即当前没有在烧开水/水已经烧好了
                 // 需要凹直升且，要么已经烧好了水，要么只需要凹直升不需要烧水
-                if (start_with_elite_two && (!m_config->get_run_for_collectible() || only_start_with_elite_two)) {
+                // 凹直升只对第一位招募的干员生效
+                if (start_with_elite_two && (!m_config->get_run_for_collectible() || only_start_with_elite_two) &&
+                    m_recruit_count == 1) {
                     if (it->elite == 2) {
-                        m_task_ptr->set_enable(false);
+                        if (m_config->get_first_floor_foldartal()) {
+                            select_oper(*it); // 放心选择精二，之后还要继续凹密文板
+                        }
+                        else {
+                            m_task_ptr->set_enable(false); // 仅当之后没有东西要凹了才停止
+                        }
                     }
                     else {
                         // 非只凹直升时，重新烧水


### PR DESCRIPTION
## Summary by Sourcery

Fix the roguelike recruit and custom start workflows to correctly handle first-floor cryptogram runs and straight-to-elite-two settings

Bug Fixes:
- Limit straight-to-elite-two behavior to the first recruited operator
- Honor the first-floor cryptogram option to either auto-select an E2 operator or end the task appropriately
- Include the first-floor cryptogram setting in the custom start plugin to continue exploration rather than stopping prematurely