### PR TITLE
feat: 完成 WDA (WebDriverAgent) 控制器实现以支持 iOS 设备

### DIFF
--- a/docs/bundle-id-detection-plan.md
+++ b/docs/bundle-id-detection-plan.md
@@ -1,0 +1,465 @@
+# Bundle ID 检测方案 - 替代分辨率检测
+
+## 核心思路
+
+使用 WDA 的 `mobile: activeAppInfo` API 查询当前前台应用的 Bundle ID，直接判断游戏是否已启动并在前台，而不是通过检测屏幕分辨率变化。
+
+## 优势分析
+
+### 相比分辨率检测的优点
+
+1. **更直接准确**
+   - 直接判断目标应用是否在前台
+   - 不受屏幕方向影响
+   - 不依赖截图操作
+
+2. **更快速**
+   - 轻量级 API 调用（< 100ms）
+   - 无需等待屏幕旋转
+   - 通常 1-3 秒内完成检测
+
+3. **更可靠**
+   - 不受分辨率变化影响
+   - 不受 WDA 缓存影响
+   - 避免了方向抖动问题
+
+4. **逻辑更清晰**
+   - 启动游戏 → 检查游戏是否在前台 → 完成初始化
+   - 不需要关心中间的屏幕旋转过程
+
+5. **代码更简单**
+   - 代码量减少约 50%
+   - 不需要复杂的状态机
+   - 不需要处理并发初始化问题
+
+## WDA API 支持
+
+### activeAppInfo 方法
+
+**HTTP 请求：**
+```http
+POST /session/{sessionId}/execute/sync
+Content-Type: application/json
+
+{
+  "script": "mobile: activeAppInfo",
+  "args": []
+}
+```
+
+**响应格式：**
+```json
+{
+  "value": {
+    "bundleId": "com.hypergryph.arknights",
+    "pid": 1234,
+    "name": "Arknights",
+    "processArguments": {
+      "args": [],
+      "env": {}
+    }
+  }
+}
+```
+
+**返回字段：**
+- `bundleId`: 前台应用的 Bundle ID（关键字段）
+- `pid`: 进程 ID
+- `name`: 应用名称
+- `processArguments`: 进程参数
+
+## 实现方案
+
+### Phase 1: WDAController 添加查询前台应用方法
+
+**File**: `src/MaaCore/Controller/WDAController.h`
+
+```cpp
+public:
+    // 查询当前前台应用的 Bundle ID
+    std::optional<std::string> get_active_bundle_id() const;
+
+private:
+    mutable std::mutex m_http_mutex;  // 保护 HTTP 通道（已在 v3 中添加）
+```
+
+**File**: `src/MaaCore/Controller/WDAController.cpp`
+
+```cpp
+std::optional<std::string> asst::WDAController::get_active_bundle_id() const
+{
+    LogTraceFunction;
+
+    // 线程安全：加锁保护 HTTP 请求
+    std::lock_guard<std::mutex> lock(m_http_mutex);
+
+    try {
+        // 使用 WDA 的 execute script API 调用 mobile: activeAppInfo
+        json::object execute_params;
+        execute_params["script"] = "mobile: activeAppInfo";
+        execute_params["args"] = json::array {};
+
+        auto response = const_cast<WDAController*>(this)->http_post(
+            "/session/" + m_session_id + "/execute/sync",
+            execute_params.to_string()
+        );
+
+        if (!response.success()) {
+            Log.warn("Failed to get active app info, status:", response.status_code);
+            return std::nullopt;
+        }
+
+        auto json_opt = json::parse(response.body);
+        if (!json_opt) {
+            Log.warn("Failed to parse active app info response");
+            return std::nullopt;
+        }
+
+        // 响应格式: {"value": {"bundleId": "...", "pid": 1234, ...}}
+        if (json_opt->contains("value") && json_opt->at("value").is_object()) {
+            const auto& value = json_opt->at("value");
+            if (value.contains("bundleId") && value.at("bundleId").is_string()) {
+                std::string bundle_id = value.at("bundleId").as_string();
+                Log.trace("Active bundle ID:", bundle_id);
+                return bundle_id;
+            }
+        }
+
+        Log.warn("bundleId not found in response");
+        return std::nullopt;
+    }
+    catch (const std::exception& e) {
+        Log.error("Exception in get_active_bundle_id:", e.what());
+        return std::nullopt;
+    }
+}
+```
+
+### Phase 2: 改进 StartGameTaskPlugin
+
+**File**: `src/MaaCore/Task/Miscellaneous/StartGameTaskPlugin.cpp`
+
+```cpp
+bool StartGameTaskPlugin::_run()
+{
+    if (m_client_type.empty()) {
+        return false;
+    }
+
+    // check for MAC / iOS
+    if (ctrler()->get_controller_type() == ControllerType::MacPlayTools ||
+        ctrler()->get_controller_type() == ControllerType::WDA) {
+
+        // 获取目标游戏的 Bundle ID
+        auto target_bundle_id = Config.get_package_name(m_client_type);
+        if (!target_bundle_id) {
+            Log.error("Failed to get bundle ID for client_type:", m_client_type);
+            return false;
+        }
+
+        Log.info("Starting game with bundle ID:", target_bundle_id.value());
+
+        bool start_result = ctrler()->start_game(m_client_type);
+        if (!start_result) {
+            return false;
+        }
+
+        // For WDA with deferred init, wait for game to be in foreground
+        if (ctrler()->get_controller_type() == ControllerType::WDA &&
+            !ctrler()->is_fully_initialized()) {
+
+            Log.info("Game start command sent, waiting for app to be in foreground...");
+
+            constexpr int max_attempts = 30;      // 30 次
+            constexpr int poll_interval_ms = 500; // 每次 500ms
+            constexpr int stable_count = 3;       // 需要连续 3 次检测到游戏在前台
+
+            int consecutive_success = 0;
+            bool game_in_foreground = false;
+
+            for (int i = 0; i < max_attempts; ++i) {
+                // 检查是否需要退出
+                if (need_exit()) {
+                    Log.info("Task exit requested during game launch wait");
+                    return false;
+                }
+
+                // 查询当前前台应用的 Bundle ID
+                auto active_bundle = ctrler()->get_active_bundle_id();
+
+                if (active_bundle && active_bundle.value() == target_bundle_id.value()) {
+                    consecutive_success++;
+                    Log.trace("Game is in foreground (stable {}/{})",
+                             consecutive_success, stable_count);
+
+                    if (consecutive_success >= stable_count) {
+                        Log.info("Game confirmed in foreground: {}", target_bundle_id.value());
+                        game_in_foreground = true;
+                        break;
+                    }
+                }
+                else {
+                    // 重置计数器（防止应用切换抖动）
+                    if (consecutive_success > 0) {
+                        Log.trace("App switched, resetting counter. Current: {}",
+                                 active_bundle.value_or("unknown"));
+                        consecutive_success = 0;
+                    }
+
+                    Log.trace("Waiting for game to be in foreground (attempt {}/{}), current: {}",
+                             i + 1, max_attempts, active_bundle.value_or("unknown"));
+                }
+
+                sleep(poll_interval_ms);
+            }
+
+            if (!game_in_foreground) {
+                Log.error("Timeout waiting for game to be in foreground after {} seconds",
+                         max_attempts * poll_interval_ms / 1000);
+                // 仍然尝试完成初始化，让分辨率检查决定是否失败
+            }
+
+            // 游戏在前台后，额外等待一小段时间让界面稳定
+            Log.info("Game in foreground, waiting for UI to stabilize...");
+            sleep(1000);  // 等待 1 秒让游戏界面完全加载和旋转
+
+            // 完成延迟初始化（此时会进行分辨率检查）
+            if (!ctrler()->complete_init()) {
+                Log.error("Failed to complete deferred initialization");
+                return false;
+            }
+
+            Log.info("WDA initialization completed successfully");
+        }
+
+        return true;
+    }
+
+    // ... rest of Android logic unchanged ...
+}
+```
+
+### Phase 3: Controller 添加接口（简化版）
+
+**File**: `src/MaaCore/Controller/Controller.h`
+
+```cpp
+public:
+    // 查询当前前台应用的标识符（WDA 返回 Bundle ID）
+    std::optional<std::string> get_active_bundle_id() const;
+```
+
+**File**: `src/MaaCore/Controller/Controller.cpp`
+
+```cpp
+std::optional<std::string> asst::Controller::get_active_bundle_id() const
+{
+    if (m_controller_type == ControllerType::WDA) {
+        auto wda_ctrl = std::dynamic_pointer_cast<WDAController>(m_controller);
+        if (wda_ctrl) {
+            return wda_ctrl->get_active_bundle_id();
+        }
+    }
+    return std::nullopt;
+}
+```
+
+## 完整流程
+
+```
+用户点击"启动游戏"
+  ↓
+Controller::connect() with deferred_init=true
+  ↓ (跳过截图和分辨率检查)
+状态: Connected
+  ↓
+StartGameTaskPlugin::_run()
+  ↓
+调用 WDA /wda/apps/launch 启动游戏
+  ↓
+轮询检测前台应用 (每 500ms)
+  ├─ 调用 get_active_bundle_id()
+  ├─ 比较 Bundle ID
+  └─ 需要连续 3 次匹配
+  ↓ (通常 1-3 秒)
+检测到目标游戏在前台
+  ↓
+等待 1 秒让界面稳定（包括屏幕旋转）
+  ↓
+调用 complete_init()
+  ├─ 截图
+  ├─ 检查分辨率（此时应该已经是横屏）
+  └─ 创建 ControlScaleProxy
+  ↓
+状态: Initialized
+  ↓
+MAA 正常运行
+```
+
+## 与 v3 方案对比
+
+| 方面 | v3 (分辨率检测) | Bundle ID 检测 |
+|------|----------------|---------------|
+| **检测目标** | 屏幕分辨率 | 前台应用 Bundle ID |
+| **数据源** | `query_window_size()` | `activeAppInfo` API |
+| **检测速度** | 慢（等待旋转）| 快（1-3 秒）|
+| **可靠性** | 中（受方向影响）| 高（直接判断）|
+| **代码复杂度** | 高（~350 行）| 低（~180 行）|
+| **状态机** | 5 状态 | 3 状态即可 |
+| **并发处理** | 需要 CV + mutex | 简单 mutex 即可 |
+| **方向抖动** | 需要处理 | 不受影响 |
+| **WDA 缓存** | 需要刷新 | 不受影响 |
+
+## 代码改动量
+
+### 新增代码
+- `WDAController::get_active_bundle_id()`: ~50 行
+- `Controller::get_active_bundle_id()`: ~10 行
+- `StartGameTaskPlugin` 轮询逻辑: ~60 行
+- **总计**: ~120 行
+
+### 修改代码
+- `Controller::connect()`: ~20 行（deferred init 逻辑）
+- `Controller::complete_init()`: ~40 行（简化版，不需要 CV）
+- **总计**: ~60 行
+
+### 对比 v3
+- v3 新增: ~250 行
+- v3 修改: ~150 行
+- **Bundle ID 方案减少约 50% 代码量**
+
+## 优势总结
+
+### 1. 更直接的判断逻辑 ✅
+- 不需要猜测屏幕是否旋转
+- 直接知道游戏是否在前台
+- 逻辑清晰易懂
+
+### 2. 更快的响应速度 ✅
+- 不需要等待屏幕旋转动画（通常 1-2 秒）
+- API 调用延迟低（< 100ms）
+- 总体等待时间减少 50%
+
+### 3. 更简单的实现 ✅
+- 不需要复杂的 5 状态状态机
+- 不需要 condition_variable
+- 不需要处理方向抖动
+- 不需要刷新 WDA 缓存
+
+### 4. 更可靠的检测 ✅
+- 不受屏幕方向影响
+- 不受分辨率缓存影响
+- Bundle ID 是确定性的字符串比较
+
+### 5. 更好的用户体验 ✅
+- 启动更快
+- 失败信息更明确（"游戏未启动"vs"分辨率不对"）
+- 减少等待时间
+
+## 潜在问题和解决方案
+
+### 问题 1: 游戏在前台但还在加载
+
+**现象**: Bundle ID 检测通过，但游戏界面还在加载中
+
+**解决方案**:
+- 检测到游戏在前台后，额外等待 1 秒
+- 这 1 秒足够让游戏完成界面加载和屏幕旋转
+- 如果仍然不够，`complete_init()` 的分辨率检查会失败
+
+### 问题 2: 游戏启动失败但没有错误
+
+**现象**: 启动命令成功，但游戏实际没有启动
+
+**解决方案**:
+- 15 秒超时机制
+- 超时后仍然尝试 `complete_init()`
+- 让分辨率检查作为最终验证
+
+### 问题 3: 用户手动切换应用
+
+**现象**: 游戏启动后，用户切换到其他应用
+
+**解决方案**:
+- 连续 3 次检测机制
+- 如果中途切换应用，计数器重置
+- 必须连续 3 次（1.5 秒）检测到游戏才认定成功
+
+### 问题 4: Bundle ID 不匹配
+
+**现象**: 配置的 Bundle ID 与实际不符
+
+**解决方案**:
+- 记录详细日志，显示当前前台应用
+- 用户可以根据日志修正配置
+- 超时后仍然尝试初始化，让用户看到错误信息
+
+## 测试用例
+
+### Test Case 1: 正常流程
+1. iPhone 主屏幕（竖屏）
+2. 连接 WDA with deferred_init
+3. 启动游戏
+4. 1 秒后检测到游戏在前台（连续 3 次）
+5. 等待 1 秒
+6. complete_init() 成功（横屏 2436x1125）
+7. MAA 正常运行
+
+### Test Case 2: 游戏启动慢
+1. 启动游戏
+2. 5 秒后才检测到游戏在前台
+3. 等待 1 秒
+4. complete_init() 成功
+5. 总耗时约 6 秒（仍在 15 秒超时内）
+
+### Test Case 3: 用户切换应用
+1. 启动游戏
+2. 检测到游戏在前台 1 次
+3. 用户切换到设置应用
+4. 计数器重置
+5. 用户切回游戏
+6. 重新开始计数，连续 3 次后成功
+
+### Test Case 4: 游戏启动失败
+1. 启动游戏命令发送
+2. 游戏实际没有启动（崩溃或其他原因）
+3. 15 秒超时
+4. 仍然尝试 complete_init()
+5. 分辨率检查失败（仍然是主屏幕）
+6. 返回错误，任务失败
+
+### Test Case 5: Bundle ID 配置错误
+1. 配置的 Bundle ID 不正确
+2. 游戏启动成功，但 Bundle ID 不匹配
+3. 15 秒超时
+4. 日志显示当前前台应用的 Bundle ID
+5. 用户可以根据日志修正配置
+
+## 风险评估
+
+| 风险 | 严重性 | 概率 | 缓解措施 |
+|------|--------|------|----------|
+| API 调用失败 | 中 | 低 | 返回 nullopt，继续轮询 |
+| Bundle ID 不匹配 | 低 | 低 | 详细日志，用户可修正 |
+| 游戏加载慢 | 低 | 中 | 额外等待 1 秒 |
+| 用户切换应用 | 低 | 低 | 连续 3 次检测 |
+| 超时 | 低 | 低 | 15 秒足够长 |
+
+## 实现优先级
+
+1. **P0**: Phase 1 (WDAController 添加 `get_active_bundle_id()`)
+2. **P0**: Phase 2 (StartGameTaskPlugin 轮询逻辑)
+3. **P1**: Phase 3 (Controller 接口封装)
+4. **P2**: 完善错误处理和日志
+
+## 结论
+
+**Bundle ID 检测方案明显优于分辨率检测方案**：
+
+1. ✅ **更快**: 1-3 秒 vs 3-15 秒
+2. ✅ **更简单**: 180 行 vs 350 行
+3. ✅ **更可靠**: 不受方向、缓存影响
+4. ✅ **更直接**: 判断游戏是否在前台，而不是猜测
+5. ✅ **更易维护**: 逻辑清晰，状态简单
+
+**推荐立即采用此方案**，替代 v3 的复杂分辨率检测方案。

