### PR TITLE
fix: 修复点击减少使用理智药品后没有再次检查的问题

### DIFF
--- a/src/MaaCore/Task/Fight/MedicineCounterTaskPlugin.cpp
+++ b/src/MaaCore/Task/Fight/MedicineCounterTaskPlugin.cpp
@@ -82,16 +82,34 @@ bool asst::MedicineCounterTaskPlugin::_run()
         }
     }
     else if (m_used_count >= m_max_count && m_use_expiring) {
-        bool changed = false;
-        for (const auto& [use, inventory, rect, is_expiring] : using_medicine->medicines | std::views::reverse) {
-            if (use > 0 && is_expiring != ExpiringStatus::Expiring) {
-                ctrler()->click(rect);
-                sleep(Config.get_options().task_delay);
-                changed = true;
+        bool changed = true;
+        int loop_count = 0;
+        while (changed && loop_count < 3) {
+            loop_count++;
+            changed = false;
+            for (const auto& [use, inventory, rect, is_expiring] : using_medicine->medicines | std::views::reverse) {
+                Log.info(
+                    __FUNCTION__,
+                    " check is_expiring, use: ",
+                    use,
+                    " inventory: ",
+                    inventory,
+                    " rect: ",
+                    rect,
+                    " is_expiring: ",
+                    expiring_status_to_string(is_expiring));
+                if (use > 0 && is_expiring != ExpiringStatus::Expiring) {
+                    ctrler()->click(rect);
+                    sleep(Config.get_options().task_delay);
+                    changed = true;
+                }
+            }
+
+            if (changed && !refresh_medicine_count()) {
+                return false;
             }
         }
-
-        if (changed && !refresh_medicine_count()) {
+        if (changed && loop_count == 3) {
             return false;
         }
     }


### PR DESCRIPTION
将非即将过期药品的点击使用逻辑改为循环，确保全部可用药品被处理。每次操作后刷新药品数量，刷新失败时提前返回。新增日志输出以便追踪每次检查的药品状态。

resolve #15975

## Summary by Sourcery

确保在启用可过期药物的情况下，当达到最大使用次数后，对不会过期的理智药物在每次使用后进行迭代复查和刷新。

Bug Fixes:
- 修复在递减使用次数时对不会过期药物处理不完整的问题，确保通过重复检查处理所有符合条件的药物。

Enhancements:
- 在每一批次用药之后添加药物计数的迭代刷新机制，并在刷新失败时中止流程。
- 在每次检查时记录药物状态日志，以帮助调试和跟踪使用行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure non-expiring sanity medicines are iteratively rechecked and refreshed after each use when the maximum usage count has been reached but expiring medicines are enabled.

Bug Fixes:
- Fix incomplete handling of non-expiring medicines when decrementing usage, ensuring all eligible medicines are processed with repeated checks.

Enhancements:
- Add iterative refresh of medicine counts after each batch of uses, aborting on refresh failure.
- Add logging of medicine state on each check to aid debugging and tracking usage behavior.

</details>