### PR TITLE
fix: fix nightly ota dotnet build

### DIFF
--- a/.github/workflows/release-nightly-ota.yml
+++ b/.github/workflows/release-nightly-ota.yml
@@ -233,7 +233,7 @@ jobs:
 
       - name: Publish WPF GUI
         run: |
-          dotnet publish src/MaaWpfGui/MaaWpfGui.csproj -c Release -o install
+          dotnet publish src/MaaWpfGui/MaaWpfGui.csproj -c Release -p:Platform=${{ matrix.arch == 'arm64' && 'ARM64' || 'x64' }} -o install
 
       - name: Collect PDB files
         run: |


### PR DESCRIPTION
https://github.com/MaaAssistantArknights/MaaAssistantArknights/actions/runs/20080000226
根据ci报错，dotnet publish 没有设置 target platform 会默认使用 Any_CPU 而不是使用 x64，导致后续生成错误

## Summary by Sourcery

Build:
- 将夜间 OTA .NET 发布步骤配置为根据矩阵中的体系结构（ARM64 或 x64）传递 Platform 属性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Set the nightly OTA .NET publish step to pass the Platform property (ARM64 or x64) according to the matrix architecture.

</details>