### PR TITLE
perf(wpf): 移除自动战斗的页签检查, 改为检查作业关卡

### DIFF
--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -1059,6 +1059,7 @@ Right-click to clear inactive jobs</system:String>
     <system:String x:Key="CopilotStartWithEmptyList">Using ｢{key=UseCopilotList}｣, but no tasks have been added</system:String>
     <system:String x:Key="CopilotSingleTaskWarning">You're using ｢{key=UseCopilotList}｣ to execute a single task, which is not recommended. For single tasks, please run them directly instead.</system:String>
     <system:String x:Key="CopilotTaskListMixedModeNotAllowed">Currently using ｢{key=UseCopilotList}｣. Mixing different job types is not supported.</system:String>
+    <system:String x:Key="CopilotTaskTypeParseFailedSkipCheck">Failed to parse some job types. Skipping type checks.</system:String>
     <!--  !Logs  -->
     <!--  !Copilot  -->
     <!--  ErrorView  -->

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -1058,9 +1058,7 @@ Right-click to clear inactive jobs</system:String>
     <system:String x:Key="CopilotCouldNotSaveFile" xml:space="preserve">Could not save copilot task to file: </system:String>
     <system:String x:Key="CopilotStartWithEmptyList">Using ｢{key=UseCopilotList}｣, but no tasks have been added</system:String>
     <system:String x:Key="CopilotSingleTaskWarning">You're using ｢{key=UseCopilotList}｣ to execute a single task, which is not recommended. For single tasks, please run them directly instead.</system:String>
-    <system:String x:Key="CopilotTaskListMixedModeNotAllowed">You're using ｢{key=UseCopilotList}｣, but mixing ｢{key=MainStageStoryCollectionSideStory}｣ and ｢{key=ParadoxSimulation}｣ is not allowed. Please create separate lists under the corresponding tabs before starting.</system:String>
-    <system:String x:Key="CopilotTaskListLegacyItemNotSupported">You're using ｢{key=UseCopilotList}｣, but the list contains legacy items (missing tab info). Please re-add these tasks under the correct tab before starting.</system:String>
-    <system:String x:Key="CopilotTaskListTabMismatch">You're using ｢{key=UseCopilotList}｣. Current tab is ｢{0}｣, but the list is from ｢{1}｣. Please switch to the corresponding tab before starting.</system:String>
+    <system:String x:Key="CopilotTaskListMixedModeNotAllowed">Currently using ｢{key=UseCopilotList}｣. Mixing different job types is not supported.</system:String>
     <!--  !Logs  -->
     <!--  !Copilot  -->
     <!--  ErrorView  -->

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -1060,6 +1060,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="CopilotStartWithEmptyList">タスクなしで「{key=UseCopilotList}」を使用した</system:String>
     <system:String x:Key="CopilotSingleTaskWarning">「{key=UseCopilotList}」を使用して単一ジョブを実行しています。これは推奨されません。単一ジョブを直接実行してください。</system:String>
     <system:String x:Key="CopilotTaskListMixedModeNotAllowed">「{key=UseCopilotList}」を使用中ですが、異なるジョブタイプの混在はサポートされていません。</system:String>
+    <system:String x:Key="CopilotTaskTypeParseFailedSkipCheck">一部のジョブタイプの解析に失敗しました。タイプチェックをスキップします。</system:String>
     <!--  !Logs  -->
     <!--  !Copilot  -->
     <!--  ErrorView  -->

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -1059,9 +1059,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="CopilotCouldNotSaveFile" xml:space="preserve">コパイロットタスクをファイルに保存できませんでした: </system:String>
     <system:String x:Key="CopilotStartWithEmptyList">タスクなしで「{key=UseCopilotList}」を使用した</system:String>
     <system:String x:Key="CopilotSingleTaskWarning">「{key=UseCopilotList}」を使用して単一ジョブを実行しています。これは推奨されません。単一ジョブを直接実行してください。</system:String>
