### PR TITLE
feat: 增加更新数据任务

### DIFF
--- a/src/MaaWpfGui/Configuration/Single/MaaTask/BaseTask.cs
+++ b/src/MaaWpfGui/Configuration/Single/MaaTask/BaseTask.cs
@@ -33,6 +33,7 @@ namespace MaaWpfGui.Configuration.Single.MaaTask;
 [JsonDerivedType(typeof(SingleStepTask), typeDiscriminator: nameof(SingleStepTask))]
 [JsonDerivedType(typeof(DepotTask), typeDiscriminator: nameof(DepotTask))]
 [JsonDerivedType(typeof(OperBoxTask), typeDiscriminator: nameof(OperBoxTask))]
+[JsonDerivedType(typeof(UserDataUpdateTask), typeDiscriminator: nameof(UserDataUpdateTask))]
 [JsonDerivedType(typeof(ReclamationTask), typeDiscriminator: nameof(ReclamationTask))]
 [JsonDerivedType(typeof(CustomTask), typeDiscriminator: nameof(CustomTask))]
 public class BaseTask : INotifyPropertyChanged

--- a/src/MaaWpfGui/Configuration/Single/MaaTask/UserDataUpdateTask.cs
+++ b/src/MaaWpfGui/Configuration/Single/MaaTask/UserDataUpdateTask.cs
@@ -1,0 +1,35 @@
+// <copyright file="UserDataUpdateTask.cs" company="MaaAssistantArknights">
+// Part of the MaaWpfGui project, maintained by the MaaAssistantArknights team (Maa Team)
+// Copyright (C) 2021-2025 MaaAssistantArknights Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License v3.0 only as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY
+// </copyright>
+
+#nullable enable
+
+using MaaWpfGui.Constants.Enums;
+using static MaaWpfGui.Main.AsstProxy;
+
+namespace MaaWpfGui.Configuration.Single.MaaTask;
+
+/// <summary>
+/// 更新用户数据任务。
+/// </summary>
+public class UserDataUpdateTask : BaseTask
+{
+    public UserDataUpdateTask() => TaskType = TaskType.UserDataUpdate;
+
+    public bool UpdateOperBox { get; set; } = true;
+
+    public bool UpdateDepot { get; set; } = true;
+
+    public UserDataUpdateTriggerInterval TriggerInterval { get; set; } = UserDataUpdateTriggerInterval.EveryTime;
+
+    public bool IsTriggered => UpdateOperBox || UpdateDepot;
+}

--- a/src/MaaWpfGui/Constants/Enums/TaskItemStatus.cs
+++ b/src/MaaWpfGui/Constants/Enums/TaskItemStatus.cs
@@ -1,0 +1,42 @@
+// <copyright file="TaskItemStatus.cs" company="MaaAssistantArknights">
+// Part of the MaaWpfGui project, maintained by the MaaAssistantArknights team (Maa Team)
+// Copyright (C) 2021-2025 MaaAssistantArknights Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License v3.0 only as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY
+// </copyright>
+
+namespace MaaWpfGui.Constants.Enums;
+
+public enum TaskItemStatus
+{
+    /// <summary>
+    /// 未开始
+    /// </summary>
+    Idle = 0,
+
+    /// <summary>
+    /// 进行中
+    /// </summary>
+    InProgress = 1,
+
+    /// <summary>
+    /// 已完成
+    /// </summary>
+    Completed = 2,
+
+    /// <summary>
+    /// 错误终止
+    /// </summary>
+    Error = 3,
+
+    /// <summary>
+    /// 跳过
+    /// </summary>
+    Skipped = 4,
+}

--- a/src/MaaWpfGui/Constants/Enums/UserDataUpdateTriggerInterval.cs
+++ b/src/MaaWpfGui/Constants/Enums/UserDataUpdateTriggerInterval.cs
@@ -1,0 +1,21 @@
+// <copyright file="UserDataUpdateTriggerInterval.cs" company="MaaAssistantArknights">
+// Part of the MaaWpfGui project, maintained by the MaaAssistantArknights team (Maa Team)
+// Copyright (C) 2021-2025 MaaAssistantArknights Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License v3.0 only as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY
+// </copyright>
+
+namespace MaaWpfGui.Constants.Enums;
+
+public enum UserDataUpdateTriggerInterval
+{
+    EveryTime,
+    Daily,
+    Weekly,
+}

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -441,6 +441,10 @@ public class AsstProxy
             if (args.Action == NotifyCollectionChangedAction.Reset)
             {
                 TaskSettingVisibilityInfo.Instance.NotifyOfTaskStatus();
+                foreach (var i in Instances.TaskQueueViewModel.TaskItemViewModels)
+                {
+                    i.SetTaskIds([]);
+                }
             }
         };
 
@@ -1039,10 +1043,6 @@ public class AsstProxy
             case AsstMsg.TaskChainStopped:
                 Instances.TaskQueueViewModel.SetStopped();
                 UpdateTaskStatus(taskId, TaskStatus.Completed);
-                foreach (var i in Instances.TaskQueueViewModel.TaskItemViewModels)
-                {
-                    i.TaskId = 0;
-                }
                 _tasksStatus.Clear();
                 break;
 
@@ -1071,7 +1071,7 @@ public class AsstProxy
 
             case AsstMsg.TaskChainStart:
                 {
-                    var taskIndex = FindTaskItemByTaskId(taskId)?.Index ?? -1;
+                    var taskIndex = Instances.TaskQueueViewModel.TaskItemViewModels.FirstOrDefault(i => i.TaskIds.Contains(taskId))?.Index ?? -1;
                     var task = taskIndex >= 0 && taskIndex < ConfigFactory.CurrentConfig.TaskQueue.Count
                         ? ConfigFactory.CurrentConfig.TaskQueue[taskIndex]
                         : null;
@@ -1100,7 +1100,7 @@ public class AsstProxy
                         }
                     }
 
-                    var taskIndex = FindTaskItemByTaskId(taskId)?.Index ?? -1;
+                    var taskIndex = Instances.TaskQueueViewModel.TaskItemViewModels.FirstOrDefault(i => i.TaskIds.Contains(taskId))?.Index ?? -1;
                     var task = taskIndex >= 0 && taskIndex < ConfigFactory.CurrentConfig.TaskQueue.Count
                         ? ConfigFactory.CurrentConfig.TaskQueue[taskIndex]
                         : null;
@@ -1188,10 +1188,6 @@ public class AsstProxy
                 }
 
                 bool buyWine = _tasksStatus.Any(t => t.Value.Type == TaskType.Mall) && Instances.SettingsViewModel.DidYouBuyWine();
-                foreach (var i in Instances.TaskQueueViewModel.TaskItemViewModels)
-                {
-                    i.TaskId = 0;
-                }
                 _tasksStatus.Clear();
 
                 Instances.TaskQueueViewModel.ResetAllTemporaryVariable();
@@ -1437,7 +1433,7 @@ public class AsstProxy
                     // 剿灭放弃上传企鹅物流的特殊处理
                     Instances.AsstProxy.TasksStatus.TryGetValue(taskId, out var value);
                     if (value is { Type: TaskType.Fight }
-                        && (FindTaskItemByTaskId(taskId)?.Index ?? -1) is int index and > -1
+                        && Instances.TaskQueueViewModel.TaskItemViewModels.FirstOrDefault(i => i.TaskIds.Contains(taskId))?.Index is int index and > -1
                         && index <= ConfigFactory.CurrentConfig.TaskQueue.Count
                         && ConfigFactory.CurrentConfig.TaskQueue[index] is Configuration.Single.MaaTask.FightTask fight
                         && FightSettingsUserControlModel.GetFightStage(fight.StagePlan) == FightSettingsUserControlModel.AnnihilationName)