--- a/src/MaaCore/Assistant.cpp
+++ b/src/MaaCore/Assistant.cpp
@@ -133,7 +133,7 @@ bool asst::Assistant::set_instance_option(InstanceOptionKey key, const std::stri
             m_ctrler->set_touch_mode(TouchMode::MacPlayTools);
             return true;
         }
-        else if (constexpr std::string_view WDA = "WDA"; value == WDA) {
+        else if (constexpr std::string_view WDA = "wda"; value == WDA) {
             m_ctrler->set_touch_mode(TouchMode::WDA);
             return true;
         }

--- a/src/MaaCore/Assistant.cpp
+++ b/src/MaaCore/Assistant.cpp
@@ -133,6 +133,10 @@ bool asst::Assistant::set_instance_option(InstanceOptionKey key, const std::stri
             m_ctrler->set_touch_mode(TouchMode::MacPlayTools);
             return true;
         }
+        else if (constexpr std::string_view WDA = "WDA"; value == WDA) {
+            m_ctrler->set_touch_mode(TouchMode::WDA);
+            return true;
+        }
         break;
     case InstanceOptionKey::DeploymentWithPause:
         if (constexpr std::string_view Enable = "1"; value == Enable) {

--- a/src/MaaCore/Common/AsstTypes.h
+++ b/src/MaaCore/Common/AsstTypes.h
@@ -54,6 +54,7 @@ enum class TouchMode
     Minitouch = 1,
     Maatouch = 2,
     MacPlayTools = 3,
+    WDA = 4,
 };
 
 namespace ControlFeat

--- a/src/MaaCore/Controller/Controller.cpp
+++ b/src/MaaCore/Controller/Controller.cpp
@@ -23,6 +23,7 @@
 #include "MaatouchController.h"
 #include "MinitouchController.h"
 #include "PlayToolsController.h"
+#include "WDAController.h"
 
 #include "Common/AsstTypes.h"
 #include "Utils/Logger.hpp"
@@ -60,6 +61,9 @@ std::shared_ptr<asst::ControllerAPI> asst::Controller::create_controller(
             break;
         case ControllerType::MacPlayTools:
             controller = std::make_shared<PlayToolsController>(m_callback, m_inst, platform_type);
+            break;
+        case ControllerType::WDA:
+            controller = std::make_shared<WDAController>(m_callback, m_inst, platform_type);
             break;
         default:
             return nullptr;
@@ -304,6 +308,9 @@ void asst::Controller::set_touch_mode(const TouchMode& mode) noexcept
         break;
     case TouchMode::MacPlayTools:
         m_controller_type = ControllerType::MacPlayTools;
+        break;
+    case TouchMode::WDA:
+        m_controller_type = ControllerType::WDA;
         break;
     default:
         m_controller_type = ControllerType::Minitouch;

--- a/src/MaaCore/Controller/Controller.h
+++ b/src/MaaCore/Controller/Controller.h
@@ -66,6 +66,9 @@ public:
     bool start_game(const std::string& client_type);
     bool stop_game(const std::string& client_type);
 
+    // Pre-start game before connection (WDA only)
+    bool pre_start_game(const std::string& client_type);
+
     bool click(const Point& p);
     bool click(const Rect& rect);
     bool input(const std::string& text);
@@ -123,8 +126,12 @@ private:
 
     bool m_swipe_with_pause = false;
     bool m_kill_adb_on_exit = false;
+    bool m_deferred_proxy_init = false;  // For WDA: defer proxy creation until first use
 
     mutable std::shared_mutex m_image_mutex;
     cv::Mat m_cache_image;
+
+    // Ensure proxy is initialized (for WDA deferred init)
+    bool ensure_proxy_initialized();
 };
 } // namespace asst

--- a/src/MaaCore/Controller/ControllerAPI.h
+++ b/src/MaaCore/Controller/ControllerAPI.h
@@ -15,6 +15,7 @@ enum class ControllerType
     Minitouch,
     Maatouch,
     MacPlayTools,
+    WDA,
 };
 
 class ControllerAPI

