### PR TITLE
perf(MaaCore): ASST_DEBUG 在 lazy_parse 后不再重新生成任务信息

### DIFF
--- a/src/MaaCore/Config/TaskData.cpp
+++ b/src/MaaCore/Config/TaskData.cpp
@@ -290,7 +290,7 @@ bool asst::TaskData::parse(const json::value& json)
         return false;
     }
 
-#ifndef ASST_DEBUG 
+#ifndef ASST_DEBUG
     // 本来重构之后完全支持惰性加载，但是发现模板图片不支持（
     // generate_task_info 中会把模板图片名加入 m_templ_required, 而 ASST_DEBUG 中语法检查已经生成过
     for (const std::string& name : m_json_all_tasks_info | std::views::keys) {


### PR DESCRIPTION
## Summary by Sourcery

在调试构建中保护主动任务信息生成以便跳过该步骤，并更新延迟任务解析中的错误日志记录样式。

增强内容：
- 在使用 `ASST_DEBUG` 构建时，解析过程中跳过 `generate_task_info` 调用，以避免重复生成任务信息并提升性能。
- 使 `lazy_parse` 的错误上报与统一的 `LogError` 流式接口保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Guard eager task info generation so it is skipped in debug builds and update error logging style in lazy task parsing.

Enhancements:
- Skip generate_task_info calls during parsing when built with ASST_DEBUG to avoid redundant task info generation and improve performance.
- Align lazy_parse error reporting with the unified LogError streaming interface.

</details>