### PR TITLE
feat: 实现通宝交换策略

### DIFF
--- a/src/MaaCore/Config/Roguelike/RoguelikeMapConfig.h
+++ b/src/MaaCore/Config/Roguelike/RoguelikeMapConfig.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <unordered_map>
+
 #include "Config/AbstractConfig.h"
 
 namespace asst

--- a/src/MaaCore/Task/Roguelike/JieGarden/RoguelikeCopperStrategy.cpp
+++ b/src/MaaCore/Task/Roguelike/JieGarden/RoguelikeCopperStrategy.cpp
@@ -1,0 +1,112 @@
+#include "RoguelikeCopperStrategy.h"
+#include <algorithm>
+
+namespace asst
+{
+
+static CopperPickupResult default_pickup_strategy(
+    const std::vector<RoguelikeCopper>& options,
+    [[maybe_unused]] const std::vector<RoguelikeCopper>& existing)
+{
+    if (options.empty()) {
+        return { 0, "empty options" };
+    }
+
+    auto it = std::max_element(options.begin(), options.end(),
+        [](const auto& a, const auto& b) { return a.pickup_priority < b.pickup_priority; });
+
+    return { static_cast<size_t>(std::distance(options.begin(), it)), "highest priority" };
+}
+
+static CopperPickupResult findling_pickup_strategy(
+    const std::vector<RoguelikeCopper>& options,
+    [[maybe_unused]] const std::vector<RoguelikeCopper>& existing)
+{
+    if (options.empty()) {
+        return { 0, "empty options" };
+    }
+
+    for (size_t i = 0; i < options.size(); ++i) {
+        if (options[i].type == CopperType::Li) {
+            return { i, "Li-type" };
+        }
+    }
+
+    auto it = std::max_element(options.begin(), options.end(),
+        [](const auto& a, const auto& b) { return a.pickup_priority < b.pickup_priority; });
+
+    return { static_cast<size_t>(std::distance(options.begin(), it)), "no Li, highest priority" };
+}
+
+static CopperExchangeResult default_exchange_strategy(
+    const RoguelikeCopper& new_copper,
+    const std::vector<RoguelikeCopper>& existing)
+{
+    if (existing.empty()) {
+        return { false, 0, "empty existing" };
+    }
+
+    auto worst = std::max_element(existing.begin(), existing.end(),
+        [](const auto& a, const auto& b) {
+            return a.get_copper_discard_priority() < b.get_copper_discard_priority();
+        });
+
+    if (worst->get_copper_discard_priority() >= new_copper.get_copper_discard_priority()) {
+        return { true, static_cast<size_t>(std::distance(existing.begin(), worst)), "better" };
+    }
+
+    return { false, 0, "worse" };
+}
+
+static CopperExchangeResult findling_exchange_strategy(
+    const RoguelikeCopper& new_copper,
+    const std::vector<RoguelikeCopper>& existing)
+{
+    if (existing.empty()) {
+        return { false, 0, "empty existing" };
+    }
+
+    if (new_copper.type == CopperType::Li) {
+        size_t worst_idx = SIZE_MAX;
+        int worst_priority = -1;
+
+        for (size_t i = 0; i < existing.size(); ++i) {
+            if (existing[i].type != CopperType::Li) {
+                int priority = existing[i].get_copper_discard_priority();
+                if (worst_idx == SIZE_MAX || priority > worst_priority) {
+                    worst_idx = i;
+                    worst_priority = priority;
+                }
+            }
+        }
+
+        if (worst_idx != SIZE_MAX) {
+            return { true, worst_idx, "Li replace non-Li" };
+        }
+
+        auto worst = std::max_element(existing.begin(), existing.end(),
+            [](const auto& a, const auto& b) {
+                return a.get_copper_discard_priority() < b.get_copper_discard_priority();
+            });
+        return { true, static_cast<size_t>(std::distance(existing.begin(), worst)), "Li replace worst Li" };
+    }
+
+    for (size_t i = 0; i < existing.size(); ++i) {
+        if (existing[i].type != CopperType::Li &&
+            existing[i].get_copper_discard_priority() > new_copper.get_copper_discard_priority()) {
+            return { true, i, "replace worse non-Li" };
+        }
+    }
+
+    return { false, 0, "keep existing" };
+}
+
+CopperStrategy get_copper_strategy(CopperStrategyType type)
+{
+    if (type == CopperStrategyType::FindLingMode) {
+        return { findling_pickup_strategy, findling_exchange_strategy };
+    }
+    return { default_pickup_strategy, default_exchange_strategy };
+}
+
+}