--- a/src/MaaCore/Controller/WDAController.cpp
+++ b/src/MaaCore/Controller/WDAController.cpp
@@ -30,6 +30,7 @@ asst::WDAController::WDAController(
 asst::WDAController::~WDAController()
 {
     destroy_session();
+    close_connection();
 }
 
 bool asst::WDAController::connect(
@@ -85,8 +86,7 @@ bool asst::WDAController::inited() const noexcept
 
 const std::string& asst::WDAController::get_uuid() const
 {
-    static const std::string uuid("com.hypergryph.arknights");
-    return uuid;
+    return m_uuid;
 }
 
 size_t asst::WDAController::get_pipe_data_size() const noexcept
@@ -99,7 +99,7 @@ size_t asst::WDAController::get_version() const noexcept
     return 0;
 }
 
-bool asst::WDAController::screencap(cv::Mat& image_payload, bool allow_reconnect [[maybe_unused]])
+bool asst::WDAController::screencap(cv::Mat& image_payload, bool allow_reconnect)
 {
     LogTraceFunction;
 
@@ -109,12 +109,35 @@ bool asst::WDAController::screencap(cv::Mat& image_payload, bool allow_reconnect
     if (!response.success()) {
         Log.error("Screenshot request failed, status:", response.status_code);
 
-        // 记录失败的截图
-        m_screencap_cost.emplace_back(-1);
-        ++m_screencap_times;
-        report_screencap_cost();
-
-        return false;
+        // 尝试重连
+        if (allow_reconnect) {
+            Log.info("Attempting reconnect due to screencap failure...");
+            if (reconnect()) {
+                // 重连成功，重试截图
+                response = http_get("/screenshot");
+                if (!response.success()) {
+                    Log.error("Screenshot still failed after reconnect, status:", response.status_code);
+                    m_screencap_cost.emplace_back(-1);
+                    ++m_screencap_times;
+                    report_screencap_cost();
+                    return false;
+                }
+            }
+            else {
+                Log.error("Reconnect failed");
+                m_screencap_cost.emplace_back(-1);
+                ++m_screencap_times;
+                report_screencap_cost();
+                return false;
+            }
+        }
+        else {
+            // 记录失败的截图
+            m_screencap_cost.emplace_back(-1);
+            ++m_screencap_times;
+            report_screencap_cost();
+            return false;
+        }
     }
 
     auto json_opt = json::parse(response.body);
@@ -154,15 +177,61 @@ bool asst::WDAController::screencap(cv::Mat& image_payload, bool allow_reconnect
     return decode_success;
 }
 
-bool asst::WDAController::start_game(const std::string& client_type [[maybe_unused]])
+bool asst::WDAController::start_game(const std::string& client_type)
 {
-    Log.info("start_game is not fully supported on WDA");
+    LogTraceFunction;
+
+    if (client_type.empty()) {
+        Log.error("client_type is empty");
+        return false;
+    }
+
+    auto bundle_id = Config.get_package_name(client_type);
+    if (!bundle_id) {
+        Log.error("Failed to get bundle ID for client_type:", client_type);
+        return false;
+    }
+
+    // 使用 WDA 的 /wda/apps/launch 接口启动应用
+    json::object launch_params;
+    launch_params["bundleId"] = bundle_id.value();
+
+    auto response = http_post("/session/" + m_session_id + "/wda/apps/launch", launch_params.to_string());
+    if (!response.success()) {
+        Log.error("Failed to start game, status:", response.status_code);
+        return false;
+    }
+
+    Log.info("Game started successfully:", bundle_id.value());
     return true;
 }
 
-bool asst::WDAController::stop_game(const std::string& client_type [[maybe_unused]])
+bool asst::WDAController::stop_game(const std::string& client_type)
 {
-    Log.info("stop_game is not fully supported on WDA");
+    LogTraceFunction;
+
+    if (client_type.empty()) {
+        Log.error("client_type is empty");
+        return false;
+    }
+
+    auto bundle_id = Config.get_package_name(client_type);
+    if (!bundle_id) {
+        Log.error("Failed to get bundle ID for client_type:", client_type);
+        return false;
+    }
+
+    // 使用 WDA 的 /wda/apps/terminate 接口停止应用
+    json::object terminate_params;
+    terminate_params["bundleId"] = bundle_id.value();
+
+    auto response = http_post("/session/" + m_session_id + "/wda/apps/terminate", terminate_params.to_string());
+    if (!response.success()) {
+        Log.error("Failed to stop game, status:", response.status_code);
+        return false;
+    }
+
+    Log.info("Game stopped successfully:", bundle_id.value());
     return true;
 }
 
@@ -188,9 +257,26 @@ bool asst::WDAController::click(const Point& p)
     return true;
 }
 
-bool asst::WDAController::input(const std::string& text [[maybe_unused]])
+bool asst::WDAController::input(const std::string& text)
 {
-    Log.info("InputText is not fully supported on WDA");
+    LogTraceFunction;
+
+    if (text.empty()) {
+        return true;
+    }
+
+    // WDA 使用 /wda/keys 接口输入文本
+    // 注意：这需要当前有一个聚焦的输入框
+    json::object keys_params;
+    keys_params["value"] = json::array { text };
+
+    auto response = http_post("/session/" + m_session_id + "/wda/keys", keys_params.to_string());
+    if (!response.success()) {
+        Log.error("WDA input text failed, status:", response.status_code);
+        return false;
+    }
+
+    Log.info("WDA input text success:", text);
     return true;
 }
 
@@ -198,10 +284,10 @@ bool asst::WDAController::swipe(
     const Point& p1,
     const Point& p2,
     int duration,
-    bool extra_swipe,
+    bool extra_swipe [[maybe_unused]],
     double slope_in [[maybe_unused]],
     double slope_out [[maybe_unused]],
-    bool with_pause [[maybe_unused]])
+    bool with_pause)
 {
     // Clamp在MAA坐标空间
     int x1 = std::clamp(p1.x, 0, m_screen_size.first - 1);
@@ -213,33 +299,33 @@ bool asst::WDAController::swipe(
     auto [wda_x1, wda_y1] = transform_to_wda_coords(x1, y1);
     auto [wda_x2, wda_y2] = transform_to_wda_coords(x2, y2);
 
+    const auto& opt = Config.get_options();
+    int actual_duration_ms = duration > 0 ? duration : opt.minitouch_swipe_default_duration;
+
+    // 转换为秒，WDA的 dragfromtoforduration 端点需要秒为单位
+    // WDA支持精确的短时间滑动，最小值设为0.1秒（100ms）
+    // 最大值为60秒（WDA限制）
+    double duration_sec = std::clamp(actual_duration_ms / 1000.0, 0.1, 60.0);
+
     Log.trace("WDA swipe: MAA(", x1, ",", y1, "->", x2, ",", y2,
               ") -> WDA(", wda_x1, ",", wda_y1, "->", wda_x2, ",", wda_y2,
-              ") duration:", duration);
+              ") duration:", duration_sec, "s");
 
-    const auto& opt = Config.get_options();
-    int actual_duration = duration > 0 ? duration : opt.minitouch_swipe_default_duration;
-
-    std::string action_json = build_w3c_swipe_action(wda_x1, wda_y1, wda_x2, wda_y2, actual_duration);
-    auto response = http_post("/session/" + m_session_id + "/actions", action_json);
-
-    if (!response.success()) {
-        Log.error("WDA swipe failed, status:", response.status_code);
+    // 使用WDA原生的drag API，duration控制精确
+    if (!perform_drag(wda_x1, wda_y1, wda_x2, wda_y2, duration_sec)) {
+        Log.error("WDA swipe failed");
         return false;
     }
 
-    // extra_swipe处理
-    if (extra_swipe && opt.minitouch_extra_swipe_duration > 0) {
+    // with_pause: 滑动结束后暂停一段时间
+    if (with_pause) {
         std::this_thread::sleep_for(std::chrono::milliseconds(opt.minitouch_swipe_extra_end_delay));
-
-        // 计算extra swipe的终点（MAA坐标空间）
-        int extra_y2 = y2 - opt.minitouch_extra_swipe_dist;
-        auto [extra_wda_x2, extra_wda_y2] = transform_to_wda_coords(x2, extra_y2);
-
-        std::string extra_action = build_w3c_swipe_action(
-            wda_x2, wda_y2, extra_wda_x2, extra_wda_y2, opt.minitouch_extra_swipe_duration);
-        http_post("/session/" + m_session_id + "/actions", extra_action);
     }
+
+    // 注意：WDA不需要extra_swipe
+    // extra_swipe是为了解决ADB的bug（滑动后惯性太大，需要反向短滑动来"刹车"）
+    // WDA的dragfromtoforduration API是精确的，滑动结束就会停止，不需要额外的滑动
+    // 如果启用extra_swipe，反而会导致滑动不停止（因为又发起了一次新的滑动）
 
     return true;
 }
@@ -260,30 +346,188 @@ void asst::WDAController::back_to_home() noexcept
     Log.info("HOME is not supported on WDA");
 }
 
+bool asst::WDAController::ensure_connection()
+{
+    // 如果socket不存在或已关闭，重新建立连接
+    if (!m_socket || !m_socket->is_open()) {
+        try {
+            m_socket = std::make_unique<tcp::socket>(m_context);
+            tcp::resolver resolver(m_context);
+
+            Log.trace("Establishing HTTP connection to", m_host, ":", m_port);
+            boost::asio::connect(*m_socket, resolver.resolve(m_host, std::to_string(m_port)));
+
+            // 设置socket选项以保持连接
+            m_socket->set_option(tcp::no_delay(true));  // 禁用Nagle算法，降低延迟
+
+            Log.trace("HTTP connection established");
+            return true;
+        }
+        catch (const std::exception& e) {
+            Log.error("Failed to establish HTTP connection:", e.what());
+            m_socket.reset();
+            return false;
+        }
+    }
+    return true;
+}
+
+void asst::WDAController::close_connection()
+{
+    if (m_socket && m_socket->is_open()) {
+        try {
+            boost::system::error_code ec;
+            m_socket->shutdown(tcp::socket::shutdown_both, ec);
+            m_socket->close(ec);
+            Log.trace("HTTP connection closed");
+        }
+        catch (const std::exception& e) {
+            Log.warn("Error closing HTTP connection:", e.what());
+        }
+    }
+    m_socket.reset();
+}
+
 asst::WDAController::HttpResponse asst::WDAController::http_get(const std::string& path)
 {
     HttpResponse response;
-    try {
-        tcp::socket socket(m_context);
-        tcp::resolver resolver(m_context);
-        boost::asio::connect(socket, resolver.resolve(m_host, std::to_string(m_port)));
 
+    if (!ensure_connection()) {
+        response.status_code = 0;
+        return response;
+    }
+
+    try {
+        // 使用 HTTP/1.1 Keep-Alive
         std::string request = "GET " + path + " HTTP/1.1\r\n"
                               "Host: " + m_host + ":" + std::to_string(m_port) + "\r\n"
                               "Accept: application/json\r\n"
-                              "Connection: close\r\n\r\n";
+                              "Connection: keep-alive\r\n\r\n";
 
-        boost::asio::write(socket, boost::asio::buffer(request));
+        boost::asio::write(*m_socket, boost::asio::buffer(request));
 
         boost::asio::streambuf response_buf;
         boost::system::error_code ec;
 
-        boost::asio::read_until(socket, response_buf, "\r\n", ec);
+        // 读取状态行
+        boost::asio::read_until(*m_socket, response_buf, "\r\n", ec);
+        if (ec) {
+            Log.warn("Connection error during read, reconnecting...");
+            close_connection();
+            if (!ensure_connection()) {
+                response.status_code = 0;
+                return response;
+            }
+            // 重试一次
+            boost::asio::write(*m_socket, boost::asio::buffer(request));
+            boost::asio::read_until(*m_socket, response_buf, "\r\n", ec);
+        }
+
         std::istream response_stream(&response_buf);
         std::string http_version;
         response_stream >> http_version >> response.status_code;
 
-        boost::asio::read_until(socket, response_buf, "\r\n\r\n", ec);
+        // 读取header
+        boost::asio::read_until(*m_socket, response_buf, "\r\n\r\n", ec);
+
+        std::string header;
+        size_t content_length = 0;
+        bool chunked = false;
+
+        while (std::getline(response_stream, header) && header != "\r") {
+            if (header.find("Content-Length:") != std::string::npos ||
+                header.find("content-length:") != std::string::npos) {
+                auto pos = header.find(':');
+                if (pos != std::string::npos) {
+                    content_length = std::stoul(header.substr(pos + 1));
+                }
+            }
+            if (header.find("Transfer-Encoding: chunked") != std::string::npos ||
+                header.find("transfer-encoding: chunked") != std::string::npos) {
+                chunked = true;
+            }
+        }
+
+        // 读取body
+        if (chunked) {
+            // 处理chunked编码（WDA通常不用，但为了完整性添加）
+            std::ostringstream ss;
+            ss << &response_buf;
+            response.body = ss.str();
+        }
+        else if (content_length > 0) {
+            size_t remaining = content_length;
+            if (response_buf.size() > 0) {
+                std::ostringstream ss;
+                ss << &response_buf;
+                response.body = ss.str();
+                remaining = content_length > response.body.size() ? content_length - response.body.size() : 0;
+            }
+            if (remaining > 0) {
+                std::vector<char> buf(remaining);
+                boost::asio::read(*m_socket, boost::asio::buffer(buf), ec);
+                response.body.append(buf.data(), buf.size());
+            }
+        }
+        else {
+            // 没有Content-Length，读取到连接关闭
+            std::ostringstream ss;
+            boost::asio::read(*m_socket, response_buf, ec);
+            ss << &response_buf;
+            response.body = ss.str();
+        }
+    }
+    catch (const std::exception& e) {
+        Log.error("HTTP GET failed:", e.what());
+        response.status_code = 0;
+        close_connection();  // 出错时关闭连接，下次会重新建立
+    }
+    return response;
+}
+
+asst::WDAController::HttpResponse asst::WDAController::http_post(const std::string& path, const std::string& json_body)
+{
+    HttpResponse response;
+
+    if (!ensure_connection()) {
+        response.status_code = 0;
+        return response;
+    }
+
+    try {
+        // 使用 HTTP/1.1 Keep-Alive
+        std::string request = "POST " + path + " HTTP/1.1\r\n"
+                              "Host: " + m_host + ":" + std::to_string(m_port) + "\r\n"
+                              "Content-Type: application/json\r\n"
+                              "Content-Length: " + std::to_string(json_body.size()) + "\r\n"
+                              "Accept: application/json\r\n"
+                              "Connection: keep-alive\r\n\r\n" + json_body;
+
+        boost::asio::write(*m_socket, boost::asio::buffer(request));
+
+        boost::asio::streambuf response_buf;
+        boost::system::error_code ec;
+
+        // 读取状态行
+        boost::asio::read_until(*m_socket, response_buf, "\r\n", ec);
+        if (ec) {
+            Log.warn("Connection error during POST, reconnecting...");
+            close_connection();
+            if (!ensure_connection()) {
+                response.status_code = 0;
+                return response;
+            }
+            // 重试一次
+            boost::asio::write(*m_socket, boost::asio::buffer(request));
+            boost::asio::read_until(*m_socket, response_buf, "\r\n", ec);
+        }
+
+        std::istream response_stream(&response_buf);
+        std::string http_version;
+        response_stream >> http_version >> response.status_code;
+
+        // 读取header
+        boost::asio::read_until(*m_socket, response_buf, "\r\n\r\n", ec);
 
         std::string header;
         size_t content_length = 0;
@@ -297,6 +541,7 @@ asst::WDAController::HttpResponse asst::WDAController::http_get(const std::strin
             }
         }
 
+        // 读取body
         if (content_length > 0) {
             size_t remaining = content_length;
             if (response_buf.size() > 0) {
@@ -307,67 +552,21 @@ asst::WDAController::HttpResponse asst::WDAController::http_get(const std::strin
             }
             if (remaining > 0) {
                 std::vector<char> buf(remaining);
-                boost::asio::read(socket, boost::asio::buffer(buf), ec);
+                boost::asio::read(*m_socket, boost::asio::buffer(buf), ec);
                 response.body.append(buf.data(), buf.size());
             }
         }
         else {
             std::ostringstream ss;
-            boost::asio::read(socket, response_buf, ec);
+            boost::asio::read(*m_socket, response_buf, ec);
             ss << &response_buf;
             response.body = ss.str();
         }
     }
     catch (const std::exception& e) {
-        Log.error("HTTP GET failed:", e.what());
-        response.status_code = 0;
-    }
-    return response;
-}
-
-asst::WDAController::HttpResponse asst::WDAController::http_post(const std::string& path, const std::string& json_body)
-{
-    HttpResponse response;
-    try {
-        tcp::socket socket(m_context);
-        tcp::resolver resolver(m_context);
-        boost::asio::connect(socket, resolver.resolve(m_host, std::to_string(m_port)));
-
-        std::string request = "POST " + path + " HTTP/1.1\r\n"
-                              "Host: " + m_host + ":" + std::to_string(m_port) + "\r\n"
-                              "Content-Type: application/json\r\n"
-                              "Content-Length: " + std::to_string(json_body.size()) + "\r\n"
-                              "Accept: application/json\r\n"
-                              "Connection: close\r\n\r\n" + json_body;
-
-        boost::asio::write(socket, boost::asio::buffer(request));
-
-        boost::asio::streambuf response_buf;
-        boost::system::error_code ec;
-
-        boost::asio::read_until(socket, response_buf, "\r\n", ec);
-        std::istream response_stream(&response_buf);
-        std::string http_version;
-        response_stream >> http_version >> response.status_code;
-
-        boost::asio::read_until(socket, response_buf, "\r\n\r\n", ec);
-        boost::asio::read(socket, response_buf, ec);
-
-        std::ostringstream ss;
-        ss << &response_buf;
-        std::string full_response = ss.str();
-
-        auto body_start = full_response.find("\r\n\r\n");
-        if (body_start != std::string::npos) {
-            response.body = full_response.substr(body_start + 4);
-        }
-        else {
-            response.body = full_response;
-        }
-    }
-    catch (const std::exception& e) {
         Log.error("HTTP POST failed:", e.what());
         response.status_code = 0;
+        close_connection();
     }
     return response;
 }
@@ -375,27 +574,44 @@ asst::WDAController::HttpResponse asst::WDAController::http_post(const std::stri
 asst::WDAController::HttpResponse asst::WDAController::http_delete(const std::string& path)
 {
     HttpResponse response;
-    try {
-        tcp::socket socket(m_context);
-        tcp::resolver resolver(m_context);
-        boost::asio::connect(socket, resolver.resolve(m_host, std::to_string(m_port)));
 
+    if (!ensure_connection()) {
+        response.status_code = 0;
+        return response;
+    }
+
+    try {
+        // 使用 HTTP/1.1 Keep-Alive
         std::string request = "DELETE " + path + " HTTP/1.1\r\n"
                               "Host: " + m_host + ":" + std::to_string(m_port) + "\r\n"
                               "Accept: application/json\r\n"
-                              "Connection: close\r\n\r\n";
+                              "Connection: keep-alive\r\n\r\n";
 
-        boost::asio::write(socket, boost::asio::buffer(request));
+        boost::asio::write(*m_socket, boost::asio::buffer(request));
 
         boost::asio::streambuf response_buf;
         boost::system::error_code ec;
 
-        boost::asio::read_until(socket, response_buf, "\r\n", ec);
+        // 读取状态行
+        boost::asio::read_until(*m_socket, response_buf, "\r\n", ec);
+        if (ec) {
+            Log.warn("Connection error during DELETE, reconnecting...");
+            close_connection();
+            if (!ensure_connection()) {
+                response.status_code = 0;
+                return response;
+            }
+            // 重试一次
+            boost::asio::write(*m_socket, boost::asio::buffer(request));
+            boost::asio::read_until(*m_socket, response_buf, "\r\n", ec);
+        }
+
         std::istream response_stream(&response_buf);
         std::string http_version;
         response_stream >> http_version >> response.status_code;
 
-        boost::asio::read(socket, response_buf, ec);
+        // 读取剩余数据
+        boost::asio::read(*m_socket, response_buf, ec);
         std::ostringstream ss;
         ss << &response_buf;
         response.body = ss.str();
@@ -403,6 +619,7 @@ asst::WDAController::HttpResponse asst::WDAController::http_delete(const std::st
     catch (const std::exception& e) {
         Log.error("HTTP DELETE failed:", e.what());
         response.status_code = 0;
+        close_connection();
     }
     return response;
 }
@@ -421,7 +638,35 @@ bool asst::WDAController::check_wda_status()
         return false;
     }
 
-    Log.info("WDA status check passed");
+    // 尝试从 /status 响应中提取设备UDID
+    // WDA响应格式: {"value": {"ios": {"udid": "..."}}}
+    // 或: {"sessionId": null, "value": {"udid": "..."}}
+    if (json_opt->contains("value") && json_opt->at("value").is_object()) {
+        const auto& value = json_opt->at("value");
+
+        // 优先从 ios.udid 获取
+        if (value.contains("ios") && value.at("ios").is_object()) {
+            const auto& ios = value.at("ios");
+            if (ios.contains("udid") && ios.at("udid").is_string()) {
+                m_uuid = ios.at("udid").as_string();
+                Log.info("Device UDID from ios.udid:", m_uuid);
+            }
+        }
+
+        // 备选：直接从 value.udid 获取
+        if (m_uuid.empty() && value.contains("udid") && value.at("udid").is_string()) {
+            m_uuid = value.at("udid").as_string();
+            Log.info("Device UDID from value.udid:", m_uuid);
+        }
+    }
+
+    // 如果仍然没有获取到UDID，使用host:port作为标识
+    if (m_uuid.empty()) {
+        m_uuid = m_host + ":" + std::to_string(m_port);
+        Log.info("Using address as UUID:", m_uuid);
+    }
+
+    Log.info("WDA status check passed, UUID:", m_uuid);
     return true;
 }
 
@@ -529,6 +774,42 @@ bool asst::WDAController::destroy_session()
     return response.success();
 }
 
+bool asst::WDAController::reconnect()
+{
+    Log.info("Attempting to reconnect to WDA...");
+
+    // 先销毁旧的session
+    destroy_session();
+
+    // 检查WDA状态
+    if (!check_wda_status()) {
+        Log.error("WDA is not running during reconnect");
+        return false;
+    }
+
+    // 创建新session
+    if (!create_session()) {
+        Log.error("Failed to create new WDA session during reconnect");
+        return false;
+    }
+
+    // 配置快速模式
+    if (!configure_fast_mode()) {
+        Log.warn("Failed to configure fast mode during reconnect");
+    }
+
+    // 重新获取逻辑分辨率
+    if (!fetch_screen_size()) {
+        Log.error("Failed to fetch screen size during reconnect");
+        return false;
+    }
+
+    m_connected = true;
+    Log.info("WDA reconnected successfully");
+
+    return true;
+}
+
 std::string asst::WDAController::build_w3c_tap_action(int x, int y)
 {
     json::object actions;
@@ -546,7 +827,7 @@ std::string asst::WDAController::build_w3c_tap_action(int x, int y)
 
     json::object move_action;
     move_action["type"] = "pointerMove";
-    move_action["duration"] = 0;
+    move_action["duration"] = 1;
     move_action["x"] = x;
     move_action["y"] = y;
     actions_seq.emplace_back(std::move(move_action));
@@ -573,50 +854,30 @@ std::string asst::WDAController::build_w3c_tap_action(int x, int y)
     return actions.to_string();
 }
 
-std::string asst::WDAController::build_w3c_swipe_action(int x1, int y1, int x2, int y2, int duration_ms)
+bool asst::WDAController::perform_drag(int from_x, int from_y, int to_x, int to_y, double duration_sec)
 {
-    json::object actions;
-    json::array action_list;
+    // 使用 WDA 的原生拖拽端点
+    // 端点: POST /session/{sessionId}/wda/dragfromtoforduration
+    // 参考: https://github.com/appium/appium-xcuitest-driver/blob/master/docs/endpoints-wda.md
+    json::object drag_params;
+    drag_params["fromX"] = from_x;
+    drag_params["fromY"] = from_y;
+    drag_params["toX"] = to_x;
+    drag_params["toY"] = to_y;
+    drag_params["duration"] = duration_sec;  // 秒为单位
 
-    json::object pointer_action;
-    pointer_action["type"] = "pointer";
-    pointer_action["id"] = "finger1";
+    Log.info("WDA perform_drag: from(", from_x, ",", from_y, ") to(", to_x, ",", to_y, ") duration:", duration_sec, "s");
+    Log.trace("WDA drag params:", drag_params.to_string());
 
-    json::object params;
-    params["pointerType"] = "touch";
-    pointer_action["parameters"] = std::move(params);
+    auto response = http_post("/session/" + m_session_id + "/wda/dragfromtoforduration", drag_params.to_string());
 
-    json::array actions_seq;
+    if (!response.success()) {
+        Log.error("WDA drag failed, status:", response.status_code, "body:", response.body);
+        return false;
+    }
 
-    json::object move_start;
-    move_start["type"] = "pointerMove";
-    move_start["duration"] = 0;
-    move_start["x"] = x1;
-    move_start["y"] = y1;
-    actions_seq.emplace_back(std::move(move_start));
-
-    json::object down_action;
-    down_action["type"] = "pointerDown";
-    down_action["button"] = 0;
-    actions_seq.emplace_back(std::move(down_action));
-
-    json::object move_end;
-    move_end["type"] = "pointerMove";
-    move_end["duration"] = duration_ms;
-    move_end["x"] = x2;
-    move_end["y"] = y2;
-    actions_seq.emplace_back(std::move(move_end));
-
-    json::object up_action;
-    up_action["type"] = "pointerUp";
-    up_action["button"] = 0;
-    actions_seq.emplace_back(std::move(up_action));
-
-    pointer_action["actions"] = std::move(actions_seq);
-    action_list.emplace_back(std::move(pointer_action));
-    actions["actions"] = std::move(action_list);
-
-    return actions.to_string();
+    Log.trace("WDA drag succeeded, response:", response.body);
+    return true;
 }
 
 std::pair<int, int> asst::WDAController::transform_to_wda_coords(int maa_x, int maa_y) const

--- a/src/MaaCore/Controller/WDAController.cpp
+++ b/src/MaaCore/Controller/WDAController.cpp
@@ -73,9 +73,16 @@ bool asst::WDAController::connect(
         return false;
     }
 
+    // Take an initial screenshot to determine physical screen size
+    // This is needed before ControlScaleProxy is created
+    cv::Mat dummy_image;
+    if (!screencap(dummy_image, false)) {
+        Log.error("Failed to capture initial screenshot");
+        return false;
+    }
+
     m_connected = true;
-    Log.info("WDA connected, logical size:", m_wda_logical_size.first, "x", m_wda_logical_size.second,
-             "(Physical size will be determined from first screenshot)");
+    Log.info("WDA connected, screen size:", m_screen_size.first, "x", m_screen_size.second);
     return true;
 }
 

--- a/src/MaaCore/Controller/WDAController.cpp
+++ b/src/MaaCore/Controller/WDAController.cpp
@@ -1,0 +1,617 @@
+#include "WDAController.h"
+
+#include <algorithm>
+#include <sstream>
+#include <thread>
+
+#include <boost/asio.hpp>
+#include <meojson/json.hpp>
+
+#include "Config/GeneralConfig.h"
+#include "MaaUtils/NoWarningCV.hpp"
+#include "Utils/Logger.hpp"
+
+using boost::asio::ip::tcp;
+
+asst::WDAController::WDAController(
+    const AsstCallback& callback,
+    Assistant* inst,
+    PlatformType type [[maybe_unused]]) :
+    InstHelper(inst),
+    m_callback(callback)
+{
+    LogTraceFunction;
+}
+
+asst::WDAController::~WDAController()
+{
+    destroy_session();
+}
+
+bool asst::WDAController::connect(
+    const std::string& adb_path [[maybe_unused]],
+    const std::string& address,
+    const std::string& config [[maybe_unused]])
+{
+    LogTraceFunction;
+
+    auto colon_pos = address.find(':');
+    if (colon_pos != std::string::npos) {
+        m_host = address.substr(0, colon_pos);
+        m_port = static_cast<uint16_t>(std::stoi(address.substr(colon_pos + 1)));
+    }
+    else {
+        m_host = address;
+        m_port = 8100;
+    }
+
+    Log.info("Connecting to WDA at", m_host, ":", m_port);
+
+    if (!check_wda_status()) {
+        Log.error("WDA is not running at", address);
+        return false;
+    }
+
+    if (!create_session()) {
+        Log.error("Failed to create WDA session");
+        return false;
+    }
+
+    if (!fetch_screen_size()) {
+        Log.error("Failed to fetch screen size from WDA");
+        return false;
+    }
+
+    m_connected = true;
+    Log.info("WDA connected successfully, screen size:", m_screen_size.first, "x", m_screen_size.second);
+    return true;
+}
+
+bool asst::WDAController::inited() const noexcept
+{
+    return m_connected && m_screen_size.first > 0;
+}
+
+const std::string& asst::WDAController::get_uuid() const
+{
+    static const std::string uuid("com.hypergryph.arknights");
+    return uuid;
+}
+
+size_t asst::WDAController::get_pipe_data_size() const noexcept
+{
+    return 0;
+}
+
+size_t asst::WDAController::get_version() const noexcept
+{
+    return 0;
+}
+
+bool asst::WDAController::screencap(cv::Mat& image_payload, bool allow_reconnect [[maybe_unused]])
+{
+    LogTraceFunction;
+
+    auto response = http_get("/screenshot");
+    if (!response.success()) {
+        Log.error("Screenshot request failed, status:", response.status_code);
+        return false;
+    }
+
+    auto json_opt = json::parse(response.body);
+    if (!json_opt) {
+        Log.error("Failed to parse screenshot response");
+        return false;
+    }
+
+    std::string base64_data;
+    if (json_opt->contains("value") && json_opt->at("value").is_string()) {
+        base64_data = json_opt->at("value").as_string();
+    }
+    else {
+        Log.error("Screenshot response missing 'value' field");
+        return false;
+    }
+
+    return decode_base64_png(base64_data, image_payload);
+}
+
+bool asst::WDAController::start_game(const std::string& client_type [[maybe_unused]])
+{
+    Log.info("start_game is not fully supported on WDA");
+    return true;
+}
+
+bool asst::WDAController::stop_game(const std::string& client_type [[maybe_unused]])
+{
+    Log.info("stop_game is not fully supported on WDA");
+    return true;
+}
+
+bool asst::WDAController::click(const Point& p)
+{
+    Log.trace("WDA click:", p.x, p.y);
+
+    std::string action_json = build_w3c_tap_action(p.x, p.y);
+    auto response = http_post("/session/" + m_session_id + "/actions", action_json);
+
+    if (!response.success()) {
+        Log.error("WDA click failed, status:", response.status_code);
+        return false;
+    }
+
+    return true;
+}
+
+bool asst::WDAController::input(const std::string& text [[maybe_unused]])
+{
+    Log.info("InputText is not fully supported on WDA");
+    return true;
+}
+
+bool asst::WDAController::swipe(
+    const Point& p1,
+    const Point& p2,
+    int duration,
+    bool extra_swipe,
+    double slope_in [[maybe_unused]],
+    double slope_out [[maybe_unused]],
+    bool with_pause [[maybe_unused]])
+{
+    Log.trace("WDA swipe:", p1.x, p1.y, "->", p2.x, p2.y, "duration:", duration);
+
+    int x1 = std::clamp(p1.x, 0, m_screen_size.first - 1);
+    int y1 = std::clamp(p1.y, 0, m_screen_size.second - 1);
+
+    const auto& opt = Config.get_options();
+    int actual_duration = duration > 0 ? duration : opt.minitouch_swipe_default_duration;
+
+    std::string action_json = build_w3c_swipe_action(x1, y1, p2.x, p2.y, actual_duration);
+    auto response = http_post("/session/" + m_session_id + "/actions", action_json);
+
+    if (!response.success()) {
+        Log.error("WDA swipe failed, status:", response.status_code);
+        return false;
+    }
+
+    if (extra_swipe && opt.minitouch_extra_swipe_duration > 0) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(opt.minitouch_swipe_extra_end_delay));
+        std::string extra_action = build_w3c_swipe_action(
+            p2.x, p2.y, p2.x, p2.y - opt.minitouch_extra_swipe_dist, opt.minitouch_extra_swipe_duration);
+        http_post("/session/" + m_session_id + "/actions", extra_action);
+    }
+
+    return true;
+}
+
+bool asst::WDAController::press_esc()
+{
+    Log.info("ESC is not supported on iOS/WDA");
+    return false;
+}
+
+std::pair<int, int> asst::WDAController::get_screen_res() const noexcept
+{
+    return m_screen_size;
+}
+
+void asst::WDAController::back_to_home() noexcept
+{
+    Log.info("HOME is not supported on WDA");
+}
+
+asst::WDAController::HttpResponse asst::WDAController::http_get(const std::string& path)
+{
+    HttpResponse response;
+    try {
+        tcp::socket socket(m_context);
+        tcp::resolver resolver(m_context);
+        boost::asio::connect(socket, resolver.resolve(m_host, std::to_string(m_port)));
+
+        std::string request = "GET " + path + " HTTP/1.1\r\n"
+                              "Host: " + m_host + ":" + std::to_string(m_port) + "\r\n"
+                              "Accept: application/json\r\n"
+                              "Connection: close\r\n\r\n";
+
+        boost::asio::write(socket, boost::asio::buffer(request));
+
+        boost::asio::streambuf response_buf;
+        boost::system::error_code ec;
+
+        boost::asio::read_until(socket, response_buf, "\r\n", ec);
+        std::istream response_stream(&response_buf);
+        std::string http_version;
+        response_stream >> http_version >> response.status_code;
+
+        boost::asio::read_until(socket, response_buf, "\r\n\r\n", ec);
+
+        std::string header;
+        size_t content_length = 0;
+        while (std::getline(response_stream, header) && header != "\r") {
+            if (header.find("Content-Length:") != std::string::npos ||
+                header.find("content-length:") != std::string::npos) {
+                auto pos = header.find(':');
+                if (pos != std::string::npos) {
+                    content_length = std::stoul(header.substr(pos + 1));
+                }
+            }
+        }
+
+        if (content_length > 0) {
+            size_t remaining = content_length;
+            if (response_buf.size() > 0) {
+                std::ostringstream ss;
+                ss << &response_buf;
+                response.body = ss.str();
+                remaining = content_length > response.body.size() ? content_length - response.body.size() : 0;
+            }
+            if (remaining > 0) {
+                std::vector<char> buf(remaining);
+                boost::asio::read(socket, boost::asio::buffer(buf), ec);
+                response.body.append(buf.data(), buf.size());
+            }
+        }
+        else {
+            std::ostringstream ss;
+            boost::asio::read(socket, response_buf, ec);
+            ss << &response_buf;
+            response.body = ss.str();
+        }
+    }
+    catch (const std::exception& e) {
+        Log.error("HTTP GET failed:", e.what());
+        response.status_code = 0;
+    }
+    return response;
+}
+
+asst::WDAController::HttpResponse asst::WDAController::http_post(const std::string& path, const std::string& json_body)
+{
+    HttpResponse response;
+    try {
+        tcp::socket socket(m_context);
+        tcp::resolver resolver(m_context);
+        boost::asio::connect(socket, resolver.resolve(m_host, std::to_string(m_port)));
+
+        std::string request = "POST " + path + " HTTP/1.1\r\n"
+                              "Host: " + m_host + ":" + std::to_string(m_port) + "\r\n"
+                              "Content-Type: application/json\r\n"
+                              "Content-Length: " + std::to_string(json_body.size()) + "\r\n"
+                              "Accept: application/json\r\n"
+                              "Connection: close\r\n\r\n" + json_body;
+
+        boost::asio::write(socket, boost::asio::buffer(request));
+
+        boost::asio::streambuf response_buf;
+        boost::system::error_code ec;
+
+        boost::asio::read_until(socket, response_buf, "\r\n", ec);
+        std::istream response_stream(&response_buf);
+        std::string http_version;
+        response_stream >> http_version >> response.status_code;
+
+        boost::asio::read_until(socket, response_buf, "\r\n\r\n", ec);
+        boost::asio::read(socket, response_buf, ec);
+
+        std::ostringstream ss;
+        ss << &response_buf;
+        std::string full_response = ss.str();
+
+        auto body_start = full_response.find("\r\n\r\n");
+        if (body_start != std::string::npos) {
+            response.body = full_response.substr(body_start + 4);
+        }
+        else {
+            response.body = full_response;
+        }
+    }
+    catch (const std::exception& e) {
+        Log.error("HTTP POST failed:", e.what());
+        response.status_code = 0;
+    }
+    return response;
+}
+
+asst::WDAController::HttpResponse asst::WDAController::http_delete(const std::string& path)
+{
+    HttpResponse response;
+    try {
+        tcp::socket socket(m_context);
+        tcp::resolver resolver(m_context);
+        boost::asio::connect(socket, resolver.resolve(m_host, std::to_string(m_port)));
+
+        std::string request = "DELETE " + path + " HTTP/1.1\r\n"
+                              "Host: " + m_host + ":" + std::to_string(m_port) + "\r\n"
+                              "Accept: application/json\r\n"
+                              "Connection: close\r\n\r\n";
+
+        boost::asio::write(socket, boost::asio::buffer(request));
+
+        boost::asio::streambuf response_buf;
+        boost::system::error_code ec;
+
+        boost::asio::read_until(socket, response_buf, "\r\n", ec);
+        std::istream response_stream(&response_buf);
+        std::string http_version;
+        response_stream >> http_version >> response.status_code;
+
+        boost::asio::read(socket, response_buf, ec);
+        std::ostringstream ss;
+        ss << &response_buf;
+        response.body = ss.str();
+    }
+    catch (const std::exception& e) {
+        Log.error("HTTP DELETE failed:", e.what());
+        response.status_code = 0;
+    }
+    return response;
+}
+
+bool asst::WDAController::check_wda_status()
+{
+    auto response = http_get("/status");
+    if (!response.success()) {
+        Log.error("WDA status check failed, status:", response.status_code);
+        return false;
+    }
+
+    auto json_opt = json::parse(response.body);
+    if (!json_opt) {
+        Log.error("Failed to parse WDA status response");
+        return false;
+    }
+
+    Log.info("WDA status check passed");
+    return true;
+}
+
+bool asst::WDAController::create_session()
+{
+    json::object capabilities;
+    capabilities["capabilities"] = json::object {};
+
+    auto response = http_post("/session", capabilities.to_string());
+    if (!response.success()) {
+        Log.error("Failed to create WDA session, status:", response.status_code);
+        return false;
+    }
+
+    auto json_opt = json::parse(response.body);
+    if (!json_opt) {
+        Log.error("Failed to parse session creation response");
+        return false;
+    }
+
+    if (json_opt->contains("sessionId") && json_opt->at("sessionId").is_string()) {
+        m_session_id = json_opt->at("sessionId").as_string();
+    }
+    else if (json_opt->contains("value") && json_opt->at("value").is_object()) {
+        const auto& value = json_opt->at("value");
+        if (value.contains("sessionId") && value.at("sessionId").is_string()) {
+            m_session_id = value.at("sessionId").as_string();
+        }
+    }
+
+    if (m_session_id.empty()) {
+        Log.error("Session ID not found in response");
+        return false;
+    }
+
+    Log.info("WDA session created:", m_session_id);
+    return true;
+}
+
+bool asst::WDAController::fetch_screen_size()
+{
+    auto response = http_get("/session/" + m_session_id + "/window/rect");
+    if (!response.success()) {
+        Log.error("Failed to fetch screen size, status:", response.status_code);
+        return false;
+    }
+
+    auto json_opt = json::parse(response.body);
+    if (!json_opt) {
+        Log.error("Failed to parse screen size response");
+        return false;
+    }
+
+    const json::value* rect = nullptr;
+    if (json_opt->contains("value") && json_opt->at("value").is_object()) {
+        rect = &json_opt->at("value");
+    }
+    else {
+        rect = &(*json_opt);
+    }
+
+    if (rect->contains("width") && rect->contains("height")) {
+        m_screen_size.first = static_cast<int>(rect->at("width").as_integer());
+        m_screen_size.second = static_cast<int>(rect->at("height").as_integer());
+        return m_screen_size.first > 0 && m_screen_size.second > 0;
+    }
+
+    Log.error("Screen size not found in response");
+    return false;
+}
+
+bool asst::WDAController::destroy_session()
+{
+    if (m_session_id.empty()) {
+        return true;
+    }
+
+    Log.info("Destroying WDA session:", m_session_id);
+    auto response = http_delete("/session/" + m_session_id);
+    m_session_id.clear();
+    m_connected = false;
+
+    return response.success();
+}
+
+std::string asst::WDAController::build_w3c_tap_action(int x, int y)
+{
+    json::object actions;
+    json::array action_list;
+
+    json::object pointer_action;
+    pointer_action["type"] = "pointer";
+    pointer_action["id"] = "finger1";
+
+    json::object params;
+    params["pointerType"] = "touch";
+    pointer_action["parameters"] = std::move(params);
+
+    json::array actions_seq;
+
+    json::object move_action;
+    move_action["type"] = "pointerMove";
+    move_action["duration"] = 0;
+    move_action["x"] = x;
+    move_action["y"] = y;
+    actions_seq.emplace_back(std::move(move_action));
+
+    json::object down_action;
+    down_action["type"] = "pointerDown";
+    down_action["button"] = 0;
+    actions_seq.emplace_back(std::move(down_action));
+
+    json::object pause_action;
+    pause_action["type"] = "pause";
+    pause_action["duration"] = 50;
+    actions_seq.emplace_back(std::move(pause_action));
+
+    json::object up_action;
+    up_action["type"] = "pointerUp";
+    up_action["button"] = 0;
+    actions_seq.emplace_back(std::move(up_action));
+
+    pointer_action["actions"] = std::move(actions_seq);
+    action_list.emplace_back(std::move(pointer_action));
+    actions["actions"] = std::move(action_list);
+
+    return actions.to_string();
+}
+
+std::string asst::WDAController::build_w3c_swipe_action(int x1, int y1, int x2, int y2, int duration_ms)
+{
+    json::object actions;
+    json::array action_list;
+
+    json::object pointer_action;
+    pointer_action["type"] = "pointer";
+    pointer_action["id"] = "finger1";
+
+    json::object params;
+    params["pointerType"] = "touch";
+    pointer_action["parameters"] = std::move(params);
+
+    json::array actions_seq;
+
+    json::object move_start;
+    move_start["type"] = "pointerMove";
+    move_start["duration"] = 0;
+    move_start["x"] = x1;
+    move_start["y"] = y1;
+    actions_seq.emplace_back(std::move(move_start));
+
+    json::object down_action;
+    down_action["type"] = "pointerDown";
+    down_action["button"] = 0;
+    actions_seq.emplace_back(std::move(down_action));
+
+    json::object move_end;
+    move_end["type"] = "pointerMove";
+    move_end["duration"] = duration_ms;
+    move_end["x"] = x2;
+    move_end["y"] = y2;
+    actions_seq.emplace_back(std::move(move_end));
+
+    json::object up_action;
+    up_action["type"] = "pointerUp";
+    up_action["button"] = 0;
+    actions_seq.emplace_back(std::move(up_action));
+
+    pointer_action["actions"] = std::move(actions_seq);
+    action_list.emplace_back(std::move(pointer_action));
+    actions["actions"] = std::move(action_list);
+
+    return actions.to_string();
+}
+
+bool asst::WDAController::decode_base64_png(const std::string& base64_data, cv::Mat& output)
+{
+    std::string decoded = base64_decode(base64_data);
+    if (decoded.empty()) {
+        Log.error("Base64 decode failed");
+        return false;
+    }
+
+    std::vector<uint8_t> png_data(decoded.begin(), decoded.end());
+    output = cv::imdecode(png_data, cv::IMREAD_COLOR);
+
+    if (output.empty()) {
+        Log.error("PNG decode failed");
+        return false;
+    }
+
+    return true;
+}
+
+std::string asst::WDAController::base64_decode(const std::string& encoded)
+{
+    static constexpr char base64_chars[] =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+    auto find_char = [](char c) -> int {
+        const char* p = std::find(base64_chars, base64_chars + 64, c);
+        return (p != base64_chars + 64) ? static_cast<int>(p - base64_chars) : -1;
+    };
+
+    auto is_base64 = [](char c) -> bool {
+        return (std::isalnum(static_cast<unsigned char>(c)) || (c == '+') || (c == '/'));
+    };
+
+    std::string decoded;
+    size_t in_len = encoded.size();
+    size_t i = 0;
+    unsigned char char_array_4[4];
+    unsigned char char_array_3[3];
+    int count = 0;
+
+    while (i < in_len && encoded[i] != '=' && is_base64(encoded[i])) {
+        char_array_4[count++] = encoded[i++];
+        if (count == 4) {
+            for (int j = 0; j < 4; j++) {
+                char_array_4[j] = static_cast<unsigned char>(find_char(char_array_4[j]));
+            }
+
+            char_array_3[0] = (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
+            char_array_3[1] = ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);
+            char_array_3[2] = ((char_array_4[2] & 0x3) << 6) + char_array_4[3];
+
+            for (int j = 0; j < 3; j++) {
+                decoded += static_cast<char>(char_array_3[j]);
+            }
+            count = 0;
+        }
+    }
+
+    if (count > 0) {
+        for (int j = count; j < 4; j++) {
+            char_array_4[j] = 0;
+        }
+        for (int j = 0; j < 4; j++) {
+            int idx = find_char(char_array_4[j]);
+            char_array_4[j] = (idx >= 0) ? static_cast<unsigned char>(idx) : 0;
+        }
+
+        char_array_3[0] = (char_array_4[0] << 2) + ((char_array_4[1] & 0x30) >> 4);
+        char_array_3[1] = ((char_array_4[1] & 0xf) << 4) + ((char_array_4[2] & 0x3c) >> 2);
+        char_array_3[2] = ((char_array_4[2] & 0x3) << 6) + char_array_4[3];
+
+        for (int j = 0; j < count - 1; j++) {
+            decoded += static_cast<char>(char_array_3[j]);
+        }
+    }
+
+    return decoded;
+}

--- a/src/MaaCore/Controller/WDAController.h
+++ b/src/MaaCore/Controller/WDAController.h
@@ -35,6 +35,9 @@ public:
     virtual bool start_game(const std::string& client_type) override;
     virtual bool stop_game(const std::string& client_type) override;
 
+    // Pre-start game before connection (uses temporary HTTP session)
+    bool pre_start_game(const std::string& client_type);
+
     virtual bool click(const Point& p) override;
 
     virtual bool input(const std::string& text) override;

--- a/src/MaaCore/Controller/WDAController.h
+++ b/src/MaaCore/Controller/WDAController.h
@@ -1,0 +1,96 @@
+#pragma once
+
+#include "ControllerAPI.h"
+
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/ip/tcp.hpp>
+
+#include "Platform/PlatformFactory.h"
+
+#include "Common/AsstMsg.h"
+#include "InstHelper.h"
+
+namespace asst
+{
+class WDAController : public ControllerAPI, protected InstHelper
+{
+public:
+    WDAController(const AsstCallback& callback, Assistant* inst, PlatformType type);
+    WDAController(const WDAController&) = delete;
+    WDAController(WDAController&&) = delete;
+    virtual ~WDAController();
+
+    virtual bool connect(const std::string& adb_path, const std::string& address, const std::string& config) override;
+    virtual bool inited() const noexcept override;
+
+    virtual const std::string& get_uuid() const override;
+
+    virtual size_t get_pipe_data_size() const noexcept override;
+
+    virtual size_t get_version() const noexcept override;
+
+    virtual bool screencap(cv::Mat& image_payload, bool allow_reconnect = false) override;
+
+    virtual bool start_game(const std::string& client_type) override;
+    virtual bool stop_game(const std::string& client_type) override;
+
+    virtual bool click(const Point& p) override;
+
+    virtual bool input(const std::string& text) override;
+
+    virtual bool swipe(
+        const Point& p1,
+        const Point& p2,
+        int duration = 0,
+        bool extra_swipe = false,
+        double slope_in = 1,
+        double slope_out = 1,
+        bool with_pause = false) override;
+
+    virtual bool inject_input_event([[maybe_unused]] const InputEvent& event) override { return false; }
+
+    virtual bool press_esc() override;
+
+    virtual ControlFeat::Feat support_features() const noexcept override { return ControlFeat::NONE; }
+
+    virtual std::pair<int, int> get_screen_res() const noexcept override;
+
+    WDAController& operator=(const WDAController&) = delete;
+    WDAController& operator=(WDAController&&) = delete;
+
+    virtual void back_to_home() noexcept override;
+
+protected:
+    AsstCallback m_callback;
+
+private:
+    boost::asio::io_context m_context;
+    std::string m_host;
+    uint16_t m_port = 8100;
+    std::string m_session_id;
+    std::pair<int, int> m_screen_size = { 0, 0 };
+    bool m_connected = false;
+
+    struct HttpResponse
+    {
+        int status_code = 0;
+        std::string body;
+        bool success() const { return status_code >= 200 && status_code < 300; }
+    };
+
+    HttpResponse http_get(const std::string& path);
+    HttpResponse http_post(const std::string& path, const std::string& json_body);
+    HttpResponse http_delete(const std::string& path);
+
+    bool check_wda_status();
+    bool create_session();
+    bool fetch_screen_size();
+    bool destroy_session();
+
+    std::string build_w3c_tap_action(int x, int y);
+    std::string build_w3c_swipe_action(int x1, int y1, int x2, int y2, int duration_ms);
+
+    bool decode_base64_png(const std::string& base64_data, cv::Mat& output);
+    static std::string base64_decode(const std::string& encoded);
+};
+} // namespace asst

--- a/src/MaaCore/Task/Interface/StartUpTask.h
+++ b/src/MaaCore/Task/Interface/StartUpTask.h
@@ -17,6 +17,9 @@ public:
 
     bool set_params(const json::value& params) override;
 
+protected:
+    bool _run() override;
+
 private:
     std::shared_ptr<StartGameTaskPlugin> m_start_game_task_ptr = nullptr;
     std::shared_ptr<ProcessTask> m_start_up_task_ptr = nullptr;

--- a/src/MaaCore/Task/Miscellaneous/StartGameTaskPlugin.cpp
+++ b/src/MaaCore/Task/Miscellaneous/StartGameTaskPlugin.cpp
@@ -33,7 +33,17 @@ bool StartGameTaskPlugin::_run()
     // check for MAC / iOS
     if (ctrler()->get_controller_type() == ControllerType::MacPlayTools ||
         ctrler()->get_controller_type() == ControllerType::WDA) {
-        return ctrler()->start_game(m_client_type);
+        if (!ctrler()->start_game(m_client_type)) {
+            return false;
+        }
+
+        // Wait for screen rotation (portrait -> landscape) on iOS devices
+        if (ctrler()->get_controller_type() == ControllerType::WDA) {
+            Log.info("Waiting 3 seconds for screen rotation...");
+            sleep(3000);
+        }
+
+        return true;
     }
 
     // check for android version, because it leads to different magic values

--- a/src/MaaCore/Task/Miscellaneous/StartGameTaskPlugin.cpp
+++ b/src/MaaCore/Task/Miscellaneous/StartGameTaskPlugin.cpp
@@ -31,7 +31,8 @@ bool StartGameTaskPlugin::_run()
     }
 
     // check for MAC / iOS
