### PR TITLE
docs: add windows vscode docs

### DIFF
--- a/docs/en-us/develop/development.md
+++ b/docs/en-us/develop/development.md
@@ -154,7 +154,27 @@ When using clangd, set `C_Cpp.intelliSenseEngine` to `disabled` to avoid conflic
 2. **CMake Tools**:
    - Select a Configure Preset from the status bar (e.g. `windows-x64`, `linux-x64`)
    - Select a Build Preset and run configure/build
-3. **clangd**: Works on Windows with MSVC without needing `compile_commands.json`. On Linux/macOS, presets enable `CMAKE_EXPORT_COMPILE_COMMANDS` and clangd uses `build/compile_commands.json` automatically
+3. **clangd**: On Linux/macOS, presets enable `CMAKE_EXPORT_COMPILE_COMMANDS` and clangd uses `build/compile_commands.json` automatically. On Windows, clangd's code completion and navigation require generating `compile_commands.json` first:
+
+   ::: warning clangd Setup on Windows
+   - In **VS Installer**, check **C++ Clang compiler for Windows** (clang-cl)
+   - Switch to the `windows-x64-clang` preset and run Configure once to generate `compile_commands.json` in `build/`, then clangd will work
+   - **This preset uses clang-cl instead of MSVC and cannot produce valid build artifacts**; switch back to `windows-x64` for actual builds
+   - clangd analyzes based on clang-cl; some code (e.g. MSVC-specific extensions) may show errors—these can be ignored and do not affect MSVC compilation
+
+   **Command-line preset switching example** (run from project root):
+
+   ```cmd
+   rem Generate compile_commands.json (Configure only, no build)
+   cmake --preset windows-x64-clang
+
+   rem Switch back to MSVC for actual build
+   cmake --preset windows-x64
+   cmake --build --preset windows-x64-RelWithDebInfo
+   ```
+
+   :::
+
 4. **Debugging**: The project includes `.vscode/launch.json` for launching MaaWpfGui or Debug Demo
 
 ### Build and Debug Shortcuts

--- a/docs/ja-jp/develop/development.md
+++ b/docs/ja-jp/develop/development.md
@@ -158,7 +158,27 @@ clangd を使用する場合、C/C++ 拡張機能の IntelliSense を無効化�
 
 1. VS Code でプロジェクトルートを開く
 2. **CMake Tools**：ステータスバーで Configure Preset（例：`windows-x64`、`linux-x64`）を選択し、Build Preset でビルドを実行
-3. **clangd**：Windows で MSVC を使用する場合、`compile_commands.json` がなくても clangd で開発可能。Linux/macOS ではプリセットで `CMAKE_EXPORT_COMPILE_COMMANDS` が有効となり、clangd は `build/compile_commands.json` を自動使用
+3. **clangd**：Linux/macOS ではプリセットで `CMAKE_EXPORT_COMPILE_COMMANDS` が有効となり、clangd は `build/compile_commands.json` を自動使用。Windows で clangd の補完・ナビゲーションを使う場合は、まず `compile_commands.json` を生成する必要があります：
+
+   ::: warning Windows での clangd 設定
+   - VS Installer で **C++ Clang コンパイラ for Windows**（clang-cl）をインストールに含める
+   - `windows-x64-clang` プリセットに切り替えて Configure を1回実行すると `build/` に `compile_commands.json` が生成され、clangd が利用可能になります
+   - **このプリセットは clang-cl を使用するため MSVC と異なり、ビルド成果物を直接生成できません**。実際のビルド時は `windows-x64` に切り替えてください
+   - clangd は clang-cl のコンパイル情報で解析するため、一部コード（MSVC 専用拡張など）でエラー表示が出る場合がありますが、無視して問題ありません。実際の MSVC ビルドには影響しません
+
+   **コマンドラインでのプリセット切り替え例**（プロジェクトルートで実行）：
+
+   ```cmd
+   rem compile_commands.json を生成（Configure のみ、ビルドなし）
+   cmake --preset windows-x64-clang
+
+   rem MSVC に戻して実際のビルドを行う
+   cmake --preset windows-x64
+   cmake --build --preset windows-x64-RelWithDebInfo
+   ```
+
+   :::
+
 4. **デバッグ**：プロジェクトには `.vscode/launch.json` が含まれており、MaaWpfGui や Debug Demo の起動が可能
 
 ### ビルドとデバッグのショートカット

