### PR TITLE
Release v6.5.1

### DIFF
--- a/.github/workflows/markdown-checker.yml
+++ b/.github/workflows/markdown-checker.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Comment (only for PR)
         if: failure() && github.event_name == 'pull_request'
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@v3
         with:
           message: |
             Dead links found in the documentation. Please fix them.

--- a/3rdparty/include/Arknights-Tile-Pos/TileDef.hpp
+++ b/3rdparty/include/Arknights-Tile-Pos/TileDef.hpp
@@ -60,7 +60,7 @@ private:
 inline Level::Level(const json::value& data)
 {
     key.stageId = data.at("stageId").as_string();
-    key.code = data.at("code").as_string();
+    key.code = data.get("code", "null");
     key.levelId = data.at("levelId").as_string();
     key.name = data.get("name", "null");
     this->height = data.at("height").as_integer();

--- a/3rdparty/include/Arknights-Tile-Pos/TileDef.hpp
+++ b/3rdparty/include/Arknights-Tile-Pos/TileDef.hpp
@@ -15,15 +15,9 @@ struct LevelKey
     std::string levelId;
     std::string name;
 
-    bool empty_or_equal(const std::string& lhs, const std::string& rhs) const noexcept
-    {
-        return (lhs.empty() || rhs.empty()) ? true : lhs == rhs;
-    }
-
     bool operator==(const LevelKey& other) const noexcept
     {
-        return empty_or_equal(stageId, other.stageId) && empty_or_equal(code, other.code)
-               && empty_or_equal(levelId, other.levelId) && empty_or_equal(name, other.name);
+        return stageId == other.stageId && code == other.code && levelId == other.levelId && name == other.name;
     }
 
     bool operator==(const std::string& any_key) const noexcept
@@ -31,8 +25,7 @@ struct LevelKey
         if (any_key.empty()) {
             return false;
         }
-        return empty_or_equal(stageId, any_key) || empty_or_equal(code, any_key)
-               || empty_or_equal(levelId, any_key) || empty_or_equal(name, any_key);
+        return stageId == any_key || code == any_key || levelId == any_key || name == any_key;
     }
 };
 
@@ -84,9 +77,10 @@ inline Level::Level(const json::value& data)
         std::vector<Tile> tmp;
         tmp.reserve(this->width);
         for (const json::value& tile : row.as_array()) {
-            tmp.emplace_back(Tile { tile.at("heightType").as_integer(),
-                                    tile.at("buildableType").as_integer(),
-                                    tile.get("tileKey", std::string()) });
+            tmp.emplace_back(
+                Tile { tile.at("heightType").as_integer(),
+                       tile.at("buildableType").as_integer(),
+                       tile.get("tileKey", std::string()) });
         }
         tiles.emplace_back(std::move(tmp));
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### 修复 | Fix
 
-* 地图解析时code为null会崩溃 @status102
+* 地图解析时 code 为 null 会崩溃 @status102
 * 地图判断不再允许 空值与非空值 => true @status102
 * 仅在刷源石锭模式下允许触发储备源石锭达到上限时停止 @ABA2396
 
@@ -20,6 +20,10 @@
 
 * Add inline styles to Trendshift badge @AnnAngela
 * Update README.md badge formatting and structure @AnnAngela
-* Reapply "fix: overview is null" @status102
-* Revert "fix: overview is null" @status102
-* Revert "fix: 改个地图code默认值" @status102
+
+## v6.5.0
+
+### 新增 | New
+
+* 卫二期 @ABA2396
+* 调整提示文本 @ABA2396

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,25 @@
-## v6.5.0
-
-### Highlight
-
-这么短写什么 Highlight ~~都怪鹰角~~
+## v6.5.1
 
 ### 新增 | New
 