-    <system:String x:Key="CopilotTaskListMixedModeNotAllowed">「{key=UseCopilotList}」を使用中ですが、「{key=MainStageStoryCollectionSideStory}」と「{key=ParadoxSimulation}」を混在させることはできません。対応するタブで別々にリストを作成してから開始してください。</system:String>
-    <system:String x:Key="CopilotTaskListLegacyItemNotSupported">「{key=UseCopilotList}」を使用中ですが、リストに旧バージョンの項目（タブ情報が不足）が含まれています。正しいタブでこれらのタスクを再追加してから開始してください。</system:String>
-    <system:String x:Key="CopilotTaskListTabMismatch">「{key=UseCopilotList}」を使用中です。現在のタブは「{0}」ですが、リストは「{1}」のものです。対応するタブに切り替えてから開始してください。</system:String>
+    <system:String x:Key="CopilotTaskListMixedModeNotAllowed">「{key=UseCopilotList}」を使用中ですが、異なるジョブタイプの混在はサポートされていません。</system:String>
     <!--  !Logs  -->
     <!--  !Copilot  -->
     <!--  ErrorView  -->

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -1060,9 +1060,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="CopilotCouldNotSaveFile" xml:space="preserve">부조종사 작업을 파일에 저장할 수 없습니다.: </system:String>
     <system:String x:Key="CopilotStartWithEmptyList">작업 없이 ｢{key=UseCopilotList}」를 사용 중입니다.</system:String>
     <system:String x:Key="CopilotSingleTaskWarning">｢{key=UseCopilotList}｣를 사용하여 단일 작업을 실행하는 것은 권장되지 않습니다. 단일 작업은 직접 실행해 주세요.</system:String>
-    <system:String x:Key="CopilotTaskListMixedModeNotAllowed">작업 목록에서 ｢{key=MainStageStoryCollectionSideStory}｣와 ｢{key=ParadoxSimulation}｣를 혼용할 수 없습니다. 해당 탭에서 각각 목록을 만든 뒤 시작해 주세요.</system:String>
-    <system:String x:Key="CopilotTaskListLegacyItemNotSupported">작업 목록에 이전 버전 항목(탭 정보 없음)이 포함되어 있습니다. 올바른 탭에서 해당 작업을 다시 추가한 뒤 시작해 주세요.</system:String>
-    <system:String x:Key="CopilotTaskListTabMismatch">현재 탭은 ｢{0}｣이지만 작업 목록은 ｢{1}｣에서 왔습니다. 해당 탭으로 전환한 뒤 시작해 주세요.</system:String>
+    <system:String x:Key="CopilotTaskListMixedModeNotAllowed">현재 ｢{key=UseCopilotList}｣를 사용 중입니다. 서로 다른 작업 유형을 혼합하는 것은 지원되지 않습니다.</system:String>
     <!--  !Logs  -->
     <!--  !Copilot  -->
     <!--  ErrorView  -->

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -1061,6 +1061,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="CopilotStartWithEmptyList">작업 없이 ｢{key=UseCopilotList}」를 사용 중입니다.</system:String>
     <system:String x:Key="CopilotSingleTaskWarning">｢{key=UseCopilotList}｣를 사용하여 단일 작업을 실행하는 것은 권장되지 않습니다. 단일 작업은 직접 실행해 주세요.</system:String>
     <system:String x:Key="CopilotTaskListMixedModeNotAllowed">현재 ｢{key=UseCopilotList}｣를 사용 중입니다. 서로 다른 작업 유형을 혼합하는 것은 지원되지 않습니다.</system:String>
