### PR TITLE
perf(wpf): 不启用卡片日志时, 不再向UI中添加卡片样式的日志

### DIFF
--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -274,7 +274,6 @@ public class TaskQueueViewModel : Screen
 
         var lastCard = LogCardViewModels[^1];
         var log = new LogItemViewModel(content, color, weight, toolTip: toolTip);
-        LogItemViewModels.Add(log);
         lastCard.Items.Add(log);
         return true;
     }
@@ -1152,6 +1151,13 @@ public class TaskQueueViewModel : Screen
         bool needsAfterSplit = splitMode == LogCardSplitMode.After || splitMode == LogCardSplitMode.Both;
 
         Execute.OnUIThread(() => {
+            if (!GuiSettingsUserControlModel.Instance.UseCardLog)
+            {
+                var log = new LogItemViewModel(content, color, weight, toolTip: toolTip);
+                LogItemViewModels.Add(log);
+                return;
+            }
+
             if (needsBeforeSplit)
             {
                 createNewCard();
@@ -1214,7 +1220,7 @@ public class TaskQueueViewModel : Screen
     /// <summary>
     /// Clears log.
     /// </summary>
-    private void ClearLog()
+    public void ClearLog()
     {
         Execute.OnUIThread(() => {
             LogItemViewModels.Clear();

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/GuiSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/GuiSettingsUserControlModel.cs
@@ -284,6 +284,7 @@ public class GuiSettingsUserControlModel : PropertyChangedBase
         get => _useCardLog;
         set {
             SetAndNotify(ref _useCardLog, value);
+            Instances.TaskQueueViewModel.ClearLog();
             ConfigurationHelper.SetValue(ConfigurationKeys.UseCardLog, value.ToString());
         }
     }


### PR DESCRIPTION
## Summary by Sourcery

在卡片日志设置的控制下启用卡片样式日志记录；当禁用卡片日志时，保留原有的扁平日志列表。

Enhancements:
- 当禁用卡片日志记录时，跳过向卡片样式 UI 添加日志条目，但仍将其记录在主日志列表中。
- 通过暴露并调用 `TaskQueueViewModel.ClearLog`，在卡片日志设置变化时触发日志清空。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Gate card-style logging behind the card log setting and keep the flat log list when card logs are disabled.

Enhancements:
- Skip adding log entries to card-style UI when card logging is disabled, while still recording them in the main log list.
- Trigger a log clear on card-log setting changes by exposing and invoking TaskQueueViewModel.ClearLog.

</details>