### PR TITLE
feat: 公招设置"自动使用加急许可"改用下拉框，支持永久保存选项

### DIFF
--- a/src/MaaWpfGui/Constants/ConfigurationKeys.cs
+++ b/src/MaaWpfGui/Constants/ConfigurationKeys.cs
@@ -177,6 +177,7 @@ public static class ConfigurationKeys
     public const string AutoRecruitFirstList = "AutoRecruit.AutoRecruitFirstList";
     public const string RefreshLevel3 = "AutoRecruit.RefreshLevel3";
     public const string ForceRefresh = "AutoRecruit.ForceRefresh";
+    public const string UseExpeditedMode = "AutoRecruit.UseExpeditedMode";
     public const string SelectExtraTags = "AutoRecruit.SelectExtraTags";
     public const string NotChooseLevel1 = "AutoRecruit.NotChooseLevel1";
     public const string RecruitChooseLevel3 = "AutoRecruit.ChooseLevel3";

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -1151,7 +1151,10 @@ Right-click to clear inactive jobs</system:String>
     <!--  AutoRecruitSettings  -->
     <system:String x:Key="AutoRefresh">Auto refresh 3★ Tags</system:String>
     <system:String x:Key="ForceRefresh">Continue trying to refresh Tags without recruitment permit</system:String>
-    <system:String x:Key="AutoUseExpedited">Auto use Expedited Plan*</system:String>
+    <system:String x:Key="AutoUseExpedited">Auto use expedited plan</system:String>
+    <system:String x:Key="UseExpeditedDisabled">Disabled</system:String>
+    <system:String x:Key="UseExpeditedOneTime">One-time use</system:String>
+    <system:String x:Key="UseExpeditedAlways">Always use (saved)</system:String>
     <system:String x:Key="Level3UseShortTime">Set 7:40 instead of 9:00 for 3★ Tags</system:String>
     <system:String x:Key="Level3UseShortTime2">Set 1:00 instead of 9:00 for 3★ Tags</system:String>
     <system:String x:Key="Level3UseShortTimeTip">Doesn't interfere with other ★ stars</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -1151,7 +1151,10 @@ C:\\leidian\\LDPlayer9
     <!--  自動募集設定  -->
     <system:String x:Key="AutoRefresh">星3タグを自動的に更新する</system:String>
     <system:String x:Key="ForceRefresh">採用不可でもタグの更新を行う</system:String>
-    <system:String x:Key="AutoUseExpedited">緊急招集票を自動的に使用*</system:String>
+    <system:String x:Key="AutoUseExpedited">緊急招集票を自動的に使用</system:String>
+    <system:String x:Key="UseExpeditedDisabled">無効</system:String>
+    <system:String x:Key="UseExpeditedOneTime">一度のみ使用</system:String>
+    <system:String x:Key="UseExpeditedAlways">常に使用（保存）</system:String>
     <system:String x:Key="Level3UseShortTime">星3タグを7:40に設定する</system:String>
     <system:String x:Key="Level3UseShortTime2">星3タグを1:00に設定する</system:String>
     <system:String x:Key="Level3UseShortTimeTip">他のレアリティには影響しない</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -1152,7 +1152,10 @@ C:\\leidian\\LDPlayer9
     <!--  AutoRecruitSettings  -->
     <system:String x:Key="AutoRefresh">★3 태그를 자동 새로고침하기</system:String>
     <system:String x:Key="ForceRefresh">모집없이 태그 새로고침 반복 시도</system:String>
-    <system:String x:Key="AutoUseExpedited">즉시 완료 허가증 자동 사용*</system:String>
+    <system:String x:Key="AutoUseExpedited">즉시 완료 허가증 자동 사용</system:String>
+    <system:String x:Key="UseExpeditedDisabled">비활성화</system:String>
+    <system:String x:Key="UseExpeditedOneTime">한 번만 사용</system:String>
+    <system:String x:Key="UseExpeditedAlways">항상 사용 (저장됨)</system:String>
     <system:String x:Key="Level3UseShortTime">★3 태그 9:00 대신 7:40 설정</system:String>
     <system:String x:Key="Level3UseShortTime2">★3 태그 9:00 대신 1:00 설정</system:String>
     <system:String x:Key="Level3UseShortTimeTip">다른 등급에는 적용되지 않습니다</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -1151,7 +1151,10 @@ C:\\leidian\\LDPlayer9。\n
     <!--  AutoRecruitSettings  -->
     <system:String x:Key="AutoRefresh">自动刷新 3 星 Tags</system:String>
     <system:String x:Key="ForceRefresh">无招聘许可时继续尝试刷新 Tags</system:String>