+    <system:String x:Key="CopilotTaskTypeParseFailedSkipCheck">일부 작업 유형을 해석하지 못했습니다. 유형 검사를 건너뜁니다.</system:String>
     <!--  !Logs  -->
     <!--  !Copilot  -->
     <!--  ErrorView  -->

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -1060,6 +1060,7 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="CopilotStartWithEmptyList">正在使用 ｢{key=UseCopilotList}｣, 但未添加任何作业</system:String>
     <system:String x:Key="CopilotSingleTaskWarning">正在使用 ｢{key=UseCopilotList}｣ 执行单个作业, 不推荐此行为。 单个作业请直接运行</system:String>
     <system:String x:Key="CopilotTaskListMixedModeNotAllowed">正在使用 ｢{key=UseCopilotList}｣，不支持混用不同类型作业</system:String>
+    <system:String x:Key="CopilotTaskTypeParseFailedSkipCheck">部分作业类型解析失败，跳过类型检查</system:String>
     <!--  !日志  -->
     <!--  !自动战斗  -->
     <!--  ErrorDialogView  -->

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -1059,9 +1059,7 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="CopilotCouldNotSaveFile" xml:space="preserve">无法保存作业文件到: </system:String>
     <system:String x:Key="CopilotStartWithEmptyList">正在使用 ｢{key=UseCopilotList}｣, 但未添加任何作业</system:String>
     <system:String x:Key="CopilotSingleTaskWarning">正在使用 ｢{key=UseCopilotList}｣ 执行单个作业, 不推荐此行为。 单个作业请直接运行</system:String>
-    <system:String x:Key="CopilotTaskListMixedModeNotAllowed">正在使用 ｢{key=UseCopilotList}｣，但不允许混用「{key=MainStageStoryCollectionSideStory}」与「{key=ParadoxSimulation}」，请分别在对应页签建立列表后再启动</system:String>
-    <system:String x:Key="CopilotTaskListLegacyItemNotSupported">正在使用 ｢{key=UseCopilotList}｣，但列表包含旧版本条目（缺少页签信息），请在正确的页签重新添加这些作业后再启动</system:String>
-    <system:String x:Key="CopilotTaskListTabMismatch">正在使用 ｢{key=UseCopilotList}｣，当前页签为「{0}」，但列表来自「{1}」，请切换到对应页签后再启动</system:String>
+    <system:String x:Key="CopilotTaskListMixedModeNotAllowed">正在使用 ｢{key=UseCopilotList}｣，不支持混用不同类型作业</system:String>
     <!--  !日志  -->
     <!--  !自动战斗  -->
     <!--  ErrorDialogView  -->

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -1060,6 +1060,7 @@ C:\\leidian\\LDPlayer9\n
     <system:String x:Key="CopilotStartWithEmptyList">正在使用 ｢{key=UseCopilotList}｣，但未新增任何作業</system:String>
     <system:String x:Key="CopilotSingleTaskWarning">正在使用 ｢{key=UseCopilotList}｣ 執行單一作業，不推薦此行為。單一作業請直接執行即可。</system:String>
     <system:String x:Key="CopilotTaskListMixedModeNotAllowed">正在使用 ｢{key=UseCopilotList}｣，不支援混用不同型別作業</system:String>
+    <system:String x:Key="CopilotTaskTypeParseFailedSkipCheck">部分作業類型解析失敗，跳過類型檢查</system:String>
     <!--  !日誌  -->
     <!--  !Copilot  -->
     <!--  ErrorView  -->

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -1059,9 +1059,7 @@ C:\\leidian\\LDPlayer9\n
     <system:String x:Key="CopilotCouldNotSaveFile" xml:space="preserve">無法儲存作業檔案至：</system:String>
     <system:String x:Key="CopilotStartWithEmptyList">正在使用 ｢{key=UseCopilotList}｣，但未新增任何作業</system:String>
     <system:String x:Key="CopilotSingleTaskWarning">正在使用 ｢{key=UseCopilotList}｣ 執行單一作業，不推薦此行為。單一作業請直接執行即可。</system:String>
