### PR TITLE
feat: 自动检测地图是否为多阶段地图, 判断是否需要使用 view[0].x 修正镜头

### DIFF
--- a/3rdparty/include/Arknights-Tile-Pos/TileCalc2.hpp
+++ b/3rdparty/include/Arknights-Tile-Pos/TileCalc2.hpp
@@ -115,15 +115,15 @@ static constexpr double rel_pos_x = 1.3143386840820312;
 static constexpr double rel_pos_y = 1.314337134361267;
 static constexpr double rel_pos_z = -0.3967874050140381;
 
-inline auto get_retreat_screen_pos(const Level& level)
+inline auto get_retreat_screen_pos(const Level& level, bool has_multi_stages = false)
 {
-    const vec3d relative_pos = { -rel_pos_x + level.view[0].x, +rel_pos_y, rel_pos_z };
+    const vec3d relative_pos = { -rel_pos_x + (has_multi_stages ? level.view[0].x : 0), +rel_pos_y, rel_pos_z };
     return world_to_screen(level, relative_pos, true);
 }
 
-inline auto get_skill_screen_pos(const Level& level)
+inline auto get_skill_screen_pos(const Level& level, bool has_multi_stages = false)
 {
-    const vec3d relative_pos = { +rel_pos_x + level.view[0].x, -rel_pos_y, rel_pos_z };
+    const vec3d relative_pos = { +rel_pos_x + (has_multi_stages ? level.view[0].x : 0), -rel_pos_y, rel_pos_z };
     return world_to_screen(level, relative_pos, true);
 }
 

--- a/src/MaaCore/Config/Miscellaneous/TilePack.h
+++ b/src/MaaCore/Config/Miscellaneous/TilePack.h
@@ -60,6 +60,7 @@ public:
         std::unordered_map<Point, TileInfo> side_tile_info;
         Point retreat_button;
         Point skill_button;
+        bool has_multi_stages = false;
     };
 
 public:

--- a/src/MaaCore/Task/BattleHelper.h
+++ b/src/MaaCore/Task/BattleHelper.h
@@ -56,7 +56,7 @@ protected:
     bool update_kills(const cv::Mat& image, const cv::Mat& image_prev = cv::Mat());
     bool update_cost(const cv::Mat& image, const cv::Mat& image_prev = cv::Mat());
 
-    cv::Mat get_top_view(const cv::Mat& cam_img, bool side = true);
+    cv::Mat get_top_view(const cv::Mat& cam_img, bool side = true, bool has_multi_stages = false);
 
     bool deploy_oper(const std::string& name, const Point& loc, battle::DeployDirection direction);
     bool retreat_oper(const std::string& name);
@@ -109,6 +109,7 @@ protected:
     std::unordered_map<Point, TilePack::TileInfo> m_normal_tile_info; // 正常的坐标映射
     Point m_skill_button_pos;
     Point m_retreat_button_pos;
+    bool m_has_multi_stages = false;
     std::unordered_map<std::string, battle::SkillUsage> m_skill_usage;
     std::unordered_map<std::string, int> m_skill_times;
     std::unordered_map<std::string, int> m_skill_error_count;


### PR DESCRIPTION
排除掉 生息演算、卫戍、促荣共竞，发现 77 个关卡的起点/终点超出屏幕范围 (1280x720)（5%容差

