### PR TITLE
ci: Add MAA COS upload step to release workflow

### DIFF
--- a/.github/workflows/release-package-distribution.yml
+++ b/.github/workflows/release-package-distribution.yml
@@ -130,10 +130,11 @@ jobs:
     name: Upload to MAA COS
     needs: meta
     if: ${{ github.event.inputs.maa_cos == 'true' && !contains(needs.meta.outputs.RELEASE_TAG, '-') }}
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     continue-on-error: true
     env:
       FILENAME: MAA-${{ needs.meta.outputs.RELEASE_TAG }}-win-x64.zip
+
     steps:
       - uses: robinraju/release-downloader@v1
         with:


### PR DESCRIPTION
Added a new step to upload to MAA COS in the release workflow.

## Summary by Sourcery

在发布分发阶段扩展发布工作流，以便可选地将 Windows 发布制品上传到 MAA COS。

CI：
- 新增一个布尔输入标志，用于控制是否将发布制品上传到 MAA COS。
- 新增一个 COS 上传任务，该任务会下载带标签的 Windows x64 发布制品，并使用配置好的密钥将其上传到腾讯云 COS。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extend the release workflow to optionally upload Windows release artifacts to MAA COS during package distribution.

CI:
- Add a new boolean input flag to control uploading release artifacts to MAA COS.
- Introduce a COS upload job that downloads the tagged Windows x64 release artifact and uploads it to Tencent COS using configured secrets.

</details>

CI：
- 为发布工作流的输入参数扩展一个布尔标志，用于控制是否将构建产物上传到 MAA COS。
- 新增一个 Windows 任务，用于下载带标签的 Windows x64 发布构建产物，并使用配置好的密钥将其上传到腾讯云 COS。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在发布分发阶段扩展发布工作流，以便可选地将 Windows 发布制品上传到 MAA COS。

CI：
- 新增一个布尔输入标志，用于控制是否将发布制品上传到 MAA COS。
- 新增一个 COS 上传任务，该任务会下载带标签的 Windows x64 发布制品，并使用配置好的密钥将其上传到腾讯云 COS。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extend the release workflow to optionally upload Windows release artifacts to MAA COS during package distribution.

CI:
- Add a new boolean input flag to control uploading release artifacts to MAA COS.
- Introduce a COS upload job that downloads the tagged Windows x64 release artifact and uploads it to Tencent COS using configured secrets.

</details>

</details>