### PR TITLE
perf: 优化自动战斗界面布局

### DIFF
--- a/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
@@ -38,6 +38,7 @@ using MaaWpfGui.Utilities.ValueType;
 using MaaWpfGui.ViewModels.Items;
 using Microsoft.Win32;
 using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Serilog;
 using Stylet;
 using static MaaWpfGui.Helper.CopilotHelper;
@@ -447,6 +448,10 @@ public partial class CopilotViewModel : Screen
             ConfigurationHelper.SetValue(ConfigurationKeys.CopilotUserAdditional, value);
         }
     }
+
+    [PropertyDependsOn(nameof(UserAdditional))]
+    public string UserAdditionalPrettyJson => string.IsNullOrWhiteSpace(UserAdditional) ? string.Empty
+        : JToken.Parse(UserAdditional).ToString(Formatting.None).Replace("},", "},\n");
 
     private bool _isUserAdditionalPopupOpen;
 

--- a/src/MaaWpfGui/Views/UI/CopilotView.xaml
+++ b/src/MaaWpfGui/Views/UI/CopilotView.xaml
@@ -338,7 +338,7 @@
                                     hc:IconElement.Geometry="{StaticResource ConfigGeometry}"
                                     BorderThickness="0"
                                     Command="{s:Action OpenUserAdditionalPopup}"
-                                    ToolTip="{Binding UserAdditional}"
+                                    ToolTip="{Binding UserAdditionalPrettyJson}"
                                     ToolTipService.ShowOnDisabled="True" />
                                 <controls:TooltipBlock TooltipText="{DynamicResource AddUserAdditionalTip}" />
                                 <Popup


### PR DESCRIPTION
`ComboBox` 的 `MinHeight` 是 `28`，所以设置它的 `Height` 为 `20` 没有用，全删掉了。

为了使勾选时列表尽量不变化，设置了“使用编队”的 `StackPanel` 高度为 `28`；同时将“借助战”选项的选择框放在了第 2 行显示，并有适当缩进，使中英文界面一致。

设置了“战斗列表”最下方的关卡名的 `MinHeight` 为 `80`，这个数值可以保证绝大多数活动关卡在查看信息时列表宽度不会发生变化，但保全派驻、悖论模拟关卡名过长（可能超过 110），可能会在查看信息时变化。为了大部分情况下美观，没有继续加大这个值。

修改 `SupportUnitUsage` 初始值为 `1`，因为 `0` 目前是无效值，而且界面上没有文字提示修改。

## Summary by Sourcery

调整副驾驶自动战斗界面的布局和默认值，以在多语言环境下提供更稳定、一致的界面体验。

Bug Fixes:
- 将默认的援助单位使用值从无效的 0 设置为 1，避免以不可用的配置开始游戏。

Enhancements:
- 优化自动战斗界面的布局，在切换选项时保持列表和控制区域的高度稳定，并使中文和英文布局之间的元素对齐更加一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust the copilot auto-battle UI layout and defaults to provide a more stable, consistent interface across languages.

Bug Fixes:
- Set the default support unit usage value to 1 instead of an invalid 0 to avoid starting with a non-functional configuration.

Enhancements:
- Refine the auto-battle UI layout to keep list and control heights stable when toggling options and to better align elements between Chinese and English layouts.

</details>