以下地图被判别为存在多阶段，即 镜头移动
```
[TN-1] 无尽灼烧与强力破坏 act1bossrush_01
[TN-2] 卷土重来 act1bossrush_02
[TN-3] 风沙轰隆隆 act1bossrush_03
[TN-4] 理念之争 act1bossrush_04
[TN-1] 无尽灼烧与强力破坏 act1bossrush_tm01
[TN-2] 卷土重来 act1bossrush_tm02
[TN-3] 风沙轰隆隆 act1bossrush_tm03
[TN-4] 理念之争 act1bossrush_tm04
[新手模式] AC-TR-1 act1vautochess_m01
[协议原型] AC-1 act1vautochess_m02
[常规模式] AC-2 act1vautochess_m03
[常规模式] AC-2 act1vautochess_m04
[常规模式] AC-2 act1vautochess_m05
[CF-9] 决战！燃烧的狩魂！ act24side_09
[CF-EX-8] 炬火燎原 act24side_ex08#f#
[CF-EX-8] 炬火燎原 act24side_ex08
[CF-S-1] 终极斗技之战 act24side_s01
[TN-1] 困顿囚徒 act2bossrush_01
[TN-2] 大块头和小不点 act2bossrush_02
[TN-3] 裂地重击 act2bossrush_03
[TN-4] 骄阳之影 act2bossrush_04
[TN-1] 困顿囚徒 act2bossrush_tm01
[TN-2] 大块头和小不点 act2bossrush_tm02
[TN-3] 裂地重击 act2bossrush_tm03
[TN-4] 骄阳之影 act2bossrush_tm04
[TN-1] 适者生存 act3bossrush_01
[TN-2] 惊惧与血色 act3bossrush_02
[TN-3] 不测之渊 act3bossrush_03
[TN-4] 虔信者的前路 act3bossrush_04
[TN-1] 适者生存 act3bossrush_tm01
[TN-2] 惊惧与血色 act3bossrush_tm02
[TN-3] 不测之渊 act3bossrush_tm03
[TN-4] 虔信者的前路 act3bossrush_tm04
[OS-10] 耶拉冈德在上 act46side_10
[TN-1] 冰霜与战火 act4bossrush_01
[TN-2] 无关音律 act4bossrush_02
[TN-3] 延烧的深池 act4bossrush_03
[TN-4] 辞旧岁 act4bossrush_04
[TN-1] 冰霜与战火 act4bossrush_tm01
[TN-2] 无关音律 act4bossrush_tm02
[TN-3] 延烧的深池 act4bossrush_tm03
[TN-4] 辞旧岁 act4bossrush_tm04
[TN-1] 严寒骤血 act5bossrush_01
[TN-2] 无声破裂 act5bossrush_02
[TN-3] 幕间重影 act5bossrush_03
[TN-4] 沸海遮日 act5bossrush_04
[TN-1] 严寒骤血 act5bossrush_ex01
[TN-2] 无声破裂 act5bossrush_ex02
[TN-3] 幕间重影 act5bossrush_ex03
[TN-4] 沸海遮日 act5bossrush_ex04
[TN-4] 沸海遮日 act5bossrush_fin04
[TN-1] 严寒骤血 act5bossrush_tm01
[TN-2] 无声破裂 act5bossrush_tm02
[TN-3] 幕间重影 act5bossrush_tm03
[TN-4] 沸海遮日 act5bossrush_tm04
[TN-2] 深度产业 act6bossrush_02
[TN-3] 荒沙剑影 act6bossrush_03
[TN-4] 凋零奏鸣 act6bossrush_04
[TN-2] 深度产业 act6bossrush_ex02
[TN-3] 荒沙剑影 act6bossrush_ex03
[TN-4] 凋零奏鸣 act6bossrush_ex04
[TN-4] 凋零奏鸣 act6bossrush_fin04
[TN-2] 深度产业 act6bossrush_tm02
[TN-3] 荒沙剑影 act6bossrush_tm03
[TN-4] 凋零奏鸣 act6bossrush_tm04
[H16-4] 异常预案-4 hard_16-04
[16-16] 示我以真 main_16-15#s
[16-16] 示我以真 main_16-15
[ISW-DF] 授法 ro4_b_7
[ISW-DF] 不容拒绝 ro4_b_8
[ISW-NO] 以血还血 ro4_duel_1
[ISW-NO] 善恶同道 ro4_duel_2
[ISW-NO] 石心双子 ro4_duel_3
[ISW-NO] 夕江对擂 ro5_duel_1
[ISW-NO] 南武群英会 ro5_duel_2
[ISW-NO] 夕江诀 ro5_duel_3
[ISW-NO] 南武约 ro5_duel_4
```


## Summary by Sourcery

基于地块位置检测多阶段地图，并相应调整与相机相关的坐标计算。

新功能：
- 通过验证起始/结束地块的屏幕位置是否在预期范围内，自动检测多阶段地图。
- 将多阶段地图信息传递到战斗辅助模块，以影响技能与撤退按钮的位置以及顶视图（top-view）的计算。

改进：
- 更新地块位置工具，使其在地图被检测为多阶段时，才可选地使用 `view[0].x` 偏移技能与撤退按钮的坐标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Detect multi-stage maps based on tile positions and adjust camera-related coordinate calculations accordingly.

New Features:
- Add automatic detection of multi-stage maps by validating start/end tile screen positions against expected bounds.
- Propagate multi-stage map information into battle helpers to influence skill and retreat button positioning and top-view calculations.

Enhancements:
- Update tile position utilities to optionally offset skill and retreat button coordinates using view[0].x only when the map is detected as multi-stage.

</details>