@@ -1744,7 +1740,7 @@ public class AsstProxy
                             {
                                 case "EndOfActionThenStop":
                                     {
-                                        var index = FindTaskItemByTaskId(taskId)?.Index ?? -1;
+                                        var index = Instances.TaskQueueViewModel.TaskItemViewModels.FirstOrDefault(i => i.TaskIds.Contains(taskId))?.Index ?? -1;
                                         if (index >= 0 && index < ConfigFactory.CurrentConfig.TaskQueue.Count && ConfigFactory.CurrentConfig.TaskQueue[index] is MallTask mall)
                                         {
                                             mall.CreditFightLastTime = DateTime.UtcNow.ToYjDate().ToFormattedString();
@@ -1756,7 +1752,7 @@ public class AsstProxy
 
                                 case "VisitLimited" or "VisitNextBlack":
                                     {
-                                        var index = FindTaskItemByTaskId(taskId)?.Index ?? -1;
+                                        var index = Instances.TaskQueueViewModel.TaskItemViewModels.FirstOrDefault(i => i.TaskIds.Contains(taskId))?.Index ?? -1;
                                         if (index >= 0 && index < ConfigFactory.CurrentConfig.TaskQueue.Count && ConfigFactory.CurrentConfig.TaskQueue[index] is MallTask mall)
                                         {
                                             mall.VisitFriendsLastTime = DateTime.UtcNow.ToYjDate().ToFormattedString();
@@ -2829,68 +2825,9 @@ public class AsstProxy
 
     public IReadOnlyDictionary<AsstTaskId, (TaskType Type, TaskStatus Status)> TasksStatus => new Dictionary<AsstTaskId, (TaskType, TaskStatus)>(_tasksStatus);
 
-    private static MaaWpfGui.ViewModels.TaskItemViewModel? FindTaskItemByTaskId(AsstTaskId taskId) =>
-        Instances.TaskQueueViewModel.TaskItemViewModels.FirstOrDefault(item => item.ContainsTaskId(taskId));
+    public delegate void TaskItemStatusDelegate(int taskId, TaskItemStatus status);
 
-    private TaskStatus GetAggregateStatusForTaskItem(MaaWpfGui.ViewModels.TaskItemViewModel taskItem)
-    {
-        // If there are no associated core task IDs, treat the item as idle.
-        if (taskItem.TaskIds == null || taskItem.TaskIds.Count == 0)
-        {
-            return TaskStatus.Idle;
-        }
-
-        var hasAnyStatus = false;
-        var hasError = false;
-        var hasInProgress = false;
-        var hasCompleted = false;
-
-        foreach (var taskId in taskItem.TaskIds)
-        {
-            if (!_tasksStatus.TryGetValue(taskId, out var value))
-            {
-                continue;
-            }
-
-            hasAnyStatus = true;
-
-            switch (value.Status)
-            {
-                case TaskStatus.Error:
-                    hasError = true;
-                    break;
-                case TaskStatus.InProgress:
-                    hasInProgress = true;
-                    break;
-                case TaskStatus.Completed:
-                    hasCompleted = true;
-                    break;
-            }
-        }
-
-        if (!hasAnyStatus)
-        {
-            return TaskStatus.Idle;
-        }
-
-        // Priority: Error > InProgress > Completed > Idle
-        if (hasError)
-        {
-            return TaskStatus.Error;
-        }
-
-        if (hasInProgress)
-        {
-            return TaskStatus.InProgress;
-        }
-
-        if (hasCompleted)
-        {
-            return TaskStatus.Completed;
-        }
-
-        return TaskStatus.Idle;
-    }
+    public event TaskItemStatusDelegate? OnTaskItemStatusChanged;
 
     private bool UpdateTaskStatus(AsstTaskId id, TaskStatus status)
     {
@@ -2911,14 +2848,7 @@ public class AsstProxy
         }
 
         _tasksStatus[id] = (value.Type, status);
-        var taskItem = FindTaskItemByTaskId(id);
-        if (taskItem is not null)
-        {
-            var aggregateStatus = GetAggregateStatusForTaskItem(taskItem);
-            taskItem.Status = (int)aggregateStatus;
-            status = aggregateStatus;
-        }
-
+        OnTaskItemStatusChanged?.Invoke(id, (TaskItemStatus)status);
         if (status == TaskStatus.InProgress)
         {
             TaskSettingVisibilityInfo.Instance.NotifyOfTaskStatus();

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -2832,6 +2832,66 @@ public class AsstProxy
     private static MaaWpfGui.ViewModels.TaskItemViewModel? FindTaskItemByTaskId(AsstTaskId taskId) =>
         Instances.TaskQueueViewModel.TaskItemViewModels.FirstOrDefault(item => item.ContainsTaskId(taskId));
 
+    private TaskStatus GetAggregateStatusForTaskItem(MaaWpfGui.ViewModels.TaskItemViewModel taskItem)
+    {
+        // If there are no associated core task IDs, treat the item as idle.
+        if (taskItem.TaskIds == null || taskItem.TaskIds.Count == 0)
+        {
+            return TaskStatus.Idle;
+        }
+
+        var hasAnyStatus = false;
+        var hasError = false;
+        var hasInProgress = false;
+        var hasCompleted = false;
+
+        foreach (var taskId in taskItem.TaskIds)
+        {
+            if (!_tasksStatus.TryGetValue(taskId, out var value))
+            {
+                continue;
+            }
+
+            hasAnyStatus = true;
+
+            switch (value.Status)
+            {
+                case TaskStatus.Error:
+                    hasError = true;
+                    break;
+                case TaskStatus.InProgress:
+                    hasInProgress = true;
+                    break;
+                case TaskStatus.Completed:
+                    hasCompleted = true;
+                    break;
+            }
+        }
+
+        if (!hasAnyStatus)
+        {
+            return TaskStatus.Idle;
+        }
+
+        // Priority: Error > InProgress > Completed > Idle
+        if (hasError)
+        {
+            return TaskStatus.Error;
+        }
+
+        if (hasInProgress)
+        {
+            return TaskStatus.InProgress;
+        }
+
+        if (hasCompleted)
+        {
+            return TaskStatus.Completed;
+        }
+
+        return TaskStatus.Idle;
+    }
+
     private bool UpdateTaskStatus(AsstTaskId id, TaskStatus status)
     {
         if (id <= 0)
@@ -2851,7 +2911,14 @@ public class AsstProxy
         }
 
         _tasksStatus[id] = (value.Type, status);
-        FindTaskItemByTaskId(id)?.Status = (int)status;
+        var taskItem = FindTaskItemByTaskId(id);
+        if (taskItem is not null)
+        {
+            var aggregateStatus = GetAggregateStatusForTaskItem(taskItem);
+            taskItem.Status = (int)aggregateStatus;
+            status = aggregateStatus;
+        }
+
         if (status == TaskStatus.InProgress)
         {
             TaskSettingVisibilityInfo.Instance.NotifyOfTaskStatus();

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -1042,7 +1042,8 @@ public class AsstProxy
         {
             case AsstMsg.TaskChainStopped:
                 Instances.TaskQueueViewModel.SetStopped();
-                UpdateTaskStatus(taskId, TaskStatus.Completed);
+
+                // UpdateTaskStatus(taskId, TaskStatus.Completed);
                 _tasksStatus.Clear();
                 break;
 

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -1071,7 +1071,7 @@ public class AsstProxy
 
             case AsstMsg.TaskChainStart:
                 {
-                    var taskIndex = Instances.TaskQueueViewModel.TaskItemViewModels.FirstOrDefault(t => t.TaskId == taskId)?.Index ?? -1;
+                    var taskIndex = FindTaskItemByTaskId(taskId)?.Index ?? -1;
                     var task = taskIndex >= 0 && taskIndex < ConfigFactory.CurrentConfig.TaskQueue.Count
                         ? ConfigFactory.CurrentConfig.TaskQueue[taskIndex]
                         : null;
@@ -1100,7 +1100,7 @@ public class AsstProxy
                         }
                     }
 
-                    var taskIndex = Instances.TaskQueueViewModel.TaskItemViewModels.FirstOrDefault(t => t.TaskId == taskId)?.Index ?? -1;
+                    var taskIndex = FindTaskItemByTaskId(taskId)?.Index ?? -1;
                     var task = taskIndex >= 0 && taskIndex < ConfigFactory.CurrentConfig.TaskQueue.Count
                         ? ConfigFactory.CurrentConfig.TaskQueue[taskIndex]
                         : null;
@@ -1437,7 +1437,7 @@ public class AsstProxy
                     // 剿灭放弃上传企鹅物流的特殊处理
                     Instances.AsstProxy.TasksStatus.TryGetValue(taskId, out var value);
                     if (value is { Type: TaskType.Fight }
-                        && (Instances.TaskQueueViewModel.TaskItemViewModels.FirstOrDefault(t => t.TaskId == taskId)?.Index ?? -1) is int index and > -1
+                        && (FindTaskItemByTaskId(taskId)?.Index ?? -1) is int index and > -1
                         && index <= ConfigFactory.CurrentConfig.TaskQueue.Count
                         && ConfigFactory.CurrentConfig.TaskQueue[index] is Configuration.Single.MaaTask.FightTask fight
                         && FightSettingsUserControlModel.GetFightStage(fight.StagePlan) == FightSettingsUserControlModel.AnnihilationName)
@@ -1744,7 +1744,7 @@ public class AsstProxy
                             {
                                 case "EndOfActionThenStop":
                                     {
-                                        var index = Instances.TaskQueueViewModel.TaskItemViewModels.FirstOrDefault(t => t.TaskId == taskId)?.Index ?? -1;
+                                        var index = FindTaskItemByTaskId(taskId)?.Index ?? -1;
                                         if (index >= 0 && index < ConfigFactory.CurrentConfig.TaskQueue.Count && ConfigFactory.CurrentConfig.TaskQueue[index] is MallTask mall)
                                         {
                                             mall.CreditFightLastTime = DateTime.UtcNow.ToYjDate().ToFormattedString();
@@ -1756,7 +1756,7 @@ public class AsstProxy
 
                                 case "VisitLimited" or "VisitNextBlack":
                                     {
-                                        var index = Instances.TaskQueueViewModel.TaskItemViewModels.FirstOrDefault(t => t.TaskId == taskId)?.Index ?? -1;
+                                        var index = FindTaskItemByTaskId(taskId)?.Index ?? -1;
                                         if (index >= 0 && index < ConfigFactory.CurrentConfig.TaskQueue.Count && ConfigFactory.CurrentConfig.TaskQueue[index] is MallTask mall)
                                         {
                                             mall.VisitFriendsLastTime = DateTime.UtcNow.ToYjDate().ToFormattedString();
@@ -1798,7 +1798,7 @@ public class AsstProxy
                 break;
 
             case "OperBox":
-                Instances.ToolboxViewModel.OperBoxParse((JObject?)subTaskDetails);
+                Instances.ToolboxViewModel.OperBoxParse((JObject?)subTaskDetails, updateSyncTime: true);
                 break;
         }
 
@@ -2802,6 +2802,9 @@ public class AsstProxy
         /// <summary>生息演算</summary>
         Reclamation,
 
+        /// <summary>更新用户数据</summary>
+        UserDataUpdate,
+
         /// <summary>小游戏</summary>
         MiniGame,
 
@@ -2819,11 +2822,15 @@ public class AsstProxy
         TaskType.Award,
         TaskType.Roguelike,
         TaskType.Reclamation,
+        TaskType.UserDataUpdate,
     ];
 
     private readonly ObservableDictionary<AsstTaskId, (TaskType Type, TaskStatus Status)> _tasksStatus = [];
 
     public IReadOnlyDictionary<AsstTaskId, (TaskType Type, TaskStatus Status)> TasksStatus => new Dictionary<AsstTaskId, (TaskType, TaskStatus)>(_tasksStatus);
+
+    private static MaaWpfGui.ViewModels.TaskItemViewModel? FindTaskItemByTaskId(AsstTaskId taskId) =>
+        Instances.TaskQueueViewModel.TaskItemViewModels.FirstOrDefault(item => item.ContainsTaskId(taskId));
 
     private bool UpdateTaskStatus(AsstTaskId id, TaskStatus status)
     {
@@ -2844,7 +2851,7 @@ public class AsstProxy
         }
 
         _tasksStatus[id] = (value.Type, status);
-        Instances.TaskQueueViewModel.TaskItemViewModels.FirstOrDefault(item => item.TaskId == id)?.Status = (int)status;
+        FindTaskItemByTaskId(id)?.Status = (int)status;
         if (status == TaskStatus.InProgress)
         {
             TaskSettingVisibilityInfo.Instance.NotifyOfTaskStatus();
@@ -2882,19 +2889,23 @@ public class AsstProxy
     /// <summary>
     /// 仓库识别。
     /// </summary>
+    /// <param name="startImmediately">是否立刻启动。</param>
     /// <returns>是否成功。</returns>
-    public bool AsstStartDepot()
+    public bool AsstStartDepot(bool startImmediately = true)
     {
-        return AsstAppendTaskWithEncoding(TaskType.Depot, AsstTaskType.Depot) && AsstStart();
+        return AsstAppendTaskWithEncoding(TaskType.Depot, AsstTaskType.Depot) &&
+               (!startImmediately || AsstStart());
     }
 
     /// <summary>
     /// 干员识别。
     /// </summary>
+    /// <param name="startImmediately">是否立刻启动。</param>
     /// <returns>是否成功。</returns>
-    public bool AsstStartOperBox()
+    public bool AsstStartOperBox(bool startImmediately = true)
     {
-        return AsstAppendTaskWithEncoding(TaskType.OperBox, AsstTaskType.OperBox) && AsstStart();
+        return AsstAppendTaskWithEncoding(TaskType.OperBox, AsstTaskType.OperBox) &&
+               (!startImmediately || AsstStart());
     }
 
     /// <summary>

--- a/src/MaaWpfGui/Models/TaskSettingVisibilityInfo.cs
+++ b/src/MaaWpfGui/Models/TaskSettingVisibilityInfo.cs
@@ -12,6 +12,7 @@
 // </copyright>
 #nullable enable
 using System;
+using System.Linq;
 using MaaWpfGui.Configuration.Factory;
 using MaaWpfGui.Configuration.Single.MaaTask;
 using MaaWpfGui.Constants;
@@ -51,6 +52,8 @@ public class TaskSettingVisibilityInfo : PropertyChangedBase
 
     public bool Reclamation { get => field; set => SetAndNotify(ref field, value); }
 
+    public bool UserDataUpdate { get => field; set => SetAndNotify(ref field, value); }
+
     public bool Custom { get => field; set => SetAndNotify(ref field, value); }
 
     public bool PostAction { get => field; set => SetAndNotify(ref field, value); }
@@ -79,8 +82,9 @@ public class TaskSettingVisibilityInfo : PropertyChangedBase
     public bool IsCurrentTaskRunning =>
         ConfigFactory.CurrentConfig.TaskQueue.Count > CurrentIndex &&
         CurrentIndex >= 0 &&
-        Instances.AsstProxy.TasksStatus.TryGetValue(Instances.TaskQueueViewModel.TaskItemViewModels[CurrentIndex].TaskId, out var status) &&
-        status.Status == TaskStatus.InProgress;
+        Instances.TaskQueueViewModel.TaskItemViewModels[CurrentIndex].TaskIds.Any(taskId =>
+            Instances.AsstProxy.TasksStatus.TryGetValue(taskId, out var status) &&
+            status.Status == TaskStatus.InProgress);
 
     public static BaseTask? CurrentTask =>
         ConfigFactory.CurrentConfig.TaskQueue.Count > Instance.CurrentIndex &&
@@ -143,6 +147,7 @@ public class TaskSettingVisibilityInfo : PropertyChangedBase
             AwardTask => Award = enable,
             RoguelikeTask => Roguelike = enable,
             ReclamationTask => Reclamation = enable,
+            UserDataUpdateTask => UserDataUpdate = enable,
             CustomTask => Custom = enable,
             _ => throw new NotImplementedException(),
         };
@@ -160,6 +165,7 @@ public class TaskSettingVisibilityInfo : PropertyChangedBase
         Award = false;
         Roguelike = false;
         Reclamation = false;
+        UserDataUpdate = false;
         Custom = false;
     }
 

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -690,6 +690,7 @@ If the game is launched in portrait mode and then switched to landscape, it may 
     <system:String x:Key="AutoRoguelike">Auto I.S.</system:String>
     <system:String x:Key="Roguelike">{key=AutoRoguelike}</system:String>
     <system:String x:Key="Reclamation">Reclamation Algorithm</system:String>
+    <system:String x:Key="UserDataUpdate">Update User Data</system:String>
     <system:String x:Key="MiniGame">Mini-Games</system:String>
     <system:String x:Key="Custom">Custom Task</system:String>
     <system:String x:Key="SingleStep">Single-Step Task</system:String>
@@ -848,7 +849,7 @@ Right Click: Select Target Process</system:String>
     <!--  Depot Recognition  -->
     <system:String x:Key="DepotRecognition">Depot</system:String>
     <system:String x:Key="Depot">{key=DepotRecognition}</system:String>
-    <system:String x:Key="LastDepotSyncTime">Last Sync Time</system:String>
+    <system:String x:Key="LastSyncTime">Last Sync Time</system:String>
     <system:String x:Key="DepotRecognitionTip">This function is still in testing. If you encounter any unexpected results, please zip the ｢debug/depot｣ folder in the installation path and submit an issue on GitHub</system:String>
     <system:String x:Key="StartToDepotRecognition">Start to Identify</system:String>
     <system:String x:Key="ExportToArkplanner">Export to Arkplanner</system:String>
@@ -1222,6 +1223,10 @@ Right-click to clear inactive jobs</system:String>
     <system:String x:Key="StageInfoError">Stage recognition error</system:String>
     <system:String x:Key="UseFormation">Use formation</system:String>
     <system:String x:Key="Current">Current</system:String>
+    <system:String x:Key="EveryTime">Every Time</system:String>
+    <system:String x:Key="Daily">Daily</system:String>
+    <system:String x:Key="Weekly">Weekly</system:String>
+    <system:String x:Key="UserDataUpdateTriggerInterval">Trigger Interval</system:String>
     <system:String x:Key="BattleFormation">Start formation</system:String>
     <system:String x:Key="BattleFormationParseFailed">Formation parse failed</system:String>
     <system:String x:Key="BattleFormationSelected" xml:space="preserve">Selected:&#160;</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -691,6 +691,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="AutoRoguelike">自動ローグ</system:String>
     <system:String x:Key="Roguelike">{key=AutoRoguelike}</system:String>
     <system:String x:Key="Reclamation">生息演算</system:String>
+    <system:String x:Key="UserDataUpdate">ユーザーデータ更新</system:String>
     <system:String x:Key="MiniGame">ミニゲーム</system:String>
     <system:String x:Key="Custom">カスタムタスク</system:String>
     <system:String x:Key="SingleStep">単一ステップタスク</system:String>
@@ -849,7 +850,7 @@ C:\\leidian\\LDPlayer9
     <!--  倉庫アイテム認識  -->
     <system:String x:Key="DepotRecognition">倉庫アイテム認識</system:String>
     <system:String x:Key="Depot">{key=DepotRecognition}</system:String>
-    <system:String x:Key="LastDepotSyncTime">前回同期時間</system:String>
+    <system:String x:Key="LastSyncTime">前回同期時間</system:String>
     <system:String x:Key="DepotRecognitionTip">この機能はまだテスト版です。エラーが発生/統計情報に問題があれば、debug/depotフォルダを圧縮し、issueを提出してください~</system:String>
     <system:String x:Key="StartToDepotRecognition">認識開始</system:String>
     <system:String x:Key="ExportToArkplanner">Arkplannerへ出力</system:String>
@@ -1223,6 +1224,10 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="StageInfoError">ステージ認識エラー</system:String>
     <system:String x:Key="UseFormation">使用編成</system:String>
     <system:String x:Key="Current">現在</system:String>
+    <system:String x:Key="EveryTime">毎回</system:String>
+    <system:String x:Key="Daily">毎日</system:String>
+    <system:String x:Key="Weekly">毎週</system:String>
+    <system:String x:Key="UserDataUpdateTriggerInterval">実行間隔</system:String>
     <system:String x:Key="BattleFormation">編成開始</system:String>
     <system:String x:Key="BattleFormationParseFailed">フォーメーション解析に失敗しました</system:String>
     <system:String x:Key="BattleFormationSelected" xml:space="preserve">{key=Operator}を選択: </system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -692,6 +692,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="AutoRoguelike">통합 전략</system:String>
     <system:String x:Key="Roguelike">{key=AutoRoguelike}</system:String>
     <system:String x:Key="Reclamation">생존 연산</system:String>
+    <system:String x:Key="UserDataUpdate">사용자 데이터 업데이트</system:String>
     <system:String x:Key="MiniGame">미니게임</system:String>
     <system:String x:Key="Custom">커스텀 작업</system:String>
     <system:String x:Key="SingleStep">단일 단계 작업</system:String>
@@ -850,7 +851,7 @@ C:\\leidian\\LDPlayer9
     <!--  창고 인식  -->
     <system:String x:Key="DepotRecognition">창고 인식</system:String>
     <system:String x:Key="Depot">{key=DepotRecognition}</system:String>
-    <system:String x:Key="LastDepotSyncTime">마지막 동기화 시간</system:String>
+    <system:String x:Key="LastSyncTime">마지막 동기화 시간</system:String>
     <system:String x:Key="DepotRecognitionTip">이 기능은 현재 테스트 중입니다. 내보내기 전 인식 결과가 맞는지 확인 후 사용하세요\n만약 오류가 있다면 MAA 경로 내 debug 폴더 안의 depot 폴더 전체를 압축해서 Github의 issue로 올려주세요</system:String>
     <system:String x:Key="StartToDepotRecognition">인식 시작</system:String>
     <system:String x:Key="ExportToArkplanner">Arkplanner로 내보내기</system:String>
@@ -1224,6 +1225,10 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="StageInfoError">스테이지 인식 오류</system:String>
     <system:String x:Key="UseFormation">편성 사용</system:String>
     <system:String x:Key="Current">현재</system:String>
+    <system:String x:Key="EveryTime">매번</system:String>
+    <system:String x:Key="Daily">매일</system:String>
+    <system:String x:Key="Weekly">매주</system:String>
+    <system:String x:Key="UserDataUpdateTriggerInterval">실행 간격</system:String>
     <system:String x:Key="BattleFormation">편성 시작</system:String>
     <system:String x:Key="BattleFormationParseFailed">편성 분석에 실패했습니다</system:String>
     <system:String x:Key="BattleFormationSelected" xml:space="preserve">{key=Operator}를 선택: </system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -691,6 +691,7 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="AutoRoguelike">自动肉鸽</system:String>
     <system:String x:Key="Roguelike">{key=AutoRoguelike}</system:String>
     <system:String x:Key="Reclamation">生息演算</system:String>
+    <system:String x:Key="UserDataUpdate">更新数据</system:String>
     <system:String x:Key="MiniGame">小游戏</system:String>
     <system:String x:Key="Custom">自定任务</system:String>
     <system:String x:Key="SingleStep">单步任务</system:String>
@@ -849,7 +850,7 @@ C:\\leidian\\LDPlayer9。\n
     <!--  仓库识别  -->
     <system:String x:Key="DepotRecognition">仓库识别</system:String>
     <system:String x:Key="Depot">{key=DepotRecognition}</system:String>
-    <system:String x:Key="LastDepotSyncTime">上次同步时间</system:String>
+    <system:String x:Key="LastSyncTime">上次同步时间</system:String>
     <system:String x:Key="DepotRecognitionTip">该功能尚处于测试阶段，请检查结果是否准确再行使用。若有误，欢迎打包 debug/depot 文件夹后向我们提交 issue ~</system:String>
     <system:String x:Key="StartToDepotRecognition">开始识别</system:String>
     <system:String x:Key="ExportToArkplanner">导出至企鹅物流刷图规划</system:String>
@@ -1223,6 +1224,10 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="StageInfoError">关卡识别错误</system:String>
     <system:String x:Key="UseFormation">使用编队</system:String>
     <system:String x:Key="Current">当前</system:String>
+    <system:String x:Key="EveryTime">每次</system:String>
+    <system:String x:Key="Daily">每天</system:String>
+    <system:String x:Key="Weekly">每周</system:String>
+    <system:String x:Key="UserDataUpdateTriggerInterval">触发间隔</system:String>
     <system:String x:Key="BattleFormation">开始编队</system:String>
     <system:String x:Key="BattleFormationParseFailed">编队解析失败</system:String>
     <system:String x:Key="BattleFormationSelected" xml:space="preserve">选择{key=Operator}: </system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -691,6 +691,7 @@ C:\\leidian\\LDPlayer9\n
     <system:String x:Key="AutoRoguelike">自動肉鴿</system:String>
     <system:String x:Key="Roguelike">{key=AutoRoguelike}</system:String>
     <system:String x:Key="Reclamation">生息演算</system:String>
+    <system:String x:Key="UserDataUpdate">更新使用者資料</system:String>
     <system:String x:Key="MiniGame">小遊戲</system:String>
     <system:String x:Key="Custom">自定義任務</system:String>
     <system:String x:Key="SingleStep">單步任務</system:String>
@@ -849,7 +850,7 @@ C:\\leidian\\LDPlayer9\n
     <!--  倉庫辨識  -->
     <system:String x:Key="DepotRecognition">倉庫辨識</system:String>
     <system:String x:Key="Depot">{key=DepotRecognition}</system:String>
-    <system:String x:Key="LastDepotSyncTime">上次同步時間</system:String>
+    <system:String x:Key="LastSyncTime">上次同步時間</system:String>
     <system:String x:Key="DepotRecognitionTip">該功能尚處於測試階段，請檢查結果是否準確再行使用。若有誤，歡迎打包 debug/depot 資料夾後向我們提交 issue ~</system:String>
     <system:String x:Key="StartToDepotRecognition">開始辨識</system:String>
     <system:String x:Key="ExportToArkplanner">匯出到企鵝物流刷圖規劃</system:String>
@@ -1223,6 +1224,10 @@ C:\\leidian\\LDPlayer9\n
     <system:String x:Key="StageInfoError">關卡辨識錯誤</system:String>
     <system:String x:Key="UseFormation">使用編隊</system:String>
     <system:String x:Key="Current">目前</system:String>
+    <system:String x:Key="EveryTime">每次</system:String>
+    <system:String x:Key="Daily">每天</system:String>
+    <system:String x:Key="Weekly">每週</system:String>
+    <system:String x:Key="UserDataUpdateTriggerInterval">觸發間隔</system:String>
     <system:String x:Key="BattleFormation">開始編隊</system:String>
     <system:String x:Key="BattleFormationParseFailed">編隊解析失敗</system:String>
     <system:String x:Key="BattleFormationSelected" xml:space="preserve">選擇{key=Operator}: </system:String>

--- a/src/MaaWpfGui/Res/Themes/Dark.xaml
+++ b/src/MaaWpfGui/Res/Themes/Dark.xaml
@@ -80,9 +80,9 @@
     <SolidColorBrush x:Key="RareOperatorLogBrush" Color="Orange" />
     <SolidColorBrush x:Key="RobotOperatorLogBrush" Color="Gray" />
 
-    <SolidColorBrush x:Key="TaskQueue.TaskStatus.InProgress" Color="#20326CF3" />
-    <SolidColorBrush x:Key="TaskQueue.TaskStatus.Completed" Color="#2090EE90" />
-    <SolidColorBrush x:Key="TaskQueue.TaskStatus.Error" Color="#20FF4444" />
+    <SolidColorBrush x:Key="TaskQueue.TaskItemStatus.InProgress" Color="#20326CF3" />
+    <SolidColorBrush x:Key="TaskQueue.TaskItemStatus.Completed" Color="#2090EE90" />
+    <SolidColorBrush x:Key="TaskQueue.TaskItemStatus.Error" Color="#20FF4444" />
 
     <SolidColorBrush x:Key="Star1OperatorLogBrush" Color="#E6E6E6" />
     <SolidColorBrush x:Key="Star1OperatorLogBrushPotentialFull" Color="#66E6E6E6" />

--- a/src/MaaWpfGui/Res/Themes/Light.xaml
+++ b/src/MaaWpfGui/Res/Themes/Light.xaml
@@ -62,9 +62,9 @@
     <SolidColorBrush x:Key="RareOperatorLogBrush" Color="DarkOrange" />
     <SolidColorBrush x:Key="RobotOperatorLogBrush" Color="DarkGray" />
 
-    <SolidColorBrush x:Key="TaskQueue.TaskStatus.InProgress" Color="#206C9CF3" />
-    <SolidColorBrush x:Key="TaskQueue.TaskStatus.Completed" Color="#2060D060" />
-    <SolidColorBrush x:Key="TaskQueue.TaskStatus.Error" Color="#20FF6666" />
+    <SolidColorBrush x:Key="TaskQueue.TaskItemStatus.InProgress" Color="#206C9CF3" />
+    <SolidColorBrush x:Key="TaskQueue.TaskItemStatus.Completed" Color="#2060D060" />
+    <SolidColorBrush x:Key="TaskQueue.TaskItemStatus.Error" Color="#20FF6666" />
 
     <SolidColorBrush x:Key="Star1OperatorLogBrush" Color="Black" />
     <SolidColorBrush x:Key="Star1OperatorLogBrushPotentialFull" Color="#66000000" />

--- a/src/MaaWpfGui/ViewModels/TaskItemViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/TaskItemViewModel.cs
@@ -19,15 +19,9 @@ using Stylet;
 
 namespace MaaWpfGui.ViewModels;
 
-public class TaskItemViewModel : PropertyChangedBase
+public class TaskItemViewModel(string name, bool? isCheckedWithNull = true) : PropertyChangedBase
 {
-    public TaskItemViewModel(string name, bool? isCheckedWithNull = true)
-    {
-        _name = name;
-        _isEnable = isCheckedWithNull;
-    }
-
-    private string _name;
+    private string _name = name;
 
     public string Name
     {
@@ -38,7 +32,7 @@ public class TaskItemViewModel : PropertyChangedBase
         }
     }
 
-    private bool? _isEnable;
+    private bool? _isEnable = isCheckedWithNull;
 
     public bool? IsEnable
     {
@@ -54,24 +48,16 @@ public class TaskItemViewModel : PropertyChangedBase
         }
     }
 
-    private int _index;
-
-    public int Index
-    {
-        get => _index;
-        set => SetAndNotify(ref _index, value);
-    }
+    public int Index { get => field; set => SetAndNotify(ref field, value); }
 
     /// <summary>
     /// Gets or sets a value indicating whether gets or sets whether the setting enabled.
     /// </summary>
-    private bool _enableSetting;
-
     public bool EnableSetting
     {
-        get => _enableSetting;
+        get => field;
         set {
-            SetAndNotify(ref _enableSetting, value);
+            SetAndNotify(ref field, value);
             TaskSettingVisibilityInfo.Instance.Set(Index, value);
         }
     }
@@ -87,28 +73,15 @@ public class TaskItemViewModel : PropertyChangedBase
         set => SetTaskIds(value > 0 ? [value] : []);
     }
 
-    private IReadOnlyList<int> _taskIds = [];
-
     public IReadOnlyList<int> TaskIds
     {
-        get => _taskIds;
-        private set => SetAndNotify(ref _taskIds, value);
-    }
+        get => field;
+        private set => SetAndNotify(ref field, value);
+    } = [];
 
-    public void SetTaskIds(IEnumerable<int> taskIds)
-    {
-        var ids = taskIds.Where(id => id > 0).Distinct().ToArray();
-        TaskIds = ids;
-        SetAndNotify(ref _taskId, ids.LastOrDefault(), nameof(TaskId));
-    }
+    public void SetTaskIds(IEnumerable<int> taskIds) => TaskIds = (IReadOnlyList<int>)taskIds;
 
     public bool ContainsTaskId(int taskId) => taskId > 0 && TaskIds.Contains(taskId);
 
-    private int _status;
-
-    public int Status
-    {
-        get => _status;
-        set => SetAndNotify(ref _status, value);
-    }
+    public int Status { get => field; set => SetAndNotify(ref field, value); }
 }

--- a/src/MaaWpfGui/ViewModels/TaskItemViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/TaskItemViewModel.cs
@@ -87,6 +87,9 @@ public class TaskItemViewModel : PropertyChangedBase, IDisposable
 
     private List<TaskItemStatus> StatusList { get; set; } = [];
 
+    /// <summary>
+    /// Gets or sets 上次状态, 可能和当前不一致
+    /// </summary>
     public TaskItemStatus StatusDisplay { get => field; set => SetAndNotify(ref field, value); }
 
     private void OnTaskStatusChanged(int taskId, TaskItemStatus status)

--- a/src/MaaWpfGui/ViewModels/TaskItemViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/TaskItemViewModel.cs
@@ -11,6 +11,8 @@
 // but WITHOUT ANY WARRANTY
 // </copyright>
 #nullable enable
+using System.Collections.Generic;
+using System.Linq;
 using MaaWpfGui.Configuration.Factory;
 using MaaWpfGui.Models;
 using Stylet;
@@ -52,16 +54,24 @@ public class TaskItemViewModel : PropertyChangedBase
         }
     }
 
-    public int Index { get => field; set => SetAndNotify(ref field, value); }
+    private int _index;
+
+    public int Index
+    {
+        get => _index;
+        set => SetAndNotify(ref _index, value);
+    }
 
     /// <summary>
     /// Gets or sets a value indicating whether gets or sets whether the setting enabled.
     /// </summary>
+    private bool _enableSetting;
+
     public bool EnableSetting
     {
-        get => field;
+        get => _enableSetting;
         set {
-            SetAndNotify(ref field, value);
+            SetAndNotify(ref _enableSetting, value);
             TaskSettingVisibilityInfo.Instance.Set(Index, value);
         }
     }
@@ -69,7 +79,36 @@ public class TaskItemViewModel : PropertyChangedBase
     /// <summary>
     /// Gets or sets 任务id，默认为0，添加后任务id应 > 0；执行后应置为0
     /// </summary>
-    public int TaskId { get; set; }
+    private int _taskId;
 
-    public int Status { get => field; set => SetAndNotify(ref field, value); }
+    public int TaskId
+    {
+        get => _taskId;
+        set => SetTaskIds(value > 0 ? [value] : []);
+    }
+
+    private IReadOnlyList<int> _taskIds = [];
+
+    public IReadOnlyList<int> TaskIds
+    {
+        get => _taskIds;
+        private set => SetAndNotify(ref _taskIds, value);
+    }
+
+    public void SetTaskIds(IEnumerable<int> taskIds)
+    {
+        var ids = taskIds.Where(id => id > 0).Distinct().ToArray();
+        TaskIds = ids;
+        SetAndNotify(ref _taskId, ids.LastOrDefault(), nameof(TaskId));
+    }
+
+    public bool ContainsTaskId(int taskId) => taskId > 0 && TaskIds.Contains(taskId);
+
+    private int _status;
+
+    public int Status
+    {
+        get => _status;
+        set => SetAndNotify(ref _status, value);
+    }
 }

--- a/src/MaaWpfGui/ViewModels/TaskItemViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/TaskItemViewModel.cs
@@ -54,7 +54,7 @@ public class TaskItemViewModel : PropertyChangedBase, IDisposable
             }
 
             ConfigFactory.CurrentConfig.TaskQueue[Index].IsEnable = value;
-            StatusDisplay = (int)TaskItemStatus.Idle;
+            StatusDisplay = TaskItemStatus.Idle;
         }
     }
 
