### PR TITLE
feat: 给 bark 通知添加默认的分类组

### DIFF
--- a/src/MaaWpfGui/Services/Notification/BarkNotificationProvider.cs
+++ b/src/MaaWpfGui/Services/Notification/BarkNotificationProvider.cs
@@ -74,6 +74,10 @@ public class BarkNotificationProvider(IHttpService httpService) : IExternalNotif
         [JsonPropertyName("body")]
         public string? Content { get; set; }
 
+        // Group and Icon properties are optional, but we set them for better organization and appearance
+        [JsonPropertyName("group")]
+        public string Group { get; } = "MaaAssistantArknights";
+
         [JsonPropertyName("icon")]
         public static string Icon { get => "https://cdn.jsdelivr.net/gh/MaaAssistantArknights/design@main/logo/maa-logo_256x256.png"; }
 


### PR DESCRIPTION
为 bark 通知添加了默认的 group 通知组（避免bark通知过多无法分类）
> TODO：在GUI上提供可配置式的 Bark Group 设置

## Summary by Sourcery

新功能：
- 引入一个默认的 Bark 通知分组值，应用于所有 Bark 通知，以实现更好的组织管理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Introduce a default Bark notification group value applied to all Bark notifications for better organization.

</details>
- 为所有发送的通知引入默认的 Bark 通知分组值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

新功能：
- 引入一个默认的 Bark 通知分组值，应用于所有 Bark 通知，以实现更好的组织管理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Introduce a default Bark notification group value applied to all Bark notifications for better organization.

</details>

</details>