-    <system:String x:Key="AutoUseExpedited">自动使用加急许可*</system:String>
+    <system:String x:Key="AutoUseExpedited">自动使用加急许可</system:String>
+    <system:String x:Key="UseExpeditedDisabled">禁用</system:String>
+    <system:String x:Key="UseExpeditedOneTime">仅本次使用</system:String>
+    <system:String x:Key="UseExpeditedAlways">保持开启</system:String>
     <system:String x:Key="Level3UseShortTime">3 星设置 7:40 而非 9:00</system:String>
     <system:String x:Key="Level3UseShortTime2">3 星设置 1:00 而非 9:00</system:String>
     <system:String x:Key="Level3UseShortTimeTip">不影响其他星级 Tags</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -1152,7 +1152,10 @@ C:\\leidian\\LDPlayer9。\n
     <!--  AutoRecruitSettings  -->
     <system:String x:Key="AutoRefresh">自動刷新 3 星 Tags</system:String>
     <system:String x:Key="ForceRefresh">無招募許可時繼續嘗試刷新 Tags</system:String>
-    <system:String x:Key="AutoUseExpedited">自動使用加急許可*</system:String>
+    <system:String x:Key="AutoUseExpedited">自動使用加急許可</system:String>
+    <system:String x:Key="UseExpeditedDisabled">禁用</system:String>
+    <system:String x:Key="UseExpeditedOneTime">僅本次使用</system:String>
+    <system:String x:Key="UseExpeditedAlways">保持開啟</system:String>
     <system:String x:Key="Level3UseShortTime">3 星設定 7:40 而非 9:00</system:String>
     <system:String x:Key="Level3UseShortTime2">3 星設定 1:00 而非 9:00</system:String>
     <system:String x:Key="Level3UseShortTimeTip">不影響其他星級 Tags</system:String>

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/RecruitSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/RecruitSettingsUserControlModel.cs
@@ -137,6 +137,7 @@ public class RecruitSettingsUserControlModel : TaskViewModel
 
     private ExpeditedMode _expeditedMode =
         int.TryParse(ConfigurationHelper.GetValue(ConfigurationKeys.UseExpeditedMode, "0"), out var outMode)
+        && Enum.IsDefined(typeof(ExpeditedMode), outMode)
             ? (ExpeditedMode)outMode
             : ExpeditedMode.Disabled;
 
@@ -151,6 +152,13 @@ public class RecruitSettingsUserControlModel : TaskViewModel
         set
         {
             var mode = (ExpeditedMode)value;
+
+            // Avoid unnecessary notifications and config writes when the value is unchanged.
+            if (mode == _expeditedMode)
+            {
+                return;
+            }
+
             SetAndNotify(ref _expeditedMode, mode);
 
             // Always save to config: mode 2 saves "2", mode 0/1 save "0"
@@ -474,7 +482,7 @@ public class RecruitSettingsUserControlModel : TaskViewModel
         Disabled = 0,
 
         /// <summary>
-        /// 仅本次使用 - Use expedited plans for this session only (resets on exit)
+        /// 仅本次使用 - Use expedited plans for this session only (resets after task completes)
         /// </summary>
         OneTime = 1,
 

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/RecruitSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/RecruitSettingsUserControlModel.cs
@@ -47,6 +47,16 @@ public class RecruitSettingsUserControlModel : TaskViewModel
             new() { Display = LocalizationHelper.GetString("SelectExtraOnlyRareTags"), Value = "2" },
         ];
 
