### PR TITLE
fix: 修复了 信用收支-拜访好友 在未触发访问上限时在无可收菜好友时大概率不会进入下一任务的问题

### DIFF
--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -2097,6 +2097,7 @@
     },
     "VisitNextOcr": {
         "algorithm": "OcrDetect",
+        "action": "ClickSelf",
         "text": ["访问下位"],
         "roi": [1080, 570, 200, 130],
         "next": ["VisitLimited", "VisitNext", "VisitNextBlack", "VisitNextOcr"]


### PR DESCRIPTION
此改动存在破坏性，移除了ocr的failback，原因是在部分场景下图像匹配会因为按钮是半透明的导致匹配失败落入ocr路径，极端情况下会一直访问到没有可访问的好友。本修改加宽了识别范围，但又不至于导致误识别，提高普通模板识别的成功率，以抵消移除failback的后果

