### PR TITLE
fix: 修复萨米肉鸽诡秘的预感节点被密文板变换后卡死的问题

### DIFF
--- a/resource/tasks/Roguelike/Sami.json
+++ b/resource/tasks/Roguelike/Sami.json
@@ -779,7 +779,11 @@
         "Doc": "诡秘的预感",
         "baseTask": "Sami@Roguelike@Stage",
         "templThreshold": 0.9,
-        "next": ["Sami@Roguelike@StageMysteriousPresageEnter", "#self"]
+        "next": [
+            "Sami@Roguelike@StageMysteriousPresageEnter",
+            "Sami@Roguelike@StageEncounterEnter",
+            "Sami@Roguelike@Stages#next"
+        ]
     },
     "Sami@Roguelike@StageMysteriousPresageEnter": {
         "baseTask": "Sami@Roguelike@StageEnter",


### PR DESCRIPTION
尝试修复issue #14935 中密文板导致的循环卡死问题。根据debug日志与截图显示，使用密文板后，下一关从诡秘的预感变换为了先行一步，但是因为此时没有有效fallback，导致无法寻找到诡秘的预感时卡死。往前看相关PR时发现PR #14749 中因识别原因，将诡秘的预感的fallback进行过了修改，与其他的关卡类型的fallback的不一致导致了无法应对密文板的情况。

### 相关日志
-12-02 00:05:24.493][TRC][Px64720][Tx11383] Board pair used, up: 源石 , down: 繁衍
[2025-12-02 00:05:24.493][TRC][Px64720][Tx11383] asst::RoguelikeFoldartalUseTaskPlugin::use_enable_pair | leave, 8254 ms
[2025-12-02 00:05:24.493][TRC][Px64720][Tx11383] asst::RoguelikeFoldartalUseTaskPlugin::_run | leave, 8254 ms
[2025-12-02 00:05:24.493][INF][Px64720][Tx11383] Assistant::append_callback | SubTaskCompleted {"class":"asst::RoguelikeFoldartalUseTaskPlugin","details":{},"subtask":"RoguelikeFoldartalUseTask","taskchain":"Roguelike","taskid":11,"uuid":"4154e6ce829ca259"}
[2025-12-02 00:05:24.493][INF][Px64720][Tx11383] Assistant::append_callback | SubTaskStart {"class":"asst::ProcessTask","details":{"action":"ClickSelf","algorithm":"MatchTemplate","exec_times":1,"max_times":2147483647,"result":{"score":0.973291},"task":"StageMysteriousPresage"},"first":["Sami@Roguelike@Begin"],"pre_task":"Sami@Roguelike@StagesChaosZero","subtask":"ProcessTask","taskchain":"Roguelike","taskid":11,"uuid":"4154e6ce829ca259"}
[2025-12-02 00:05:24.493][TRC][Px64720][Tx11383] Click with scaled coordinates (842, 377) 1.5
[2025-12-02 00:05:24.493][TRC][Px64720][Tx11383] minitouch click: (1263, 565)
[2025-12-02 00:05:24.594][INF][Px64720][Tx11383] Assistant::append_callback | SubTaskCompleted {"class":"asst::ProcessTask","details":{"action":"ClickSelf","algorithm":"MatchTemplate","exec_times":1,"max_times":2147483647,"result":{"score":0.973291},"task":"StageMysteriousPresage"},"first":["Sami@Roguelike@Begin"],"pre_task":"Sami@Roguelike@StagesChaosZero","subtask":"ProcessTask","taskchain":"Roguelike","taskid":11,"uuid":"4154e6ce829ca259"}
[2025-12-02 00:05:24.594][TRC][Px64720][Tx11383] ready to sleep 500
[2025-12-02 00:05:25.095][TRC][Px64720][Tx11383] end of sleep 500
（进行了20次retry）

### 问题描述
- 密文板变换"诡秘的预感"节点时会卡死
- 推测原因是PR#14749中将#self 作为 fallback 导致了无限循环，密文板无法找到诡秘的预感时，fallback是#self -> 还是诡秘的预感，但实际下一关已经变成了先行一步

### 解决方案
- revert了之前的改动，Stages#next作为最后一层fallback，符合此肉鸽内其他关卡的fallback模式，例如凶戾的预感。
- 新增 `StageEncounterEnter` 作为中间层：考虑到此前 PR 提到的诡秘的预感使用Stages#next时存在误识别风险，优先尝试点击通用的事件入口。

Fixes #14935

## 由 Sourcery 提供的摘要

修复 Sami roguelike 节点处理逻辑，以避免当 **Mysterious Presage** 被密码棋盘转换时出现无限循环，并确保使用有效的备用导航路径。

错误修复：
- 解决一个软锁问题：当 **Mysterious Presage** 节点被密码棋盘转换后，由于无效的自引用备用路径而导致无限循环。

增强内容：
- 调整 **Mysterious Presage** 阶段的备用序列，使其与其他 Sami roguelike 阶段保持一致：通过使用 `Stages#next` 作为最终备用路径，并引入一个通用的 `StageEncounterEnter` 中间步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix the Sami roguelike node handling to avoid infinite loops when Mysterious Presage is transformed by the cipher board and ensure a valid fallback navigation path is used.

Bug Fixes:
- Resolve a soft-lock where the Mysterious Presage node would loop indefinitely after being transformed by the cipher board due to an invalid self-referential fallback.

Enhancements:
- Adjust the fallback sequence for the Mysterious Presage stage to align with other Sami roguelike stages by using Stages#next as the final fallback and introducing a generic StageEncounterEnter intermediate step.

</details>