--- a/docs/ko-kr/develop/development.md
+++ b/docs/ko-kr/develop/development.md
@@ -157,7 +157,27 @@ clangd 사용 시 C/C++ 확장의 IntelliSense를 비활성화(`C_Cpp.intelliSen
 
 1. VSCode에서 프로젝트 루트 열기
 2. **CMake Tools**: 상태 표시줄에서 Configure Preset(예: `windows-x64`, `linux-x64`) 선택 후 Build Preset으로 빌드 실행
-3. **clangd**: Windows에서 MSVC 사용 시 `compile_commands.json` 없이도 clangd로 개발 가능. Linux/macOS에서는 프리셋에서 `CMAKE_EXPORT_COMPILE_COMMANDS`가 활성화되어 clangd가 `build/compile_commands.json`을 자동 사용
+3. **clangd**: Linux/macOS에서는 프리셋에서 `CMAKE_EXPORT_COMPILE_COMMANDS`가 활성화되어 clangd가 `build/compile_commands.json`을 자동 사용합니다. Windows에서 clangd의 코드 완성 및 탐색 기능을 사용하려면 먼저 `compile_commands.json`을 생성해야 합니다:
+
+   ::: warning Windows에서 clangd 설정 안내
+   - VS Installer에서 **C++용 Clang 컴파일러 (Windows)**(clang-cl)를 선택하여 설치
+   - `windows-x64-clang` 프리셋으로 전환 후 Configure를 한 번 실행하면 `build/`에 `compile_commands.json`이 생성되며, 이후 clangd가 동작합니다
+   - **해당 프리셋은 clang-cl을 사용하므로 MSVC가 아니어서 실제 빌드 산출물을 생성할 수 없습니다**. 실제 빌드 시에는 `windows-x64`로 다시 전환해야 합니다
+   - clangd는 clang-cl의 컴파일 정보로 분석하므로, 일부 코드(예: MSVC 전용 확장)에서 오류가 표시될 수 있으나 무시해도 되며 실제 MSVC 빌드에는 영향을 주지 않습니다
+
+   **명령줄에서 프리셋 전환 예시** (프로젝트 루트에서 실행):
+
+   ```cmd
+   rem compile_commands.json 생성 (Configure만, 빌드 없음)
+   cmake --preset windows-x64-clang
+
+   rem MSVC로 전환하여 실제 빌드 수행
+   cmake --preset windows-x64
+   cmake --build --preset windows-x64-RelWithDebInfo
+   ```
+
+   :::
+
 4. **디버깅**: 프로젝트에 `.vscode/launch.json`이 포함되어 MaaWpfGui 또는 Debug Demo를 바로 실행 가능
 
 ### 빌드 및 디버깅 단축키

--- a/docs/zh-cn/develop/development.md
+++ b/docs/zh-cn/develop/development.md
@@ -154,7 +154,27 @@ icon: iconoir:developer
 2. 使用 **CMake Tools**：
    - 状态栏选择 Configure Preset（如 `windows-x64`、`linux-x64` 等）
    - 选择 Build Preset，执行配置与构建
-3. 使用 **clangd**：在 Windows 上配合 MSVC 使用时无需 `compile_commands.json` 即可正常开发。Linux/macOS 下预设已开启 `CMAKE_EXPORT_COMPILE_COMMANDS`，clangd 会自动使用 `build/compile_commands.json`
+3. 使用 **clangd**：Linux/macOS 下预设已开启 `CMAKE_EXPORT_COMPILE_COMMANDS`，clangd 会自动使用 `build/compile_commands.json`。在 Windows 上如需 clangd 的补全与跳转，需先生成 `compile_commands.json`：
+
+   ::: warning Windows 下 clangd 配置说明
+   - 在 VS Installer 中勾选安装 **用于 Windows 的 C++ Clang 编译器**（clang-cl）
+   - 需切换为 `windows-x64-clang` 执行一次 Configure 以在 `build/` 下生成 `compile_commands.json`，此后 clangd 即可使用
+   - **该 preset 使用 clang-cl 而非 MSVC，无法直接编译出可用产物**，实际构建时必须切回 `windows-x64`
+   - clangd 基于 clang-cl 的编译信息进行分析，部分代码（如 MSVC 特有扩展）可能仍会显示报错，可忽略，不影响实际 MSVC 编译
+
+   **命令行切换 preset 示例**（在项目根目录执行）：
+
+   ```cmd
+   rem 生成 compile_commands.json（仅 Configure，不构建）
+   cmake --preset windows-x64-clang
+
+   rem 切回 MSVC 进行实际构建
+   cmake --preset windows-x64
+   cmake --build --preset windows-x64-RelWithDebInfo
+   ```
+
+   :::
+
 4. **调试**：项目已包含 `.vscode/launch.json`，可直接启动 MaaWpfGui 或 Debug Demo 进行调试
 
 ### 快速构建与调试

--- a/docs/zh-tw/develop/development.md
+++ b/docs/zh-tw/develop/development.md
@@ -155,7 +155,27 @@ icon: iconoir:developer
 2. **CMake Tools**：
    - 於狀態列選擇 Configure Preset（如 `windows-x64`、`linux-x64` 等）
    - 選擇 Build Preset，執行設定與建置
-3. **clangd**：在 Windows 上搭配 MSVC 使用時無需 `compile_commands.json` 即可正常開發。Linux/macOS 下預設已開啟 `CMAKE_EXPORT_COMPILE_COMMANDS`，clangd 會自動使用 `build/compile_commands.json`
+3. **clangd**：Linux/macOS 下預設已開啟 `CMAKE_EXPORT_COMPILE_COMMANDS`，clangd 會自動使用 `build/compile_commands.json`。在 Windows 上如需 clangd 的補全與跳轉，需先生成 `compile_commands.json`：
+
+   ::: warning Windows 下 clangd 設定說明
+   - 在 VS Installer 中勾選安裝 **用於 Windows 的 C++ Clang 編譯器**（clang-cl）
+   - 需切換為 `windows-x64-clang` 執行一次 Configure 以在 `build/` 下生成 `compile_commands.json`，此後 clangd 即可使用
+   - **該 preset 使用 clang-cl 而非 MSVC，無法直接編譯出可用產物**，實際建置時必須切回 `windows-x64`
+   - clangd 基於 clang-cl 的編譯資訊進行分析，部分程式碼（如 MSVC 特有擴充）可能仍會顯示報錯，可忽略，不影響實際 MSVC 編譯
+
+   **命令列切換 preset 範例**（在專案根目錄執行）：
+
+   ```cmd
+   rem 生成 compile_commands.json（僅 Configure，不建置）
+   cmake --preset windows-x64-clang
+
+   rem 切回 MSVC 進行實際建置
+   cmake --preset windows-x64
+   cmake --build --preset windows-x64-RelWithDebInfo
+   ```
+
+   :::
+
 4. **除錯**：專案已包含 `.vscode/launch.json`，可直接啟動 MaaWpfGui 或 Debug Demo 進行除錯
 
 ### 快速建置與除錯


### PR DESCRIPTION
@Constrat I'm adding some development docs for #15758 ,but I dont have the write access so I have to open a PR for it.

## Summary by Sourcery

Documentation:
- 为 VS Code 添加 Windows clangd 的设置说明，包括使用 `windows-x64-clang` 预设在切换回用于实际构建的 MSVC 预设之前生成 `compile_commands.json`，并适用于所有受支持的语言。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Add Windows clangd setup instructions for VS Code, including use of the windows-x64-clang preset to generate compile_commands.json before switching back to MSVC presets for real builds in all supported languages.

</details>