@@ -83,15 +83,11 @@ public class TaskItemViewModel : PropertyChangedBase, IDisposable
     {
         _taskIds = [.. taskIds];
         StatusList = [.. Enumerable.Repeat(TaskItemStatus.Idle, TaskIds.Count)];
-        if (TaskIds.Count == 0)
-        {
-            StatusDisplay = (int)TaskItemStatus.Idle;
-        }
     }
 
     private List<TaskItemStatus> StatusList { get; set; } = [];
 
-    public int StatusDisplay { get => field; set => SetAndNotify(ref field, value); }
+    public TaskItemStatus StatusDisplay { get => field; set => SetAndNotify(ref field, value); }
 
     private void OnTaskStatusChanged(int taskId, TaskItemStatus status)
     {
@@ -107,23 +103,23 @@ public class TaskItemViewModel : PropertyChangedBase, IDisposable
         StatusList[index] = status;
         if (StatusList.Any(s => s == TaskItemStatus.Error))
         {
-            StatusDisplay = (int)TaskItemStatus.Error;
+            StatusDisplay = TaskItemStatus.Error;
         }
         else if (StatusList.Any(s => s == TaskItemStatus.InProgress))
         {
-            StatusDisplay = (int)TaskItemStatus.InProgress;
+            StatusDisplay = TaskItemStatus.InProgress;
         }
         else if (StatusList.All(s => s == TaskItemStatus.Completed))
         {
-            StatusDisplay = (int)TaskItemStatus.Completed;
+            StatusDisplay = TaskItemStatus.Completed;
         }
         else if (StatusList.Any(s => s == TaskItemStatus.Skipped))
         {
-            StatusDisplay = (int)TaskItemStatus.Skipped;
+            StatusDisplay = TaskItemStatus.Skipped;
         }
         else
         {
-            StatusDisplay = (int)TaskItemStatus.Idle;
+            StatusDisplay = TaskItemStatus.Idle;
         }
     }
 

