### PR TITLE
fix: 远程控制截图无法获取最新图像

### DIFF
--- a/src/MaaWpfGui/Services/RemoteControl/RemoteControlService.cs
+++ b/src/MaaWpfGui/Services/RemoteControl/RemoteControlService.cs
@@ -422,7 +422,7 @@ public class RemoteControlService
                         bool connected = await Task.Run(() => Instances.AsstProxy.AsstConnect(ref errMsg));
                         if (connected)
                         {
-                            var image = await Instances.AsstProxy.AsstGetImageAsync();
+                            var image = await Instances.AsstProxy.AsstGetFreshImageAsync();
                             if (image == null)
                             {
                                 status = "FAILED";
@@ -531,7 +531,7 @@ public class RemoteControlService
                         bool connected = await Task.Run(() => Instances.AsstProxy.AsstConnect(ref errMsg));
                         if (connected)
                         {
-                            var image = Instances.AsstProxy.AsstGetImage();
+                            var image = Instances.AsstProxy.AsstGetFreshImage();
                             if (image == null)
                             {
                                 status = "FAILED";


### PR DESCRIPTION
现有机制下当没有任务运行时，远程控制调用 AsstGetImage() 只返回缓存，没有任务执行来触发新的截图，因此会获取到过期的截图，改为 AsstGetFreshImage() 重新获取截图

## Summary by Sourcery

Bug Fixes:
- 修复远程控制截图获取方式，改用最新的图像 API，以确保始终捕获最新的屏幕内容。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix remote control screenshot retrieval to use fresh image APIs so the latest screen content is always captured.

</details>