### PR TITLE
fix: 去除路径左右的空格与控制字符

### DIFF
--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/GameSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/GameSettingsUserControlModel.cs
@@ -15,8 +15,8 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.Threading.Tasks;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using MaaWpfGui.Constants;
 using MaaWpfGui.Helper;
 using MaaWpfGui.States;


### PR DESCRIPTION
#15076

## 由 Sourcery 提供的总结

错误修复：
- 在游戏设置中检查和执行脚本之前，通过移除脚本路径开头和结尾的空白字符及控制字符来规范化脚本路径。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Normalize script path by removing leading/trailing whitespace and control characters before checking and executing it in game settings.

</details>