### PR TITLE
fix: vertical alignment to top instead of center for updatesettings

### DIFF
--- a/src/MaaWpfGui/Views/UserControl/Settings/VersionUpdateSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/Settings/VersionUpdateSettingsUserControl.xaml
@@ -44,132 +44,131 @@
                 Grid.Row="0"
                 Grid.Column="0"
                 VerticalAlignment="Top">
-                <StackPanel VerticalAlignment="Top">
+                <CheckBox
+                    Margin="8"
+                    HorizontalAlignment="Left"
+                    VerticalAlignment="Center"
+                    Content="{DynamicResource StartupUpdateCheck}"
+                    IsChecked="{Binding StartupUpdateCheck}"
+                    IsEnabled="False" />
+                <StackPanel Margin="8" Orientation="Horizontal">
                     <CheckBox
-                        Margin="8"
                         HorizontalAlignment="Left"
                         VerticalAlignment="Center"
-                        Content="{DynamicResource StartupUpdateCheck}"
-                        IsChecked="{Binding StartupUpdateCheck}"
-                        IsEnabled="False" />
-                    <StackPanel Margin="8" Orientation="Horizontal">
-                        <CheckBox
+                        Content="{DynamicResource UpdateAutoCheck}"
+                        IsChecked="{Binding UpdateAutoCheck}" />
+                    <controls:TooltipBlock TooltipText="{DynamicResource UpdateAutoCheckTip}" />
+                </StackPanel>
+                <CheckBox
+                    Margin="8"
+                    HorizontalAlignment="Left"
+                    VerticalAlignment="Center"
+                    Content="{DynamicResource UpdateAutoDownload}"
+                    IsChecked="{Binding AutoDownloadUpdatePackage}" />
+                <CheckBox
+                    Margin="8"
+                    HorizontalAlignment="Left"
+                    VerticalAlignment="Center"
+                    Content="{DynamicResource AutoInstallUpdatePackage}"
+                    IsChecked="{Binding AutoInstallUpdatePackage}" />
+                <StackPanel
+                    Margin="8"
+                    Orientation="Horizontal"
+                    Visibility="{c:Binding 'UpdateSource == &quot;Github&quot;'}">
+                    <CheckBox
+                        HorizontalAlignment="Left"
+                        VerticalAlignment="Center"
+                        Content="{DynamicResource ForceGithubGlobalSource}"
+                        IsChecked="{Binding ForceGithubGlobalSource}" />
+                    <controls:TooltipBlock TooltipText="{DynamicResource ForceGithubGlobalSourceTip}" />
+                </StackPanel>
+                <StackPanel Margin="8">
+                    <StackPanel Margin="0,0,0,5" Orientation="Horizontal">
+                        <controls:TextBlock
+                            Margin="8,0,0,0"
                             HorizontalAlignment="Left"
-                            VerticalAlignment="Center"
-                            Content="{DynamicResource UpdateAutoCheck}"
-                            IsChecked="{Binding UpdateAutoCheck}" />
-                        <controls:TooltipBlock TooltipText="{DynamicResource UpdateAutoCheckTip}" />
+                            Text="{DynamicResource UpdateCheck}" />
+                        <controls:TooltipBlock TooltipMaxWidth="350" TooltipText="{DynamicResource UpdateCheckTip}" />
                     </StackPanel>
-                    <CheckBox
-                        Margin="8"
+                    <hc:ComboBox
+                        Width="150"
                         HorizontalAlignment="Left"
                         VerticalAlignment="Center"
-                        Content="{DynamicResource UpdateAutoDownload}"
-                        IsChecked="{Binding AutoDownloadUpdatePackage}" />
-                    <CheckBox
-                        Margin="8"
-                        HorizontalAlignment="Left"
-                        VerticalAlignment="Center"
-                        Content="{DynamicResource AutoInstallUpdatePackage}"
-                        IsChecked="{Binding AutoInstallUpdatePackage}" />
-                    <StackPanel
-                        Margin="8"
-                        Orientation="Horizontal"
-                        Visibility="{c:Binding 'UpdateSource == &quot;Github&quot;'}">
-                        <CheckBox
-                            HorizontalAlignment="Left"
-                            VerticalAlignment="Center"
-                            Content="{DynamicResource ForceGithubGlobalSource}"
-                            IsChecked="{Binding ForceGithubGlobalSource}" />
-                        <controls:TooltipBlock TooltipText="{DynamicResource ForceGithubGlobalSourceTip}" />
-                    </StackPanel>
+                        DisplayMemberPath="Display"
+                        ItemsSource="{Binding VersionTypeList}"
+                        SelectedValue="{Binding VersionType}"
+                        SelectedValuePath="Value" />
+                </StackPanel>
+
+                <StackPanel>
                     <StackPanel Margin="8">
                         <StackPanel Margin="0,0,0,5" Orientation="Horizontal">
                             <controls:TextBlock
                                 Margin="8,0,0,0"
                                 HorizontalAlignment="Left"
