### PR TITLE
rft: 过期关卡使用删除线表示

### DIFF
--- a/src/MaaWpfGui/Configuration/Converter/FightTaskStageResetModeConverter.cs
+++ b/src/MaaWpfGui/Configuration/Converter/FightTaskStageResetModeConverter.cs
@@ -57,13 +57,13 @@ internal class FightTaskStageResetModeConverter : JsonConverter<Root>
                         {
                             if (!taskElement.TryGetProperty("StageResetMode", out _))
                             {
-                                if (fightTask.UseOptionalStage)
+                                if (fightTask.HideUnavailableStage)
                                 {
-                                    fightTask.StageResetMode = FightStageResetMode.Invalid;
+                                    fightTask.StageResetMode = FightStageResetMode.Current;
                                 }
                                 else
                                 {
-                                    fightTask.StageResetMode = FightStageResetMode.Current;
+                                    fightTask.StageResetMode = FightStageResetMode.Ignore;
                                 }
                             }
                         }

--- a/src/MaaWpfGui/Configuration/Converter/FightTaskStageResetModeInvalidToIgnoreConverter.cs
+++ b/src/MaaWpfGui/Configuration/Converter/FightTaskStageResetModeInvalidToIgnoreConverter.cs
@@ -1,0 +1,133 @@
+// <copyright file="FightTaskStageResetModeInvalidToIgnoreConverter.cs" company="MaaAssistantArknights">
+// Part of the MaaWpfGui project, maintained by the MaaAssistantArknights team (Maa Team)
+// Copyright (C) 2021-2025 MaaAssistantArknights Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License v3.0 only as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY
+// </copyright>
+#nullable enable
+using System;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+
+namespace MaaWpfGui.Configuration.Converter;
+
+internal class FightTaskStageResetModeInvalidToIgnoreConverter : JsonConverter<Root>
+{
+    private const string TypeDiscriminatorProperty = "$type";
+    private const string FightTaskTypeName = "FightTask";
+    private const string StageResetModeProperty = "StageResetMode";
+    private const string InvalidValue = "Invalid";
+    private const string IgnoreValue = "Ignore";
+
+    public override Root? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.StartObject)
+        {
+            throw new JsonException("Expected StartObject token");
+        }
+
+        using var jsonDoc = JsonDocument.ParseValue(ref reader);
+        JsonNode? rootNode = JsonNode.Parse(jsonDoc.RootElement.GetRawText());
+
+        if (rootNode is JsonObject rootObj)
+        {
+            ReplaceInvalidStageResetModeInTaskQueues(rootObj);
+        }
+
+        string modifiedJson = rootNode?.ToJsonString() ?? string.Empty;
+        return JsonSerializer.Deserialize<Root>(modifiedJson, GetOptionsWithoutThisConverter(options));
+    }
+
+    /// <summary>
+    /// 遍历 Configurations.*.TaskQueue，将 $type 为 FightTask 且 StageResetMode 为 "Invalid" 的项改为 "Ignore"
+    /// </summary>
+    private static void ReplaceInvalidStageResetModeInTaskQueues(JsonObject root)
+    {
+        if (root["Configurations"] is not JsonObject configurations)
+        {
+            return;
+        }
+
+        foreach (var (_, configNode) in configurations)
+        {
+            if (configNode is not JsonObject config)
+            {
+                continue;
+            }
+
+            if (config["TaskQueue"] is not JsonArray taskQueue)
+            {
+                continue;
+            }
+
+            foreach (var taskNode in taskQueue)
+            {
+                if (taskNode is not JsonObject task)
+                {
+                    continue;
+                }
+
+                if (!IsFightTask(task))
+                {
+                    continue;
+                }
+
+                if (task[StageResetModeProperty] is JsonValue modeNode &&
+                    modeNode.GetValue<string>() == InvalidValue)
+                {
+                    task[StageResetModeProperty] = IgnoreValue;
+                }
+
+                if (task["StagePlan"] is JsonArray stagePlan)
+                {
+                    for (int i = 0; i < stagePlan.Count; i++)
+                    {
+                        if (stagePlan[i] is JsonValue stageNode &&
+                            stageNode.GetValue<string>() == "__INVALID__")
+                        {
+                            stagePlan[i] = "OR-8";
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// 判断任务节点是否为 FightTask（依据 $type 字段）
+    /// </summary>
+    private static bool IsFightTask(JsonObject task)
+    {
+        if (task[TypeDiscriminatorProperty] is not JsonValue typeNode)
+        {
+            return false;
+        }
+
+        return typeNode.GetValue<string>() == FightTaskTypeName;
+    }
+
+    public override void Write(Utf8JsonWriter writer, Root value, JsonSerializerOptions options)
+    {
+        JsonSerializer.Serialize(writer, value, GetOptionsWithoutThisConverter(options));
+    }
+
+    private static JsonSerializerOptions GetOptionsWithoutThisConverter(JsonSerializerOptions options)
+    {
+        var newOptions = new JsonSerializerOptions(options);
+        for (int i = newOptions.Converters.Count - 1; i >= 0; i--)
+        {
+            if (newOptions.Converters[i] is FightTaskStageResetModeInvalidToIgnoreConverter)
+            {
+                newOptions.Converters.RemoveAt(i);
+            }
+        }
+        return newOptions;
+    }
+}

--- a/src/MaaWpfGui/Configuration/Factory/ConfigFactory.cs
+++ b/src/MaaWpfGui/Configuration/Factory/ConfigFactory.cs
@@ -61,7 +61,7 @@ public static class ConfigFactory
     // ReSharper disable once EventNeverSubscribedTo.Global
     public static event ConfigurationUpdateEventHandler? ConfigurationUpdateEvent;
 
-    private static readonly JsonSerializerOptions _options = new() { WriteIndented = true, Converters = { new JsonStringEnumConverter(), new FightTaskStageResetModeConverter() }, Encoder = JavaScriptEncoder.Create(UnicodeRanges.All), DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull };
+    private static readonly JsonSerializerOptions _options = new() { WriteIndented = true, Converters = { new JsonStringEnumConverter(), new FightTaskStageResetModeInvalidToIgnoreConverter (), new FightTaskStageResetModeConverter() }, Encoder = JavaScriptEncoder.Create(UnicodeRanges.All), DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull };
 
     // TODO: 参考 ConfigurationHelper ，拆几个函数出来
     private static readonly Lazy<Root> _rootConfig = new(() => {

--- a/src/MaaWpfGui/Constants/Enums/FightStageResetMode.cs
+++ b/src/MaaWpfGui/Constants/Enums/FightStageResetMode.cs
@@ -21,7 +21,7 @@ public enum FightStageResetMode
     Current,
 
     /// <summary>
-    /// 无效关卡
+    /// 忽略 / 不变
     /// </summary>
-    Invalid,
+    Ignore,
 }

--- a/src/MaaWpfGui/Helper/ConfigConverter.cs
+++ b/src/MaaWpfGui/Helper/ConfigConverter.cs
@@ -212,7 +212,7 @@ public class ConfigConverter
                 ConfigurationHelper.DeleteValue(ConfigurationKeys.HideUnavailableStage);
                 ConfigurationHelper.DeleteValue(ConfigurationKeys.CustomStageCode);
                 ConfigurationHelper.DeleteValue(ConfigurationKeys.UseAlternateStage);
-                fightTask.StageResetMode = fightTask.UseOptionalStage ? FightStageResetMode.Invalid : FightStageResetMode.Current;
+                fightTask.StageResetMode = fightTask.HideUnavailableStage ? FightStageResetMode.Current : FightStageResetMode.Ignore;
 
                 if (fightTask.Series > 6)
                 {

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -1426,7 +1426,7 @@ public class AsstProxy
                         && (Instances.TaskQueueViewModel.TaskItemViewModels.FirstOrDefault(t => t.TaskId == taskId)?.Index ?? -1) is int index and > -1
                         && index <= ConfigFactory.CurrentConfig.TaskQueue.Count
                         && ConfigFactory.CurrentConfig.TaskQueue[index] is Configuration.Single.MaaTask.FightTask fight
-                        && FightTask.GetFightStage(fight.StagePlan) is "Annihilation")
+                        && FightTask.GetFightStage(fight) is "Annihilation")
                     {
                         Instances.TaskQueueViewModel.AddLog("AnnihilationStage, " + LocalizationHelper.GetString("GiveUpUploadingPenguins"));
                         break;

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -748,7 +748,7 @@ Do not adjust the proxy multiplier setting in the game</system:String>
     <!--<system:String x:Key="CurrentStage">Current Stage</system:String>-->
     <!--<system:String x:Key="LastBattle">Last Battle</system:String>-->
     <system:String x:Key="DefaultStage">Cur/Last</system:String>
-    <system:String x:Key="InvalidStage">Invalid</system:String>
+    <!--<system:String x:Key="InvalidStage">Invalid</system:String>-->
     <system:String x:Key="ClosedStage">The event is not open</system:String>
     <system:String x:Key="UnsupportedStages">Unsupported stages</system:String>
     <system:String x:Key="LowVersion">Old Version, Update required</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -749,7 +749,7 @@ C:\\leidian\\LDPlayer9
     <!--<system:String x:Key="CurrentStage">当前关卡</system:String> -->
     <!--<system:String x:Key="LastBattle">上次作战</system:String>-->
     <system:String x:Key="DefaultStage">現在/前回</system:String>
-    <system:String x:Key="InvalidStage">無効なレベル</system:String>
+    <!--<system:String x:Key="InvalidStage">無効なレベル</system:String>-->
     <system:String x:Key="ClosedStage">ステージが未公開か既に終了している</system:String>
     <system:String x:Key="UnsupportedStages">未サポートステージ</system:String>
     <system:String x:Key="LowVersion">バージョンの更新が必要</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -750,7 +750,7 @@ C:\\leidian\\LDPlayer9
     <!--<system:String x:Key="CurrentStage">현재 스테이지</system:String>
     <system:String x:Key="LastBattle">최근 작전</system:String>-->
     <system:String x:Key="DefaultStage">현재/최근</system:String>
-    <system:String x:Key="InvalidStage">잘못된 스테이지</system:String>
+    <!--<system:String x:Key="InvalidStage">잘못된 스테이지</system:String>-->
     <system:String x:Key="ClosedStage">미개방 스테이지</system:String>
     <system:String x:Key="UnsupportedStages">미지원 스테이지</system:String>
     <system:String x:Key="LowVersion">낮은 버전</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -749,7 +749,7 @@ C:\\leidian\\LDPlayer9。\n
     <!--<system:String x:Key="CurrentStage">当前关卡</system:String> -->
     <!--<system:String x:Key="LastBattle">上次作战</system:String>-->
     <system:String x:Key="DefaultStage">当前/上次</system:String>
-    <system:String x:Key="InvalidStage">无效关卡</system:String>
+    <!--<system:String x:Key="InvalidStage">无效关卡</system:String>-->
     <system:String x:Key="ClosedStage">活动未开放</system:String>
     <system:String x:Key="UnsupportedStages">不支持的关卡</system:String>
     <system:String x:Key="LowVersion">版本过低</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -749,7 +749,7 @@ C:\\leidian\\LDPlayer9\n
     <!--<system:String x:Key="CurrentStage">目前關卡</system:String>-->
     <!--<system:String x:Key="LastBattle">上次作戰</system:String>-->
     <system:String x:Key="DefaultStage">目前/上次</system:String>
-    <system:String x:Key="InvalidStage">無效關卡</system:String>
+    <!--<system:String x:Key="InvalidStage">無效關卡</system:String>-->
     <system:String x:Key="ClosedStage">活動未開放</system:String>
     <system:String x:Key="UnsupportedStages">不支援的關卡</system:String>
     <system:String x:Key="LowVersion">版本過低</system:String>

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/FightSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/FightSettingsUserControlModel.cs
@@ -643,13 +643,7 @@ public class FightSettingsUserControlModel : TaskSettingsViewModel
             return null;
         }
 
-        // 不再显式标明过期关卡后, 需要提前过滤掉过期关卡
-        var stageList = Instances.StageManager.GetStageList();
         var list = fightTask.StagePlan;
-        if (!fightTask.IsStageManually)
-        {
-            list = [.. list.Where(stage => stageList.Any(p => p.Value == stage))];
-        }
         var stage = list?.FirstOrDefault(Instances.TaskQueueViewModel.IsStageOpen);
         stage ??= list?.FirstOrDefault();
         return stage;

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/FightSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/FightSettingsUserControlModel.cs
@@ -722,7 +722,6 @@ public class FightSettingsUserControlModel : TaskSettingsViewModel
         {
             return SerializeTask(fight, Instances.TaskQueueViewModel.TaskItemViewModels[index].TaskId);
         }
-        _logger.Error("Failed to set fight params: current task is not in the task queue.");
         return null;
     }
 

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/MallSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/MallSettingsUserControlModel.cs
@@ -196,7 +196,7 @@ public class MallSettingsUserControlModel : TaskSettingsViewModel
         var fightStageEmpty = ConfigFactory.CurrentConfig.TaskQueue
             .OfType<FightTask>()
             .Where(task => task.IsEnable is not false)
-            .Any(task => string.IsNullOrEmpty(FightSettingsUserControlModel.GetFightStage(task.StagePlan)));
+            .Any(task => string.IsNullOrEmpty(FightSettingsUserControlModel.GetFightStage(task)));
         var task = new AsstMallTask() {
             CreditFight = CreditFightTaskEnabled && !fightStageEmpty,
             FormationIndex = CreditFightSelectFormation,

--- a/src/MaaWpfGui/Views/UserControl/TaskQueue/FightSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/TaskQueue/FightSettingsUserControl.xaml
@@ -267,17 +267,28 @@
                                     <!--  当 CustomStageCode 为 false 时显示 ComboBox  -->
                                     <ComboBox
                                         ItemsSource="{Binding StageListSource, Source={x:Static ui_vms:TaskQueueViewModel.FightTask}}"
+                                        ScrollViewer.CanContentScroll="False"
                                         SelectedValue="{Binding Stage}"
                                         SelectedValuePath="Value"
                                         Visibility="{c:Binding !CustomStageCode,
                                                                Source={x:Static ui_vms:TaskQueueViewModel.FightTask}}">
+
+                                        <ComboBox.ItemContainerStyle>
+                                            <Style BasedOn="{StaticResource ComboBoxItemBaseStyle}" TargetType="ComboBoxItem">
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding IsVisible}" Value="False">
+                                                        <Setter Property="Visibility" Value="Collapsed" />
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </ComboBox.ItemContainerStyle>
                                         <ComboBox.ItemTemplate>
                                             <DataTemplate>
                                                 <TextBlock Text="{Binding Display}">
                                                     <TextBlock.Style>
                                                         <Style TargetType="TextBlock">
                                                             <Style.Triggers>
-                                                                <DataTrigger Binding="{Binding IsVisible}" Value="False">
+                                                                <DataTrigger Binding="{Binding IsOutdated}" Value="True">
                                                                     <Setter Property="TextDecorations" Value="Strikethrough" />
                                                                 </DataTrigger>
                                                                 <DataTrigger Binding="{Binding IsOpen}" Value="False">

--- a/src/MaaWpfGui/Views/UserControl/TaskQueue/FightSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/TaskQueue/FightSettingsUserControl.xaml
@@ -266,28 +266,32 @@
                                     Margin="-10,0,0,0">
                                     <!--  当 CustomStageCode 为 false 时显示 ComboBox  -->
                                     <ComboBox
-                                        DisplayMemberPath="Display"
                                         ItemsSource="{Binding StageListSource, Source={x:Static ui_vms:TaskQueueViewModel.FightTask}}"
-                                        Opacity="{c:Binding 'IsOpen ? 1 : 0.5'}"
                                         SelectedValue="{Binding Stage}"
                                         SelectedValuePath="Value"
                                         Visibility="{c:Binding !CustomStageCode,
                                                                Source={x:Static ui_vms:TaskQueueViewModel.FightTask}}">
-                                        <ComboBox.ItemContainerStyle>
-                                            <Style BasedOn="{StaticResource ComboBoxItemBaseStyle}" TargetType="ComboBoxItem">
-                                                <Style.Triggers>
-                                                    <DataTrigger Binding="{Binding IsVisible}" Value="False">
-                                                        <Setter Property="Visibility" Value="Collapsed" />
-                                                    </DataTrigger>
-                                                    <DataTrigger Binding="{Binding IsOpen}" Value="False">
-                                                        <Setter Property="Opacity" Value="0.4" />
-                                                    </DataTrigger>
-                                                    <DataTrigger Binding="{Binding IsOpen}" Value="True">
-                                                        <Setter Property="Opacity" Value="1" />
-                                                    </DataTrigger>
-                                                </Style.Triggers>
-                                            </Style>
-                                        </ComboBox.ItemContainerStyle>
+                                        <ComboBox.ItemTemplate>
+                                            <DataTemplate>
+                                                <TextBlock Text="{Binding Display}">
+                                                    <TextBlock.Style>
+                                                        <Style TargetType="TextBlock">
+                                                            <Style.Triggers>
+                                                                <DataTrigger Binding="{Binding IsVisible}" Value="False">
+                                                                    <Setter Property="TextDecorations" Value="Strikethrough" />
+                                                                </DataTrigger>
+                                                                <DataTrigger Binding="{Binding IsOpen}" Value="False">
+                                                                    <Setter Property="Opacity" Value="0.5" />
+                                                                </DataTrigger>
+                                                                <DataTrigger Binding="{Binding IsOpen}" Value="True">
+                                                                    <Setter Property="Opacity" Value="1" />
+                                                                </DataTrigger>
+                                                            </Style.Triggers>
+                                                        </Style>
+                                                    </TextBlock.Style>
+                                                </TextBlock>
+                                            </DataTemplate>
+                                        </ComboBox.ItemTemplate>
                                     </ComboBox>
 
                                     <!--  当 CustomStageCode 为 true 时显示 TextBox  -->


### PR DESCRIPTION
## Summary by Sourcery

调整战斗任务关卡重置行为，移除显式的“无效关卡”占位符，改为忽略或清理不可用关卡，并迁移现有配置。

增强内容：
- 将战斗关卡重置模式的语义从“Invalid”占位符改为“Ignore”选项，并更新相关的枚举、绑定以及默认逻辑。
- 更新自动关卡选择和序列化逻辑，使其直接基于战斗任务配置工作，并改进关卡计划重置的日志记录。
- 在 UI 中标记已过期的关卡，而不是注入一个伪造的无效关卡条目，并相应调整关卡开放状态的绑定。
- 通过将 `Invalid` 关卡重置模式转换为 `Ignore`，并将 `__INVALID__` 关卡条目替换为真实关卡，来迁移旧版配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust fight task stage reset behavior to remove the explicit "invalid stage" placeholder, favor ignoring or clearing unavailable stages and migrating existing configs.

Enhancements:
- Change fight stage reset mode semantics from an "Invalid" placeholder to an "Ignore" option and update related enums, bindings, and defaulting logic.
- Update automatic stage selection and serialization to work directly from the fight task configuration and improve logging for stage plan resets.
- Mark outdated stages in the UI instead of injecting a synthetic invalid stage entry, and adjust stage openness binding accordingly.
- Migrate legacy configurations by converting `Invalid` stage reset modes to `Ignore` and replacing `__INVALID__` stage entries with a real stage.

</details>