### PR TITLE
fix: 筛选开放关卡

### DIFF
--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/FightSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/FightSettingsUserControlModel.cs
@@ -733,8 +733,17 @@ public class FightSettingsUserControlModel : TaskSettingsViewModel
         // 如果设置为"不重置"，只选择第一个开放的关卡，如果没有开放的则返回 null
         if (fight.StageResetMode == FightStageResetMode.DoNotReset)
         {
-            var list = fight.StagePlan.Where(i => i != InvalidStage.Value);
+            var list = fight.StagePlan.Where(i => i != InvalidStage.Value && !string.IsNullOrEmpty(i)).ToList();
+            _logger.Information("DoNotReset mode: StagePlan contains {Count} stages: {Stages}", list.Count, string.Join(", ", list));
             stage = list.FirstOrDefault(Instances.TaskQueueViewModel.IsStageOpen);
+            if (stage != null)
+            {
+                _logger.Information("DoNotReset mode: Selected open stage: {Stage}", stage);
+            }
+            else
+            {
+                _logger.Information("DoNotReset mode: No open stage found in StagePlan, task will be skipped");
+            }
         }
         else
         {


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 确保 "DoNotReset" 战斗阶段重置模式只在计划中第一个打开的阶段运行，并在计划的阶段都未打开时跳过执行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure "DoNotReset" fight stage reset mode only runs on the first open stage in the plan and skips execution when none of the planned stages are open.

</details>