### PR TITLE
feat(core): Android 原生支持

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -328,6 +328,79 @@ jobs:
             release/*.AppImage
             release/*.tar.gz
 
+  android:
+    name: Build for Android
+    needs: meta
+    runs-on: macos-26
+    strategy:
+      matrix:
+        include:
+          - arch: arm64
+            abi: arm64-v8a
+            triplet: arm64-android
+          - arch: x64
+            abi: x86_64
+            triplet: x64-android
+      fail-fast: false
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          show-progress: false
+
+      - name: Fetch submodules
+        run: |
+          git submodule update --init --depth 1 src/MaaUtils
+
+      - name: Cache MaaDeps
+        id: cache-maadeps
+        uses: actions/cache@v5
+        continue-on-error: true
+        with:
+          path: ./src/MaaUtils/MaaDeps
+          key: ${{ runner.os }}-${{ matrix.triplet }}-maadeps-${{ hashFiles('tools/maadeps-download.py') }}
+
+      - name: Bootstrap MaaDeps
+        if: steps.cache-maadeps.outputs.cache-hit != 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 tools/maadeps-download.py ${{ matrix.triplet }}
+
+      - name: Setup Android NDK
+        id: setup-ndk
+        uses: nttld/setup-ndk@v1
+        with:
+          ndk-version: r28c
+
+      - name: Configure, build and install
+        run: |
+          cmake -B build -G Ninja \
+            -DCMAKE_TOOLCHAIN_FILE=${{ steps.setup-ndk.outputs.ndk-path }}/build/cmake/android.toolchain.cmake \
+            -DANDROID_ABI=${{ matrix.abi }} \
+            -DANDROID_PLATFORM=android-28 \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DMAADEPS_TRIPLET='maa-${{ matrix.triplet }}' \
+            -DINSTALL_RESOURCE=ON \
+            -DINSTALL_PYTHON=OFF \
+            -DBUILD_WPF_GUI=OFF \
+            -DBUILD_DEBUG_DEMO=OFF \
+            -DMAA_HASH_VERSION='${{ needs.meta.outputs.tag }}'
+          cmake --build build --parallel $(sysctl -n hw.logicalcpu)
+          cmake --install build --prefix install
+
+      - name: Tar files
+        run: |
+          cd install
+          tar czvf $GITHUB_WORKSPACE/MAA-${{ needs.meta.outputs.tag }}-android-${{ matrix.arch }}.tar.gz .
+
+      - name: Upload MAA to GitHub
+        uses: actions/upload-artifact@v6
+        with:
+          name: MAA-android-${{ matrix.arch }}
+          path: MAA-*.tar.gz
+
   macOS-Core:
     name: Build Core for macOS
     needs: meta
@@ -540,7 +613,7 @@ jobs:
   release:
     name: Publish Release
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [meta, windows, ubuntu, macOS-Core, macOS-GUI]
+    needs: [meta, windows, ubuntu, android, macOS-Core, macOS-GUI]
     runs-on: ubuntu-latest
     steps:
       - name: Download MAA from GitHub

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,16 +370,8 @@ jobs:
 
       - name: Configure, build and install
         run: |
-          cmake -B build -G Ninja \
+          cmake -B build --preset 'android-publish-${{ matrix.arch }}' \
             -DCMAKE_TOOLCHAIN_FILE=${{ steps.setup-ndk.outputs.ndk-path }}/build/cmake/android.toolchain.cmake \
-            -DANDROID_ABI=${{ matrix.arch == 'arm64' && 'arm64-v8a' || 'x86_64' }} \
-            -DANDROID_PLATFORM=android-28 \
-            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-            -DMAADEPS_TRIPLET='maa-${{ matrix.arch }}-android' \
-            -DINSTALL_RESOURCE=ON \
-            -DINSTALL_PYTHON=OFF \
-            -DBUILD_WPF_GUI=OFF \
-            -DBUILD_DEBUG_DEMO=OFF \
             -DMAA_HASH_VERSION='${{ needs.meta.outputs.tag }}'
           cmake --build build --parallel $(sysctl -n hw.logicalcpu)
           cmake --install build --prefix install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,7 +366,7 @@ jobs:
         id: setup-ndk
         uses: nttld/setup-ndk@v1
         with:
-          ndk-version: r28c
+          ndk-version: r29
 
       - name: Configure, build and install
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -334,13 +334,7 @@ jobs:
     runs-on: macos-26
     strategy:
       matrix:
-        include:
-          - arch: arm64
-            abi: arm64-v8a
-            triplet: arm64-android
-          - arch: x64
-            abi: x86_64
-            triplet: x64-android
+        arch: [arm64, x64]
       fail-fast: false
 
     steps:
@@ -359,14 +353,14 @@ jobs:
         continue-on-error: true
         with:
           path: ./src/MaaUtils/MaaDeps
-          key: ${{ runner.os }}-${{ matrix.triplet }}-maadeps-${{ hashFiles('tools/maadeps-download.py') }}
+          key: ${{ runner.os }}-${{ matrix.arch }}-android-maadeps-${{ hashFiles('tools/maadeps-download.py') }}
 
       - name: Bootstrap MaaDeps
         if: steps.cache-maadeps.outputs.cache-hit != 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          python3 tools/maadeps-download.py ${{ matrix.triplet }}
+          python3 tools/maadeps-download.py ${{ matrix.arch }}-android
 
       - name: Setup Android NDK
         id: setup-ndk
@@ -378,10 +372,10 @@ jobs:
         run: |
           cmake -B build -G Ninja \
             -DCMAKE_TOOLCHAIN_FILE=${{ steps.setup-ndk.outputs.ndk-path }}/build/cmake/android.toolchain.cmake \
-            -DANDROID_ABI=${{ matrix.abi }} \
+            -DANDROID_ABI=${{ matrix.arch == 'arm64' && 'arm64-v8a' || 'x86_64' }} \
             -DANDROID_PLATFORM=android-28 \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-            -DMAADEPS_TRIPLET='maa-${{ matrix.triplet }}' \
+            -DMAADEPS_TRIPLET='maa-${{ matrix.arch }}-android' \
             -DINSTALL_RESOURCE=ON \
             -DINSTALL_PYTHON=OFF \
             -DBUILD_WPF_GUI=OFF \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,13 @@ if(BUILD_WPF_GUI)
     endif()
 endif()
 
+if (ANDROID)
+    add_library(stdc++fs INTERFACE)
+    add_compile_options(-Wno-unused-parameter)
+    add_compile_options(-ffunction-sections -fdata-sections)
+    add_link_options(-Wl,--gc-sections)
+endif()
+
 if(INSTALL_PYTHON)
     install(DIRECTORY src/Python DESTINATION .)
 endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -159,6 +159,39 @@
             }
         },
         {
+            "name": "android-base",
+            "hidden": true,
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/build",
+            "$comment": [
+                "Base for Android presets; cross-compilation via NDK toolchain",
+                "CMAKE_TOOLCHAIN_FILE must be passed externally pointing to NDK's android.toolchain.cmake"
+            ],
+            "cacheVariables": {
+                "CMAKE_SYSTEM_NAME": "Android",
+                "ANDROID_PLATFORM": "android-28",
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+            }
+        },
+        {
+            "name": "android-arm64",
+            "inherits": "android-base",
+            "displayName": "Android arm64",
+            "cacheVariables": {
+                "ANDROID_ABI": "arm64-v8a",
+                "MAADEPS_TRIPLET": "maa-arm64-android"
+            }
+        },
+        {
+            "name": "android-x64",
+            "inherits": "android-base",
+            "displayName": "Android x64",
+            "cacheVariables": {
+                "ANDROID_ABI": "x86_64",
+                "MAADEPS_TRIPLET": "maa-x64-android"
+            }
+        },
+        {
             "name": "publish-base",
             "$comment": [
                 "All the name contains 'publish' are used for github actions",
@@ -231,6 +264,22 @@
                 "macos-arm64"
             ],
             "displayName": "macOS arm64 Publish"
+        },
+        {
+            "name": "android-publish-arm64",
+            "inherits": ["publish-base", "android-arm64"],
+            "displayName": "Android arm64 Publish",
+            "cacheVariables": {
+                "INSTALL_PYTHON": "OFF"
+            }
+        },
+        {
+            "name": "android-publish-x64",
+            "inherits": ["publish-base", "android-x64"],
+            "displayName": "Android x64 Publish",
+            "cacheVariables": {
+                "INSTALL_PYTHON": "OFF"
+            }
         },
         {
             "name": "smoke-test",
@@ -392,6 +441,16 @@
             "displayName": "Build macOS arm64 Publish",
             "configurePreset": "macos-publish-arm64",
             "configuration": "RelWithDebInfo"
+        },
+        {
+            "name": "android-publish-arm64",
+            "displayName": "Build Android arm64 Publish",
+            "configurePreset": "android-publish-arm64"
+        },
+        {
+            "name": "android-publish-x64",
+            "displayName": "Build Android x64 Publish",
+            "configurePreset": "android-publish-x64"
         },
         {
             "name": "smoke-test",

--- a/src/MaaCore/Assistant.cpp
+++ b/src/MaaCore/Assistant.cpp
@@ -707,7 +707,7 @@ void asst::Assistant::call_proc()
         append_callback(AsstMsg::AsyncCallInfo, cb_info);
     }
 
-#ifdef ANDROID
+#ifdef __ANDROID__
     if (env) {
         LogInfo << "Use Android AttachThread";
         lib.DetachThread(env);

--- a/src/MaaCore/Assistant.cpp
+++ b/src/MaaCore/Assistant.cpp
@@ -147,8 +147,8 @@ bool asst::Assistant::set_instance_option(InstanceOptionKey key, const std::stri
             m_ctrler->set_touch_mode(TouchMode::Android);
             return true;
         }
-        break;
 #endif
+        break;
     case InstanceOptionKey::DeploymentWithPause:
         if (constexpr std::string_view Enable = "1"; value == Enable) {
             m_ctrler->set_swipe_with_pause(true);

--- a/src/MaaCore/Assistant.cpp
+++ b/src/MaaCore/Assistant.cpp
@@ -142,11 +142,13 @@ bool asst::Assistant::set_instance_option(InstanceOptionKey key, const std::stri
             m_ctrler->set_touch_mode(TouchMode::MacPlayTools);
             return true;
         }
+#ifdef __ANDROID__
         else if (constexpr std::string_view Android = "Android"; value == Android) {
             m_ctrler->set_touch_mode(TouchMode::Android);
             return true;
         }
         break;
+#endif
     case InstanceOptionKey::DeploymentWithPause:
         if (constexpr std::string_view Enable = "1"; value == Enable) {
             m_ctrler->set_swipe_with_pause(true);

--- a/src/MaaCore/CMakeLists.txt
+++ b/src/MaaCore/CMakeLists.txt
@@ -116,3 +116,15 @@ if(WIN32)
         $<TARGET_FILE_DIR:MaaCore>
         COMMAND_EXPAND_LISTS)
 endif()
+
+if(ANDROID)
+    if(CMAKE_STRIP)
+        add_custom_command(
+            TARGET MaaCore
+            POST_BUILD
+            COMMAND ${CMAKE_STRIP} --strip-all $<TARGET_FILE:MaaCore>
+            COMMENT "Stripping MaaCore for Android")
+    else()
+        message(WARNING "CMAKE_STRIP not found, Android library will not be stripped")
+    endif()
+endif()

--- a/src/MaaCore/CMakeLists.txt
+++ b/src/MaaCore/CMakeLists.txt
@@ -44,6 +44,10 @@ if(APPLE AND WITH_MAC_SCK)
                                   "-framework ScreenCaptureKit")
 endif()
 
+if(ANDROID)
+    target_link_libraries(MaaCore log dl)
+endif()
+
 file(GLOB_RECURSE MaaCore_PUBLIC_HEADERS ${PROJECT_SOURCE_DIR}/include/*.h)
 target_sources(MaaCore PUBLIC ${MaaCore_PUBLIC_HEADERS})
 set_target_properties(MaaCore PROPERTIES PUBLIC_HEADER "${MaaCore_PUBLIC_HEADERS}")

--- a/src/MaaCore/Common/AsstTypes.h
+++ b/src/MaaCore/Common/AsstTypes.h
@@ -158,7 +158,7 @@ struct Point
     {                                                                     \
         return { lhs.x Op rhs.x, lhs.y Op rhs.y };                        \
     }                                                                     \
-    friend Point& operator Op## =(Point& val, const Point& opd) noexcept   \
+    friend Point& operator Op##=(Point& val, const Point& opd) noexcept   \
     {                                                                     \
         val.x Op## = opd.x;                                               \
         val.y Op## = opd.y;                                               \
@@ -263,7 +263,7 @@ struct Rect
     static Rect bounding_box(const std::vector<Rect>& rects)
     {
         if (rects.empty()) {
-            return { };
+            return {};
         }
 
         int min_x = INT_MAX;
@@ -306,11 +306,11 @@ struct AnalyzerResult
 {
     virtual ~AnalyzerResult() = default;
 
-    virtual std::string to_string() const { return { }; };
+    virtual std::string to_string() const { return {}; };
 
     explicit operator std::string() const { return to_string(); }
 
-    virtual json::object to_json() const { return { }; };
+    virtual json::object to_json() const { return {}; };
 
     explicit operator json::object() const { return to_json(); }
 };
@@ -421,8 +421,8 @@ struct pair_hash
 {
     size_t operator()(const std::pair<T1, T2>& p) const noexcept
     {
-        std::size_t hash1 = std::hash<T1> { }(p.first);
-        std::size_t hash2 = std::hash<T2> { }(p.second);
+        std::size_t hash1 = std::hash<T1> {}(p.first);
+        std::size_t hash2 = std::hash<T2> {}(p.second);
         hash1 ^= hash2 + 0x9e3779b9 + (hash1 << 6) + (hash1 >> 2);
 
         hash1 ^= hash1 >> 32;

--- a/src/MaaCore/Common/AsstTypes.h
+++ b/src/MaaCore/Common/AsstTypes.h
@@ -36,6 +36,9 @@ enum class StaticOptionKey
     CpuOCR = 1, // use CPU to OCR, no value. It does not support switching after the resource is loaded.
     GpuOCR = 2, // use GPU to OCR, value is gpu_id int to string. It does not support switching after the resource
                 // is loaded.
+#ifdef __ANDROID__
+    AndroidExternalLib = 3
+#endif // __ANDROID__
 };
 
 enum class InstanceOptionKey
@@ -54,6 +57,9 @@ enum class TouchMode
     Minitouch = 1,
     Maatouch = 2,
     MacPlayTools = 3,
+#ifdef __ANDROID__
+    Android = 4,
+#endif // __ANDROID__
 };
 
 #ifdef _WIN32
@@ -152,7 +158,7 @@ struct Point
     {                                                                     \
         return { lhs.x Op rhs.x, lhs.y Op rhs.y };                        \
     }                                                                     \
-    friend Point& operator Op##=(Point& val, const Point& opd) noexcept   \
+    friend Point& operator Op## =(Point& val, const Point& opd) noexcept   \
     {                                                                     \
         val.x Op## = opd.x;                                               \
         val.y Op## = opd.y;                                               \
@@ -257,7 +263,7 @@ struct Rect
     static Rect bounding_box(const std::vector<Rect>& rects)
     {
         if (rects.empty()) {
-            return {};
+            return { };
         }
 
         int min_x = INT_MAX;
@@ -300,11 +306,11 @@ struct AnalyzerResult
 {
     virtual ~AnalyzerResult() = default;
 
-    virtual std::string to_string() const { return {}; };
+    virtual std::string to_string() const { return { }; };
 
     explicit operator std::string() const { return to_string(); }
 
-    virtual json::object to_json() const { return {}; };
+    virtual json::object to_json() const { return { }; };
 
     explicit operator json::object() const { return to_json(); }
 };
@@ -415,8 +421,8 @@ struct pair_hash
 {
     size_t operator()(const std::pair<T1, T2>& p) const noexcept
     {
-        std::size_t hash1 = std::hash<T1> {}(p.first);
-        std::size_t hash2 = std::hash<T2> {}(p.second);
+        std::size_t hash1 = std::hash<T1> { }(p.first);
+        std::size_t hash2 = std::hash<T2> { }(p.second);
         hash1 ^= hash2 + 0x9e3779b9 + (hash1 << 6) + (hash1 >> 2);
 
         hash1 ^= hash1 >> 32;

--- a/src/MaaCore/Controller/Android/AndroidController.cpp
+++ b/src/MaaCore/Controller/Android/AndroidController.cpp
@@ -1,0 +1,561 @@
+#ifdef __ANDROID__
+
+#include "AndroidController.h"
+
+#include <chrono>
+#include <thread>
+
+#include "AndroidExternalLib.h"
+#include "Common/AsstTypes.h"
+#include "Config/GeneralConfig.h"
+#include "Utils/Logger.hpp"
+#include "opencv2/imgproc.hpp"
+
+using namespace asst;
+
+AndroidController::AndroidController(const AsstCallback& callback, Assistant* inst) :
+    InstHelper(inst),
+    m_callback(callback)
+{
+    LogTraceFunction;
+}
+
+AndroidController::~AndroidController()
+{
+    LogTraceFunction;
+    std::cout << "~AndroidController" << std::endl;
+}
+
+bool AndroidController::connect(const std::string& adb_path, const std::string& address, const std::string& config)
+{
+    LogTraceFunction;
+    LogInfo << "AndroidController connecting, adb_path:" << adb_path << ", address:" << address
+            << ", config:" << config;
+
+    if (const auto& lib = AndroidExternalLib::instance(); !lib.is_loaded()) {
+        LogInfo << "AndroidExternalLib not loaded";
+        return false;
+    }
+
+    if (!config.empty()) {
+        auto config_opt = json::parse(config);
+        if (config_opt.has_value()) {
+            auto& config_json = config_opt.value();
+            if (config_json.contains("screen_resolution")) {
+                auto& res = config_json["screen_resolution"];
+                if (res.contains("width") && res.contains("height")) {
+                    int width = res.get("width", 1920);
+                    int height = res.get("height", 1080);
+                    m_screen_resolution = { width, height };
+                    LogInfo << "Parsed screen resolution from config:" << width << "x" << height;
+                }
+            }
+            if (config_json.contains("display_id")) {
+                m_display_id = config_json.get("display_id", 0);
+                LogInfo << "Parsed display_id from config:" << m_display_id;
+            }
+            if (config_json.contains("force_stop")) {
+                m_force_stop = config_json.get("force_stop", false);
+                LogInfo << "Parsed force_stop from config:" << m_force_stop;
+            }
+        }
+        else {
+            LogWarn << "Failed to parse config as JSON, using default resolution";
+            return false;
+        }
+    }
+
+    m_uuid = "IAndroidController";
+    m_inited = true;
+
+    callback(
+        AsstMsg::ConnectionInfo,
+        json::object { { "uuid", m_uuid },
+                       { "details",
+                         json::object {
+                             { "adb", adb_path },
+                             { "address", address },
+                             { "config", config },
+                         } } });
+
+    LogInfo << "AndroidController connected successfully, uuid:" << m_uuid;
+    return true;
+}
+
+bool AndroidController::inited() const noexcept
+{
+    return m_inited;
+}
+
+const std::string& AndroidController::get_uuid() const
+{
+    return m_uuid;
+}
+
+size_t AndroidController::get_pipe_data_size() const noexcept
+{
+    return 0;
+}
+
+size_t AndroidController::get_version() const noexcept
+{
+    return 1;
+}
+
+bool AndroidController::screencap(cv::Mat& image, [[maybe_unused]] bool allow_reconnect)
+{
+    LogTraceFunction;
+
+    if (!m_inited) {
+        LogError << "AndroidController not initialized";
+        return false;
+    }
+
+    auto& library = AndroidExternalLib::instance();
+    auto info = library.GetLockedPixels();
+
+    if (!info.data || info.width == 0 || info.height == 0) {
+        LogError << "GetLockedPixels returned invalid data";
+        return false;
+    }
+
+    cv::Mat src(info.height, info.width, CV_8UC4, info.data, info.stride);
+    cv::Mat bgr;
+
+    auto cvt_start = std::chrono::high_resolution_clock::now();
+    cv::cvtColor(src, bgr, cv::COLOR_RGBA2BGR);
+    auto cvt_end = std::chrono::high_resolution_clock::now();
+    auto cvt_duration = std::chrono::duration_cast<std::chrono::microseconds>(cvt_end - cvt_start);
+    LogDebug << "cvtColor(RGBA->BGR) took: " << cvt_duration.count() << " microseconds";
+
+    image = bgr;
+
+    int unlock_ret = library.UnlockPixels(info);
+    if (unlock_ret == 0) {
+        LogInfo << "UnlockPixels Successful " << unlock_ret;
+        return true;
+    }
+
+    return false;
+}
+
+bool AndroidController::start_game(const std::string& client_type)
+{
+    LogTraceFunction;
+    LogInfo << "Starting game with client_type:" << client_type;
+
+    if (!m_inited) {
+        LogError << "AndroidController not initialized";
+        return false;
+    }
+
+    auto package_name = Config.get_package_name(client_type);
+    if (!package_name) {
+        LogError << "Unknown client_type: " << client_type;
+        return false;
+    }
+
+    auto& library = AndroidExternalLib::instance();
+
+    MethodParam start_param;
+    start_param.display_id = m_display_id;
+    start_param.method = START_GAME;
+    start_param.args.start_game.package_name = package_name->c_str();
+    start_param.args.start_game.force_stop = m_force_stop ? 1 : 0;
+
+    if (library.DispatchInputMessage(start_param) != 0) {
+        LogError << "Failed to start game with client_type: " << client_type;
+        return false;
+    }
+
+    LogInfo << "Game started successfully with client_type: " << client_type << ", package: " << *package_name;
+    return true;
+}
+
+bool AndroidController::stop_game(const std::string& client_type)
+{
+    LogTraceFunction;
+    LogInfo << "Stopping game with client_type:" << client_type;
+
+    if (!m_inited) {
+        LogError << "AndroidController not initialized";
+        return false;
+    }
+
+    auto& library = AndroidExternalLib::instance();
+
+    MethodParam stop_param;
+    stop_param.display_id = m_display_id;
+    stop_param.method = STOP_GAME;
+    stop_param.args.stop_game.client_type = client_type.c_str();
+
+    if (library.DispatchInputMessage(stop_param) != 0) {
+        LogError << "Failed to stop game with client_type: " << client_type;
+        return false;
+    }
+
+    LogInfo << "Game stopped successfully with client_type: " << client_type;
+    return true;
+}
+
+bool AndroidController::click(const Point& p)
+{
+    LogTraceFunction;
+    LogTrace << "Clicking at point:" << p.x << "," << p.y;
+    if (!m_inited) {
+        LogError << "AndroidController not initialized";
+        return false;
+    }
+
+    if (p.x < 0 || p.x >= m_screen_resolution.first || p.y < 0 || p.y >= m_screen_resolution.second) {
+        LogError << "click point out of range: " << p.x << "," << p.y << " screen:" << m_screen_resolution.first << "x"
+                 << m_screen_resolution.second;
+    }
+
+    auto& library = AndroidExternalLib::instance();
+
+    // key_down
+    MethodParam touch_down_param;
+    touch_down_param.display_id = m_display_id;
+    touch_down_param.method = TOUCH_DOWN;
+    touch_down_param.args.touch.p = { p.x, p.y };
+
+    if (library.DispatchInputMessage(touch_down_param) != 0) {
+        LogError << "Failed to send TOUCH_DOWN event";
+        return false;
+    }
+    sleep(20);
+
+    // key_up
+    MethodParam touch_up_param;
+    touch_up_param.display_id = m_display_id;
+    touch_up_param.method = TOUCH_UP;
+    touch_up_param.args.touch.p = { p.x, p.y };
+
+    if (library.DispatchInputMessage(touch_up_param) != 0) {
+        LogError << "Failed to send TOUCH_UP event";
+        return false;
+    }
+
+    LogInfo << "Click completed successfully at: " << p.x << "," << p.y;
+    return true;
+}
+
+bool AndroidController::input(const std::string& text)
+{
+    LogTraceFunction;
+    LogTrace << "Input text:" << text;
+
+    if (!m_inited) {
+        LogError << "AndroidController not initialized";
+        return false;
+    }
+
+    if (text.empty()) {
+        LogWarn << "Input text is empty";
+        return true;
+    }
+
+    auto& library = AndroidExternalLib::instance();
+
+    // input
+    MethodParam input_param;
+    input_param.display_id = m_display_id;
+    input_param.method = INPUT;
+    input_param.args.input.text = text.c_str();
+
+    if (library.DispatchInputMessage(input_param) != 0) {
+        LogError << "Failed to send INPUT event";
+        return false;
+    }
+
+    LogInfo << "Input completed successfully, text length: " << text.length();
+    return true;
+}
+
+bool AndroidController::swipe(
+    const Point& p1,
+    const Point& p2,
+    int duration,
+    bool extra_swipe,
+    double slope_in,
+    double slope_out,
+    bool with_pause)
+{
+    LogTraceFunction;
+    LogTrace << "AndroidController swipe" << p1 << p2 << duration << extra_swipe << slope_in << slope_out;
+
+    if (!m_inited) {
+        LogError << "AndroidController not initialized";
+        return false;
+    }
+
+    int x1 = p1.x, y1 = p1.y;
+    int x2 = p2.x, y2 = p2.y;
+
+    // 起点不能在屏幕外，但是终点可以
+    if (x1 < 0 || x1 >= m_screen_resolution.first || y1 < 0 || y1 >= m_screen_resolution.second) {
+        LogWarn << "swipe point1 is out of range" << x1 << y1;
+        x1 = std::clamp(x1, 0, m_screen_resolution.first - 1);
+        y1 = std::clamp(y1, 0, m_screen_resolution.second - 1);
+    }
+
+    auto& library = AndroidExternalLib::instance();
+
+    // 触摸按下起点
+    MethodParam touch_down_param;
+    touch_down_param.display_id = m_display_id;
+    touch_down_param.method = TOUCH_DOWN;
+    touch_down_param.args.touch.p = { x1, y1 };
+
+    if (library.DispatchInputMessage(touch_down_param) != 0) {
+        LogError << "Failed to send TOUCH_DOWN event for swipe";
+        return false;
+    }
+
+    constexpr int TimeInterval = 2; // 类似 Minitoucher::DefaultSwipeDelay
+
+    auto cubic_spline = [](double slope_0, double slope_1, double t) {
+        const double a = slope_0;
+        const double b = -(2 * slope_0 + slope_1 - 3);
+        const double c = -(-slope_0 - slope_1 + 2);
+        return a * t + b * std::pow(t, 2) + c * std::pow(t, 3);
+    };
+
+    bool need_pause = with_pause;
+    const auto& opt = Config.get_options();
+    int swipe_with_pause_required_distance = opt.swipe_with_pause_required_distance;
+
+    auto android_move = [&](int _x1, int _y1, int _x2, int _y2, int _duration) -> bool {
+        for (int cur_time = TimeInterval; cur_time < _duration; cur_time += TimeInterval) {
+            double progress = cubic_spline(slope_in, slope_out, static_cast<double>(cur_time) / duration);
+            int cur_x = static_cast<int>(std::lerp(_x1, _x2, progress));
+            int cur_y = static_cast<int>(std::lerp(_y1, _y2, progress));
+
+            // 暂停逻辑
+            if (need_pause &&
+                std::sqrt(std::pow(cur_x - _x1, 2) + std::pow(cur_y - _y1, 2)) > swipe_with_pause_required_distance) {
+                need_pause = false;
+                // send esc
+                constexpr int EscKeyCode = 27;
+                MethodParam key_down_param;
+                key_down_param.display_id = m_display_id;
+                key_down_param.method = KEY_DOWN;
+                key_down_param.args.key.key_code = EscKeyCode;
+
+                MethodParam key_up_param;
+                key_up_param.display_id = m_display_id;
+                key_up_param.method = KEY_UP;
+                key_up_param.args.key.key_code = EscKeyCode;
+
+                if (library.DispatchInputMessage(key_down_param) != 0 ||
+                    library.DispatchInputMessage(key_up_param) != 0) {
+                    LogWarn << "Failed to send ESC key during swipe pause";
+                }
+            }
+
+            if (cur_x < 0 || cur_x > m_screen_resolution.first || cur_y < 0 || cur_y > m_screen_resolution.second) {
+                continue;
+            }
+
+            MethodParam touch_move_param;
+            touch_move_param.display_id = m_display_id;
+            touch_move_param.method = TOUCH_MOVE;
+            touch_move_param.args.touch.p = { cur_x, cur_y };
+
+            if (library.DispatchInputMessage(touch_move_param) != 0) {
+                return false;
+            }
+
+            std::this_thread::sleep_for(std::chrono::milliseconds(TimeInterval));
+        }
+
+        // 最终移动到终点
+        if (_x2 >= 0 && _x2 <= m_screen_resolution.first && _y2 >= 0 && _y2 <= m_screen_resolution.second) {
+            MethodParam final_move_param;
+            final_move_param.display_id = m_display_id;
+            final_move_param.method = TOUCH_MOVE;
+            final_move_param.args.touch.p = { _x2, _y2 };
+
+            if (library.DispatchInputMessage(final_move_param) != 0) {
+                return false;
+            }
+        }
+        return true;
+    };
+
+    // 默认滑动时长
+    int swipe_duration = duration > 0 ? duration : 500; // 默认500ms
+
+    if (!android_move(x1, y1, x2, y2, swipe_duration)) {
+        LogError << "Failed during main swipe movement";
+        // key_up
+        MethodParam touch_up_param;
+        touch_up_param.display_id = m_display_id;
+        touch_up_param.method = TOUCH_UP;
+        touch_up_param.args.touch.p = { x2, y2 };
+        library.DispatchInputMessage(touch_up_param);
+        return false;
+    }
+
+    // 额外滑动逻辑
+    if (extra_swipe) {
+        constexpr int extra_end_delay = 50;
+        constexpr int extra_swipe_dist = 10;
+        constexpr int extra_swipe_duration = 100;
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(extra_end_delay));
+
+        if (!android_move(x2, y2, x2, y2 - extra_swipe_dist, extra_swipe_duration)) {
+            LogWarn << "Failed during extra swipe movement";
+        }
+    }
+
+    // key_up
+    MethodParam touch_up_param;
+    touch_up_param.display_id = m_display_id;
+    touch_up_param.method = TOUCH_UP;
+    touch_up_param.args.touch.p = { x2, y2 };
+
+    if (library.DispatchInputMessage(touch_up_param) != 0) {
+        LogError << "Failed to send TOUCH_UP event for swipe";
+        return false;
+    }
+
+    LogInfo << "AndroidController swipe completed successfully";
+    return true;
+}
+
+bool AndroidController::inject_input_event(const InputEvent& event)
+{
+    LogTraceFunction;
+    LogTrace << "Injecting input event, type:" << static_cast<int>(event.type) << " point:(" << event.point.x << ","
+             << event.point.y << ")"
+             << " keycode:" << event.keycode;
+
+    if (!m_inited) {
+        LogError << "AndroidController not initialized";
+        return false;
+    }
+
+    auto& library = AndroidExternalLib::instance();
+    MethodParam param;
+    param.display_id = m_display_id;
+
+    switch (event.type) {
+    case InputEvent::Type::KEY_DOWN:
+        param.method = KEY_DOWN;
+        param.args.key.key_code = event.keycode;
+        break;
+
+    case InputEvent::Type::KEY_UP:
+        param.method = KEY_UP;
+        param.args.key.key_code = event.keycode;
+        break;
+
+    case InputEvent::Type::TOUCH_DOWN:
+        param.method = TOUCH_DOWN;
+        param.args.touch.p = { event.point.x, event.point.y };
+        break;
+
+    case InputEvent::Type::TOUCH_UP:
+        param.method = TOUCH_UP;
+        param.args.touch.p = { event.point.x, event.point.y };
+        break;
+
+    case InputEvent::Type::TOUCH_MOVE:
+        param.method = TOUCH_MOVE;
+        param.args.touch.p = { event.point.x, event.point.y };
+        break;
+
+    case InputEvent::Type::TOUCH_RESET:
+    case InputEvent::Type::WAIT_MS:
+    case InputEvent::Type::COMMIT:
+        LogWarn << "InputEvent type not supported by DispatchInputMessage: " << static_cast<int>(event.type);
+        return true; // 不支持的事件类型，但不报错
+
+    case InputEvent::Type::UNKNOWN:
+    default:
+        LogError << "Unknown input event type: " << static_cast<int>(event.type);
+        return false;
+    }
+
+    if (library.DispatchInputMessage(param) != 0) {
+        LogError << "Failed to dispatch input event";
+        return false;
+    }
+
+    LogInfo << "Input event injected successfully";
+    return true;
+}
+
+bool AndroidController::press_esc()
+{
+    LogTraceFunction;
+
+    if (!m_inited) {
+        LogError << "AndroidController not initialized";
+        return false;
+    }
+
+    auto& library = AndroidExternalLib::instance();
+
+    constexpr int EscKeyCode = 27; // ESC键代码
+
+    // 按键按下
+    MethodParam key_down_param;
+    key_down_param.display_id = m_display_id;
+    key_down_param.method = KEY_DOWN;
+    key_down_param.args.key.key_code = EscKeyCode;
+
+    if (library.DispatchInputMessage(key_down_param) != 0) {
+        LogError << "Failed to send KEY_DOWN event for ESC";
+        return false;
+    }
+
+    // 按键抬起
+    MethodParam key_up_param;
+    key_up_param.display_id = m_display_id;
+    key_up_param.method = KEY_UP;
+    key_up_param.args.key.key_code = EscKeyCode;
+
+    if (library.DispatchInputMessage(key_up_param) != 0) {
+        LogError << "Failed to send KEY_UP event for ESC";
+        return false;
+    }
+
+    LogInfo << "ESC key pressed successfully";
+    return true;
+}
+
+ControlFeat::Feat AndroidController::support_features() const noexcept
+{
+    // AndroidController 支持精确滑动和暂停滑动功能
+    auto feat = ControlFeat::PRECISE_SWIPE;
+    feat |= ControlFeat::SWIPE_WITH_PAUSE;
+    return feat;
+}
+
+std::pair<int, int> AndroidController::get_screen_res() const noexcept
+{
+    return m_screen_resolution;
+}
+
+void AndroidController::back_to_home() noexcept
+{
+    LogTraceFunction;
+
+    if (!m_inited) {
+        LogError << "AndroidController not initialized";
+        return;
+    }
+}
+
+void AndroidController::callback(AsstMsg msg, const json::value& details)
+{
+    if (m_callback) {
+        m_callback(msg, details, inst());
+    }
+}
+
+#endif // __ANDROID__

--- a/src/MaaCore/Controller/Android/AndroidController.cpp
+++ b/src/MaaCore/Controller/Android/AndroidController.cpp
@@ -111,18 +111,18 @@ bool AndroidController::screencap(cv::Mat& image, [[maybe_unused]] bool allow_re
         return false;
     }
 
-    auto& library = AndroidExternalLib::instance();
-    auto info = library.GetLockedPixels();
+    const auto& library = AndroidExternalLib::instance();
+    const auto info = library.GetLockedPixels();
 
     if (!info.data || info.width == 0 || info.height == 0) {
         LogError << "GetLockedPixels returned invalid data";
         return false;
     }
 
-    cv::Mat src(info.height, info.width, CV_8UC4, info.data, info.stride);
+    const cv::Mat src(info.height, info.width, CV_8UC4, info.data, info.stride);
     cv::Mat bgr;
 
-    auto cvt_start = std::chrono::high_resolution_clock::now();
+    const auto cvt_start = std::chrono::high_resolution_clock::now();
     cv::cvtColor(src, bgr, cv::COLOR_RGBA2BGR);
     auto cvt_end = std::chrono::high_resolution_clock::now();
     auto cvt_duration = std::chrono::duration_cast<std::chrono::microseconds>(cvt_end - cvt_start);

--- a/src/MaaCore/Controller/Android/AndroidController.cpp
+++ b/src/MaaCore/Controller/Android/AndroidController.cpp
@@ -120,16 +120,11 @@ bool AndroidController::screencap(cv::Mat& image, [[maybe_unused]] bool allow_re
         return false;
     }
 
-    const cv::Mat src(info.height, info.width, CV_8UC4, info.data, info.stride);
-    cv::Mat bgr;
+    const cv::Mat bgr_raw(info.height, info.width, CV_8UC3, info.data, info.stride);
 
-    const auto cvt_start = std::chrono::high_resolution_clock::now();
-    cv::cvtColor(src, bgr, cv::COLOR_RGBA2BGR);
-    auto cvt_end = std::chrono::high_resolution_clock::now();
-    auto cvt_duration = std::chrono::duration_cast<std::chrono::microseconds>(cvt_end - cvt_start);
-    LogDebug << "cvtColor(RGBA->BGR) took: " << cvt_duration.count() << " microseconds";
+    image = bgr_raw.clone();
 
-    image = bgr;
+    LogDebug << "Screencap: BGR frame received via NEON, size: " << info.width << "x" << info.height;
 
     int unlock_ret = library.UnlockPixels(info);
     if (unlock_ret == 0) {

--- a/src/MaaCore/Controller/Android/AndroidController.h
+++ b/src/MaaCore/Controller/Android/AndroidController.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#ifdef __ANDROID__
+
+#include "../ControllerAPI.h"
+
+#include <functional>
+#include <string>
+
+#include "Common/AsstMsg.h"
+#include "InstHelper.h"
+
+namespace asst
+{
+
+class AndroidController : public ControllerAPI, protected InstHelper
+{
+public:
+    AndroidController(const AsstCallback& callback, Assistant* inst);
+    AndroidController(const AndroidController&) = delete;
+    AndroidController(AndroidController&&) = delete;
+    ~AndroidController() override ;
+
+
+    virtual bool connect(const std::string& adb_path, const std::string& address, const std::string& config) override;
+    virtual bool inited() const noexcept override;
+    virtual const std::string& get_uuid() const override;
+    virtual size_t get_pipe_data_size() const noexcept override;
+    virtual size_t get_version() const noexcept override;
+    
+    virtual bool screencap(cv::Mat& image_payload, bool allow_reconnect = false) override;
+    virtual bool start_game(const std::string& client_type) override;
+    virtual bool stop_game(const std::string& client_type) override;
+    virtual bool click(const Point& p) override;
+    virtual bool input(const std::string& text) override;
+    virtual bool swipe(
+        const Point& p1,
+        const Point& p2,
+        int duration = 0,
+        bool extra_swipe = false,
+        double slope_in = 1,
+        double slope_out = 1,
+        bool with_pause = false) override;
+    
+    virtual bool inject_input_event(const InputEvent& event) override;
+    virtual bool press_esc() override;
+    virtual ControlFeat::Feat support_features() const noexcept override;
+    virtual std::pair<int, int> get_screen_res() const noexcept override;
+    virtual void back_to_home() noexcept override;
+
+    AndroidController& operator=(const AndroidController&) = delete;
+    AndroidController& operator=(AndroidController&&) = delete;
+
+private:
+    void callback(AsstMsg msg, const json::value& details);
+
+    bool m_inited = false;
+    std::string m_uuid;
+
+    std::pair<int, int> m_screen_resolution = { 1920, 1080 };
+
+    int m_display_id = 0;
+    bool m_force_stop = false;
+
+    AsstCallback m_callback = nullptr;
+};
+
+} // namespace asst
+
+#endif // __ANDROID__

--- a/src/MaaCore/Controller/Android/AndroidExternalLib.cpp
+++ b/src/MaaCore/Controller/Android/AndroidExternalLib.cpp
@@ -1,0 +1,342 @@
+#ifdef __ANDROID__
+
+#include "AndroidExternalLib.h"
+
+#include "Utils/Logger.hpp"
+
+using namespace asst;
+
+AndroidExternalLib* AndroidExternalLib::s_instance = nullptr;
+
+AndroidExternalLib::AndroidExternalLib()
+{
+    LogTraceFunction;
+    LogInfo << "AndroidExternalLib instance created";
+}
+
+AndroidExternalLib::~AndroidExternalLib()
+{
+    LogTraceFunction;
+    if (m_handle) {
+        LogInfo << "Unloading library: " << m_library_path;
+        dlclose(m_handle);
+        m_handle = nullptr;
+    }
+}
+
+AndroidExternalLib& AndroidExternalLib::instance()
+{
+    if (!s_instance) {
+        s_instance = new AndroidExternalLib();
+    }
+    return *s_instance;
+}
+
+bool AndroidExternalLib::load(const std::string& library_path)
+{
+    LogTraceFunction;
+
+    if (library_path.empty()) {
+        LogError << "Library path is empty";
+        return false;
+    }
+
+    auto& inst = instance();
+
+    if (inst.m_loaded && inst.m_library_path == library_path) {
+        LogInfo << "Library already loaded: " << library_path;
+        return true;
+    }
+
+    if (inst.load_library(library_path)) {
+        LogInfo << "Successfully loaded library: " << library_path;
+        return true;
+    } else {
+        LogError << "Failed to load library: " << library_path;
+        return false;
+    }
+}
+
+bool AndroidExternalLib::load_library(const std::string& library_path)
+{
+    LogTraceFunction;
+    LogInfo << "Loading library: " << library_path;
+
+    if (m_handle && m_library_path == library_path && m_loaded) {
+        LogInfo << "Library already loaded: " << library_path;
+        return true;
+    }
+
+    if (m_handle) {
+        LogInfo << "Unloading previous library: " << m_library_path;
+        dlclose(m_handle);
+        m_handle = nullptr;
+        m_loaded = false;
+        clear_symbols();
+    }
+
+    m_handle = dlopen(library_path.c_str(), RTLD_LAZY);
+    if (!m_handle) {
+        LogError << "Failed to load library: " << dlerror();
+        m_loaded = false;
+        return false;
+    }
+
+    m_library_path = library_path;
+
+    if (!resolve_symbols()) {
+        LogError << "Failed to resolve symbols from library";
+        dlclose(m_handle);
+        m_handle = nullptr;
+        clear_symbols();
+        return false;
+    }
+
+    m_loaded = true;
+    LogInfo << "Successfully loaded library and resolved symbols: " << library_path;
+    return true;
+}
+
+bool AndroidExternalLib::resolve_symbols()
+{
+    LogTraceFunction;
+
+    if (!m_handle) {
+        LogError << "No library handle available";
+        return false;
+    }
+
+    dlerror();
+
+    // 解析 GetLockedPixels
+    m_funcs.get_locked_pixels = (GetLockedPixels_t)dlsym(m_handle, "GetLockedPixels");
+    if (!m_funcs.get_locked_pixels) {
+        LogError << "Failed to resolve GetLockedPixels: " << dlerror();
+        return false;
+    }
+
+    // 解析 UnlockPixels
+    m_funcs.unlock_pixels = (UnlockPixels_t)dlsym(m_handle, "UnlockPixels");
+    if (!m_funcs.unlock_pixels) {
+        LogError << "Failed to resolve UnlockPixels: " << dlerror();
+        return false;
+    }
+
+    // 解析 AttachThread
+    m_funcs.attach_thread = (AttachThread_t)dlsym(m_handle, "AttachThread");
+    if (!m_funcs.attach_thread) {
+        LogError << "Failed to resolve AttachThread: " << dlerror();
+        return false;
+    }
+
+    // 解析 DetachThread
+    m_funcs.detach_thread = (DetachThread_t)dlsym(m_handle, "DetachThread");
+    if (!m_funcs.detach_thread) {
+        LogError << "Failed to resolve DetachThread: " << dlerror();
+        return false;
+    }
+
+    // 解析 DispatchInputMessage
+    m_funcs.dispatch_input_message = (DispatchInputMessage_t)dlsym(m_handle, "DispatchInputMessage");
+    if (!m_funcs.dispatch_input_message) {
+        LogError << "Failed to resolve DispatchInputMessage: " << dlerror();
+        return false;
+    }
+
+    LogInfo << "All symbols resolved successfully";
+    return true;
+}
+
+void AndroidExternalLib::clear_symbols()
+{
+    m_funcs.get_locked_pixels = nullptr;
+    m_funcs.unlock_pixels = nullptr;
+    m_funcs.attach_thread = nullptr;
+    m_funcs.detach_thread = nullptr;
+    m_funcs.dispatch_input_message = nullptr;
+}
+
+bool AndroidExternalLib::is_loaded() const
+{
+    return m_handle != nullptr && m_loaded &&
+           m_funcs.get_locked_pixels != nullptr;
+}
+
+FrameInfo AndroidExternalLib::GetLockedPixels(void) const
+{
+    LogTraceFunction;
+
+    static constexpr FrameInfo empty_result = {
+        0,       // width
+        0,       // height
+        0,       // stride
+        0,       // length
+        nullptr, // data
+        nullptr  // frame_ref
+    };
+
+    if (!is_loaded()) {
+        LogError << "Library not properly loaded";
+        return empty_result;
+    }
+
+    if (!m_funcs.get_locked_pixels) {
+        LogError << "GetLockedPixels function not available";
+        return empty_result;
+    }
+
+    LogInfo << "Calling GetLockedPixels()...";
+    FrameInfo result = m_funcs.get_locked_pixels();
+
+    LogInfo << "GetLockedPixels() completed successfully";
+    LogDebug << "LockedPixels - width: " << result.width
+             << ", height: " << result.height
+             << ", stride: " << result.stride
+             << ", length: " << result.length
+             << ", data: " << result.data
+             << ", frame_ref: " << result.frame_ref;
+
+    return result;
+}
+
+int AndroidExternalLib::UnlockPixels(FrameInfo info) const
+{
+    LogTraceFunction;
+
+    if (!is_loaded()) {
+        LogError << "Library not properly loaded";
+        return -1;
+    }
+
+    if (!m_funcs.unlock_pixels) {
+        LogError << "UnlockPixels function not available";
+        return -1;
+    }
+
+    LogInfo << "Calling UnlockPixels()...";
+    LogDebug << "Unlocking pixels - data: " << info.data
+             << ", frame_ref: " << info.frame_ref;
+
+    int result = m_funcs.unlock_pixels(info);
+
+    if (result == 0) {
+        LogInfo << "UnlockPixels() completed successfully";
+    } else {
+        LogError << "UnlockPixels() failed with code: " << result;
+    }
+
+    return result;
+}
+
+void* AndroidExternalLib::AttachThread() const
+{
+    LogTraceFunction;
+
+    if (!is_loaded()) {
+        LogError << "Library not properly loaded";
+        return nullptr;
+    }
+
+    if (!m_funcs.attach_thread) {
+        LogError << "AttachThread function not available";
+        return nullptr;
+    }
+
+    LogInfo << "Calling AttachThread()...";
+    void* env = m_funcs.attach_thread();
+
+    if (env) {
+        LogInfo << "AttachThread() completed successfully, env: " << env;
+    } else {
+        LogError << "AttachThread() returned null env";
+    }
+
+    return env;
+}
+
+int AndroidExternalLib::DetachThread(void* env) const
+{
+    LogTraceFunction;
+
+    if (!is_loaded()) {
+        LogError << "Library not properly loaded";
+        return -1;
+    }
+
+    if (!m_funcs.detach_thread) {
+        LogError << "DetachThread function not available";
+        return -1;
+    }
+
+    LogInfo << "Calling DetachThread() with env: " << env;
+    int result = m_funcs.detach_thread(env);
+
+    if (result == 0) {
+        LogInfo << "DetachThread() completed successfully";
+    } else {
+        LogError << "DetachThread() failed with code: " << result;
+    }
+
+    return result;
+}
+
+int AndroidExternalLib::DispatchInputMessage(MethodParam param) const
+{
+    LogTraceFunction;
+
+    if (!is_loaded()) {
+        LogError << "Library not properly loaded";
+        return -1;
+    }
+
+    if (!m_funcs.dispatch_input_message) {
+        LogError << "DispatchInputMessage function not available";
+        return -1;
+    }
+
+    LogInfo << "Calling DispatchInputMessage() with method: " << static_cast<int>(param.method)
+            << ", display_id: " << param.display_id;
+
+    switch (param.method) {
+        case START_GAME:
+            LogDebug << "START_GAME - package_name: " << (param.args.start_game.package_name ? param.args.start_game.package_name : "null")
+                     << ", force_stop: " << param.args.start_game.force_stop;
+            break;
+        case STOP_GAME:
+            LogDebug << "STOP_GAME - client_type: " << (param.args.stop_game.client_type ? param.args.stop_game.client_type : "null");
+            break;
+        case INPUT:
+            LogDebug << "INPUT - text: " << (param.args.input.text ? param.args.input.text : "null");
+            break;
+        case TOUCH_DOWN:
+            LogDebug << "TOUCH_DOWN - point: (" << param.args.touch.p.x << ", " << param.args.touch.p.y << ")";
+            break;
+        case TOUCH_MOVE:
+            LogDebug << "TOUCH_MOVE - point: (" << param.args.touch.p.x << ", " << param.args.touch.p.y << ")";
+            break;
+        case TOUCH_UP:
+            LogDebug << "TOUCH_UP - point: (" << param.args.touch.p.x << ", " << param.args.touch.p.y << ")";
+            break;
+        case KEY_DOWN:
+            LogDebug << "KEY_DOWN - key_code: " << param.args.key.key_code;
+            break;
+        case KEY_UP:
+            LogDebug << "KEY_UP - key_code: " << param.args.key.key_code;
+            break;
+        default:
+            LogWarn << "Unknown method type: " << static_cast<int>(param.method);
+            break;
+    }
+
+    int result = m_funcs.dispatch_input_message(param);
+
+    if (result == 0) {
+        LogInfo << "DispatchInputMessage() completed successfully";
+    } else {
+        LogError << "DispatchInputMessage() failed with code: " << result;
+    }
+
+    return result;
+}
+
+#endif // __ANDROID__

--- a/src/MaaCore/Controller/Android/AndroidExternalLib.h
+++ b/src/MaaCore/Controller/Android/AndroidExternalLib.h
@@ -1,0 +1,134 @@
+#pragma once
+
+#ifdef __ANDROID__
+
+#include <string>
+#include <dlfcn.h>
+#include <cstdint>
+
+namespace asst
+{
+
+// Frame info structure - for reading screen frames (32 bytes)
+typedef struct {
+    uint32_t width;          // Width - 4 bytes
+    uint32_t height;         // Height - 4 bytes
+    uint32_t stride;         // Row stride - 4 bytes
+    uint32_t length;         // Data length - 4 bytes
+    void *data;              // Pixel data pointer - 8 bytes
+    void *frame_ref;         // FrameBuffer pointer for unlocking - 8 bytes
+} FrameInfo;
+
+typedef enum {
+    IMAGE_FORMAT_UNKNOWN = 0,
+    IMAGE_FORMAT_RGBA_8888 = 2
+} ImageFormat;
+
+typedef enum {
+    START_GAME = 1,
+    STOP_GAME = 2,
+    INPUT = 4,
+    TOUCH_DOWN = 6,
+    TOUCH_MOVE = 7,
+    TOUCH_UP = 8,
+    KEY_DOWN = 9,
+    KEY_UP = 10
+} MethodType;
+
+typedef struct {
+    int x;
+    int y;
+} Position;
+
+typedef struct {
+    const char *package_name;   // 应用包名
+    int force_stop;             // 是否强制停止 (0=false, 1=true)
+} StartGameArgs;
+
+typedef struct {
+    const char *client_type;
+} StopGameArgs;
+
+typedef struct {
+    const char *text;
+} InputArgs;
+
+typedef struct {
+    Position p;
+} TouchArgs;
+
+typedef struct {
+    int key_code;
+} KeyArgs;
+
+typedef union {
+    StartGameArgs start_game;
+    StopGameArgs stop_game;
+    InputArgs input;
+    TouchArgs touch;
+    KeyArgs key;
+} ArgUnion;
+
+typedef struct {
+    int display_id;
+    MethodType method;
+    ArgUnion args;
+} MethodParam;
+
+class AndroidExternalLib
+{
+public:
+    static AndroidExternalLib& instance();
+
+    static bool load(const std::string& library_path);
+
+    AndroidExternalLib(const AndroidExternalLib&) = delete;
+    AndroidExternalLib& operator=(const AndroidExternalLib&) = delete;
+
+    ~AndroidExternalLib();
+
+
+    FrameInfo GetLockedPixels(void) const;
+
+
+    int UnlockPixels(FrameInfo info) const;
+
+    void* AttachThread() const;
+
+    int DetachThread(void* env) const;
+
+    int DispatchInputMessage(MethodParam param) const;
+
+    bool is_loaded() const;
+
+private:
+    AndroidExternalLib();
+
+    bool load_library(const std::string& library_path);
+    bool resolve_symbols();
+    void clear_symbols();
+
+    void* m_handle = nullptr;
+    std::string m_library_path;
+    bool m_loaded = false;
+
+    typedef FrameInfo (*GetLockedPixels_t)(void);
+    typedef int (*UnlockPixels_t)(FrameInfo);
+    typedef void* (*AttachThread_t)(void);
+    typedef int (*DetachThread_t)(void*);
+    typedef int (*DispatchInputMessage_t)(MethodParam);
+
+    struct FunctionPointers {
+        GetLockedPixels_t get_locked_pixels = nullptr;
+        UnlockPixels_t unlock_pixels = nullptr;
+        AttachThread_t attach_thread = nullptr;
+        DetachThread_t detach_thread = nullptr;
+        DispatchInputMessage_t dispatch_input_message = nullptr;
+    } m_funcs;
+
+    static AndroidExternalLib* s_instance;
+};
+
+} // namespace asst
+
+#endif // __ANDROID__

--- a/src/MaaCore/Controller/Controller.cpp
+++ b/src/MaaCore/Controller/Controller.cpp
@@ -260,11 +260,14 @@ bool asst::Controller::connect(const std::string& adb_path, const std::string& a
     }
 #endif
 
+    // Android uses lazy loading; no need to check in advance
+#ifndef __ANDROID__
     // try to find the fastest way
     if (!screencap()) {
         Log.error("Cannot find a proper way to screencap!");
         return false;
     }
+#endif
 
     auto proxy_callback = [&](const json::object& details) {
         json::value connection_info = json::object {

--- a/src/MaaCore/Controller/Controller.cpp
+++ b/src/MaaCore/Controller/Controller.cpp
@@ -378,6 +378,11 @@ void asst::Controller::set_touch_mode(const TouchMode& mode) noexcept
     case TouchMode::MacPlayTools:
         m_controller_type = ControllerType::MacPlayTools;
         break;
+#ifdef __ANDROID__
+    case TouchMode::Android:
+        m_controller_type = ControllerType::Android;
+        break;
+#endif
     default:
         m_controller_type = ControllerType::Minitouch;
     }
@@ -409,7 +414,7 @@ cv::Mat asst::Controller::get_image(bool raw)
 {
     if (get_scale_size() == std::pair(0, 0)) {
         Log.error("Unknown image size");
-        return {};
+        return { };
     }
 
     // 有些模拟器adb偶尔会莫名其妙截图失败，多试几次
@@ -433,7 +438,7 @@ cv::Mat asst::Controller::get_image(bool raw)
             { "uuid", m_uuid },
             { "what", "ScreencapFailed" },
             { "why", "ScreencapFailed" },
-            { "details", json::object {} },
+            { "details", json::object { } },
         };
         callback(AsstMsg::ConnectionInfo, info);
 

--- a/src/MaaCore/Controller/Controller.cpp
+++ b/src/MaaCore/Controller/Controller.cpp
@@ -27,6 +27,10 @@
 #include "Win32Controller.h"
 #endif
 
+#ifdef __ANDROID__
+#include "Android/AndroidController.h"
+#endif
+
 #include "Common/AsstTypes.h"
 #include "Utils/Logger.hpp"
 
@@ -64,6 +68,12 @@ std::shared_ptr<asst::ControllerAPI> asst::Controller::create_controller(
         case ControllerType::MacPlayTools:
             controller = std::make_shared<PlayToolsController>(m_callback, m_inst, platform_type);
             break;
+#ifdef __ANDROID__
+        case ControllerType::Android:
+            Log.debug("Use Android");
+            controller = std::make_shared<AndroidController>(m_callback, m_inst);
+            break;
+#endif
         default:
             return nullptr;
         }

--- a/src/MaaCore/Controller/ControllerAPI.h
+++ b/src/MaaCore/Controller/ControllerAPI.h
@@ -18,6 +18,9 @@ enum class ControllerType
 #ifdef _WIN32
     Win32,
 #endif
+#ifdef __ANDROID__
+    Android,
+#endif
 };
 
 class ControllerAPI

--- a/src/MaaCore/Task/Miscellaneous/StartGameTaskPlugin.cpp
+++ b/src/MaaCore/Task/Miscellaneous/StartGameTaskPlugin.cpp
@@ -4,8 +4,13 @@
 
 using namespace asst;
 
-bool StartGameTaskPlugin::start_game_with_retries(size_t pipe_data_size_limit, bool newer_android) const
+bool StartGameTaskPlugin::start_game_with_retries([[maybe_unused]] size_t pipe_data_size_limit,
+                                                  [[maybe_unused]] bool newer_android) const
 {
+#ifdef __ANDROID__
+    // On Android, start_game returns true only after the game is actually started
+    return !need_exit() && ctrler()->start_game(m_client_type);
+#else
     int extra_runs = 0;
     for (int i = 0; i < 30; ++i) {
         if (need_exit() || !ctrler()->start_game(m_client_type)) {
@@ -22,6 +27,7 @@ bool StartGameTaskPlugin::start_game_with_retries(size_t pipe_data_size_limit, b
     }
 
     return false;
+#endif
 }
 
 bool StartGameTaskPlugin::_run()

--- a/src/MaaCore/Utils/Logger.hpp
+++ b/src/MaaCore/Utils/Logger.hpp
@@ -251,7 +251,7 @@ public:
     }
 
 private:
-    std::vector<id> m_state {};
+    std::vector<id> m_state { };
 };
 } // namespace detail
 
@@ -320,7 +320,7 @@ public:
     requires has_stream_insertion_operator<std::ostream, T>
     ostreams& operator<<(T&& x)
     {
-        streams_put(m_ofss, x, std::index_sequence_for<Args...> {});
+        streams_put(m_ofss, x, std::index_sequence_for<Args...> { });
         return *this;
     }
 
@@ -332,7 +332,7 @@ public:
 
     ostreams& operator<<(std::ostream& (*pf)(std::ostream&))
     {
-        streams_put(m_ofss, pf, std::index_sequence_for<Args...> {});
+        streams_put(m_ofss, pf, std::index_sequence_for<Args...> { });
         return *this;
     }
 
@@ -476,7 +476,7 @@ public:
 #else
                 int pid = ::getpid();
 #endif
-                auto tid = static_cast<uint16_t>(std::hash<std::thread::id> {}(std::this_thread::get_id()));
+                auto tid = static_cast<uint16_t>(std::hash<std::thread::id> { }(std::this_thread::get_id()));
 
                 s << std::format("[{}][{}][Px{}][Tx{}]", MAA_NS::format_now(), v.str, pid, tid);
             }
@@ -491,7 +491,7 @@ public:
             }
             else if constexpr (std::ranges::input_range<T>) {
                 s << "[";
-                std::string_view comma_space {};
+                std::string_view comma_space { };
                 for (const auto& elem : std::forward<T>(v)) {
                     s << comma_space;
                     stream_put(s, elem);
@@ -979,11 +979,14 @@ private:
         // Windows: 设置未处理异常过滤器
         SetUnhandledExceptionFilter(unhandled_exception_filter);
 #endif
-
+// android not need this
+#ifndef __ANDROID__
         std::signal(SIGSEGV, signal_handler);
         std::signal(SIGABRT, signal_handler);
         std::signal(SIGFPE, signal_handler);
         std::signal(SIGILL, signal_handler);
+#endif
+
 #ifdef ASST_DEBUG
         const auto& path = UserDir.get() / "debug" / "crash.log";
         if (std::filesystem::exists(path)) {
@@ -1032,7 +1035,7 @@ private:
     std::ostream m_of;
     std::size_t m_file_size = 0;
 
-    static inline utils::NullStreambuf null_buf {};
+    static inline utils::NullStreambuf null_buf { };
     static inline std::ostream null_stream { &null_buf };
     const std::size_t MaxLogSize = 64LL * 1024 * 1024;
 };

--- a/src/MaaCore/Utils/Logger.hpp
+++ b/src/MaaCore/Utils/Logger.hpp
@@ -4,7 +4,12 @@
 #include <fcntl.h>
 #include <io.h>
 #endif
+#include <atomic>
+#include <array>
 #include <csignal>
+#include <cstdint>
+#include <cstdlib>
+#include <exception>
 #include <filesystem>
 #include <format>
 #include <fstream>
@@ -15,6 +20,7 @@
 #include <streambuf>
 #include <thread>
 #include <type_traits>
+#include <typeinfo>
 #include <utility>
 
 #include "Common/AsstTypes.h"
@@ -29,6 +35,14 @@
 
 #if defined(__APPLE__) || defined(__linux__)
 #include <unistd.h>
+#endif
+
+#ifdef __ANDROID__
+#include <android/log.h>
+#include <dlfcn.h>
+#include <unwind.h>
+
+#include "Demangle.hpp"
 #endif
 
 namespace asst
@@ -839,7 +853,23 @@ private:
         trace("-----------------------------");
     }
 
-    inline static std::atomic<const char*> g_last_signal_reason { nullptr };
+    inline static std::atomic<int> g_last_signal { 0 };
+
+    static std::string format_signal_reason(int sig)
+    {
+        switch (sig) {
+        case SIGSEGV:
+            return "SIGSEGV (Segmentation Fault)";
+        case SIGABRT:
+            return "SIGABRT (Abort)";
+        case SIGFPE:
+            return "SIGFPE (Floating Point Error)";
+        case SIGILL:
+            return "SIGILL (Illegal Instruction)";
+        default:
+            return std::format("Signal {}", sig);
+        }
+    }
 
     static void write_crash_file(const char* reason, const char* detail = nullptr) noexcept
     {
@@ -897,6 +927,103 @@ private:
     }
 #endif
 
+#ifdef __ANDROID__
+    static constexpr const char* AndroidCrashLogTag = "MaaCoreCrash";
+
+    struct AndroidBacktraceState
+    {
+        void** current = nullptr;
+        void** end = nullptr;
+    };
+
+    static _Unwind_Reason_Code android_unwind_callback(_Unwind_Context* context, void* arg) noexcept
+    {
+        auto* state = static_cast<AndroidBacktraceState*>(arg);
+        if (state == nullptr || state->current == state->end) {
+            return _URC_END_OF_STACK;
+        }
+
+        const auto pc = reinterpret_cast<void*>(_Unwind_GetIP(context));
+        if (pc == nullptr) {
+            return _URC_NO_REASON;
+        }
+
+        *state->current++ = pc;
+        return _URC_NO_REASON;
+    }
+
+    static std::size_t capture_android_backtrace(void** frames, std::size_t max_frames) noexcept
+    {
+        AndroidBacktraceState state {
+            .current = frames,
+            .end = frames + max_frames,
+        };
+
+        _Unwind_Backtrace(android_unwind_callback, &state);
+        return static_cast<std::size_t>(state.current - frames);
+    }
+
+    static void log_android_crash_signal(const char* signal_reason) noexcept
+    {
+        __android_log_write(ANDROID_LOG_FATAL, AndroidCrashLogTag, "=== FATAL ERROR ===");
+        if (signal_reason != nullptr) {
+            __android_log_print(ANDROID_LOG_FATAL, AndroidCrashLogTag, "Fatal Signal: %s", signal_reason);
+        }
+        __android_log_write(ANDROID_LOG_FATAL, AndroidCrashLogTag, "===================");
+    }
+
+    static void log_android_crash_terminate(const char* exception_info) noexcept
+    {
+        __android_log_write(ANDROID_LOG_FATAL, AndroidCrashLogTag, "=== FATAL ERROR ===");
+        if (exception_info != nullptr) {
+            __android_log_print(ANDROID_LOG_FATAL, AndroidCrashLogTag, "Unhandled exception: %s", exception_info);
+        }
+        __android_log_write(ANDROID_LOG_FATAL, AndroidCrashLogTag, "===================");
+    }
+
+    static void dump_android_stacktrace(Logger& logger) noexcept
+    {
+        std::array<void*, 32> frames { };
+        const auto frame_count = capture_android_backtrace(frames.data(), frames.size());
+
+        std::size_t frame_start = 0;
+        while (frame_start < frame_count && frames[frame_start] == nullptr) {
+            ++frame_start;
+        }
+        if (frame_start < frame_count) {
+            ++frame_start; // Skip the helper frame itself.
+        }
+
+        const auto dump_count = frame_count > frame_start ? frame_count - frame_start : 0;
+        __android_log_print(ANDROID_LOG_FATAL, AndroidCrashLogTag, "Native backtrace (%zu frames):", dump_count);
+        logger.error("Native backtrace", dump_count, "frames");
+
+        for (std::size_t i = frame_start; i < frame_count; ++i) {
+            Dl_info info { };
+            std::string frame_message;
+            if (dladdr(frames[i], &info) != 0 && info.dli_sname != nullptr) {
+                const auto symbol_name = utils::demangle(info.dli_sname);
+                const auto base = reinterpret_cast<std::uintptr_t>(info.dli_saddr);
+                const auto pc = reinterpret_cast<std::uintptr_t>(frames[i]);
+                const auto offset = pc >= base ? pc - base : 0;
+                frame_message = std::format(
+                    "#{:02} pc {:p} {} ({}+0x{:x})",
+                    i - frame_start,
+                    frames[i],
+                    info.dli_fname != nullptr ? info.dli_fname : "<unknown>",
+                    symbol_name,
+                    offset);
+            }
+            else {
+                frame_message = std::format("#{:02} pc {:p}", i - frame_start, frames[i]);
+            }
+
+            __android_log_write(ANDROID_LOG_FATAL, AndroidCrashLogTag, frame_message.c_str());
+            logger.error(frame_message);
+        }
+    }
+#endif
+
     static void custom_terminate_handler() noexcept
     {
         static bool in_handler = false;
@@ -905,18 +1032,13 @@ private:
         }
         in_handler = true;
 
+        const int last_signal = g_last_signal.exchange(0);
+        std::string signal_info;
+        if (last_signal != 0) {
+            signal_info = format_signal_reason(last_signal);
+        }
+
         try {
-            auto& logger = Logger::get_instance();
-
-            // 先写信号信息
-            if (auto sig_reason = g_last_signal_reason.load()) {
-                logger.error("=== FATAL ERROR ===");
-                logger.error("Signal caught:", sig_reason);
-                logger.flush();
-                write_crash_file("Fatal Signal", sig_reason);
-            }
-
-            // 再处理 C++ 异常
             std::string exception_info = "Unknown exception";
             if (auto eptr = std::current_exception()) {
                 try {
@@ -930,11 +1052,29 @@ private:
                 }
             }
 
+#ifdef __ANDROID__
+            if (last_signal == 0) {
+                log_android_crash_terminate(exception_info.c_str());
+            }
+#endif
+
+            auto& logger = Logger::get_instance();
+
+            if (!signal_info.empty()) {
+                logger.error("=== FATAL ERROR ===");
+                logger.error("Signal caught:", signal_info);
+                logger.flush();
+                write_crash_file("Fatal Signal", signal_info.c_str());
+            }
+
             logger.error("=== FATAL ERROR ===");
             logger.error("Version", MAA_VERSION);
             logger.error("Built at", __DATE__, __TIME__);
             logger.error("User Dir", UserDir.get());
             logger.error("Unhandled exception caught:", exception_info);
+#ifdef __ANDROID__
+            dump_android_stacktrace(logger);
+#endif
             logger.error("Program terminating...");
             logger.error("===================");
             logger.flush();
@@ -950,28 +1090,22 @@ private:
 
     static void signal_handler(int sig)
     {
-        std::string sig_name;
-        switch (sig) {
-        case SIGSEGV:
-            sig_name = "SIGSEGV (Segmentation Fault)";
-            break;
-        case SIGABRT:
-            sig_name = "SIGABRT (Abort)";
-            break;
-        case SIGFPE:
-            sig_name = "SIGFPE (Floating Point Error)";
-            break;
-        case SIGILL:
-            sig_name = "SIGILL (Illegal Instruction)";
-            break;
-        default:
-            sig_name = "Signal " + std::to_string(sig);
-            break;
-        }
-        g_last_signal_reason.store(sig_name.c_str());
+        const auto signal_reason = format_signal_reason(sig);
+#ifdef __ANDROID__
+        log_android_crash_signal(signal_reason.c_str());
+#endif
+        g_last_signal.store(sig);
         custom_terminate_handler();
         std::_Exit(EXIT_FAILURE);
     }
+
+#ifdef __ANDROID__
+    [[noreturn]] static void android_terminate_handler() noexcept
+    {
+        custom_terminate_handler();
+        std::_Exit(EXIT_FAILURE);
+    }
+#endif
 
     static void initialize_exception_handlers()
     {
@@ -979,13 +1113,13 @@ private:
         // Windows: 设置未处理异常过滤器
         SetUnhandledExceptionFilter(unhandled_exception_filter);
 #endif
-// android not need this
-#ifndef __ANDROID__
+#ifdef __ANDROID__
+        std::set_terminate(android_terminate_handler);
+#endif
         std::signal(SIGSEGV, signal_handler);
         std::signal(SIGABRT, signal_handler);
         std::signal(SIGFPE, signal_handler);
         std::signal(SIGILL, signal_handler);
-#endif
 
 #ifdef ASST_DEBUG
         const auto& path = UserDir.get() / "debug" / "crash.log";


### PR DESCRIPTION
## What

  为 MaaCore 添加 Android 原生平台支持，使其可以直接在 Android 设备上运行，而非仅通过 ADB 控制
  具体实现为 [MAA-Meow](https://github.com/Aliothmoon/MAA-Meow)

  ## Changes

  ### Android Controller (`src/MaaCore/Controller/Android/`)

  - **AndroidController**: 实现 `ControllerAPI`
  接口，支持截图（`screencap`）、点击（`click`）、滑动（`swipe`）、输入（`input`）、启动/停止游戏等操作。截图通过
  `GetLockedPixels` 获取 RGBA 帧数据并转换为 OpenCV Mat；触控操作通过 `DispatchInputMessage` 分发
  - **AndroidExternalLib**: 通过 `dlopen`/`dlsym` 动态加载外部 .so 库，解析
  `GetLockedPixels`、`UnlockPixels`、`AttachThread`、`DetachThread`、`DispatchInputMessage` 五个函数， 通过
  `StaticOptionKey::AndroidExternalLib` 在运行时指定库

  ### Build

  - `CMakeLists.txt`: 添加 Android 编译选项（`-ffunction-sections -fdata-sections`、`-Wl,--gc-sections`），构建后自动
  strip
  - `CMakePresets.json`: 新增 `android-arm64`、`android-x64` 及对应的 publish presets，基于 NDK toolchain 交叉编译。
  - `src/MaaCore/CMakeLists.txt`: 添加 Android strip post-build 步骤

  ### Core

  - `AsstTypes.h`: 新增 `TouchMode::Android`、`StaticOptionKey::AndroidExternalLib`
  - `Assistant.cpp`: `set_static_option` 处理 `AndroidExternalLib` 加载；`set_instance_option` 处理
  `TouchMode::Android`
  - `AsstCaller.h` / `AsstCaller.cpp`: 条件编译 `__ANDROID__` 下的控制器创建路径

  ### CI

  - `.github/workflows/ci.yml`: 新增 `android` job，在 `macos-26` runner 上使用 NDK r29 交叉编译 arm64 和
  x64，产物上传为 `MAA-android-{arch}.tar.gz`；release job 加入 android 依赖

  ## Note

  所有 Android 相关代码均通过 `#ifdef __ANDROID__` 条件编译隔离，不影响现有 Windows/Linux/macOS 平台的构建和行为

## Summary by Sourcery

为 MaaCore 添加原生 Android 平台支持，包括新的控制器实现、对外部 Android 库的动态链接，以及面向 Android 目标的平台构建与 CI 配置。

New Features:
- 引入 `AndroidController` 实现，使其在 Android 设备上支持直接截屏、触摸、滑动、键盘输入以及游戏生命周期控制。
- 添加 `AndroidExternalLib` 抽象，用于动态加载提供屏幕捕获、输入分发以及线程附加/分离钩子的外部 `.so` 库。
- 扩展核心配置，以便选择 Android 触控模式，并在运行时指定外部 Android 库路径。

Enhancements:
- 将控制器工厂和助手工作流接入 Android 控制器的创建与使用，并在回调循环中管理 Android 特有的线程附加。
- 调整信号处理和部分工具默认值，以确保核心日志与崩溃处理兼容 Android 构建。
- 简化 Android 上的“启动游戏重试”行为，使其与平台原生启动语义保持一致。

Build:
- 添加 Android 专用的编译器和链接器选项（包括 dead-code stripping），并为 MaaCore 二进制文件引入 Android 平台的 strip 构建后步骤。
- 扩展顶层 CMake 和 CMakePresets，使其支持使用 NDK 工具链为 `android-arm64` 和 `android-x64` 交叉编译 MaaCore。

CI:
- 添加 GitHub Actions 中的 Android 任务，使用 NDK r29 为 arm64 和 x64 交叉编译 MaaCore，打包构建产物并作为 Android tarball 上传。
- 更新发布工作流，使其依赖 Android 构建并在打标签发布时包含 Android 构建产物。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add native Android platform support to MaaCore, including a new controller implementation, dynamic linkage to an external Android library, and CI/build plumbing for Android targets.

New Features:
- Introduce an AndroidController implementation that enables direct on-device screenshot, touch, swipe, keyboard input, and game lifecycle control on Android.
- Add an AndroidExternalLib abstraction to dynamically load an external .so providing screen capture, input dispatch, and thread attach/detach hooks for Android.
- Extend core configuration to select an Android touch mode and to specify the external Android library path at runtime.

Enhancements:
- Wire the controller factory and assistant workflow to create and use the Android controller and to manage Android-specific thread attachment in the callback loop.
- Adjust signal handling and minor utility defaults so core logging and crash handling are compatible with Android builds.
- Simplify start-game retry behavior on Android by aligning it with the platform’s native start semantics.

Build:
- Add Android-specific compiler and linker options, including dead-code stripping, and introduce an Android strip post-build step for MaaCore binaries.
- Extend the top-level CMake and CMakePresets to support cross-compiling MaaCore for android-arm64 and android-x64 using the NDK toolchain.

CI:
- Add a GitHub Actions android job that cross-compiles MaaCore for arm64 and x64 with NDK r29, packages the artifacts, and uploads them as Android tarballs.
- Update the release workflow to depend on the Android build and include its artifacts in tagged releases.

</details>