### PR TITLE
perf: move_camera 允许微调镜头

### DIFF
--- a/src/MaaCore/Task/BattleHelper.cpp
+++ b/src/MaaCore/Task/BattleHelper.cpp
@@ -973,8 +973,8 @@ bool asst::BattleHelper::move_camera(const std::pair<double, double>& delta)
 
     update_kills(m_inst_helper.ctrler()->get_image());
 
-    // 还没转场的时候
-    if (m_kills != 0) {
+    // 等待转场，但排除微调
+    if (m_kills != 0 && delta.first > 2) {
         wait_until_end(false);
     }
 


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 当使用非常小的水平位移调用 `move_camera` 时，防止出现不必要的过渡等待，从而允许在不阻塞的情况下对摄像机进行精细调整。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent unnecessary transition waiting when move_camera is called with very small horizontal deltas, allowing fine camera adjustments without blocking.

</details>