--- a/src/MaaWpfGui/ViewModels/TaskItemViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/TaskItemViewModel.cs
@@ -11,17 +11,27 @@
 // but WITHOUT ANY WARRANTY
 // </copyright>
 #nullable enable
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using MaaWpfGui.Configuration.Factory;
+using MaaWpfGui.Constants.Enums;
+using MaaWpfGui.Helper;
 using MaaWpfGui.Models;
 using Stylet;
 
 namespace MaaWpfGui.ViewModels;
 
-public class TaskItemViewModel(string name, bool? isCheckedWithNull = true) : PropertyChangedBase
+public class TaskItemViewModel : PropertyChangedBase, IDisposable
 {
-    private string _name = name;
+    public TaskItemViewModel(string name, bool? isCheckedWithNull = true)
+    {
+        _name = name;
+        _isEnable = isCheckedWithNull;
+        Instances.AsstProxy.OnTaskItemStatusChanged += OnTaskStatusChanged;
+    }
+
+    private string _name;
 
     public string Name
     {
@@ -32,7 +42,7 @@ public class TaskItemViewModel(string name, bool? isCheckedWithNull = true) : Pr
         }
     }
 
-    private bool? _isEnable = isCheckedWithNull;
+    private bool? _isEnable;
 
     public bool? IsEnable
     {
@@ -44,7 +54,7 @@ public class TaskItemViewModel(string name, bool? isCheckedWithNull = true) : Pr
             }
 
             ConfigFactory.CurrentConfig.TaskQueue[Index].IsEnable = value;
-            Status = 0;
+            StatusDisplay = (int)TaskItemStatus.Idle;
         }
     }
 
@@ -63,25 +73,59 @@ public class TaskItemViewModel(string name, bool? isCheckedWithNull = true) : Pr
     }
 
     /// <summary>
-    /// Gets or sets 任务id，默认为0，添加后任务id应 > 0；执行后应置为0
+    /// Gets or sets 任务id，默认为[]，添加后任务id应 > 0；执行后应置为[]
     /// </summary>
-    private int _taskId;
+    private List<int> _taskIds = [];
 
-    public int TaskId
+    public IReadOnlyList<int> TaskIds => _taskIds;
+
+    public void SetTaskIds(IEnumerable<int> taskIds)
     {
-        get => _taskId;
-        set => SetTaskIds(value > 0 ? [value] : []);
+        _taskIds = [.. taskIds];
+        StatusList = [.. Enumerable.Repeat(TaskItemStatus.Idle, TaskIds.Count)];
+        if (TaskIds.Count == 0)
+        {
+            StatusDisplay = (int)TaskItemStatus.Idle;
+        }
     }
 
-    public IReadOnlyList<int> TaskIds
+    private List<TaskItemStatus> StatusList { get; set; } = [];
+
+    public int StatusDisplay { get => field; set => SetAndNotify(ref field, value); }
+
+    private void OnTaskStatusChanged(int taskId, TaskItemStatus status)
     {
-        get => field;
-        private set => SetAndNotify(ref field, value);
-    } = [];
+        if (taskId < 0)
+        {
+            return;
+        }
+        int index = _taskIds.IndexOf(taskId);
+        if (index < 0)
+        {
+            return;
+        }
+        StatusList[index] = status;
+        if (StatusList.Any(s => s == TaskItemStatus.Error))
+        {
+            StatusDisplay = (int)TaskItemStatus.Error;
+        }
+        else if (StatusList.Any(s => s == TaskItemStatus.InProgress))
+        {
+            StatusDisplay = (int)TaskItemStatus.InProgress;
+        }
+        else if (StatusList.All(s => s == TaskItemStatus.Completed))
+        {
+            StatusDisplay = (int)TaskItemStatus.Completed;
+        }
+        else if (StatusList.Any(s => s == TaskItemStatus.Skipped))
+        {
+            StatusDisplay = (int)TaskItemStatus.Skipped;
+        }
+        else
+        {
+            StatusDisplay = (int)TaskItemStatus.Idle;
+        }
+    }
 
-    public void SetTaskIds(IEnumerable<int> taskIds) => TaskIds = (IReadOnlyList<int>)taskIds;
-
-    public bool ContainsTaskId(int taskId) => taskId > 0 && TaskIds.Contains(taskId);
-
-    public int Status { get => field; set => SetAndNotify(ref field, value); }
+    void IDisposable.Dispose() => Instances.AsstProxy.OnTaskItemStatusChanged -= OnTaskStatusChanged;
 }

--- a/src/MaaWpfGui/ViewModels/TaskSettingsViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/TaskSettingsViewModel.cs
@@ -85,4 +85,6 @@ public interface ITaskQueueModelSerialize
 {
     /// <inheritdoc cref="TaskSettingsViewModel.SerializeTask"/>
     public abstract (bool? IsSuccess, IEnumerable<int> TaskId) Serialize(BaseTask? baseTask, int? taskId);
+
+    protected static (bool? IsSuccess, IEnumerable<int> TaskId) FromSingle((bool? IsSuccess, int TaskId) result) => (result.IsSuccess, result.TaskId > 0 ? [result.TaskId] : []);
 }

--- a/src/MaaWpfGui/ViewModels/TaskSettingsViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/TaskSettingsViewModel.cs
@@ -13,6 +13,7 @@
 
 #nullable enable
 using System;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using MaaWpfGui.Configuration.Factory;
 using MaaWpfGui.Configuration.Single.MaaTask;
@@ -77,11 +78,11 @@ public abstract class TaskSettingsViewModel : PropertyChangedBase
     /// <param name="baseTask">存储的任务</param>
     /// <param name="taskId">任务id, null时追加任务, 非null为设置任务参数</param>
     /// <returns>null为未序列化, false失败, true成功</returns>
-    public abstract (bool? IsSuccess, int TaskId) SerializeTask(BaseTask? baseTask, int? taskId = null);
+    public abstract (bool? IsSuccess, IEnumerable<int> TaskId) SerializeTask(BaseTask? baseTask, int? taskId = null);
 }
 
 public interface ITaskQueueModelSerialize
 {
     /// <inheritdoc cref="TaskSettingsViewModel.SerializeTask"/>
-    public abstract (bool? IsSuccess, int TaskId) Serialize(BaseTask? baseTask, int? taskId);
+    public abstract (bool? IsSuccess, IEnumerable<int> TaskId) Serialize(BaseTask? baseTask, int? taskId);
 }

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -1812,7 +1812,7 @@ public class TaskQueueViewModel : Screen
 
             foreach (var item in Instances.TaskQueueViewModel.TaskItemViewModels)
             {
-                item.Status = status;
+                item.StatusDisplay = status;
             }
         }
     }
@@ -1821,7 +1821,7 @@ public class TaskQueueViewModel : Screen
     {
         foreach (var item in TaskItemViewModels)
         {
-            item.Status = (int)Main.TaskStatus.Idle;
+            item.StatusDisplay = (int)Main.TaskStatus.Idle;
         }
     }
 

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -124,6 +124,11 @@ public class TaskQueueViewModel : Screen
     public static ReclamationSettingsUserControlModel ReclamationTask => ReclamationSettingsUserControlModel.Instance;
 
     /// <summary>
+    /// Gets 更新用户数据任务Model
+    /// </summary>
+    public static UserDataUpdateSettingsUserControlModel UserDataUpdateTask => UserDataUpdateSettingsUserControlModel.Instance;
+
+    /// <summary>
     /// Gets 生稀盐酸任务Model
     /// </summary>
     public static CustomSettingsUserControlModel CustomTask => CustomSettingsUserControlModel.Instance;
@@ -1277,6 +1282,7 @@ public class TaskQueueViewModel : Screen
             new GenericCombinedData<Type> { Display = LocalizationHelper.GetString("Award"), Value = typeof(AwardTask) },
             new GenericCombinedData<Type> { Display = LocalizationHelper.GetString("Roguelike"), Value = typeof(RoguelikeTask) },
             new GenericCombinedData<Type> { Display = LocalizationHelper.GetString("Reclamation"), Value = typeof(ReclamationTask) },
+            new GenericCombinedData<Type> { Display = LocalizationHelper.GetString("UserDataUpdate"), Value = typeof(UserDataUpdateTask) },
             new GenericCombinedData<Type> { Display = LocalizationHelper.GetString("Custom"), Value = typeof(CustomTask) },
         ]);
 
@@ -1743,12 +1749,15 @@ public class TaskQueueViewModel : Screen
 
             try
             {
+                var existingTaskIds = Instances.AsstProxy.TasksStatus.Keys.ToHashSet();
                 var (isSuccess, taskId) = SerializeTask(item);
                 switch (isSuccess)
                 {
                     case true:
                         ++count;
-                        Instances.TaskQueueViewModel.TaskItemViewModels.ElementAtOrDefault(index)?.TaskId = taskId;
+                        var newTaskIds = Instances.AsstProxy.TasksStatus.Keys.Where(taskId => !existingTaskIds.Contains(taskId)).ToArray();
+                        Instances.TaskQueueViewModel.TaskItemViewModels[index].SetTaskIds(newTaskIds);
+                        // Instances.TaskQueueViewModel.TaskItemViewModels.ElementAtOrDefault(index)?.TaskId = taskId;
                         break;
                     case false:
                         taskRet = false;

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -1810,10 +1810,7 @@ public class TaskQueueViewModel : Screen
                 return;
             }
 
-            foreach (var item in Instances.TaskQueueViewModel.TaskItemViewModels)
-            {
-                item.StatusDisplay = status;
-            }
+            Instances.TaskQueueViewModel.TaskItemViewModels[index].TaskItemStatus = status;
         }
     }
 

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -31,6 +31,7 @@ using JetBrains.Annotations;
 using MaaWpfGui.Configuration.Factory;
 using MaaWpfGui.Configuration.Single.MaaTask;
 using MaaWpfGui.Constants;
+using MaaWpfGui.Constants.Enums;
 using MaaWpfGui.Extensions;
 using MaaWpfGui.Helper;
 using MaaWpfGui.Main;
@@ -1743,7 +1744,7 @@ public class TaskQueueViewModel : Screen
                 item.IsEnable);
             if (!IsTaskEnable(item))
             {
-                SetTaskStatus(index, 4);
+                SetTaskStatus(index, TaskItemStatus.Skipped);
                 continue;
             }
 
@@ -1760,11 +1761,11 @@ public class TaskQueueViewModel : Screen
                     case false:
                         taskRet = false;
                         AddLog(LocalizationHelper.GetStringFormat("TaskAppend.Error", LocalizationHelper.GetString(item.TaskType.ToString()), item.Name), UiLogColor.Error);
-                        SetTaskStatus(index, (int)Main.TaskStatus.Error);
+                        SetTaskStatus(index, TaskItemStatus.Error);
                         break;
                     case null:
                         AddLog(LocalizationHelper.GetStringFormat("TaskAppend.Skip", LocalizationHelper.GetString(item.TaskType.ToString()), item.Name), UiLogColor.Info);
-                        SetTaskStatus(index, 4);
+                        SetTaskStatus(index, TaskItemStatus.Skipped);
                         break;
                 }
             }
@@ -1803,14 +1804,14 @@ public class TaskQueueViewModel : Screen
         AchievementTrackerHelper.Instance.MissionStartCountAdd();
         AchievementTrackerHelper.Instance.UseDailyAdd();
 
-        void SetTaskStatus(int index, int status)
+        static void SetTaskStatus(int index, TaskItemStatus status)
         {
             if (index < 0 || index >= Instances.TaskQueueViewModel.TaskItemViewModels.Count)
             {
                 return;
             }
 
-            Instances.TaskQueueViewModel.TaskItemViewModels[index].TaskItemStatus = status;
+            Instances.TaskQueueViewModel.TaskItemViewModels[index].StatusDisplay = status;
         }
     }
 
