### PR TITLE
fix: 完善通宝识别失败时的分支处理

### DIFF
--- a/src/MaaCore/Task/Roguelike/JieGarden/RoguelikeCoppersTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/JieGarden/RoguelikeCoppersTaskPlugin.cpp
@@ -148,7 +148,7 @@ bool asst::RoguelikeCoppersTaskPlugin::handle_pickup_mode()
     }
 
     if (m_pending_copper.empty()) {
-        Log.error(__FUNCTION__, "| no valid coppers found for pickup");
+        LogError << __FUNCTION__ << "| no valid coppers found for pickup";
         // 如果没有有效通宝，尝试点击最后一个检测到的名称错误的通宝位置作为回退
         if (click_point_fallback.x != 0 && click_point_fallback.y != 0) {
             LogWarn << __FUNCTION__ << "| clicking fallback point at (" << click_point_fallback.x << ","
@@ -156,6 +156,8 @@ bool asst::RoguelikeCoppersTaskPlugin::handle_pickup_mode()
             ctrler()->click(click_point_fallback);
             return true;
         }
+        LogError << __FUNCTION__ << "| no coppers recognized to fallback";
+        return false;
     }
 
     // 从待选通宝中选择拾取优先级最高的


### PR DESCRIPTION
## Summary by Sourcery

改进在 roguelike 拾取模式下对铜币识别失败的处理。

Bug 修复：
- 当在拾取模式下未识别到任何有效铜币且没有可用的备用点击点时，返回失败，而不是静默继续执行。

增强：
- 标准化在拾取铜币时未找到任何有效铜币以及无法使用备用铜币时的错误日志记录方式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve handling of failed copper recognition in roguelike pickup mode.

Bug Fixes:
- Return failure instead of silently continuing when no valid coppers are recognized and no fallback click point is available in pickup mode.

Enhancements:
- Standardize error logging when no valid coppers are found for pickup and when no fallback copper can be used.

</details>