### PR TITLE
chore: 仅在VS Code中添加辅助项目

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,11 +35,13 @@ if(BUILD_WPF_GUI)
     include_external_msproject(MaaWpfGui ${PROJECT_SOURCE_DIR}/src/MaaWpfGui/MaaWpfGui.csproj)
 
     add_dependencies(MaaWpfGui MaaCore)
-    add_custom_target(run-MaaWpfGui
-        COMMAND "${CMAKE_BINARY_DIR}/bin/$<CONFIG>/MAA.exe"
-        DEPENDS MaaWpfGui
-        WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin/$<CONFIG>"
-    )
+    if(DEFINED ENV{VSCODE_PID})
+        add_custom_target(run-MaaWpfGui
+            COMMAND "${CMAKE_BINARY_DIR}/bin/$<CONFIG>/MAA.exe"
+            DEPENDS MaaWpfGui
+            WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin/$<CONFIG>"
+        )
+    endif()
 endif()
 
 if(INSTALL_PYTHON)


### PR DESCRIPTION
## Summary by Sourcery

增强功能：
- 重命名并限定 WPF GUI 自定义运行目标的作用域，使其仅在从 VS Code 构建时才会被创建。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Rename and scope the WPF GUI custom run target so it is only created when building from VS Code.

</details>