### PR TITLE
ci: PR中的ci尝试以Merge后的结果进行测试

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,8 +107,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          fetch-depth: ${{ github.event_name == 'pull_request' && 0 || 1 }}
           show-progress: false
+          fetch-depth: ${{ github.event_name != 'pull_request' && 1 || 0 }}
 
       - name: Merge target branch into PR
         if: github.event_name == 'pull_request'
@@ -243,8 +243,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          fetch-depth: ${{ github.event_name == 'pull_request' && 0 || 1 }}
           show-progress: false
+          fetch-depth: ${{ github.event_name != 'pull_request' && 1 || 0 }}
 
       - name: Merge target branch into PR
         if: github.event_name == 'pull_request'
@@ -360,8 +360,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          fetch-depth: ${{ github.event_name == 'pull_request' && 0 || 1 }}
           show-progress: false
+          fetch-depth: ${{ github.event_name != 'pull_request' && 1 || 0 }}
 
       - name: Merge target branch into PR
         if: github.event_name == 'pull_request'
@@ -415,17 +415,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          fetch-depth: ${{ github.event_name == 'pull_request' && 0 || 1 }}
           show-progress: false
-
-      - name: Merge target branch into PR
-        if: github.event_name == 'pull_request'
-        run: |
-          git fetch origin ${{ github.event.pull_request.base.ref }}
-          git config user.email "actions@github.com"
-          git config user.name "github-actions"
-          git checkout ${{ github.event.pull_request.head.sha }}
-          git merge origin/${{ github.event.pull_request.base.ref }} --no-edit || { git merge --abort; echo "::warning::Merge had conflicts, skipped. CI is running on PR head without merging target branch."; exit 0; }
 
       - name: Install dependencies
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
+          fetch-depth: ${{ github.event_name == 'pull_request' && 0 || 1 }}
           show-progress: false
+
+      - name: Merge target branch into PR
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "actions@github.com"
+          git config user.name "github-actions"
+          git checkout ${{ github.event.pull_request.head.sha }}
+          git merge origin/${{ github.event.pull_request.base.ref }} --no-edit || { git merge --abort; echo "::warning::Merge had conflicts, skipped. CI is running on PR head without merging target branch."; exit 0; }
 
       - name: Fetch submodules
         run: |
@@ -233,7 +243,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
+          fetch-depth: ${{ github.event_name == 'pull_request' && 0 || 1 }}
           show-progress: false
+
+      - name: Merge target branch into PR
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "actions@github.com"
+          git config user.name "github-actions"
+          git checkout ${{ github.event.pull_request.head.sha }}
+          git merge origin/${{ github.event.pull_request.base.ref }} --no-edit || { git merge --abort; echo "::warning::Merge had conflicts, skipped. CI is running on PR head without merging target branch."; exit 0; }
 
       - name: Fetch submodules
         run: |
@@ -340,7 +360,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
+          fetch-depth: ${{ github.event_name == 'pull_request' && 0 || 1 }}
           show-progress: false
+
+      - name: Merge target branch into PR
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "actions@github.com"
+          git config user.name "github-actions"
+          git checkout ${{ github.event.pull_request.head.sha }}
+          git merge origin/${{ github.event.pull_request.base.ref }} --no-edit || { git merge --abort; echo "::warning::Merge had conflicts, skipped. CI is running on PR head without merging target branch."; exit 0; }
 
       - name: Fetch submodules
         run: |
@@ -385,7 +415,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
         with:
+          fetch-depth: ${{ github.event_name == 'pull_request' && 0 || 1 }}
           show-progress: false
+
+      - name: Merge target branch into PR
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "actions@github.com"
+          git config user.name "github-actions"
+          git checkout ${{ github.event.pull_request.head.sha }}
+          git merge origin/${{ github.event.pull_request.base.ref }} --no-edit || { git merge --abort; echo "::warning::Merge had conflicts, skipped. CI is running on PR head without merging target branch."; exit 0; }
 
       - name: Install dependencies
         if: startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/smoke-testing.yml
+++ b/.github/workflows/smoke-testing.yml
@@ -47,6 +47,15 @@ jobs:
         with:
           show-progress: false
 
+      - name: Merge target branch into PR
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "actions@github.com"
+          git config user.name "github-actions"
+          git checkout ${{ github.event.pull_request.head.sha }}
+          git merge origin/${{ github.event.pull_request.base.ref }} --no-edit || { git merge --abort; echo "::warning::Merge had conflicts, skipped. CI is running on PR head without merging target branch."; exit 0; }
+
       - name: Generate cache key
         id: cache_key
         continue-on-error: true

--- a/.github/workflows/smoke-testing.yml
+++ b/.github/workflows/smoke-testing.yml
@@ -46,6 +46,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           show-progress: false
+          fetch-depth: ${{ github.event_name != 'pull_request' && 1 || 0 }}
 
       - name: Merge target branch into PR
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

对目标分支的合并视图运行拉取请求（pull request）的 CI，以更好地检测集成问题。

CI：
- 调整 `pull_request` 工作流的检出深度，以便在运行 CI 之前可以合并目标分支。
- 在 CI 和冒烟测试工作流中，将 PR 的基础分支合并到 PR 的头分支中；如果发生合并冲突，则回退为仅测试 PR 头分支。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI：
- 更新 CI 和冒烟测试工作流，在运行检查之前先将 PR 的基准分支合并到头部分支；如果发生合并冲突，则回退为仅对头部分支进行测试。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Update CI and smoke-testing workflows to merge the PR base branch into the head before running checks, falling back to testing the head alone if merge conflicts occur.

</details>

</details>