-    if (ctrler()->get_controller_type() == ControllerType::MacPlayTools) {
+    if (ctrler()->get_controller_type() == ControllerType::MacPlayTools ||
+        ctrler()->get_controller_type() == ControllerType::WDA) {
         return ctrler()->start_game(m_client_type);
     }
 

--- a/src/MaaCore/Task/Miscellaneous/StartGameTaskPlugin.h
+++ b/src/MaaCore/Task/Miscellaneous/StartGameTaskPlugin.h
@@ -22,6 +22,8 @@ public:
 
     StartGameTaskPlugin& set_client_type(std::string client_type) noexcept;
 
+    const std::string& get_client_type() const noexcept { return m_client_type; }
+
 protected:
     bool _run() override;
 

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -604,6 +604,13 @@ public class AsstProxy
         }
 
         _runningState.SetInit(true);
+
+        // Force WDA touch mode for WDA connection
+        if (SettingsViewModel.ConnectSettings.ConnectConfig == "WDA")
+        {
+            SettingsViewModel.ConnectSettings.TouchMode = "wda";
+        }
+
         AsstSetInstanceOption(InstanceOptionKey.TouchMode, SettingsViewModel.ConnectSettings.TouchMode);
         AsstSetInstanceOption(InstanceOptionKey.DeploymentWithPause, SettingsViewModel.GameSettings.DeploymentWithPause ? "1" : "0");
         AsstSetInstanceOption(InstanceOptionKey.AdbLiteEnabled, SettingsViewModel.ConnectSettings.AdbLiteEnabled ? "1" : "0");

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -606,7 +606,7 @@ public class AsstProxy
         _runningState.SetInit(true);
 
         // Force WDA touch mode for WDA connection
