### PR TITLE
fix: 保存招募券结束后等待确认招募按钮消失

### DIFF
--- a/src/MaaCore/Task/Roguelike/RoguelikeRecruitTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeRecruitTaskPlugin.cpp
@@ -121,6 +121,8 @@ bool asst::RoguelikeRecruitTaskPlugin::_run()
                     return true;
                 }
             }
+            // 没有消失的话就继续招募流程
+            Log.warn(__FUNCTION__, "| Confirm button did not disappear in time, continue recruitment process.");
         }
     }
 


### PR DESCRIPTION
界园肉鸽保留招募券结束后可能因卡顿等原因让下一个任务识别到右下角的确认招募，导致多点几次，可能会进编队页面，导致卡死。所以点完确认招募后面判断已经没有确认招募按钮后再继续下一步的任务

## Summary by Sourcery

Bug Fixes:
- Insert 500ms sleep after recruitment confirmation to avoid misrecognition and unintended extra taps

## Summary by Sourcery

Bug Fixes:
- Add a loop that checks for and waits up to 5×200ms for the confirm recruitment button to vanish before proceeding