### PR TITLE
ci: 为死链检查工作流指定根目录

### DIFF
--- a/.github/workflows/markdown-checker.yml
+++ b/.github/workflows/markdown-checker.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           # 仅检查内部链接，排除所有外部链接
           args: >
-            --root-dir ./docs
+            --root-dir ./docs/.vuepress/public
             --verbose --no-progress
             --cache --max-cache-age 1d --cache-exclude-status '429, 500..599'
             --exclude 'https?://.*'


### PR DESCRIPTION
## Summary by Sourcery

CI：
- 将 Markdown 链接检查器的 GitHub Actions 任务范围限定为在检查内部链接时，将 `./docs` 作为根目录使用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Scope the markdown link checker GitHub Actions job to use ./docs as the root directory when checking internal links.

</details>