### PR TITLE
fix: allow usage of CLI build instead of only VS

### DIFF
--- a/src/MaaWpfGui/MaaWpfGui.csproj
+++ b/src/MaaWpfGui/MaaWpfGui.csproj
@@ -17,7 +17,8 @@
 
   <!-- Build and Publish -->
   <PropertyGroup>
-    <OutputPath>$(MSBuildProjectDirectory)\..\..\build\bin\$(Configuration)\</OutputPath>
+    <SolutionDir Condition="'$(SolutionDir)'==''">$(MSBuildProjectDirectory)\..\..\build\</SolutionDir>
+    <OutputPath>$(SolutionDir)\bin\$(Configuration)\</OutputPath>
     <PublishReadyToRun>false</PublishReadyToRun>
     <PublishSingleFile>false</PublishSingleFile>
     <PublishTrimmed>false</PublishTrimmed>


### PR DESCRIPTION
Changing to this variable allows a simple and direct `cmake --build build --config RelWithDebInfo' from CLI without having to pass through VS26 first.

Before this PR if the command was ran from the project dir, the binary output would be placed in my disk root, which made no sense at all.

I'm not sure this is the right approach. Let me know. (Untested in linux AND macos)

## Summary by Sourcery

Bug Fixes:
- 修复在通过命令行调用构建（例如使用 `cmake --build`）而不是仅通过 Visual Studio 构建时，生成的二进制文件输出路径不正确的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix incorrect binary output path when invoking CLI builds (e.g., via `cmake --build`) instead of building solely through Visual Studio.

</details>