### PR TITLE
feat: 引入移除开机自启注册表项的脚本

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,7 @@ jobs:
           rm -rf install/*.h
 
           cp tools/DependencySetup_依赖库安装.bat install
+          cp tools/RemoveAutoStartReg_移除开机自启注册表项.bat install
 
       - name: Zip files
         run: |

--- a/.github/workflows/release-nightly-ota.yml
+++ b/.github/workflows/release-nightly-ota.yml
@@ -263,6 +263,7 @@ jobs:
           rm -rf install/*.h
 
           cp tools/DependencySetup_依赖库安装.bat install
+          cp tools/RemoveAutoStartReg_移除开机自启注册表项.bat install
 
       - name: Upload MAA to GitHub
         uses: actions/upload-artifact@v7

--- a/tools/RemoveAutoStartReg_移除开机自启注册表项.bat
+++ b/tools/RemoveAutoStartReg_移除开机自启注册表项.bat
@@ -1,0 +1,42 @@
+@echo off
+chcp 65001 >nul
+setlocal enabledelayedexpansion
+
+echo -----------------------------------------------------
+echo  Removing MAA autostart registry entries...
+echo  删除 MAA 的开机自启注册表项…
+echo -----------------------------------------------------
+
+set RUN_KEY="HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Run"
+set TARGET_PATH="%~dp0MAA.exe"
+
+:: Convert to long path
+for %%I in (%TARGET_PATH%) do set TARGET_PATH=%%~fI
+
+echo Looking for values with executable path:
+echo     %TARGET_PATH%
+echo.
+
+:: Enumerate all value names under Run
+for /f "tokens=1*" %%A in ('reg query %RUN_KEY% 2^>nul ^| findstr /r "REG_SZ"') do (
+    set ValueName=%%A
+
+    :: Query value data
+    for /f "skip=2 tokens=2,*" %%X in ('reg query %RUN_KEY% /v "%%A" 2^>nul') do (
+        set ValueData=%%Y
+
+        :: Compare case-insensitively
+        if /I !ValueData!=="%TARGET_PATH%" (
+            echo Found matching entry: %%A
+            echo Removing...
+            reg delete %RUN_KEY% /v "%%A" /f >nul
+        )
+    )
+)
+
+echo.
+echo Done.
+
+pause
+
+@REM exit /b 0


### PR DESCRIPTION
## Summary by Sourcery

添加用于移除 Windows 自动启动注册表项的脚本，并将其包含在打包的安装工件中。

新功能：
- 提供一个批处理脚本，用于从 Windows 启动配置中移除自动启动注册表项。

构建：
- 在 CI 安装工件的打包过程中包含自动启动移除脚本。
- 在每夜构建的 OTA 发布打包过程中包含自动启动移除脚本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a script for removing Windows auto-start registry entries and include it in packaged installation artifacts.

New Features:
- Provide a batch script to remove auto-start registry entries from Windows startup configuration.

Build:
- Include the auto-start removal script in CI packaging of install artifacts.
- Include the auto-start removal script in nightly OTA release packaging.

</details>