### PR TITLE
fix: YostarKR stuck after send clues

### DIFF
--- a/resource/global/YoStarKR/resource/tasks/tasks.json
+++ b/resource/global/YoStarKR/resource/tasks/tasks.json
@@ -1195,16 +1195,16 @@
     },
     "ClueGiveTo1stConfirm": {
         "doc": "단서 전달 화면에서 단서 전달 이후 멈추는 문제를 위한 postDelay",
-        "postDelay": 1000
+        "postDelay": 500
     },
     "ClueGiveTo2ndConfirm": {
-        "postDelay": 1000
+        "postDelay": 500
     },
     "ClueGiveTo3rdConfirm": {
-        "postDelay": 1000
+        "postDelay": 500
     },
     "ClueGiveTo4thConfirm": {
-        "postDelay": 1000
+        "postDelay": 500
     },
     "InfrastTrainingIdle": {
         "text": ["미사용중"],


### PR DESCRIPTION
fix #15221

## Summary by Sourcery

Bug Fixes:
- 通过调整全局任务 JSON 中的任务配置，解决了 YoStarKR 客户端在发送线索后可能卡住的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Resolve an issue where the YoStarKR client could become stuck after sending clues by adjusting task configuration in the global tasks JSON.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- 通过调整全局任务 JSON 中的任务配置，解决了 YoStarKR 客户端在发送线索后可能卡住的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Resolve an issue where the YoStarKR client could become stuck after sending clues by adjusting task configuration in the global tasks JSON.

</details>

</details>