### PR TITLE
fix: 修复 TaskDialog 按钮文本赋值时的语法错误及空引用保护

### DIFF
--- a/src/MaaWpfGui/Helper/MessageBoxHelper.cs
+++ b/src/MaaWpfGui/Helper/MessageBoxHelper.cs
@@ -265,17 +265,29 @@ public static class MessageBoxHelper
 
         if (!string.IsNullOrEmpty(cancel))
         {
-            page.Buttons.FirstOrDefault(b => b == System.Windows.Forms.TaskDialogButton.Cancel)?.Text = cancel;
+            var cancelButton = page.Buttons.FirstOrDefault(b => b == TaskDialogButton.Cancel);
+            if (cancelButton != null)
+            {
+                cancelButton.Text = cancel;
+            }
         }
 
         if (!string.IsNullOrEmpty(yes))
         {
-            page.Buttons.FirstOrDefault(b => b == TaskDialogButton.Yes)?.Text = yes;
+            var yesButton = page.Buttons.FirstOrDefault(b => b == TaskDialogButton.Yes);
+            if (yesButton != null)
+            {
+                yesButton.Text = yes;
+            }
         }
 
         if (!string.IsNullOrEmpty(no))
         {
-            page.Buttons.FirstOrDefault(b => b == TaskDialogButton.No)?.Text = no;
+            var noButton = page.Buttons.FirstOrDefault(b => b == TaskDialogButton.No);
+            if (noButton != null)
+            {
+                noButton.Text = no;
+            }
         }
 
         // Allow cancel


### PR DESCRIPTION
修复了在赋值语句左侧使用 ?. 导致的代码无效/编译错误问题

- 将原本无效的 FirstOrDefault(...)?.Text = ... 写法改为显式的空值检查。
- 确保在设置 cancel, yes, no 按钮文案之前，先判断按钮是否存在，避免潜在的异常。

## Summary by Sourcery

Bug Fixes:
- 通过显式的空值检查来保护对 TaskDialog 的取消、是和否按钮文本的赋值操作，以防止编译错误和潜在的空引用问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Guard TaskDialog cancel, yes, and no button text assignments with explicit null checks to prevent compilation errors and potential null reference issues.

</details>