### PR TITLE
fix: 允许先添加自定义干员后借用助战

### DIFF
--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -127,7 +127,7 @@ bool asst::BattleFormationTask::_run()
                 return oper.name == m_specific_support_unit.name && oper.skill == m_specific_support_unit.skill;
             });
         it != missing_opers.end()) {
-        missing_opers = {*it};
+        missing_opers = { *it };
     }
 
     // ————————————————————————————————————————————————————————————————

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -117,7 +117,7 @@ bool asst::BattleFormationTask::_run()
 
     // 等到支持 C++23 之后直接改成 std::ranges::to
     std::vector<RequiredOper> missing_opers;
-    for (const auto&& oper: missing_opers_view) {
+    for (const auto&& oper : missing_opers_view) {
         missing_opers.emplace_back(oper);
     }
 

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -128,8 +128,8 @@ bool asst::BattleFormationTask::_run()
                 return oper.name == m_specific_support_unit.name && oper.skill == m_specific_support_unit.skill;
             });
         it != missing_opers.end()) {
-        missing_opers.erase(missing_opers.begin(), it);
         missing_opers.erase(it + 1, missing_opers.end());
+        missing_opers.erase(missing_opers.begin(), it);
     }
 
     // ————————————————————————————————————————————————————————————————

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -134,6 +134,15 @@ bool asst::BattleFormationTask::_run()
             if (m_opers_in_formation->contains(name)) {
                 continue;
             }
+            if (const auto it = std::ranges::find_if(
+                    missing_opers,
+                    [&name](const battle::OperUsage& oper) { return oper.name == name; });
+                it != missing_opers.end()) {
+                if (missing_opers.size() == 1) {
+                    continue;
+                }
+                missing_opers.erase(it);
+            }
             if (--limit < 0) {
                 break;
             }

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -128,8 +128,7 @@ bool asst::BattleFormationTask::_run()
                 return oper.name == m_specific_support_unit.name && oper.skill == m_specific_support_unit.skill;
             });
         it != missing_opers.end()) {
-        missing_opers.erase(it + 1, missing_opers.end());
-        missing_opers.erase(missing_opers.begin(), it);
+        missing_opers = {*it};
     }
 
     // ————————————————————————————————————————————————————————————————

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -140,14 +140,14 @@ bool asst::BattleFormationTask::_run()
             if (m_opers_in_formation->contains(name)) {
                 continue;
             }
-            if (const auto it = std::ranges::find_if(
+            if (const size_t count = std::ranges::count_if(
                     missing_opers,
                     [&name](const RequiredOper& oper) { return oper.name == name; });
-                it != missing_opers.end()) {
-                if (missing_opers.size() == 1) {
+                count > 0) {
+                if (missing_opers.size() <= count) {
                     continue;
                 }
-                missing_opers.erase(it);
+                std::erase_if(missing_opers, [&name](const RequiredOper& oper) { return oper.name == name; });
             }
             if (--limit < 0) {
                 break;

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -117,9 +117,7 @@ bool asst::BattleFormationTask::_run()
 
     // 等到支持 C++23 之后直接改成 std::ranges::to
     std::vector<RequiredOper> missing_opers;
-    for (const auto&& oper : missing_opers_view) {
-        missing_opers.emplace_back(oper);
-    }
+    std::ranges::for_each(missing_opers_view, [&missing_opers](const auto&& oper) { missing_opers.emplace_back(oper); });
 
     // 如果缺失干员里包含指定助战干员，就只招募这位干员就好了
     if (auto it = std::ranges::find_if(


### PR DESCRIPTION
## Summary by Sourcery

Refine battle formation handling of missing operators to better integrate user-defined operators and support units when completing formations.

Bug Fixes:
- Allow borrowing a support unit after adding user-defined operators by reordering and restructuring the missing-operator and support-selection logic.
- Prevent attempts to auto-complete formations in cases where missing operators cannot be reasonably filled, reporting the issue earlier instead.

Enhancements:
- Introduce preprocessing of missing operator groups and a consolidated missing-operator list to simplify formation completion logic.
- Adjust handling of specifically requested support units so that only the matching support is recruited when present among missing operators.
- Ensure user-defined additional operators are considered before requesting overlapping operators via support to avoid redundant recruitment attempts.