### PR TITLE
fix: waydroid rawbync screencap 2>/dev/null

### DIFF
--- a/resource/config.json
+++ b/resource/config.json
@@ -146,7 +146,7 @@
             "start": "[Adb] -s [AdbSerial] shell am start --windowingMode 4 -n [PackageName]/com.u8.sdk.U8UnityContext",
             "screencapRawWithGzip": "[Adb] -s [AdbSerial] exec-out \"screencap 2>/dev/null | gzip -1\"",
             "screencapEncode": "[Adb] -s [AdbSerial] exec-out \"screencap -p 2>/dev/null\"",
-            "screencapRawByNC": "[Adb] -s [AdbSerial] exec-out \"screencap 2>/dev/null | nc -w 3 [NcAddress] [NcPort]\"",
+            "screencapRawByNC": "[Adb] -s [AdbSerial] exec-out \"screencap 2>/dev/null | nc -w 3 [NcAddress] [NcPort]\""
         }
     ]
 }


### PR DESCRIPTION
redir stderr to null for waydroid screencap rawbync as well

## Summary by Sourcery

通过在配置中将 stderr 重定向到 `/dev/null`，使 Waydroid 的 `rawbync screencap` 命令静默标准错误输出。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Silence stderr output for the Waydroid rawbync screencap command by redirecting it to /dev/null in the configuration.

</details>