-        if (SettingsViewModel.ConnectSettings.ConnectConfig == "WDA")
+        if (SettingsViewModel.ConnectSettings.ConnectConfig == "wda")
         {
             SettingsViewModel.ConnectSettings.TouchMode = "wda";
         }
@@ -2394,7 +2394,7 @@ public class AsstProxy
             }
         }
 
-        bool ret = AsstConnect(_handle, SettingsViewModel.ConnectSettings.AdbPath, SettingsViewModel.ConnectSettings.ConnectAddress, SettingsViewModel.ConnectSettings.ConnectConfig);
+        bool ret = AsstConnect(_handle, SettingsViewModel.ConnectSettings.AdbPath, SettingsViewModel.ConnectSettings.ConnectAddress, SettingsViewModel.ConnectSettings.ConnectConfig == "wda" ? "" : SettingsViewModel.ConnectSettings.ConnectConfig);
 
         // 尝试默认的备选端口
         if (!ret && SettingsViewModel.ConnectSettings.AutoDetectConnection)
@@ -2404,7 +2404,7 @@ public class AsstProxy
                 foreach (var address in value
                              .TakeWhile(_ => !_runningState.GetIdle()))
                 {
-                    ret = AsstConnect(_handle, SettingsViewModel.ConnectSettings.AdbPath, address, SettingsViewModel.ConnectSettings.ConnectConfig);
+                    ret = AsstConnect(_handle, SettingsViewModel.ConnectSettings.AdbPath, address, SettingsViewModel.ConnectSettings.ConnectConfig == "wda" ? "" : SettingsViewModel.ConnectSettings.ConnectConfig);
                     if (!ret)
                     {
                         continue;

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -429,6 +429,9 @@ If you are concerned about leftover entries, please disable this option before d
     <system:String x:Key="MiniTouchMode">Minitouch (Default)</system:String>
     <system:String x:Key="MaaTouchMode">MaaTouch (Experimental)</system:String>
     <system:String x:Key="AdbTouchMode">ADB Input (Deprecated)</system:String>
+    <system:String x:Key="WDA">WDA (iOS)</system:String>
+    <system:String x:Key="WDATouchMode">WDA (iOS Device)</system:String>
+    <system:String x:Key="WDANoAutoDetect">WDA does not support auto-detection. Please manually enter device address (e.g., 127.0.0.1:8100)</system:String>
     <system:String x:Key="AdditionCommand">Additional command arguments</system:String>
     <system:String x:Key="AdditionCommandTip" xml:space="preserve">Additional commands for emulator parameters (e.g. ｢--instance 1｣ for instance 1).&#10;Command formats vary by emulator, typically including instance numbers and window modes, please consult your emulator's documentation.</system:String>
     <system:String x:Key="StartsWithScript">Starts with Script</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -429,6 +429,9 @@ MAA は非インストール型のアプリケーションであり、レジス�
     <system:String x:Key="MiniTouchMode">Minitouch (標準)</system:String>
     <system:String x:Key="MaaTouchMode">MaaTouch (実験機能)</system:String>
     <system:String x:Key="AdbTouchMode">ADB Input (非推奨)</system:String>
+    <system:String x:Key="WDA">WDA (iOS)</system:String>
+    <system:String x:Key="WDATouchMode">WDA（iOSデバイス）</system:String>
+    <system:String x:Key="WDANoAutoDetect">WDAは自動検出をサポートしていません。デバイスアドレスを手動で入力してください（例：127.0.0.1:8100）</system:String>
     <system:String x:Key="AdditionCommand">追加コマンド</system:String>
     <system:String x:Key="AdditionCommandTip" xml:space="preserve">エミュレーター起動パラメータの追加コマンド（例：「--instance 1」は 1 番インスタンス）。&#10;コマンド形式はエミュレーターにより異なり、通常はインスタンス番号やウィンドウモードなどを含みます。</system:String>
     <system:String x:Key="StartsWithScript">スクリプトを使用して始めます</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -429,6 +429,9 @@ MAA는 비설치형 응용 프로그램으로, 삭제 시 레지스트리 항목
     <system:String x:Key="MiniTouchMode">Minitouch (기본값)</system:String>
     <system:String x:Key="MaaTouchMode">MaaTouch (실험적)</system:String>
     <system:String x:Key="AdbTouchMode">ADB Input (비권장)</system:String>
+    <system:String x:Key="WDA">WDA (iOS)</system:String>
+    <system:String x:Key="WDATouchMode">WDA（iOS 기기）</system:String>
+    <system:String x:Key="WDANoAutoDetect">WDA는 자동 감지를 지원하지 않습니다. 장치 주소를 수동으로 입력하십시오（예: 127.0.0.1:8100）</system:String>
     <system:String x:Key="AdditionCommand">추가 변수</system:String>
     <system:String x:Key="AdditionCommandTip" xml:space="preserve">에뮬레이터 실행 매개변수 추가 명령 (예: ｢--instance 1｣ 은 1 번 인스턴스).&#10;명령 형식은 에뮬레이터마다 다르며 일반적으로 인스턴스 번호나 창 모드 등을 포함합니다.</system:String>
     <system:String x:Key="StartsWithScript">시작 시 추가 스크립트</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -429,6 +429,9 @@
     <system:String x:Key="MiniTouchMode">Minitouch（默认）</system:String>
     <system:String x:Key="MaaTouchMode">MaaTouch（实验功能）</system:String>
     <system:String x:Key="AdbTouchMode">ADB Input（不推荐使用）</system:String>
+    <system:String x:Key="WDA">WDA (iOS)</system:String>
+    <system:String x:Key="WDATouchMode">WDA（iOS 设备）</system:String>
+    <system:String x:Key="WDANoAutoDetect">WDA 不支持自动检测，请手动输入设备地址（例如：127.0.0.1:8100）</system:String>
     <system:String x:Key="AdditionCommand">附加命令</system:String>
     <system:String x:Key="AdditionCommandTip" xml:space="preserve">附加命令用于指定模拟器启动参数（如 ｢--instance 1｣ 表示启动 1 号实例）。&#10;不同模拟器的命令格式不同，通常包括实例编号、窗口模式等参数，请参考您使用的模拟器文档</system:String>
     <system:String x:Key="StartsWithScript">开始前脚本</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -429,6 +429,9 @@
     <system:String x:Key="MiniTouchMode">Minitouch（預設）</system:String>
     <system:String x:Key="MaaTouchMode">MaaTouch（實驗功能）</system:String>
     <system:String x:Key="AdbTouchMode">ADB Input（不推薦使用）</system:String>
+    <system:String x:Key="WDA">WDA (iOS)</system:String>
+    <system:String x:Key="WDATouchMode">WDA（iOS 裝置）</system:String>
+    <system:String x:Key="WDANoAutoDetect">WDA 不支援自動偵測，請手動輸入裝置位址（例如：127.0.0.1:8100）</system:String>
     <system:String x:Key="AdditionCommand">附加命令</system:String>
     <system:String x:Key="AdditionCommandTip" xml:space="preserve">附加命令用於指定模擬器啟動參數（如 ｢--instance 1｣ 表示啟動 1 號實例）。&#10;不同模擬器的命令格式不同，通常包括實例編號、視窗模式等參數，請參考您使用的模擬器說明文件。</system:String>
     <system:String x:Key="StartsWithScript">開始前腳本</system:String>

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/ConnectSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/ConnectSettingsUserControlModel.cs
@@ -70,6 +70,7 @@ public class ConnectSettingsUserControlModel : PropertyChangedBase
             new() { Display = LocalizationHelper.GetString("Nox"), Value = "Nox" },
             new() { Display = LocalizationHelper.GetString("XYAZ"), Value = "XYAZ" },
             new() { Display = LocalizationHelper.GetString("WSA"), Value = "WSA" },
+            new() { Display = LocalizationHelper.GetString("WDA"), Value = "WDA" },
             new() { Display = LocalizationHelper.GetString("Compatible"), Value = "Compatible" },
             new() { Display = LocalizationHelper.GetString("SecondResolution"), Value = "SecondResolution" },
             new() { Display = LocalizationHelper.GetString("GeneralWithoutScreencapErr"), Value = "GeneralWithoutScreencapErr" },
@@ -83,6 +84,7 @@ public class ConnectSettingsUserControlModel : PropertyChangedBase
             new() { Display = LocalizationHelper.GetString("MiniTouchMode"), Value = "minitouch" },
             new() { Display = LocalizationHelper.GetString("MaaTouchMode"), Value = "maatouch" },
             new() { Display = LocalizationHelper.GetString("AdbTouchMode"), Value = "adb" },
+            new() { Display = LocalizationHelper.GetString("WDATouchMode"), Value = "wda" },
         ];
 
     private bool _autoDetectConnection = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.AutoDetect, bool.TrueString));
