### PR TITLE
feat: LogDebug 宏支持 DEBUG.txt 特性

### DIFF
--- a/src/MaaCore/Utils/Logger.hpp
+++ b/src/MaaCore/Utils/Logger.hpp
@@ -1050,7 +1050,7 @@ private:
     std::ostream m_of;
     std::size_t m_file_size = 0;
 
-    static utils::NullStreambuf null_buf;
+    static inline utils::NullStreambuf null_buf {};
     static inline std::ostream null_stream { &null_buf };
     const std::size_t MaxLogSize = 64LL * 1024 * 1024;
 };


### PR DESCRIPTION
## Summary by Sourcery

在非调试构建中，通过 `DEBUG.txt` 标记文件控制调试日志输出，并集中使用共享的空日志流。

Enhancements:
- 仅当存在 `DEBUG.txt` 文件时，在发布构建中启用类似 `LogDebug` 的调试输出。
- 优化启动崩溃日志，更清晰地标注 MaaCore 的基地址。
- 重构日志记录器，使用可由调试助手重复利用的共享空输出流。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Gate debug logging behind a DEBUG.txt marker file in non-debug builds and centralize use of a shared null log stream.

Enhancements:
- Enable LogDebug-style debug output in release builds only when a DEBUG.txt file is present.
- Refine the startup crash log to label the MaaCore base address more clearly.
- Refactor the logger to use a shared null output stream that can be reused by debug helpers.

</details>