### PR TITLE
build: use vs2026 in publish

### DIFF
--- a/.github/workflows/ci-avalonia.yml
+++ b/.github/workflows/ci-avalonia.yml
@@ -51,7 +51,7 @@ jobs:
       matrix:
         include:
           - name: windows-x64
-            os: windows-latest
+            os: windows-2025-vs2026
             rid: win-x64
             self_contained: true
             cmake_preset: windows-publish-x64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
       matrix:
         arch: [arm64, x64]
       fail-fast: false
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
       matrix:
         arch: [arm64, x64]
       fail-fast: false
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/release-nightly-ota.yml
+++ b/.github/workflows/release-nightly-ota.yml
@@ -28,7 +28,7 @@ jobs:
   build-win-nightly:
     name: Build Nightly for Windows
     if: github.repository_owner == 'MaaAssistantArknights'
-    runs-on: windows-latest
+    runs-on: windows-2025-vs2026
     strategy:
       matrix:
         arch: [x64]

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -180,11 +180,6 @@
                 "publish-base",
                 "windows-x64"
             ],
-            "$comment": [
-                "github actions only support Visual Studio 17 2022",
-                "see https://github.com/actions/runner-images/issues/13291"
-            ],
-            "generator": "Visual Studio 17 2022",
             "displayName": "Windows x64 Publish"
         },
         {
@@ -193,11 +188,6 @@
                 "publish-base",
                 "windows-arm64"
             ],
-            "$comment": [
-                "github actions only support Visual Studio 17 2022",
-                "see https://github.com/actions/runner-images/issues/13291"
-            ],
-            "generator": "Visual Studio 17 2022",
             "displayName": "Windows arm64 Publish"
         },
         {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -214,6 +214,9 @@
                 "publish-base",
                 "windows-x64"
             ],
+            "cacheVariables": {
+                "BUILD_WPF_GUI": "ON"
+            },
             "displayName": "Windows x64 Publish"
         },
         {
@@ -222,6 +225,9 @@
                 "publish-base",
                 "windows-arm64"
             ],
+            "cacheVariables": {
+                "BUILD_WPF_GUI": "ON"
+            },
             "displayName": "Windows arm64 Publish"
         },
         {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -214,14 +214,6 @@
                 "publish-base",
                 "windows-x64"
             ],
-            "cacheVariables": {
-                "BUILD_WPF_GUI": "ON"
-            },
-            "$comment": [
-                "github actions only support Visual Studio 17 2022",
-                "see https://github.com/actions/runner-images/issues/13291"
-            ],
-            "generator": "Visual Studio 17 2022",
             "displayName": "Windows x64 Publish"
         },
         {
@@ -230,14 +222,6 @@
                 "publish-base",
                 "windows-arm64"
             ],
-            "cacheVariables": {
-                "BUILD_WPF_GUI": "ON"
-            },
-            "$comment": [
-                "github actions only support Visual Studio 17 2022",
-                "see https://github.com/actions/runner-images/issues/13291"
-            ],
-            "generator": "Visual Studio 17 2022",
             "displayName": "Windows arm64 Publish"
         },
         {


### PR DESCRIPTION
will use windows-lastest instead of windows-2025-vs2026 when vs2026 is available in windows-lastest
windows-2025-vs2026 is now public beta

see also: https://github.com/actions/runner-images/issues/13638
see also: https://github.com/actions/runner-images/issues/13291

## Summary by Sourcery

Build:
- 更新 GitHub Actions CI 工作流程，使 Windows 构建目标为 `windows-2025-vs2026` 运行器镜像。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Update GitHub Actions CI workflow to target the windows-2025-vs2026 runner image for Windows builds.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- 更新 GitHub Actions CI 工作流程，使 Windows 构建目标为 `windows-2025-vs2026` 运行器镜像。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Update GitHub Actions CI workflow to target the windows-2025-vs2026 runner image for Windows builds.

</details>

</details>