-                                Text="{DynamicResource UpdateCheck}" />
-                            <controls:TooltipBlock TooltipMaxWidth="350" TooltipText="{DynamicResource UpdateCheckTip}" />
+                                Text="{DynamicResource UpdateSource}" />
+                            <controls:TooltipBlock TooltipMaxWidth="350" TooltipText="{DynamicResource UpdateSourceTip}" />
                         </StackPanel>
                         <hc:ComboBox
                             Width="150"
                             HorizontalAlignment="Left"
                             VerticalAlignment="Center"
                             DisplayMemberPath="Display"
-                            ItemsSource="{Binding VersionTypeList}"
-                            SelectedValue="{Binding VersionType}"
+                            ItemsSource="{Binding UpdateSourceList}"
+                            SelectedValue="{Binding UpdateSource}"
                             SelectedValuePath="Value" />
                     </StackPanel>
-
-                    <StackPanel>
-                        <StackPanel Margin="8">
-                            <StackPanel Margin="0,0,0,5" Orientation="Horizontal">
-                                <controls:TextBlock
-                                    Margin="8,0,0,0"
-                                    HorizontalAlignment="Left"
-                                    Text="{DynamicResource UpdateSource}" />
-                                <controls:TooltipBlock TooltipMaxWidth="350" TooltipText="{DynamicResource UpdateSourceTip}" />
-                            </StackPanel>
-                            <hc:ComboBox
-                                Width="150"
-                                HorizontalAlignment="Left"
-                                VerticalAlignment="Center"
-                                DisplayMemberPath="Display"
-                                ItemsSource="{Binding UpdateSourceList}"
-                                SelectedValue="{Binding UpdateSource}"
-                                SelectedValuePath="Value" />
-                        </StackPanel>
-                        <StackPanel Margin="8" Visibility="{c:Binding 'UpdateSource == &quot;MirrorChyan&quot;'}">
-                            <controls:TextBlock Margin="8,0,0,5" HorizontalAlignment="Left">
-                                <TextBlock.Text>
-                                    <MultiBinding StringFormat="{}{0} CDK">
-                                        <Binding Source="{StaticResource MirrorChyan}" />
-                                    </MultiBinding>
-                                </TextBlock.Text>
-                            </controls:TextBlock>
-                            <Grid Width="150">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="Auto" />
-                                </Grid.ColumnDefinitions>
-                                <hc:PasswordBox
-                                    hc:BorderElement.CornerRadius="4,0,0,4"
-                                    IsSafeEnabled="False"
-                                    ShowEyeButton="True"
-                                    UnsafePassword="{Binding MirrorChyanCdk}" />
-                                <Button
-                                    Grid.Column="1"
-                                    hc:BorderElement.CornerRadius="0,4,4,0"
-                                    BorderThickness="0,1,1,1"
-                                    Command="{s:Action MirrorChyanCdkCopy}"
-                                    Content="{DynamicResource Copy}" />
-                            </Grid>
-                            <controls:TextBlock
-                                MaxWidth="150"
-                                Margin="0,5,0,0"
-                                Foreground="{DynamicResource ErrorLogBrush}"
-                                Text="{DynamicResource MirrorChyanCdkFetchFailed}"
-                                TextWrapping="Wrap"
-                                Visibility="{c:Binding MirrorChyanCdkFetchFailed}" />
-                            <controls:TextBlock
-                                MaxWidth="150"
-                                Margin="0,5,0,0"
-                                d:Foreground="{DynamicResource SuccessLogBrush}"
-                                d:Text="{DynamicResource MirrorChyanCdkRemainingDays}"
-                                uiBehaviors:ResourceReferenceHelper.ForegroundResourceKey="{Binding MirrorChyanCdkRemainingBrush}"
-                                Text="{Binding MirrorChyanCdkRemainingText}"
-                                TextWrapping="Wrap"
-                                ToolTip="{Binding MirrorChyanCdkExpiredLocalTime}" />
-                        </StackPanel>
-                        <controls:TextBlock HorizontalAlignment="Center" VerticalAlignment="Center">
-                            <Hyperlink
-                                Cursor="Hand"
-                                NavigateUri="{Binding Source={x:Static constants:MaaUrls.MirrorChyanWebsite}}"
-                                TextDecorations="None">
-                                <TextBlock Text="{DynamicResource MirrorChyan}" />
-                            </Hyperlink>
+                    <StackPanel Margin="8" Visibility="{c:Binding 'UpdateSource == &quot;MirrorChyan&quot;'}">
+                        <controls:TextBlock Margin="8,0,0,5" HorizontalAlignment="Left">
+                            <TextBlock.Text>
+                                <MultiBinding StringFormat="{}{0} CDK">
+                                    <Binding Source="{StaticResource MirrorChyan}" />
+                                </MultiBinding>
+                            </TextBlock.Text>
                         </controls:TextBlock>
