### PR TITLE
feat: 支持自动调整PC客户端窗口大小至16:9，并自动居中光标，结束后还原

### DIFF
--- a/src/MaaCore/Assistant.cpp
+++ b/src/MaaCore/Assistant.cpp
@@ -723,6 +723,11 @@ void Assistant::clear_cache()
     m_status->clear_number();
     m_status->clear_rect();
     m_status->clear_str();
+#ifdef _WIN32
+    if (m_ctrler->get_controller_type() == ControllerType::Win32) {
+        m_ctrler->clear_info();
+    }
+#endif
 }
 
 bool asst::Assistant::inited() const noexcept

--- a/src/MaaCore/Controller/Controller.cpp
+++ b/src/MaaCore/Controller/Controller.cpp
@@ -298,7 +298,7 @@ bool asst::Controller::attach_window(
 
     clear_info();
 
-    auto win32_controller = std::make_shared<Win32Controller>(m_callback, m_inst);
+    auto win32_controller = std::make_shared<Win32Controller>(m_callback, m_inst, hwnd);
     if (!win32_controller->attach(hwnd, screencap_method, mouse_method, keyboard_method)) {
         Log.error("attach_window failed");
         return false;

--- a/src/MaaCore/Controller/Controller.h
+++ b/src/MaaCore/Controller/Controller.h
@@ -106,11 +106,12 @@ public:
     Controller& operator=(Controller&&) = delete;
 
     bool back_to_home();
+    void clear_info() noexcept;
 
 private:
     cv::Mat get_resized_image_cache() const;
 
-    void clear_info() noexcept;
+
     void callback(AsstMsg msg, const json::value& details);
     void sync_params();
 

--- a/src/MaaCore/Controller/Win32Controller.cpp
+++ b/src/MaaCore/Controller/Win32Controller.cpp
@@ -12,10 +12,11 @@
 
 namespace asst
 {
-Win32Controller::Win32Controller(const AsstCallback& callback, Assistant* inst) :
+Win32Controller::Win32Controller(const AsstCallback& callback, Assistant* inst, void* hwnd) :
     InstHelper(inst),
     m_callback(callback),
-    m_loader(std::make_unique<Win32ControlUnitLoader>())
+    m_loader(std::make_unique<Win32ControlUnitLoader>()),
+    window_guard(std::make_unique<WindowGuard>(hwnd))
 {
     LogTraceFunction;
 }

--- a/src/MaaCore/Controller/Win32Controller.h
+++ b/src/MaaCore/Controller/Win32Controller.h
@@ -11,6 +11,7 @@
 #include "ControllerAPI.h"
 #include "InstHelper.h"
 #include "Win32ControlUnitLoader.h"
+#include "WindowGuard.h"
 
 namespace asst
 {
@@ -19,7 +20,7 @@ class Assistant;
 class Win32Controller : public ControllerAPI, private InstHelper
 {
 public:
-    Win32Controller(const AsstCallback& callback, Assistant* inst);
+    Win32Controller(const AsstCallback& callback, Assistant* inst, void* hwnd);
     virtual ~Win32Controller() override;
 
     Win32Controller(const Win32Controller&) = delete;
@@ -96,6 +97,8 @@ private:
     Win32ScreencapMethod m_screencap_method = Win32Screencap::None;
     Win32InputMethod m_mouse_method = Win32Input::None;
     Win32InputMethod m_keyboard_method = Win32Input::None;
+
+    std::unique_ptr<WindowGuard> window_guard;
 };
 } // namespace asst
 

--- a/src/MaaCore/Controller/WindowGuard.cpp
+++ b/src/MaaCore/Controller/WindowGuard.cpp
@@ -1,0 +1,106 @@
+#ifdef _WIN32
+
+#include "WindowGuard.h"
+
+namespace asst
+{
+WindowGuard::WindowGuard(void* hwnd) :
+    m_restore(false),
+    m_hwnd(reinterpret_cast<HWND>(hwnd)),
+    m_clientRect { }
+{
+    if (m_hwnd == nullptr || !IsWindow(m_hwnd)) {
+        Log.error(__FUNCTION__, "invalid hwnd");
+        return;
+    }
+    m_style = GetWindowLongPtr(m_hwnd, GWL_STYLE);
+    if ((m_style & WS_POPUP) != 0) {
+        Log.error(__FUNCTION__, "Does not support full screen!");
+        return;
+    }
+    ShowWindow(m_hwnd, SW_RESTORE);
+    UpdateWindow(m_hwnd);
+    if (!GetClientRect(m_hwnd, &m_clientRect)) {
+        Log.error(__FUNCTION__, "GetClientRect failed!");
+        return;
+    }
+    Log.info(
+        __FUNCTION__,
+        "clientRect, left: ",
+        m_clientRect.left,
+        ", right: ",
+        m_clientRect.right,
+        ", top: ",
+        m_clientRect.top,
+        ", bottom: ",
+        m_clientRect.bottom);
+    POINT centerPoint;
+    centerPoint.x = (m_clientRect.left + m_clientRect.right) / 2;
+    centerPoint.y = (m_clientRect.top + m_clientRect.bottom) / 2;
+    if (static_cast<double>(m_clientRect.right - m_clientRect.left) /
+                static_cast<double>(m_clientRect.bottom - m_clientRect.top) !=
+            0 &&
+        std::fabs(
+            static_cast<double>(WindowWidthDefault) / static_cast<double>(WindowHeightDefault) -
+            static_cast<double>(m_clientRect.right - m_clientRect.left) /
+                static_cast<double>(m_clientRect.bottom - m_clientRect.top)) > 1e-7) {
+        Log.info(__FUNCTION__, "The resolution is not 16:9, try adjusting the window size");
+        m_restore = true;
+        LONG_PTR exStyle = GetWindowLongPtr(m_hwnd, GWL_EXSTYLE);
+        BOOL hasMenu = (GetMenu(m_hwnd) != NULL);
+        RECT rect = { 0, 0, WindowWidthDefault, WindowHeightDefault };
+        AdjustWindowRectEx(&rect, (DWORD)m_style, hasMenu, (DWORD)exStyle);
+        Log.info(
+            __FUNCTION__,
+            "AdjustWindow, left: ",
+            rect.left,
+            ", right: ",
+            rect.right,
+            ", top: ",
+            rect.top,
+            ", bottom: ",
+            rect.bottom);
+        SetWindowPos(
+            m_hwnd,
+            HWND_NOTOPMOST,
+            0,
+            0,
+            rect.right - rect.left,
+            rect.bottom - rect.top,
+            SWP_SHOWWINDOW | SWP_FRAMECHANGED);
+
+        if (GetClientRect(m_hwnd, &rect)) {
+            centerPoint.x = (rect.left + rect.right) / 2;
+            centerPoint.y = (rect.top + rect.bottom) / 2;
+        }
+    }
+    // 将光标移动到窗口中央防止因UI偏斜导致后续找图失败
+    if (ClientToScreen(m_hwnd, &centerPoint)) {
+        SetCursorPos(centerPoint.x, centerPoint.y);
+    }
+}
+
+WindowGuard::~WindowGuard()
+{
+    Log.info(__FUNCTION__, "WindowGuard destroy");
+    if (m_restore) {
+        Log.info(__FUNCTION__, "restore window");
+        ShowWindow(m_hwnd, SW_RESTORE);
+        UpdateWindow(m_hwnd);
+        LONG_PTR exStyle = GetWindowLongPtr(m_hwnd, GWL_EXSTYLE);
+        BOOL hasMenu = (GetMenu(m_hwnd) != NULL);
+        RECT rect = { 0, 0, m_clientRect.right - m_clientRect.left, m_clientRect.bottom - m_clientRect.top };
+        AdjustWindowRectEx(&rect, (DWORD)m_style, hasMenu, (DWORD)exStyle);
+        SetWindowPos(
+            m_hwnd,
+            HWND_NOTOPMOST,
+            0,
+            0,
+            rect.right - rect.left,
+            rect.bottom - rect.top,
+            SWP_SHOWWINDOW | SWP_FRAMECHANGED);
+    }
+}
+}
+
+#endif // _WIN32

--- a/src/MaaCore/Controller/WindowGuard.h
+++ b/src/MaaCore/Controller/WindowGuard.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#ifdef _WIN32
+
+#include "MaaUtils/SafeWindows.hpp"
+#include <Utils/Logger.hpp>
+#include <cmath>
+
+namespace asst
+{
+class WindowGuard
+{
+public:
+    WindowGuard(void* hwnd);
+
+    ~WindowGuard();
+
+private:
+    RECT m_clientRect = { 0, 0, 0, 0 };
+    HWND m_hwnd = nullptr;
+    LONG_PTR m_style = 0;
+    bool m_restore = false;
+};
+}
+
+#endif // _WIN32
+

--- a/src/MaaCore/Task/Fight/MedicineCounterTaskPlugin.cpp
+++ b/src/MaaCore/Task/Fight/MedicineCounterTaskPlugin.cpp
@@ -67,7 +67,7 @@ bool asst::MedicineCounterTaskPlugin::_run()
                 Log.error(__FUNCTION__, "unable to analyze UseMedicine");
                 return false;
             }
-            using_medicine = MedicineResult { .using_count = 0, .medicines = {} };
+            using_medicine = MedicineResult { .using_count = 0, .medicines = { } };
         }
         else {
             using_medicine = count;
@@ -82,16 +82,33 @@ bool asst::MedicineCounterTaskPlugin::_run()
         }
     }
     else if (m_used_count >= m_max_count && m_use_expiring) {
-        bool changed = false;
-        for (const auto& [use, inventory, rect, is_expiring] : using_medicine->medicines | std::views::reverse) {
-            if (use > 0 && is_expiring != ExpiringStatus::Expiring) {
-                ctrler()->click(rect);
-                sleep(Config.get_options().task_delay);
-                changed = true;
+        bool changed = true;
+        int loop_count = 0;
+        while (changed && loop_count < 3) {
+            loop_count++;
+            changed = false;
+            for (const auto& [use, inventory, rect, is_expiring] : using_medicine->medicines | std::views::reverse) {
+                Log.info(
+                    __FUNCTION__,
+                    " check is_expiring, use: ",
+                    use,
+                    " inventory: ",
+                    inventory,
+                    " rect: ",
+                    rect,
+                    " is_expiring: ",
+                    expiring_status_to_string(is_expiring));
+                if (use > 0 && is_expiring != ExpiringStatus::Expiring) {
+                    ctrler()->click(rect);
+                    sleep(Config.get_options().task_delay);
+                    changed = true;
+                }
+            }
+            if (changed && !refresh_medicine_count()) {
+                return false;
             }
         }
-
-        if (changed && !refresh_medicine_count()) {
+        if (changed && loop_count == 3) {
             return false;
         }
     }
@@ -266,7 +283,7 @@ std::optional<int> asst::MedicineCounterTaskPlugin::get_target_of_sanity(const c
     const auto& ocr_task = Task.get<OcrTaskInfo>("UsingMedicine-Target");
     const auto& ocr_replace = ocr_task->replace_map;
 
-    std::decay_t<decltype(ocr_replace)> merged_replace {};
+    std::decay_t<decltype(ocr_replace)> merged_replace { };
     merged_replace.reserve(number_replace.size() + ocr_replace.size());
     std::ranges::copy(number_replace, std::back_inserter(merged_replace));
     std::ranges::copy(ocr_replace, std::back_inserter(merged_replace));


### PR DESCRIPTION
Resolves #15745

## Summary by Sourcery

通过使用 WindowGuard 助手调整 PC Win32 控制器以管理窗口大小和光标位置，并在清除助手缓存时确保控制器状态也被清除；在启用过期物品时优化药品使用逻辑，并进行一些小的清理。

New Features:
- 使用 WindowGuard 助手自动将附加的 Win32 游戏窗口规范化为 16:9 的客户端区域，并将光标居中，在退出时恢复原始窗口大小。

Bug Fixes:
- 在启用会过期的药品时，当达到最大使用次数时改进药品使用选择逻辑，重试更新并记录状态日志，以避免状态过期（stale state）。

Enhancements:
- 在清除助手缓存时确保 Win32 控制器实例被重置，防止保留过期的控制器/窗口信息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust PC Win32 controller to manage window size and cursor position via a WindowGuard helper and ensure controller state is cleared with the assistant cache; refine medicine usage handling when expiring items are enabled and perform minor cleanups.

New Features:
- Automatically normalize attached Win32 game windows to a 16:9 client area and center the cursor using a WindowGuard helper, restoring the original size on exit.

Bug Fixes:
- Improve medicine usage selection when the maximum usage count is reached with expiring medicines, retrying updates and logging status to avoid stale state.

Enhancements:
- Ensure Win32 controller instance is reset when clearing the assistant cache to avoid retaining stale controller/window information.

</details>