### PR TITLE
fix: 修复放弃通宝的后续任务逻辑

### DIFF
--- a/resource/tasks/Roguelike/JieGarden.json
+++ b/resource/tasks/Roguelike/JieGarden.json
@@ -160,7 +160,7 @@
         "postDelay": 1000,
         "templThreshold": 0.85,
         "cache": true,
-        "next": ["JieGarden@Roguelike@CoppersExchangeConfirm", "#self"]
+        "next": ["JieGarden@Roguelike@CoppersAbandonConfirm", "#self"]
     },
     "JieGarden@Roguelike@CoppersAnalyzer-CastOCR": {
         "Doc": "通宝已投出状态识别 - 通宝已投出识别用 roi 为 通宝类型 的 Rect.move(me.roi)",
@@ -228,10 +228,16 @@
         "baseTask": "JieGarden@Roguelike@CoppersBox"
     },
     "JieGarden@Roguelike@CoppersExchangeConfirm": {
-        "Doc": "确认放弃/交换通宝的确认按钮",
+        "Doc": "交换通宝的确认按钮",
         "baseTask": "JieGarden@Roguelike@CoppersListDialogConfirm",
         "template": "JieGarden@Roguelike@CoppersListDialogConfirm.png",
         "next": ["JieGarden@Roguelike@CoppersExchangeFinish", "#self"]
+    },
+    "JieGarden@Roguelike@CoppersAbandonConfirm": {
+        "Doc": "放弃交换通宝的确认按钮",
+        "baseTask": "JieGarden@Roguelike@CoppersListDialogConfirm",
+        "template": "JieGarden@Roguelike@CoppersListDialogConfirm.png",
+        "next": ["JieGarden@Roguelike@CoppersTakeFlag#next", "#self"]
     },
     "JieGarden@Roguelike@CoppersExchangeFinish": {
         "Doc": "通宝交换完成后的交换按钮 (用于确认交换操作完成)",


### PR DESCRIPTION
忘了把拾取通宝和放弃的next分开了

fix #14839

## Summary by Sourcery

Bug Fixes:
- Correct the follow-up task logic when the player abandons Tongbao in the JieGarden roguelike tasks.