### PR TITLE
fix: 超出范围的Rect使用{0, 0, 0, 0}代替原样返回, x, y为负值时width和height改正错误

### DIFF
--- a/src/MaaCore/Vision/VisionHelper.cpp
+++ b/src/MaaCore/Vision/VisionHelper.cpp
@@ -83,7 +83,7 @@ Rect VisionHelper::correct_rect(const Rect& rect, const cv::Mat& image)
     if (rect.empty()) {
         return { 0, 0, image.cols, image.rows };
     }
-    if (rect.x >= image.cols || rect.y >= image.rows) {
+    if (rect.x >= image.cols || rect.y >= image.rows || rect.x + rect.width < 0 || rect.y + rect.height < 0) {
         Log.error(__FUNCTION__, "roi is out of range", image.cols, image.rows, rect.to_string());
         return { 0, 0, 0, 0 };
     }


### PR DESCRIPTION
## Summary by Sourcery

调整矩形校正逻辑，以更安全地处理超出范围和带负坐标的矩形。

Bug 修复：
- 当请求的 ROI 完全在图像边界之外时，返回一个空的 `{0,0,0,0}` 矩形，而不是原始矩形。
- 当对负的 x 或 y 进行限制（clamp）时，重新计算宽度和高度，以确保校正后的矩形尺寸在图像范围内保持一致且有效。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust rectangle correction logic to handle out-of-range and negative-coordinate rectangles more safely.

Bug Fixes:
- Return an empty {0,0,0,0} rectangle instead of the original when the requested ROI is completely outside the image bounds.
- Recalculate width and height when clamping negative x or y so that the corrected rectangle size remains consistent and valid within image bounds.

</details>