### PR TITLE
feat: 在资源更新时禁用配置切换按钮

### DIFF
--- a/src/MaaWpfGui/Views/UserControl/ConfigurationMgrUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/ConfigurationMgrUserControl.xaml
@@ -33,7 +33,7 @@
             hc:TitleElement.HorizontalAlignment="Center"
             hc:TitleElement.Title="{DynamicResource ConfigurationName}"
             IsEditable="True"
-            IsHitTestVisible="{Binding Idle}"
+            IsHitTestVisible="{c:Binding 'Idle and !VersionUpdateSettings.IsCheckingForUpdates'}"
             IsReadOnly="True"
             ItemsSource="{Binding ConfigurationList}"
             SelectedValue="{Binding CurrentConfiguration}"


### PR DESCRIPTION
经测试发现，在资源更新时“正在编辑索引”环节切换配置会导致资源损坏，故在资源更新时禁用切换配置功能

## Summary by Sourcery

新功能：
- 添加 UI 逻辑，在资源更新操作期间禁用配置开关控件，以避免损坏资源。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Add UI logic to disable the configuration switch control during resource update operations to avoid damaging resources.

</details>