### PR TITLE
fix: improve validation logic for CustomInfrastPlanSelect

### DIFF
--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/InfrastSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/InfrastSettingsUserControlModel.cs
@@ -531,14 +531,17 @@ public class InfrastSettingsUserControlModel : TaskViewModel
         }
         finally
         {
-            int index = CustomInfrastPlanList.Any(i => i.Period.Count > 0) ? -1 : 0;
-            if (index != CustomInfrastPlanSelect)
+            bool hasPeriods = CustomInfrastPlanList.Any(i => i.Period.Count > 0);
+            bool isInBounds = CustomInfrastPlanSelect >= 0 && CustomInfrastPlanSelect < CustomInfrastPlanList.Count;
+            bool isValid = (hasPeriods && CustomInfrastPlanSelect == -1) || isInBounds;
+
+            if (isValid)
             {
-                CustomInfrastPlanSelect = index;
+                NotifyOfPropertyChange(nameof(CustomInfrastPlanSelect));
             }
             else
             {
-                NotifyOfPropertyChange(nameof(CustomInfrastPlanSelect));
+                CustomInfrastPlanSelect = hasPeriods ? -1 : 0;
             }
         }
     }


### PR DESCRIPTION
link to #15222

## Summary by Sourcery

错误修复：
- 通过在更改之前将当前选择与可用套餐及其周期进行校验，修复了 `CustomInfrastPlanSelect` 被错误重置的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix incorrect resetting of CustomInfrastPlanSelect by validating the current selection against available plans and their periods before changing it.

</details>