### PR TITLE
feat: 添加Mac PlayTools Controller的截屏耗时记录

### DIFF
--- a/src/MaaCore/Controller/PlayToolsController.cpp
+++ b/src/MaaCore/Controller/PlayToolsController.cpp
@@ -404,16 +404,20 @@ void asst::PlayToolsController::recordScreencapCost(long long cost, bool success
 
     // 只在首次达到10次截图时统计并显示一次
     if (m_screencap_times > 9 && !m_screencap_cost_reported) {
-        m_screencap_cost_reported = true; // 标记已报告，后续不再显示
-        
         auto filtered_cost = m_screencap_cost | std::views::filter([](auto num) { return num > 0; });
-        if (filtered_cost.empty()) {
+        
+        // 检查是否有有效数据
+        if (std::ranges::begin(filtered_cost) == std::ranges::end(filtered_cost)) {
             return;
         }
 
+        m_screencap_cost_reported = true; // 标记已报告，后续不再显示
+
         // 过滤后的有效截图用时次数
         auto filtered_count = m_screencap_cost.size() - std::ranges::count(m_screencap_cost, -1);
-        auto [screencap_cost_min, screencap_cost_max] = std::ranges::minmax(filtered_cost);
+        auto [min_it, max_it] = std::ranges::minmax_element(filtered_cost);
+        auto screencap_cost_min = *min_it;
+        auto screencap_cost_max = *max_it;
 
         json::value info = json::object {
             { "uuid", get_uuid() },

--- a/src/MaaCore/Controller/PlayToolsController.h
+++ b/src/MaaCore/Controller/PlayToolsController.h
@@ -5,6 +5,7 @@
 
 #include <boost/asio/io_context.hpp>
 #include <boost/asio/ip/tcp.hpp>
+#include <deque>
 
 #include "Platform/PlatformFactory.h"
 
@@ -70,6 +71,10 @@ protected:
     std::string m_address;
     std::pair<int, int> m_screen_size = { 0, 0 };
 
+    std::deque<long long> m_screencap_cost; // 截图用时
+    int m_screencap_times = 0;              // 截图次数
+    bool m_screencap_cost_reported = false; // 是否已报告截图耗时
+    
     enum class TouchPhase
     {
         Began = 0,
@@ -93,5 +98,6 @@ private:
     bool check_version();
     bool fetch_screen_res();
     bool toucher_commit(const TouchPhase phase, const Point& p, const int delay);
+    void recordScreencapCost(long long cost, bool success);
 };
 } // namespace asst


### PR DESCRIPTION
## Problem

Mac 前端已经支持 `ScreencapCost` 的 Log 显示，但只有 ADB 模式下才有输出。
PlayCover 的连接方式下没有截屏耗时的统计。

## Change

添加 Mac 端使用 PlayTools Controller 连接 PlayCover 执行截图时的耗时记录。

<img width="580" height="297" alt="image" src="https://github.com/user-attachments/assets/13d27b46-463e-4320-b84f-4f8a5507e04b" />

## Test

没有单测，CI正常

<img width="869" height="231" alt="image" src="https://github.com/user-attachments/assets/74a9d833-4e44-4a64-a1c3-b666e3049d81" />

## Summary by Sourcery

为 Mac PlayTools 控制器与 PlayCover 的连接记录并上报截图延迟指标。

New Features:
- 跟踪基于 PlayTools 的截图的整体截屏耗时和成功状态，并在收集到足够样本后汇总上报指标。
- 对前几次 PlayTools 截图调用记录简要的分阶段性能拆分（请求、接收、转换）。

Enhancements:
- 关闭 PlayTools 连接时重置内部截图性能统计数据，避免会话之间出现陈旧数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Record and report screenshot latency metrics for Mac PlayTools Controller connections to PlayCover.

New Features:
- Track total screencap duration and success status for PlayTools-based screenshots and report aggregated metrics once after enough samples.
- Log a brief per-stage performance breakdown (request, receive, convert) for the first few PlayTools screencap calls.

Enhancements:
- Reset internal screencap performance statistics when closing the PlayTools connection to avoid stale data between sessions.

</details>