### PR TITLE
chore: 更新 macos.cmake

### DIFF
--- a/cmake/macos.cmake
+++ b/cmake/macos.cmake
@@ -1,5 +1,6 @@
 if (BUILD_XCFRAMEWORK)
-    file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/xcframework)
+    set(XCFRAMEWORK_DIR "${CMAKE_BINARY_DIR}/xcframework")
+    file(MAKE_DIRECTORY ${XCFRAMEWORK_DIR})
 
     # Macro to find a unique library file
     macro(find_unique_library lib_name glob_pattern output_var)
@@ -17,64 +18,64 @@ if (BUILD_XCFRAMEWORK)
         endif()
     endmacro()
 
-    add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/xcframework/MaaCore.xcframework
-        COMMAND ${CMAKE_COMMAND} -E rm -rf "${CMAKE_BINARY_DIR}/xcframework/MaaCore.xcframework"
+    add_custom_command(OUTPUT ${XCFRAMEWORK_DIR}/MaaCore.xcframework
+        COMMAND ${CMAKE_COMMAND} -E rm -rf "${XCFRAMEWORK_DIR}/MaaCore.xcframework"
         COMMAND xcodebuild -create-xcframework 
             -library $<TARGET_FILE:MaaCore> 
             -headers ${PROJECT_SOURCE_DIR}/include 
             -output MaaCore.xcframework
         DEPENDS MaaCore
-        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/xcframework
+        WORKING_DIRECTORY ${XCFRAMEWORK_DIR}
         COMMENT "Generating MaaCore.xcframework"
     )
     
-    add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/xcframework/MaaUtils.xcframework
-        COMMAND ${CMAKE_COMMAND} -E rm -rf "${CMAKE_BINARY_DIR}/xcframework/MaaUtils.xcframework"
+    add_custom_command(OUTPUT ${XCFRAMEWORK_DIR}/MaaUtils.xcframework
+        COMMAND ${CMAKE_COMMAND} -E rm -rf "${XCFRAMEWORK_DIR}/MaaUtils.xcframework"
         COMMAND xcodebuild -create-xcframework 
             -library $<TARGET_FILE:MaaUtils> 
             -output MaaUtils.xcframework
         DEPENDS MaaUtils
-        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/xcframework
+        WORKING_DIRECTORY ${XCFRAMEWORK_DIR}
         COMMENT "Generating MaaUtils.xcframework"
     )
 
     find_unique_library("OpenCV" "libopencv_world*.dylib" OPENCV_LIB)
-    add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/xcframework/OpenCV.xcframework
-        COMMAND ${CMAKE_COMMAND} -E rm -rf "${CMAKE_BINARY_DIR}/xcframework/OpenCV.xcframework"
+    add_custom_command(OUTPUT ${XCFRAMEWORK_DIR}/OpenCV.xcframework
+        COMMAND ${CMAKE_COMMAND} -E rm -rf "${XCFRAMEWORK_DIR}/OpenCV.xcframework"
         COMMAND xcodebuild -create-xcframework 
             -library "${OPENCV_LIB}" 
             -output OpenCV.xcframework
-        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/xcframework
+        WORKING_DIRECTORY ${XCFRAMEWORK_DIR}
         COMMENT "Generating OpenCV.xcframework"
     )
 
     find_unique_library("ONNXRuntime" "libonnxruntime*.dylib" ONNXRUNTIME_LIB)
-    add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/xcframework/ONNXRuntime.xcframework
-        COMMAND ${CMAKE_COMMAND} -E rm -rf "${CMAKE_BINARY_DIR}/xcframework/ONNXRuntime.xcframework"
+    add_custom_command(OUTPUT ${XCFRAMEWORK_DIR}/ONNXRuntime.xcframework
+        COMMAND ${CMAKE_COMMAND} -E rm -rf "${XCFRAMEWORK_DIR}/ONNXRuntime.xcframework"
         COMMAND xcodebuild -create-xcframework 
             -library "${ONNXRUNTIME_LIB}" 
             -output ONNXRuntime.xcframework
-        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/xcframework
+        WORKING_DIRECTORY ${XCFRAMEWORK_DIR}
         COMMENT "Generating ONNXRuntime.xcframework"
     )
 
