### PR TITLE
fix: 上调助战栏位匹配分数阈值

### DIFF
--- a/resource/tasks/Copilot/formation.json
+++ b/resource/tasks/Copilot/formation.json
@@ -10,7 +10,7 @@
         "doc": ["匹配助战干员时，应用于 Matcher 的配置任务", "| specificRect: 截取助战干员的 templ 时所使用的 rect"],
         "template": "empty.png",
         "roi": [95, 106, 1185, 550],
-        "templThreshold": 0.7,
+        "templThreshold": 0.9,
         "action": "ClickRect",
         "specificRect": [0, 106, 129, 550]
     },


### PR DESCRIPTION
惊了，即便是两个不同的好友借出不同的干员，匹配分数也可以高达 0.72。

## Summary by Sourcery

Bug Fixes:
- Raise the matching score threshold for assist slots in formation.json to avoid unrealistically high match scores when different operators are borrowed from friends.