-* 卫二期 @ABA2396
-* 调整提示文本 @ABA2396
+* 设置指引中的每次重新检测添加高亮提示 @ABA2396
+* 添加重看设置指引按钮 @ABA2396
+* 中断返回添加重试 @ABA2396
+
+### 改进 | Improved
+
+* 提取高亮提示勾选框为通用组件 @ABA2396
+
+### 修复 | Fix
+
+* 地图解析时code为null会崩溃 @status102
+* 地图判断不再允许 空值与非空值 => true @status102
+* 仅在刷源石锭模式下允许触发储备源石锭达到上限时停止 @ABA2396
+
+### 其他 | Other
+
+* Add inline styles to Trendshift badge @AnnAngela
+* Update README.md badge formatting and structure @AnnAngela
+* Reapply "fix: overview is null" @status102
+* Revert "fix: overview is null" @status102
+* Revert "fix: 改个地图code默认值" @status102

--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@
 <br>
 <div>
     <img alt="C++" src="https://img.shields.io/badge/C++-20-%2300599C?logo=cplusplus">
-</div>
-<div>
     <img alt="platform" src="https://img.shields.io/badge/platform-Windows%20%7C%20Linux%20%7C%20macOS-blueviolet">
 </div>
 <div>
@@ -24,7 +22,9 @@
 <div>
     <a href="https://deepwiki.com/MaaAssistantArknights/MaaAssistantArknights"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
 </div>
-<a href="https://trendshift.io/repositories/979" target="_blank"><img src="https://trendshift.io/api/badge/repositories/979" alt="MaaAssistantArknights%2FMaaAssistantArknights | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
+    <a href="https://trendshift.io/repositories/979" target="_blank"><img src="https://trendshift.io/api/badge/repositories/979" alt="MaaAssistantArknights%2FMaaAssistantArknights | Trendshift" width="250" height="55"/></a>
+<div>
+</div>
 <br>
 
 <!-- markdownlint-restore -->

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@
 <div>
     <a href="https://deepwiki.com/MaaAssistantArknights/MaaAssistantArknights"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
 </div>
-    <a href="https://trendshift.io/repositories/979" target="_blank"><img src="https://trendshift.io/api/badge/repositories/979" alt="MaaAssistantArknights%2FMaaAssistantArknights | Trendshift" width="250" height="55"/></a>
+    <a href="https://trendshift.io/repositories/979" target="_blank"><img src="https://trendshift.io/api/badge/repositories/979" alt="MaaAssistantArknights%2FMaaAssistantArknights | Trendshift" width="250" height="55" style="width: 250px; height: 55px;" /></a>
 <div>
 </div>
 <br>

--- a/resource/tasks/MiniGame/SPA.json
+++ b/resource/tasks/MiniGame/SPA.json
@@ -128,6 +128,6 @@
         "doc": "二期新加的允许中断返回",
         "action": "ClickSelf",
         "roi": [717, 573, 242, 141],
-        "next": ["MiniGame@SPA@ConfirmResult"]
+        "next": ["#self", "MiniGame@SPA@ConfirmResult"]
     }
 }

