### PR TITLE
fix: 统一 CopilotViewModel 中 Windows 下的文件名格式

### DIFF
--- a/src/MaaWpfGui/ViewModels/Items/CopilotItemViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/Items/CopilotItemViewModel.cs
@@ -11,6 +11,7 @@
 // but WITHOUT ANY WARRANTY
 // </copyright>
 
+using System.IO;
 using MaaWpfGui.Helper;
 using Newtonsoft.Json;
 using Stylet;
@@ -31,7 +32,7 @@ public class CopilotItemViewModel : PropertyChangedBase
     public CopilotItemViewModel(string name, string filePath, bool isRaid = false, int copilotId = 0, bool isChecked = true)
     {
         Name = name;
-        FilePath = filePath;
+        FilePath = Path.GetFullPath(filePath); // 之后可以改回去。只要启动一次 maa，配置就改好了
         _isRaid = isRaid;
         CopilotId = copilotId;
         _isChecked = isChecked;

--- a/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
@@ -1638,11 +1638,13 @@ public partial class CopilotViewModel : Screen
         }
 
         var fileName = !string.IsNullOrEmpty(stageCode) ? stageCode : DateTimeOffset.Now.ToUnixTimeSeconds().ToString();
-        var cachePath = $"{CopilotJsonDir}/{fileName}.json";
+        var cachePath = Path.Combine(CopilotJsonDir, $"{fileName}.json");
+
+        // assert: cachePath == Path.GetFullPath(cachePath) && i.FilePath == Path.GetFullPath(i.FilePath)
         await _semaphore.WaitAsync();
         if (File.Exists(cachePath) && CopilotItemViewModels.Any(i => i.FilePath == cachePath))
         {
-            cachePath = $"{CopilotJsonDir}/{fileName}_{DateTimeOffset.Now.ToUnixTimeMilliseconds()}.json";
+            cachePath = Path.Combine(CopilotJsonDir, $"{fileName}_{DateTimeOffset.Now.ToUnixTimeMilliseconds()}.json");
             if (CopilotItemViewModels.Any(i => i.FilePath == cachePath))
             {
                 _logger.Error("Could not add copilot task with duplicate stage name: {StageName}", copilot.StageName);


### PR DESCRIPTION
改成 `Path.Combine`，不要用 `'/'`

## Summary by Sourcery

规范 copilot 缓存文件路径，以使用适用于 Windows 的路径格式，并进行一致的完整路径比较。

Bug Fixes:
- 修复 copilot 缓存文件名的构建方式，改为使用 `Path.Combine` 而不是硬编码的路径分隔符，从而在 Windows 上确保路径正确。

Enhancements:
- 在初始化视图模型时，将 copilot 条目的文件路径规范化为完整路径，以确保与缓存路径进行一致的相等性检查。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize copilot cache file paths to use Windows-appropriate paths and consistent full-path comparisons.

Bug Fixes:
- Fix copilot cache file name construction to use Path.Combine instead of hard-coded path separators, ensuring correct paths on Windows.

Enhancements:
- Normalize copilot item file paths to full paths when initializing view models to ensure consistent equality checks against cache paths.

</details>