### PR TITLE
perf: hoist image-side cvtColor out of template loop in Matcher

### DIFF
--- a/src/MaaCore/Vision/Matcher.cpp
+++ b/src/MaaCore/Vision/Matcher.cpp
@@ -82,6 +82,18 @@ Matcher::ResultOpt Matcher::analyze() const
 std::vector<Matcher::RawResult> Matcher::preproc_and_match(const cv::Mat& image, const MatcherConfig::Params& params)
 {
     std::vector<Matcher::RawResult> results;
+
+    // Image-side color conversions: compute once, reuse across all templates
+    cv::Mat image_match;
+    cv::cvtColor(image, image_match, cv::COLOR_BGR2RGB);
+
+    cv::Mat image_gray;
+    if (!params.mask_ranges.empty() || !params.color_scales.empty()) {
+        cv::cvtColor(image, image_gray, cv::COLOR_BGR2GRAY);
+    }
+
+    cv::Mat image_hsv;
+
     for (size_t i = 0; i != params.templs.size(); ++i) {
         const auto& ptempl = params.templs[i];
         auto method = MatchMethod::Ccoeff;
@@ -134,14 +146,18 @@ std::vector<Matcher::RawResult> Matcher::preproc_and_match(const cv::Mat& image,
         }
 
         cv::Mat matched;
-        cv::Mat image_match, image_count, image_gray;
         cv::Mat templ_match, templ_count, templ_gray;
-        cv::cvtColor(image, image_match, cv::COLOR_BGR2RGB);
         cv::cvtColor(templ, templ_match, cv::COLOR_BGR2RGB);
-        cv::cvtColor(image, image_gray, cv::COLOR_BGR2GRAY);
-        cv::cvtColor(templ, templ_gray, cv::COLOR_BGR2GRAY);
+        if (!image_gray.empty()) {
+            cv::cvtColor(templ, templ_gray, cv::COLOR_BGR2GRAY);
+        }
+
+        cv::Mat image_count;
         if (method == MatchMethod::HSVCount) {
-            cv::cvtColor(image, image_count, cv::COLOR_BGR2HSV);
+            if (image_hsv.empty()) {
+                cv::cvtColor(image, image_hsv, cv::COLOR_BGR2HSV);
+            }
+            image_count = image_hsv;
             cv::cvtColor(templ, templ_count, cv::COLOR_BGR2HSV);
         }
         else if (method == MatchMethod::RGBCount) {


### PR DESCRIPTION
少来点cvtColor（

## Summary by Sourcery

增强：
- 将输入图像的 BGR→RGB、条件式 BGR→GRAY 以及延迟执行的 BGR→HSV 转换提升到模板循环之外，以减少在匹配过程中重复调用 `cvtColor`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Hoist BGR→RGB, conditional BGR→GRAY, and lazy BGR→HSV conversions of the input image out of the template loop to reduce repeated cvtColor calls during matching.

</details>