@@ -1818,7 +1819,7 @@ public class TaskQueueViewModel : Screen
     {
         foreach (var item in TaskItemViewModels)
         {
-            item.StatusDisplay = (int)Main.TaskStatus.Idle;
+            item.StatusDisplay = TaskItemStatus.Idle;
         }
     }
 

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -1749,14 +1749,12 @@ public class TaskQueueViewModel : Screen
 
             try
             {
-                var existingTaskIds = Instances.AsstProxy.TasksStatus.Keys.ToHashSet();
-                var (isSuccess, taskId) = SerializeTask(item);
+                var (isSuccess, taskIds) = SerializeTask(item);
                 switch (isSuccess)
                 {
                     case true:
                         ++count;
-                        var newTaskIds = Instances.AsstProxy.TasksStatus.Keys.Where(taskId => !existingTaskIds.Contains(taskId)).ToArray();
-                        Instances.TaskQueueViewModel.TaskItemViewModels[index].SetTaskIds(newTaskIds);
+                        Instances.TaskQueueViewModel.TaskItemViewModels[index].SetTaskIds(taskIds);
                         // Instances.TaskQueueViewModel.TaskItemViewModels.ElementAtOrDefault(index)?.TaskId = taskId;
                         break;
                     case false:
@@ -2074,10 +2072,10 @@ public class TaskQueueViewModel : Screen
     /// <param name="task">存储的任务</param>
     /// <param name="taskId">任务id, null时追加任务, 非null为设置任务参数</param>
     /// <returns>null为未序列化, false失败, true成功</returns>
-    private static (bool? IsSuccess, int TaskId) SerializeTask(BaseTask task, int? taskId = null)
+    private static (bool? IsSuccess, IEnumerable<int> TaskIds) SerializeTask(BaseTask task, int? taskId = null)
     {
         bool? ret = null;
-        int id = 0;
+        IEnumerable<int> id = [];
         foreach (var instance in _taskViewModelTypes)
         {
             if (ret is null)

--- a/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
@@ -932,6 +932,30 @@ public class ToolboxViewModel : Screen
     }
 
     /// <summary>
+    /// 重置仓库识别状态。
+    /// </summary>
+    public void ResetDepotRecognitionState()
+    {
+        DepotClear();
+    }
+
+    /// <summary>
+    /// 追加或启动仓库识别任务。
+    /// </summary>
+    /// <param name="startImmediately">是否立刻启动。</param>
+    /// <returns>是否成功。</returns>
+    public bool StartDepotRecognitionTask(bool startImmediately = true)
+    {
+        bool ret = Instances.AsstProxy.AsstStartDepot(startImmediately);
+        if (ret)
+        {
+            DepotInfo = LocalizationHelper.GetString("Identifying");
+        }
+
+        return ret;
+    }
+
+    /// <summary>
     /// Starts depot recognition.
     /// UI 绑定的方法
     /// </summary>
@@ -950,15 +974,41 @@ public class ToolboxViewModel : Screen
             return;
         }
 
-        DepotInfo = LocalizationHelper.GetString("Identifying");
-        DepotClear();
-
-        Instances.AsstProxy.AsstStartDepot();
+        ResetDepotRecognitionState();
+        StartDepotRecognitionTask();
     }
 
     #endregion Depot
 
     #region OperBox
+
+    private DateTime? _lastOperBoxSyncTime;
+
+    /// <summary>
+    /// Gets or sets 上次干员同步时间（UTC 时间）
+    /// </summary>
+    public DateTime? LastOperBoxSyncTime
+    {
+        get => _lastOperBoxSyncTime;
+        set => SetAndNotify(ref _lastOperBoxSyncTime, value);
+    }
+
+    /// <summary>
+    /// Gets 上次干员同步时间的显示文本（本地时间）
+    /// </summary>
+    [PropertyDependsOn(nameof(LastOperBoxSyncTime))]
+    public string LastOperBoxSyncTimeText
+    {
+        get {
+            if (LastOperBoxSyncTime == null)
+            {
+                return string.Empty;
+            }
+
+            var localTime = LastOperBoxSyncTime.Value.ToLocalTime();
+            return localTime.ToString();
+        }
+    }
 
     private int _operBoxSelectedIndex = 0;
 
@@ -1030,7 +1080,7 @@ public class ToolboxViewModel : Screen
 
         public int IdNumber { get; } = ExtractIdNumber(id);
 
-        public string RarityStars => IsPallas ? LocalizationHelper.GetPallasString(6, 6) : new('★', Rarity);
+        public string RarityStars => (IsPallas && Level > 0) ? LocalizationHelper.GetPallasString(6, 6) : new('★', Rarity);
 
         /// <summary>
         /// Gets the path to the Elite icon image
@@ -1047,7 +1097,7 @@ public class ToolboxViewModel : Screen
         /// <summary>
         /// Gets the resource key based on rarity
         /// </summary>
-        public string RarityColorResourceKey => IsPallas ? "AchievementBrush.Rare.LinearGradientBrush" : $"Star{Rarity}OperatorLogBrush";
+        public string RarityColorResourceKey => (IsPallas && Level > 0) ? "AchievementBrush.Rare.LinearGradientBrush" : $"Star{Rarity}OperatorLogBrush";
 
         public bool Equals(Operator? other) => other != null && Name == other.Name && Rarity == other.Rarity;
 
@@ -1105,11 +1155,19 @@ public class ToolboxViewModel : Screen
         set => SetAndNotify(ref _operBoxNotHaveList, value);
     }
 
-    private static void SaveOperBoxDetails(List<OperBoxData.OperData> details)
+    private void SaveOperBoxDetails(List<OperBoxData.OperData> details)
     {
-        // var json = details.ToString(Formatting.None);
-        // ConfigurationHelper.SetValue(ConfigurationKeys.OperBoxData, json);
-        JsonDataHelper.Set(JsonDataKey.OperBoxData, JArray.FromObject(details));
+        var data = new JObject {
+            ["done"] = true,
+            ["own_opers"] = JArray.FromObject(details),
+        };
+
+        if (LastOperBoxSyncTime.HasValue)
+        {
+            data["syncTime"] = LastOperBoxSyncTime.Value.ToString("o");
+        }
+
+        JsonDataHelper.Set(JsonDataKey.OperBoxData, data);
     }
 
     private void SortOperBoxLists()
@@ -1126,7 +1184,7 @@ public class ToolboxViewModel : Screen
         }
 
         return [.. list
-            .OrderByDescending(x => x.IsPallas)
+            .OrderByDescending(x => x.IsPallas && x.Level > 0)
             .ThenByDescending(x => x.Rarity)
             .ThenByDescending(x => x.Elite)
             .ThenByDescending(x => x.Level)
@@ -1147,39 +1205,55 @@ public class ToolboxViewModel : Screen
 
         try
         {
-            var ownOpers = JsonConvert.DeserializeObject<List<OperBoxData.OperData>>(json)?.Where(i => !string.IsNullOrEmpty(i.Id)).ToList();
-            if (ownOpers is null)
+            if (JToken.Parse(json) is JArray oldArray)
             {
+                var ownOpers = oldArray.ToObject<List<OperBoxData.OperData>>()?.Where(i => !string.IsNullOrEmpty(i.Id)).ToList();
+                if (ownOpers is null)
+                {
+                    return;
+                }
+
+                LoadOperBoxList(ownOpers);
                 return;
             }
 
-            var operDataMap = ownOpers.ToDictionary(o => o.Id);
-            foreach (var (id, oper) in DataHelper.Operators)
+            if (JObject.Parse(json) is { } details)
             {
-                if (DataHelper.IsCharacterAvailableInClient(oper, SettingsViewModel.GameSettings.ClientType))
-                {
-                    var name = DataHelper.GetLocalizedCharacterName(oper) ?? "???";
-                    if (operDataMap.TryGetValue(id, out var operData))
-                    {
-                        OperBoxHaveList.Add(new Operator(id, name, oper.Rarity, operData.Elite, operData.Level, operData.Potential));
-
-                        if (id == "char_485_pallas")
-                        {
-                            AchievementTrackerHelper.Instance.Unlock(AchievementIds.WarehouseKeeper);
-                        }
-                    }
-                    else
-                    {
-                        OperBoxNotHaveList.Add(new Operator(id, name, oper.Rarity));
-                    }
-                }
+                OperBoxParse(details, updateSyncTime: false);
             }
-
-            SortOperBoxLists();
         }
         catch
         {
             // 兼容老数据或异常时忽略
+        }
+
+        void LoadOperBoxList(List<OperBoxData.OperData> ownOpers)
+        {
+            var operDataMap = ownOpers.ToDictionary(o => o.Id);
+            foreach (var (id, oper) in DataHelper.Operators)
+            {
+                if (!DataHelper.IsCharacterAvailableInClient(oper, SettingsViewModel.GameSettings.ClientType))
+                {
+                    continue;
+                }
+
+                var name = DataHelper.GetLocalizedCharacterName(oper) ?? "???";
+                if (operDataMap.TryGetValue(id, out var operData))
+                {
+                    OperBoxHaveList.Add(new Operator(id, name, oper.Rarity, operData.Elite, operData.Level, operData.Potential));
+
+                    if (id == "char_485_pallas")
+                    {
+                        AchievementTrackerHelper.Instance.Unlock(AchievementIds.WarehouseKeeper);
+                    }
+                }
+                else
+                {
+                    OperBoxNotHaveList.Add(new Operator(id, name, oper.Rarity));
+                }
+            }
+
+            SortOperBoxLists();
         }
     }
 
@@ -1188,7 +1262,7 @@ public class ToolboxViewModel : Screen
     /// </summary>
     private HashSet<string> _tempOperHaveSet = [];
 
-    public bool OperBoxParse(JObject? details)
+    public bool OperBoxParse(JObject? details, bool updateSyncTime = true)
     {
         if (details == null)
         {
@@ -1236,10 +1310,52 @@ public class ToolboxViewModel : Screen
             OperBoxSelectedIndex = 0;
         }
 
+        if (updateSyncTime)
+        {
+            LastOperBoxSyncTime = DateTime.UtcNow;
+        }
+        else
+        {
+            var syncTimeStr = details["syncTime"]?.ToString(Formatting.None)?.Trim('"');
+            if (!string.IsNullOrEmpty(syncTimeStr) &&
+                DateTime.TryParseExact(syncTimeStr, "O", null, DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal, out var lastOperBoxSyncTime))
+            {
+                LastOperBoxSyncTime = lastOperBoxSyncTime;
+            }
+        }
+
         OperBoxInfo = $"{LocalizationHelper.GetString("IdentificationCompleted")}\n{LocalizationHelper.GetString("OperBoxRecognitionTip")}";
         SaveOperBoxDetails(ownOpers);
         _tempOperHaveSet = [];
         return true;
+    }
+
+    /// <summary>
+    /// 重置干员识别状态。
+    /// </summary>
+    public void ResetOperBoxRecognitionState()
+    {
+        OperBoxSelectedIndex = 1;
+        _operBoxPotential = null;
+        _tempOperHaveSet = [];
+        OperBoxHaveList = [];
+        OperBoxNotHaveList = [];
+    }
+
+    /// <summary>
+    /// 追加或启动干员识别任务。
+    /// </summary>
+    /// <param name="startImmediately">是否立刻启动。</param>
+    /// <returns>是否成功。</returns>
+    public bool StartOperBoxRecognitionTask(bool startImmediately = true)
+    {
+        bool ret = Instances.AsstProxy.AsstStartOperBox(startImmediately);
+        if (ret)
+        {
+            OperBoxInfo = LocalizationHelper.GetString("Identifying");
+        }
+
+        return ret;
     }
 
     /// <summary>
@@ -1250,13 +1366,8 @@ public class ToolboxViewModel : Screen
     [UsedImplicitly]
     public async Task StartOperBox()
     {
-        OperBoxSelectedIndex = 1;
-        _operBoxPotential = null;
-        _tempOperHaveSet = [];
-        OperBoxHaveList = [];
-        OperBoxNotHaveList = [];
+        ResetOperBoxRecognitionState();
         _runningState.SetIdle(false);
-
         string errMsg = string.Empty;
         OperBoxInfo = LocalizationHelper.GetString("ConnectingToEmulator");
         bool caught = await Task.Run(() => Instances.AsstProxy.AsstConnect(ref errMsg));
@@ -1267,10 +1378,7 @@ public class ToolboxViewModel : Screen
             return;
         }
 
-        if (Instances.AsstProxy.AsstStartOperBox())
-        {
-            OperBoxInfo = LocalizationHelper.GetString("Identifying");
-        }
+        StartOperBoxRecognitionTask();
     }
 
     // UI 绑定的方法

--- a/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
@@ -1205,19 +1205,21 @@ public class ToolboxViewModel : Screen
 
         try
         {
-            if (JToken.Parse(json) is JArray oldArray)
+            var token = JToken.Parse(json);
+            if (token is JArray oldArray)
             {
-                var ownOpers = oldArray.ToObject<List<OperBoxData.OperData>>()?.Where(i => !string.IsNullOrEmpty(i.Id)).ToList();
+                var ownOpers = oldArray
+                    .ToObject<List<OperBoxData.OperData>>()?
+                    .Where(i => !string.IsNullOrEmpty(i.Id))
+                    .ToList();
                 if (ownOpers is null)
                 {
                     return;
                 }
-
                 LoadOperBoxList(ownOpers);
                 return;
             }
-
-            if (JObject.Parse(json) is { } details)
+            else if (token is JObject details)
             {
                 OperBoxParse(details, updateSyncTime: false);
             }

--- a/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
@@ -947,7 +947,7 @@ public class ToolboxViewModel : Screen
     public bool StartDepotRecognitionTask(bool startImmediately = true)
     {
         bool ret = Instances.AsstProxy.AsstStartDepot(startImmediately);
-        if (ret)
+        if (ret && startImmediately)
         {
             DepotInfo = LocalizationHelper.GetString("Identifying");
         }
@@ -1350,7 +1350,7 @@ public class ToolboxViewModel : Screen
     public bool StartOperBoxRecognitionTask(bool startImmediately = true)
     {
         bool ret = Instances.AsstProxy.AsstStartOperBox(startImmediately);
-        if (ret)
+        if (ret && startImmediately)
         {
             OperBoxInfo = LocalizationHelper.GetString("Identifying");
         }

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/AwardSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/AwardSettingsUserControlModel.cs
@@ -12,6 +12,7 @@
 // </copyright>
 
 #nullable enable
+using System.Collections.Generic;
 using System.Windows;
 using MaaWpfGui.Configuration.Single.MaaTask;
 using MaaWpfGui.Helper;
@@ -109,15 +110,15 @@ public class AwardSettingsUserControlModel : TaskSettingsViewModel, AwardSetting
         }
     }
 
-    public override (bool? IsSuccess, int TaskId) SerializeTask(BaseTask? baseTask, int? taskId = null) => (this as ISerialize)?.Serialize(baseTask, taskId) ?? (null, 0);
+    public override (bool? IsSuccess, IEnumerable<int> TaskId) SerializeTask(BaseTask? baseTask, int? taskId = null) => (this as ISerialize).Serialize(baseTask, taskId);
 
     private interface ISerialize : ITaskQueueModelSerialize
     {
-        (bool? IsSuccess, int TaskId) ITaskQueueModelSerialize.Serialize(BaseTask? baseTask, int? taskId)
+        (bool? IsSuccess, IEnumerable<int> TaskId) ITaskQueueModelSerialize.Serialize(BaseTask? baseTask, int? taskId)
         {
             if (baseTask is not AwardTask award)
             {
-                return (null, 0);
+                return (null, []);
             }
 
             var task = new AsstAwardTask() {
@@ -129,9 +130,9 @@ public class AwardSettingsUserControlModel : TaskSettingsViewModel, AwardSetting
                 SpecialAccess = award.SpecialAccess,
             };
             return taskId switch {
-                int id when id > 0 => (Instances.AsstProxy.AsstSetTaskParamsEncoded(id, task), id),
-                null => Instances.AsstProxy.AsstAppendTaskWithEncoding(TaskType.Award, task),
-                _ => (null, 0),
+                int id when id > 0 => (Instances.AsstProxy.AsstSetTaskParamsEncoded(id, task), [id]),
+                null => FromSingle(Instances.AsstProxy.AsstAppendTaskWithEncoding(TaskType.Award, task)),
+                _ => (null, []),
             };
         }
     }

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/CustomSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/CustomSettingsUserControlModel.cs
@@ -13,6 +13,7 @@
 
 #nullable enable
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using MaaWpfGui.Configuration.Single.MaaTask;
 using MaaWpfGui.Helper;
@@ -70,24 +71,24 @@ public class CustomSettingsUserControlModel : TaskSettingsViewModel, CustomSetti
         }
     }
 
