### PR TITLE
feat: 支持自动调整PC客户端窗口大小至16：9

### DIFF
--- a/src/MaaCore/Assistant.cpp
+++ b/src/MaaCore/Assistant.cpp
@@ -723,9 +723,11 @@ void Assistant::clear_cache()
     m_status->clear_number();
     m_status->clear_rect();
     m_status->clear_str();
+#ifdef _WIN32
     if (m_ctrler->get_controller_type() == ControllerType::Win32) {
         m_ctrler->clear_info();
     }
+#endif
 }
 
 bool asst::Assistant::inited() const noexcept

--- a/src/MaaCore/Assistant.cpp
+++ b/src/MaaCore/Assistant.cpp
@@ -723,6 +723,7 @@ void Assistant::clear_cache()
     m_status->clear_number();
     m_status->clear_rect();
     m_status->clear_str();
+    m_ctrler->clear_info();
 }
 
 bool asst::Assistant::inited() const noexcept

--- a/src/MaaCore/Assistant.cpp
+++ b/src/MaaCore/Assistant.cpp
@@ -723,7 +723,9 @@ void Assistant::clear_cache()
     m_status->clear_number();
     m_status->clear_rect();
     m_status->clear_str();
-    m_ctrler->clear_info();
+    if (m_ctrler->get_controller_type() == ControllerType::Win32) {
+        m_ctrler->clear_info();
+    }
 }
 
 bool asst::Assistant::inited() const noexcept

