### PR TITLE
fix: 使追加自定干员为空时悬浮在齿轮图标上不显示tooltip

### DIFF
--- a/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
@@ -411,9 +411,12 @@ public partial class CopilotViewModel : Screen
         set {
             value = value.Trim();
             SetAndNotify(ref _userAdditional, value);
+            NotifyOfPropertyChange(nameof(UserAdditionalEmpty));
             ConfigurationHelper.SetValue(ConfigurationKeys.CopilotUserAdditional, value);
         }
     }
+
+    public bool UserAdditionalEmpty => string.IsNullOrEmpty(_userAdditional);
 
     private bool _isUserAdditionalPopupOpen;
 

--- a/src/MaaWpfGui/Views/UI/CopilotView.xaml
+++ b/src/MaaWpfGui/Views/UI/CopilotView.xaml
@@ -327,6 +327,7 @@
                                     hc:IconElement.Geometry="{StaticResource ConfigGeometry}"
                                     BorderThickness="0"
                                     Command="{s:Action OpenUserAdditionalPopup}"
+                                    ToolTipService.IsEnabled="{c:Binding !UserAdditionalEmpty}"
                                     ToolTip="{Binding UserAdditional}" />
                                 <controls:TooltipBlock TooltipText="{DynamicResource AddUserAdditionalTip}" />
                                 <Popup


### PR DESCRIPTION
before:
<img width="428" height="393" alt="9edb3f4587bbfbc429a16495b680260d" src="https://github.com/user-attachments/assets/6784a4fc-c35d-4db4-a51e-9dfd93da4514" />

## Summary by Sourcery

处理 Copilot 视图中用户自定义运算符输入状态为空的情况，以支持正确的 UI 行为。

Bug 修复：
- 确保当附加运算符输入变为空时通知 UI，以便工具提示的可见性可以正确更新。

改进：
- 暴露一个布尔类型的视图模型属性，用于指示附加运算符输入是否为空，以便在视图中进行绑定。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle empty user-defined operator input state for the copilot view to support correct UI behavior.

Bug Fixes:
- Ensure the UI is notified when the additional operator input becomes empty so tooltip visibility can update correctly.

Enhancements:
- Expose a boolean view-model property indicating whether the additional operator input is empty for binding in the view.

</details>