### PR TITLE
perf: debug下非根路径文件限3日内

### DIFF
--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/IssueReportUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/IssueReportUserControlModel.cs
@@ -126,9 +126,12 @@ public class IssueReportUserControlModel : PropertyChangedBase
                 }
             }
 
-            // ====== part02+：debug 子目录文件按 PartSize 分卷 ======
+            // ====== part02：debug 子目录文件按 PartSize 分卷 ======
+            var threeDaysAgo = DateTime.Now.AddDays(-3);
             var debugSubFiles = Directory.EnumerateFiles(debugPath, "*", SearchOption.AllDirectories)
-                .Where(f => Path.GetDirectoryName(f) != debugPath).ToList();
+                .Where(f => Path.GetDirectoryName(f) != debugPath)
+                .Where(f => new FileInfo(f).LastWriteTime >= threeDaysAgo)
+                .ToList();
 
             int partNumber = 2;
             while (debugSubFiles.Count > 0)


### PR DESCRIPTION
## Summary by Sourcery

增强功能：
- 在将调试子目录中的文件分块打包进支持负载归档之前，先根据最后写入时间进行过滤，仅保留最近三天内修改的文件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Filter debug subdirectory files by last write time (within three days) before chunking them into parts for the support payload archive.

</details>