### PR TITLE
fix: 避免其他locale下，掉落次数误认数字字符

### DIFF
--- a/src/MaaCore/Vision/Miscellaneous/StageDropsImageAnalyzer.cpp
+++ b/src/MaaCore/Vision/Miscellaneous/StageDropsImageAnalyzer.cpp
@@ -136,7 +136,7 @@ bool asst::StageDropsImageAnalyzer::analyze_times()
     std::string raw_str = rec_analyzer.get_result().text;
     Log.info(__FUNCTION__, "raw_str", raw_str);
 
-    boost::regex re(R"(\d+)");
+    boost::regex re(R"([0-9]+)");
     boost::smatch match;
     if (!boost::regex_search(raw_str, match, re)) {
         m_times = -2;


### PR DESCRIPTION
在英文操作系统下，由于系统locale变为了latin-1，“已成功代理作战N次”的“已”(```e5 b7 b2```)中的```b2```会被误认为角标“²”(```b2```)并被boost::regex捕获，见[附件](https://github.com/user-attachments/files/24449076/out.txt)。

比较elegant的解决方案是用```boost::wregex```或者```boost::make_u32regex```或者```boost::regex_constants::ECMAScript```，但是我想我们只需要里面的数字，就没必要引入更多的依赖了，直接圈死0-9算数。

## Summary by Sourcery

错误修复：
- 通过仅在识别的文本中匹配 ASCII 数字，防止在非 UTF-8 或 Latin-1 语言环境下运行时错误检测掉落计数。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent incorrect detection of drop counts when running under non-UTF-8 or Latin-1 locales by matching only ASCII digits in the recognized text.

</details>