### PR TITLE
fix: 招募助战后补充低信赖干员数量不足

### DIFF
--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -366,7 +366,7 @@ bool asst::BattleFormationTask::add_trust_operators()
     }
 
     // 需要追加的信赖干员数量
-    int append_count = 12 - (int)m_opers_in_formation->size();
+    int append_count = 12 + m_used_support_unit - (int)m_opers_in_formation->size();
     if (append_count == 0) {
         return true;
     }


### PR DESCRIPTION
之前在借助战干员模式为“补漏”的情况下，补充低信赖干员时编队人数不满，会少一人。

这个 commit 修复了这个问题。

## Summary by Sourcery

错误修复：
- 修正低信任度干员的追加数量，使在补漏模式下使用借用助战干员时，编队能够达到预期人数。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct the append count for low-trust operators so formations reach the intended size when using borrowed support units in补漏 mode.

</details>