### PR TITLE
fix: 处理通宝置换/投钱后可能出现的藏品/通宝获得弹窗

### DIFF
--- a/resource/tasks/Roguelike/JieGarden.json
+++ b/resource/tasks/Roguelike/JieGarden.json
@@ -117,7 +117,8 @@
             "JieGarden@Roguelike@Stages#next",
             "JieGarden@Roguelike@DropsFlag",
             "JieGarden@Roguelike@CloseEvent",
-            "JieGarden@Roguelike@ChooseOperFlag"
+            "JieGarden@Roguelike@ChooseOperFlag",
+            "JieGarden@Roguelike@CoppersAfterAction"
         ]
     },
     "JieGarden@Roguelike@CloseCollectionContinue": {
@@ -128,7 +129,8 @@
             "JieGarden@Roguelike@Stages#next",
             "JieGarden@Roguelike@DropsFlag",
             "JieGarden@Roguelike@CloseEvent",
-            "JieGarden@Roguelike@ChooseOperFlag"
+            "JieGarden@Roguelike@ChooseOperFlag",
+            "JieGarden@Roguelike@CoppersAfterAction"
         ]
     },
     "JieGarden@Roguelike@CloseEvent": {
@@ -242,7 +244,7 @@
         "Doc": "交换通宝的确认按钮",
         "baseTask": "JieGarden@Roguelike@CoppersListDialogConfirm",
         "template": "JieGarden@Roguelike@CoppersListDialogConfirm.png",
-        "next": ["JieGarden@Roguelike@CoppersExchangeFinish", "#self"]
+        "next": ["JieGarden@Roguelike@CoppersAfterAction", "#self"]
     },
     "JieGarden@Roguelike@CoppersExchangeFinish": {
         "Doc": "通宝交换完成后的交换按钮 (用于确认交换操作完成)",
@@ -365,14 +367,25 @@
         "baseTask": "JieGarden@Roguelike@CoppersListDialogConfirm",
         "template": "JieGarden@Roguelike@CoppersListDialogConfirm.png",
         "postDelay": 3000,
-        "next": ["JieGarden@Roguelike@CoppersRecastResult", "#self"]
+        "next": ["JieGarden@Roguelike@CoppersRecastResult", "JieGarden@Roguelike@CoppersAfterAction", "#self"]
     },
     "JieGarden@Roguelike@CoppersRecastResult": {
         "Doc": "点击投钱结果界面的对号 有时延迟时间比较长会失败 目前依赖retry_times有20次兜底",
         "action": "ClickSelf",
         "template": "JieGarden@Roguelike@StageEncounterDrawCopperResult.png",
         "postDelay": 500,
-        "roi": [1033, 462, 153, 155]
+        "roi": [1033, 462, 153, 155],
+        "next": ["JieGarden@Roguelike@CoppersAfterAction", "#self"]
+    },
+    "JieGarden@Roguelike@CoppersAfterAction": {
+        "template": "empty.png",
+        "Doc": "通宝操作完成后的跳转逻辑",
+        "next": [
+            "JieGarden@Roguelike@CoppersExchangeFinish",
+            "JieGarden@Roguelike@CoppersRecastConfirm",
+            "JieGarden@Roguelike@CloseCollectionContinue",
+            "JieGarden@Roguelike@CloseCollectionClose"
+        ]
     },
     "JieGarden@Roguelike@CoppersTakeConfirm": {
         "Doc": "交换通宝确认按钮 (用于插件 RoguelikeCoppersTaskPlugin 的确认操作)",


### PR DESCRIPTION
适配dlc2的新通宝"厉-勾吴盛景“和”花-得见繁花“在处理通宝时可能出现的藏品/通宝获得弹窗
fix #15485 
fix #15724

## Summary by Sourcery

调整 roguelike JieGarden 任务配置，以解决在通宝交换或投币操作后出现的错误奖励弹窗问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust roguelike JieGarden task configuration to address incorrect reward popups after currency exchange or coin insertion actions.

</details>