### PR TITLE
docs: Modify git clone command to use --single-branch

### DIFF
--- a/docs/en-us/develop/development.md
+++ b/docs/en-us/develop/development.md
@@ -45,6 +45,10 @@ We've preset several different development environments for you to choose from:
    git clone --recurse-submodules <your repository link> -b dev-v2 --single-branch
    ```
 
+   ::: tip
+   `--single-branch` only fetches the history for `dev-v2`. If you later want to switch to another branch, run `git remote set-branches origin '*'` and fetch again so Git can download the missing branch data, or re-clone the repository without `--single-branch`.
+   :::
+
    ::: warning
    If using Git GUI clients like Visual Studio without `--recurse-submodules` support, run `git submodule update --init` after cloning to initialize submodules.
    :::

--- a/docs/en-us/develop/development.md
+++ b/docs/en-us/develop/development.md
@@ -42,7 +42,7 @@ We've preset several different development environments for you to choose from:
 3. Clone the dev branch of your repository with submodules:
 
    ```bash
-   git clone --recurse-submodules <your repository link> -b dev-v2
+   git clone --recurse-submodules <your repository link> -b dev-v2 --single-branch
    ```
 
    ::: warning

--- a/docs/ja-jp/develop/development.md
+++ b/docs/ja-jp/develop/development.md
@@ -42,7 +42,7 @@ icon: iconoir:developer
 3. 自身のリポジトリの dev ブランチをクローン（サブモジュール含む）
 
    ```bash
-   git clone --recurse-submodules <リポジトリの git リンク> -b dev-v2
+   git clone --recurse-submodules <リポジトリの git リンク> -b dev-v2 --single-branch
    ```
 
    ::: warning

--- a/docs/ja-jp/develop/development.md
+++ b/docs/ja-jp/develop/development.md
@@ -45,6 +45,10 @@ icon: iconoir:developer
    git clone --recurse-submodules <リポジトリの git リンク> -b dev-v2 --single-branch
    ```
 
+   ::: tip
+   `--single-branch` で取得されるのは `dev-v2` の履歴だけです。あとで別のブランチに切り替えたい場合は、先に `git remote set-branches origin '*'` を実行してから再度 fetch するか、`--single-branch` なしでリポジトリを再度クローンして不足しているブランチ情報を取得してください。
+   :::
+
    ::: warning
    Visual Studio など `--recurse-submodules` パラメータに対応していない Git GUI を使用する場合、クローン後に以下を実行：
 

--- a/docs/ko-kr/develop/development.md
+++ b/docs/ko-kr/develop/development.md
@@ -42,7 +42,7 @@ icon: iconoir:developer
 3. 본인 저장소의 dev 브랜치를 서브모듈 포함 클론:
 
    ```bash
-   git clone --recurse-submodules <저장소 git 링크> -b dev-v2
+   git clone --recurse-submodules <저장소 git 링크> -b dev-v2 --single-branch
    ```
 
    ::: warning

--- a/docs/ko-kr/develop/development.md
+++ b/docs/ko-kr/develop/development.md
@@ -45,6 +45,10 @@ icon: iconoir:developer
    git clone --recurse-submodules <저장소 git 링크> -b dev-v2 --single-branch
    ```
 
+   ::: tip
+   `--single-branch`는 `dev-v2` 브랜치 기록만 가져옵니다. 나중에 다른 브랜치로 전환하려면 먼저 `git remote set-branches origin '*'`를 실행한 뒤 다시 fetch해서 다른 브랜치 정보를 받아오거나, `--single-branch` 없이 저장소를 다시 클론해야 합니다.
+   :::
+
    ::: warning
    Visual Studio 등 --recurse-submodules 미지원 Git GUI 사용 시, 클론 후 다음 실행:
 

--- a/docs/zh-cn/develop/development.md
+++ b/docs/zh-cn/develop/development.md
@@ -45,6 +45,10 @@ icon: iconoir:developer
    git clone --recurse-submodules <你的仓库的 git 链接> -b dev-v2 --single-branch
    ```
 
+   ::: tip
+   `--single-branch` 只会拉取 `dev-v2` 的提交记录。如果之后想切换到其他分支，需要先执行 `git remote set-branches origin '*'` 并重新拉取，来补齐其他分支的信息；或者重新克隆一个不带 `--single-branch` 的仓库。
+   :::
+
    ::: warning
    如果正在使用 Visual Studio 等不附带 `--recurse-submodules` 参数的 Git GUI，则需在克隆后再执行 `git submodule update --init` 以拉取子模块。
    :::

--- a/docs/zh-cn/develop/development.md
+++ b/docs/zh-cn/develop/development.md
@@ -42,7 +42,7 @@ icon: iconoir:developer
 3. 克隆你自己仓库下的 dev 分支到本地，并拉取子模块
 
    ```bash
-   git clone --recurse-submodules <你的仓库的 git 链接> -b dev-v2
+   git clone --recurse-submodules <你的仓库的 git 链接> -b dev-v2 --single-branch
    ```
 
    ::: warning