@@ -91,6 +93,18 @@ public class ConnectSettingsUserControlModel : PropertyChangedBase
     {
         get => _autoDetectConnection;
         set {
+            // WDA does not support auto-detection
+            if (ConnectConfig == "WDA" && value)
+            {
+                Execute.OnUIThreadAsync(() =>
+                {
+                    ToastNotification.ShowDirect(
+                        LocalizationHelper.GetString("WDANoAutoDetect"),
+                        ToastNotification.DisplayDuration.Short);
+                });
+                return;
+            }
+
             if (!SetAndNotify(ref _autoDetectConnection, value))
             {
                 return;
@@ -193,6 +207,14 @@ public class ConnectSettingsUserControlModel : PropertyChangedBase
     {
         get => _adbPath;
         set {
+            // WDA does not require ADB path
+            if (ConnectConfig == "WDA")
+            {
+                SetAndNotify(ref _adbPath, string.Empty);
+                ConfigurationHelper.SetValue(ConfigurationKeys.AdbPath, string.Empty);
+                return;
+            }
+
             if (!Path.GetFileName(value).ToLower().Contains("adb"))
             {
                 var count = 3;
@@ -812,6 +834,7 @@ public class ConnectSettingsUserControlModel : PropertyChangedBase
             { "Nox", ["127.0.0.1:62001", "127.0.0.1:59865"] },
             { "XYAZ", ["127.0.0.1:21503"] },
             { "WSA", ["127.0.0.1:58526"] },
+            { "WDA", ["127.0.0.1:8100"] },
         };
 
     /// <summary>

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/ConnectSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/ConnectSettingsUserControlModel.cs
@@ -70,7 +70,7 @@ public class ConnectSettingsUserControlModel : PropertyChangedBase
             new() { Display = LocalizationHelper.GetString("Nox"), Value = "Nox" },
             new() { Display = LocalizationHelper.GetString("XYAZ"), Value = "XYAZ" },
             new() { Display = LocalizationHelper.GetString("WSA"), Value = "WSA" },
-            new() { Display = LocalizationHelper.GetString("WDA"), Value = "WDA" },
+            new() { Display = LocalizationHelper.GetString("WDA"), Value = "wda" },
             new() { Display = LocalizationHelper.GetString("Compatible"), Value = "Compatible" },
             new() { Display = LocalizationHelper.GetString("SecondResolution"), Value = "SecondResolution" },
             new() { Display = LocalizationHelper.GetString("GeneralWithoutScreencapErr"), Value = "GeneralWithoutScreencapErr" },
@@ -94,7 +94,7 @@ public class ConnectSettingsUserControlModel : PropertyChangedBase
         get => _autoDetectConnection;
         set {
             // WDA does not support auto-detection
-            if (ConnectConfig == "WDA" && value)
+            if (ConnectConfig == "wda" && value)
             {
                 Execute.OnUIThreadAsync(() =>
                 {
@@ -207,7 +207,7 @@ public class ConnectSettingsUserControlModel : PropertyChangedBase
         get => _adbPath;
         set {
             // WDA does not require ADB path
-            if (ConnectConfig == "WDA")
+            if (ConnectConfig == "wda")
             {
                 SetAndNotify(ref _adbPath, string.Empty);
                 ConfigurationHelper.SetValue(ConfigurationKeys.AdbPath, string.Empty);
@@ -833,7 +833,7 @@ public class ConnectSettingsUserControlModel : PropertyChangedBase
             { "Nox", ["127.0.0.1:62001", "127.0.0.1:59865"] },
             { "XYAZ", ["127.0.0.1:21503"] },
             { "WSA", ["127.0.0.1:58526"] },
-            { "WDA", ["127.0.0.1:8100"] },
+            { "wda", ["127.0.0.1:8100"] },
         };
 
     /// <summary>

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/ConnectSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/ConnectSettingsUserControlModel.cs
@@ -99,8 +99,7 @@ public class ConnectSettingsUserControlModel : PropertyChangedBase
                 Execute.OnUIThreadAsync(() =>
                 {
                     ToastNotification.ShowDirect(
-                        LocalizationHelper.GetString("WDANoAutoDetect"),
-                        ToastNotification.DisplayDuration.Short);
+                        LocalizationHelper.GetString("WDANoAutoDetect"));
                 });
                 return;
             }

--- a/src/MaaWpfGui/Views/UserControl/Settings/ConnectSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/Settings/ConnectSettingsUserControl.xaml
@@ -39,7 +39,8 @@
                     HorizontalAlignment="Center"
                     VerticalAlignment="Center"
                     Content="{DynamicResource AutoDetectConnection}"
-                    IsChecked="{Binding AutoDetectConnection}" />
+                    IsChecked="{Binding AutoDetectConnection}"
+                    IsEnabled="{c:Binding 'ConnectConfig!=&quot;WDA&quot;'}" />
                 <controls:TooltipBlock TooltipText="{DynamicResource AutoDetectConnectionTip}" />
             </StackPanel>
             <CheckBox
@@ -53,7 +54,7 @@
             <StackPanel
                 Margin="10"
                 HorizontalAlignment="Center"
-                IsEnabled="{c:Binding !AutoDetectConnection}"
+                IsEnabled="{c:Binding '!AutoDetectConnection &amp;&amp; ConnectConfig!=&quot;WDA&quot;'}"
                 Orientation="Horizontal">
                 <controls:TooltipBlock Visibility="Hidden" />
                 <Grid Width="420">
@@ -269,7 +270,7 @@
                 hc:TitleElement.Title="{DynamicResource TouchMode}"
                 hc:TitleElement.TitlePlacement="Left"
                 DisplayMemberPath="Display"
-                IsHitTestVisible="{Binding Idle, Source={x:Static helper:Instances.SettingsViewModel}}"
+                IsEnabled="{c:Binding 'Idle &amp;&amp; ConnectConfig!=&quot;WDA&quot;'}"
                 ItemsSource="{Binding TouchModeList}"
                 SelectedValue="{Binding TouchMode}"
                 SelectedValuePath="Value" />
@@ -278,7 +279,8 @@
                 Margin="10"
                 HorizontalAlignment="Left"
                 Command="{s:Action ReplaceAdb}"
-                Content="{DynamicResource ForcedReplaceAdb}" />
+                Content="{DynamicResource ForcedReplaceAdb}"
+                Visibility="{c:Binding 'ConnectConfig!=&quot;WDA&quot;'}" />
         </StackPanel>
 
         <StackPanel Grid.Row="7">

--- a/src/MaaWpfGui/Views/UserControl/Settings/ConnectSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/Settings/ConnectSettingsUserControl.xaml
@@ -40,7 +40,7 @@
                     VerticalAlignment="Center"
                     Content="{DynamicResource AutoDetectConnection}"
                     IsChecked="{Binding AutoDetectConnection}"
-                    IsEnabled="{c:Binding 'ConnectConfig!=&quot;WDA&quot;'}" />
+                    IsEnabled="{c:Binding 'ConnectConfig!=&quot;wda&quot;'}" />
                 <controls:TooltipBlock TooltipText="{DynamicResource AutoDetectConnectionTip}" />
             </StackPanel>
             <CheckBox
@@ -54,7 +54,7 @@
             <StackPanel
                 Margin="10"
                 HorizontalAlignment="Center"
-                IsEnabled="{c:Binding '!AutoDetectConnection &amp;&amp; ConnectConfig!=&quot;WDA&quot;'}"
+                IsEnabled="{c:Binding '!AutoDetectConnection &amp;&amp; ConnectConfig!=&quot;wda&quot;'}"
                 Orientation="Horizontal">
                 <controls:TooltipBlock Visibility="Hidden" />
                 <Grid Width="420">
@@ -270,7 +270,7 @@
                 hc:TitleElement.Title="{DynamicResource TouchMode}"
                 hc:TitleElement.TitlePlacement="Left"
                 DisplayMemberPath="Display"
-                IsEnabled="{c:Binding 'Idle &amp;&amp; ConnectConfig!=&quot;WDA&quot;'}"
+                IsEnabled="{c:Binding 'Idle &amp;&amp; ConnectConfig!=&quot;wda&quot;'}"
                 ItemsSource="{Binding TouchModeList}"
                 SelectedValue="{Binding TouchMode}"
                 SelectedValuePath="Value" />
@@ -280,7 +280,7 @@
                 HorizontalAlignment="Left"
                 Command="{s:Action ReplaceAdb}"
                 Content="{DynamicResource ForcedReplaceAdb}"
-                Visibility="{c:Binding 'ConnectConfig!=&quot;WDA&quot;'}" />
+                Visibility="{c:Binding 'ConnectConfig!=&quot;wda&quot;'}" />
         </StackPanel>
 
         <StackPanel Grid.Row="7">


### PR DESCRIPTION
## 概述

  本 PR 完成了 WDA (WebDriverAgent) 控制器的实现，为 MaaAssistantArknights 提供的 iOS 设备支持，包括屏幕截图、触摸控制、坐标转换等全面功能。

目前仅支持16:9iPhone设备支持，如iPhone SE3.

  ## 更改内容

  ### 性能优化与监控 (Commit 3f0eea810)

  - **截图性能追踪**
    - 添加延迟统计（最小值/最大值/平均值），每 10 次截图报告一次
    - 帮助识别性能瓶颈和连接问题

  - **WDA 快速模式配置**
    - 禁用 `waitForIdleTimeout` 和 `animationCoolOffTimeout` 设置
    - 显著提高触摸操作的响应时间
    - 降低截图延迟

  ### 坐标系统修复 (Commit 3f0eea810)

  - **三层坐标转换系统**
    - MAA 坐标（裁剪后的 16:9 图像）
    - 物理像素（设备原生分辨率）
    - WDA 逻辑坐标（UIScreen.bounds points）
    - 正确处理 iOS 的 Points/Pixels 双坐标系统

  - **精确触摸控制**
    - 添加 PRECISE_SWIPE 支持用于战斗干员部署
    - 使用裁剪偏移量转换滑动坐标
    - 为点击和滑动操作添加详细日志


  ### 稳定性改进 (Commit 50948c566)

  - **自动重连**
    - 实现截图失败时的重连逻辑
    - 当 `allow_reconnect=true` 且截图失败时自动重连
    - 提高长时间自动化会话的稳定性

  - **应用生命周期管理**
    - 使用 `/wda/apps/launch` 端点实现 `start_game()`
    - 使用 `/wda/apps/terminate` 端点实现 `stop_game()`
    - 支持基于 bundle ID 的应用控制

  - **文本输入支持**
    - 使用 `/wda/keys` 端点实现 `input()` 方法
    - 支持聚焦文本框的键盘输入
    - 某些游戏功能所需

  - **设备识别**
    - 从 WDA 会话中存储实际设备 UDID
    - 用真实设备 UUID 替换硬编码的 bundle ID
    - 改进多设备支持

  - **连接管理**
    - 添加持久化 HTTP 连接基础设施
    - 实现 `ensure_connection()` 和 `close_connection()` 方法
    - 为 HTTP Keep-Alive 实现做准备

  ## 技术细节

  MAA 点击坐标 (100, 200)
    ↓ + 裁剪偏移 (219, 0)
  物理坐标 (319, 200)
    ↓ ÷ 缩放因子 (3.0)
  WDA 坐标 (106, 67) ✓ 触摸正确响应

  ### 性能指标

  - 截图延迟：平均约 280-350ms（启用快速模式）
  - 触摸操作延迟：约 150-200ms
  - 重连时间：约 1-2 秒

  ## 测试

  - ✅ 带 16:9 裁剪的屏幕截图
  - ✅ 三层坐标转换
  - ✅ 精确定位的点击操作
  - ✅ 用于干员部署的滑动操作
  - ✅ 连接断开时的自动重连
  - ✅ 通过 WDA API 启动/停止应用
  - ❌ 肉鸽尚未支持，战斗开始场景检测错误
  - ❌  左右滑动手势适配还有问题


  ## 破坏性变更

  无。这是新功能添加，对现有控制器没有影响。

## Summary by Sourcery

添加一个基于 WebDriverAgent 的新控制器以支持 iOS 设备，包括截图捕获、输入控制和坐标转换，并将其接入现有的控制器/触控模式选择流程。

新功能：
- 引入一个实现 ControllerAPI 的 WDAController，通过 WebDriverAgent 驱动 iOS 设备，支持截图、点击、滑动和文本输入。
- 通过 WDA 使用 bundle ID 支持在 iOS 目标设备上启动和终止应用。
- 为 WDA 新增一个 TouchMode 和 ControllerType，并支持通过实例选项进行选择。

增强内容：
- 为 WDA 会话实现持久化 HTTP 连接处理和基础重连逻辑，包括状态检查和会话生命周期管理。
- 为截图延迟添加性能追踪，并通过现有的回调机制定期上报。
- 实现三层坐标映射和 16:9 裁剪流水线，以正确地将 MAA 坐标转换为 iOS WDA 的逻辑坐标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a new WebDriverAgent-based controller to support iOS devices, including screenshot capture, input control, and coordinate conversion, and wire it into the existing controller/touch-mode selection flow.

New Features:
- Introduce a WDAController implementing the ControllerAPI to drive iOS devices via WebDriverAgent, supporting screenshots, taps, swipes, and text input.
- Support launching and terminating apps on iOS targets via WDA using bundle IDs.
- Add a new TouchMode and ControllerType for WDA and allow selecting it through instance options.

Enhancements:
- Implement persistent HTTP connection handling and basic reconnect logic for WDA sessions, including status checks and session lifecycle management.
- Add performance tracking for screenshot latency and periodic reporting via the existing callback mechanism.
- Implement a three-layer coordinate mapping and 16:9 cropping pipeline to correctly translate MAA coordinates to iOS WDA logical coordinates.

</details>