### PR TITLE
perf: Stacktrace Linux 优化

### DIFF
--- a/src/MaaCore/Utils/ExceptionStacktrace.hpp
+++ b/src/MaaCore/Utils/ExceptionStacktrace.hpp
@@ -46,7 +46,7 @@ public:
         HMODULE hModule = NULL;
         BOOL ret = GetModuleHandleExA(
             GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
-            reinterpret_cast<LPCSTR>(reinterpret_cast<const void*>(&get_base_address)),
+            reinterpret_cast<LPCSTR>(&get_base_address),
             &hModule);
         if (!ret) {
             return 0;
@@ -100,7 +100,7 @@ public:
             unsigned long start_raw = 0;
             char perms[5] = { 0 };
             char pathbuf[PATH_MAX] = { 0 };
-            int matched = std::sscanf(line.c_str(), "%lx-%*lx %4s %*s %*s %*s %s", &start_raw, perms, pathbuf);
+            int matched = std::sscanf(line.c_str(), "%lx-%*lx %4s %*s %*s %*s %4095s", &start_raw, perms, pathbuf);
 
             if (matched < 2) { // 至少要有地址和权限
                 continue;


### PR DESCRIPTION
## Summary by Sourcery

改进跨平台的异常堆栈追踪基址检测，在 Windows 上更安全地获取模块句柄，并在 Linux 上实现更健壮的可执行文件映射解析。

Bug 修复：
- 在 Windows 上校验 `GetModuleHandleExA` 的返回结果，当无法获得模块句柄时返回安全的默认值。
- 在 Linux 上防范无效或缺失的 `dladdr` 结果，并在无法打开 `/proc/self/maps` 时返回安全的默认值。

增强功能：
- 加强 Linux 基址发现机制，优先使用 `dladdr`，然后扫描 `/proc/self/maps` 以选取当前二进制的可执行段，并在必要时使用合理的可执行段回退策略。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve cross-platform base address detection for exception stacktraces, with safer Windows module handle retrieval and more robust Linux executable mapping resolution.

Bug Fixes:
- Validate GetModuleHandleExA results on Windows and return a safe default when the module handle cannot be obtained.
- Guard against invalid or missing dladdr results on Linux and handle failure to open /proc/self/maps by returning a safe default.

Enhancements:
- Enhance Linux base address discovery by preferring dladdr, then scanning /proc/self/maps to select the executable segment of the current binary, with a reasonable executable-segment fallback.

</details>

Bug 修复：
- 通过验证 `GetModuleHandleExA` 的返回结果，防止在 Windows 上为堆栈追踪收集模块句柄时可能出现的失败或未定义行为。
- 通过优先使用 `dladdr`、验证其结果，并在解析 `/proc/self/maps` 失败时进行优雅降级，提高 Linux 上堆栈追踪基地址解析的可靠性。

功能增强：
- 通过扫描 `/proc/self/maps`，在 Linux 上增强堆栈追踪基地址发现逻辑，优先选择当前可执行文件的可执行段，并在必要时使用合理的回退方案。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

改进跨平台的异常堆栈追踪基址检测，在 Windows 上更安全地获取模块句柄，并在 Linux 上实现更健壮的可执行文件映射解析。

Bug 修复：
- 在 Windows 上校验 `GetModuleHandleExA` 的返回结果，当无法获得模块句柄时返回安全的默认值。
- 在 Linux 上防范无效或缺失的 `dladdr` 结果，并在无法打开 `/proc/self/maps` 时返回安全的默认值。

增强功能：
- 加强 Linux 基址发现机制，优先使用 `dladdr`，然后扫描 `/proc/self/maps` 以选取当前二进制的可执行段，并在必要时使用合理的可执行段回退策略。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve cross-platform base address detection for exception stacktraces, with safer Windows module handle retrieval and more robust Linux executable mapping resolution.

Bug Fixes:
- Validate GetModuleHandleExA results on Windows and return a safe default when the module handle cannot be obtained.
- Guard against invalid or missing dladdr results on Linux and handle failure to open /proc/self/maps by returning a safe default.

Enhancements:
- Enhance Linux base address discovery by preferring dladdr, then scanning /proc/self/maps to select the executable segment of the current binary, with a reasonable executable-segment fallback.

</details>

</details>