### PR TITLE
fix: 仓库识别显示不全

### DIFF
--- a/src/MaaWpfGui/Views/UI/ToolboxView.xaml
+++ b/src/MaaWpfGui/Views/UI/ToolboxView.xaml
@@ -346,7 +346,7 @@
                     VirtualizingPanel.ScrollUnit="Pixel">
                     <DataGrid.ItemsPanel>
                         <ItemsPanelTemplate>
-                            <vwp:VirtualizingWrapPanel HorizontalAlignment="Center" />
+                            <WrapPanel HorizontalAlignment="Center" />
                         </ItemsPanelTemplate>
                     </DataGrid.ItemsPanel>
                     <DataGrid.Columns>


### PR DESCRIPTION
说实话我没太懂为什么改回 `WrapPanel` 就行了，但是 `VirtualizingWrapPanel` 不行。貌似是因为滚动时候 `DataGrid` 和 `VirtualizingWrapPanel` 的行为不一致。看之前是因为追求性能加的 `VirtualizingWrapPanel`，其他部分我就没动，只改了仓库识别，先确保正确性吧。

想要问题复现可以点到最后一个 Item，然后按 Tab 键看能不能跳回第一个，如果不能就说明有一部分识别结果没有显示出来。

用 `WrapPanel` 的效果是 3 列，如果要其他列数可以换成 `UniformGrid`。

## Summary by Sourcery

错误修复：
- 修复工具箱视图中仓库识别结果显示不完整以及焦点导航异常的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix incomplete display and focus navigation of repository recognition results in the toolbox view.

</details>