--- a/src/MaaCore/Config/Miscellaneous/TilePack.cpp
+++ b/src/MaaCore/Config/Miscellaneous/TilePack.cpp
@@ -29,7 +29,7 @@ bool asst::TilePack::parse(const json::value& json)
     for (const auto& [_, summary] : json.as_object()) {
         LevelKey level_key {
             .stageId = summary.at("stageId").as_string(),
-            .code = summary.get("code", "Unknown"),
+            .code = summary.get("code", ""),
             .levelId = summary.at("levelId").as_string(),
             .name = summary.get("name", "UnknownLevelName"),
         };

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -113,6 +113,8 @@
     <system:String x:Key="GuideOpenSourceTitle">💡 Participate in Open Source</system:String>
     <system:String x:Key="GuideOpenSourceDescription">As an open source project, users can participate in MAA's development on GitHub platform under the AGPL-3.0 license. MAA Team encourages users to contribute valuable code instead of just reporting issues.</system:String>
     <system:String x:Key="GuideUserAgreement">By using MAA, you agree to comply with the "User Agreement". The complete agreement can be found in the link at the bottom of the official website.</system:String>
+    <system:String x:Key="RestartGuide">Restart Settings Guide</system:String>
+    <system:String x:Key="RestartGuidePrompt">The settings guide will be displayed on the main interface. Restart the application now?</system:String>
     <!--  !Settings Guide  -->
     <system:String x:Key="Dorm">Dormitory</system:String>
     <system:String x:Key="Mfg">Factory</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -113,6 +113,8 @@
     <system:String x:Key="GuideOpenSourceTitle">💡 オープンソースへの参加</system:String>
     <system:String x:Key="GuideOpenSourceDescription">オープンソースプロジェクトとして、ユーザーは AGPL-3.0 ライセンスの下で GitHub プラットフォーム上で MAA の開発に参加できます。MAA Team は、問題報告の代わりに価値あるコード貢献をすることを推奨しています。</system:String>
     <system:String x:Key="GuideUserAgreement">MAA を使用することにより、「利用規約」に同意したものとみなされます。完全な規約は、公式サイトの下部のリンクからご覧いただけます。</system:String>
+    <system:String x:Key="RestartGuide">設定ガイドを再表示</system:String>
+    <system:String x:Key="RestartGuidePrompt">設定ガイドはメイン画面に表示されます。今すぐアプリケーションを再起動しますか？</system:String>
     <!--  !設定ガイド  -->
     <system:String x:Key="Dorm">宿舎</system:String>
     <system:String x:Key="Mfg">製造所</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -113,6 +113,8 @@
     <system:String x:Key="GuideOpenSourceTitle">💡 오픈소스 참여</system:String>
     <system:String x:Key="GuideOpenSourceDescription">오픈소스 프로젝트로서 사용자는 AGPL-3.0 라이선스에 따라 GitHub 플랫폼에서 MAA 개발에 참여할 수 있습니다. MAA Team은 문제 보고 대신 더 가치 있는 코드 기여를 권장합니다.</system:String>
     <system:String x:Key="GuideUserAgreement">MAA를 사용함으로써 귀하는 "사용자 동의"를 준수하는 데 동의하게 됩니다. 전체 동의서는 공식 웹사이트 하단의 링크에서 확인할 수 있습니다.</system:String>
+    <system:String x:Key="RestartGuide">설정 가이드 다시 보기</system:String>
+    <system:String x:Key="RestartGuidePrompt">설정 가이드는 기본 인터페이스에 표시됩니다. 지금 애플리케이션을 다시 시작하시겠습니까?</system:String>
     <!--  !설정 가이드  -->
     <system:String x:Key="Dorm">숙소</system:String>
     <system:String x:Key="Mfg">제조소</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -113,6 +113,8 @@
     <system:String x:Key="GuideOpenSourceTitle">💡 参与开源</system:String>
     <system:String x:Key="GuideOpenSourceDescription">作为开源项目，用户可依据 AGPL-3.0 许可证在 GitHub 平台参与 MAA 的开发。MAA Team 鼓励用户通过更有价值的代码贡献代替问题反馈。</system:String>
     <system:String x:Key="GuideUserAgreement">使用 MAA 即表示您同意遵守「用户协议」，完整协议内容可在官网底部的链接中查看。</system:String>
+    <system:String x:Key="RestartGuide">重看设置指引</system:String>
+    <system:String x:Key="RestartGuidePrompt">设置指引将在主界面显示，是否立即重启应用？</system:String>
     <!--  !设置指引  -->
     <system:String x:Key="Dorm">宿舍</system:String>
     <system:String x:Key="Mfg">制造站</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -113,6 +113,8 @@
     <system:String x:Key="GuideOpenSourceTitle">💡 參與開源</system:String>
     <system:String x:Key="GuideOpenSourceDescription">作為開源專案，使用者可依據 AGPL-3.0 許可證在 GitHub 平台參與 MAA 的開發。MAA Team 鼓勵使用者透過更有價值的程式碼貢獻代替問題回饋。</system:String>
     <system:String x:Key="GuideUserAgreement">使用 MAA 即表示您同意遵守「用戶協議」，完整協議內容可在官網底部的連結中查看。</system:String>
+    <system:String x:Key="RestartGuide">重看設定指引</system:String>
+    <system:String x:Key="RestartGuidePrompt">設定指引將在主介面顯示，是否立即重啟應用程式？</system:String>
     <!--  !設定指引  -->
     <system:String x:Key="Dorm">宿舍</system:String>
     <system:String x:Key="Mfg">製造站</system:String>

--- a/src/MaaWpfGui/Res/Style.xaml
+++ b/src/MaaWpfGui/Res/Style.xaml
@@ -7,6 +7,7 @@
         <ResourceDictionary Source="Styles/MessageBox.xaml" />
         <ResourceDictionary Source="Styles/TextBlock.xaml" />
         <ResourceDictionary Source="Styles/Button.xaml" />
+        <ResourceDictionary Source="Styles/CheckBox.xaml" />
         <ResourceDictionary Source="Styles/ComboBox.xaml" />
         <ResourceDictionary Source="Styles/NumericUpDown.xaml" />
         <ResourceDictionary Source="Styles/TextBox.xaml" />

--- a/src/MaaWpfGui/Res/Styles/CheckBox.xaml
+++ b/src/MaaWpfGui/Res/Styles/CheckBox.xaml
@@ -1,0 +1,14 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
+
+    <Style x:Key="ErrorHighlightCheckBoxStyle" BasedOn="{StaticResource {x:Type CheckBox}}" TargetType="CheckBox">
+        <Style.Triggers>
+            <Trigger Property="IsChecked" Value="True">
+                <Setter Property="Foreground" Value="{DynamicResource ErrorLogBrush}" />
+            </Trigger>
+            <Trigger Property="IsChecked" Value="False">
+                <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}" />
+            </Trigger>
+        </Style.Triggers>
+    </Style>
+
+</ResourceDictionary>

