### PR TITLE
fix: add MaaWin32ControlUnit to nightly build

### DIFF
--- a/.github/workflows/release-nightly-ota.yml
+++ b/.github/workflows/release-nightly-ota.yml
@@ -199,6 +199,21 @@ jobs:
           mkdir -p install
           cmake --install build --prefix install --config RelWithDebInfo
 
+      - name: Download MaaFramework
+        if: matrix.arch == 'x64'
+        uses: robinraju/release-downloader@v1
+        with:
+          repository: MaaXYZ/MaaFramework
+          latest: true
+          fileName: '*win-x86_64*.zip'
+          extract: true
+          out-file-path: MaaFramework-temp
+
+      - name: Copy MaaWin32ControlUnit
+        if: matrix.arch == 'x64'
+        run: |
+          cp MaaFramework-temp/bin/*Win32ControlUnit* install/
+
       - name: Cache .nuke/temp, ~/.nuget/packages
         id: cache-nuget
         uses: actions/cache@v5


### PR DESCRIPTION
sync #15407

## Summary by Sourcery

Build:
- 在夜间 OTA 工作流中获取 MaaFramework 的 win-x86_64 构件，并将 `MaaWin32ControlUnit` 复制到 x64 安装输出目录中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Fetch MaaFramework win-x86_64 artifacts in the nightly OTA workflow and copy MaaWin32ControlUnit into the x64 install output.

</details>