### PR TITLE
fix: 繁中服周年月卡領取及贈送單抽的處理錯誤

### DIFF
--- a/resource/global/txwy/resource/tasks/tasks.json
+++ b/resource/global/txwy/resource/tasks/tasks.json
@@ -773,13 +773,13 @@
         "text": ["贈送", "次", "小時", "分鐘"]
     },
     "RecruitingActivitiesRecruit": {
-        "text": ["尋訪一次", "尋訪"]
+        "text": ["贈送一次", "贈送"]
     },
     "RecruitingActivitiesRecruitEnd": {
         "text": ["尋訪一次", "尋訪"]
     },
     "SpecialAccessActivities": {
-        "text": ["周年", "專享", "活動", "月卡", "推薦"]
+        "text": ["周年", "專享", "月卡", "推薦"]
     },
     "SpecialAccessActivitiesConfirm": {
         "text": ["立即", "立即領取"]


### PR DESCRIPTION
## Summary by Sourcery

错误修复：
- 修复从繁体中文服周年纪念月卡任务中领取和发放单抽奖励时配置不正确的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix incorrect configuration for claiming and granting single-draw rewards from the Traditional Chinese server anniversary monthly card tasks.

</details>