-    public override (bool? IsSuccess, int TaskId) SerializeTask(BaseTask? baseTask, int? taskId = null) => (this as ISerialize)?.Serialize(baseTask, taskId) ?? (null, 0);
+    public override (bool? IsSuccess, IEnumerable<int> TaskId) SerializeTask(BaseTask? baseTask, int? taskId = null) => (this as ISerialize).Serialize(baseTask, taskId);
 
     private interface ISerialize : ITaskQueueModelSerialize
     {
-        (bool? IsSuccess, int TaskId) ITaskQueueModelSerialize.Serialize(BaseTask? baseTask, int? taskId)
+        (bool? IsSuccess, IEnumerable<int> TaskId) ITaskQueueModelSerialize.Serialize(BaseTask? baseTask, int? taskId)
         {
             if (baseTask is not CustomTask custom)
             {
-                return (null, 0);
+                return (null, []);
             }
 
             var task = new AsstCustomTask() {
                 CustomTasks = [.. custom.CustomTaskName.Split(',', StringSplitOptions.RemoveEmptyEntries).Select(task => task.Trim())],
             };
             return taskId switch {
-                int id when id > 0 => (Instances.AsstProxy.AsstSetTaskParamsEncoded(id, task), id),
-                null => Instances.AsstProxy.AsstAppendTaskWithEncoding(TaskType.Custom, task),
-                _ => (null, 0),
+                int id when id > 0 => (Instances.AsstProxy.AsstSetTaskParamsEncoded(id, task), [id]),
+                null => FromSingle(Instances.AsstProxy.AsstAppendTaskWithEncoding(TaskType.Custom, task)),
+                _ => (null, []),
             };
         }
     }

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/FightSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/FightSettingsUserControlModel.cs
@@ -702,7 +702,7 @@ public class FightSettingsUserControlModel : TaskSettingsViewModel, FightSetting
         return null;
     }
 
-    public override (bool? IsSuccess, int TaskId) SerializeTask(BaseTask? baseTask, int? taskId = null) => (this as ISerialize).Serialize(baseTask, taskId);
+    public override (bool? IsSuccess, IEnumerable<int> TaskId) SerializeTask(BaseTask? baseTask, int? taskId = null) => (this as ISerialize).Serialize(baseTask, taskId);
 
     #region 关卡列表更新
 
@@ -912,23 +912,23 @@ public class FightSettingsUserControlModel : TaskSettingsViewModel, FightSetting
 
     private interface ISerialize : ITaskQueueModelSerialize
     {
-        (bool? IsSuccess, int TaskId) ITaskQueueModelSerialize.Serialize(BaseTask? baseTask, int? taskId)
+        (bool? IsSuccess, IEnumerable<int> TaskId) ITaskQueueModelSerialize.Serialize(BaseTask? baseTask, int? taskId)
         {
             if (baseTask is not FightTask fight || taskId is int and <= 0)
             {
-                return (null, 0);
+                return (null, []);
             }
 
             if (fight.UseWeeklySchedule && fight.WeeklySchedule.TryGetValue(Instances.TaskQueueViewModel.CurDayOfWeek, out var isEnabled) && !isEnabled)
             {
-                return (null, 0);
+                return (null, []);
             }
 
             using var scope = _lock.EnterScope();
             var stage = FightSettingsUserControlModel.GetFightStage(fight.StagePlan);
             if (stage is null)
             {
-                return (null, 0);
+                return (null, []);
             }
             var task = new AsstFightTask() {
                 Stage = stage,
@@ -962,9 +962,9 @@ public class FightSettingsUserControlModel : TaskSettingsViewModel, FightSetting
             }
 
             return taskId switch {
-                int id when id > 0 => (Instances.AsstProxy.AsstSetTaskParamsEncoded(id, task), id),
-                null => Instances.AsstProxy.AsstAppendTaskWithEncoding(TaskType.Fight, task),
-                _ => (null, 0),
+                int id when id > 0 => (Instances.AsstProxy.AsstSetTaskParamsEncoded(id, task), [id]),
+                null => FromSingle(Instances.AsstProxy.AsstAppendTaskWithEncoding(TaskType.Fight, task)),
+                _ => (null, []),
             };
         }
     }

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/FightSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/FightSettingsUserControlModel.cs
@@ -695,9 +695,9 @@ public class FightSettingsUserControlModel : TaskSettingsViewModel, FightSetting
             return null;
         }
 
-        if (ConfigFactory.CurrentConfig.TaskQueue.IndexOf(fight) is int index && index > -1 && Instances.TaskQueueViewModel.TaskItemViewModels[index].TaskId > 0)
+        if (ConfigFactory.CurrentConfig.TaskQueue.IndexOf(fight) is int index && index > -1 && Instances.TaskQueueViewModel.TaskItemViewModels[index].TaskIds.Count > 0)
         {
-            return SerializeTask(fight, Instances.TaskQueueViewModel.TaskItemViewModels[index].TaskId).IsSuccess;
+            return SerializeTask(fight, Instances.TaskQueueViewModel.TaskItemViewModels[index].TaskIds[0]).IsSuccess;
         }
         return null;
     }

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/InfrastSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/InfrastSettingsUserControlModel.cs
@@ -541,15 +541,15 @@ public class InfrastSettingsUserControlModel : TaskSettingsViewModel, InfrastSet
         }
     }
 
-    public override (bool? IsSuccess, int TaskId) SerializeTask(BaseTask? baseTask, int? taskId = null) => (this as ISerialize)?.Serialize(baseTask, taskId) ?? (null, 0);
+    public override (bool? IsSuccess, IEnumerable<int> TaskId) SerializeTask(BaseTask? baseTask, int? taskId = null) => (this as ISerialize).Serialize(baseTask, taskId);
 
     private interface ISerialize : ITaskQueueModelSerialize
     {
-        (bool? IsSuccess, int TaskId) ITaskQueueModelSerialize.Serialize(BaseTask? baseTask, int? taskId)
+        (bool? IsSuccess, IEnumerable<int> TaskId) ITaskQueueModelSerialize.Serialize(BaseTask? baseTask, int? taskId)
         {
             if (baseTask is not InfrastTask infrast)
             {
-                return (null, 0);
+                return (null, []);
             }
 
             var task = new AsstInfrastTask {
@@ -594,9 +594,9 @@ public class InfrastSettingsUserControlModel : TaskSettingsViewModel, InfrastSet
             }
 
             return taskId switch {
-                int id when id > 0 => (Instances.AsstProxy.AsstSetTaskParamsEncoded(id, task), id),
-                null => Instances.AsstProxy.AsstAppendTaskWithEncoding(TaskType.Infrast, task),
-                _ => (null, 0),
+                int id when id > 0 => (Instances.AsstProxy.AsstSetTaskParamsEncoded(id, task), [id]),
+                null => FromSingle(Instances.AsstProxy.AsstAppendTaskWithEncoding(TaskType.Infrast, task)),
+                _ => (null, []),
             };
         }
     }

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/MallSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/MallSettingsUserControlModel.cs
@@ -187,15 +187,15 @@ public class MallSettingsUserControlModel : TaskSettingsViewModel, MallSettingsU
         }
     }
 
-    public override (bool? IsSuccess, int TaskId) SerializeTask(BaseTask? baseTask, int? taskId = null) => (this as ISerialize)?.Serialize(baseTask, taskId) ?? (null, 0);
+    public override (bool? IsSuccess, IEnumerable<int> TaskId) SerializeTask(BaseTask? baseTask, int? taskId = null) => (this as ISerialize).Serialize(baseTask, taskId);
 
     private interface ISerialize : ITaskQueueModelSerialize
     {
-        (bool? IsSuccess, int TaskId) ITaskQueueModelSerialize.Serialize(BaseTask? baseTask, int? taskId)
+        (bool? IsSuccess, IEnumerable<int> TaskId) ITaskQueueModelSerialize.Serialize(BaseTask? baseTask, int? taskId)
         {
             if (baseTask is not MallTask mall)
             {
-                return (null, 0);
+                return (null, []);
             }
 
             var fightStageEmpty = false;
@@ -240,9 +240,9 @@ public class MallSettingsUserControlModel : TaskSettingsViewModel, MallSettingsU
             };
 
             return taskId switch {
-                int id when id > 0 => (Instances.AsstProxy.AsstSetTaskParamsEncoded(id, task), id),
-                null => Instances.AsstProxy.AsstAppendTaskWithEncoding(TaskType.Mall, task),
-                _ => (null, 0),
+                int id when id > 0 => (Instances.AsstProxy.AsstSetTaskParamsEncoded(id, task), [id]),
+                null => FromSingle(Instances.AsstProxy.AsstAppendTaskWithEncoding(TaskType.Mall, task)),
+                _ => (null, []),
             };
 
             string? GetStageForDayOfWeek(FightTask fightTask, DayOfWeek day)

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/ReclamationSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/ReclamationSettingsUserControlModel.cs
@@ -137,15 +137,15 @@ public class ReclamationSettingsUserControlModel : TaskSettingsViewModel, Reclam
         }
     }
 
-    public override (bool? IsSuccess, int TaskId) SerializeTask(BaseTask? baseTask, int? taskId = null) => (this as ISerialize)?.Serialize(baseTask, taskId) ?? (null, 0);
+    public override (bool? IsSuccess, IEnumerable<int> TaskId) SerializeTask(BaseTask? baseTask, int? taskId = null) => (this as ISerialize).Serialize(baseTask, taskId);
 
     private interface ISerialize : ITaskQueueModelSerialize
     {
-        (bool? IsSuccess, int TaskId) ITaskQueueModelSerialize.Serialize(BaseTask? baseTask, int? taskId)
+        (bool? IsSuccess, IEnumerable<int> TaskId) ITaskQueueModelSerialize.Serialize(BaseTask? baseTask, int? taskId)
         {
             if (baseTask is not ReclamationTask reclamation)
             {
-                return (null, 0);
+                return (null, []);
             }
 
             var toolToCraft = !string.IsNullOrEmpty(reclamation.ToolToCraft) ? reclamation.ToolToCraft : LocalizationHelper.GetString("ReclamationToolToCraftPlaceholder", DataHelper.ClientLanguageMapper[SettingsViewModel.GameSettings.ClientType]);
@@ -159,9 +159,9 @@ public class ReclamationSettingsUserControlModel : TaskSettingsViewModel, Reclam
             };
 
             return taskId switch {
-                int id when id > 0 => (Instances.AsstProxy.AsstSetTaskParamsEncoded(id, task), id),
-                null => Instances.AsstProxy.AsstAppendTaskWithEncoding(TaskType.Reclamation, task),
-                _ => (null, 0),
+                int id when id > 0 => (Instances.AsstProxy.AsstSetTaskParamsEncoded(id, task), [id]),
+                null => FromSingle(Instances.AsstProxy.AsstAppendTaskWithEncoding(TaskType.Reclamation, task)),
+                _ => (null, []),
             };
         }
     }

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/RecruitSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/RecruitSettingsUserControlModel.cs
@@ -254,15 +254,15 @@ public class RecruitSettingsUserControlModel : TaskSettingsViewModel, RecruitSet
         }
     }
 
-    public override (bool? IsSuccess, int TaskId) SerializeTask(BaseTask? baseTask, int? taskId = null) => (this as ISerialize)?.Serialize(baseTask, taskId) ?? (null, 0);
+    public override (bool? IsSuccess, IEnumerable<int> TaskId) SerializeTask(BaseTask? baseTask, int? taskId = null) => (this as ISerialize).Serialize(baseTask, taskId);
 
     private interface ISerialize : ITaskQueueModelSerialize
     {
-        (bool? IsSuccess, int TaskId) ITaskQueueModelSerialize.Serialize(BaseTask? baseTask, int? taskId)
+        (bool? IsSuccess, IEnumerable<int> TaskId) ITaskQueueModelSerialize.Serialize(BaseTask? baseTask, int? taskId)
         {
             if (baseTask is not RecruitTask recruit)
             {
-                return (null, 0);
+                return (null, []);
             }
 
             var task = new AsstRecruitTask() {
@@ -309,9 +309,9 @@ public class RecruitSettingsUserControlModel : TaskSettingsViewModel, RecruitSet
             }
 
             return taskId switch {
-                int id when id > 0 => (Instances.AsstProxy.AsstSetTaskParamsEncoded(id, task), id),
-                null => Instances.AsstProxy.AsstAppendTaskWithEncoding(TaskType.Recruit, task),
-                _ => (null, 0),
+                int id when id > 0 => (Instances.AsstProxy.AsstSetTaskParamsEncoded(id, task), [id]),
+                null => FromSingle(Instances.AsstProxy.AsstAppendTaskWithEncoding(TaskType.Recruit, task)),
+                _ => (null, []),
             };
         }
     }

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/RoguelikeSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/RoguelikeSettingsUserControlModel.cs
@@ -1052,15 +1052,15 @@ public class RoguelikeSettingsUserControlModel : TaskSettingsViewModel, Roguelik
         }
     }
 
-    public override (bool? IsSuccess, int TaskId) SerializeTask(BaseTask? baseTask, int? taskId = null) => (this as ISerialize)?.Serialize(baseTask, taskId) ?? (null, 0);
+    public override (bool? IsSuccess, IEnumerable<int> TaskId) SerializeTask(BaseTask? baseTask, int? taskId = null) => (this as ISerialize).Serialize(baseTask, taskId);
 
     private interface ISerialize : ITaskQueueModelSerialize
     {
-        (bool? IsSuccess, int TaskId) ITaskQueueModelSerialize.Serialize(BaseTask? baseTask, int? taskId)
+        (bool? IsSuccess, IEnumerable<int> TaskId) ITaskQueueModelSerialize.Serialize(BaseTask? baseTask, int? taskId)
         {
             if (baseTask is not RoguelikeTask roguelike)
             {
-                return (null, 0);
+                return (null, []);
             }
 
             bool roguelikeSquadIsProfessional = roguelike.Mode == Mode.Collectible && roguelike.Theme != Theme.Phantom && roguelike.Squad is "突击战术分队" or "堡垒战术分队" or "远程战术分队" or "破坏战术分队";
@@ -1136,9 +1136,9 @@ public class RoguelikeSettingsUserControlModel : TaskSettingsViewModel, Roguelik
             }
 
             return taskId switch {
-                int id when id > 0 => (Instances.AsstProxy.AsstSetTaskParamsEncoded(id, task), id),
-                null => Instances.AsstProxy.AsstAppendTaskWithEncoding(TaskType.Roguelike, task),
-                _ => (null, 0),
+                int id when id > 0 => (Instances.AsstProxy.AsstSetTaskParamsEncoded(id, task), [id]),
+                null => FromSingle(Instances.AsstProxy.AsstAppendTaskWithEncoding(TaskType.Roguelike, task)),
+                _ => (null, []),
             };
         }
     }

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/StartUpSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/StartUpSettingsUserControlModel.cs
@@ -12,6 +12,7 @@
 // </copyright>
 
 #nullable enable