+    /// <summary>
+    /// Gets the list of use expedited mode options.
+    /// </summary>
+    public List<CombinedData> UseExpeditedModeList { get; } =
+        [
+            new() { Display = LocalizationHelper.GetString("UseExpeditedDisabled"), Value = "0" },
+            new() { Display = LocalizationHelper.GetString("UseExpeditedOneTime"), Value = "1" },
+            new() { Display = LocalizationHelper.GetString("UseExpeditedAlways"), Value = "2" },
+        ];
+
     private static readonly List<string> _autoRecruitTagList = ["近战位", "远程位", "先锋干员", "近卫干员", "狙击干员", "重装干员", "医疗干员", "辅助干员", "术师干员", "治疗", "费用回复", "输出", "生存", "群攻", "防护", "减速",];
 
     private static readonly Lazy<List<CombinedData>> _autoRecruitTagShowList = new(() =>
@@ -125,36 +135,48 @@ public class RecruitSettingsUserControlModel : TaskViewModel
         }
     }
 
-    private bool? _useExpeditedWithNull = false;
+    private ExpeditedMode _expeditedMode =
+        int.TryParse(ConfigurationHelper.GetValue(ConfigurationKeys.UseExpeditedMode, "0"), out var outMode)
+            ? (ExpeditedMode)outMode
+            : ExpeditedMode.Disabled;
 
-    public bool? UseExpeditedWithNull
+    /// <summary>
+    /// Gets or sets the use expedited mode as an integer for XAML binding.
+    /// Maps to <see cref="ExpeditedMode"/> enum internally.
+    /// 0 = Disabled, 1 = One-time (resets after task), 2 = Always (saved to config)
+    /// </summary>
+    public int UseExpeditedMode
     {
-        get => _useExpeditedWithNull;
+        get => (int)_expeditedMode;
         set
         {
-            if (value == true)
-            {
-                value = null;
-            }
+            var mode = (ExpeditedMode)value;
+            SetAndNotify(ref _expeditedMode, mode);
 
-            SetAndNotify(ref _useExpeditedWithNull, value);
+            // Always save to config: mode 2 saves "2", mode 0/1 save "0"
+            // Mode 1 (one-time) is ephemeral: runs this session, but config shows "0" for next restart
+            ConfigurationHelper.SetValue(
+                ConfigurationKeys.UseExpeditedMode,
+                mode == ExpeditedMode.Always ? "2" : "0");
         }
     }
 
     /// <summary>
     /// Gets or sets a value indicating whether to use expedited.
+    /// Used for backward compatibility with Serialize method.
     /// </summary>
     public bool UseExpedited
     {
-        get => UseExpeditedWithNull != false;
-        set => UseExpeditedWithNull = value;
+        get => UseExpeditedMode > (int)ExpeditedMode.Disabled;
+        set => UseExpeditedMode = value ? (int)ExpeditedMode.OneTime : (int)ExpeditedMode.Disabled;
     }
 
     public void ResetRecruitVariables()
     {
-        if (UseExpeditedWithNull == null)
+        // Reset one-time mode to disabled after task completes
+        if (UseExpeditedMode == (int)ExpeditedMode.OneTime)
         {
-            UseExpedited = false;
+            UseExpeditedMode = (int)ExpeditedMode.Disabled;
         }
     }
 
@@ -439,5 +461,26 @@ public class RecruitSettingsUserControlModel : TaskViewModel
         }
 
         return task.Serialize();
+    }
+
+    /// <summary>
+    /// Expedited plan usage mode for recruitment
+    /// </summary>
+    public enum ExpeditedMode
+    {
+        /// <summary>
+        /// 禁用 - Never use expedited plans
+        /// </summary>
+        Disabled = 0,
+
+        /// <summary>
+        /// 仅本次使用 - Use expedited plans for this session only (resets on exit)
+        /// </summary>
+        OneTime = 1,
+
+        /// <summary>
+        /// 保持开启 - Always use expedited plans (persists to config)
+        /// </summary>
+        Always = 2,
     }
 }

