### PR TITLE
perf: 在禁用时 TooltipBlock 显示特效

### DIFF
--- a/src/MaaWpfGui/Styles/Controls/TooltipBlock.xaml
+++ b/src/MaaWpfGui/Styles/Controls/TooltipBlock.xaml
@@ -14,10 +14,14 @@
         VerticalAlignment="Center"
         Background="{DynamicResource MouseOverRegionBrushOpacity75}"
         DataContext="{Binding RelativeSource={RelativeSource FindAncestor, AncestorType={x:Type UserControl}}}"
+        MouseEnter="OnMouseEnter"
+        MouseLeave="OnMouseLeave"
         Style="{StaticResource BorderCircular}"
         ToolTipService.InitialShowDelay="{Binding InitialShowDelay}"
         ToolTipService.IsEnabled="{c:Binding !TooltipTextEmpty}"
-        ToolTipService.ShowOnDisabled="True">
+        ToolTipService.ShowOnDisabled="True"
+        ToolTipService.ToolTipClosing="OnToolTipClosing"
+        ToolTipService.ToolTipOpening="OnToolTipOpening">
         <Border.ToolTip>
             <TextBlock
                 MaxWidth="{Binding TooltipMaxWidth}"


### PR DESCRIPTION
接着 https://github.com/MaaAssistantArknights/MaaAssistantArknights/pull/15186 的修改，监听全局输入，实现 TooltipBlock 在禁用时也显示特效

## Summary by Sourcery

通过监听全局鼠标输入并相应更新不透明度，让即使处于禁用状态的 TooltipBlock 也能对悬停状态作出响应。

增强内容：
- 使用全局输入监听器跟踪被禁用的 TooltipBlock 实例，根据鼠标位置更新悬停视觉效果。
- 为 TooltipBlock 的加载、卸载、可见性以及启用状态变化添加生命周期处理，以保持悬停效果的一致性。
- 当目标不透明度与当前值一致时进行短路处理，避免重复触发不必要的不透明度动画。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable TooltipBlock to react to hover state even when disabled by listening to global mouse input and updating its opacity accordingly.

Enhancements:
- Track disabled TooltipBlock instances with a global input listener to update hover visuals based on mouse position.
- Add lifecycle handling for TooltipBlock load, unload, visibility, and enabled-state changes to keep hover effects consistent.
- Avoid redundant opacity animations by short-circuiting when the target opacity matches the current value.

</details>