-    <system:String x:Key="CopilotTaskListMixedModeNotAllowed">正在使用 ｢{key=UseCopilotList}｣，但不允許混用「{key=MainStageStoryCollectionSideStory}」與「{key=ParadoxSimulation}」，請分別在對應標籤頁建立列表後再啟動</system:String>
-    <system:String x:Key="CopilotTaskListLegacyItemNotSupported">正在使用 ｢{key=UseCopilotList}｣，但列表包含舊版本項目（缺少標籤頁資訊），請在正確的標籤頁重新新增這些作業後再啟動</system:String>
-    <system:String x:Key="CopilotTaskListTabMismatch">正在使用 ｢{key=UseCopilotList}｣，目前標籤頁為「{0}」，但列表來自「{1}」，請切換到對應標籤頁後再啟動</system:String>
+    <system:String x:Key="CopilotTaskListMixedModeNotAllowed">正在使用 ｢{key=UseCopilotList}｣，不支援混用不同型別作業</system:String>
     <!--  !日誌  -->
     <!--  !Copilot  -->
     <!--  ErrorView  -->

--- a/src/MaaWpfGui/ViewModels/Items/CopilotItemViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/Items/CopilotItemViewModel.cs
@@ -55,12 +55,6 @@ public class CopilotItemViewModel : PropertyChangedBase
     [JsonProperty("copilot_id")]
     public int CopilotId { get; set; }
 
-    /// <summary>
-    /// Gets or sets 作业来源的 CopilotTabIndex
-    /// </summary>
-    [JsonProperty("tab_index", DefaultValueHandling = DefaultValueHandling.Ignore)]
-    public int? TabIndex { get; set; }
-
     [JsonProperty("is_raid")]
     private bool _isRaid;
 

--- a/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
@@ -80,6 +80,9 @@ public partial class CopilotViewModel : Screen
     [GeneratedRegex(InvalidStageNameChars)]
     private static partial Regex InvalidStageNameRegex();
 
+    [GeneratedRegex(@"^act\d+(side|mini)_")]
+    private static partial Regex SideStoryStageIdRegex();
+
     /// <summary>
     /// Gets the view models of log items.
     /// </summary>
@@ -1669,20 +1672,20 @@ public partial class CopilotViewModel : Screen
 
             name ??= stageCode;
 
-            var item = new CopilotItemViewModel(name, cachePath, false, copilotId) { Index = CopilotItemViewModels.Count, TabIndex = CopilotTabIndex, };
+            var item = new CopilotItemViewModel(name, cachePath, false, copilotId) { Index = CopilotItemViewModels.Count, };
             CopilotItemViewModels.Add(item);
         }
         else
         {
             if (flags.HasFlag(CopilotModel.DifficultyFlags.Normal))
             {
-                var item = new CopilotItemViewModel(stageCode, cachePath, false, copilotId) { Index = CopilotItemViewModels.Count, TabIndex = CopilotTabIndex, };
+                var item = new CopilotItemViewModel(stageCode, cachePath, false, copilotId) { Index = CopilotItemViewModels.Count, };
                 CopilotItemViewModels.Add(item);
             }
 
             if (flags.HasFlag(CopilotModel.DifficultyFlags.Raid))
             {
-                var item = new CopilotItemViewModel(stageCode, cachePath, true, copilotId) { Index = CopilotItemViewModels.Count, TabIndex = CopilotTabIndex, };
+                var item = new CopilotItemViewModel(stageCode, cachePath, true, copilotId) { Index = CopilotItemViewModels.Count, };
                 CopilotItemViewModels.Add(item);
             }
         }
@@ -1842,27 +1845,15 @@ public partial class CopilotViewModel : Screen
             return false;
         }
 