--- a/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
@@ -631,6 +631,23 @@ public class SettingsViewModel : Screen
         GuideStepIndex = GuideMaxStep;
     }
 
+    // UI 绑定的方法
+    [UsedImplicitly]
+    public void RestartGuide()
+    {
+        GuideStepIndex = 0;
+        TaskSettingVisibilities.Guide = true;
+        var result = MessageBoxHelper.Show(
+            LocalizationHelper.GetString("RestartGuidePrompt"),
+            LocalizationHelper.GetString("Tip"),
+            MessageBoxButton.OKCancel,
+            MessageBoxImage.Question);
+        if (result == MessageBoxResult.OK)
+        {
+            Bootstrapper.ShutdownAndRestartWithoutArgs();
+        }
+    }
+
     #endregion SettingsGuide
 
     #region 设置页面列表和滚动视图联动绑定

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/RoguelikeSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/RoguelikeSettingsUserControlModel.cs
@@ -1077,8 +1077,8 @@ public class RoguelikeSettingsUserControlModel : TaskSettingsViewModel, Roguelik
                 UseSupportNonFriend = roguelike.UseSupportNonFriend,
 
                 InvestmentEnabled = roguelike.Investment,
-                InvestmentCount = roguelike.InvestCount,
-                InvestmentStopWhenFull = roguelike.StopWhenDepositFull,
+                InvestmentCount = roguelike.Mode == Mode.Investment ? roguelike.InvestCount : int.MaxValue,
+                InvestmentStopWhenFull = roguelike.StopWhenDepositFull && roguelike.Mode == Mode.Investment,
                 InvestmentWithMoreScore = roguelike.InvestWithMoreScore && roguelike.Mode == Mode.Investment,
                 RefreshTraderWithDice = roguelike.Theme == Theme.Mizuki && roguelike.RefreshTraderWithDice,
 

