### PR TITLE
fix: 避免通宝插件通过任务链作用到通宝以外的地方

### DIFF
--- a/src/MaaCore/Task/Roguelike/JieGarden/RoguelikeCoppersTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/JieGarden/RoguelikeCoppersTaskPlugin.cpp
@@ -362,7 +362,6 @@ bool asst::RoguelikeCoppersTaskPlugin::handle_exchange_mode()
     if (worst_it->get_copper_discard_priority() < m_new_copper.get_copper_discard_priority()) {
         LogInfo << __FUNCTION__ << "new copper (" << m_new_copper.name
                 << ") is worse than all existing coppers, abandoning exchange";
-        ProcessTask(*this, { "JieGarden@Roguelike@CoppersAbandonExchange" }).run();
         return true;
     }
 


### PR DESCRIPTION
之前为了修#14840 ，为CoppersAbandonConfirm任务添加了"JieGarden@Roguelike@DropsFlag","JieGarden@Roguelike@CloseEvent"作为next。没想到这个任务是在插件里通过ProcessTask调用的任务的next，这样就会随着任务链作用到不该通宝插件管理的地方。现在把ProcessTask删了

fix #14862

## Summary by Sourcery

错误修复：
- 当新的 copper 比现有的更差时，停止通过 `ProcessTask` 调用 `CoppersAbandonExchange` 任务，从而避免在 coppers 插件之外出现意外的任务链副作用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Stop invoking the CoppersAbandonExchange task via ProcessTask when a new copper is worse than existing ones, avoiding unintended task-chain side effects outside the coppers plugin.

</details>

## Summary by Sourcery

错误修复：
- 防止“铜币兑换”流程通过 `ProcessTask` 调用 `CoppersAbandonExchange` 任务，从而避免在 coppers 插件之外产生副作用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent the coppers exchange flow from invoking the CoppersAbandonExchange task via ProcessTask to avoid side effects outside the coppers plugin.

</details>