### PR TITLE
fix: refactor ADB connection logic to only connect when needed

### DIFF
--- a/src/MaaCore/Controller/AdbController.cpp
+++ b/src/MaaCore/Controller/AdbController.cpp
@@ -926,7 +926,7 @@ bool asst::AdbController::connect(const std::string& adb_path, const std::string
         // 设置配置 connect、release 命令，即使这里不连接，后续也会需要用到
         m_adb.connect = cmd_replace(adb_cfg.connect);
         m_adb.release = cmd_replace(adb_cfg.release);
-        if need_connect {
+        if (need_connect) {
             // 如果不包含 `:` 且需要连接，connect 命令也不会成功
             if (address.find(':') == std::string::npos) {
                 json::value info = get_info_json() | json::object {

--- a/src/MaaCore/Controller/AdbController.cpp
+++ b/src/MaaCore/Controller/AdbController.cpp
@@ -931,32 +931,31 @@ bool asst::AdbController::connect(const std::string& adb_path, const std::string
             if (address.find(':') == std::string::npos) {
                 json::value info = get_info_json() | json::object {
                     { "what", "ConnectFailed" },
-                    { "why", "Address does not contain ':' and no devices found" },
+                    { "why", "Address does not contain ':' and no connected" },
                 };
                 callback(AsstMsg::ConnectionInfo, info);
                 return false;
             }
 
-            // TODO: adb lite server 尚未实现，第一次连接需要执行一次 adb.exe 启动 daemon
             auto connect_ret = call_command(m_adb.connect, 60LL * 1000, false /* adb 连接时不允许重试 */);
-            bool is_connect_success = false;
             if (connect_ret) {
                 auto& connect_str = connect_ret.value();
                 // 检查连接字符串是否包含 "connected"
-                is_connect_success = connect_str.find("connected") != std::string::npos;
-                // NOTE:这玩意啥都没干，有什么用吗？
-                if (connect_str.find("daemon started successfully") != std::string::npos &&
-                    connect_str.find("daemon still not running") == std::string::npos) {
+                if (connect_str.find("connected") != std::string::npos) {
+                    json::value info = get_info_json() | json::object {
+                        { "what", "ConnectFailed" },
+                        { "why", "Connection command did not report \"connected\"" },
+                    };
+                    callback(AsstMsg::ConnectionInfo, info);
+                    return false;
                 }
-            }
-
-            if (!is_connect_success) {
-                json::value info = get_info_json() | json::object {
+            } else {
+                json::value info = get_info_json() | json::object{
                     { "what", "ConnectFailed" },
                     { "why", "Connection command failed to exec" },
                 };
                 callback(AsstMsg::ConnectionInfo, info);
-                return false;
+                return false
             }
         }
     }

--- a/src/MaaCore/Controller/AdbController.cpp
+++ b/src/MaaCore/Controller/AdbController.cpp
@@ -941,7 +941,7 @@ bool asst::AdbController::connect(const std::string& adb_path, const std::string
             if (connect_ret) {
                 auto& connect_str = connect_ret.value();
                 // 检查连接字符串是否包含 "connected"
-                if (connect_str.find("connected") != std::string::npos) {
+                if (connect_str.find("connected") == std::string::npos) {
                     json::value info = get_info_json() | json::object {
                         { "what", "ConnectFailed" },
                         { "why", "Connection command did not report \"connected\"" },
@@ -955,7 +955,7 @@ bool asst::AdbController::connect(const std::string& adb_path, const std::string
                     { "why", "Connection command failed to exec" },
                 };
                 callback(AsstMsg::ConnectionInfo, info);
-                return false
+                return false;
             }
         }
     }

--- a/src/MaaCore/Controller/AdbController.cpp
+++ b/src/MaaCore/Controller/AdbController.cpp
@@ -931,7 +931,7 @@ bool asst::AdbController::connect(const std::string& adb_path, const std::string
             if (address.find(':') == std::string::npos) {
                 json::value info = get_info_json() | json::object {
                     { "what", "ConnectFailed" },
-                    { "why", "Address does not contain ':' and no connected" },
+                    { "why", "Cannot connect: address appears to be serial number but device not found" },
                 };
                 callback(AsstMsg::ConnectionInfo, info);
                 return false;

--- a/src/MaaCore/Controller/AdbController.cpp
+++ b/src/MaaCore/Controller/AdbController.cpp
@@ -923,38 +923,40 @@ bool asst::AdbController::connect(const std::string& adb_path, const std::string
             }
         }
 
-        // 如果不包含 `:` 且需要连接，connect 命令也不会成功
-        if (address.find(':') == std::string::npos && need_connect) {
-            json::value info = get_info_json() | json::object {
-                { "what", "ConnectFailed" },
-                { "why", "Address does not contain ':' and no devices found" },
-            };
-            callback(AsstMsg::ConnectionInfo, info);
-            return false;
-        }
-
-        // TODO: adb lite server 尚未实现，第一次连接需要执行一次 adb.exe 启动 daemon
-        m_adb.connect = cmd_replace(adb_cfg.connect);
-        m_adb.release = cmd_replace(adb_cfg.release);
-        auto connect_ret = call_command(m_adb.connect, 60LL * 1000, false /* adb 连接时不允许重试 */);
-        bool is_connect_success = false;
-        if (connect_ret) {
-            auto& connect_str = connect_ret.value();
-            // 检查连接字符串是否包含 "connected"
-            is_connect_success = connect_str.find("connected") != std::string::npos;
-            // NOTE:这玩意啥都没干，有什么用吗？
-            if (connect_str.find("daemon started successfully") != std::string::npos &&
-                connect_str.find("daemon still not running") == std::string::npos) {
+        if need_connect {
+            // 如果不包含 `:` 且需要连接，connect 命令也不会成功
+            if (address.find(':') == std::string::npos) {
+                json::value info = get_info_json() | json::object {
+                    { "what", "ConnectFailed" },
+                    { "why", "Address does not contain ':' and no devices found" },
+                };
+                callback(AsstMsg::ConnectionInfo, info);
+                return false;
             }
-        }
 
-        if (!is_connect_success && need_connect) {
-            json::value info = get_info_json() | json::object {
-                { "what", "ConnectFailed" },
-                { "why", "Connection command failed to exec" },
-            };
-            callback(AsstMsg::ConnectionInfo, info);
-            return false;
+            // TODO: adb lite server 尚未实现，第一次连接需要执行一次 adb.exe 启动 daemon
+            m_adb.connect = cmd_replace(adb_cfg.connect);
+            m_adb.release = cmd_replace(adb_cfg.release);
+            auto connect_ret = call_command(m_adb.connect, 60LL * 1000, false /* adb 连接时不允许重试 */);
+            bool is_connect_success = false;
+            if (connect_ret) {
+                auto& connect_str = connect_ret.value();
+                // 检查连接字符串是否包含 "connected"
+                is_connect_success = connect_str.find("connected") != std::string::npos;
+                // NOTE:这玩意啥都没干，有什么用吗？
+                if (connect_str.find("daemon started successfully") != std::string::npos &&
+                    connect_str.find("daemon still not running") == std::string::npos) {
+                }
+            }
+
+            if (!is_connect_success) {
+                json::value info = get_info_json() | json::object {
+                    { "what", "ConnectFailed" },
+                    { "why", "Connection command failed to exec" },
+                };
+                callback(AsstMsg::ConnectionInfo, info);
+                return false;
+            }
         }
     }
 

--- a/src/MaaCore/Controller/AdbController.cpp
+++ b/src/MaaCore/Controller/AdbController.cpp
@@ -923,6 +923,9 @@ bool asst::AdbController::connect(const std::string& adb_path, const std::string
             }
         }
 
+        // 设置配置 connect、release 命令，即使这里不连接，后续也会需要用到
+        m_adb.connect = cmd_replace(adb_cfg.connect);
+        m_adb.release = cmd_replace(adb_cfg.release);
         if need_connect {
             // 如果不包含 `:` 且需要连接，connect 命令也不会成功
             if (address.find(':') == std::string::npos) {
@@ -935,8 +938,6 @@ bool asst::AdbController::connect(const std::string& adb_path, const std::string
             }
 
             // TODO: adb lite server 尚未实现，第一次连接需要执行一次 adb.exe 启动 daemon
-            m_adb.connect = cmd_replace(adb_cfg.connect);
-            m_adb.release = cmd_replace(adb_cfg.release);
             auto connect_ret = call_command(m_adb.connect, 60LL * 1000, false /* adb 连接时不允许重试 */);
             bool is_connect_success = false;
             if (connect_ret) {

--- a/src/MaaCore/Controller/AdbController.cpp
+++ b/src/MaaCore/Controller/AdbController.cpp
@@ -930,7 +930,7 @@ bool asst::AdbController::connect(const std::string& adb_path, const std::string
             if (connect_ret) {
                 auto& connect_str = connect_ret.value();
                 // 检查连接字符串是否包含 "connected"
-                if (connect_str.find("connected") != std::string::npos) {
+                if (connect_str.find("connected") == std::string::npos) {
                     json::value info = get_info_json() | json::object {
                         { "what", "ConnectFailed" },
                         { "why", "Connection command did not report \"connected\"" },
@@ -944,7 +944,7 @@ bool asst::AdbController::connect(const std::string& adb_path, const std::string
                     { "why", "Connection command failed to exec" },
                 };
                 callback(AsstMsg::ConnectionInfo, info);
-                return false
+                return false;
             }
         }
     }

--- a/src/MaaCore/Controller/AdbController.cpp
+++ b/src/MaaCore/Controller/AdbController.cpp
@@ -912,38 +912,40 @@ bool asst::AdbController::connect(const std::string& adb_path, const std::string
             }
         }
 
-        // 如果不包含 `:` 且需要连接，connect 命令也不会成功
-        if (address.find(':') == std::string::npos && need_connect) {
-            json::value info = get_info_json() | json::object {
-                { "what", "ConnectFailed" },
-                { "why", "Address does not contain ':' and no devices found" },
-            };
-            callback(AsstMsg::ConnectionInfo, info);
-            return false;
-        }
-
-        // TODO: adb lite server 尚未实现，第一次连接需要执行一次 adb.exe 启动 daemon
-        m_adb.connect = m_conn_ctx.replace_cmd(adb_cfg.connect);
-        m_adb.release = m_conn_ctx.replace_cmd(adb_cfg.release);
-        auto connect_ret = call_command(m_adb.connect, 60LL * 1000, false /* adb 连接时不允许重试 */);
-        bool is_connect_success = false;
-        if (connect_ret) {
-            auto& connect_str = connect_ret.value();
-            // 检查连接字符串是否包含 "connected"
-            is_connect_success = connect_str.find("connected") != std::string::npos;
-            // NOTE:这玩意啥都没干，有什么用吗？
-            if (connect_str.find("daemon started successfully") != std::string::npos &&
-                connect_str.find("daemon still not running") == std::string::npos) {
+        if (need_connect) {
+            // 如果不包含 `:` 且需要连接，connect 命令也不会成功
+            if (address.find(':') == std::string::npos) {
+                json::value info = get_info_json() | json::object {
+                    { "what", "ConnectFailed" },
+                    { "why", "Address does not contain ':' and no devices found" },
+                };
+                callback(AsstMsg::ConnectionInfo, info);
+                return false;
             }
-        }
 
-        if (!is_connect_success && need_connect) {
-            json::value info = get_info_json() | json::object {
-                { "what", "ConnectFailed" },
-                { "why", "Connection command failed to exec" },
-            };
-            callback(AsstMsg::ConnectionInfo, info);
-            return false;
+            // TODO: adb lite server 尚未实现，第一次连接需要执行一次 adb.exe 启动 daemon
+            m_adb.connect = m_conn_ctx.replace_cmd(adb_cfg.connect);
+            m_adb.release = m_conn_ctx.replace_cmd(adb_cfg.release);
+            auto connect_ret = call_command(m_adb.connect, 60LL * 1000, false /* adb 连接时不允许重试 */);
+            bool is_connect_success = false;
+            if (connect_ret) {
+                auto& connect_str = connect_ret.value();
+                // 检查连接字符串是否包含 "connected"
+                is_connect_success = connect_str.find("connected") != std::string::npos;
+                // NOTE:这玩意啥都没干，有什么用吗？
+                if (connect_str.find("daemon started successfully") != std::string::npos &&
+                    connect_str.find("daemon still not running") == std::string::npos) {
+                }
+            }
+
+            if (!is_connect_success) {
+                json::value info = get_info_json() | json::object {
+                    { "what", "ConnectFailed" },
+                    { "why", "Connection command failed to exec" },
+                };
+                callback(AsstMsg::ConnectionInfo, info);
+                return false;
+            }
         }
     }
 

--- a/src/MaaCore/Controller/AdbController.cpp
+++ b/src/MaaCore/Controller/AdbController.cpp
@@ -912,6 +912,9 @@ bool asst::AdbController::connect(const std::string& adb_path, const std::string
             }
         }
 
+        // 设置配置 connect、release 命令，即使这里不连接，后续也会需要用到
+        m_adb.connect = m_conn_ctx.replace_cmd(adb_cfg.connect);
+        m_adb.release = m_conn_ctx.replace_cmd(adb_cfg.release);
         if (need_connect) {
             // 如果不包含 `:` 且需要连接，connect 命令也不会成功
             if (address.find(':') == std::string::npos) {
@@ -924,8 +927,6 @@ bool asst::AdbController::connect(const std::string& adb_path, const std::string
             }
 
             // TODO: adb lite server 尚未实现，第一次连接需要执行一次 adb.exe 启动 daemon
-            m_adb.connect = m_conn_ctx.replace_cmd(adb_cfg.connect);
-            m_adb.release = m_conn_ctx.replace_cmd(adb_cfg.release);
             auto connect_ret = call_command(m_adb.connect, 60LL * 1000, false /* adb 连接时不允许重试 */);
             bool is_connect_success = false;
             if (connect_ret) {

--- a/src/MaaCore/Controller/AdbController.cpp
+++ b/src/MaaCore/Controller/AdbController.cpp
@@ -920,7 +920,7 @@ bool asst::AdbController::connect(const std::string& adb_path, const std::string
             if (address.find(':') == std::string::npos) {
                 json::value info = get_info_json() | json::object {
                     { "what", "ConnectFailed" },
-                    { "why", "Address does not contain ':' and no connected" },
+                    { "why", "Cannot connect: address appears to be serial number but device not found" },
                 };
                 callback(AsstMsg::ConnectionInfo, info);
                 return false;
@@ -938,8 +938,9 @@ bool asst::AdbController::connect(const std::string& adb_path, const std::string
                     callback(AsstMsg::ConnectionInfo, info);
                     return false;
                 }
-            } else {
-                json::value info = get_info_json() | json::object{
+            }
+            else {
+                json::value info = get_info_json() | json::object {
                     { "what", "ConnectFailed" },
                     { "why", "Connection command failed to exec" },
                 };

--- a/src/MaaCore/Controller/AdbController.cpp
+++ b/src/MaaCore/Controller/AdbController.cpp
@@ -920,32 +920,31 @@ bool asst::AdbController::connect(const std::string& adb_path, const std::string
             if (address.find(':') == std::string::npos) {
                 json::value info = get_info_json() | json::object {
                     { "what", "ConnectFailed" },
-                    { "why", "Address does not contain ':' and no devices found" },
+                    { "why", "Address does not contain ':' and no connected" },
                 };
                 callback(AsstMsg::ConnectionInfo, info);
                 return false;
             }
 
-            // TODO: adb lite server 尚未实现，第一次连接需要执行一次 adb.exe 启动 daemon
             auto connect_ret = call_command(m_adb.connect, 60LL * 1000, false /* adb 连接时不允许重试 */);
-            bool is_connect_success = false;
             if (connect_ret) {
                 auto& connect_str = connect_ret.value();
                 // 检查连接字符串是否包含 "connected"
-                is_connect_success = connect_str.find("connected") != std::string::npos;
-                // NOTE:这玩意啥都没干，有什么用吗？
-                if (connect_str.find("daemon started successfully") != std::string::npos &&
-                    connect_str.find("daemon still not running") == std::string::npos) {
+                if (connect_str.find("connected") != std::string::npos) {
+                    json::value info = get_info_json() | json::object {
+                        { "what", "ConnectFailed" },
+                        { "why", "Connection command did not report \"connected\"" },
+                    };
+                    callback(AsstMsg::ConnectionInfo, info);
+                    return false;
                 }
-            }
-
-            if (!is_connect_success) {
-                json::value info = get_info_json() | json::object {
+            } else {
+                json::value info = get_info_json() | json::object{
                     { "what", "ConnectFailed" },
                     { "why", "Connection command failed to exec" },
                 };
                 callback(AsstMsg::ConnectionInfo, info);
-                return false;
+                return false
             }
         }
     }


### PR DESCRIPTION
只有在需要 connect 的时候再使用 `adb connect`。在之前的逻辑里如果 address 不是 ip:port 的形式，依然会尝试 connect，这样会导致无法连接实体机。

现在这个修改应该没有什么问题，在前面已经检测到连接的情况下，理论上也不需要再一次进行 connect 了。当然，如果这里面有什么其他的坑，我可以再改一下。

Fixes MaaAssistantArknights/maa-cli#472

## Summary by Sourcery

优化 ADB 连接处理逻辑，避免不必要的连接尝试，并在连接不需要或无效时改进错误报告。

Bug Fixes:
- 当不需要建立新连接时，避免对非 `ip:port` 地址调用 `adb connect`，从而防止在物理设备上出现连接失败。

Enhancements:
- 无论是否发起新的连接，都配置 ADB 的连接和释放命令，确保它们在之后需要时可以被使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine ADB connection handling to avoid unnecessary connect attempts and improve error reporting when connection is not required or invalid.

Bug Fixes:
- Prevent adb connect from being called for non-ip:port addresses when a fresh connection is not needed, avoiding failures with physical devices.

Enhancements:
- Configure ADB connect and release commands regardless of whether a new connection is initiated, ensuring they are available for later use.

</details>

## 由 Sourcery 提供的总结

优化 ADB 连接处理逻辑，仅在必要时建立新连接，并改进对无效或未成功连接尝试的失败报告。

错误修复：
- 当不适合建立新连接时，避免对非 `ip:port` 地址调用 `adb connect`，以防止在使用物理设备或已连接目标时出现失败。
- 当 `adb connect` 命令未表明连接成功或无法执行时，提供更清晰的连接失败原因说明。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

优化 ADB 连接处理逻辑，仅在需要新连接时才发出连接命令，并在连接尝试失败时改进错误报告。

Bug 修复：
- 避免在需要新连接时，对非 `ip:port` 地址执行 ADB 连接操作，从而防止在针对物理设备或已连接设备时出现失败。
- 在 ADB connect 命令未执行或未表明连接成功时，报告更清晰的失败原因。

功能增强：
- 始终配置 ADB connect 和 release 命令，即使当前未执行连接操作，也确保它们可用于后续操作。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine ADB connection handling to only issue connect commands when a new connection is required and to improve reporting when connection attempts fail.

Bug Fixes:
- Avoid attempting ADB connect for non ip:port addresses when a new connection is needed, preventing failures when targeting physical or already-connected devices.
- Report clearer failure reasons when the ADB connect command does not execute or does not indicate a successful connection.

Enhancements:
- Always configure ADB connect and release commands so they are available for later operations even when no immediate connection is performed.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

优化 ADB 连接处理逻辑，仅在必要时建立新连接，并改进对无效或未成功连接尝试的失败报告。

错误修复：
- 当不适合建立新连接时，避免对非 `ip:port` 地址调用 `adb connect`，以防止在使用物理设备或已连接目标时出现失败。
- 当 `adb connect` 命令未表明连接成功或无法执行时，提供更清晰的连接失败原因说明。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

优化 ADB 连接处理逻辑，仅在需要新连接时才发出连接命令，并在连接尝试失败时改进错误报告。

Bug 修复：
- 避免在需要新连接时，对非 `ip:port` 地址执行 ADB 连接操作，从而防止在针对物理设备或已连接设备时出现失败。
- 在 ADB connect 命令未执行或未表明连接成功时，报告更清晰的失败原因。

功能增强：
- 始终配置 ADB connect 和 release 命令，即使当前未执行连接操作，也确保它们可用于后续操作。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine ADB connection handling to only issue connect commands when a new connection is required and to improve reporting when connection attempts fail.

Bug Fixes:
- Avoid attempting ADB connect for non ip:port addresses when a new connection is needed, preventing failures when targeting physical or already-connected devices.
- Report clearer failure reasons when the ADB connect command does not execute or does not indicate a successful connection.

Enhancements:
- Always configure ADB connect and release commands so they are available for later operations even when no immediate connection is performed.

</details>

</details>

</details>