-    add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/xcframework/fastdeploy_ppocr.xcframework
-        COMMAND ${CMAKE_COMMAND} -E rm -rf "${CMAKE_BINARY_DIR}/xcframework/fastdeploy_ppocr.xcframework"
+    add_custom_command(OUTPUT ${XCFRAMEWORK_DIR}/fastdeploy_ppocr.xcframework
+        COMMAND ${CMAKE_COMMAND} -E rm -rf "${XCFRAMEWORK_DIR}/fastdeploy_ppocr.xcframework"
         COMMAND xcodebuild -create-xcframework 
             -library "${MAADEPS_DIR}/runtime/${MAADEPS_TRIPLET}/libfastdeploy_ppocr.dylib" 
             -output fastdeploy_ppocr.xcframework
-        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/xcframework
+        WORKING_DIRECTORY ${XCFRAMEWORK_DIR}
         COMMENT "Generating fastdeploy_ppocr.xcframework"
     )
 
     add_custom_target(MaaXCFramework ALL
         DEPENDS 
             MaaCore 
-            ${CMAKE_BINARY_DIR}/xcframework/MaaCore.xcframework 
+            ${XCFRAMEWORK_DIR}/MaaCore.xcframework 
             MaaUtils 
-            ${CMAKE_BINARY_DIR}/xcframework/MaaUtils.xcframework 
-            ${CMAKE_BINARY_DIR}/xcframework/OpenCV.xcframework 
-            ${CMAKE_BINARY_DIR}/xcframework/ONNXRuntime.xcframework 
-            ${CMAKE_BINARY_DIR}/xcframework/fastdeploy_ppocr.xcframework
+            ${XCFRAMEWORK_DIR}/MaaUtils.xcframework 
+            ${XCFRAMEWORK_DIR}/OpenCV.xcframework 
+            ${XCFRAMEWORK_DIR}/ONNXRuntime.xcframework 
+            ${XCFRAMEWORK_DIR}/fastdeploy_ppocr.xcframework
     )
 endif (BUILD_XCFRAMEWORK)


### PR DESCRIPTION
稍微利好一下我这样的 CMake 用户，主要是减少第三方库版本 Hardcoding，顺带把所有 xcframework 都输出到同一个目录下。

## Summary by Sourcery

优化 macOS xcframework 的构建配置，使其更少依赖硬编码并更健壮。

增强内容：
- 将所有生成的 xcframework 输出到专用目录 `${CMAKE_BINARY_DIR}/xcframework` 中，并相应更新聚合目标（aggregate target）的依赖关系。
- 在创建 xcframework 时，通过 MaaCore 和 MaaUtils 各自的 CMake 目标输出路径来解析库文件，而不是使用硬编码的 dylib 文件名。
- 通过带有校验的全局匹配（globbing）方式动态定位唯一的 OpenCV 和 ONNXRuntime dylib，以避免硬编码的带版本库名以及多重匹配带来的歧义。
- 为 xcframework 生成命令添加工作目录设置和描述性注释，从而提升构建过程的清晰度和可靠性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine macOS xcframework build configuration to be less hardcoded and more robust.

Enhancements:
- Output all generated xcframeworks into a dedicated `${CMAKE_BINARY_DIR}/xcframework` directory and update the aggregate target dependencies accordingly.
- Resolve MaaCore and MaaUtils libraries via their CMake target output paths instead of hardcoded dylib filenames when creating xcframeworks.
- Dynamically locate unique OpenCV and ONNXRuntime dylibs via globbing with validation to avoid hardcoded, versioned library names and ambiguous matches.
- Add working directory settings and descriptive comments to xcframework generation commands to improve build clarity and reliability.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

优化 macOS xcframework 的构建配置，使其更少依赖硬编码并更健壮。

增强内容：
- 将所有生成的 xcframework 输出到专用目录 `${CMAKE_BINARY_DIR}/xcframework` 中，并相应更新聚合目标（aggregate target）的依赖关系。
- 在创建 xcframework 时，通过 MaaCore 和 MaaUtils 各自的 CMake 目标输出路径来解析库文件，而不是使用硬编码的 dylib 文件名。
- 通过带有校验的全局匹配（globbing）方式动态定位唯一的 OpenCV 和 ONNXRuntime dylib，以避免硬编码的带版本库名以及多重匹配带来的歧义。
- 为 xcframework 生成命令添加工作目录设置和描述性注释，从而提升构建过程的清晰度和可靠性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine macOS xcframework build configuration to be less hardcoded and more robust.