-        // 列表必须严格归属页签：不兼容旧版本缺少 TabIndex 的条目
-        if (selected.Any(i => i.TabIndex is null))
+        var types = new HashSet<CopilotType>(await Task.WhenAll(selected.Select(item => GetCopilotTypeAsync(item.FilePath))));
+        if (types.Contains(CopilotType.Unknown))
         {
-            AddLog(LocalizationHelper.GetString("CopilotTaskListLegacyItemNotSupported"), UiLogColor.Error, showTime: false);
+            AddLog("部分作业类型解析失败, 跳过类型检查", UiLogColor.Error, showTime: false);
             return false;
         }
-
-        var tabs = selected.Select(i => i.TabIndex!.Value).Distinct().ToArray();
-        if (tabs.Length > 1)
+        else if (types.Count > 1)
         {
-            AddLog(LocalizationHelper.GetString("CopilotTaskListMixedModeNotAllowed"), UiLogColor.Error, showTime: false);
-            return false;
-        }
-
-        var listTab = tabs[0];
-        if (listTab != tabIndex)
-        {
-            AddLog(LocalizationHelper.GetStringFormat(
-                "CopilotTaskListTabMismatch",
-                GetCopilotTabName(tabIndex),
-                GetCopilotTabName(listTab)), UiLogColor.Error, showTime: false);
+            AddLog(LocalizationHelper.GetString("CopilotTaskListMixedModeNotAllowed") + "\n" + string.Join(", ", types.Select(i => GetCopilotTabName(i))), UiLogColor.Error, showTime: false);
             return false;
         }
 
@@ -2086,13 +2077,7 @@ public partial class CopilotViewModel : Screen
         _runningState.SetIdle(true);
     }
 
-    private bool _isDataFromWeb;
-
-    private bool IsDataFromWeb
-    {
-        get => _isDataFromWeb;
-        set => SetAndNotify(ref _isDataFromWeb, value);
-    }
+    private bool IsDataFromWeb { get => field; set => SetAndNotify(ref field, value); }
 
     private int _copilotId;
 
@@ -2203,16 +2188,14 @@ public partial class CopilotViewModel : Screen
         return ok;
     }
 
-    private static string GetCopilotTabName(int tabIndex)
-    {
-        return tabIndex switch {
-            0 => LocalizationHelper.GetString("MainStageStoryCollectionSideStory"),
-            1 => LocalizationHelper.GetString("SSS"),
-            2 => LocalizationHelper.GetString("ParadoxSimulation"),
-            3 => LocalizationHelper.GetString("OtherActivityStage"),
-            _ => tabIndex.ToString(),
-        };
-    }
+    private static string GetCopilotTabName(CopilotType type) =>
+         type switch {
+             CopilotType.MainStageAndSideStory => LocalizationHelper.GetString("MainStageStoryCollectionSideStory"),
+             CopilotType.SSS => LocalizationHelper.GetString("SSS"),
+             CopilotType.Paradox => LocalizationHelper.GetString("ParadoxSimulation"),
+             CopilotType.Other => LocalizationHelper.GetString("OtherActivityStage"),
+             _ => type.ToString(),
+         };
 
     /// <summary>
     /// 点击后移除界面中元素焦点
@@ -2253,5 +2236,63 @@ public partial class CopilotViewModel : Screen
         DependencyObject scope = FocusManager.GetFocusScope(element);
         FocusManager.SetFocusedElement(scope, element);
         Keyboard.ClearFocus();