--- a/src/MaaWpfGui/Views/UserControl/GuideUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/GuideUserControl.xaml
@@ -162,12 +162,28 @@
                                             IsChecked="{Binding AutoDetectConnection}" />
                                         <controls:TooltipBlock TooltipText="{DynamicResource AutoDetectConnectionTip}" />
                                     </StackPanel>
-                                    <CheckBox
-                                        Margin="0,10"
-                                        HorizontalAlignment="Left"
-                                        Content="{DynamicResource AlwaysAutoDetectConnection}"
-                                        IsChecked="{Binding AlwaysAutoDetectConnection}"
-                                        Visibility="{c:Binding AutoDetectConnection}" />
+                                    <StackPanel HorizontalAlignment="Left" Orientation="Horizontal">
+                                        <CheckBox
+                                            Margin="0,10"
+                                            HorizontalAlignment="Left"
+                                            Content="{DynamicResource AlwaysAutoDetectConnection}"
+                                            IsChecked="{Binding AlwaysAutoDetectConnection}"
+                                            Visibility="{c:Binding AutoDetectConnection}">
+                                            <CheckBox.Style>
+                                                <Style BasedOn="{StaticResource {x:Type CheckBox}}" TargetType="CheckBox">
+                                                    <Style.Triggers>
+                                                        <Trigger Property="IsChecked" Value="True">
+                                                            <Setter Property="Foreground" Value="{DynamicResource ErrorLogBrush}" />
+                                                        </Trigger>
+                                                        <Trigger Property="IsChecked" Value="False">
+                                                            <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}" />
+                                                        </Trigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </CheckBox.Style>
+                                        </CheckBox>
+                                        <controls:TooltipBlock TooltipText="{DynamicResource AlwaysAutoDetectConnectionTip}" />
+                                    </StackPanel>
                                 </StackPanel>
 
                                 <!--  连接配置  -->

--- a/src/MaaWpfGui/Views/UserControl/GuideUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/GuideUserControl.xaml
@@ -168,20 +168,8 @@
                                             HorizontalAlignment="Left"
                                             Content="{DynamicResource AlwaysAutoDetectConnection}"
                                             IsChecked="{Binding AlwaysAutoDetectConnection}"
-                                            Visibility="{c:Binding AutoDetectConnection}">
-                                            <CheckBox.Style>
-                                                <Style BasedOn="{StaticResource {x:Type CheckBox}}" TargetType="CheckBox">
-                                                    <Style.Triggers>
-                                                        <Trigger Property="IsChecked" Value="True">
-                                                            <Setter Property="Foreground" Value="{DynamicResource ErrorLogBrush}" />
-                                                        </Trigger>
-                                                        <Trigger Property="IsChecked" Value="False">
-                                                            <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}" />
-                                                        </Trigger>
-                                                    </Style.Triggers>
-                                                </Style>
-                                            </CheckBox.Style>
-                                        </CheckBox>
+                                            Style="{StaticResource ErrorHighlightCheckBoxStyle}"
+                                            Visibility="{c:Binding AutoDetectConnection}" />
                                         <controls:TooltipBlock TooltipText="{DynamicResource AlwaysAutoDetectConnectionTip}" />
                                     </StackPanel>
                                 </StackPanel>

--- a/src/MaaWpfGui/Views/UserControl/Settings/ConnectSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/Settings/ConnectSettingsUserControl.xaml
@@ -46,20 +46,10 @@
                 Margin="5"
                 Orientation="Horizontal"
                 Visibility="{c:Binding AutoDetectConnection}">
-                <CheckBox Content="{DynamicResource AlwaysAutoDetectConnection}" IsChecked="{Binding AlwaysAutoDetectConnection}">
-                    <CheckBox.Style>
-                        <Style BasedOn="{StaticResource {x:Type CheckBox}}" TargetType="CheckBox">
-                            <Style.Triggers>
-                                <Trigger Property="IsChecked" Value="True">
-                                    <Setter Property="Foreground" Value="{DynamicResource ErrorLogBrush}" />
-                                </Trigger>
-                                <Trigger Property="IsChecked" Value="False">
-                                    <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}" />
-                                </Trigger>
-                            </Style.Triggers>
-                        </Style>
-                    </CheckBox.Style>
-                </CheckBox>
+                <CheckBox
+                    Content="{DynamicResource AlwaysAutoDetectConnection}"
+                    IsChecked="{Binding AlwaysAutoDetectConnection}"
+                    Style="{StaticResource ErrorHighlightCheckBoxStyle}" />
                 <controls:TooltipBlock TooltipText="{DynamicResource AlwaysAutoDetectConnectionTip}" />
             </StackPanel>
         </StackPanel>

