### PR TITLE
feat: OperNameAnalyzer 支持左对齐检测

### DIFF
--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -789,14 +789,8 @@
             [".*威龙陈", "假日威龙陈"],
             ["青积", "青枳"],
             [".*烬艾雅法.*", "纯烬艾雅法拉"],
-            ["^一?山\\w*$", "山"],
-            ["^一?余\\w*$", "余"],
-            ["^一?锏\\w*$", "锏"],
-            ["^一?煌\\w*$", "煌"],
-            ["^一?年\\w*$", "年"],
-            ["^一?[委泰黍]\\w*$", "黍"],
-            ["^一?令\\w*$", "令"],
-            ["^一?[H夕]\\w*$", "夕"],
+            ["^[委泰黍]$", "黍"],
+            ["^[H夕]$", "夕"],
             ["12E", "12F"],
             ["归.*幽灵鲨", "归溟幽灵鲨"],
             ["(临六$|^临光.*)", "临光"],
@@ -3649,9 +3643,9 @@
             "trim_threshold_low",
             "trim_threshold_high",
             "左侧收缩时检测图的底部屏蔽高度",
-            "左侧收缩时连续n像素低于bin_thresh"
+            "左侧收缩时连续 n 像素低于 bin_thresh"
         ],
-        "specialParams": [140, 2, 0, 0, 3, 10]
+        "specialParams": [160, 4, 0, 0, 3, 10]
     },
     "BattleStartPre": {
         "algorithm": "OcrDetect",
@@ -3780,16 +3774,32 @@
     "BattleOperName": {
         "algorithm": "OcrDetect",
         "text": [],
-        "useRaw": false,
         "fullMatch": true,
-        "roi": [5, 177, 191, 37]
+        "roi": [5, 177, 191, 37],
+        "specialParams_doc": [
+            "bin_threshold",
+            "bin_expansion",
+            "trim_threshold_low",
+            "trim_threshold_high",
+            "收缩时检测图的底部屏蔽高度",
+            "右侧收缩时连续 n 像素低于 bin_thresh"
+        ],
+        "specialParams": [160, 4, 0, 0, 0, 10]
     },
     "SSSBattleOperName": {
         "algorithm": "OcrDetect",
         "text": [],
-        "useRaw": false,
         "fullMatch": true,
-        "roi": [0, 102, 190, 37]
+        "roi": [0, 102, 190, 37],
+        "specialParams_doc": [
+            "bin_threshold",
+            "bin_expansion",
+            "trim_threshold_low",
+            "trim_threshold_high",
+            "收缩时检测图的底部屏蔽高度",
+            "右侧收缩时连续 n 像素低于 bin_thresh"
+        ],
+        "specialParams": [160, 4, 0, 0, 0, 10]
     },
     "BattleOfficiallyBegin": {
         "roi": [1165, 20, 75, 65],

--- a/src/MaaCore/Task/BattleHelper.cpp
+++ b/src/MaaCore/Task/BattleHelper.cpp
@@ -16,6 +16,7 @@
 #include "Vision/Battle/BattlefieldClassifier.h"
 #include "Vision/Battle/BattlefieldMatcher.h"
 #include "Vision/Matcher.h"
+#include "Vision/Miscellaneous/OperNameAnalyzer.h"
 #include "Vision/MultiMatcher.h"
 #include "Vision/RegionOCRer.h"
 #include <ranges>
@@ -996,8 +997,16 @@ std::string asst::BattleHelper::analyze_detail_page_oper_name(const cv::Mat& ima
     const auto& replace_task = Task.get<OcrTaskInfo>("CharsNameOcrReplace");
     const auto& task = Task.get<OcrTaskInfo>(oper_name_ocr_task_name());
 
-    RegionOCRer preproc_analyzer(image);
+    // 使用 OperNameAnalyzer 处理左对齐文本
+    OperNameAnalyzer preproc_analyzer(image);
     preproc_analyzer.set_task_info(task);
+    preproc_analyzer.set_text_alignment(OperNameAnalyzer::TextAlignment::Left); // 左对齐
+    const auto& params = task->special_params;
+    preproc_analyzer.set_bin_threshold(params[0]);
+    preproc_analyzer.set_bin_expansion(params[1]);
+    preproc_analyzer.set_bin_trim_threshold(params[2], params[3]);
+    preproc_analyzer.set_bottom_line_height(params[4]);
+    preproc_analyzer.set_width_threshold(params[5]);
     preproc_analyzer.set_replace(replace_task->replace_map, replace_task->replace_full);
     auto preproc_result_opt = preproc_analyzer.analyze();
 

--- a/src/MaaCore/Vision/Miscellaneous/OperNameAnalyzer.cpp
+++ b/src/MaaCore/Vision/Miscellaneous/OperNameAnalyzer.cpp
@@ -5,25 +5,86 @@
 
 asst::OperNameAnalyzer::ResultOpt asst::OperNameAnalyzer::analyze() const
 {
+    int kPadding = m_params.bin_expansion;
+
     cv::Mat gray, bin;
     cv::Mat ocr = make_roi(m_image, m_roi);
+
+    if (ocr.empty()) {
+        return std::nullopt;
+    }
+
     cv::cvtColor(ocr, gray, cv::COLOR_BGR2GRAY);
     cv::inRange(gray, m_params.bin_threshold_lower, m_params.bin_threshold_upper, bin);
-    for (int r = bin.cols - 1; r >= 0; --r) {
-        if (cv::hasNonZero(bin.col(r))) { // 右边界向左收缩
-            bin = bin.adjustROI(0, 0, 0, -(bin.cols - r - 1));
+
+    int move = 0;
+    bool isRight = (m_text_alignment == TextAlignment::Right);
+
+    int start = isRight ? bin.cols - 1 : 0;
+    int end = isRight ? -1 : bin.cols;
+    int step = isRight ? -1 : 1;
+
+    // 1. 裁剪首个包含文字的列（Left = 左边界，Right = 右边界），保留 padding
+    for (int r = start; r != end; r += step) {
+        if (cv::hasNonZero(bin.col(r))) {
+            int cut = isRight ? (bin.cols - r - 1 - kPadding) : (r - kPadding);
+            cut = std::clamp(cut, 0, bin.cols - 1);
+
+            if (cut > 0) {
+                bin = isRight ? bin.adjustROI(0, 0, 0, -cut) : bin.adjustROI(0, 0, -cut, 0);
+                ocr = isRight ? ocr.adjustROI(0, 0, 0, -cut) : ocr.adjustROI(0, 0, -cut, 0);
+
+                if (!isRight) {
+                    move = cut;
+                }
+            }
             break;
         }
     }
 
-    bin = bin.adjustROI(0, -m_bottom_line_height, 0, 0); // 底部收缩排除白线
-    int move = 0;
-    for (int r = bin.cols - m_width_threshold - 1; r >= 0; --r) {
-        if (!cv::hasNonZero(bin.colRange(r, r + m_width_threshold))) { // 左边界排除无文字区域
-            move = r + m_width_threshold - 3;
-            ocr = ocr.adjustROI(0, 0, -move, 0);
+    if (bin.empty() || bin.cols <= 0 || bin.rows <= 0) {
+        return std::nullopt;
+    }
+
+    // 2. 底部裁剪（防止裁过头）
+    if (m_bottom_line_height > 0 && m_bottom_line_height < bin.rows) {
+        bin = bin.adjustROI(0, -m_bottom_line_height, 0, 0);
+        ocr = ocr.adjustROI(0, -m_bottom_line_height, 0, 0);
+    }
+
+    if (bin.cols < m_width_threshold) {
+        return std::nullopt;
+    }
+
+    // 3. 扫描连续空白块，裁剪另一侧
+    start = isRight ? (bin.cols - m_width_threshold) : 0;
+    end = isRight ? -1 : (bin.cols - m_width_threshold + 1);
+
+    for (int r = start; r != end; r += step) {
+        int rEnd = r + m_width_threshold;
+        if (r < 0 || rEnd > bin.cols) {
+            continue;
+        }
+
+        if (!cv::hasNonZero(bin.colRange(r, rEnd))) {
+            if (isRight) {
+                int cut = rEnd - kPadding;
+                cut = std::clamp(cut, 0, ocr.cols - 1);
+                move = cut;
+                ocr = ocr.adjustROI(0, 0, -cut, 0);
+            }
+            else {
+                int cut = std::clamp(r + kPadding, 0, ocr.cols);
+                int rightTrim = ocr.cols - cut;
+                rightTrim = std::clamp(rightTrim, 0, ocr.cols - 1);
+                ocr = ocr.adjustROI(0, 0, 0, -rightTrim);
+            }
             break;
         }
+    }
+
+    if (ocr.empty() || ocr.cols <= 0 || ocr.rows <= 0) {
+        return std::nullopt;
     }
 
     RegionOCRer region(ocr);

--- a/src/MaaCore/Vision/Miscellaneous/OperNameAnalyzer.h
+++ b/src/MaaCore/Vision/Miscellaneous/OperNameAnalyzer.h
@@ -12,6 +12,12 @@ public:
     using Result = OCRer::Result;
     using ResultOpt = std::optional<Result>;
 
+    enum class TextAlignment
+    {
+        Right, // 右对齐，从右往左扫描截断左侧
+        Left   // 左对齐，从左往右扫描截断右侧
+    };
+
 public:
     using VisionHelper::VisionHelper;
     virtual ~OperNameAnalyzer() override = default;
@@ -23,6 +29,8 @@ public:
     void set_bottom_line_height(int height) { m_bottom_line_height = height; }
 
     void set_width_threshold(int threshold) { m_width_threshold = threshold; }
+
+    void set_text_alignment(TextAlignment alignment) { m_text_alignment = alignment; }
 
     // FIXME: 老接口太难重构了，先弄个这玩意兼容下，后续慢慢全删掉
     const auto& get_result() const noexcept { return m_result; }
@@ -36,7 +44,8 @@ private:
     // FIXME: 老接口太难重构了，先弄个这玩意兼容下，后续慢慢全删掉
     mutable Result m_result;
     bool m_use_raw = true;
-    int m_bottom_line_height = 3; // 底部线条高度
-    int m_width_threshold = 5;    // 宽度阈值
+    int m_bottom_line_height = 0;                          // 底部线条高度
+    int m_width_threshold = 5;                             // 宽度阈值
+    TextAlignment m_text_alignment = TextAlignment::Right; // 默认右对齐（保持向后兼容）
 };
 }; // namespace asst


### PR DESCRIPTION
rft: OperNameAnalyzer 支持左对齐检测

## 由 Sourcery 生成的摘要

在保留现有右对齐识别行为的前提下，为 `OperNameAnalyzer` 增加对左对齐干员名的 OCR 支持，并将其应用于战斗详情页的干员名识别。

新功能：
- 为 `OperNameAnalyzer` 添加可配置的文本对齐模式（左对齐或右对齐），以实现更灵活的 ROI 裁剪。
- 在战斗详情页中，对左对齐干员名的预处理改为使用 `OperNameAnalyzer`，而不是通用的 `RegionOCRer`。

错误修复：
- 在 `OperNameAnalyzer` 中通过在调整 ROI 时增加空值与尺寸检查，避免越界或无效的 ROI。

优化改进：
- 优化 `OperNameAnalyzer` 的 ROI 裁剪逻辑，引入填充（padding）、底线处理，以及对两种对齐方式都适用的对称裁剪。
- 将默认底线高度改为 0，以减少 `OperNameAnalyzer` 中不必要的垂直裁剪。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support left-aligned operator name OCR while preserving existing right-aligned behavior in OperNameAnalyzer and apply it to battle detail page operator name recognition.

New Features:
- Add configurable text alignment mode (left or right) to OperNameAnalyzer for more flexible ROI trimming.
- Use OperNameAnalyzer for preprocessing left-aligned operator names on the battle detail page instead of a generic RegionOCRer.

Bug Fixes:
- Avoid out-of-bounds or invalid ROIs in OperNameAnalyzer by adding empty and size checks during ROI adjustments.

Enhancements:
- Refine OperNameAnalyzer ROI cropping logic with padding, bottom-line handling, and symmetric trimming for both text alignments.
- Change the default bottom line height to zero to reduce unnecessary vertical cropping in OperNameAnalyzer.

</details>