### PR TITLE
docs: 更新文档中的 .NET 版本至 10

### DIFF
--- a/docs/en-us/manual/device/linux.md
+++ b/docs/en-us/manual/device/linux.md
@@ -19,7 +19,7 @@ The MAA WPF GUI can currently be run through Wine.
 
 #### Installation Steps
 
-1. Go to the [.NET download page](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) and download/install the Windows version of .NET **Desktop** Runtime.
+1. Go to the [.NET download page](https://dotnet.microsoft.com/en-us/download/dotnet/10.0) and download/install the Windows version of .NET **Desktop** Runtime.
 
 2. Download the Windows version of MAA, extract it, and run `wine MAA.exe`.
 

--- a/docs/en-us/manual/faq.md
+++ b/docs/en-us/manual/faq.md
@@ -15,13 +15,13 @@ The most common issue is related to runtime libraries, and many people keep aski
 Please run `DependencySetup_依赖库安装.bat` in the MAA directory, or execute the following command in terminal:
 
 ```sh
-winget install "Microsoft.VCRedist.2015+.x64" --override "/repair /passive /norestart" --force --uninstall-previous --accept-package-agreements && winget install "Microsoft.DotNet.DesktopRuntime.8" --override "/repair /passive /norestart" --force --uninstall-previous --accept-package-agreements
+winget install "Microsoft.VCRedist.2015+.x64" --override "/repair /passive /norestart" --force --uninstall-previous --accept-package-agreements && winget install "Microsoft.DotNet.DesktopRuntime.10" --override "/repair /passive /norestart" --force --uninstall-previous --accept-package-agreements
 ```
 
 Or manually download and install these <u>**two**</u> runtime libraries to solve the problem:
 
 - [Visual C++ Redistributable](https://aka.ms/vs/17/release/vc_redist.x64.exe)
-- [.NET Desktop Runtime 8](https://aka.ms/dotnet/8.0/windowsdesktop-runtime-win-x64.exe)
+- [.NET Desktop Runtime 10](https://aka.ms/dotnet/10.0/windowsdesktop-runtime-win-x64.exe)
 
 :::
 
@@ -51,7 +51,7 @@ For Windows N/KN (European/Korean versions), you also need to install the [Media
 
 #### Windows 7
 
-.NET 8 doesn't support Windows 7/8/8.1 systems<sup>[source](https://github.com/dotnet/core/issues/7556)</sup>, so MAA no longer supports them either. The last usable .NET 8 version is [`v5.4.0-beta.1.d035.gd2e5001e7`](https://github.com/MaaAssistantArknights/MaaRelease/releases/tag/v5.4.0-beta.1.d035.gd2e5001e7); the last usable .NET 4.8 version is [`v4.28.8`](https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases/tag/v4.28.8). Self-compilation feasibility remains undetermined.
+.NET 10 doesn't support Windows 7/8/8.1 systems<sup>[source](https://github.com/dotnet/core/issues/7556)</sup>, so MAA no longer supports them either. The last usable .NET 8 version is [`v5.4.0-beta.1.d035.gd2e5001e7`](https://github.com/MaaAssistantArknights/MaaRelease/releases/tag/v5.4.0-beta.1.d035.gd2e5001e7); the last usable .NET 4.8 version is [`v4.28.8`](https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases/tag/v4.28.8). Self-compilation feasibility remains undetermined.
 
 For Windows 7, before installing the two runtime libraries mentioned above, check if these patches are installed:
 

--- a/docs/en-us/manual/newbie.md
+++ b/docs/en-us/manual/newbie.md
@@ -25,7 +25,7 @@ Quick start guide!
 
 4. Install runtime libraries
 
-   MAA requires VCRedist x64 and .NET 8. Please run `DependencySetup_依赖库安装.bat` in the MAA directory to install them.
+   MAA requires VCRedist x64 and .NET 10. Please run `DependencySetup_依赖库安装.bat` in the MAA directory to install them.
 
    For more information, please refer to the pinned section in [FAQ](./faq.md).
 

--- a/docs/ja-jp/manual/faq.md
+++ b/docs/ja-jp/manual/faq.md
@@ -15,13 +15,13 @@ MAAがアップデート後に動作しなくなった場合、またはエラ�
 MAAディレクトリ内の `DependencySetup_依赖库安装.bat` を実行するか、以下のコマンドを端末で実行するか、
 
 ```sh
-winget install "Microsoft.VCRedist.2015+.x64" --override "/repair /passive /norestart" --force --uninstall-previous --accept-package-agreements && winget install "Microsoft.DotNet.DesktopRuntime.8" --override "/repair /passive /norestart" --force --uninstall-previous --accept-package-agreements
+winget install "Microsoft.VCRedist.2015+.x64" --override "/repair /passive /norestart" --force --uninstall-previous --accept-package-agreements && winget install "Microsoft.DotNet.DesktopRuntime.10" --override "/repair /passive /norestart" --force --uninstall-previous --accept-package-agreements
 ```
 
 以下の<u>**2つ**</u>のランタイムライブラリを手動でダウンロードしてインストールして問題を解決してください。
 
 - [Visual C++ 再頒布可能パッケージ](https://aka.ms/vs/17/release/vc_redist.x64.exe)
-- [.NET デスクトップランタイム 8](https://aka.ms/dotnet/8.0/windowsdesktop-runtime-win-x64.exe)
+- [.NET デスクトップランタイム 10](https://aka.ms/dotnet/10.0/windowsdesktop-runtime-win-x64.exe)
 
 :::
 
@@ -51,7 +51,7 @@ Windows N/KN（ヨーロッパ/韓国）の場合、[メディア機能パック
 
 #### Windows 7 関連
 
-.NET 8 は Windows 7 / 8 / 8.1 システムをサポートしていないため<sup>[ソース](https://github.com/dotnet/core/issues/7556)</sup>、MAA も同様にサポートしていません。最後に利用可能な .NET 8 バージョンは [`v5.4.0-beta.1.d035.gd2e5001e7`](https://github.com/MaaAssistantArknights/MaaRelease/releases/tag/v5.4.0-beta.1.d035.gd2e5001e7) です。最後に利用可能な .NET 4.8 バージョンは [`v4.28.8`](https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases/tag/v4.28.8) です。自己コンパイルの実現可能性はまだ確認されていません。
+.NET 10 は Windows 7 / 8 / 8.1 システムをサポートしていないため<sup>[ソース](https://github.com/dotnet/core/issues/7556)</sup>、MAA も同様にサポートしていません。最後に利用可能な .NET 8 バージョンは [`v5.4.0-beta.1.d035.gd2e5001e7`](https://github.com/MaaAssistantArknights/MaaRelease/releases/tag/v5.4.0-beta.1.d035.gd2e5001e7) です。最後に利用可能な .NET 4.8 バージョンは [`v4.28.8`](https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases/tag/v4.28.8) です。自己コンパイルの実現可能性はまだ確認されていません。
 
 Windows 7 の場合、上記の 2 つのランタイムライブラリをインストールする前に、以下のパッチがインストールされているかどうかを確認する必要があります：
 

--- a/docs/ja-jp/manual/newbie.md
+++ b/docs/ja-jp/manual/newbie.md
@@ -23,7 +23,7 @@ icon: ri:guide-fill
 
 4. ランタイムライブラリをインストールする
 
-   MAAはVCRedist x64と.NET 8が必要です。MAAディレクトリ内の `DependencySetup_依赖库安装.bat` を実行してインストールしてください。
+   MAAはVCRedist x64と.NET 10が必要です。MAAディレクトリ内の `DependencySetup_依赖库安装.bat` を実行してインストールしてください。
 
 5. エミュレータのサポートを確認
 

--- a/docs/ko-kr/manual/device/linux.md
+++ b/docs/ko-kr/manual/device/linux.md
@@ -19,7 +19,7 @@ MAA WPF GUI는 현재 Wine을 통해 실행할 수 있습니다.
 
 #### 설치 단계
 
-1. [.NET 릴리스 페이지](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)에서 Windows용 .NET **데스크톱** 런타임을 다운로드하고 설치합니다.
+1. [.NET 릴리스 페이지](https://dotnet.microsoft.com/en-us/download/dotnet/10.0)에서 Windows용 .NET **데스크톱** 런타임을 다운로드하고 설치합니다.
 
 2. Windows용 MAA를 다운로드하고 압축을 푼 후 `wine MAA.exe`를 실행합니다.
 

--- a/docs/ko-kr/manual/faq.md
+++ b/docs/ko-kr/manual/faq.md
@@ -15,13 +15,13 @@ MAA가 업데이트 후 실행되지 않거나 MAA의 오류 창을 통해 여�
 MAA 디렉토리에서 `DependencySetup_依赖库安装.bat`를 실행하거나, 터미널에서 아래 명령을 실행하거나,
 
 ```sh
-winget install "Microsoft.VCRedist.2015+.x64" --override "/repair /passive /norestart" --force --uninstall-previous --accept-package-agreements && winget install "Microsoft.DotNet.DesktopRuntime.8" --override "/repair /passive /norestart" --force --uninstall-previous --accept-package-agreements
+winget install "Microsoft.VCRedist.2015+.x64" --override "/repair /passive /norestart" --force --uninstall-previous --accept-package-agreements && winget install "Microsoft.DotNet.DesktopRuntime.10" --override "/repair /passive /norestart" --force --uninstall-previous --accept-package-agreements
 ```
 
 아래<u>**두 개**</u>의 실행 라이브러리를 수동으로 다운로드하여 설치하여 문제를 해결하세요.
 
 - [Visual C++ 재배포 가능 패키지](https://aka.ms/vs/17/release/vc_redist.x64.exe)
-- [.NET 데스크톱 런타임 8](https://aka.ms/dotnet/8.0/windowsdesktop-runtime-win-x64.exe)
+- [.NET 데스크톱 런타임 10](https://aka.ms/dotnet/10.0/windowsdesktop-runtime-win-x64.exe)
 
 :::
 
@@ -43,7 +43,7 @@ Windows 8/8.1/10/11 N/KN(유럽/한국) 버전을 사용하는 경우, [미디�
 
 #### Windows 7 관련
 
-.NET 8은 Windows 7 / 8 / 8.1 시스템을 지원하지 않으므로<sup>[출처](https://github.com/dotnet/core/issues/7556)</sup>, MAA도 더 이상 지원하지 않습니다. 마지막으로 사용 가능한 .NET 8 버전은 [`v5.4.0-beta.1.d035.gd2e5001e7`](https://github.com/MaaAssistantArknights/MaaRelease/releases/tag/v5.4.0-beta.1.d035.gd2e5001e7)입니다. 마지막으로 사용 가능한 .NET 4.8 버전은 [`v4.28.8`](https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases/tag/v4.28.8)입니다. 자체 컴파일의 실현 가능성은 아직 확인되지 않았습니다.
+.NET 10은 Windows 7 / 8 / 8.1 시스템을 지원하지 않으므로<sup>[출처](https://github.com/dotnet/core/issues/7556)</sup>, MAA도 더 이상 지원하지 않습니다. 마지막으로 사용 가능한 .NET 8 버전은 [`v5.4.0-beta.1.d035.gd2e5001e7`](https://github.com/MaaAssistantArknights/MaaRelease/releases/tag/v5.4.0-beta.1.d035.gd2e5001e7)입니다. 마지막으로 사용 가능한 .NET 4.8 버전은 [`v4.28.8`](https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases/tag/v4.28.8)입니다. 자체 컴파일의 실현 가능성은 아직 확인되지 않았습니다.
 
 Windows 7의 경우, 위에서 언급한 두 개의 런타임 라이브러리를 설치하기 전에 다음 패치가 설치되어 있는지 확인해야 합니다:
 

--- a/docs/ko-kr/manual/newbie.md
+++ b/docs/ko-kr/manual/newbie.md
@@ -25,7 +25,7 @@ icon: ri:guide-fill
 
 4. 런타임 설치
 
-   MAA는 VCRedist x64 및 .NET 8이 필요합니다. MAA 디렉토리의 `DependencySetup_依赖库安装.bat`를 실행하여 설치하세요.
+   MAA는 VCRedist x64 및 .NET 10이 필요합니다. MAA 디렉토리의 `DependencySetup_依赖库安装.bat`를 실행하여 설치하세요.
 
    자세한 정보는 [FAQ](./faq.md#가능성-2-런타임-문제)를 참조하세요.
 

--- a/docs/zh-cn/manual/device/linux.md
+++ b/docs/zh-cn/manual/device/linux.md
@@ -19,7 +19,7 @@ MAA WPF GUI 当前可以通过 Wine 运行。
 
 #### 安装步骤
 
-1. 前往 [.NET 发布页](https://dotnet.microsoft.com/en-us/download/dotnet/8.0)下载并安装 Windows 版 .NET **桌面**运行时。
+1. 前往 [.NET 发布页](https://dotnet.microsoft.com/en-us/download/dotnet/10.0)下载并安装 Windows 版 .NET **桌面**运行时。
 
 2. 下载 Windows 版 MAA，解压后运行 `wine MAA.exe`。
 

--- a/docs/zh-cn/manual/faq.md
+++ b/docs/zh-cn/manual/faq.md
@@ -15,13 +15,13 @@ icon: ph:question-fill
 请运行 MAA 目录下的 `DependencySetup_依赖库安装.bat`，或在终端中运行以下命令，
 
 ```sh
-winget install "Microsoft.VCRedist.2015+.x64" --override "/repair /passive /norestart" --force --uninstall-previous --accept-package-agreements && winget install "Microsoft.DotNet.DesktopRuntime.8" --override "/repair /passive /norestart" --force --uninstall-previous --accept-package-agreements
+winget install "Microsoft.VCRedist.2015+.x64" --override "/repair /passive /norestart" --force --uninstall-previous --accept-package-agreements && winget install "Microsoft.DotNet.DesktopRuntime.10" --override "/repair /passive /norestart" --force --uninstall-previous --accept-package-agreements
 ```
 
 或手动下载并安装以下<u>**两个**</u>运行库来解决问题。
 
 - [Visual C++ 可再发行程序包](https://aka.ms/vs/17/release/vc_redist.x64.exe)
-- [.NET 桌面运行时 8](https://aka.ms/dotnet/8.0/windowsdesktop-runtime-win-x64.exe)
+- [.NET 桌面运行时 10](https://aka.ms/dotnet/10.0/windowsdesktop-runtime-win-x64.exe)
 
 :::
 
@@ -51,7 +51,7 @@ winget install "Microsoft.VCRedist.2015+.x64" --override "/repair /passive /nore
 
 #### Windows 7
 
-.NET 8 不支持 Windows 7 / 8 / 8.1 系统<sup>[源](https://github.com/dotnet/core/issues/7556)</sup>，所以 MAA 也同样不再支持。最后一个可用的 .NET 8 版本为 [`v5.4.0-beta.1.d035.gd2e5001e7`](https://github.com/MaaAssistantArknights/MaaRelease/releases/tag/v5.4.0-beta.1.d035.gd2e5001e7)；最后一个可用的 .NET 4.8 版本为 [`v4.28.8`](https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases/tag/v4.28.8)。尚未确定自行编译的可行性。
+.NET 10 不支持 Windows 7 / 8 / 8.1 系统<sup>[源](https://github.com/dotnet/core/issues/7556)</sup>，所以 MAA 也同样不再支持。最后一个可用的 .NET 8 版本为 [`v5.4.0-beta.1.d035.gd2e5001e7`](https://github.com/MaaAssistantArknights/MaaRelease/releases/tag/v5.4.0-beta.1.d035.gd2e5001e7)；最后一个可用的 .NET 4.8 版本为 [`v4.28.8`](https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases/tag/v4.28.8)。尚未确定自行编译的可行性。
 
 对于 Windows 7，在安装上文提到的两个运行库之前，还需检查以下补丁是否已安装：
 

--- a/docs/zh-cn/manual/newbie.md
+++ b/docs/zh-cn/manual/newbie.md
@@ -27,7 +27,7 @@ icon: ri:guide-fill
 
 4. 安装运行库
 
-   MAA 需要 VCRedist x64 和 .NET 8，请运行 MAA 目录下的 `DependencySetup_依赖库安装.bat` 以安装。
+   MAA 需要 VCRedist x64 和 .NET 10，请运行 MAA 目录下的 `DependencySetup_依赖库安装.bat` 以安装。
 
    更多信息请参考[常见问题](./faq.md)置顶。
 

--- a/docs/zh-tw/manual/faq.md
+++ b/docs/zh-tw/manual/faq.md
@@ -15,13 +15,13 @@ icon: ph:question-fill
 請運行 MAA 目錄下的 `DependencySetup_依赖库安装.bat`，或者在終端中運行以下命令，
 
 ```sh
-winget install "Microsoft.VCRedist.2015+.x64" --override "/repair /passive /norestart" --force --uninstall-previous --accept-package-agreements && winget install "Microsoft.DotNet.DesktopRuntime.8" --override "/repair /passive /norestart" --force --uninstall-previous --accept-package-agreements
+winget install "Microsoft.VCRedist.2015+.x64" --override "/repair /passive /norestart" --force --uninstall-previous --accept-package-agreements && winget install "Microsoft.DotNet.DesktopRuntime.10" --override "/repair /passive /norestart" --force --uninstall-previous --accept-package-agreements
 ```
 
 或者手動下載並安裝以下<u>**兩個**</u>運行庫來解決問題。
 
 - [Visual C++ 可再發行程序包](https://aka.ms/vs/17/release/vc_redist.x64.exe)
-- [.NET 桌面運行時 8](https://aka.ms/dotnet/8.0/windowsdesktop-runtime-win-x64.exe)
+- [.NET 桌面運行時 10](https://aka.ms/dotnet/10.0/windowsdesktop-runtime-win-x64.exe)
 
 :::
 
@@ -51,7 +51,7 @@ winget install "Microsoft.VCRedist.2015+.x64" --override "/repair /passive /nore
 
 #### Windows 7
 
-.NET 8 不支持 Windows 7 / 8 / 8.1 系統<sup>[源](https://github.com/dotnet/core/issues/7556)</sup>，所以 MAA 也同樣不再支持。最後一個可用的 .NET 8 版本為 [`v5.4.0-beta.1.d035.gd2e5001e7`](https://github.com/MaaAssistantArknights/MaaRelease/releases/tag/v5.4.0-beta.1.d035.gd2e5001e7)；最後一個可用的 .NET 4.8 版本為 [`v4.28.8`](https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases/tag/v4.28.8)。尚未確定自行編譯的可行性。
+.NET 10 不支持 Windows 7 / 8 / 8.1 系統<sup>[源](https://github.com/dotnet/core/issues/7556)</sup>，所以 MAA 也同樣不再支持。最後一個可用的 .NET 8 版本為 [`v5.4.0-beta.1.d035.gd2e5001e7`](https://github.com/MaaAssistantArknights/MaaRelease/releases/tag/v5.4.0-beta.1.d035.gd2e5001e7)；最後一個可用的 .NET 4.8 版本為 [`v4.28.8`](https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases/tag/v4.28.8)。尚未確定自行編譯的可行性。
 
 對於 Windows 7，在安裝上文提到的兩個運行庫之前，還需檢查以下補丁是否已安裝：
 

--- a/docs/zh-tw/manual/newbie.md
+++ b/docs/zh-tw/manual/newbie.md
@@ -25,7 +25,7 @@ icon: ri:guide-fill
 
 4. 安裝運行庫
 
-   MAA 需要 VCRedist x64 和 .NET 8，請運行 MAA 目錄下的 `DependencySetup_依赖库安装.bat` 來安裝。
+   MAA 需要 VCRedist x64 和 .NET 10，請運行 MAA 目錄下的 `DependencySetup_依赖库安装.bat` 來安裝。
 
    更多信息參考[常見問題](faq.md#可能性-2--執行庫問題)。
 


### PR DESCRIPTION
## Summary by Sourcery

更新文档以反映在所有受支持的平台和语言上，从 .NET 8 迁移到 .NET 10 的变更。

Documentation:
- 在所有语言中刷新 FAQ 和新手指南，使其引用 .NET 10 桌面运行时，包括安装命令和下载链接。
- 明确说明 .NET 10（而非 .NET 8）不再支持 Windows 7/8/8.1，同时保留关于最后兼容的旧版的说明。
- 更新 Linux 下使用 Wine 的设置说明，使其使用 .NET 10 桌面运行时的下载页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update documentation to reflect migration from .NET 8 to .NET 10 across supported platforms and languages.

Documentation:
- Refresh FAQ and newbie guides in all languages to reference .NET 10 desktop runtime, including installation commands and download links.
- Clarify that .NET 10 (instead of .NET 8) does not support Windows 7/8/8.1 while keeping notes about the last compatible legacy versions.
- Update Linux-on-Wine setup instructions to use the .NET 10 desktop runtime download page.

</details>