### PR TITLE
fix(wpf): normalize chip stage inventory tip display

### DIFF
--- a/src/MaaWpfGui/Services/StageManager.cs
+++ b/src/MaaWpfGui/Services/StageManager.cs
@@ -699,29 +699,24 @@ public class StageManager
             // Drop groups tips (for chip stages like PR-A-1/2)
             if (stage.DropGroups != null && stage.DropGroups.Count > 0)
             {
-                var groupTexts = new List<string>();
-                bool hasPositiveCount = false;
-                foreach (var dropGroup in stage.DropGroups)
-                {
-                    var itemCounts = dropGroup
+                var normalizedCountGroups = stage.DropGroups
+                    .Select(dropGroup => dropGroup
                         .Select(dropId => {
                             var depotItem = Instances.ToolboxViewModel?.DepotResult?.FirstOrDefault(d => d.Id == dropId);
-                            if ((depotItem?.Count ?? 0) > 0)
-                            {
-                                hasPositiveCount = true;
-                            }
-
-                            var displayCount = depotItem?.DisplayCount;
-                            return string.IsNullOrEmpty(displayCount) || displayCount == "-1" ? "0" : displayCount;
+                            return depotItem is { Count: > 0 } ? depotItem.Count : 0;
                         })
-                        .ToList();
-                    groupTexts.Add(string.Join(" & ", itemCounts));
-                }
+                        .ToList())
+                    .ToList();
 
-                string inventoryLabel = LocalizationHelper.GetString("Inventory");
-                string inventoryText = $" ({inventoryLabel} {string.Join(" / ", groupTexts)})";
+                bool hasPositiveCount = normalizedCountGroups.SelectMany(group => group).Any(count => count > 0);
                 if (hasPositiveCount)
                 {
+                    var groupTexts = normalizedCountGroups
+                        .Select(group => string.Join(" & ", group.Select(count => count.FormatNumber(false))))
+                        .ToList();
+
+                    string inventoryLabel = LocalizationHelper.GetString("Inventory");
+                    string inventoryText = $" ({inventoryLabel} {string.Join(" / ", groupTexts)})";
                     lines.Add(inventoryText);
                 }
             }

--- a/src/MaaWpfGui/Services/StageManager.cs
+++ b/src/MaaWpfGui/Services/StageManager.cs
@@ -700,17 +700,30 @@ public class StageManager
             if (stage.DropGroups != null && stage.DropGroups.Count > 0)
             {
                 var groupTexts = new List<string>();
+                bool hasPositiveCount = false;
                 foreach (var dropGroup in stage.DropGroups)
                 {
                     var itemCounts = dropGroup
-                        .Select(dropId => Instances.ToolboxViewModel?.DepotResult?.FirstOrDefault(d => d.Id == dropId)?.DisplayCount ?? "-1")
+                        .Select(dropId => {
+                            var depotItem = Instances.ToolboxViewModel?.DepotResult?.FirstOrDefault(d => d.Id == dropId);
+                            if ((depotItem?.Count ?? 0) > 0)
+                            {
+                                hasPositiveCount = true;
+                            }
+
+                            var displayCount = depotItem?.DisplayCount;
+                            return string.IsNullOrEmpty(displayCount) || displayCount == "-1" ? "0" : displayCount;
+                        })
                         .ToList();
                     groupTexts.Add(string.Join(" & ", itemCounts));
                 }
 
                 string inventoryLabel = LocalizationHelper.GetString("Inventory");
                 string inventoryText = $" ({inventoryLabel} {string.Join(" / ", groupTexts)})";
-                lines.Add(inventoryText);
+                if (hasPositiveCount)
+                {
+                    lines.Add(inventoryText);
+                }
             }
         }
 


### PR DESCRIPTION
Fix chip-stage inventory tip: unknown/missing counts no longer show as -1, and the inventory line is shown only when at least one count is greater than 0.

## Summary by Sourcery

规范 WPF 阶段中芯片阶段库存提示的显示方式，使库存信息只在有意义时显示，并避免将未知数量显示为负值。

Bug Fixes:
- 防止未知或缺失的芯片库存数量在芯片阶段提示中显示为 -1。
- 当所有相关的物料数量均为 0 或缺失时，在阶段提示中隐藏芯片库存这一行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Normalize chip-stage inventory tip display for WPF stages so that inventory information is only shown when meaningful and unknown counts are no longer surfaced as negative values.

Bug Fixes:
- Prevent unknown or missing chip inventory counts from displaying as -1 in chip-stage tips.
- Hide the chip inventory line in stage tips when all related item counts are zero or missing.

</details>