--- a/src/MaaWpfGui/Views/UserControl/Settings/GuiSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/Settings/GuiSettingsUserControl.xaml
@@ -152,6 +152,14 @@
                         DisplayMemberPath="Value"
                         ItemsSource="{Binding WindowTitleAllShowDict}" />
                 </StackPanel>
+                <Button
+                    Width="180"
+                    Margin="8"
+                    HorizontalAlignment="Left"
+                    Command="{s:Action RestartGuide,
+                                       Target={x:Static helper:Instances.SettingsViewModel}}"
+                    Content="{DynamicResource RestartGuide}"
+                    Style="{StaticResource ButtonPrimary}" />
             </StackPanel>
         </Grid>
     </StackPanel>

--- a/src/MaaWpfGui/Views/UserControl/TaskQueue/RoguelikeSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/TaskQueue/RoguelikeSettingsUserControl.xaml
@@ -153,7 +153,7 @@
                 Margin="0,10"
                 d:Visibility="Visible"
                 IsChecked="{Binding RoguelikeStopWhenInvestmentFull}"
-                Visibility="{c:Binding 'RoguelikeInvestmentEnabled and RoguelikeMode != task:RoguelikeMode.Collectible',
+                Visibility="{c:Binding 'RoguelikeInvestmentEnabled and RoguelikeMode == task:RoguelikeMode.Investment',
                                        Source={x:Static taskQueue_vms:RoguelikeSettingsUserControlModel.Instance}}">
                 <TextBlock
                     Block.TextAlignment="Left"
@@ -188,7 +188,8 @@
                 hc:InfoElement.Title="{DynamicResource GoldTimesLimit}"
                 Maximum="999"
                 Minimum="0"
-                Visibility="{c:Binding RoguelikeInvestmentEnabled}"
+                Visibility="{c:Binding 'RoguelikeInvestmentEnabled and RoguelikeMode == task:RoguelikeMode.Investment',
+                                       Source={x:Static taskQueue_vms:RoguelikeSettingsUserControlModel.Instance}}"
                 Value="{Binding RoguelikeInvestsCount}" />
             <CheckBox
                 Margin="0,10"
@@ -406,8 +407,8 @@
                 HorizontalAlignment="Center"
                 FontWeight="Bold"
                 Text="{DynamicResource MultiTasksShareTip}"
-                TextWrapping="Wrap"
-                TextAlignment="Left" />
+                TextAlignment="Left"
+                TextWrapping="Wrap" />
             <CheckBox Margin="0,10" IsChecked="{Binding RoguelikeDelayAbortUntilCombatComplete}">
                 <TextBlock
                     Block.TextAlignment="Left"

--- a/src/MaaWpfGui/Views/UserControl/TaskQueue/StartUpTaskUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/TaskQueue/StartUpTaskUserControl.xaml
@@ -87,20 +87,10 @@
                     Margin="0,10"
                     Orientation="Horizontal"
                     Visibility="{c:Binding AutoDetectConnection}">
