### PR TITLE
fix: 给缺失干员检查补上 Unavailable

### DIFF
--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -107,7 +107,7 @@ bool asst::BattleFormationTask::_run()
         const auto& missing_group = missing_groups.begin(); // 只有一个缺失干员组，直接取第一个
         for (const battle::OperUsage& oper :
              missing_group->second | std::views::filter([&](const battle::OperUsage& oper) {
-                 return oper.status == battle::OperStatus::Missing;
+                 return oper.status == battle::OperStatus::Missing || oper.status == battle::OperStatus::Unavailable;
              })) {
             // 如果指定助战干员正好可以补齐编队，则只招募指定助战干员就好了，记得再次确认一下 skill
             // 如果编队里正好有【艾雅法拉 - 2】和 【艾雅法拉 - 3】呢？


### PR DESCRIPTION
## Summary by Sourcery

在缺少干员检查时处理不可用干员，并在为战斗编队添加支援单位时输出额外信息。

Bug Fixes:
- 在判断战斗编队中缺少哪些干员时，将状态为 Unavailable 的干员一并纳入考虑。

Enhancements:
- 在战斗编队中发起支援单位选择时，通过回调发送详细的所需干员信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle unavailable operators during missing-operator checks and emit extra info when adding support units to battle formations.

Bug Fixes:
- Include operators with Unavailable status when determining missing operators in battle formations.

Enhancements:
- Send detailed required-operator information via callback when initiating support-unit selection in battle formations.

</details>