### PR TITLE
ci: use git2/vendored-openssl feature flag for cli

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,10 +278,10 @@ jobs:
 
       - name: Build CLI
         run: |
-          cargo build --release --locked --package maa-cli --features vendored-openssl
+          cargo build --release --locked --package maa-cli --features git2/vendored-openssl
           cp -v target/$CARGO_BUILD_TARGET/release/maa $GITHUB_WORKSPACE/install/maa
           cargo build --release --locked --package maa-cli --no-default-features \
-            --features git2,vendored-openssl
+            --features git2,git2/vendored-openssl
           cp -v target/$CARGO_BUILD_TARGET/release/maa $GITHUB_WORKSPACE/appimage-maa
         working-directory: src/maa-cli
 


### PR DESCRIPTION
我打算删掉 vendored-openssl 这个 feature flag。所以现在这里改一下，直接指定 git2 的 feature flag。

## 由 Sourcery 提供的摘要

CI：
- 调整 CI 工作流中的 `maa-cli` 构建步骤，在启用和禁用默认特性（default 与 no-default-features）两种构建中都启用 `git2/vendored-openssl` 功能标志（feature flag）。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Adjust maa-cli build steps in the CI workflow to enable the git2/vendored-openssl feature flag for both default and no-default-features builds.

</details>