### PR TITLE
ci: remove lldb

### DIFF
--- a/tools/SmokeTesting/run_tests.sh
+++ b/tools/SmokeTesting/run_tests.sh
@@ -9,8 +9,7 @@ mkdir -p "$log_dir"
 
 pids=""
 for client in $clients; do
-    lldb -o run -o 'bt all' -o kill -o quit \
-        -- ./install/smoke_test "$client" > "$log_dir/asst_${client}.log" 2>&1 &
+    ./install/smoke_test "$client" > "$log_dir/asst_${client}.log" 2>&1 &
     pid=$!
     pids="$pids $pid"
 


### PR DESCRIPTION
## Summary by Sourcery

CI:
- 更新 smoke test 的 shell 脚本，使其在 CI 中直接运行 `smoke_test` 可执行文件，而不是通过 lldb 运行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Update smoke test shell script to run the smoke_test executable directly rather than via lldb in CI.

</details>