+using System.Collections.Generic;
 using JetBrains.Annotations;
 using MaaWpfGui.Configuration.Single.MaaTask;
 using MaaWpfGui.Constants;
@@ -73,15 +74,15 @@ public class StartUpSettingsUserControlModel : TaskSettingsViewModel, StartUpSet
         }
     }
 
-    public override (bool? IsSuccess, int TaskId) SerializeTask(BaseTask? baseTask, int? taskId = null) => (this as ISerialize)?.Serialize(baseTask, taskId) ?? (null, 0);
+    public override (bool? IsSuccess, IEnumerable<int> TaskId) SerializeTask(BaseTask? baseTask, int? taskId = null) => (this as ISerialize).Serialize(baseTask, taskId);
 
     private interface ISerialize : ITaskQueueModelSerialize
     {
-        (bool? IsSuccess, int TaskId) ITaskQueueModelSerialize.Serialize(BaseTask? baseTask, int? taskId)
+        (bool? IsSuccess, IEnumerable<int> TaskId) ITaskQueueModelSerialize.Serialize(BaseTask? baseTask, int? taskId)
         {
             if (baseTask is not StartUpTask startUp)
             {
-                return (null, 0);
+                return (null, []);
             }
 
             var clientType = SettingsViewModel.GameSettings.ClientType;
@@ -97,9 +98,9 @@ public class StartUpSettingsUserControlModel : TaskSettingsViewModel, StartUpSet
             };
 
             return taskId switch {
-                int id when id > 0 => (Instances.AsstProxy.AsstSetTaskParamsEncoded(id, task), id),
-                null => Instances.AsstProxy.AsstAppendTaskWithEncoding(TaskType.StartUp, task),
-                _ => (null, 0),
+                int id when id > 0 => (Instances.AsstProxy.AsstSetTaskParamsEncoded(id, task), [id]),
+                null => FromSingle(Instances.AsstProxy.AsstAppendTaskWithEncoding(TaskType.StartUp, task)),
+                _ => (null, []),
             };
         }
     }

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/UserDataUpdateSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/UserDataUpdateSettingsUserControlModel.cs
@@ -1,0 +1,145 @@
+// <copyright file="UserDataUpdateSettingsUserControlModel.cs" company="MaaAssistantArknights">
+// Part of the MaaWpfGui project, maintained by the MaaAssistantArknights team (Maa Team)
+// Copyright (C) 2021-2025 MaaAssistantArknights Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License v3.0 only as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using MaaWpfGui.Configuration.Single.MaaTask;
+using MaaWpfGui.Constants.Enums;
+using MaaWpfGui.Extensions;
+using MaaWpfGui.Helper;
+using MaaWpfGui.Utilities.ValueType;
+
+namespace MaaWpfGui.ViewModels.UserControl.TaskQueue;
+
+public class UserDataUpdateSettingsUserControlModel : TaskSettingsViewModel, UserDataUpdateSettingsUserControlModel.ISerialize
+{
+    static UserDataUpdateSettingsUserControlModel()
+    {
+        Instance = new();
+    }
+
+    public static UserDataUpdateSettingsUserControlModel Instance { get; }
+
+    public bool UpdateOperBox
+    {
+        get => GetTaskConfig<UserDataUpdateTask>().UpdateOperBox;
+        set => SetTaskConfig<UserDataUpdateTask>(t => t.UpdateOperBox == value, t => t.UpdateOperBox = value);
+    }
+
+    public bool UpdateDepot
+    {
+        get => GetTaskConfig<UserDataUpdateTask>().UpdateDepot;
+        set => SetTaskConfig<UserDataUpdateTask>(t => t.UpdateDepot == value, t => t.UpdateDepot = value);
+    }
+
+    public UserDataUpdateTriggerInterval TriggerInterval
+    {
+        get => GetTaskConfig<UserDataUpdateTask>().TriggerInterval;
+        set => SetTaskConfig<UserDataUpdateTask>(t => t.TriggerInterval == value, t => t.TriggerInterval = value);
+    }
+
+    public List<GenericCombinedData<UserDataUpdateTriggerInterval>> TriggerIntervalList { get; } =
+    [
+        new() { Display = LocalizationHelper.GetString("EveryTime"), Value = UserDataUpdateTriggerInterval.EveryTime },
+        new() { Display = LocalizationHelper.GetString("Daily"), Value = UserDataUpdateTriggerInterval.Daily },
+        new() { Display = LocalizationHelper.GetString("Weekly"), Value = UserDataUpdateTriggerInterval.Weekly },
+    ];
+
+    public override void RefreshUI(BaseTask baseTask)
+    {
+        if (baseTask is UserDataUpdateTask)
+        {
+            Refresh();
+        }
+    }
+
+    public override bool? SerializeTask(BaseTask? baseTask, int? taskId = null) => (this as ISerialize).Serialize(baseTask, taskId);
+
+    private interface ISerialize : ITaskQueueModelSerialize
+    {
+        bool? ITaskQueueModelSerialize.Serialize(BaseTask? baseTask, int? taskId)
+        {
+            if (baseTask is not UserDataUpdateTask updateTask)
+            {
+                return null;
+            }
+
+            if (taskId is int id && id > 0)
+            {
+                return null;
+            }
+
+            if (!updateTask.IsTriggered)
+            {
+                return null;
+            }
+
+            bool operBoxTriggerDue = updateTask.UpdateOperBox && IsTriggerDue(Instances.ToolboxViewModel.LastOperBoxSyncTime, updateTask.TriggerInterval);
+            bool depotTriggerDue = updateTask.UpdateDepot && IsTriggerDue(Instances.ToolboxViewModel.LastDepotSyncTime, updateTask.TriggerInterval);
+
+            if (!operBoxTriggerDue && !depotTriggerDue)
+            {
+                return null;
+            }
+
+            bool ret = false;
+            if (operBoxTriggerDue)
+            {
+                Instances.ToolboxViewModel.ResetOperBoxRecognitionState();
+                ret = Instances.ToolboxViewModel.StartOperBoxRecognitionTask(startImmediately: false);
+                if (!ret)
+                {
+                    return false;
+                }
+            }
+
+            if (depotTriggerDue)
+            {
+                Instances.ToolboxViewModel.ResetDepotRecognitionState();
+                ret = Instances.ToolboxViewModel.StartDepotRecognitionTask(startImmediately: false);
+                if (!ret)
+                {
+                    return false;
+                }
+            }
+
+            return ret ? true : null;
+        }
+
+        private static bool IsTriggerDue(DateTime? lastSyncTime, UserDataUpdateTriggerInterval triggerInterval)
+        {
+            if (triggerInterval == UserDataUpdateTriggerInterval.EveryTime)
+            {
+                return true;
+            }
+
+            if (!lastSyncTime.HasValue)
+            {
+                return true;
+            }
+
+            var now = DateTime.UtcNow.ToYjDate();
+            var lastDate = lastSyncTime.Value.ToYjDate();
+
+            return triggerInterval switch
+            {
+                UserDataUpdateTriggerInterval.Daily => now > lastDate,
+                UserDataUpdateTriggerInterval.Weekly => ISOWeek.GetYear(now) != ISOWeek.GetYear(lastDate) || ISOWeek.GetWeekOfYear(now) != ISOWeek.GetWeekOfYear(lastDate),
+                _ => true,
+            };
+        }
+    }
+}

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/UserDataUpdateSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/UserDataUpdateSettingsUserControlModel.cs
@@ -16,7 +16,9 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using MaaWpfGui.Configuration.Single.MaaTask;
+using MaaWpfGui.Constants;
 using MaaWpfGui.Constants.Enums;
 using MaaWpfGui.Extensions;
 using MaaWpfGui.Helper;
@@ -66,25 +68,26 @@ public class UserDataUpdateSettingsUserControlModel : TaskSettingsViewModel, Use
         }
     }
 
-    public override bool? SerializeTask(BaseTask? baseTask, int? taskId = null) => (this as ISerialize).Serialize(baseTask, taskId);
+    public override (bool? IsSuccess, IEnumerable<int> TaskId) SerializeTask(BaseTask? baseTask, int? taskId = null) => (this as ISerialize).Serialize(baseTask, taskId);
 
     private interface ISerialize : ITaskQueueModelSerialize
     {
-        bool? ITaskQueueModelSerialize.Serialize(BaseTask? baseTask, int? taskId)
+        (bool? IsSuccess, IEnumerable<int> TaskId) ITaskQueueModelSerialize.Serialize(BaseTask? baseTask, int? taskId)
         {
             if (baseTask is not UserDataUpdateTask updateTask)
             {
-                return null;
+                return (null, []);
             }
 
             if (taskId is int id && id > 0)
             {
-                return null;
+                Instances.TaskQueueViewModel.AddLog("Unable to modify existing UserDataUpdateTask.", UiLogColor.Error);
+                return (null, []);
             }
 
             if (!updateTask.IsTriggered)
             {
-                return null;
+                return (null, []);
             }
 
             bool operBoxTriggerDue = updateTask.UpdateOperBox && IsTriggerDue(Instances.ToolboxViewModel.LastOperBoxSyncTime, updateTask.TriggerInterval);
@@ -92,9 +95,10 @@ public class UserDataUpdateSettingsUserControlModel : TaskSettingsViewModel, Use
 
             if (!operBoxTriggerDue && !depotTriggerDue)
             {
-                return null;
+                return (null, []);
             }
 
+            List<int> ids = [];
             bool ret = false;
             if (operBoxTriggerDue)
             {
@@ -102,21 +106,23 @@ public class UserDataUpdateSettingsUserControlModel : TaskSettingsViewModel, Use
                 ret = Instances.ToolboxViewModel.StartOperBoxRecognitionTask(startImmediately: false);
                 if (!ret)
                 {
-                    return false;
+                    return (false, []);
                 }
+                ids.Add(Instances.AsstProxy.TasksStatus.Last().Key);
             }
 
             if (depotTriggerDue)
             {
                 Instances.ToolboxViewModel.ResetDepotRecognitionState();
-                ret = Instances.ToolboxViewModel.StartDepotRecognitionTask(startImmediately: false);
+                ret = Instances.ToolboxViewModel.StartDepotRecognitionTask(false);
                 if (!ret)
                 {
-                    return false;
+                    return (false, []);
                 }
+                ids.Add(Instances.AsstProxy.TasksStatus.Last().Key);
             }
 
-            return ret ? true : null;
+            return ret ? (true, ids) : (null, []);
         }
 
         private static bool IsTriggerDue(DateTime? lastSyncTime, UserDataUpdateTriggerInterval triggerInterval)
@@ -134,8 +140,7 @@ public class UserDataUpdateSettingsUserControlModel : TaskSettingsViewModel, Use
             var now = DateTime.UtcNow.ToYjDate();
             var lastDate = lastSyncTime.Value.ToYjDate();
 
-            return triggerInterval switch
-            {
+            return triggerInterval switch {
                 UserDataUpdateTriggerInterval.Daily => now > lastDate,
                 UserDataUpdateTriggerInterval.Weekly => ISOWeek.GetYear(now) != ISOWeek.GetYear(lastDate) || ISOWeek.GetWeekOfYear(now) != ISOWeek.GetWeekOfYear(lastDate),
                 _ => true,

--- a/src/MaaWpfGui/Views/UI/TaskQueueView.xaml
+++ b/src/MaaWpfGui/Views/UI/TaskQueueView.xaml
@@ -9,6 +9,7 @@
     xmlns:hc="https://handyorg.github.io/handycontrol"
     xmlns:helper="clr-namespace:MaaWpfGui.Helper"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:enums="clr-namespace:MaaWpfGui.Constants.Enums"
     xmlns:properties="clr-namespace:MaaWpfGui.Styles.Properties"
     xmlns:s="https://github.com/canton7/Stylet"
     xmlns:taskQueue="clr-namespace:MaaWpfGui.Views.UserControl.TaskQueue"
@@ -78,19 +79,19 @@
                                                 <Setter Property="Opacity" Value="1" />
                                                 <Style.Triggers>
                                                     <!--  运行中 - 蓝色  -->
-                                                    <DataTrigger Binding="{Binding StatusDisplay}" Value="1">
-                                                        <Setter Property="Background" Value="{DynamicResource TaskQueue.TaskStatus.InProgress}" />
+                                                    <DataTrigger Binding="{Binding StatusDisplay}" Value="{x:Static enums:TaskItemStatus.InProgress}">
+                                                        <Setter Property="Background" Value="{DynamicResource TaskQueue.TaskItemStatus.InProgress}" />
                                                     </DataTrigger>
                                                     <!--  成功完成 - 绿色  -->
-                                                    <DataTrigger Binding="{Binding StatusDisplay}" Value="2">
-                                                        <Setter Property="Background" Value="{DynamicResource TaskQueue.TaskStatus.Completed}" />
+                                                    <DataTrigger Binding="{Binding StatusDisplay}" Value="{x:Static enums:TaskItemStatus.Completed}">
+                                                        <Setter Property="Background" Value="{DynamicResource TaskQueue.TaskItemStatus.Completed}" />
                                                     </DataTrigger>
                                                     <!--  出现错误 - 红色  -->
-                                                    <DataTrigger Binding="{Binding StatusDisplay}" Value="3">
-                                                        <Setter Property="Background" Value="{DynamicResource TaskQueue.TaskStatus.Error}" />
+                                                    <DataTrigger Binding="{Binding StatusDisplay}" Value="{x:Static enums:TaskItemStatus.Error}">
+                                                        <Setter Property="Background" Value="{DynamicResource TaskQueue.TaskItemStatus.Error}" />
                                                     </DataTrigger>
                                                     <!--  已跳过 - 灰色  -->
-                                                    <DataTrigger Binding="{Binding StatusDisplay}" Value="4">
+                                                    <DataTrigger Binding="{Binding StatusDisplay}" Value="{x:Static enums:TaskItemStatus.Skipped}">
                                                         <Setter Property="Opacity" Value="0.5" />
                                                     </DataTrigger>
                                                 </Style.Triggers>

--- a/src/MaaWpfGui/Views/UI/TaskQueueView.xaml
+++ b/src/MaaWpfGui/Views/UI/TaskQueueView.xaml
@@ -289,7 +289,12 @@
                                             Padding="0,3"
                                             Command="{s:Action AddTaskQueueTask}"
                                             CommandParameter="{Binding TaskTypeList[8].Value}"
-                                            Header="{Binding TaskTypeList[8].Display}"
+                                            Header="{Binding TaskTypeList[8].Display}" />
+                                        <MenuItem
+                                            Padding="0,3"
+                                            Command="{s:Action AddTaskQueueTask}"
+                                            CommandParameter="{Binding TaskTypeList[9].Value}"
+                                            Header="{Binding TaskTypeList[9].Display}"
                                             Visibility="{c:Binding ShowDebugTask}" />
                                     </ContextMenu>
                                 </hc:ContextMenuButton.Menu>
@@ -494,6 +499,12 @@
                                                                                   AncestorType={x:Type UserControl}}}" />
                         <taskQueue:RoguelikeSettingsUserControl DataContext="{Binding RoguelikeTask}" Visibility="{c:Binding DataContext.TaskSettingVisibilities.Roguelike, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type UserControl}}}" />
                         <taskQueue:ReclamationSettingsUserControl DataContext="{Binding ReclamationTask}" Visibility="{c:Binding DataContext.TaskSettingVisibilities.Reclamation, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type UserControl}}}" />
+                        <taskQueue:UserDataUpdateSettingsUserControl
+                            DataContext="{Binding UserDataUpdateTask}"
+                            IsEnabled="{Binding DataContext.Idle, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type UserControl}}}"
+                            Visibility="{c:Binding DataContext.TaskSettingVisibilities.UserDataUpdate,
+                                                   RelativeSource={RelativeSource Mode=FindAncestor,
+                                                                                  AncestorType={x:Type UserControl}}}" />
                         <taskQueue:CustomUserControl DataContext="{Binding CustomTask}" Visibility="{c:Binding DataContext.TaskSettingVisibilities.Custom, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type UserControl}}}" />
                         <taskQueue:PostActionUserControl DataContext="{Binding PostActionSetting}" Visibility="{c:Binding DataContext.TaskSettingVisibilities.PostAction, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type UserControl}}}" />
                     </hc:SimpleStackPanel>
