### PR TITLE
feat: add abs_rect to ocr logging results

### DIFF
--- a/src/MaaCore/Config/Miscellaneous/OcrPack.cpp
+++ b/src/MaaCore/Config/Miscellaneous/OcrPack.cpp
@@ -70,7 +70,8 @@ bool asst::OcrPack::load(const std::filesystem::path& path)
     return !m_det_model_path.empty() && !m_rec_model_path.empty() && !m_rec_label_path.empty();
 }
 
-asst::OcrPack::ResultsVec asst::OcrPack::recognize(const cv::Mat& image, bool without_det)
+asst::OcrPack::ResultsVec
+    asst::OcrPack::recognize(const cv::Mat& image, bool without_det, const std::optional<Rect>& base_roi)
 {
     if (!check_and_load()) {
         Log.error(__FUNCTION__, "check_and_load failed");
@@ -101,18 +102,26 @@ asst::OcrPack::ResultsVec asst::OcrPack::recognize(const cv::Mat& image, bool wi
 #endif
 
     ResultsVec raw_results;
+
+    std::string class_type = utils::demangle(typeid(*this).name());
+    std::string raw_log = "[";
+
     for (size_t i = 0; i != ocr_result.text.size(); ++i) {
         // the box rect like ↓
         // 0 - 1
         // 3 - 2
+        Rect abs_rect;
         Rect det_rect;
-        if (!without_det && i < ocr_result.boxes.size()) {
+        if (i < ocr_result.boxes.size()) {
             const auto& box = ocr_result.boxes.at(i);
             int x_collect[] = { box[0], box[2], box[4], box[6] };
             int y_collect[] = { box[1], box[3], box[5], box[7] };
             auto [left, right] = std::ranges::minmax(x_collect);
             auto [top, bottom] = std::ranges::minmax(y_collect);
-            det_rect = Rect(left, top, right - left, bottom - top);
+            abs_rect = Rect(left, top, right - left, bottom - top);
+        }
+        if (!without_det && i < ocr_result.boxes.size()) {
+            det_rect = abs_rect;
         }
         else {
             det_rect = Rect(0, 0, image.cols, image.rows);
@@ -121,13 +130,34 @@ asst::OcrPack::ResultsVec asst::OcrPack::recognize(const cv::Mat& image, bool wi
 #ifdef ASST_DEBUG
         cv::rectangle(draw, make_rect<cv::Rect>(det_rect), cv::Scalar(0, 0, 255), 2);
 #endif
+
+        if (i > 0) {
+            raw_log += ", ";
+        }
+        if (base_roi) {
+            Rect moved_rect(base_roi->x + abs_rect.x, base_roi->y + abs_rect.y, det_rect.width, det_rect.height);
+            raw_log += std::format(
+                "{{ text: {}, moved_rect: {}, rect: {}, score: {:.6f} }}",
+                ocr_result.text.at(i),
+                moved_rect.to_string(),
+                det_rect.to_string(),
+                ocr_result.rec_scores.at(i));
+        }
+        else {
+            raw_log += std::format(
+                "{{ text: {}, rect: {}, score: {:.6f} }}",
+                ocr_result.text.at(i),
+                det_rect.to_string(),
+                ocr_result.rec_scores.at(i));
+        }
+
         raw_results.emplace_back(Result(det_rect, ocr_result.rec_scores.at(i), std::move(ocr_result.text.at(i))));
     }
 
+    raw_log += "]";
     auto costs =
         std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_time).count();
-    std::string class_type = utils::demangle(typeid(*this).name());
-    Log.trace(class_type, raw_results, without_det ? "by OCR Rec" : "by OCR Pipeline", ", cost", costs, "ms");
+    Log.trace(class_type, raw_log, without_det ? "by OCR Rec" : "by OCR Pipeline", ", cost", costs, "ms");
     return raw_results;
 }
 

--- a/src/MaaCore/Config/Miscellaneous/OcrPack.cpp
+++ b/src/MaaCore/Config/Miscellaneous/OcrPack.cpp
@@ -120,6 +120,7 @@ asst::OcrPack::ResultsVec
             auto [top, bottom] = std::ranges::minmax(y_collect);
             abs_rect = Rect(left, top, right - left, bottom - top);
         }
+
         if (!without_det && i < ocr_result.boxes.size()) {
             det_rect = abs_rect;
         }
@@ -134,7 +135,7 @@ asst::OcrPack::ResultsVec
         if (i > 0) {
             raw_log += ", ";
         }
-        if (base_roi) {
+        if (base_roi && i < ocr_result.boxes.size()) {
             Rect moved_rect(base_roi->x + abs_rect.x, base_roi->y + abs_rect.y, det_rect.width, det_rect.height);
             raw_log += std::format(
                 "{{ text: {}, moved_rect: {}, rect: {}, score: {:.6f} }}",

--- a/src/MaaCore/Config/Miscellaneous/OcrPack.h
+++ b/src/MaaCore/Config/Miscellaneous/OcrPack.h
@@ -44,7 +44,7 @@ public:
 
     void use_gpu(int gpu_id) { m_gpu_id = gpu_id; }
 
-    ResultsVec recognize(const cv::Mat& image, bool without_det = false);
+    ResultsVec recognize(const cv::Mat& image, bool without_det = false, const std::optional<Rect>& base_roi = {});
 
 protected:
     OcrPack();

--- a/src/MaaCore/Vision/OCRer.cpp
+++ b/src/MaaCore/Vision/OCRer.cpp
@@ -22,7 +22,7 @@ OCRer::ResultsVecOpt OCRer::analyze() const
     else {
         ocr_ptr = &WordOcr::get_instance();
     }
-    ResultsVec raw_results = ocr_ptr->recognize(make_roi(m_image, m_roi), m_params.without_det);
+    ResultsVec raw_results = ocr_ptr->recognize(make_roi(m_image, m_roi), m_params.without_det, m_roi);
     ocr_ptr = nullptr;
 
     /* post process */


### PR DESCRIPTION
- #15754 for dev-2

## Summary by Sourcery

为 OCR 识别添加对“绝对”边界矩形的跟踪支持，并在 OCR 操作的详细跟踪日志中包含这些信息。

新功能：
- 在运行 OCR 时暴露一个可选的基础 ROI，用于为每个识别到的文本项计算绝对边界矩形。

增强内容：
- 增强 OCR 跟踪日志，输出结构化信息，包括每个检测结果的文本内容、边界矩形以及识别得分。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for tracking absolute OCR bounding rectangles and include them in detailed trace logging for OCR operations.

New Features:
- Expose an optional base ROI when running OCR to compute absolute bounding rectangles for each recognized text item.

Enhancements:
- Augment OCR trace logging to output structured information including text content, bounding rectangles, and recognition scores for each detection.

</details>