+                        <Grid Width="150">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <hc:PasswordBox
+                                hc:BorderElement.CornerRadius="4,0,0,4"
+                                IsSafeEnabled="False"
+                                ShowEyeButton="True"
+                                UnsafePassword="{Binding MirrorChyanCdk}" />
+                            <Button
+                                Grid.Column="1"
+                                hc:BorderElement.CornerRadius="0,4,4,0"
+                                BorderThickness="0,1,1,1"
+                                Command="{s:Action MirrorChyanCdkCopy}"
+                                Content="{DynamicResource Copy}" />
+                        </Grid>
+                        <controls:TextBlock
+                            MaxWidth="150"
+                            Margin="0,5,0,0"
+                            Foreground="{DynamicResource ErrorLogBrush}"
+                            Text="{DynamicResource MirrorChyanCdkFetchFailed}"
+                            TextWrapping="Wrap"
+                            Visibility="{c:Binding MirrorChyanCdkFetchFailed}" />
+                        <controls:TextBlock
+                            MaxWidth="150"
+                            Margin="0,5,0,0"
+                            d:Foreground="{DynamicResource SuccessLogBrush}"
+                            d:Text="{DynamicResource MirrorChyanCdkRemainingDays}"
+                            uiBehaviors:ResourceReferenceHelper.ForegroundResourceKey="{Binding MirrorChyanCdkRemainingBrush}"
+                            Text="{Binding MirrorChyanCdkRemainingText}"
+                            TextWrapping="Wrap"
+                            ToolTip="{Binding MirrorChyanCdkExpiredLocalTime}"
+                            Visibility="{c:Binding 'MirrorChyanCdkRemainingText != &quot;&quot;'}" />
                     </StackPanel>
+                    <controls:TextBlock HorizontalAlignment="Center" VerticalAlignment="Center">
+                        <Hyperlink
+                            Cursor="Hand"
+                            NavigateUri="{Binding Source={x:Static constants:MaaUrls.MirrorChyanWebsite}}"
+                            TextDecorations="None">
+                            <TextBlock Text="{DynamicResource MirrorChyan}" />
+                        </Hyperlink>
+                    </controls:TextBlock>
                 </StackPanel>
             </StackPanel>
             <Grid


### PR DESCRIPTION
The scenario:
in such a situation where I want to manually update MAA (when I want to) I always disable "auto download update".
The new update logging moves all the buttons on the left side making it impossible to re disable auto download update during an update process. 

This PR anchors everything to TOP, this way the user has a much cleaner experience to click buttons while keeping logging.

Something similar happens when enabling / disabling myrrorchyan, but on the right side buttons since the alignement is centered, the total height changes, shifting the buttons.

<img width="200" height="543" alt="Screenshot 2026-01-10 150105" src="https://github.com/user-attachments/assets/9c8669eb-fe9f-4340-ad01-73357d9980bb" />
<img width="200" height="600" alt="Screenshot 2026-01-10 150121" src="https://github.com/user-attachments/assets/4d5462e9-17a3-4d7a-bb78-fb8043a20bd3" />

