### PR TITLE
feat: AVD截图增强

### DIFF
--- a/resource/config.json
+++ b/resource/config.json
@@ -142,6 +142,10 @@
             "screencapRawWithGzip": "[Adb] -s [AdbSerial] exec-out \"screencap 2>/dev/null | gzip -1\"",
             "screencapEncode": "[Adb] -s [AdbSerial] exec-out \"screencap -p 2>/dev/null\"",
             "screencapRawByNC": "[Adb] -s [AdbSerial] exec-out \"screencap 2>/dev/null | nc -w 3 [NcAddress] [NcPort]\""
+        },
+        {
+            "configName": "AVD",
+            "baseConfig": "General"
         }
     ]
 }

--- a/src/MaaCore/Assistant.cpp
+++ b/src/MaaCore/Assistant.cpp
@@ -133,6 +133,10 @@ bool asst::Assistant::set_instance_option(InstanceOptionKey key, const std::stri
             m_ctrler->set_touch_mode(TouchMode::MacPlayTools);
             return true;
         }
+        else if (constexpr std::string_view MaaFwAdb = "MaaFwAdb"; value == MaaFwAdb) {
+            m_ctrler->set_touch_mode(TouchMode::MaaFwAdb);
+            return true;
+        }
         break;
     case InstanceOptionKey::DeploymentWithPause:
         if (constexpr std::string_view Enable = "1"; value == Enable) {

--- a/src/MaaCore/Common/AsstTypes.h
+++ b/src/MaaCore/Common/AsstTypes.h
@@ -54,6 +54,7 @@ enum class TouchMode
     Minitouch = 1,
     Maatouch = 2,
     MacPlayTools = 3,
+    MaaFwAdb = 4,
 };
 
 #ifdef _WIN32

--- a/src/MaaCore/Controller/Controller.cpp
+++ b/src/MaaCore/Controller/Controller.cpp
@@ -20,6 +20,7 @@
 
 #include "AdbController.h"
 #include "ControllerAPI.h"
+#include "MaaFwAdbController.h"
 #include "MaatouchController.h"
 #include "MinitouchController.h"
 #include "PlayToolsController.h"
@@ -63,6 +64,9 @@ std::shared_ptr<asst::ControllerAPI> asst::Controller::create_controller(
             break;
         case ControllerType::MacPlayTools:
             controller = std::make_shared<PlayToolsController>(m_callback, m_inst, platform_type);
+            break;
+        case ControllerType::MaaFwAdb:
+            controller = std::make_shared<MaaFwAdbController>(m_callback, m_inst, platform_type);
             break;
         default:
             return nullptr;
@@ -367,6 +371,9 @@ void asst::Controller::set_touch_mode(const TouchMode& mode) noexcept
         break;
     case TouchMode::MacPlayTools:
         m_controller_type = ControllerType::MacPlayTools;
+        break;
+    case TouchMode::MaaFwAdb:
+        m_controller_type = ControllerType::MaaFwAdb;
         break;
     default:
         m_controller_type = ControllerType::Minitouch;

--- a/src/MaaCore/Controller/ControllerAPI.h
+++ b/src/MaaCore/Controller/ControllerAPI.h
@@ -18,6 +18,7 @@ enum class ControllerType
 #ifdef _WIN32
     Win32,
 #endif
+    MaaFwAdb,
 };
 
 class ControllerAPI

