### PR TITLE
chore: 制造站加入苍苔组，避免苍苔与阿罗玛冲突

### DIFF
--- a/resource/infrast.json
+++ b/resource/infrast.json
@@ -1852,6 +1852,34 @@
                 ]
             },
             {
+                "desc": "苍苔组",
+                "necessary": [
+                    {
+                        "desc": "苍苔-2",
+                        "efficient": {
+                            "PureGold": 35.1
+                        },
+                        "skills": ["bskill_man_skill_spd3", "bskill_man_gold1"]
+                    }
+                ],
+                "optional": [
+                    {
+                        "desc": "金属工艺·β",
+                        "efficient": {
+                            "PureGold": 40.1
+                        },
+                        "skills": ["bskill_man_gold2"]
+                    },
+                    {
+                        "desc": "金属工艺·α",
+                        "efficient": {
+                            "PureGold": 35.1
+                        },
+                        "skills": ["bskill_man_gold1"]
+                    }
+                ]
+            },
+            {
                 "desc": "多萝西-2组",
                 "necessary": [
                     {


### PR DESCRIPTION
如果单纯按一般逻辑筛选，会导致阿罗玛和苍苔同时使用，亏苍苔加成。
故单独加入苍苔组逻辑，避免同时选中苍苔和阿罗玛（以及未来可能会出现的其他非金属工艺的赤金制造加成干员）

## Summary by Sourcery

新功能：
- 在制造站逻辑中引入专用的 Cangtai 干员分组，以防止其与 Aroma 以及未来类似的非金属金币产出干员被同时选中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Introduce a dedicated Cangtai operator group in manufacturing station logic to prevent simultaneous selection with Aroma and similar future non-metal gold-production operators.

</details>