### PR TITLE
feat: 增加冬时至基建温蒂组并调整温蒂组选人逻辑

### DIFF
--- a/resource/infrast.json
+++ b/resource/infrast.json
@@ -2127,9 +2127,16 @@
                     {
                         "desc": "森蚺-2",
                         "efficient": {
-                            "all": 30
+                            "all": 30.2
                         },
                         "skills": ["bskill_man_spd&power2"]
+                    },
+                    {
+                        "desc": "冬时-1",
+                        "efficient": {
+                            "all": 30
+                        },
+                        "skills": ["bskill_man_spd_manu2"]
                     },
                     {
                         "desc": "清流-1",
@@ -2156,7 +2163,7 @@
                     {
                         "desc": "温蒂、森蚺-2",
                         "efficient": {
-                            "all": 30
+                            "all": 30.2
                         },
                         "skills": ["bskill_man_spd&power2"]
                     }
@@ -2165,9 +2172,16 @@
                     {
                         "desc": "温蒂、森蚺-2",
                         "efficient": {
-                            "all": 30
+                            "all": 30.2
                         },
                         "skills": ["bskill_man_spd&power2"]
+                    },
+                    {
+                        "desc": "冬时-1",
+                        "efficient": {
+                            "all": 30
+                        },
+                        "skills": ["bskill_man_spd_manu2"]
                     },
                     {
                         "desc": "清流-1",
@@ -2200,6 +2214,13 @@
                     }
                 ],
                 "optional": [
+                    {
+                        "desc": "冬时-1",
+                        "efficient": {
+                            "all": 30
+                        },
+                        "skills": ["bskill_man_spd_manu2"]
+                    },
                     {
                         "desc": "森蚺-2",
                         "efficient": {
@@ -2239,12 +2260,81 @@
                 ],
                 "optional": [
                     {
+                        "desc": "冬时-1",
+                        "efficient": {
+                            "all": 30
+                        },
+                        "skills": ["bskill_man_spd_manu2"]
+                    },
+                    {
                         "desc": "温蒂、森蚺-2",
                         "efficient": {
                             "all": 20
                         },
                         "skills": ["bskill_man_spd&power2"]
                     },
+                    {
+                        "desc": "清流-1",
+                        "efficient": {
+                            "PureGold_reg": "[NumOfTrade] * 20"
+                        },
+                        "skills": ["bskill_man_spd&trade"]
+                    },
+                    {
+                        "desc": "森蚺、异客2",
+                        "efficient": {
+                            "all": 10
+                        },
+                        "skills": ["bskill_man_spd&power1"]
+                    }
+                ]
+            },
+            {
+                "conditions": {
+                    "NumOfPower": 3
+                },
+                "desc": "冬时组",
+                "necessary": [
+                    {
+                        "desc": "冬时-1",
+                        "efficient": {
+                            "all": 30
+                        },
+                        "skills": ["bskill_man_spd_manu2"]
+                    }
+                ],
+                "optional": [
+                    {
+                        "desc": "清流-1",
+                        "efficient": {
+                            "PureGold_reg": "[NumOfTrade] * 20"
+                        },
+                        "skills": ["bskill_man_spd&trade"]
+                    },
+                    {
+                        "desc": "森蚺、异客2",
+                        "efficient": {
+                            "all": 15
+                        },
+                        "skills": ["bskill_man_spd&power1"]
+                    }
+                ]
+            },
+            {
+                "conditions": {
+                    "NumOfPower": 2
+                },
+                "desc": "冬时组: 2电站",
+                "necessary": [
+                    {
+                        "desc": "冬时-1",
+                        "efficient": {
+                            "all": 30
+                        },
+                        "skills": ["bskill_man_spd_manu2"]
+                    }
+                ],
+                "optional": [
                     {
                         "desc": "清流-1",
                         "efficient": {


### PR DESCRIPTION
将 温蒂组: 2电站 时 温蒂/森蚺-2 权重由 30 修正到了正确的 20。
将 冬时-1 加入温蒂组的换班逻辑中。
考虑到现在 冬时-1 + 森蚺/异客2 + 清流-1 也可以构成温蒂组，新增逻辑“冬时组”，加入了上述换班逻辑。
将 温蒂/森蚺-2（三电站）的权重上调至30.2（考虑到 温蒂/森蚺2 可受 晨曦格雷伊 加成），在选人时会优先选择 温蒂/森蚺-2 而不是 冬时-1。

## 由 Sourcery 生成的摘要

调整基础设施干员选择权重，并为基础班次分配新增基于“冬至”的温蒂组逻辑。

错误修复：
- 将双发电站温蒂组中温蒂/水月-2 的选择权重从 30 修正为 20。

功能增强：
- 将冬至-1 纳入温蒂组轮班逻辑。
- 引入新的“冬至组”，将冬至-1 与水月/推进之王-2 以及 清流-1 组合，用于类似温蒂组的轮换。
- 在三发电站配置中提高温蒂/水月-2 的选择优先级，使其优先于冬至-1，以适配晨露格雷伊的加成效果。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的摘要

调整基础设施干员选择权重，并扩展 Wendy 组的排班逻辑，以支持基于冬至配置的新方案。

错误修复：
- 将双电站 Wendy 组中 Wendy/Mizuki-2 的选择权重从 30 更正为 20。

功能增强：
- 将 Winter Solstice-1 纳入 Wendy 组的轮班逻辑。
- 引入新的 Winter Solstice 组，将 Winter Solstice-1 与 Mizuki/Passenger-2 和 Purestream-1 组合，以实现类似 Wendy 的轮换。
- 在三电站配置中提高 Wendy/Mizuki-2 的选择优先级，使其在考虑 GreyThroat Morning 加成时优先于 Winter Solstice-1 被选中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust infrastructure operator selection weights and extend the Wendy-group scheduling logic to support new Winter Solstice-based configurations.

Bug Fixes:
- Correct the selection weight for Wendy/Mizuki-2 in the two-power-plant Wendy group from 30 to 20.

Enhancements:
- Include Winter Solstice-1 in the Wendy group shift-rotation logic.
- Introduce a new Winter Solstice group combining Winter Solstice-1 with Mizuki/Passenger-2 and Purestream-1 for Wendy-like rotations.
- Increase the selection priority of Wendy/Mizuki-2 in three-power-plant setups so they are chosen over Winter Solstice-1, accounting for GreyThroat Morning add-ons.

</details>

</details>