### PR TITLE
fix: invert dice refresh with invest system priority in IS3

### DIFF
--- a/resource/global/YoStarEN/resource/tasks/Roguelike/base.json
+++ b/resource/global/YoStarEN/resource/tasks/Roguelike/base.json
@@ -1197,9 +1197,6 @@
         ],
         "roi": [0, 395, 725, 235]
     },
-    "Roguelike@StageTraderInvestSystem": {
-        "maskRange": [1, 255]
-    },
     "Roguelike@StageTraderInvestSystemFull": {
         "text": ["Storage full"]
     },

--- a/resource/tasks/Roguelike/base.json
+++ b/resource/tasks/Roguelike/base.json
@@ -1419,8 +1419,8 @@
         "next": [
             "Roguelike@StageVerticalConfirmTrader",
             "Roguelike@StageTraderEnter",
-            "Roguelike@StageTraderRefreshWithDice",
             "Roguelike@StageTraderInvestSystem",
+            "Roguelike@StageTraderRefreshWithDice",
             "Roguelike@TraderRandomShopping",
             "Roguelike@StageTraderLeave",
             "Roguelike@StageTraderLeaveConfirm"
@@ -1556,8 +1556,8 @@
         "next": [
             "Roguelike@StageTraderSpecialShoppingAfterRefresh",
             "Roguelike@StageTraderRefreshWithDice",
-            "Roguelike@TraderRandomShopping",
             "Roguelike@StageTraderInvestSystem",
+            "Roguelike@TraderRandomShopping",
             "Roguelike@StageTraderLeave",
             "Roguelike@StageTraderRefreshWithDiceDoubleConfirm"
         ]
@@ -1604,8 +1604,8 @@
         "baseTask": "Roguelike@StageVerticalConfirm",
         "next": [
             "Roguelike@StageTraderEnter",
-            "Roguelike@StageTraderRefreshWithDice",
             "Roguelike@StageTraderInvestSystem",
+            "Roguelike@StageTraderRefreshWithDice",
             "Roguelike@TraderRandomShopping",
             "Roguelike@StageTraderLeave"
         ]


### PR DESCRIPTION
fix #15735

## Summary by Sourcery

Bug Fixes:
- 通过更新 Roguelike 任务资源，修复了 IS3 中骰子刷新与投资系统优先级之间交互不正确的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix incorrect interaction between dice refresh and invest system priority in IS3 by updating roguelike task resources.

</details>