--- a/src/MaaWpfGui/Views/UserControl/TaskQueue/RecruitSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/TaskQueue/RecruitSettingsUserControl.xaml
@@ -21,10 +21,13 @@
     mc:Ignorable="d">
     <StackPanel>
         <StackPanel Visibility="{c:Binding !EnableAdvancedSettings, Source={x:Static setting:TaskQueueViewModel.TaskSettingVisibilities}}">
-            <StackPanel Margin="0,10" Orientation="Horizontal">
-                <CheckBox Content="{DynamicResource AutoUseExpedited}" IsChecked="{Binding UseExpeditedWithNull}" />
-                <controls:TooltipBlock TooltipText="{DynamicResource CheckBoxesNotSaved}" />
-            </StackPanel>
+            <hc:ComboBox
+                Margin="0,10"
+                hc:InfoElement.Title="{DynamicResource AutoUseExpedited}"
+                DisplayMemberPath="Display"
+                ItemsSource="{Binding UseExpeditedModeList}"
+                SelectedValue="{Binding UseExpeditedMode}"
+                SelectedValuePath="Value" />
 
             <hc:NumericUpDown
                 Margin="0,5"


### PR DESCRIPTION
**Closes** #3432
**Relates to** #12157, #11332, #4960, #1500, #850

### 变更摘要
将公招设置中的“自动使用加急许可”由原本的勾选框重构为下拉框，提供三种明确模式，解决交互歧义并满足希望保持开启的用户需求。

### 详细改动

**UI 交互变更**：
    * **Before**: CheckBox (仅支持 开/关，且“是否保存”逻辑不明确)。
    * **After**: ComboBox，包含三个选项：
        1.  **禁用** (Disabled) - 默认。
        2.  **仅本次使用** (One-time) - 任务完成后重置为禁用，且**不写入**配置文件（防止异常退出导致配置残留）。
        3.  **永久开启** (Always) - 写入配置文件，重启后依然生效。

### 设计思路

此次改动主要为了解决以下 UX 和功能痛点：
1.  **消除歧义**：旧版 CheckBox 让用户困惑“这个勾选是单次生效还是永久生效？”（Issue #12157）。下拉框将两种意图明确拆分。
2.  **响应社区需求**：持续有Issue反馈希望保持开启加急许可，代表功能至少有一小批的用户需求。
3.  **交互成本考量**：考虑3组用户群体
A组：不常用加急许可功能，偶尔开启一次清仓（预期主要群体）-> 不影响体验，虽一步操作变为两步，但此操作频率低
B组：常用加急许可功能，希望通过稍微用几次许可来加速完成日常任务 -> 提升体验，不需要经常点击了
C组：偶尔有点头脑蒙蒙的，不清楚方块填充和打勾的区别，也不喜欢看问号的注释 -> 提升体验，下拉框更易于理解

### 截图
<img width="263" height="146" alt="image" src="https://github.com/user-attachments/assets/e38d04e0-48ca-4e9a-bd7a-6114f07879b4" />
<img width="272" height="185" alt="image" src="https://github.com/user-attachments/assets/8bc9e981-399e-4ec2-8afc-c97d4156ff91" />


## Summary by Sourcery

通过将原有的传统复选框替换为多模式选择，细化“公开招募加急方案”的设置，以区分一次性使用和持久使用，同时保持对现有配置的向后兼容性。

新功能：
- 为加急方案的使用引入三种模式配置：禁用、每个会话一次性使用，以及带持久化的始终启用模式。

增强改进：
- 增加专用的配置键和基于枚举的模型属性，以支持新的加急使用模式，并确保“一次性模式”在使用后会自动重置。
- 更新本地化资源和招募设置界面绑定，以在所有支持的语言中一致展示新的加急使用选项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine public recruitment expedited plan settings by replacing the legacy checkbox with a multi-mode selection that distinguishes one-time and persistent usage, while preserving backward compatibility with existing configuration.

New Features:
- Introduce a three-mode configuration for using expedited plans: disabled, one-time per session, and always-on with persistence.

Enhancements:
- Add a dedicated configuration key and enum-backed model property to support the new expedited usage modes and ensure one-time mode resets automatically after use.
- Update localization resources and recruitment settings UI bindings to present the new expedited usage options consistently across supported languages.

</details>