### PR TITLE
docs: 更新 Visual C++ 可再发行程序包链接至 V14 版本

### DIFF
--- a/docs/en-us/manual/faq.md
+++ b/docs/en-us/manual/faq.md
@@ -20,7 +20,7 @@ winget install "Microsoft.VCRedist.2015+.x64" --override "/repair /passive /nore
 
 Or manually download and install these <u>**two**</u> runtime libraries to solve the problem:
 
-- [Visual C++ Redistributable](https://aka.ms/vs/17/release/vc_redist.x64.exe)
+- [Visual C++ Redistributable](https://aka.ms/vc14/vc_redist.x64.exe)
 - [.NET Desktop Runtime 10](https://aka.ms/dotnet/10.0/windowsdesktop-runtime-win-x64.exe)
 
 :::

--- a/docs/ja-jp/manual/faq.md
+++ b/docs/ja-jp/manual/faq.md
@@ -20,7 +20,7 @@ winget install "Microsoft.VCRedist.2015+.x64" --override "/repair /passive /nore
 
 以下の<u>**2つ**</u>のランタイムライブラリを手動でダウンロードしてインストールして問題を解決してください。
 
-- [Visual C++ 再頒布可能パッケージ](https://aka.ms/vs/17/release/vc_redist.x64.exe)
+- [Visual C++ 再頒布可能パッケージ](https://aka.ms/vc14/vc_redist.x64.exe)
 - [.NET デスクトップランタイム 10](https://aka.ms/dotnet/10.0/windowsdesktop-runtime-win-x64.exe)
 
 :::

--- a/docs/ko-kr/manual/faq.md
+++ b/docs/ko-kr/manual/faq.md
@@ -20,7 +20,7 @@ winget install "Microsoft.VCRedist.2015+.x64" --override "/repair /passive /nore
 
 아래<u>**두 개**</u>의 실행 라이브러리를 수동으로 다운로드하여 설치하여 문제를 해결하세요.
 
-- [Visual C++ 재배포 가능 패키지](https://aka.ms/vs/17/release/vc_redist.x64.exe)
+- [Visual C++ 재배포 가능 패키지](https://aka.ms/vc14/vc_redist.x64.exe)
 - [.NET 데스크톱 런타임 10](https://aka.ms/dotnet/10.0/windowsdesktop-runtime-win-x64.exe)
 
 :::

--- a/docs/zh-cn/manual/faq.md
+++ b/docs/zh-cn/manual/faq.md
@@ -20,7 +20,7 @@ winget install "Microsoft.VCRedist.2015+.x64" --override "/repair /passive /nore
 
 或手动下载并安装以下<u>**两个**</u>运行库来解决问题。
 
-- [Visual C++ 可再发行程序包](https://aka.ms/vs/17/release/vc_redist.x64.exe)
+- [Visual C++ 可再发行程序包](https://aka.ms/vc14/vc_redist.x64.exe)
 - [.NET 桌面运行时 10](https://aka.ms/dotnet/10.0/windowsdesktop-runtime-win-x64.exe)
 
 :::

--- a/docs/zh-tw/manual/faq.md
+++ b/docs/zh-tw/manual/faq.md
@@ -20,7 +20,7 @@ winget install "Microsoft.VCRedist.2015+.x64" --override "/repair /passive /nore
 
 或者手動下載並安裝以下<u>**兩個**</u>運行庫來解決問題。
 
-- [Visual C++ 可再發行程序包](https://aka.ms/vs/17/release/vc_redist.x64.exe)
+- [Visual C++ 可再發行程序包](https://aka.ms/vc14/vc_redist.x64.exe)
 - [.NET 桌面運行時 10](https://aka.ms/dotnet/10.0/windowsdesktop-runtime-win-x64.exe)
 
 :::

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -1347,7 +1347,7 @@ With save file: farm points through crafting (advanced).
     <system:String x:Key="UnknownDllDetected" xml:space="preserve">Unknown DLL files have been detected in the MAA runtime directory, which may cause DLL hijacking and unexpected consequences.
 Please extract MAA into a separate new folder, or remove any DLL files that do not belong to MAA.
     </system:String>
-    <system:String x:Key="VC++NotInstalled" xml:space="preserve">Detected that Microsoft Visual C++ Redistributable 2015-2022 (x64) is NOT installed or the version is too low.
+    <system:String x:Key="VC++NotInstalled" xml:space="preserve">Detected that Microsoft Visual C++ V14 Redistributable (x64) is NOT installed or the version is too low.
 Click "{key=Confirm}" to execute the installation script and exit MAA. Click "{key=Cancel}" to exit MAA directly.
     </system:String>
     <system:String x:Key="MultiInstanceUnderSamePath" xml:space="preserve">Only one instance can be launched under the same path!

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -1348,7 +1348,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="UnknownDllDetected" xml:space="preserve">MAA の実行ディレクトリに不明な DLL ファイルが検出されました。DLL ハイジャックが発生し、予期しない結果を招く可能性があります。
 MAA を新しい独立したフォルダーに解凍するか、MAA に属さない DLL ファイルを削除してください。
     </system:String>
-    <system:String x:Key="VC++NotInstalled" xml:space="preserve">Microsoft Visual C++ redistributable 2015-2022 (x64) がインストールされていないか、バージョンが低すぎることが検出されました。
+    <system:String x:Key="VC++NotInstalled" xml:space="preserve">Microsoft Visual C++ V14 Redistributable (x64) がインストールされていないか、バージョンが低すぎることが検出されました。
 「{key=Confirm}」をクリックするとインストールスクリプトが実行され、MAA が終了します。「{key=Cancel}」をクリックすると MAA が直接終了します。
     </system:String>
     <system:String x:Key="MultiInstanceUnderSamePath" xml:space="preserve">同じパスの下で起動できるのは1つのインスタンスのみ！

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -1348,7 +1348,7 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="UnknownDllDetected" xml:space="preserve">检测到 MAA 运行目录下存在未知 DLL 文件，可能导致 DLL 劫持并产生意外后果。
 请将 MAA 解压到一个独立的新文件夹中，或移除不属于 MAA 的 DLL 文件。
     </system:String>
-    <system:String x:Key="VC++NotInstalled" xml:space="preserve">检测到 Microsoft Visual C++ Redistributable 2015-2022 (x64) 未安装或版本过低,
+    <system:String x:Key="VC++NotInstalled" xml:space="preserve">检测到 Microsoft Visual C++ V14 Redistributable (x64) 未安装或版本过低,
 点击 "{key=Confirm}" 执行安装脚本并退出 MAA, 点击 "{key=Cancel}" 将直接退出.
     </system:String>
     <system:String x:Key="MultiInstanceUnderSamePath" xml:space="preserve">同一路径下只能启动一个实例！

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -1348,7 +1348,7 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="UnknownDllDetected" xml:space="preserve">檢測到 MAA 執行目錄下存在未知的 DLL 檔案，可能導致 DLL 劫持並產生意外後果。
 請將 MAA 解壓縮到一個獨立的新資料夾中，或移除不屬於 MAA 的 DLL 檔案。
     </system:String>
-    <system:String x:Key="VC++NotInstalled" xml:space="preserve">偵測到 Microsoft Visual C++ Redistributable 2015-2022 (x64) 未安裝或版本過低,
+    <system:String x:Key="VC++NotInstalled" xml:space="preserve">偵測到 Microsoft Visual C++ V14 Redistributable (x64) 未安裝或版本過低,
 點擊 "{key=Confirm}" 將執行安裝腳本並退出 MAA，點擊 "{key=Cancel}" 將直接退出 MAA。
     </system:String>
     <system:String x:Key="MultiInstanceUnderSamePath" xml:space="preserve">同一路徑下只能啟動一個實例！

--- a/tools/DependencySetup_依赖库安装.bat
+++ b/tools/DependencySetup_依赖库安装.bat
@@ -70,7 +70,7 @@ if %ErrorOccurred% equ 0 (
     echo %YELLOW%If the installation is successful, you don't need to run this dependency installation script again.%RESET%
     echo.
     echo %WHITE%Microsoft Visual C++ Redistributable:%RESET%
-    echo %CYAN%https://aka.ms/vs/17/release/vc_redist.x64.exe%RESET%
+    echo %CYAN%https://aka.ms/vc14/vc_redist.x64.exe%RESET%
     echo.
     echo %WHITE%.NET Desktop Runtime 10.0:%RESET%
     echo %CYAN%https://aka.ms/dotnet/10.0/windowsdesktop-runtime-win-x64.exe%RESET%


### PR DESCRIPTION
## 来源

https://learn.microsoft.com/zh-cn/cpp/windows/latest-supported-vc-redist?view=msvc-170#latest-supported-redistributable-version


## Summary by Sourcery

Documentation:
- 将 Visual C++ 可再发行组件下载链接更新为指向 vc14 的地址，适用于英文、日文、韩文、简体中文和繁体中文的常见问题解答页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Update Visual C++ Redistributable download URL to the vc14 link in English, Japanese, Korean, Simplified Chinese, and Traditional Chinese FAQ pages.

</details>