### PR TITLE
refactor: 移除 CopilotItemViewModel 中的 Index 属性并更新相关逻辑

### DIFF
--- a/src/MaaWpfGui/ViewModels/CopilotItemViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/CopilotItemViewModel.cs
@@ -84,12 +84,4 @@ public class CopilotItemViewModel : PropertyChangedBase
             Instances.CopilotViewModel.SaveCopilotTask();
         }
     }
-
-    private int _index;
-
-    public int Index
-    {
-        get => _index;
-        set => SetAndNotify(ref _index, value);
-    }
 }

--- a/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
@@ -124,7 +124,6 @@ public partial class CopilotViewModel : Screen
         var list = JsonConvert.DeserializeObject<List<CopilotItemViewModel>>(copilotTaskList) ?? [];
         for (int i = 0; i < list.Count; i++)
         {
-            list[i].Index = i;
             CopilotItemViewModels.Add(list[i]);
         }
 
@@ -930,9 +929,9 @@ public partial class CopilotViewModel : Screen
     [UsedImplicitly]
     public void SelectCopilotTask(object? sender, MouseButtonEventArgs? e = null)
     {
-        if (e?.Source is FrameworkElement element && element.Tag is int index)
+        if (e?.Source is FrameworkElement element && element.Tag is CopilotItemViewModel item)
         {
-            Filename = CopilotItemViewModels[index].FilePath; // 假设原方法接受int参数
+            Filename = item.FilePath;
             if (e.ChangedButton == MouseButton.Right)
             {
                 UseCopilotList = false;
@@ -942,10 +941,10 @@ public partial class CopilotViewModel : Screen
 
     // UI 绑定的方法
     [UsedImplicitly]
-    public void DeleteCopilotTask(int index)
+    public void DeleteCopilotTask(CopilotItemViewModel item)
     {
-        CopilotItemViewModels.RemoveAt(index);
-        CopilotItemIndexChanged();
+        CopilotItemViewModels.Remove(item);
+        SaveCopilotTask();
     }
 
     // UI 绑定的方法
@@ -956,8 +955,7 @@ public partial class CopilotViewModel : Screen
         {
             CopilotItemViewModels.Remove(item);
         }
-
-        CopilotItemIndexChanged();
+        SaveCopilotTask();
     }
 
     // UI 绑定的方法
@@ -1641,20 +1639,20 @@ public partial class CopilotViewModel : Screen
 
             name ??= stageCode;
 
-            var item = new CopilotItemViewModel(name, cachePath, false, copilotId) { Index = CopilotItemViewModels.Count, };
+            var item = new CopilotItemViewModel(name, cachePath, false, copilotId);
             CopilotItemViewModels.Add(item);
         }
         else
         {
             if (flags.HasFlag(CopilotModel.DifficultyFlags.Normal))
             {
-                var item = new CopilotItemViewModel(stageCode, cachePath, false, copilotId) { Index = CopilotItemViewModels.Count, };
+                var item = new CopilotItemViewModel(stageCode, cachePath, false, copilotId);
                 CopilotItemViewModels.Add(item);
             }
 
             if (flags.HasFlag(CopilotModel.DifficultyFlags.Raid))
             {
-                var item = new CopilotItemViewModel(stageCode, cachePath, true, copilotId) { Index = CopilotItemViewModels.Count, };
+                var item = new CopilotItemViewModel(stageCode, cachePath, true, copilotId);
                 CopilotItemViewModels.Add(item);
             }
         }
@@ -1691,23 +1689,6 @@ public partial class CopilotViewModel : Screen
                 }
 
                 break;
-            }
-
-            SaveCopilotTask();
-        });
-    }
-
-    /// <summary>
-    /// 更新任务顺序
-    /// UI 绑定的方法
-    /// </summary>
-    [UsedImplicitly]
-    public void CopilotItemIndexChanged()
-    {
-        Execute.OnUIThread(() => {
-            for (int i = 0; i < CopilotItemViewModels.Count; i++)
-            {
-                CopilotItemViewModels[i].Index = i;
             }
 
             SaveCopilotTask();

--- a/src/MaaWpfGui/Views/UI/CopilotView.xaml
+++ b/src/MaaWpfGui/Views/UI/CopilotView.xaml
@@ -514,7 +514,7 @@
                         hc:BorderElement.CornerRadius="4,4,0,0"
                         properties:AutoScroll.AutoScroll="True"
                         BorderThickness="1,1,1,0"
-                        DragDrop.Drop="{s:Action CopilotItemIndexChanged}"
+                        DragDrop.Drop="{s:Action SaveCopilotTask}"
                         IsEnabled="{c:Binding StartEnabled}"
                         ItemsSource="{Binding Path=CopilotItemViewModels}"
                         Style="{DynamicResource NoSelectedHighlightListBoxStyle}"
@@ -558,7 +558,7 @@
                                         IsEnabled="{Binding ElementName=CopilotList, Path=DataContext.Idle}"
                                         MouseRightButtonUp="{s:Action SelectCopilotTask}"
                                         PreviewMouseLeftButtonUp="{s:Action SelectCopilotTask}"
-                                        Tag="{c:Binding Index}" />
+                                        Tag="{Binding}" />
                                     <Button
                                         Grid.Column="2"
                                         Margin="0"
@@ -569,7 +569,7 @@
                                         Background="Transparent"
                                         BorderThickness="0"
                                         Command="{s:Action DeleteCopilotTask}"
-                                        CommandParameter="{c:Binding Index}"
+                                        CommandParameter="{Binding}"
                                         IsEnabled="{Binding ElementName=CopilotList, Path=DataContext.Idle}" />
                                 </Grid>
                             </DataTemplate>


### PR DESCRIPTION
此前在条目拖动后，执行删除和预览操作可能会显示其他条目，此问题可稳定复现。造成此问题的原因是 UI 绑定的 `Index` **值**并没有随 `CopilotItemIndexChanged` 更新。

此 pr 删除了 `Index` 属性并更新相关逻辑，直接绑定 `CopilotItemViewModel` 条目，并修改相应逻辑，因为 `Index` 属性不应在 ViewModel 中维护，而应在需要时计算出来。

## Summary by Sourcery

重构 Copilot 任务的选择和删除逻辑，使其直接绑定到 `CopilotItemViewModel` 实例，而不是维护一个 Index 属性。

Bug 修复：
- 通过避免使用过期的基于索引的访问，修复拖放操作后 Copilot 任务删除和预览行为不正确的问题。

增强项：
- 从 `CopilotItemViewModel` 中移除 Index 字段和相关的索引重计算逻辑，改为依赖集合顺序和直接的项目引用。
- 更新 Copilot 任务的添加、选择和清理流程，使其使用具体的项目实例，并通过 `SaveCopilotTask` 持久化更改，而不是通过索引更新。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor copilot task selection and deletion to bind directly to CopilotItemViewModel instances instead of maintaining an Index property.

Bug Fixes:
- Fix incorrect copilot task deletion and preview behavior after drag-and-drop by avoiding stale index-based access.

Enhancements:
- Remove the Index field from CopilotItemViewModel and related index-recalculation logic, relying on collection order and direct item references instead.
- Update copilot task add, select, and cleanup flows to use item instances and persist changes via SaveCopilotTask rather than index updates.

</details>