### PR TITLE
chore: 调整凛御银灰酒神肉鸽抓取与表现策略

### DIFF
--- a/resource/roguelike/JieGarden/recruitment.json
+++ b/resource/roguelike/JieGarden/recruitment.json
@@ -3571,7 +3571,22 @@
             "name": "回费",
             "opers": [
                 {
-                    "name": "凛御银灰"
+                    "name": "凛御银灰",
+                    "skill": 3,
+                    "alternate_skill": 2,
+                    "skill_usage": 2,
+                    "alternate_skill_usage": 2,
+                    "is_key": true,
+                    "recruit_priority": 750,
+                    "promote_priority": 800,
+                    "recruit_priority_offsets": [
+                        {
+                            "groups": ["新能", "益达", "玛恩纳", "重装"],
+                            "threshold": 1,
+                            "is_less": true,
+                            "offset": -300
+                        }
+                    ]
                 },
                 {
                     "name": "伊内丝"

--- a/resource/roguelike/Mizuki/recruitment.json
+++ b/resource/roguelike/Mizuki/recruitment.json
@@ -2981,7 +2981,22 @@
             "name": "回费",
             "opers": [
                 {
-                    "name": "凛御银灰"
+                    "name": "凛御银灰",
+                    "skill": 3,
+                    "alternate_skill": 2,
+                    "skill_usage": 2,
+                    "alternate_skill_usage": 2,
+                    "is_key": true,
+                    "recruit_priority": 750,
+                    "promote_priority": 800,
+                    "recruit_priority_offsets": [
+                        {
+                            "groups": ["高台C", "益达", "玛恩纳", "号角", "地面C", "重装"],
+                            "threshold": 1,
+                            "is_less": true,
+                            "offset": -300
+                        }
+                    ]
                 },
                 {
                     "name": "伊内丝"

--- a/resource/roguelike/Phantom/recruitment.json
+++ b/resource/roguelike/Phantom/recruitment.json
@@ -2223,6 +2223,23 @@
             "name": "术师",
             "opers": [
                 {
+                    "name": "酒神",
+                    "skill": 3,
+                    "alternate_skill": 1,
+                    "is_key": true,
+                    "recruit_priority": 800,
+                    "promote_priority": 900,
+                    "recruit_priority_offsets": [
+                        {
+                            "groups": ["高台C", "地面阻挡", "银灰", "近卫", "重装", "地面单切", "回费"],
+                            "is_less": true,
+                            "threshold": 2,
+                            "offset": -350,
+                            "doc": "群组类别干员<=2时，优先级降低"
+                        }
+                    ]
+                },
+                {
                     "name": "澄闪"
                 },
                 {
@@ -2470,7 +2487,21 @@
             "doc": "减速辅助和脆弱辅助",
             "opers": [
                 {
-                    "name": "酒神"
+                    "name": "酒神",
+                    "skill": 3,
+                    "alternate_skill": 1,
+                    "is_key": true,
+                    "recruit_priority": 800,
+                    "promote_priority": 900,
+                    "recruit_priority_offsets": [
+                        {
+                            "groups": ["高台C", "地面阻挡", "银灰", "近卫", "重装", "地面单切", "回费"],
+                            "is_less": true,
+                            "threshold": 2,
+                            "offset": -350,
+                            "doc": "群组类别干员<=2时，优先级降低"
+                        }
+                    ]
                 },
                 {
                     "name": "塑心"
@@ -3153,7 +3184,22 @@
             "name": "回费",
             "opers": [
                 {
-                    "name": "凛御银灰"
+                    "name": "凛御银灰",
+                    "skill": 3,
+                    "alternate_skill": 2,
+                    "skill_usage": 2,
+                    "alternate_skill_usage": 2,
+                    "is_key": true,
+                    "recruit_priority": 750,
+                    "promote_priority": 800,
+                    "recruit_priority_offsets": [
+                        {
+                            "groups": ["高台C", "益达", "玛恩纳", "银灰", "地面单切", "重装"],
+                            "threshold": 1,
+                            "is_less": true,
+                            "offset": -300
+                        }
+                    ]
                 },
                 {
                     "name": "伊内丝"

--- a/resource/roguelike/Sami/recruitment.json
+++ b/resource/roguelike/Sami/recruitment.json
@@ -3215,7 +3215,22 @@
             "name": "回费",
             "opers": [
                 {
-                    "name": "凛御银灰"
+                    "name": "凛御银灰",
+                    "skill": 3,
+                    "alternate_skill": 2,
+                    "skill_usage": 2,
+                    "alternate_skill_usage": 2,
+                    "is_key": true,
+                    "recruit_priority": 750,
+                    "promote_priority": 800,
+                    "recruit_priority_offsets": [
+                        {
+                            "groups": ["高台C", "益达", "玛恩纳", "水陈", "重装"],
+                            "threshold": 1,
+                            "is_less": true,
+                            "offset": -300
+                        }
+                    ]
                 },
                 {
                     "name": "伊内丝"

--- a/resource/roguelike/Sarkaz/recruitment.json
+++ b/resource/roguelike/Sarkaz/recruitment.json
@@ -2352,6 +2352,23 @@
             "name": "术师",
             "opers": [
                 {
+                    "name": "酒神",
+                    "skill": 3,
+                    "alternate_skill": 1,
+                    "is_key": true,
+                    "recruit_priority": 800,
+                    "promote_priority": 900,
+                    "recruit_priority_offsets": [
+                        {
+                            "groups": ["地面阻挡", "近卫", "重装", "回费", "益达", "玛恩纳"],
+                            "is_less": true,
+                            "threshold": 2,
+                            "offset": -350,
+                            "doc": "群组类别干员<=2时，优先级降低"
+                        }
+                    ]
+                },
+                {
                     "name": "圣聆初雪",
                     "skill": 2,
                     "skill_usage": 0,
@@ -2728,7 +2745,21 @@
             "name": "辅助",
             "opers": [
                 {
-                    "name": "酒神"
+                    "name": "酒神",
+                    "skill": 3,
+                    "alternate_skill": 1,
+                    "is_key": true,
+                    "recruit_priority": 800,
+                    "promote_priority": 900,
+                    "recruit_priority_offsets": [
+                        {
+                            "groups": ["地面阻挡", "近卫", "重装", "回费", "益达", "玛恩纳"],
+                            "is_less": true,
+                            "threshold": 2,
+                            "offset": -350,
+                            "doc": "群组类别干员<=2时，优先级降低"
+                        }
+                    ]
                 },
                 {
                     "name": "塑心"
@@ -3547,7 +3578,22 @@
             "name": "回费",
             "opers": [
                 {
-                    "name": "凛御银灰"
+                    "name": "凛御银灰",
+                    "skill": 3,
+                    "alternate_skill": 2,
+                    "skill_usage": 2,
+                    "alternate_skill_usage": 2,
+                    "is_key": true,
+                    "recruit_priority": 750,
+                    "promote_priority": 800,
+                    "recruit_priority_offsets": [
+                        {
+                            "groups": ["高台C", "益达", "玛恩纳", "水陈", "重装"],
+                            "threshold": 1,
+                            "is_less": true,
+                            "offset": -300
+                        }
+                    ]
                 },
                 {
                     "name": "伊内丝"


### PR DESCRIPTION
增强酒神在傀影萨卡兹肉鸽作为术士以及辅助分组的表现，优化凛御银灰抓取策略

## Summary by Sourcery

Enhancements:
- 针对杰园、缪希、幻影、萨米以及萨卡兹肉鸽模式调整招募设置，以改进单位分组和表现呈现。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Tune recruitment settings for JieGarden, Mizuki, Phantom, Sami, and Sarkaz roguelike modes to improve unit grouping and performance representation.

</details>