--- a/docs/zh-tw/develop/development.md
+++ b/docs/zh-tw/develop/development.md
@@ -42,7 +42,7 @@ icon: iconoir:developer
 3. 複製（Clone）您自己倉庫下的 dev 分支到在地，並拉取子模組（Submodules）。
 
    ```bash
-   git clone --recurse-submodules <您的倉庫 git 連結> -b dev-v2
+   git clone --recurse-submodules <您的倉庫 git 連結> -b dev-v2 --single-branch
    ```
 
    ::: warning

--- a/docs/zh-tw/develop/development.md
+++ b/docs/zh-tw/develop/development.md
@@ -45,6 +45,10 @@ icon: iconoir:developer
    git clone --recurse-submodules <您的倉庫 git 連結> -b dev-v2 --single-branch
    ```
 
+   ::: tip
+   `--single-branch` 只會拉取 `dev-v2` 的提交記錄。如果之後想切換到其他分支，需要先執行 `git remote set-branches origin '*'` 並重新抓取，來補齊其他分支的資訊；或者重新複製一個不帶 `--single-branch` 的倉庫。
+   :::
+
    ::: warning
    如果正在使用 Visual Studio 等不附帶 `--recurse-submodules` 參數的 Git GUI，則需在複製後再執行 `git submodule update --init` 以拉取子模組。
    :::


### PR DESCRIPTION
经过测试，`--single-branch` 能显著减少克隆时需要下载的数据量：

Testing has shown that `--single-branch` can significantly reduce the amount of data that needs to be downloaded during cloning:

----

未使用 `--single-branch` 时：

When NOT using `--single-branch`:

```
@AnnAngela ➜ /workspaces/test $ git clone --recurse-submodules https://github.com/MaaAssistantArknights/MaaAssistantArknights.git -b dev-v2
Cloning into 'MaaAssistantArknights'...
remote: Enumerating objects: 270284, done.
remote: Counting objects: 100% (21850/21850), done.
remote: Compressing objects: 100% (484/484), done.
remote: Total 270284 (delta 21393), reused 21376 (delta 21366), pack-reused 248434 (from 3)
Receiving objects: 100% (270284/270284), 952.51 MiB | 19.62 MiB/s, done.
Resolving deltas: 100% (191116/191116), done.
Updating files: 100% (9806/9806), done.
<SUBMODULE LOGS HAVE BEEN TRUNCATED FOR EASIER READING>

@AnnAngela ➜ /workspaces/test $ du -hs MaaAssistantArknights
1.6G    MaaAssistantArknights
```

----

使用 `--single-branch` 时：

When using `--single-branch`:

```
@AnnAngela ➜ /workspaces/test--single-branch $ git clone --recurse-submodules https://github.com/MaaAssistantArknights/MaaAssistantArknights.git -b dev-v2 --single-branch
Cloning into 'MaaAssistantArknights'...
remote: Enumerating objects: 173570, done.
remote: Counting objects: 100% (18126/18126), done.
remote: Compressing objects: 100% (577/577), done.
remote: Total 173570 (delta 17574), reused 17563 (delta 17549), pack-reused 155444 (from 3)
Receiving objects: 100% (173570/173570), 394.56 MiB | 13.23 MiB/s, done.
Resolving deltas: 100% (119648/119648), done.
Updating files: 100% (9806/9806), done.
<SUBMODULE LOGS HAVE BEEN TRUNCATED FOR EASIER READING>

@AnnAngela ➜ /workspaces/test--single-branch $ du -hs MaaAssistantArknights
987M    MaaAssistantArknights
```

----

实测，下载数据量从 952.51 MiB 下降为 394.56 MiB，节约了 557.95 MiB / 58.577%；克隆后大小从 1.6 GB（1596080987 B）下降为 987 MB（1007402595 B），节约了 561.4 MiB / 36.883%。

有鉴于此，我建议在开发文档里建议开发者使用 `--single-branch`。

Testing has shown that: the downloaded data size decreased from 952.51 MiB to 394.56 MiB, saving 557.95 MiB / 58.577%; the cloned size decreased from 1.6 GB (1596080987 B) to 987 MB (1007402595 B), saving 561.4 MiB / 36.883%.

Therefore, I recommend that developers use `--single-branch` in the development documentation.

## Summary by Sourcery

Documentation:
- 在所有支持的语言中更新开发环境搭建指南，在针对 `dev-v2` 分支的 `git clone` 命令中加入 `--single-branch` 参数。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Update development setup guides in all supported languages to include the --single-branch flag in git clone commands for the dev-v2 branch.

</details>

## Summary by Sourcery

文档：
- 在所有本地化的开发环境设置指南中更新 `git clone` 示例，为 `dev-v2` 分支添加 `--single-branch` 标志，并记录在需要时如何后续获取其他分支。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Update git clone examples in all localized development setup guides to include the --single-branch flag for the dev-v2 branch and document how to later fetch additional branches if needed.

</details>