--- a/src/MaaCore/Controller/Controller.cpp
+++ b/src/MaaCore/Controller/Controller.cpp
@@ -298,7 +298,7 @@ bool asst::Controller::attach_window(
 
     clear_info();
 
-    auto win32_controller = std::make_shared<Win32Controller>(m_callback, m_inst);
+    auto win32_controller = std::make_shared<Win32Controller>(m_callback, m_inst, hwnd);
     if (!win32_controller->attach(hwnd, screencap_method, mouse_method, keyboard_method)) {
         Log.error("attach_window failed");
         return false;

--- a/src/MaaCore/Controller/Controller.h
+++ b/src/MaaCore/Controller/Controller.h
@@ -106,11 +106,12 @@ public:
     Controller& operator=(Controller&&) = delete;
 
     bool back_to_home();
+    void clear_info() noexcept;
 
 private:
     cv::Mat get_resized_image_cache() const;
 
-    void clear_info() noexcept;
+
     void callback(AsstMsg msg, const json::value& details);
     void sync_params();
 

--- a/src/MaaCore/Controller/Win32Controller.cpp
+++ b/src/MaaCore/Controller/Win32Controller.cpp
@@ -12,10 +12,11 @@
 
 namespace asst
 {
-Win32Controller::Win32Controller(const AsstCallback& callback, Assistant* inst) :
+Win32Controller::Win32Controller(const AsstCallback& callback, Assistant* inst, void* hwnd) :
     InstHelper(inst),
     m_callback(callback),
-    m_loader(std::make_unique<Win32ControlUnitLoader>())
+    m_loader(std::make_unique<Win32ControlUnitLoader>()),
+    window_guard(std::make_unique<WindowGuard>(hwnd))
 {
     LogTraceFunction;
 }

--- a/src/MaaCore/Controller/Win32Controller.h
+++ b/src/MaaCore/Controller/Win32Controller.h
@@ -11,6 +11,7 @@
 #include "ControllerAPI.h"
 #include "InstHelper.h"
 #include "Win32ControlUnitLoader.h"
+#include "WindowGuard.h"
 
 namespace asst
 {
@@ -19,7 +20,7 @@ class Assistant;
 class Win32Controller : public ControllerAPI, private InstHelper
 {
 public:
-    Win32Controller(const AsstCallback& callback, Assistant* inst);
+    Win32Controller(const AsstCallback& callback, Assistant* inst, void* hwnd);
     virtual ~Win32Controller() override;
 
     Win32Controller(const Win32Controller&) = delete;
@@ -96,6 +97,8 @@ private:
     Win32ScreencapMethod m_screencap_method = Win32Screencap::None;
     Win32InputMethod m_mouse_method = Win32Input::None;
     Win32InputMethod m_keyboard_method = Win32Input::None;
+
+    std::unique_ptr<WindowGuard> window_guard;
 };
 } // namespace asst
 

--- a/src/MaaCore/Controller/WindowGuard.cpp
+++ b/src/MaaCore/Controller/WindowGuard.cpp
@@ -1,0 +1,89 @@
+#ifdef _WIN32
+
+#include "WindowGuard.h"
+
+namespace asst
+{
+WindowGuard::WindowGuard(void* hwnd) :
+    m_restore(false),
+    m_hwnd(reinterpret_cast<HWND>(hwnd)),
+    m_style(GetWindowLongPtr(m_hwnd, GWL_STYLE)),
+    m_clientRect { }
+{
+    if ((m_style & WS_POPUP) != 0) {
+        Log.error(__FUNCTION__, "Does not support full screen!");
+        return;
+    }
+    ShowWindow(m_hwnd, SW_RESTORE);
+    UpdateWindow(m_hwnd);
+    GetClientRect(m_hwnd, &m_clientRect);
+    Log.info(
+        __FUNCTION__,
+        "clientRect, left: ",
+        m_clientRect.left,
+        ", right: ",
+        m_clientRect.right,
+        ", top: ",
+        m_clientRect.top,
+        ", bottom: ",
+        m_clientRect.bottom);
+    if (std::fabs(
+            static_cast<double>(WindowWidthDefault) / static_cast<double>(WindowHeightDefault) -
+            static_cast<double>(m_clientRect.right - m_clientRect.left) /
+                static_cast<double>(m_clientRect.bottom - m_clientRect.top)) > 1e-7) {
+        Log.info(__FUNCTION__, "The resolution is not 16:9, try adjusting the window size");
+        m_restore = true;
+        LONG_PTR exStyle = GetWindowLongPtr(m_hwnd, GWL_EXSTYLE);
+        BOOL hasMenu = (GetMenu(m_hwnd) != NULL);
+        RECT rect = { 0, 0, 1920, 1080 };
+        AdjustWindowRectEx(&rect, (DWORD)m_style, hasMenu, (DWORD)exStyle);
+        Log.info(
+            __FUNCTION__,
+            "AdjustWindow, left: ",
+            rect.left,
+            ", right: ",
+            rect.right,
+            ", top: ",
+            rect.top,
+            ", bottom: ",
+            rect.bottom);
+        SetWindowPos(
+            m_hwnd,
+            HWND_NOTOPMOST,
+            0,
+            0,
+            rect.right - rect.left,
+            rect.bottom - rect.top,
+            SWP_SHOWWINDOW | SWP_FRAMECHANGED);
+        // 将光标移动到窗口中央防止因UI偏斜导致后续找图失败
+        SetCursorPos(960, 540);
+    }
+    else {
+        SetCursorPos((m_clientRect.right - m_clientRect.left) / 2, (m_clientRect.bottom - m_clientRect.top) / 2);
+    }
+}
+
+WindowGuard::~WindowGuard()
+{
+    Log.info(__FUNCTION__, "WindowGuard destroy");
+    if (m_restore) {
+        Log.info(__FUNCTION__, "restore window");
+        ShowWindow(m_hwnd, SW_RESTORE);
+        UpdateWindow(m_hwnd);
+        LONG_PTR exStyle = GetWindowLongPtr(m_hwnd, GWL_EXSTYLE);
+        BOOL hasMenu = (GetMenu(m_hwnd) != NULL);
+        RECT rect = { 0, 0, m_clientRect.right - m_clientRect.left, m_clientRect.bottom - m_clientRect.top };
+        AdjustWindowRectEx(&rect, (DWORD)m_style, hasMenu, (DWORD)exStyle);
+        SetWindowPos(
+            m_hwnd,
+            HWND_NOTOPMOST,
+            0,
+            0,
+            rect.right - rect.left,
+            rect.bottom - rect.top,
+            SWP_SHOWWINDOW | SWP_FRAMECHANGED);
+    }
+}
+}
+
+#endif // _WIN32

--- a/src/MaaCore/Controller/WindowGuard.cpp
+++ b/src/MaaCore/Controller/WindowGuard.cpp
@@ -7,20 +7,23 @@ namespace asst
 WindowGuard::WindowGuard(void* hwnd) :
     m_restore(false),
     m_hwnd(reinterpret_cast<HWND>(hwnd)),
-    m_style(GetWindowLongPtr(m_hwnd, GWL_STYLE)),
     m_clientRect { }
 {
     if (m_hwnd == nullptr || !IsWindow(m_hwnd)) {
         Log.error(__FUNCTION__, "hwnd iellegal!");
         return;
     }
+    m_style = GetWindowLongPtr(m_hwnd, GWL_STYLE);
     if ((m_style & WS_POPUP) != 0) {
         Log.error(__FUNCTION__, "Does not support full screen!");
         return;
     }
     ShowWindow(m_hwnd, SW_RESTORE);
     UpdateWindow(m_hwnd);
-    GetClientRect(m_hwnd, &m_clientRect);
+    if (!GetClientRect(m_hwnd, &m_clientRect)) {
+        Log.error(__FUNCTION__, "GetClientRect failed!");
+        return;
+    }
     Log.info(
         __FUNCTION__,
         "clientRect, left: ",

--- a/src/MaaCore/Controller/WindowGuard.cpp
+++ b/src/MaaCore/Controller/WindowGuard.cpp
@@ -10,6 +10,10 @@ WindowGuard::WindowGuard(void* hwnd) :
     m_style(GetWindowLongPtr(m_hwnd, GWL_STYLE)),
     m_clientRect { }
 {
+    if (m_hwnd == nullptr || !IsWindow(m_hwnd)) {
+        Log.error(__FUNCTION__, "hwnd iellegal!");
+        return;
+    }
     if ((m_style & WS_POPUP) != 0) {
         Log.error(__FUNCTION__, "Does not support full screen!");
         return;
@@ -27,6 +31,9 @@ WindowGuard::WindowGuard(void* hwnd) :
         m_clientRect.top,
         ", bottom: ",
         m_clientRect.bottom);
+    POINT centerPoint;
+    centerPoint.x = (m_clientRect.left + m_clientRect.right) / 2;
+    centerPoint.y = (m_clientRect.top + m_clientRect.bottom) / 2;
     if (std::fabs(
             static_cast<double>(WindowWidthDefault) / static_cast<double>(WindowHeightDefault) -
             static_cast<double>(m_clientRect.right - m_clientRect.left) /
@@ -35,7 +42,7 @@ WindowGuard::WindowGuard(void* hwnd) :
         m_restore = true;
         LONG_PTR exStyle = GetWindowLongPtr(m_hwnd, GWL_EXSTYLE);
         BOOL hasMenu = (GetMenu(m_hwnd) != NULL);
-        RECT rect = { 0, 0, 1920, 1080 };
+        RECT rect = { 0, 0, WindowWidthDefault, WindowHeightDefault };
         AdjustWindowRectEx(&rect, (DWORD)m_style, hasMenu, (DWORD)exStyle);
         Log.info(
             __FUNCTION__,
@@ -55,11 +62,15 @@ WindowGuard::WindowGuard(void* hwnd) :
             rect.right - rect.left,
             rect.bottom - rect.top,
             SWP_SHOWWINDOW | SWP_FRAMECHANGED);
-        // 将光标移动到窗口中央防止因UI偏斜导致后续找图失败
-        SetCursorPos(960, 540);
+
+        if (GetClientRect(m_hwnd, &rect)) {
+            centerPoint.x = (rect.left + rect.right) / 2;
+            centerPoint.y = (rect.top + rect.bottom) / 2;
+        }
     }
-    else {
-        SetCursorPos((m_clientRect.right - m_clientRect.left) / 2, (m_clientRect.bottom - m_clientRect.top) / 2);
+    // 将光标移动到窗口中央防止因UI偏斜导致后续找图失败
+    if (ClientToScreen(m_hwnd, &centerPoint)) {
+        SetCursorPos(centerPoint.x, centerPoint.y);
     }
 }
 

--- a/src/MaaCore/Controller/WindowGuard.cpp
+++ b/src/MaaCore/Controller/WindowGuard.cpp
@@ -10,7 +10,7 @@ WindowGuard::WindowGuard(void* hwnd) :
     m_clientRect { }
 {
     if (m_hwnd == nullptr || !IsWindow(m_hwnd)) {
-        Log.error(__FUNCTION__, "hwnd iellegal!");
+        Log.error(__FUNCTION__, "invalid hwnd");
         return;
     }
     m_style = GetWindowLongPtr(m_hwnd, GWL_STYLE);
@@ -37,7 +37,10 @@ WindowGuard::WindowGuard(void* hwnd) :
     POINT centerPoint;
     centerPoint.x = (m_clientRect.left + m_clientRect.right) / 2;
     centerPoint.y = (m_clientRect.top + m_clientRect.bottom) / 2;
-    if (std::fabs(
+    if (static_cast<double>(m_clientRect.right - m_clientRect.left) /
+                static_cast<double>(m_clientRect.bottom - m_clientRect.top) !=
+            0 &&
+        std::fabs(
             static_cast<double>(WindowWidthDefault) / static_cast<double>(WindowHeightDefault) -
             static_cast<double>(m_clientRect.right - m_clientRect.left) /
                 static_cast<double>(m_clientRect.bottom - m_clientRect.top)) > 1e-7) {

--- a/src/MaaCore/Controller/WindowGuard.h
+++ b/src/MaaCore/Controller/WindowGuard.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#ifdef _WIN32
+
+#include "MaaUtils/SafeWindows.hpp"
+#include <Utils/Logger.hpp>
+#include <cmath>
+
+namespace asst
+{
+class WindowGuard
+{
+public:
+    WindowGuard(void* hwnd);
+
+    ~WindowGuard();
+
+private:
+    RECT m_clientRect = { 0, 0, 0, 0 };
+    HWND m_hwnd = nullptr;
+    LONG_PTR m_style = 0;
+    bool m_restore = false;
+};
+}
+
+#endif // _WIN32
+


### PR DESCRIPTION
## Summary by Sourcery

为 Win32 控制器添加自动窗口宽高比管理，并确保在重置助手时清除控制器状态。

新功能：
- 引入 WindowGuard 工具，用于将 PC 客户端窗口大小标准化为默认 16:9 分辨率（可选恢复），并将光标居中到窗口内。

改进：
- 扩展 Win32Controller，使其在附加 Win32 窗口时拥有一个绑定到目标 HWND 的 WindowGuard。
- 暴露 `Controller::clear_info`，以便 Assistant 在缓存重置时清除控制器特定的缓存状态。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add automatic window aspect ratio management for the Win32 controller and ensure controller state is cleared when resetting the assistant.

New Features:
- Introduce a WindowGuard utility to normalize and optionally restore PC client window size to a default 16:9 resolution and center the cursor within the window.

Enhancements:
- Extend Win32Controller to own a WindowGuard tied to the target HWND when attaching a Win32 window.
- Expose Controller::clear_info so Assistant can clear controller-specific cached state on cache reset.

</details>