+    }
+
+    private async Task<CopilotType> GetCopilotTypeAsync(string filePath)
+    {
+        var str = await File.ReadAllTextAsync(filePath);
+        var job = JsonConvert.DeserializeObject<CopilotBase>(str, new CopilotContentConverter());
+        return GetCopilotType(job);
+    }
+
+    private CopilotType GetCopilotType(CopilotBase? @base)
+    {
+        if (@base is null)
+        {
+            return CopilotType.Unknown;
+        }
+        else if (@base is SSSCopilotModel)
+        {
+            return CopilotType.SSS;
+        }
+        else if (@base is CopilotModel copilot)
+        {
+            if (string.IsNullOrEmpty(copilot.StageName))
+            {
+                return CopilotType.Unknown;
+            }
+            var mapInfo = DataHelper.FindMap(copilot.StageName);
+            if (mapInfo is null)
+            {
+                return CopilotType.Unknown;
+            }
+            if (mapInfo.StageId?.StartsWith("mem_") is true)
+            {
+                return CopilotType.Paradox;
+            }
+            else if (mapInfo.StageId?.StartsWith("main_") is true || SideStoryStageIdRegex().IsMatch(mapInfo.StageId ?? string.Empty))
+            {
+                return CopilotType.MainStageAndSideStory;
+            }
+        }
+
+        return CopilotType.Unknown;
+    }
+
+    private enum CopilotType
+    {
+        Unknown = -1,
+
+        /// <summary>主线, 故事集, 支线作业</summary>
+        MainStageAndSideStory = 0,
+
+        /// <summary>保全</summary>
+        SSS,
+
+        /// <summary>悖论模拟</summary>
+        Paradox,
+
+        /// <summary>其他</summary>
+        Other,
     }
 }

--- a/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
@@ -1848,7 +1848,7 @@ public partial class CopilotViewModel : Screen
         var types = new HashSet<CopilotType>(await Task.WhenAll(selected.Select(item => GetCopilotTypeAsync(item.FilePath))));
         if (types.Contains(CopilotType.Unknown))
         {
-            AddLog("部分作业类型解析失败, 跳过类型检查", UiLogColor.Error, showTime: false);
+            AddLog(LocalizationHelper.GetString("CopilotTaskTypeParseFailedSkipCheck"), UiLogColor.Error, showTime: false);
             return false;
         }
         else if (types.Count > 1)
@@ -2240,9 +2240,22 @@ public partial class CopilotViewModel : Screen
 
     private async Task<CopilotType> GetCopilotTypeAsync(string filePath)
     {
-        var str = await File.ReadAllTextAsync(filePath);
-        var job = JsonConvert.DeserializeObject<CopilotBase>(str, new CopilotContentConverter());
-        return GetCopilotType(job);
+        try
+        {
+            if (!File.Exists(filePath))
+            {
+                _logger.Error("file not found: {Path}, return: {Return}", filePath, CopilotType.Unknown);
+                return CopilotType.Unknown;
+            }
+            var str = await File.ReadAllTextAsync(filePath);
+            var job = JsonConvert.DeserializeObject<CopilotBase>(str, new CopilotContentConverter());
+            return GetCopilotType(job);
+        }
+        catch (Exception ex)
+        {
+            _logger.Error(ex, "could not read & parse copilot file: {Path}", filePath);
+            return CopilotType.Unknown;
+        }
     }
 
     private CopilotType GetCopilotType(CopilotBase? @base)


### PR DESCRIPTION
## Summary by Sourcery

根据推断的任务类型而非 UI 标签页索引来验证 copilot 任务列表，并移除每个条目的标签页索引元数据。

增强内容：
- 从反序列化的任务数据和关卡映射中推断 copilot 任务类型（主线/支线、SSS、悖论、其他），包括对支线关卡 ID 模式的检测。
- 验证选定的 copilot 任务，以确保它们都属于同一种推断类型；当检测到混合类型或无法解析的类型时记录错误日志。
- 通过移除已存储的标签页索引字段并改为依赖基于类型的验证逻辑，简化 copilot 条目模型。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Validate copilot task lists by inferred job type instead of UI tab index and remove per-item tab index metadata.

Enhancements:
- Infer copilot job type (main/side story, SSS, paradox, other) from deserialized job data and stage mapping, including side-story stage ID pattern detection.
- Validate selected copilot tasks to ensure they are all of the same inferred type and log an error when mixed types or unresolvable types are detected.
- Simplify copilot item models by dropping the stored tab index field and relying on type-based validation instead.

</details>