### PR TITLE
feat: 适配maafw新Win32触控方式

### DIFF
--- a/include/AsstCaller.h
+++ b/include/AsstCaller.h
@@ -30,6 +30,8 @@ typedef enum AsstWin32InputMethodEnum
     AsstWin32InputMethod_PostThreadMessage = 1 << 4,
     AsstWin32InputMethod_SendMessageWithCursorPos = 1 << 5,
     AsstWin32InputMethod_PostMessageWithCursorPos = 1 << 6,
+    AsstWin32InputMethod_SendMessageWithWindowPos = 1 << 7,
+    AsstWin32InputMethod_PostMessageWithWindowPos = 1 << 8,
 } AsstWin32InputMethodEnum;
 #endif
 

--- a/src/MaaCore/Common/AsstTypes.h
+++ b/src/MaaCore/Common/AsstTypes.h
@@ -85,6 +85,8 @@ constexpr Win32InputMethod LegacyEvent = 1ULL << 3;
 constexpr Win32InputMethod PostThreadMessage = 1ULL << 4;
 constexpr Win32InputMethod SendMessageWithCursorPos = 1ULL << 5;
 constexpr Win32InputMethod PostMessageWithCursorPos = 1ULL << 6;
+constexpr Win32InputMethod SendMessageWithWindowPos = 1ULL << 7;
+constexpr Win32InputMethod PostMessageWithWindowPos = 1ULL << 8;
 } // namespace Win32Input
 
 #endif // _WIN32

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -1265,6 +1265,8 @@ Before use, please ensure:
     <system:String x:Key="AttachWindowInputSeize">Seize (Foreground, More Stable)</system:String>
     <system:String x:Key="AttachWindowInputPostWithCursor">PostMessageWithCursor (Semi-background)</system:String>
     <system:String x:Key="AttachWindowInputSendWithCursor">SendMessageWithCursor (Semi-background, Backup)</system:String>
+    <system:String x:Key="AttachWindowInputPostWithWindowPos">PostMessageWithWindowPos (Background Window)</system:String>
+    <system:String x:Key="AttachWindowInputSendWithWindowPos">SendMessageWithWindowPos (Background Window, Backup)</system:String>
     <!--  !AsstProxy  -->
     <!--  TrayIcon  -->
     <system:String x:Key="ForceShow">Force display of MAA</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -1266,6 +1266,8 @@ MAA Team の開発リソースが限られているため、PC 対応は専任�
     <system:String x:Key="AttachWindowInputSeize">Seize（フォアグラウンド、より安定）</system:String>
     <system:String x:Key="AttachWindowInputPostWithCursor">PostMessageWithCursor（半バックグラウンド）</system:String>
     <system:String x:Key="AttachWindowInputSendWithCursor">SendMessageWithCursor（半バックグラウンド、予備）</system:String>
+    <system:String x:Key="AttachWindowInputPostWithWindowPos">PostMessageWithWindowPos（バックグラウンドウィンドウ）</system:String>
+    <system:String x:Key="AttachWindowInputSendWithWindowPos">SendMessageWithWindowPos（バックグラウンドウィンドウ、予備）</system:String>
     <!--  !AsstProxy  -->
     <!--  TrayIcon  -->
     <system:String x:Key="ForceShow">MAAの強制表示</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -1267,6 +1267,8 @@ MAA Team의 개발 인력이 제한되어 있어 PC 지원은 전담 관리가 �
     <system:String x:Key="AttachWindowInputSeize">Seize (포그라운드, 더 안정적)</system:String>
     <system:String x:Key="AttachWindowInputPostWithCursor">PostMessageWithCursor (반 백그라운드)</system:String>
     <system:String x:Key="AttachWindowInputSendWithCursor">SendMessageWithCursor (반 백그라운드, 백업)</system:String>
+    <system:String x:Key="AttachWindowInputPostWithWindowPos">PostMessageWithWindowPos (백그라운드 윈도우)</system:String>
+    <system:String x:Key="AttachWindowInputSendWithWindowPos">SendMessageWithWindowPos (백그라운드 윈도우, 백업)</system:String>
     <!--  !AsstProxy  -->
     <!--  TrayIcon  -->
     <system:String x:Key="ForceShow">MAA 강제 표시</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -1266,6 +1266,8 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="AttachWindowInputSeize">Seize（前台，更稳定）</system:String>
     <system:String x:Key="AttachWindowInputPostWithCursor">PostMessageWithCursor（半后台）</system:String>
     <system:String x:Key="AttachWindowInputSendWithCursor">SendMessageWithCursor（半后台，备用）</system:String>
+    <system:String x:Key="AttachWindowInputPostWithWindowPos">PostMessageWithWindowPos（后台窗口）</system:String>
+    <system:String x:Key="AttachWindowInputSendWithWindowPos">SendMessageWithWindowPos（后台窗口，备用）</system:String>
     <!--  !AsstProxy  -->
     <!--  TrayIcon  -->
     <system:String x:Key="ForceShow">强制显示MAA</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -1266,6 +1266,8 @@ C:\\leidian\\LDPlayer9\n
     <system:String x:Key="AttachWindowInputSeize">Seize（前台，更穩定）</system:String>
     <system:String x:Key="AttachWindowInputPostWithCursor">PostMessageWithCursor（半背景）</system:String>
     <system:String x:Key="AttachWindowInputSendWithCursor">SendMessageWithCursor（半背景，備用）</system:String>
+    <system:String x:Key="AttachWindowInputPostWithWindowPos">PostMessageWithWindowPos（後台視窗）</system:String>
+    <system:String x:Key="AttachWindowInputSendWithWindowPos">SendMessageWithWindowPos（後台視窗，備用）</system:String>
     <!--  !AsstProxy  -->
     <!--  TrayIcon  -->
     <system:String x:Key="ForceShow">強制顯示 MAA</system:String>

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/ConnectSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/ConnectSettingsUserControlModel.cs
@@ -1243,6 +1243,8 @@ public class ConnectSettingsUserControlModel : PropertyChangedBase
         new() { Display = LocalizationHelper.GetString("AttachWindowInputSeize"), Value = "1" },
         new() { Display = LocalizationHelper.GetString("AttachWindowInputPostWithCursor"), Value = "64" },
         new() { Display = LocalizationHelper.GetString("AttachWindowInputSendWithCursor"), Value = "32" },
+        new() { Display = LocalizationHelper.GetString("AttachWindowInputPostWithWindowPos"), Value = "256" },
+        new() { Display = LocalizationHelper.GetString("AttachWindowInputSendWithWindowPos"), Value = "128" },
     ];
 
     private string _attachWindowMouseMethod = ConfigurationHelper.GetValue(ConfigurationKeys.AttachWindowMouseMethod, "64"); // 默认 PostMessageWithCursorPos


### PR DESCRIPTION
## Summary by Sourcery

为新的基于窗口相对位置的 Win32 触摸/输入方法提供支持，并在 UI 配置选项中对其进行暴露。

新功能：
- 为使用窗口相对位置的 SendMessage/PostMessage 引入新的 Win32 输入方法标志。
- 在“附加窗口”鼠标设置 UI 中，将新的基于窗口位置的输入方法作为可选项进行暴露。

文档：
- 为新“附加窗口”输入方法在所有受支持的语言中添加本地化字符串。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for new Win32 touch/input methods based on window-relative positions and expose them in the UI configuration options.

New Features:
- Introduce new Win32 input method flags for SendMessage/PostMessage using window-relative positions.
- Expose the new window-position-based input methods as selectable options in the attach-window mouse settings UI.

Documentation:
- Add localization strings for the new attach-window input methods across supported languages.

</details>