@@ -540,7 +551,7 @@
                             <controls:TooltipBlock.TooltipText>
                                 <MultiBinding StringFormat="{}{0}&#x0a;{1}: {2}">
                                     <Binding Source="{StaticResource InventoryUpdateTip}" />
-                                    <Binding Source="{StaticResource LastDepotSyncTime}" />
+                                    <Binding Source="{StaticResource LastSyncTime}" />
                                     <Binding Path="LastDepotSyncTimeText" Source="{x:Static helper:Instances.ToolboxViewModel}" />
                                 </MultiBinding>
                             </controls:TooltipBlock.TooltipText>

--- a/src/MaaWpfGui/Views/UI/TaskQueueView.xaml
+++ b/src/MaaWpfGui/Views/UI/TaskQueueView.xaml
@@ -78,19 +78,19 @@
                                                 <Setter Property="Opacity" Value="1" />
                                                 <Style.Triggers>
                                                     <!--  运行中 - 蓝色  -->
-                                                    <DataTrigger Binding="{Binding Status}" Value="1">
+                                                    <DataTrigger Binding="{Binding StatusDisplay}" Value="1">
                                                         <Setter Property="Background" Value="{DynamicResource TaskQueue.TaskStatus.InProgress}" />
                                                     </DataTrigger>
                                                     <!--  成功完成 - 绿色  -->
-                                                    <DataTrigger Binding="{Binding Status}" Value="2">
+                                                    <DataTrigger Binding="{Binding StatusDisplay}" Value="2">
                                                         <Setter Property="Background" Value="{DynamicResource TaskQueue.TaskStatus.Completed}" />
                                                     </DataTrigger>
                                                     <!--  出现错误 - 红色  -->
-                                                    <DataTrigger Binding="{Binding Status}" Value="3">
+                                                    <DataTrigger Binding="{Binding StatusDisplay}" Value="3">
                                                         <Setter Property="Background" Value="{DynamicResource TaskQueue.TaskStatus.Error}" />
                                                     </DataTrigger>
                                                     <!--  已跳过 - 灰色  -->
-                                                    <DataTrigger Binding="{Binding Status}" Value="4">
+                                                    <DataTrigger Binding="{Binding StatusDisplay}" Value="4">
                                                         <Setter Property="Opacity" Value="0.5" />
                                                     </DataTrigger>
                                                 </Style.Triggers>

--- a/src/MaaWpfGui/Views/UI/ToolboxView.xaml
+++ b/src/MaaWpfGui/Views/UI/ToolboxView.xaml
@@ -211,12 +211,25 @@
             <Grid Margin="20,0,20,20">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />
+                    <RowDefinition Height="Auto" />
                     <RowDefinition Height="*" />
                     <RowDefinition Height="Auto" />
                 </Grid.RowDefinitions>
 
                 <controls:TextBlock
                     Grid.Row="0"
+                    HorizontalAlignment="Center"
+                    d:Text="上次同步时间: 2026/1/1 上午00:00:00"
+                    Visibility="{c:Binding 'LastOperBoxSyncTime.Length > 0'}">
+                    <TextBlock.Text>
+                        <MultiBinding StringFormat="{}{0}: {1}">
+                            <Binding Source="{StaticResource LastSyncTime}" />
+                            <Binding Path="LastOperBoxSyncTimeText" Source="{x:Static helper:Instances.ToolboxViewModel}" />
+                        </MultiBinding>
+                    </TextBlock.Text>
+                </controls:TextBlock>
+                <controls:TextBlock
+                    Grid.Row="1"
                     Margin="10"
                     HorizontalAlignment="Center"
                     VerticalAlignment="Top"
@@ -226,7 +239,7 @@
                     Text="{Binding OperBoxInfo}"
                     TextWrapping="Wrap" />
                 <TabControl
-                    Grid.Row="1"
+                    Grid.Row="2"
                     Background="{DynamicResource MouseOverRegionBrushOpacity75}"
                     BorderThickness="0"
                     SelectedIndex="{Binding OperBoxSelectedIndex}"
@@ -361,7 +374,7 @@
                     </TabItem>
                 </TabControl>
                 <StackPanel
-                    Grid.Row="2"
+                    Grid.Row="3"
                     Margin="0,10,0,0"
                     HorizontalAlignment="Center"
                     VerticalAlignment="Center"
@@ -398,7 +411,7 @@
                         Visibility="{c:Binding 'LastDepotSyncTimeText.Length > 0'}">
                         <TextBlock.Text>
                             <MultiBinding StringFormat="{}{0}: {1}">
-                                <Binding Source="{StaticResource LastDepotSyncTime}" />
+                                <Binding Source="{StaticResource LastSyncTime}" />
                                 <Binding Path="LastDepotSyncTimeText" Source="{x:Static helper:Instances.ToolboxViewModel}" />
                             </MultiBinding>
                         </TextBlock.Text>

--- a/src/MaaWpfGui/Views/UI/ToolboxView.xaml
+++ b/src/MaaWpfGui/Views/UI/ToolboxView.xaml
@@ -220,7 +220,7 @@
                     Grid.Row="0"
                     HorizontalAlignment="Center"
                     d:Text="上次同步时间: 2026/1/1 上午00:00:00"
-                    Visibility="{c:Binding 'LastOperBoxSyncTime.Length > 0'}">
+                    Visibility="{c:Binding 'LastOperBoxSyncTimeText.Length > 0'}">
                     <TextBlock.Text>
                         <MultiBinding StringFormat="{}{0}: {1}">
                             <Binding Source="{StaticResource LastSyncTime}" />

--- a/src/MaaWpfGui/Views/UserControl/TaskQueue/UserDataUpdateSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/TaskQueue/UserDataUpdateSettingsUserControl.xaml
@@ -1,0 +1,63 @@
+<UserControl
+    x:Class="MaaWpfGui.Views.UserControl.TaskQueue.UserDataUpdateSettingsUserControl"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:c="clr-namespace:CalcBinding;assembly=CalcBinding"
+    xmlns:controls="clr-namespace:MaaWpfGui.Styles.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:hc="https://handyorg.github.io/handycontrol"
+    xmlns:helper="clr-namespace:MaaWpfGui.Helper"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:s="https://github.com/canton7/Stylet"
+    xmlns:taskQueue_vms="clr-namespace:MaaWpfGui.ViewModels.UserControl.TaskQueue"
+    xmlns:ui_vms="clr-namespace:MaaWpfGui.ViewModels.UI"
+    d:Background="White"
+    d:DataContext="{d:DesignInstance {x:Type taskQueue_vms:UserDataUpdateSettingsUserControlModel}}"
+    d:DesignWidth="220"
+    s:View.ActionTarget="{Binding}"
+    mc:Ignorable="d">
+    <StackPanel Visibility="{c:Binding !EnableAdvancedSettings, Source={x:Static ui_vms:TaskQueueViewModel.TaskSettingVisibilities}}">
+        <StackPanel Margin="0,10">
+            <CheckBox Content="{DynamicResource OperBoxRecognition}" IsChecked="{Binding UpdateOperBox}" />
+            <controls:TextBlock
+                Margin="0,5,0,0"
+                HorizontalAlignment="Left"
+                TextWrapping="Wrap"
+                Visibility="{c:Binding 'LastOperBoxSyncTimeText.Length > 0',
+                                       Source={x:Static helper:Instances.ToolboxViewModel}}">
+                <TextBlock.Text>
+                    <MultiBinding StringFormat="{}{0}: {1}">
+                        <Binding Source="{StaticResource LastSyncTime}" />
+                        <Binding Path="LastOperBoxSyncTimeText" Source="{x:Static helper:Instances.ToolboxViewModel}" />
+                    </MultiBinding>
+                </TextBlock.Text>
+            </controls:TextBlock>
+        </StackPanel>
+        <StackPanel Margin="0,10">
+            <CheckBox Content="{DynamicResource DepotRecognition}" IsChecked="{Binding UpdateDepot}" />
+            <controls:TextBlock
+                Margin="0,5,0,0"
+                HorizontalAlignment="Left"
+                TextWrapping="Wrap"
+                Visibility="{c:Binding 'LastDepotSyncTimeText.Length > 0',
+                                       Source={x:Static helper:Instances.ToolboxViewModel}}">
+                <TextBlock.Text>
+                    <MultiBinding StringFormat="{}{0}: {1}">
+                        <Binding Source="{StaticResource LastSyncTime}" />
+                        <Binding Path="LastDepotSyncTimeText" Source="{x:Static helper:Instances.ToolboxViewModel}" />
+                    </MultiBinding>
+                </TextBlock.Text>
+            </controls:TextBlock>
+        </StackPanel>
+        <StackPanel Margin="0,10">
+            <hc:ComboBox
+                VerticalContentAlignment="Center"
+                hc:InfoElement.Title="{DynamicResource UserDataUpdateTriggerInterval}"
+                hc:TitleElement.HorizontalAlignment="Left"
+                DisplayMemberPath="Display"
+                ItemsSource="{Binding TriggerIntervalList}"
+                SelectedValue="{Binding TriggerInterval}"
+                SelectedValuePath="Value" />
+        </StackPanel>
+    </StackPanel>
+</UserControl>

--- a/src/MaaWpfGui/Views/UserControl/TaskQueue/UserDataUpdateSettingsUserControl.xaml.cs
+++ b/src/MaaWpfGui/Views/UserControl/TaskQueue/UserDataUpdateSettingsUserControl.xaml.cs
@@ -1,0 +1,28 @@
+// <copyright file="UserDataUpdateSettingsUserControl.xaml.cs" company="MaaAssistantArknights">
+// Part of the MaaWpfGui project, maintained by the MaaAssistantArknights team (Maa Team)
+// Copyright (C) 2021-2025 MaaAssistantArknights Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License v3.0 only as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY
+// </copyright>
+
+namespace MaaWpfGui.Views.UserControl.TaskQueue;
+
+/// <summary>
+/// UserDataUpdateSettingsUserControl.xaml 的交互逻辑
+/// </summary>
+public partial class UserDataUpdateSettingsUserControl : System.Windows.Controls.UserControl
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UserDataUpdateSettingsUserControl"/> class.
+    /// </summary>
+    public UserDataUpdateSettingsUserControl()
+    {
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION


https://github.com/user-attachments/assets/41f68acc-63fe-4bb2-855f-0e686f5f47df



feat: 增加更新数据任务

## Summary by Sourcery

添加一个可配置的用户数据更新任务，定期触发仓库与干员盒识别，同时重构相关识别流程和任务跟踪逻辑，以支持多个后端任务 ID 和同步时间戳。

New Features:
- 引入 `UserDataUpdate` 任务类型，可按可配置间隔（每次、每日或每周）更新干员盒与仓库数据。
- 新增专用的用户数据更新任务设置 ViewModel 和 WPF 用户控件，包括新的本地化条目以及在任务队列 UI 中为该任务类型接线。
- 在 toolbox ViewModel 中暴露最近一次干员盒同步时间（以本地时间显示），并为仓库与干员识别任务新增重置/启动方法。

Enhancements:
- 优化干员盒数据持久化逻辑，用于保存完成标记和同步时间戳，并增强加载逻辑以同时支持旧的数组格式和新的对象格式。
- 调整干员显示逻辑，使 Pallas 专属样式仅在干员等级非 0 时生效，并微调排序逻辑以正确优先显示有等级的 Pallas。
- 允许任务条目跟踪多个底层助手任务 ID，并基于任一关联 ID 更新任务状态/可见性，同时提供共享辅助方法以通过任务 ID 查找任务条目。
- 更新仓库与干员识别的启动 API，使其可以选择性地追加任务而不立即开始执行，从而支持在新的用户数据更新工作流中进行组合。
- 扩展 `TaskSettingVisibilityInfo` 和任务类型注册逻辑，以在可见性逻辑和序列化中处理新的用户数据更新任务。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a configurable user data update task that periodically triggers depot and operator box recognition, while refactoring related recognition flows and task tracking to support multiple backend task IDs and sync timestamps.

New Features:
- Introduce a UserDataUpdate task type with settings to update operator box and depot data on configurable intervals (every time, daily, or weekly).
- Add a dedicated user data update task settings view model and WPF user control, including new localization entries and task type wiring in the task queue UI.
- Expose last operator box sync time (with local-time display) and new reset/start methods for depot and operator recognition tasks in the toolbox view model.

Enhancements:
- Refine operator box data persistence to store completion flags and sync timestamps, and enhance loading to support both legacy array and new object formats.
- Adjust operator display logic so Pallas-specific styling only applies when the operator has a non-zero level, and tweak sorting to prioritize leveled Pallas correctly.
- Allow task items to track multiple underlying assistant task IDs and update task status/visibility based on any associated ID, with a shared helper to find items by task ID.
- Update depot and operator recognition startup APIs to optionally append tasks without immediately starting execution, enabling composition within the new user data update workflow.
- Extend TaskSettingVisibilityInfo and task type registration to handle the new user data update task in visibility logic and serialization.

</details>