Enhancements:
- Output all generated xcframeworks into a dedicated `${CMAKE_BINARY_DIR}/xcframework` directory and update the aggregate target dependencies accordingly.
- Resolve MaaCore and MaaUtils libraries via their CMake target output paths instead of hardcoded dylib filenames when creating xcframeworks.
- Dynamically locate unique OpenCV and ONNXRuntime dylibs via globbing with validation to avoid hardcoded, versioned library names and ambiguous matches.
- Add working directory settings and descriptive comments to xcframework generation commands to improve build clarity and reliability.

</details>

</details>

增强内容：
- 将所有生成的 xcframework 输出到专用目录 `${CMAKE_BINARY_DIR}/xcframework` 中，并相应调整构建依赖关系。
- 在创建 xcframework 时，通过 CMake 目标文件路径解析 MaaCore 和 MaaUtils 库，而不是使用硬编码的 dylib 名称。
- 通过通配符匹配并校验的方式动态发现 OpenCV 和 ONNXRuntime 的 dylib，以避免对带版本号库文件名的硬编码以及可能出现的模糊匹配。
- 为 xcframework 生成命令添加工作目录设置和描述性注释，使构建过程更加清晰可靠。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

优化 macOS xcframework 的构建配置，使其更少依赖硬编码并更健壮。

增强内容：
- 将所有生成的 xcframework 输出到专用目录 `${CMAKE_BINARY_DIR}/xcframework` 中，并相应更新聚合目标（aggregate target）的依赖关系。
- 在创建 xcframework 时，通过 MaaCore 和 MaaUtils 各自的 CMake 目标输出路径来解析库文件，而不是使用硬编码的 dylib 文件名。
- 通过带有校验的全局匹配（globbing）方式动态定位唯一的 OpenCV 和 ONNXRuntime dylib，以避免硬编码的带版本库名以及多重匹配带来的歧义。
- 为 xcframework 生成命令添加工作目录设置和描述性注释，从而提升构建过程的清晰度和可靠性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine macOS xcframework build configuration to be less hardcoded and more robust.

Enhancements:
- Output all generated xcframeworks into a dedicated `${CMAKE_BINARY_DIR}/xcframework` directory and update the aggregate target dependencies accordingly.
- Resolve MaaCore and MaaUtils libraries via their CMake target output paths instead of hardcoded dylib filenames when creating xcframeworks.
- Dynamically locate unique OpenCV and ONNXRuntime dylibs via globbing with validation to avoid hardcoded, versioned library names and ambiguous matches.
- Add working directory settings and descriptive comments to xcframework generation commands to improve build clarity and reliability.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

优化 macOS xcframework 的构建配置，使其更少依赖硬编码并更健壮。

增强内容：
- 将所有生成的 xcframework 输出到专用目录 `${CMAKE_BINARY_DIR}/xcframework` 中，并相应更新聚合目标（aggregate target）的依赖关系。
- 在创建 xcframework 时，通过 MaaCore 和 MaaUtils 各自的 CMake 目标输出路径来解析库文件，而不是使用硬编码的 dylib 文件名。
- 通过带有校验的全局匹配（globbing）方式动态定位唯一的 OpenCV 和 ONNXRuntime dylib，以避免硬编码的带版本库名以及多重匹配带来的歧义。
- 为 xcframework 生成命令添加工作目录设置和描述性注释，从而提升构建过程的清晰度和可靠性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine macOS xcframework build configuration to be less hardcoded and more robust.

Enhancements:
- Output all generated xcframeworks into a dedicated `${CMAKE_BINARY_DIR}/xcframework` directory and update the aggregate target dependencies accordingly.
- Resolve MaaCore and MaaUtils libraries via their CMake target output paths instead of hardcoded dylib filenames when creating xcframeworks.
- Dynamically locate unique OpenCV and ONNXRuntime dylibs via globbing with validation to avoid hardcoded, versioned library names and ambiguous matches.
- Add working directory settings and descriptive comments to xcframework generation commands to improve build clarity and reliability.

</details>

</details>

</details>