### PR TITLE
feat: 在任务开始后的禁用组件内也能查看tooltip

### DIFF
--- a/src/MaaWpfGui/Styles/Controls/TooltipBlock.xaml
+++ b/src/MaaWpfGui/Styles/Controls/TooltipBlock.xaml
@@ -16,7 +16,8 @@
         DataContext="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}}"
         Style="{StaticResource BorderCircular}"
         ToolTipService.InitialShowDelay="{Binding InitialShowDelay}"
-        ToolTipService.IsEnabled="{c:Binding !TooltipTextEmpty}">
+        ToolTipService.IsEnabled="{c:Binding !TooltipTextEmpty}"
+        ToolTipService.ShowOnDisabled="True">
         <Border.ToolTip>
             <TextBlock
                 MaxWidth="{Binding TooltipMaxWidth}"


### PR DESCRIPTION
此前在任务开始后看不了 tooltip 信息，现在可以方便查看勾选内容是否合乎自己心意。

- before:

<img width="70%" alt="修改前" src="https://github.com/user-attachments/assets/d4d4a2f1-9aed-4108-97bb-aa5507111856" />

- after:

<img width="70%" alt="修改后" src="https://github.com/user-attachments/assets/e7cce1e9-f0c3-49ff-9b7f-d46186e56bee" />

## Summary by Sourcery

增强功能：
- 更新 TooltipBlock 的样式，使禁用的控件在任务执行期间仍然可以显示其工具提示内容。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Update TooltipBlock styling so disabled controls can still display their tooltip content during an active task.

</details>