### PR TITLE
fix: SendClues for Yostar server

### DIFF
--- a/resource/global/YoStarEN/resource/tasks/tasks.json
+++ b/resource/global/YoStarEN/resource/tasks/tasks.json
@@ -1124,6 +1124,10 @@
     "UnlockClues": {
         "templThreshold": 0.85
     },
+    "SendClues": {
+        "doc": "Remove this after 'Quickly place clues' and 'One-tap send duplicate clues' features are added (#14966)",
+        "roi": [1160, 350, 80, 80]
+    },
     "InfrastTrainingIdle": {
         "text": ["Idle", "ldle"],
         "roi": [326, 637, 165, 41]

--- a/resource/global/YoStarJP/resource/tasks/tasks.json
+++ b/resource/global/YoStarJP/resource/tasks/tasks.json
@@ -1062,6 +1062,10 @@
     "InfrastEnterOperList": {
         "text": ["体力", "休憩中", "仕事中", "配属"]
     },
+    "SendClues": {
+        "doc": "Remove this after 'Quickly place clues' and 'One-tap send duplicate clues' are added (#14966)",
+        "roi": [1160, 350, 80, 80]
+    },
     "InfrastTrainingIdle": {
         "text": ["待機中"],
         "roi": [325, 637, 180, 50]

--- a/resource/global/YoStarKR/resource/tasks/tasks.json
+++ b/resource/global/YoStarKR/resource/tasks/tasks.json
@@ -1189,6 +1189,10 @@
     "InfrastClueSelfFull": {
         "text": ["도달", "불가", "최대치"]
     },
+    "SendClues": {
+        "doc": "Remove this after 'Quickly place clues' and 'One-tap send duplicate clues' are added (#14966)",
+        "roi": [1160, 350, 80, 80]
+    },
     "InfrastTrainingIdle": {
         "text": ["미사용중"],
         "roi": [380, 645, 135, 35]

--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -3196,7 +3196,7 @@
     },
     "SendClues": {
         "action": "ClickSelf",
-        "roi": [1160, 320, 80, 100],
+        "roi": [1160, 320, 80, 90],
         "maskRange": [1, 255],
         "postDelay": 1000,
         "next": ["InfrastClueQuickSendDuplicates", "SelectClue", "CloseSendClue"]


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 调整 YoStar EN/JP/KR 任务配置文件中的任务定义，以修复这些服务器上 `SendClues` 处理方式的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Adjust task definitions in YoStar EN/JP/KR task configuration files to fix SendClues handling on those servers.

</details>