### PR TITLE
fix: Make Starting Operator searching dropdown case insensitive for en

### DIFF
--- a/src/MaaWpfGui/Extensions/ComboBoxExtensions.cs
+++ b/src/MaaWpfGui/Extensions/ComboBoxExtensions.cs
@@ -79,7 +79,7 @@ public static class ComboBoxExtensions
             _logger.Debug("Searching for: {SearchTerm}", searchTerm);
 
             // 如果文字完全匹配某个选项，恢复完整列表
-            object exactMatchItem = targetComboBox.ItemsSource.Cast<object>().FirstOrDefault(obj => obj?.ToString() == searchTerm);
+            object exactMatchItem = targetComboBox.ItemsSource.Cast<object>().FirstOrDefault(obj => string.Equals(obj?.ToString(), searchTerm, StringComparison.CurrentCultureIgnoreCase));
 
             if (exactMatchItem != null)
             {
@@ -96,7 +96,7 @@ public static class ComboBoxExtensions
             }
             else
             {
-                targetComboBox.Items.Filter = item => item?.ToString()?.Contains(searchTerm) ?? false;
+                targetComboBox.Items.Filter = item => item?.ToString()?.Contains(searchTerm, StringComparison.CurrentCultureIgnoreCase) ?? false;
             }
         };
 


### PR DESCRIPTION
Make starting operator search dropdown in IS config case insensitive
before:

<img width="544" height="355" alt="image" src="https://github.com/user-attachments/assets/59172dd7-690d-4981-bd18-82de4f18b98f" />

after:

<img width="498" height="270" alt="image" src="https://github.com/user-attachments/assets/718f02aa-1cc5-414b-b34f-c22f57fec977" />

## Summary by Sourcery

增强功能：
- 规范 ComboBox 项目的匹配和过滤逻辑，对搜索词使用不区分大小写的字符串比较。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Normalize ComboBox item matching and filtering to use case-insensitive string comparison for search terms.

</details>