--- a/src/MaaCore/Controller/LDExtras.cpp
+++ b/src/MaaCore/Controller/LDExtras.cpp
@@ -75,7 +75,7 @@ std::optional<cv::Mat> LDExtras::screencap() const
 
 bool LDExtras::load_ld_library()
 {
-    auto lib_path = ld_path_ / "ldopengl64.dll";
+    auto lib_path = ld_path_ / "ldopengl64";
 
     if (!load_library(lib_path)) {
         LogError << "Failed to load library" << VAR(lib_path);

--- a/src/MaaCore/Controller/MaaFwAdbController.cpp
+++ b/src/MaaCore/Controller/MaaFwAdbController.cpp
@@ -110,7 +110,7 @@ bool MaaFwAdbController::connect(const std::string& adb_path, const std::string&
         : config == "AVD"          ? "{\"extras\":{\"avd\":{\"enable\":true}}}"
                                    : "{}",
         // MaaAgentBinary目录
-        ResDir.get().c_str());
+        utils::path_to_utf8_string(ResDir.get()).c_str());
 
     if (!m_unit_handle) {
         LogError << "Failed to create MaaAdbControlUnit";

--- a/src/MaaCore/Controller/MaaFwAdbController.cpp
+++ b/src/MaaCore/Controller/MaaFwAdbController.cpp
@@ -3,6 +3,7 @@
 #include <fastdeploy/vision/ocr/ppocr/utils/clipper.h>
 #include <thread>
 
+#include "Common/AsstMsg.h"
 #include "Config/GeneralConfig.h"
 #include "Controller/MaaFwControlUnitInterface.h"
 #include "Utils/Logger.hpp"
@@ -74,6 +75,20 @@ bool MaaFwAdbController::connect(const std::string& adb_path, const std::string&
     LogTraceFunction;
 
     m_inited = false;
+    m_uuid.clear();
+    m_screen_size = { 0, 0 };
+
+    auto get_info_json = [&]() -> json::object {
+        return json::object {
+            { "uuid", m_uuid },
+            { "details",
+              json::object {
+                  { "adb", adb_path },
+                  { "address", address },
+                  { "config", config },
+              } },
+        };
+    };
 
     if (!init_library()) {
         return false;
@@ -106,23 +121,66 @@ bool MaaFwAdbController::connect(const std::string& adb_path, const std::string&
         LogError << "MaaAdbControlUnit failed to connect";
         m_destroy_func(m_unit_handle);
         m_unit_handle = nullptr;
+        callback(
+            AsstMsg::ConnectionInfo,
+            json::object {
+                { "what", "ConnectFailed" },
+                { "why", "MaaAdbControlUnit failed to connect" },
+            } | get_info_json());
         return false;
     }
 
     if (!m_unit_handle->request_uuid(m_uuid)) {
-        LogWarn << "Failed to get UUID from MaaFwAdbControlUnit, fallback to address";
-        m_uuid = address;
+        LogWarn << "Failed to get UUID from MaaFwAdbControlUnit";
+        callback(
+            AsstMsg::ConnectionInfo,
+            json::object {
+                { "what", "ConnectFailed" },
+                { "why", "MaaFwAdbControlUnit failed to get UUID" },
+            } | get_info_json());
+        return false;
     }
+
+    callback(
+        AsstMsg::ConnectionInfo,
+        json::object {
+            { "what", "UuidGot" },
+            { "why", "" },
+            { "details",
+              json::object {
+                  { "uuid", m_uuid },
+              } },
+        } | get_info_json());
 
     // 尝试进行一次截图以获取屏幕分辨率
     cv::Mat image;
-    if (m_unit_handle->screencap(image)) {
-        m_screen_size = { image.cols, image.rows };
-        LogInfo << "Connected to ADB. Screen size:" << m_screen_size.first << "x" << m_screen_size.second
-                << VAR(m_unit_handle) << VAR(this);
+    if (!m_unit_handle->screencap(image) || image.cols == 0 || image.rows == 0) {
+        callback(
+            AsstMsg::ConnectionInfo,
+            json::object {
+                { "what", "ResolutionError" },
+                { "why", "Get resolution failed" },
+            } | get_info_json());
+        return false;
     }
+    m_screen_size = { image.cols, image.rows };
+    LogInfo << "Connected to ADB. Screen size:" << m_screen_size.first << "x" << m_screen_size.second;
+    callback(
+        AsstMsg::ConnectionInfo,
+        json::object {
+            { "what", "ResolutionGot" },
+            { "why", "" },
+            { "width", m_screen_size.first },
+            { "height", m_screen_size.second },
+        } | get_info_json());
 
     m_inited = true;
+    callback(
+        AsstMsg::ConnectionInfo,
+        json::object {
+            { "what", "Connected" },
+            { "why", "" },
+        } | get_info_json());
     return true;
 }
 

--- a/src/MaaCore/Controller/MaaFwAdbController.cpp
+++ b/src/MaaCore/Controller/MaaFwAdbController.cpp
@@ -1,0 +1,289 @@
+#include "MaaFwAdbController.h"
+
+#include <fastdeploy/vision/ocr/ppocr/utils/clipper.h>
+#include <thread>
+
+#include "Config/GeneralConfig.h"
+#include "Controller/MaaFwControlUnitInterface.h"
+#include "Utils/Logger.hpp"
+#include "Utils/WorkingDir.hpp"
+
+namespace asst
+{
+
+MaaFwAdbController::MaaFwAdbController(
+    const AsstCallback& callback,
+    Assistant* inst,
+    PlatformType type [[maybe_unused]]) :
+    InstHelper(inst),
+    m_callback(callback)
+{
+    LogTraceFunction;
+}
+
+MaaFwAdbController::~MaaFwAdbController()
+{
+    LogTraceFunction;
+
+    if (m_unit_handle && m_destroy_func) {
+        LogInfo << "Cleaning up MaaAdbControlUnit";
+        m_destroy_func(m_unit_handle);
+        m_unit_handle = nullptr;
+    }
+}
+
+bool MaaFwAdbController::init_library()
+{
+    if (m_get_version_func && m_create_func && m_destroy_func) {
+        LogInfo << "MaaAdbControlUnit library already loaded";
+        return true;
+    }
+    if (!load_library(
+#ifndef _WIN32
+            "lib"
+#endif
+            "MaaAdbControlUnit"
+#ifdef _WIN32
+            ".dll"
+#elif defined(__APPLE__)
+            ".dylib"
+#else
+            ".so"
+#endif
+            )) {
+        LogError << "Failed to load MaaAdbControlUnit library";
+        return false;
+    }
+
+    m_get_version_func = get_function<GetVersionFunc>("MaaAdbControlUnitGetVersion");
+    m_create_func = get_function<CreateFunc>("MaaAdbControlUnitCreate");
+    m_destroy_func = get_function<DestroyFunc>("MaaAdbControlUnitDestroy");
+
+    if (!m_get_version_func || !m_create_func || !m_destroy_func) {
+        LogError << "Failed to get function pointers from MaaAdbControlUnit library";
+        return false;
+    }
+
+    LogInfo << "MaaAdbControlUnit library version:" << m_get_version_func();
+
+    return true;
+}
+
+bool MaaFwAdbController::connect(const std::string& adb_path, const std::string& address, const std::string& config)
+{
+    LogTraceFunction;
+
+    m_inited = false;
+
+    if (!init_library()) {
+        return false;
+    }
+
+    if (m_unit_handle && m_destroy_func) {
+        LogInfo << "Cleaning up the old connection and reconnecting";
+        m_destroy_func(m_unit_handle);
+        m_unit_handle = nullptr;
+    }
+
+    m_unit_handle = m_create_func(
+        adb_path.c_str(),
+        address.c_str(),
+        MaaAdbScreencapMethod::Default,
+        MaaAdbInputMethod::AdbShell | MaaAdbInputMethod::EmulatorExtras,
+        config == "MuMuEmulator12" ? "{\"extras\":{\"mumu\":{\"enable\":true}}}"
+        : config == "LDPlayer"     ? "{\"extras\":{\"ld\":{\"enable\":true}}}"
+        : config == "AVD"          ? "{\"extras\":{\"avd\":{\"enable\":true}}}"
+                                   : "{}",
+        // MaaAgentBinary目录
+        ResDir.get().c_str());
+
+    if (!m_unit_handle) {
+        LogError << "Failed to create MaaAdbControlUnit";
+        return false;
+    }
+
+    if (!m_unit_handle->connect()) {
+        LogError << "MaaAdbControlUnit failed to connect";
+        m_destroy_func(m_unit_handle);
+        m_unit_handle = nullptr;
+        return false;
+    }
+
+    if (!m_unit_handle->request_uuid(m_uuid)) {
+        LogWarn << "Failed to get UUID from MaaFwAdbControlUnit, fallback to address";
+        m_uuid = address;
+    }
+
+    // 尝试进行一次截图以获取屏幕分辨率
+    cv::Mat image;
+    if (m_unit_handle->screencap(image)) {
+        m_screen_size = { image.cols, image.rows };
+        LogInfo << "Connected to ADB. Screen size:" << m_screen_size.first << "x" << m_screen_size.second
+                << VAR(m_unit_handle) << VAR(this);
+    }
+
+    m_inited = true;
+    return true;
+}
+
+bool MaaFwAdbController::inited() const noexcept
+{
+    return m_inited && m_unit_handle && m_unit_handle->connected();
+}
+
+const std::string& MaaFwAdbController::get_uuid() const
+{
+    return m_uuid;
+}
+
+bool MaaFwAdbController::screencap(cv::Mat& image_payload, bool allow_reconnect [[maybe_unused]])
+{
+    LogTraceFunction;
+    if (!m_unit_handle) {
+        LogWarn << "MaaAdbControlUnit is not initialized";
+        return false;
+    }
+
+    if (!m_unit_handle->screencap(image_payload)) {
+        LogWarn << "MaaAdbControlUnit screencap failed";
+        return false;
+    }
+
+    if (m_screen_size.first == 0) {
+        m_screen_size = { image_payload.cols, image_payload.rows };
+    }
+
+    return true;
+}
+
+bool MaaFwAdbController::start_game(const std::string& client_type)
+{
+    LogTraceFunction;
+    if (!m_unit_handle) {
+        LogWarn << "MaaAdbControlUnit is not initialized";
+        return false;
+    }
+
+    auto package_name = Config.get_package_name(client_type);
+    if (!package_name) {
+        LogWarn << "Invalid client_type" << VAR(client_type);
+        return false;
+    }
+    return m_unit_handle->start_app(*package_name);
+}
+
+bool MaaFwAdbController::stop_game(const std::string& client_type)
+{
+    LogTraceFunction;
+    if (!m_unit_handle) {
+        LogWarn << "MaaAdbControlUnit is not initialized";
+        return false;
+    }
+
+    auto package_name = Config.get_package_name(client_type);
+    if (!package_name) {
+        LogWarn << "Invalid client_type" << VAR(client_type);
+        return false;
+    }
+    return m_unit_handle->stop_app(*package_name);
+}
+
+bool MaaFwAdbController::click(const Point& p)
+{
+    LogTraceFunction;
+    if (!m_unit_handle) {
+        LogWarn << "MaaAdbControlUnit is not initialized";
+        return false;
+    }
+    return m_unit_handle->click(p.x, p.y);
+}
+
+bool MaaFwAdbController::input(const std::string& text)
+{
+    LogTraceFunction;
+    if (!m_unit_handle) {
+        LogWarn << "MaaAdbControlUnit is not initialized";
+        return false;
+    }
+    return m_unit_handle->input_text(text);
+}
+
+bool MaaFwAdbController::swipe(
+    const Point& p1,
+    const Point& p2,
+    int duration,
+    bool extra_swipe [[maybe_unused]],
+    double slope_in [[maybe_unused]],
+    double slope_out [[maybe_unused]],
+    bool with_pause [[maybe_unused]])
+{
+    LogTraceFunction;
+    if (!m_unit_handle) {
+        LogWarn << "MaaAdbControlUnit is not initialized";
+        return false;
+    }
+
+    return m_unit_handle->swipe(p1.x, p1.y, p2.x, p2.y, duration);
+}
+
+bool MaaFwAdbController::inject_input_event(const InputEvent& event)
+{
+    LogTraceFunction;
+    if (!m_unit_handle) {
+        LogWarn << "MaaAdbControlUnit is not initialized";
+        return false;
+    }
+
+    switch (event.type) {
+    case InputEvent::Type::TOUCH_DOWN:
+        return m_unit_handle->touch_down(event.pointerId, event.point.x, event.point.y, 0);
+    case InputEvent::Type::TOUCH_MOVE:
+        return m_unit_handle->touch_move(event.pointerId, event.point.x, event.point.y, 0);
+    case InputEvent::Type::TOUCH_UP:
+        return m_unit_handle->touch_up(event.pointerId);
+    case InputEvent::Type::TOUCH_RESET:
+        return true;
+    case InputEvent::Type::KEY_DOWN:
+        return m_unit_handle->key_down(event.keycode);
+    case InputEvent::Type::KEY_UP:
+        return m_unit_handle->key_up(event.keycode);
+    case InputEvent::Type::WAIT_MS:
+        std::this_thread::sleep_for(std::chrono::milliseconds(event.milisec));
+        return true;
+    case InputEvent::Type::COMMIT:
+        return true;
+    default:
+        LogError << "unknown input event type" << VAR(static_cast<int>(event.type));
+        return false;
+    }
+}
+
+bool MaaFwAdbController::press_esc()
+{
+    LogTraceFunction;
+    if (!m_unit_handle) {
+        LogWarn << "MaaAdbControlUnit is not initialized";
+        return false;
+    }
+
+    return m_unit_handle->click_key(111); // KEYCODE_ESCAPE
+}
+
+ControlFeat::Feat MaaFwAdbController::support_features() const noexcept
+{
+    return ControlFeat::PRECISE_SWIPE;
+}
+
+std::pair<int, int> MaaFwAdbController::get_screen_res() const noexcept
+{
+    return m_screen_size;
+}
+
+void MaaFwAdbController::callback(AsstMsg msg, const json::value& details)
+{
+    if (m_callback) {
+        m_callback(msg, details, m_inst);
+    }
+}
+
+} // namespace asst

--- a/src/MaaCore/Controller/MaaFwAdbController.cpp
+++ b/src/MaaCore/Controller/MaaFwAdbController.cpp
@@ -38,19 +38,7 @@ bool MaaFwAdbController::init_library()
         LogInfo << "MaaAdbControlUnit library already loaded";
         return true;
     }
-    if (!load_library(
-#ifndef _WIN32
-            "lib"
-#endif
-            "MaaAdbControlUnit"
-#ifdef _WIN32
-            ".dll"
-#elif defined(__APPLE__)
-            ".dylib"
-#else
-            ".so"
-#endif
-            )) {
+    if (!load_library("MaaAdbControlUnit")) {
         LogError << "Failed to load MaaAdbControlUnit library";
         return false;
     }

--- a/src/MaaCore/Controller/MaaFwAdbController.cpp
+++ b/src/MaaCore/Controller/MaaFwAdbController.cpp
@@ -1,6 +1,5 @@
 #include "MaaFwAdbController.h"
 
-#include <fastdeploy/vision/ocr/ppocr/utils/clipper.h>
 #include <thread>
 
 #include "Common/AsstMsg.h"
@@ -132,6 +131,8 @@ bool MaaFwAdbController::connect(const std::string& adb_path, const std::string&
 
     if (!m_unit_handle->request_uuid(m_uuid)) {
         LogWarn << "Failed to get UUID from MaaFwAdbControlUnit";
+        m_destroy_func(m_unit_handle);
+        m_unit_handle = nullptr;
         callback(
             AsstMsg::ConnectionInfo,
             json::object {
@@ -155,6 +156,8 @@ bool MaaFwAdbController::connect(const std::string& adb_path, const std::string&
     // 尝试进行一次截图以获取屏幕分辨率
     cv::Mat image;
     if (!m_unit_handle->screencap(image) || image.cols == 0 || image.rows == 0) {
+        m_destroy_func(m_unit_handle);
+        m_unit_handle = nullptr;
         callback(
             AsstMsg::ConnectionInfo,
             json::object {

--- a/src/MaaCore/Controller/MaaFwAdbController.cpp
+++ b/src/MaaCore/Controller/MaaFwAdbController.cpp
@@ -104,10 +104,7 @@ bool MaaFwAdbController::connect(const std::string& adb_path, const std::string&
         address.c_str(),
         MaaAdbScreencapMethod::Default,
         MaaAdbInputMethod::AdbShell | MaaAdbInputMethod::EmulatorExtras,
-        config == "MuMuEmulator12" ? "{\"extras\":{\"mumu\":{\"enable\":true}}}"
-        : config == "LDPlayer"     ? "{\"extras\":{\"ld\":{\"enable\":true}}}"
-        : config == "AVD"          ? "{\"extras\":{\"avd\":{\"enable\":true}}}"
-                                   : "{}",
+        config == "AVD" ? "{\"extras\":{\"avd\":{\"enable\":true}}}" : "{}",
         // MaaAgentBinary目录
         utils::path_to_utf8_string(ResDir.get()).c_str());
 

--- a/src/MaaCore/Controller/MaaFwAdbController.h
+++ b/src/MaaCore/Controller/MaaFwAdbController.h
@@ -31,9 +31,9 @@ public:
 
     virtual const std::string& get_uuid() const override;
 
-    virtual size_t get_pipe_data_size() const noexcept override { return 0; }
+    virtual size_t get_pipe_data_size() const noexcept override { return 114514; }
 
-    virtual size_t get_version() const noexcept override { return 0; }
+    virtual size_t get_version() const noexcept override { return 114514; }
 
     virtual bool screencap(cv::Mat& image_payload, bool allow_reconnect = false) override;
 

--- a/src/MaaCore/Controller/MaaFwAdbController.h
+++ b/src/MaaCore/Controller/MaaFwAdbController.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <string>
+#include <utility>
+
+#include "Common/AsstMsg.h"
+#include "ControllerAPI.h"
+#include "InstHelper.h"
+#include "MaaFwControlUnitInterface.h"
+#include "Platform/PlatformFactory.h"
+#include "Utils/LibraryHolder.hpp"
+
+namespace asst
+{
+class Assistant;
+
+class MaaFwAdbController : public ControllerAPI, private InstHelper, public LibraryHolder<MaaFwAdbController>
+{
+public:
+    MaaFwAdbController(const AsstCallback& callback, Assistant* inst, PlatformType type);
+    virtual ~MaaFwAdbController() override;
+
+    MaaFwAdbController(const MaaFwAdbController&) = delete;
+    MaaFwAdbController& operator=(const MaaFwAdbController&) = delete;
+    MaaFwAdbController(MaaFwAdbController&&) = delete;
+    MaaFwAdbController& operator=(MaaFwAdbController&&) = delete;
+
+public:
+    virtual bool connect(const std::string& adb_path, const std::string& address, const std::string& config) override;
+    virtual bool inited() const noexcept override;
+
+    virtual const std::string& get_uuid() const override;
+
+    virtual size_t get_pipe_data_size() const noexcept override { return 0; }
+
+    virtual size_t get_version() const noexcept override { return 0; }
+
+    virtual bool screencap(cv::Mat& image_payload, bool allow_reconnect = false) override;
+
+    virtual bool start_game(const std::string& client_type) override;
+    virtual bool stop_game(const std::string& client_type) override;
+
+    virtual bool click(const Point& p) override;
+    virtual bool input(const std::string& text) override;
+    virtual bool swipe(
+        const Point& p1,
+        const Point& p2,
+        int duration = 0,
+        bool extra_swipe = false,
+        double slope_in = 1,
+        double slope_out = 1,
+        bool with_pause = false) override;
+
+    virtual bool inject_input_event(const InputEvent& event) override;
+
+    virtual bool press_esc() override;
+    virtual ControlFeat::Feat support_features() const noexcept override;
+
+    virtual std::pair<int, int> get_screen_res() const noexcept override;
+
+private:
+    bool m_inited = false;
+    std::string m_uuid;
+    std::pair<int, int> m_screen_size = { 0, 0 };
+
+    MaaFwAdbControlUnitAPI* m_unit_handle = nullptr;
+    bool init_library();
+
+    AsstCallback m_callback = nullptr;
+    void callback(AsstMsg msg, const json::value& details);
+
+    // MaaFramework/source/include/ControlUnit/AdbControlUnitAPI.h
+    using GetVersionFunc = const char*();
+    using CreateFunc = MaaFwAdbControlUnitAPI*(const char*, const char*, uint64_t, uint64_t, const char*, const char*);
+    using DestroyFunc = void(MaaFwAdbControlUnitAPI*);
+
+    std::function<GetVersionFunc> m_get_version_func;
+    std::function<CreateFunc> m_create_func;
+    std::function<DestroyFunc> m_destroy_func;
+};
+} // namespace asst

--- a/src/MaaCore/Controller/MaaFwControlUnitInterface.h
+++ b/src/MaaCore/Controller/MaaFwControlUnitInterface.h
@@ -1,10 +1,10 @@
 #pragma once
 
+#include "MaaUtils/NoWarningCVMat.hpp"
+#include <chrono>
 #include <cstdint>
 #include <string>
-#include <chrono>
 #include <vector>
-#include "MaaUtils/NoWarningCVMat.hpp"
 
 namespace asst
 {
@@ -48,8 +48,10 @@ public:
     virtual ~MaaFwAdbControlUnitAPI() = default;
 
     virtual bool find_device(std::vector<std::string>& devices) = 0;
-    virtual bool
-        shell(const std::string& cmd, std::string& output, std::chrono::milliseconds timeout = std::chrono::milliseconds(20000)) = 0;
+    virtual bool shell(
+        const std::string& cmd,
+        std::string& output,
+        std::chrono::milliseconds timeout = std::chrono::milliseconds(20000)) = 0;
 };
 
 // 与 MaaFramework 的 MaaControllerFeature 兼容的常量
@@ -59,4 +61,32 @@ constexpr uint64_t None = 0;
 constexpr uint64_t UseMouseDownAndUpInsteadOfClick = 1ULL << 1;
 constexpr uint64_t UseKeyboardDownAndUpInsteadOfClick = 1ULL << 2;
 } // namespace MaaFeature
+
+// 与 MaaFramework 的 MaaAdbScreencapMethod 兼容的常量
+namespace MaaAdbScreencapMethod
+{
+constexpr uint64_t EncodeToFileAndPull = 1ULL;
+constexpr uint64_t Encode = 1ULL << 1;
+constexpr uint64_t RawWithGzip = 1ULL << 2;
+constexpr uint64_t RawByNetcat = 1ULL << 3;
+constexpr uint64_t MinicapDirect = 1ULL << 4;
+constexpr uint64_t MinicapStream = 1ULL << 5;
+constexpr uint64_t EmulatorExtras = 1ULL << 6;
+constexpr uint64_t None = 0ULL;
+constexpr uint64_t All = ~None;
+constexpr uint64_t Default = All & ~RawByNetcat & ~MinicapDirect & ~MinicapStream;
+}
+
+// 与 MaaFramework 的 MaaAdbInputMethod 兼容的常量
+namespace MaaAdbInputMethod
+{
+constexpr uint64_t AdbShell = 1ULL;
+constexpr uint64_t MinitouchAndAdbKey = 1ULL << 1;
+constexpr uint64_t Maatouch = 1ULL << 2;
+constexpr uint64_t EmulatorExtras = 1ULL << 3;
+
+constexpr uint64_t None = 0ULL;
+constexpr uint64_t All = ~None;
+constexpr uint64_t Default = All & ~EmulatorExtras;
+}
 } // namespace asst

--- a/src/MaaCore/Controller/MaaFwControlUnitInterface.h
+++ b/src/MaaCore/Controller/MaaFwControlUnitInterface.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <chrono>
+#include <vector>
+#include "MaaUtils/NoWarningCVMat.hpp"
+
+namespace asst
+{
+// 与 MaaFramework 的 ControlUnitAPI 接口保持 ABI 兼容
+// 虚函数表布局必须与 MaaFramework 完全一致
+class MaaFwControlUnitAPI
+{
+public:
+    virtual ~MaaFwControlUnitAPI() = default;
+
+    virtual bool connect() = 0;
+    virtual bool connected() const = 0;
+
+    virtual bool request_uuid(std::string& uuid) = 0;
+    virtual uint64_t get_features() const = 0;
+
+    virtual bool start_app(const std::string& intent) = 0;
+    virtual bool stop_app(const std::string& intent) = 0;
+
+    virtual bool screencap(cv::Mat& image) = 0;
+
+    virtual bool click(int x, int y) = 0;
+    virtual bool swipe(int x1, int y1, int x2, int y2, int duration) = 0;
+
+    virtual bool touch_down(int contact, int x, int y, int pressure) = 0;
+    virtual bool touch_move(int contact, int x, int y, int pressure) = 0;
+    virtual bool touch_up(int contact) = 0;
+
+    virtual bool click_key(int key) = 0;
+    virtual bool input_text(const std::string& text) = 0;
+
+    virtual bool key_down(int key) = 0;
+    virtual bool key_up(int key) = 0;
+
+    virtual bool scroll(int dx, int dy) = 0;
+};
+
+class MaaFwAdbControlUnitAPI : public MaaFwControlUnitAPI
+{
+public:
+    virtual ~MaaFwAdbControlUnitAPI() = default;
+
+    virtual bool find_device(std::vector<std::string>& devices) = 0;
+    virtual bool
+        shell(const std::string& cmd, std::string& output, std::chrono::milliseconds timeout = std::chrono::milliseconds(20000)) = 0;
+};
+
+// 与 MaaFramework 的 MaaControllerFeature 兼容的常量
+namespace MaaFeature
+{
+constexpr uint64_t None = 0;
+constexpr uint64_t UseMouseDownAndUpInsteadOfClick = 1ULL << 1;
+constexpr uint64_t UseKeyboardDownAndUpInsteadOfClick = 1ULL << 2;
+} // namespace MaaFeature
+} // namespace asst

--- a/src/MaaCore/Controller/Win32ControlUnitLoader.h
+++ b/src/MaaCore/Controller/Win32ControlUnitLoader.h
@@ -5,57 +5,15 @@
 #include <cstdint>
 #include <filesystem>
 #include <memory>
-#include <string>
 
 #include "MaaUtils/SafeWindows.hpp"
 
 #include "Common/AsstTypes.h"
-#include "MaaUtils/NoWarningCVMat.hpp"
+
+#include "MaaFwControlUnitInterface.h"
 
 namespace asst
 {
-// 与 MaaFramework 的 ControlUnitAPI 接口保持 ABI 兼容
-// 虚函数表布局必须与 MaaFramework 完全一致
-class MaaControlUnitInterface
-{
-public:
-    virtual ~MaaControlUnitInterface() = default;
-
-    virtual bool connect() = 0;
-    virtual bool connected() const = 0;
-
-    virtual bool request_uuid(std::string& uuid) = 0;
-    virtual uint64_t get_features() const = 0;
-
-    virtual bool start_app(const std::string& intent) = 0;
-    virtual bool stop_app(const std::string& intent) = 0;
-
-    virtual bool screencap(cv::Mat& image) = 0;
-
-    virtual bool click(int x, int y) = 0;
-    virtual bool swipe(int x1, int y1, int x2, int y2, int duration) = 0;
-
-    virtual bool touch_down(int contact, int x, int y, int pressure) = 0;
-    virtual bool touch_move(int contact, int x, int y, int pressure) = 0;
-    virtual bool touch_up(int contact) = 0;
-
-    virtual bool click_key(int key) = 0;
-    virtual bool input_text(const std::string& text) = 0;
-
-    virtual bool key_down(int key) = 0;
-    virtual bool key_up(int key) = 0;
-
-    virtual bool scroll(int dx, int dy) = 0;
-};
-
-// 与 MaaFramework 的 MaaControllerFeature 兼容的常量
-namespace MaaFeature
-{
-constexpr uint64_t None = 0;
-constexpr uint64_t UseMouseDownAndUpInsteadOfClick = 1ULL << 1;
-constexpr uint64_t UseKeyboardDownAndUpInsteadOfClick = 1ULL << 2;
-} // namespace MaaFeature
-
 // 动态加载 MaaWin32ControlUnit.dll
 class Win32ControlUnitLoader
 {

--- a/src/MaaCore/Controller/Win32Controller.cpp
+++ b/src/MaaCore/Controller/Win32Controller.cpp
@@ -75,7 +75,7 @@ bool Win32Controller::attach(
     }
 
     // 获取 UUID
-    auto* unit = static_cast<MaaControlUnitInterface*>(m_unit_handle);
+    auto* unit = static_cast<MaaFwControlUnitAPI*>(m_unit_handle);
     if (!unit->request_uuid(m_uuid)) {
         std::stringstream ss;
         ss << hwnd;
@@ -248,11 +248,11 @@ bool Win32Controller::inject_input_event(const InputEvent& event)
     case InputEvent::Type::TOUCH_MOVE:
         return unit_touch_move(event.pointerId, event.point.x, event.point.y, 0);
     case InputEvent::Type::KEY_DOWN: {
-        auto* unit = static_cast<MaaControlUnitInterface*>(m_unit_handle);
+        auto* unit = static_cast<MaaFwControlUnitAPI*>(m_unit_handle);
         return unit ? unit->key_down(event.keycode) : false;
     }
     case InputEvent::Type::KEY_UP: {
-        auto* unit = static_cast<MaaControlUnitInterface*>(m_unit_handle);
+        auto* unit = static_cast<MaaFwControlUnitAPI*>(m_unit_handle);
         return unit ? unit->key_up(event.keycode) : false;
     }
     case InputEvent::Type::WAIT_MS:
@@ -293,7 +293,7 @@ void Win32Controller::callback(AsstMsg msg, const json::value& details)
 
 bool Win32Controller::unit_connect()
 {
-    auto* unit = static_cast<MaaControlUnitInterface*>(m_unit_handle);
+    auto* unit = static_cast<MaaFwControlUnitAPI*>(m_unit_handle);
     if (!unit) {
         return false;
     }
@@ -302,7 +302,7 @@ bool Win32Controller::unit_connect()
 
 bool Win32Controller::unit_screencap(cv::Mat& image)
 {
-    auto* unit = static_cast<MaaControlUnitInterface*>(m_unit_handle);
+    auto* unit = static_cast<MaaFwControlUnitAPI*>(m_unit_handle);
     if (!unit) {
         return false;
     }
@@ -311,7 +311,7 @@ bool Win32Controller::unit_screencap(cv::Mat& image)
 
 bool Win32Controller::unit_click(int x, int y)
 {
-    auto* unit = static_cast<MaaControlUnitInterface*>(m_unit_handle);
+    auto* unit = static_cast<MaaFwControlUnitAPI*>(m_unit_handle);
     if (!unit) {
         return false;
     }
@@ -320,7 +320,7 @@ bool Win32Controller::unit_click(int x, int y)
 
 bool Win32Controller::unit_swipe(int x1, int y1, int x2, int y2, int duration)
 {
-    auto* unit = static_cast<MaaControlUnitInterface*>(m_unit_handle);
+    auto* unit = static_cast<MaaFwControlUnitAPI*>(m_unit_handle);
     if (!unit) {
         return false;
     }
@@ -329,7 +329,7 @@ bool Win32Controller::unit_swipe(int x1, int y1, int x2, int y2, int duration)
 
 bool Win32Controller::unit_touch_down(int contact, int x, int y, int pressure)
 {
-    auto* unit = static_cast<MaaControlUnitInterface*>(m_unit_handle);
+    auto* unit = static_cast<MaaFwControlUnitAPI*>(m_unit_handle);
     if (!unit) {
         return false;
     }
@@ -338,7 +338,7 @@ bool Win32Controller::unit_touch_down(int contact, int x, int y, int pressure)
 
 bool Win32Controller::unit_touch_move(int contact, int x, int y, int pressure)
 {
-    auto* unit = static_cast<MaaControlUnitInterface*>(m_unit_handle);
+    auto* unit = static_cast<MaaFwControlUnitAPI*>(m_unit_handle);
     if (!unit) {
         return false;
     }
@@ -347,7 +347,7 @@ bool Win32Controller::unit_touch_move(int contact, int x, int y, int pressure)
 
 bool Win32Controller::unit_touch_up(int contact)
 {
-    auto* unit = static_cast<MaaControlUnitInterface*>(m_unit_handle);
+    auto* unit = static_cast<MaaFwControlUnitAPI*>(m_unit_handle);
     if (!unit) {
         return false;
     }
@@ -356,7 +356,7 @@ bool Win32Controller::unit_touch_up(int contact)
 
 bool Win32Controller::unit_input_text(const std::string& text)
 {
-    auto* unit = static_cast<MaaControlUnitInterface*>(m_unit_handle);
+    auto* unit = static_cast<MaaFwControlUnitAPI*>(m_unit_handle);
     if (!unit) {
         return false;
     }
@@ -365,7 +365,7 @@ bool Win32Controller::unit_input_text(const std::string& text)
 
 bool Win32Controller::unit_click_key(int key)
 {
-    auto* unit = static_cast<MaaControlUnitInterface*>(m_unit_handle);
+    auto* unit = static_cast<MaaFwControlUnitAPI*>(m_unit_handle);
     if (!unit) {
         return false;
     }

--- a/src/MaaCore/Utils/LibraryHolder.hpp
+++ b/src/MaaCore/Utils/LibraryHolder.hpp
@@ -71,14 +71,17 @@ inline bool LibraryHolder<T>::load_library(const std::filesystem::path& libname)
 
 #ifdef _WIN32
     module_ = LoadLibrary(libname.c_str());
-#else
-    module_ = dlopen(libname.c_str(), RTLD_LAZY);
-#endif
-
     if (module_ == nullptr) {
-        LogError << "Failed to load library" << VAR(libname);
+        LogError << "LoadLibrary failed" << VAR(libname) << VAR(GetLastError());
         return false;
     }
+#else
+    module_ = dlopen(libname.c_str(), RTLD_LAZY);
+    if (module_ == nullptr) {
+        LogError << "dlopen failed" << VAR(libname) << VAR(dlerror());
+        return false;
+    }
+#endif
 
     libname_ = libname;
     ++ref_count_;

--- a/src/MaaCore/Utils/LibraryHolder.hpp
+++ b/src/MaaCore/Utils/LibraryHolder.hpp
@@ -3,7 +3,6 @@
 #include <filesystem>
 #include <functional>
 #include <mutex>
-#include <type_traits>
 
 #ifdef _WIN32
 #include "MaaUtils/SafeWindows.hpp"
@@ -67,18 +66,35 @@ inline bool LibraryHolder<T>::load_library(const std::filesystem::path& libname)
         return true;
     }
 
-    LogInfo << "Loading library" << VAR(libname);
+    // 根据操作系统平台惯例为动态库文件名添加前后缀lib*.{dll,dylib,so}
+    // 逻辑抄自boost::dll::shared_library::decorate
+    std::filesystem::path filename = libname;
+#ifndef _WIN32
+    if (std::strncmp(libname.filename().string().c_str(), "lib", 3)) {
+        filename = std::filesystem::path(
+            (libname.has_parent_path() ? libname.parent_path() / "lib" : "lib").native() + libname.filename().native());
+    }
+#endif
+#ifdef _WIN32
+    filename += ".dll";
+#elif defined(__APPLE__)
+    filename += ".dylib";
+#else
+    filename += ".so";
+#endif
+
+    LogInfo << "Loading library" << VAR(libname) << VAR(filename);
 
 #ifdef _WIN32
-    module_ = LoadLibrary(libname.c_str());
+    module_ = LoadLibrary(filename.c_str());
     if (module_ == nullptr) {
-        LogError << "LoadLibrary failed" << VAR(libname) << VAR(GetLastError());
+        LogError << "LoadLibrary failed" << VAR(filename) << VAR(GetLastError());
         return false;
     }
 #else
-    module_ = dlopen(libname.c_str(), RTLD_LAZY);
+    module_ = dlopen(filename.c_str(), RTLD_LAZY);
     if (module_ == nullptr) {
-        LogError << "dlopen failed" << VAR(libname) << VAR(dlerror());
+        LogError << "dlopen failed" << VAR(filename) << VAR(dlerror());
         return false;
     }
 #endif

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -453,6 +453,7 @@ If you are concerned about leftover entries, please disable this option before d
     <system:String x:Key="MiniTouchMode">Minitouch (Default)</system:String>
     <system:String x:Key="MaaTouchMode">MaaTouch (Experimental)</system:String>
     <system:String x:Key="AdbTouchMode">ADB Input (Deprecated)</system:String>
+    <system:String x:Key="MaaFwAdbTouchMode">MaaFramework (Experimental)</system:String>
     <system:String x:Key="AdditionCommand">Additional command arguments</system:String>
     <system:String x:Key="AdditionCommandTip" xml:space="preserve">Additional commands for emulator parameters (e.g. ｢--instance 1｣ for instance 1).&#10;Command formats vary by emulator, typically including instance numbers and window modes, please consult your emulator's documentation.</system:String>
     <system:String x:Key="StartsWithScript">Starts with Script</system:String>

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -178,6 +178,7 @@ To customize rotation schedules, please use ｢{key=InfrastModeCustom}｣.</syst
     <system:String x:Key="BlueStacks">BlueStacks</system:String>
     <system:String x:Key="MuMuEmulator12">MuMu Emulator 12</system:String>
     <system:String x:Key="LDPlayer">LD Player</system:String>
+    <system:String x:Key="AVD">Android Virtual Device (AVD)</system:String>
     <system:String x:Key="Nox">Nox</system:String>
     <system:String x:Key="XYAZ">MEmu</system:String>
     <system:String x:Key="WSA">Old version of WSA</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -178,6 +178,7 @@
     <system:String x:Key="BlueStacks">BlueStacks</system:String>
     <system:String x:Key="MuMuEmulator12">MuMu Player</system:String>
     <system:String x:Key="LDPlayer">LDPlayer</system:String>
+    <system:String x:Key="AVD">Android Virtual Device (AVD)</system:String>
     <system:String x:Key="Nox">NoxPlayer</system:String>
     <system:String x:Key="XYAZ">MEmu</system:String>
     <system:String x:Key="WSA">古いバージョンのWSA</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -453,6 +453,7 @@ MAA は非インストール型のアプリケーションであり、レジス�
     <system:String x:Key="MiniTouchMode">Minitouch (標準)</system:String>
     <system:String x:Key="MaaTouchMode">MaaTouch (実験機能)</system:String>
     <system:String x:Key="AdbTouchMode">ADB Input (非推奨)</system:String>
+    <system:String x:Key="MaaFwAdbTouchMode">MaaFramework (実験機能)</system:String>
     <system:String x:Key="AdditionCommand">追加コマンド</system:String>
     <system:String x:Key="AdditionCommandTip" xml:space="preserve">エミュレーター起動パラメータの追加コマンド（例：「--instance 1」は 1 番インスタンス）。&#10;コマンド形式はエミュレーターにより異なり、通常はインスタンス番号やウィンドウモードなどを含みます。</system:String>
     <system:String x:Key="StartsWithScript">スクリプトを使用して始めます</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -178,6 +178,7 @@
     <system:String x:Key="BlueStacks">BlueStacks</system:String>
     <system:String x:Key="MuMuEmulator12">MuMu Player</system:String>
     <system:String x:Key="LDPlayer">LD Player</system:String>
+    <system:String x:Key="AVD">Android Virtual Device (AVD)</system:String>
     <system:String x:Key="Nox">Nox</system:String>
     <system:String x:Key="XYAZ">MEmu</system:String>
     <system:String x:Key="WSA">WSA 레거시 버전</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -453,6 +453,7 @@ MAA는 비설치형 응용 프로그램으로, 삭제 시 레지스트리 항목
     <system:String x:Key="MiniTouchMode">Minitouch (기본값)</system:String>
     <system:String x:Key="MaaTouchMode">MaaTouch (실험적)</system:String>
     <system:String x:Key="AdbTouchMode">ADB Input (비권장)</system:String>
+    <system:String x:Key="MaaFwAdbTouchMode">MaaFramework (실험적)</system:String>
     <system:String x:Key="AdditionCommand">추가 변수</system:String>
     <system:String x:Key="AdditionCommandTip" xml:space="preserve">에뮬레이터 실행 매개변수 추가 명령 (예: ｢--instance 1｣ 은 1 번 인스턴스).&#10;명령 형식은 에뮬레이터마다 다르며 일반적으로 인스턴스 번호나 창 모드 등을 포함합니다.</system:String>
     <system:String x:Key="StartsWithScript">시작 시 추가 스크립트</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -453,6 +453,7 @@
     <system:String x:Key="MiniTouchMode">Minitouch（默认）</system:String>
     <system:String x:Key="MaaTouchMode">MaaTouch（实验功能）</system:String>
     <system:String x:Key="AdbTouchMode">ADB Input（不推荐使用）</system:String>
+    <system:String x:Key="MaaFwAdbTouchMode">MaaFramework（实验功能）</system:String>
     <system:String x:Key="AdditionCommand">附加命令</system:String>
     <system:String x:Key="AdditionCommandTip" xml:space="preserve">附加命令用于指定模拟器启动参数（如 ｢--instance 1｣ 表示启动 1 号实例）。&#10;不同模拟器的命令格式不同，通常包括实例编号、窗口模式等参数，请参考您使用的模拟器文档</system:String>
     <system:String x:Key="StartsWithScript">开始前脚本</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -177,6 +177,7 @@
     <system:String x:Key="General">通用模式</system:String>
     <system:String x:Key="BlueStacks">蓝叠模拟器</system:String>
     <system:String x:Key="MuMuEmulator12">MuMu 模拟器</system:String>
+    <system:String x:Key="AVD">Android 虚拟设备（AVD）</system:String>
     <system:String x:Key="LDPlayer">雷电模拟器</system:String>
     <system:String x:Key="Nox">夜神模拟器</system:String>
     <system:String x:Key="XYAZ">逍遥模拟器</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -178,6 +178,7 @@
     <system:String x:Key="BlueStacks">藍疊模擬器</system:String>
     <system:String x:Key="MuMuEmulator12">MuMu 模擬器 12</system:String>
     <system:String x:Key="LDPlayer">雷電模擬器</system:String>
+    <system:String x:Key="AVD">Android 虛擬裝置（AVD）</system:String>
     <system:String x:Key="Nox">夜神模擬器</system:String>
     <system:String x:Key="XYAZ">逍遙模擬器</system:String>
     <system:String x:Key="WSA">WSA 舊版本</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -453,6 +453,7 @@
     <system:String x:Key="MiniTouchMode">Minitouch（預設）</system:String>
     <system:String x:Key="MaaTouchMode">MaaTouch（實驗功能）</system:String>
     <system:String x:Key="AdbTouchMode">ADB Input（不推薦使用）</system:String>
+    <system:String x:Key="MaaFwAdbTouchMode">MaaFramework（實驗功能）</system:String>
     <system:String x:Key="AdditionCommand">附加命令</system:String>
     <system:String x:Key="AdditionCommandTip" xml:space="preserve">附加命令用於指定模擬器啟動參數（如 ｢--instance 1｣ 表示啟動 1 號實例）。&#10;不同模擬器的命令格式不同，通常包括實例編號、視窗模式等參數，請參考您使用的模擬器說明文件。</system:String>
     <system:String x:Key="StartsWithScript">開始前腳本</system:String>

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/ConnectSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/ConnectSettingsUserControlModel.cs
@@ -73,6 +73,7 @@ public class ConnectSettingsUserControlModel : PropertyChangedBase
             new() { Display = LocalizationHelper.GetString("BlueStacks"), Value = "BlueStacks" },
             new() { Display = LocalizationHelper.GetString("MuMuEmulator12"), Value = "MuMuEmulator12" },
             new() { Display = LocalizationHelper.GetString("LDPlayer"), Value = "LDPlayer" },
+            new() { Display = LocalizationHelper.GetString("AVD"), Value = "AVD" },
             new() { Display = LocalizationHelper.GetString("Nox"), Value = "Nox" },
             new() { Display = LocalizationHelper.GetString("XYAZ"), Value = "XYAZ" },
             new() { Display = LocalizationHelper.GetString("PC"), Value = "PC" },

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/ConnectSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/ConnectSettingsUserControlModel.cs
@@ -91,6 +91,7 @@ public class ConnectSettingsUserControlModel : PropertyChangedBase
             new() { Display = LocalizationHelper.GetString("MiniTouchMode"), Value = "minitouch" },
             new() { Display = LocalizationHelper.GetString("MaaTouchMode"), Value = "maatouch" },
             new() { Display = LocalizationHelper.GetString("AdbTouchMode"), Value = "adb" },
+            new() { Display = LocalizationHelper.GetString("MaaFwAdbTouchMode"), Value = "MaaFwAdb" },
         ];
 
     private bool _autoDetectConnection = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.AutoDetect, bool.TrueString));


### PR DESCRIPTION
AVD是非Windows平台用户少数几个能用的模拟器选项之一，也是兼容性最好的，但adb截图性能较差。为了解决此问题，我 ~~最近和Android Emulator开发团队交流合作了下~~ 研究了AVD的源码，找到了一个2018年就存在但文档稀烂没有人发现的功能：共享内存输出画面。

执行`adb emu screenrecord webrtc start`，Android Emulator即会创建一个名为`videmulator5554`的共享内存，然后随着画面刷新向其中不断写入BGRA8888格式的像素数据。命令里虽然有webrtc字样，但其实跟WebRTC没有任何关系……在Linux上可以用`ls /dev/shm`看到当前系统中的所有共享内存，其他操作系统大概只能编程读写。

```console
$ adb devices
List of devices attached
emulator-5554   device

$ adb emu screenrecord webrtc start
videmulator5554
OK
$ ls /dev/shm
videmulator5554
```

我仿照MumuExtras和LDExtras实现了一个AVDExtras，用读取共享内存的方式截图。在Linux上测试运行正常，加速效果相当震撼：

```
[2026-02-06 09:17:52.609][INF][Px24662][Tx54976] Try to find the fastest way to screencap
[2026-02-06 09:17:52.716][INF][Px24662][Tx54976] Call ` adb -s emulator-5554 exec-out "screencap | nc -w 3 10.0.2.2 53681" ` ret 0 , cost 106 ms , stdout size: 0 , socket size: 3686416
[2026-02-06 09:17:52.732][INF][Px24662][Tx54976] screencap_end_of_line is LF
[2026-02-06 09:17:52.732][INF][Px24662][Tx54976] RawByNc cost 122 ms
[2026-02-06 09:17:52.846][INF][Px24662][Tx54976] Call ` adb -s emulator-5554 exec-out "screencap | gzip -1" ` ret 0 , cost 114 ms , stdout size: 937165 , socket size: 0
[2026-02-06 09:17:52.858][INF][Px24662][Tx54976] screencap_end_of_line is LF
[2026-02-06 09:17:52.859][INF][Px24662][Tx54976] RawWithGzip cost 126 ms
[2026-02-06 09:17:53.229][INF][Px24662][Tx54976] Call ` adb -s emulator-5554 exec-out screencap -p ` ret 0 , cost 370 ms , stdout size: 646292 , socket size: 0
[2026-02-06 09:17:53.251][INF][Px24662][Tx54976] screencap_end_of_line is LF
[2026-02-06 09:17:53.251][INF][Px24662][Tx54976] Encode cost 392 ms
[2026-02-06 09:17:53.251][INF][Px24662][Tx54976] AVDExtras cost 0 ms
[2026-02-06 09:17:53.251][INF][Px24662][Tx54976] The fastest way is AVDExtras , cost: 0 ms
```

我一度以为我测错了，加了个sleep再测，发现没错。共享内存，恐怖如斯。

与MumuExtras/LDExtras采用的模拟器截图接口不同的是，虽然MAA可以自由决定什么时候读取画面，但即使不去读取，模拟器也会按渲染帧率将画面不停写入共享内存，可能有一些性能影响，不过理论上也就跟开个录屏软件一样，应该问题不大。

这个功能前置要求#15300，因为`adb emu`命令只接受`emulator-5554`这样的设备名，不接受`localhost:5555`这样的地址。

我既不熟悉C++又不熟悉MAA架构，关于具体如何集成可以进一步讨论。考虑到其他基于Android Emulator魔改的第三方模拟器有可能也可以用这种方法加速截图，我不确定单列一个AVD连接配置是不是合理的做法。因为我只有Linux设备，PR中所有Win32和GUI部分都是盲写的，没有经过任何测试。POSIX实现理论上在macOS也适用，同样有待测试。总的来说这个PR起到一个抛砖引玉的作用，#help-wanted（逃

## Sourcery 总结

添加一个基于 MaaFramework 的 ADB 控制器，并将其接入核心控制器、触摸模式选择和 GUI，同时统一 MaaFramework 控制单元接口并改进动态库加载诊断。

新特性：
- 引入 `MaaFwAdbController`，使用 `MaaAdbControlUnit` 处理 ADB 连接、快速截图和输入，支持包括 AVD、MuMu 和 LDPlayer 在内的模拟器。
- 暴露新的 `MaaFwAdb` 触摸模式和控制器类型，使助手可以在运行时根据配置选择该控制器。
- 在 WPF GUI 设置中新增可选的 AVD 模拟器配置以及 `MaaFwAdb` 触摸模式选项。

缺陷修复：
- 在所有平台上改进动态库加载的错误处理，为 `LoadLibrary` 和 `dlopen` 记录详细的失败原因日志。

改进：
- 抽取共享的 `MaaFwControlUnitAPI` 接口（及相关 MaaFramework 枚举），并更新 Win32 控制器以使用该接口，确保与 MaaFramework 控制单元的 ABI 兼容性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a MaaFramework-based ADB controller and wire it into the core controller, touch mode selection, and GUI, while unifying the MaaFramework control-unit interface and improving dynamic library loading diagnostics.

New Features:
- Introduce MaaFwAdbController that uses MaaAdbControlUnit to handle ADB connection, fast screencap, and input for supported emulators including AVD, MuMu, and LDPlayer.
- Expose a new MaaFwAdb touch mode and controller type so the assistant can select this controller at runtime based on configuration.
- Add AVD as a selectable emulator configuration and MaaFwAdb touch mode option in the WPF GUI settings.

Bug Fixes:
- Improve dynamic library loading error handling on all platforms by logging detailed failure reasons for LoadLibrary and dlopen.

Enhancements:
- Extract a shared MaaFwControlUnitAPI interface (and related MaaFramework enums) and update the Win32 controller to use it, ensuring ABI compatibility with MaaFramework control units.

</details>

新功能：
- 引入 AVDExtras 截屏方法，从 Android 模拟器共享内存中读取帧，以获得显著更快的截图速度。
- 在 GUI 和配置中新增 AVD 作为可选的模拟器连接类型，并添加用于启动和停止模拟器 WebRTC 共享内存输出的命令。

错误修复：
- 改进 ADB 连接处理逻辑，仅在需要时运行连接命令，并在连接尝试失败时提供更清晰的错误报告。

增强：
- 将新的 AVDExtras 方法接入截屏方法的自动检测和重连逻辑，使其可以被选为最快的可用路径。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

添加一个基于 MaaFramework 的 ADB 控制器，并将其接入核心控制器、触摸模式选择和 GUI，同时统一 MaaFramework 控制单元接口并改进动态库加载诊断。

新特性：
- 引入 `MaaFwAdbController`，使用 `MaaAdbControlUnit` 处理 ADB 连接、快速截图和输入，支持包括 AVD、MuMu 和 LDPlayer 在内的模拟器。
- 暴露新的 `MaaFwAdb` 触摸模式和控制器类型，使助手可以在运行时根据配置选择该控制器。
- 在 WPF GUI 设置中新增可选的 AVD 模拟器配置以及 `MaaFwAdb` 触摸模式选项。

缺陷修复：
- 在所有平台上改进动态库加载的错误处理，为 `LoadLibrary` 和 `dlopen` 记录详细的失败原因日志。

改进：
- 抽取共享的 `MaaFwControlUnitAPI` 接口（及相关 MaaFramework 枚举），并更新 Win32 控制器以使用该接口，确保与 MaaFramework 控制单元的 ABI 兼容性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a MaaFramework-based ADB controller and wire it into the core controller, touch mode selection, and GUI, while unifying the MaaFramework control-unit interface and improving dynamic library loading diagnostics.

New Features:
- Introduce MaaFwAdbController that uses MaaAdbControlUnit to handle ADB connection, fast screencap, and input for supported emulators including AVD, MuMu, and LDPlayer.
- Expose a new MaaFwAdb touch mode and controller type so the assistant can select this controller at runtime based on configuration.
- Add AVD as a selectable emulator configuration and MaaFwAdb touch mode option in the WPF GUI settings.

Bug Fixes:
- Improve dynamic library loading error handling on all platforms by logging detailed failure reasons for LoadLibrary and dlopen.

Enhancements:
- Extract a shared MaaFwControlUnitAPI interface (and related MaaFramework enums) and update the Win32 controller to use it, ensuring ABI compatibility with MaaFramework control units.

</details>

</details>