### PR TITLE
fix: 初始化 StartEnabled 属性为 true

### DIFF
--- a/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
@@ -220,7 +220,7 @@ public partial class CopilotViewModel : Screen
     /// <summary>
     /// Gets or sets a value indicating whether the start button is enabled.
     /// </summary>
-    public bool StartEnabled { get => field; set => SetAndNotify(ref field, value); }
+    public bool StartEnabled { get => field; set => SetAndNotify(ref field, value); } = true;
 
     private int _copilotTabIndex = 0;
 


### PR DESCRIPTION
修复了直接点击“战斗列表”后，“开始”未启用的bug。

## Summary by Sourcery

错误修复：
- 修复了在直接打开战斗列表时开始按钮未被启用的问题，方法是确保其绑定的属性默认值为 `true`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix the start button not being enabled when directly opening the battle list by ensuring its bound property defaults to true.

</details>