### PR TITLE
fix: 修复了特殊路径下执行adb命令可能失败的问题(#15381)

### DIFF
--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/StartSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/StartSettingsUserControlModel.cs
@@ -400,8 +400,8 @@ public class StartSettingsUserControlModel : PropertyChangedBase
         };
 
         process.Start();
-        process.StandardInput.WriteLine($"{adbPath} kill-server");
-        process.StandardInput.WriteLine($"{adbPath} start-server");
+        process.StandardInput.WriteLine($"\"{adbPath}\" kill-server");
+        process.StandardInput.WriteLine($"\"{adbPath}\" start-server");
         process.StandardInput.WriteLine("exit");
         process.WaitForExit();
     }
@@ -430,7 +430,7 @@ public class StartSettingsUserControlModel : PropertyChangedBase
         Process process = new Process { StartInfo = processStartInfo, };
 
         process.Start();
-        process.StandardInput.WriteLine($"{adbPath} disconnect {address}");
+        process.StandardInput.WriteLine($"\"{adbPath}\" disconnect {address}");
         process.StandardInput.WriteLine("exit");
         process.WaitForExit();
     }


### PR DESCRIPTION
这件事情教会我们，处理文件路径别忘了加引号.jpg

## Summary by Sourcery

错误修复：
- 修复当 adb 路径包含空格或特殊字符时，`adb restart` 和 `adb reconnect` 命令会失败的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix adb restart and reconnect commands failing when the adb path contains spaces or special characters.

</details>