### PR TITLE
perf: 适配 PlayCover 的优化截图性能

### DIFF
--- a/src/MaaCore/Controller/PlayToolsController.h
+++ b/src/MaaCore/Controller/PlayToolsController.h
@@ -67,8 +67,16 @@ protected:
     boost::asio::io_context m_context;
     boost::asio::ip::tcp::socket m_socket;
 
+    std::vector<uint8_t> m_screencap_buffer;
+
     std::string m_address;
     std::pair<int, int> m_screen_size = { 0, 0 };
+
+    enum class ScreencapMethod
+    {
+        RGBA,
+        BGR,
+    } m_screencap_method = ScreencapMethod::RGBA;
 
     enum class TouchPhase
     {
@@ -87,11 +95,14 @@ protected:
     void toucher_wait(const int delay);
 
 private:
-    static constexpr int MinimalVersion = 2;
+    unsigned m_minimal_version = 2;
     void close();
     bool open();
     bool check_version();
     bool fetch_screen_res();
     bool toucher_commit(const TouchPhase phase, const Point& p, const int delay);
+
+    bool screencap_rgba(cv::Mat& image_payload, bool allow_reconnect);
+    bool screencap_bgr(cv::Mat& image_payload, bool allow_reconnect);
 };
 } // namespace asst


### PR DESCRIPTION
当检测到连接的 MaaTools 版本 >= 3 时，会直接向服务端请求 BGR 格式的图像数据；旧版本自动回退到 RGBA 格式。

将原本在 screencap() 内部每次都要重新分配的局部 std::vector<uint8_t> buffer，提取为类成员变量 m_screencap_buffer。现在每次截图只需 resize() 调整大小，避免了频繁的内存分配以及悬垂指针隐患。

## Summary by Sourcery

为更新版本的 MaaTools 优化 PlayTools 的截图处理，并减少逐帧分配的开销。

改进点：
- 对于 MaaTools 3 及以上版本，请求 BGR 格式的截图，同时对旧版本继续使用 RGBA 处理。
- 在 PlayToolsController 中复用持久化的截图缓冲区并记录远程版本，以避免在截图捕获过程中反复进行内存分配。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize PlayTools screencap handling for newer MaaTools versions and reduce per-frame allocation overhead.

Enhancements:
- Request BGR-format screenshots from MaaTools versions 3 and above while retaining RGBA handling for older versions.
- Reuse a persistent screencap buffer and track remote version in PlayToolsController to avoid repeated allocations during screenshot capture.

</details>