-                    <CheckBox Content="{DynamicResource AlwaysAutoDetectConnection}" IsChecked="{Binding AlwaysAutoDetectConnection}">
-                        <CheckBox.Style>
-                            <Style BasedOn="{StaticResource {x:Type CheckBox}}" TargetType="CheckBox">
-                                <Style.Triggers>
-                                    <Trigger Property="IsChecked" Value="True">
-                                        <Setter Property="Foreground" Value="{DynamicResource ErrorLogBrush}" />
-                                    </Trigger>
-                                    <Trigger Property="IsChecked" Value="False">
-                                        <Setter Property="Foreground" Value="{DynamicResource PrimaryTextBrush}" />
-                                    </Trigger>
-                                </Style.Triggers>
-                            </Style>
-                        </CheckBox.Style>
-                    </CheckBox>
+                    <CheckBox
+                        Content="{DynamicResource AlwaysAutoDetectConnection}"
+                        IsChecked="{Binding AlwaysAutoDetectConnection}"
+                        Style="{StaticResource ErrorHighlightCheckBoxStyle}" />
                     <controls:TooltipBlock TooltipText="{DynamicResource AlwaysAutoDetectConnectionTip}" />
                 </StackPanel>
             </StackPanel>

--- a/tools/ResourceUpdater/main.cpp
+++ b/tools/ResourceUpdater/main.cpp
@@ -825,6 +825,11 @@ bool update_levels_json(const fs::path& input_file, const fs::path& output_dir)
         stage_obj.erase("tiles");
         stage_obj.erase("view");
         stage_obj["filename"] = filename;
+        for (auto& [key, val] : stage_obj) {
+            if (val.is_null()) {
+                stage_obj[key] = "Unknown";
+            }
+        }
         overview[std::move(stem)] = std::move(stage_obj);
     }
 

--- a/tools/ResourceUpdater/main.cpp
+++ b/tools/ResourceUpdater/main.cpp
@@ -825,11 +825,6 @@ bool update_levels_json(const fs::path& input_file, const fs::path& output_dir)
         stage_obj.erase("tiles");
         stage_obj.erase("view");
         stage_obj["filename"] = filename;
-        for (auto& [key, val] : stage_obj) {
-            if (val.is_null()) {
-                stage_obj[key] = "Unknown";
-            }
-        }
         overview[std::move(stem)] = std::move(stage_obj);
     }
 


### PR DESCRIPTION
## Summary by Sourcery

收紧瓦片键匹配语义，调整可选关卡元数据的处理方式，优化 Rogue-like 投资行为，同时增加重新启动新手引导的 UI 选项，并更新辅助文档和 CI 配置。

New Features:
- 在设置界面中新增操作，用于重新启动应用内引导并重新启动应用程序。
- 引入新的 WPF `CheckBox` 样式资源，以及针对设置和引导视图相关的 XAML/UI 更新。

Bug Fixes:
- 在比较或搜索时，要求瓦片关卡键必须精确匹配，不再将空字段视为通配符。
- 确保 Rogue-like 投资选项仅在投资模式激活时才生效，避免在其他模式中出现非预期的限制。

Enhancements:
- 放宽对关卡定义的 JSON 解析，对缺失的 `code` 与 `name` 字段使用中性默认值进行容错。
- 调整瓦片包解析中对缺失关卡代码值的默认处理。
- 微调 README 徽章和样式，以获得更好的排版效果和一致性。

CI:
- 更新 markdown 检查工作流，使用最新版主要版本的 sticky pull request comment action。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Tighten tile key matching semantics, adjust handling of optional level metadata, and refine roguelike investment behavior while adding a UI option to restart the onboarding guide and updating auxiliary docs and CI configuration.

New Features:
- Add a settings UI action to restart the in-app guide and relaunch the application.
- Introduce a new WPF CheckBox style resource and related XAML/UI updates for settings and guide views.

Bug Fixes:
- Require exact matches for tile level keys instead of treating empty fields as wildcards when comparing or searching.
- Ensure roguelike investment options are only applied when the investment mode is active, avoiding unintended limits in other modes.

Enhancements:
- Relax JSON parsing for level definitions to tolerate missing code and name fields with neutral defaults.
- Adjust tile pack parsing defaults for missing level code values.
- Tweak README badges and styling for better formatting and consistency.

CI:
- Update the markdown checker workflow to use the latest major version of the sticky pull request comment action.

</details>