### PR TITLE
ci: implement matrix for uploading myrror + ubuntu for winget

### DIFF
--- a/.github/workflows/release-package-distribution.yml
+++ b/.github/workflows/release-package-distribution.yml
@@ -103,7 +103,7 @@ jobs:
     name: Upload to WinGet
     needs: meta
     if: ${{ github.event.inputs.winget == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     continue-on-error: true
 
     env:


### PR DESCRIPTION
docs say it's fine since we don't use .msi

## Summary by Sourcery

Update release workflow to run MirrorChyan uploads and WinGet publishing on Ubuntu with a matrix for platform-specific artifacts.

CI:
- Switch MirrorChyan upload job from macOS to Ubuntu and introduce a matrix to handle Windows and macOS artifacts in a single step.
- Change WinGet upload job to run on Ubuntu instead of Windows.