### PR TITLE
feat(InterfaceTask): 在PC连接模式下任务开始前移动鼠标到屏幕左下角，避免鼠标遮挡识别

### DIFF
--- a/src/MaaCore/Controller/Controller.cpp
+++ b/src/MaaCore/Controller/Controller.cpp
@@ -136,6 +136,12 @@ bool asst::Controller::back_to_home()
     return true;
 }
 
+void asst::Controller::move_cursor_out_of_view() noexcept
+{
+    CHECK_EXIST(m_controller, );
+    m_controller->move_cursor_out_of_view();
+}
+
 cv::Mat asst::Controller::get_resized_image_cache() const
 {
     const static cv::Size d_size(m_scale_size.first, m_scale_size.second);

--- a/src/MaaCore/Controller/Controller.h
+++ b/src/MaaCore/Controller/Controller.h
@@ -106,6 +106,7 @@ public:
     Controller& operator=(Controller&&) = delete;
 
     bool back_to_home();
+    void move_cursor_out_of_view() noexcept;
 
 private:
     cv::Mat get_resized_image_cache() const;

--- a/src/MaaCore/Controller/ControllerAPI.h
+++ b/src/MaaCore/Controller/ControllerAPI.h
@@ -68,6 +68,10 @@ public:
     ControllerAPI& operator=(ControllerAPI&&) = delete;
 
     virtual void back_to_home() noexcept {}
+
+    // 将光标移到被控窗口外，避免悬停效果干扰游戏画面。
+    // 默认空实现；Win32Controller 会覆盖此方法。
+    virtual void move_cursor_out_of_view() noexcept {}
 };
 
 struct InputEvent

--- a/src/MaaCore/Controller/Win32Controller.cpp
+++ b/src/MaaCore/Controller/Win32Controller.cpp
@@ -284,6 +284,21 @@ std::pair<int, int> Win32Controller::get_screen_res() const noexcept
     return m_screen_size;
 }
 
+void Win32Controller::move_cursor_out_of_view() noexcept
+{
+    if (!m_hwnd || !m_inited) {
+        return;
+    }
+
+    RECT rect;
+    if (!GetWindowRect(static_cast<HWND>(m_hwnd), &rect)) {
+        return;
+    }
+    // 将光标移到被控窗口矩形的左下角正下方一像素处。
+    // 该位置基于窗口的实际屏幕坐标计算，可正确处理多显示器布局。
+    SetCursorPos(rect.left, rect.bottom);
+}
+
 void Win32Controller::callback(AsstMsg msg, const json::value& details)
 {
     if (m_callback) {

--- a/src/MaaCore/Controller/Win32Controller.h
+++ b/src/MaaCore/Controller/Win32Controller.h
@@ -67,6 +67,8 @@ public: // ControllerAPI 接口
 
     virtual std::pair<int, int> get_screen_res() const noexcept override;
 
+    virtual void move_cursor_out_of_view() noexcept override;
+
 private:
     void callback(AsstMsg msg, const json::value& details);
 

--- a/src/MaaCore/Task/InterfaceTask.cpp
+++ b/src/MaaCore/Task/InterfaceTask.cpp
@@ -1,7 +1,15 @@
 #include "InterfaceTask.h"
 
+#include "Controller/Controller.h"
+
 bool asst::InterfaceTask::run()
 {
+    // PC 连接模式（Win32）下将光标移到被控窗口左下角外侧，避免悬停效果干扰画面。
+    // 其他控制器的默认实现为空操作，此处无需平台判断。
+    if (ctrler()) {
+        ctrler()->move_cursor_out_of_view();
+    }
+
     if (PackageTask::run()) {
         return true;
     }


### PR DESCRIPTION
截图方式使用默认，鼠标输入使用半后台的方式，这样应该可以避免鼠标遮挡截图画面

## Summary by Sourcery

增强功能：
- 在使用 Win32 PC 连接控制器时，为避免鼠标光标遮挡屏幕截图，在开始任务之前将鼠标光标移动到屏幕左下角。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Move the mouse cursor to the bottom-left corner of the screen before starting tasks when using the Win32 PC connection controller to avoid cursor obstructing screen capture.

</details>