--- a/src/MaaCore/Task/Roguelike/JieGarden/RoguelikeCopperStrategy.cpp
+++ b/src/MaaCore/Task/Roguelike/JieGarden/RoguelikeCopperStrategy.cpp
@@ -1,5 +1,6 @@
 #include "RoguelikeCopperStrategy.h"
 #include <algorithm>
+#include <limits>
 
 namespace asst
 {
@@ -12,13 +13,14 @@ static CopperPickupResult default_pickup_strategy(
         return { 0, "empty options" };
     }
 
-    auto it = std::max_element(options.begin(), options.end(),
-        [](const auto& a, const auto& b) { return a.pickup_priority < b.pickup_priority; });
+    auto it = std::max_element(options.begin(), options.end(), [](const auto& a, const auto& b) {
+        return a.pickup_priority < b.pickup_priority;
+    });
 
     return { static_cast<size_t>(std::distance(options.begin(), it)), "highest priority" };
 }
 
-static CopperPickupResult findling_pickup_strategy(
+static CopperPickupResult findplaytime_pickup_strategy(
     const std::vector<RoguelikeCopper>& options,
     [[maybe_unused]] const std::vector<RoguelikeCopper>& existing)
 {
@@ -26,30 +28,37 @@ static CopperPickupResult findling_pickup_strategy(
         return { 0, "empty options" };
     }
 
+    size_t best_li_idx = SIZE_MAX;
+    int best_li_priority = std::numeric_limits<int>::min();
+
     for (size_t i = 0; i < options.size(); ++i) {
-        if (options[i].type == CopperType::Li) {
-            return { i, "Li-type" };
+        if (options[i].type == CopperType::Li && options[i].pickup_priority > best_li_priority) {
+            best_li_idx = i;
+            best_li_priority = options[i].pickup_priority;
         }
     }
 
-    auto it = std::max_element(options.begin(), options.end(),
-        [](const auto& a, const auto& b) { return a.pickup_priority < b.pickup_priority; });
+    if (best_li_idx != SIZE_MAX) {
+        return { best_li_idx, "best Li by pickup priority" };
+    }
+
+    auto it = std::max_element(options.begin(), options.end(), [](const auto& a, const auto& b) {
+        return a.pickup_priority < b.pickup_priority;
+    });
 
     return { static_cast<size_t>(std::distance(options.begin(), it)), "no Li, highest priority" };
 }
 
-static CopperExchangeResult default_exchange_strategy(
-    const RoguelikeCopper& new_copper,
-    const std::vector<RoguelikeCopper>& existing)
+static CopperExchangeResult
+    default_exchange_strategy(const RoguelikeCopper& new_copper, const std::vector<RoguelikeCopper>& existing)
 {
     if (existing.empty()) {
         return { false, 0, "empty existing" };
     }
 
-    auto worst = std::max_element(existing.begin(), existing.end(),
-        [](const auto& a, const auto& b) {
-            return a.get_copper_discard_priority() < b.get_copper_discard_priority();
-        });
+    auto worst = std::max_element(existing.begin(), existing.end(), [](const auto& a, const auto& b) {
+        return a.get_copper_discard_priority() < b.get_copper_discard_priority();
+    });
 
     if (worst->get_copper_discard_priority() >= new_copper.get_copper_discard_priority()) {
         return { true, static_cast<size_t>(std::distance(existing.begin(), worst)), "better" };
@@ -58,9 +67,8 @@ static CopperExchangeResult default_exchange_strategy(
     return { false, 0, "worse" };
 }
 
-static CopperExchangeResult findling_exchange_strategy(
-    const RoguelikeCopper& new_copper,
-    const std::vector<RoguelikeCopper>& existing)
+static CopperExchangeResult
+    findplaytime_exchange_strategy(const RoguelikeCopper& new_copper, const std::vector<RoguelikeCopper>& existing)
 {
     if (existing.empty()) {
         return { false, 0, "empty existing" };
@@ -84,18 +92,29 @@ static CopperExchangeResult findling_exchange_strategy(
             return { true, worst_idx, "Li replace non-Li" };
         }
 
-        auto worst = std::max_element(existing.begin(), existing.end(),
-            [](const auto& a, const auto& b) {
-                return a.get_copper_discard_priority() < b.get_copper_discard_priority();
-            });
+        auto worst = std::max_element(existing.begin(), existing.end(), [](const auto& a, const auto& b) {
+            return a.get_copper_discard_priority() < b.get_copper_discard_priority();
+        });
         return { true, static_cast<size_t>(std::distance(existing.begin(), worst)), "Li replace worst Li" };
     }
 
+    size_t worst_non_li_idx = SIZE_MAX;
+    int worst_non_li_priority = new_copper.get_copper_discard_priority();
+
     for (size_t i = 0; i < existing.size(); ++i) {
-        if (existing[i].type != CopperType::Li &&
-            existing[i].get_copper_discard_priority() > new_copper.get_copper_discard_priority()) {
-            return { true, i, "replace worse non-Li" };
+        if (existing[i].type == CopperType::Li) {
+            continue;
         }
+
+        const int priority = existing[i].get_copper_discard_priority();
+        if (priority > worst_non_li_priority) {
+            worst_non_li_priority = priority;
+            worst_non_li_idx = i;
+        }
+    }
+
+    if (worst_non_li_idx != SIZE_MAX) {
+        return { true, worst_non_li_idx, "replace worst non-Li" };
     }
 
     return { false, 0, "keep existing" };
@@ -103,8 +122,8 @@ static CopperExchangeResult findling_exchange_strategy(
 
 CopperStrategy get_copper_strategy(CopperStrategyType type)
 {
-    if (type == CopperStrategyType::FindLingMode) {
-        return { findling_pickup_strategy, findling_exchange_strategy };
+    if (type == CopperStrategyType::FindPlaytimeLingMode) {
+        return { findplaytime_pickup_strategy, findplaytime_exchange_strategy };
     }
     return { default_pickup_strategy, default_exchange_strategy };
 }

--- a/src/MaaCore/Task/Roguelike/JieGarden/RoguelikeCopperStrategy.cpp
+++ b/src/MaaCore/Task/Roguelike/JieGarden/RoguelikeCopperStrategy.cpp
@@ -28,7 +28,7 @@ static CopperPickupResult findplaytime_pickup_strategy(
         return { 0, "empty options" };
     }
 
-    size_t best_li_idx = SIZE_MAX;
+    size_t best_li_idx = std::numeric_limits<size_t>::max();
     int best_li_priority = std::numeric_limits<int>::min();
 
     for (size_t i = 0; i < options.size(); ++i) {
@@ -38,7 +38,7 @@ static CopperPickupResult findplaytime_pickup_strategy(
         }
     }
 
-    if (best_li_idx != SIZE_MAX) {
+    if (best_li_idx != std::numeric_limits<size_t>::max()) {
         return { best_li_idx, "best Li by pickup priority" };
     }
 
@@ -75,30 +75,35 @@ static CopperExchangeResult
     }
 
     if (new_copper.type == CopperType::Li) {
-        size_t worst_idx = SIZE_MAX;
+        size_t worst_idx = std::numeric_limits<size_t>::max();
         int worst_priority = -1;
 
         for (size_t i = 0; i < existing.size(); ++i) {
             if (existing[i].type != CopperType::Li) {
                 int priority = existing[i].get_copper_discard_priority();
-                if (worst_idx == SIZE_MAX || priority > worst_priority) {
+                if (worst_idx == std::numeric_limits<size_t>::max() || priority > worst_priority) {
                     worst_idx = i;
                     worst_priority = priority;
                 }
             }
         }
 
-        if (worst_idx != SIZE_MAX) {
+        if (worst_idx != std::numeric_limits<size_t>::max()) {
             return { true, worst_idx, "Li replace non-Li" };
         }
 
         auto worst = std::max_element(existing.begin(), existing.end(), [](const auto& a, const auto& b) {
             return a.get_copper_discard_priority() < b.get_copper_discard_priority();
         });
-        return { true, static_cast<size_t>(std::distance(existing.begin(), worst)), "Li replace worst Li" };
+        const int worst_li_priority = worst->get_copper_discard_priority();
+        const int new_li_priority = new_copper.get_copper_discard_priority();
+        if (new_li_priority < worst_li_priority) {
+            return { true, static_cast<size_t>(std::distance(existing.begin(), worst)), "Li replace worse Li" };
+        }
+        return { false, 0, "keep existing Li" };
     }
 
-    size_t worst_non_li_idx = SIZE_MAX;
+    size_t worst_non_li_idx = std::numeric_limits<size_t>::max();
     int worst_non_li_priority = new_copper.get_copper_discard_priority();
 
     for (size_t i = 0; i < existing.size(); ++i) {
@@ -113,7 +118,7 @@ static CopperExchangeResult
         }
     }
 
-    if (worst_non_li_idx != SIZE_MAX) {
+    if (worst_non_li_idx != std::numeric_limits<size_t>::max()) {
         return { true, worst_non_li_idx, "replace worst non-Li" };
     }
 

--- a/src/MaaCore/Task/Roguelike/JieGarden/RoguelikeCopperStrategy.h
+++ b/src/MaaCore/Task/Roguelike/JieGarden/RoguelikeCopperStrategy.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "Config/Roguelike/JieGarden/RoguelikeCoppersConfig.h"
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace asst
+{
+
+struct CopperPickupResult
+{
+    size_t selected_index = 0;
+    std::string reason;
+};
+
+struct CopperExchangeResult
+{
+    bool should_exchange = false;
+    size_t discard_index = 0;
+    std::string reason;
+};
+
+enum class CopperStrategyType
+{
+    Default,
+    FindLingMode
+};
+
+using CopperPickupStrategyFunction =
+    std::function<CopperPickupResult(const std::vector<RoguelikeCopper>&, const std::vector<RoguelikeCopper>&)>;
+
+using CopperExchangeStrategyFunction =
+    std::function<CopperExchangeResult(const RoguelikeCopper&, const std::vector<RoguelikeCopper>&)>;
+
+struct CopperStrategy
+{
+    CopperPickupStrategyFunction pickup;
+    CopperExchangeStrategyFunction exchange;
+};
+
+CopperStrategy get_copper_strategy(CopperStrategyType type);
+}

--- a/src/MaaCore/Task/Roguelike/JieGarden/RoguelikeCopperStrategy.h
+++ b/src/MaaCore/Task/Roguelike/JieGarden/RoguelikeCopperStrategy.h
@@ -24,7 +24,7 @@ struct CopperExchangeResult
 enum class CopperStrategyType
 {
     Default,
-    FindLingMode
+    FindPlaytimeLingMode
 };
 
 using CopperPickupStrategyFunction =

--- a/src/MaaCore/Task/Roguelike/JieGarden/RoguelikeCoppersTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/JieGarden/RoguelikeCoppersTaskPlugin.cpp
@@ -6,6 +6,7 @@
 #include "Controller/Controller.h"
 #include "MaaUtils/ImageIo.h"
 #include "Task/ProcessTask.h"
+#include "Task/Roguelike/Map/RoguelikeBoskyPassageMap.h"
 #include "Task/Roguelike/RoguelikeConfig.h"
 #include "Utils/DebugImageHelper.hpp"
 #include "Utils/Logger.hpp"
@@ -176,7 +177,7 @@ asst::CopperTaskResult asst::RoguelikeCoppersTaskPlugin::handle_pickup_mode()
     }
 
     const auto& [copper, point] = m_pending_copper[result.selected_index];
-    LogInfo << __FUNCTION__ << "| selected" << copper.name << "reason:" << result.reason;
+    LogInfo << __FUNCTION__ << "|selected" << copper.name << "|reason:" << result.reason;
 
     ctrler()->click(point);
 
@@ -399,7 +400,7 @@ asst::CopperTaskResult asst::RoguelikeCoppersTaskPlugin::handle_exchange_mode()
     auto& worst_copper = m_copper_list[discard_index];
 
     auto strategy_name =
-        (get_current_strategy_type() == CopperStrategyType::FindLingMode) ? "FindLing" : "Default";
+        (get_current_strategy_type() == CopperStrategyType::FindPlaytimeLingMode) ? "FindPlaytime-Ling" : "Default";
 
     // 执行交换
     LogInfo << __FUNCTION__ << "| Exchanging copper using strategy: " << strategy_name << " - " << worst_copper.name
@@ -663,10 +664,10 @@ void asst::RoguelikeCoppersTaskPlugin::save_debug_image(
 // 获取当前游戏模式对应的交换策略
 asst::CopperStrategyType asst::RoguelikeCoppersTaskPlugin::get_current_strategy_type() const
 {
-    // 检查当前游戏是否为FindLing模式
-    // 检查是否是界园主题且为FindPlaytime（刷常乐节点）模式
-    if (m_config->get_theme() == RoguelikeTheme::JieGarden && m_config->get_mode() == RoguelikeMode::FindPlaytime) {
-        return CopperStrategyType::FindLingMode;
+    // 仅在界园 FindPlaytime 且目标常乐子类型为 Ling 时启用特殊策略
+    if (m_config->get_theme() == RoguelikeTheme::JieGarden && m_config->get_mode() == RoguelikeMode::FindPlaytime &&
+        m_config->get_find_playTime_target() == static_cast<int>(RoguelikeBoskySubNodeType::Ling)) {
+        return CopperStrategyType::FindPlaytimeLingMode;
     }
 
     // 默认使用标准策略
@@ -681,7 +682,7 @@ bool asst::RoguelikeCoppersTaskPlugin::decide_exchange_by_strategy(
     auto strategy = get_copper_strategy(get_current_strategy_type());
     auto result = strategy.exchange(new_copper, existing_coppers);
 
-    LogInfo << __FUNCTION__ << result.reason;
+    LogInfo << __FUNCTION__ << "|" << result.reason;
 
     if (result.should_exchange) {
         discard_index = result.discard_index;

--- a/src/MaaCore/Task/Roguelike/JieGarden/RoguelikeCoppersTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/JieGarden/RoguelikeCoppersTaskPlugin.h
@@ -3,6 +3,7 @@
 
 #include "Common/AsstTypes.h"
 #include "Config/Roguelike/JieGarden/RoguelikeCoppersConfig.h"
+#include "Task/Roguelike/JieGarden/RoguelikeCopperStrategy.h"
 #include "Vision/Roguelike/JieGarden/RoguelikeCoppersAnalyzer.h"
 
 namespace asst
@@ -80,6 +81,15 @@ private:
 
     // 保存调试图像到文件
     void save_debug_image(const cv::Mat& image, const std::string& suffix, bool auto_clean = true) const;
+
+    // 获取当前游戏模式对应的通宝策略类型
+    CopperStrategyType get_current_strategy_type() const;
+
+    // 根据策略决定是否交换通宝
+    bool decide_exchange_by_strategy(
+        const RoguelikeCopper& new_copper,
+        const std::vector<RoguelikeCopper>& existing_coppers,
+        size_t& discard_index) const;
 
     mutable asst::CoppersTaskRunMode m_run_mode; // 当前运行模式
 


### PR DESCRIPTION
在刷令节点模式下优先保留厉钱

close #14668
close #15123

## Summary by Sourcery

引入可配置的铜币拾取与交换策略，并对 JieGarden 的 FindPlaytime 模式进行特殊处理，以优先选择 Li 类型铜币并改进决策日志记录。

新功能：
- 添加铜币拾取与交换的策略抽象，包括一个专用于 FindLing/FindPlaytime 模式的策略，以优先选择 Li 类型铜币。

改进：
- 重构 `RoguelikeCoppersTaskPlugin` 中的铜币拾取与交换逻辑，将决策委托给策略函数，并增加决策及其原因的校验和详细日志记录。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce configurable copper pickup and exchange strategies with special handling for JieGarden FindPlaytime mode to prioritize Li-type coppers and improve decision logging.

New Features:
- Add a strategy abstraction for copper pickup and exchange, including a dedicated strategy for FindLing/FindPlaytime mode that prioritizes Li-type coppers.

Enhancements:
- Refactor copper pickup and exchange logic in RoguelikeCoppersTaskPlugin to delegate decisions to strategy functions, with validation and detailed logging of decisions and reasons.

</details>