### PR TITLE
chore: 添加响石、赤刃明霄陈基建技能加成

### DIFF
--- a/resource/infrast.json
+++ b/resource/infrast.json
@@ -2891,6 +2891,9 @@
             },
             "bskill_meet_bd_to_spd": {
                 "desc": ["进驻会客室时，线索搜集速度提升20%，同时每10点人间烟火额外提升1%"],
+                "efficient": {
+                    "General": 20
+                },
                 "name": ["扶危行侠"],
                 "template": "Bskill_meet_bd_to_spd.png"
             },
@@ -2925,6 +2928,9 @@
             },
             "bskill_meet_exchange2": {
                 "desc": ["进驻会客室时，处于线索交流时线索搜集速度提升30%"],
+                "efficient": {
+                    "General": 15
+                },
                 "name": ["特殊渠道顾问"],
                 "template": "Bskill_meet_exchange2.png"
             },


### PR DESCRIPTION
响石效率参照技能同为线索交流期间加成的跃跃填写

## Summary by Sourcery

增强内容：
- 调整基础设施效率设置，将干员响石和赤刃明霄的基础技能加成纳入其中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Adjust infrastructure efficiency settings to include base skill bonuses for the operators 响石 and 赤刃明霄.

</details>