### PR TITLE
perf(wpf): 当热更资源命中时, 不再二次加载资源

### DIFF
--- a/src/MaaWpfGui/Services/StageManager.cs
+++ b/src/MaaWpfGui/Services/StageManager.cs
@@ -91,13 +91,11 @@ public class StageManager
             }
         }
 
-        var webStages = await LoadWebStages();
-        if (webStages is null)
+        var loaded = await LoadWebStages();
+        if (!loaded)
         {
             return;
         }
-
-        MergePermanentAndActivityStages(webStages);
 
         _ = Execute.OnUIThreadAsync(() => {
             var growlInfo = new GrowlInfo {
@@ -123,9 +121,9 @@ public class StageManager
         return clientType;
     }
 
-    private static JObject LoadLocalStages()
+    private static JObject? LoadLocalStages()
     {
-        JObject activity = Instances.MaaApiService.LoadApiCache(StageApi);
+        JObject? activity = Instances.MaaApiService.LoadApiCache(StageApi);
         return activity;
     }
 
@@ -137,7 +135,7 @@ public class StageManager
         const string AllFileDownloadCompleteFile = "allFileDownloadComplete.json";
         JObject localLastUpdatedJson = Instances.MaaApiService.LoadApiCache(StageAndTasksUpdateTime);
         JObject allFileDownloadCompleteJson = Instances.MaaApiService.LoadApiCache(AllFileDownloadCompleteFile);
-        JObject webLastUpdatedJson = await Instances.MaaApiService.RequestMaaApiWithCache(StageAndTasksUpdateTime).ConfigureAwait(false);
+        var (_, webLastUpdatedJson) = await Instances.MaaApiService.RequestMaaApiWithCache(StageAndTasksUpdateTime).ConfigureAwait(false);
 
         if (localLastUpdatedJson?["timestamp"] == null || webLastUpdatedJson?["timestamp"] == null)
         {
@@ -151,7 +149,7 @@ public class StageManager
     }
     */
 
-    private static async Task<JObject?> LoadWebStages()
+    private async Task<bool> LoadWebStages()
     {
         var clientType = GetClientType();
 
@@ -160,9 +158,10 @@ public class StageManager
 
         await Task.WhenAll(activityTask, tasksTask);
 
-        var activityJson = await activityTask;
-        var tasksJson = await tasksTask;
+        var (activityCached, activityJson) = await activityTask;
+        var (taskCached, tasksJson) = await tasksTask;
         JObject? globalTasksJson = null;
+        bool globalTasksCached = true;
         if (clientType != ClientType.Official && tasksJson != null)
         {
             var tasksPath = "resource/global/" + clientType + '/' + TasksApi;
@@ -170,23 +169,31 @@ public class StageManager
             // Download the client specific resources only when the Official ones are successfully downloaded so that the client specific resource version is the actual version
             // TODO: There may be an issue when the CN resource is loaded from cache (e.g. network down) while global resource is downloaded (e.g. network up again)
             // var tasksJsonClient = fromWeb ? WebService.RequestMaaApiWithCache(tasksPath) : WebService.RequestMaaApiWithCache(tasksPath);
-            globalTasksJson = await Instances.MaaApiService.RequestMaaApiWithCache(tasksPath, false);
+            (globalTasksCached, globalTasksJson) = await Instances.MaaApiService.RequestMaaApiWithCache(tasksPath, false);
         }
 
         if (activityJson is null || tasksJson is null)
         {
-            return null;
+            return false;
         }
 
         if (clientType != ClientType.Official && globalTasksJson is null)
         {
-            return null;
+            return false;
         }
 
-        await Task.Run(() => {
-            _ = Instances.AsstProxy.LoadResourceWhenIdleAsync();
-        });
-        return activityJson;
+        if (!taskCached || !globalTasksCached)
+        {
+            await Task.Run(() => {
+                _ = Instances.AsstProxy.LoadResourceWhenIdleAsync();
+            });
+        }
+
+        if (!activityCached)
+        {
+            MergePermanentAndActivityStages(activityJson);
+        }
+        return true;
     }
 
     private void MergePermanentAndActivityStages(JObject? activity)

--- a/src/MaaWpfGui/Services/Web/IMaaApiService.cs
+++ b/src/MaaWpfGui/Services/Web/IMaaApiService.cs
@@ -10,7 +10,7 @@
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY
 // </copyright>
-
+#nullable enable
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 
@@ -18,7 +18,7 @@ namespace MaaWpfGui.Services.Web;
 
 public interface IMaaApiService
 {
-    Task<JObject> RequestMaaApiWithCache(string api, bool allowFallbackToCache = true);
+    Task<(bool Cached, JObject? Response)> RequestMaaApiWithCache(string api, bool allowFallbackToCache = true);
 
-    JObject LoadApiCache(string api);
+    JObject? LoadApiCache(string api);
 }

--- a/src/MaaWpfGui/Services/Web/MaaApiService.cs
+++ b/src/MaaWpfGui/Services/Web/MaaApiService.cs
@@ -26,67 +26,69 @@ public class MaaApiService : IMaaApiService
 {
     private static readonly string CacheDir = PathsHelper.CacheDir;
 
-    public async Task<JObject?> RequestMaaApiWithCache(string api, bool allowFallbackToCache = true)
+    public async Task<(bool Cached, JObject? Response)> RequestMaaApiWithCache(string api, bool allowFallbackToCache = true)
     {
         return await RequestWithFallback(api, MaaUrls.MaaApi, MaaUrls.MaaApi2, allowFallbackToCache);
     }
 
-    private async Task<JObject?> RequestWithFallback(string api, string primaryBaseUrl, string? fallbackBaseUrl = null, bool allowFallbackToCache = true)
+    private async Task<(bool Cached, JObject? Response)> RequestWithFallback(string api, string primaryBaseUrl, string? fallbackBaseUrl = null, bool allowFallbackToCache = true)
     {
-        var json = await TryRequest(api, primaryBaseUrl, allowFallbackToCache);
-        if (json != null || string.IsNullOrEmpty(fallbackBaseUrl))
+        var result = await TryRequest(api, primaryBaseUrl, allowFallbackToCache);
+        if (result.Response != null || string.IsNullOrEmpty(fallbackBaseUrl))
         {
-            return json;
+            return result;
         }
 
         return await TryRequest(api, fallbackBaseUrl, allowFallbackToCache);
     }
 
-    private async Task<JObject?> TryRequest(string api, string baseUrl, bool allowFallbackToCache = true)
+    private async Task<(bool Cached, JObject? Response)> TryRequest(string api, string baseUrl, bool allowFallbackToCache = true)
     {
         var url = baseUrl + api;
-        var cache = Path.Combine(CacheDir, api);
-
-        var response = await ETagCache.FetchResponseWithEtag(url, !File.Exists(cache));
-        if (response == null)
+        var cachePath = Path.Combine(CacheDir, api);
+        var response = await ETagCache.FetchResponseWithEtag(url, !File.Exists(cachePath));
+        if (response?.StatusCode == System.Net.HttpStatusCode.NotModified)
         {
-            return allowFallbackToCache ? LoadApiCache(api) : null;
+            var cache = LoadApiCache(api);
+            return (cache != null, cache);
         }
 
-        if (response.StatusCode == System.Net.HttpStatusCode.NotModified)
+        if (response == null || response.StatusCode != System.Net.HttpStatusCode.OK)
         {
-            return LoadApiCache(api);
-        }
+            if (!allowFallbackToCache)
+            {
+                return (false, null);
+            }
 
-        if (response.StatusCode != System.Net.HttpStatusCode.OK)
-        {
-            return allowFallbackToCache ? LoadApiCache(api) : null;
+            var cache = LoadApiCache(api);
+            return (cache != null, cache);
         }
 
         var body = await HttpResponseHelper.GetStringAsync(response);
         if (string.IsNullOrEmpty(body))
         {
-            return LoadApiCache(api);
+            var cache = LoadApiCache(api);
+            return (cache != null, cache);
         }
 
         try
         {
             var json = (JObject?)JsonConvert.DeserializeObject(body);
-            string? directoryPath = Path.GetDirectoryName(cache);
+            string? directoryPath = Path.GetDirectoryName(cachePath);
 
             if (!Directory.Exists(directoryPath))
             {
                 Directory.CreateDirectory(directoryPath!);
             }
 
-            await File.WriteAllTextAsync(cache, body);
+            await File.WriteAllTextAsync(cachePath, body);
             ETagCache.Set(response, url);
 
-            return json;
+            return (false, json);
         }
         catch
         {
-            return null;
+            return (false, null);
         }
     }
 

--- a/src/MaaWpfGui/ViewModels/Dialogs/VersionUpdateDialogViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/Dialogs/VersionUpdateDialogViewModel.cs
@@ -880,7 +880,7 @@ public class VersionUpdateDialogViewModel : Screen
 
     private async Task<CheckUpdateRetT> CheckUpdateByMaaApi()
     {
-        JObject json = await Instances.MaaApiService.RequestMaaApiWithCache(MaaUpdateApi);
+        var (_, json) = await Instances.MaaApiService.RequestMaaApiWithCache(MaaUpdateApi);
 
         if (json is null)
         {
@@ -908,7 +908,7 @@ public class VersionUpdateDialogViewModel : Screen
 
     private async Task<CheckUpdateRetT> GetVersionDetailsByMaaApi(string versionType)
     {
-        var json = await Instances.MaaApiService.RequestMaaApiWithCache($"version/{versionType}.json", false);
+        var (_, json) = await Instances.MaaApiService.RequestMaaApiWithCache($"version/{versionType}.json", false);
         if (json is null)
         {
             return CheckUpdateRetT.NetworkError;


### PR DESCRIPTION
修改前启动时将会加载两次resource和两次cache/resource，总耗时在 14~18s 左右

## Summary by Sourcery

通过跟踪缓存使用情况，并在响应来自缓存时避免不必要的重新加载，从而优化 Maa API 资源加载。

新特性：
- 通过返回元组类型暴露 Maa API 请求的缓存命中信息，用于指示响应是否来自缓存。

改进：
- 调整关卡加载流程，当数据在缓存中已是最新时，跳过合并和高开销的资源加载。
- 使 Maa API 服务方法支持空值感知（nullable-aware），并相应更新其调用方，以便更明确地处理缺失或来自缓存的响应。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize Maa API resource loading by tracking cache usage and avoiding unnecessary reloads when responses are served from cache.

New Features:
- Expose cache-hit information from Maa API requests via a tuple return type indicating whether the response came from cache.

Enhancements:
- Adjust stage loading workflow to skip merging and heavy resource loading when data is already up to date in cache.
- Make Maa API service methods nullable-aware and update consumers accordingly to handle missing or cached responses more explicitly.

</details>