### PR TITLE
增加了对于傀影二结局的支持

### DIFF
--- a/resource/roguelike/Phantom/encounter/default.json
+++ b/resource/roguelike/Phantom/encounter/default.json
@@ -165,12 +165,30 @@
         {
             "name": "解脱?",
             "option_num": 2,
-            "choose": 2
+            "choose": 2,
+            "next_event": "解脱?-第二结局"
+        },
+        {
+            "name": "解脱?-第二结局",
+            "option_num": 1,
+            "choose": 1
         },
         {
             "name": "疯狂玩偶",
             "option_num": 2,
-            "choose": 2
+            "choose": 1,
+            "next_event": "疯狂玩偶-2"
+        },
+        {
+            "name": "疯狂玩偶-2",
+            "option_num": 2,
+            "choose": 1,
+            "next_event": "疯狂玩偶-3"
+        },
+        {
+            "name": "疯狂玩偶-3",
+            "option_num": 1,
+            "choose": 1
         },
         {
             "name": "解脱",

--- a/resource/roguelike/Phantom/encounter/ending2.json
+++ b/resource/roguelike/Phantom/encounter/ending2.json
@@ -1,0 +1,11 @@
+{
+    "theme": "Phantom",
+    "mode": [ 8 ],
+    "stage": [
+        {
+            "name": "解脱?",
+            "option_num": 2,
+            "choose": 1
+        }
+    ]
+}

--- a/resource/tasks/Roguelike/Phantom.json
+++ b/resource/tasks/Roguelike/Phantom.json
@@ -35,7 +35,8 @@
     },
     "Phantom@Roguelike@CloseEvent": {},
     "Phantom@Roguelike@CloseInterview": {
-        "template": "Phantom@Roguelike@StageEncounterSpecialClose.png"
+        "template": "Phantom@Roguelike@StageEncounterSpecialClose.png",
+        "next": ["Phantom@Roguelike@CloseEvent", "Phantom@Roguelike@StrategyChange", "Phantom@Roguelike@NextLevel"]
     },
     "Phantom@Roguelike@Continue": {},
     "Phantom@Roguelike@DeepExploration": {
@@ -355,6 +356,18 @@
         ]
     },
     "Phantom@Roguelike@StrategyChange_mode7": {
+        "text": ["_aggressive", "_pragmatic", "_default"],
+        "ocrReplace": [
+            ["迷雾歧途", "_aggressive"],
+            ["落阳庭院", "_aggressive"],
+            ["故土残躯", "_aggressive"],
+            ["噩梦之始", "_pragmatic"],
+            ["血月长廊", "_pragmatic"],
+            ["渴欲大厅", "_default"]
+        ]
+    },
+    "Phantom@Roguelike@StrategyChange_mode8": {
+        "Doc": "第二结局模式",
         "text": ["_aggressive", "_pragmatic", "_default"],
         "ocrReplace": [
             ["迷雾歧途", "_aggressive"],

--- a/resource/tasks/Roguelike/base.json
+++ b/resource/tasks/Roguelike/base.json
@@ -1768,6 +1768,10 @@
     "Roguelike@StrategyChange_mode7": {
         "baseTask": "Roguelike@StrategyChange_default"
     },
+    "Roguelike@StrategyChange_mode8": {
+        "Doc": "第二结局模式",
+        "baseTask": "Roguelike@StrategyChange_default"
+    },
     "Roguelike@TempRecruitFlag": {
         "roi": [587, 76, 100, 20],
         "templThreshold": 0.5

--- a/src/MaaCore/Config/ResourceLoader.cpp
+++ b/src/MaaCore/Config/ResourceLoader.cpp
@@ -244,6 +244,12 @@ bool asst::ResourceLoader::load(const std::filesystem::path& path)
             "RoguelikeStageEncounterConfig")) {
         return false;
     }
+    // ending2.json for Phantom SecondEnding mode
+    if (!load_with_custom.template operator()<RoguelikeStageEncounterConfig>(
+            roguelike_path("Phantom", "encounter"_p / "ending2.json"_p),
+            "RoguelikeStageEncounterConfig")) {
+        return false;
+    }
 
     // Map Config（仅 Sarkaz 和 JieGarden）
     for (auto theme : { "Sarkaz", "JieGarden" }) {

--- a/src/MaaCore/Task/Roguelike/RoguelikeConfig.h
+++ b/src/MaaCore/Task/Roguelike/RoguelikeConfig.h
@@ -30,6 +30,9 @@ enum class RoguelikeMode
     Squad = 6,       // 6 - 月度小队，尽可能稳定地打更多层数，不期而遇采用激进策略
     Exploration = 7, // 7 - 深入调查，尽可能稳定地打更多层数，不期而遇采用激进策略
 
+    // ------------------ 傀影主题专用模式 ------------------
+    SecondEnding = 8, // 8 - 第二结局，优先第二结局通关，不期而遇采用保守策略（使用 ending2.json）
+
     // ------------------ 萨米主题专用模式 ------------------
     CLP_PDS = 5, // 5 - 刷隐藏坍缩范式,以增加坍缩值为最优先目标
 
@@ -94,6 +97,7 @@ public:
     {
         return mode == RoguelikeMode::Exp || mode == RoguelikeMode::Investment || mode == RoguelikeMode::Collectible ||
                mode == RoguelikeMode::Squad || mode == RoguelikeMode::Exploration ||
+               (mode == RoguelikeMode::SecondEnding && theme == RoguelikeTheme::Phantom) ||
                (mode == RoguelikeMode::CLP_PDS && theme == RoguelikeTheme::Sami) ||
                (mode == RoguelikeMode::FastPass && theme == RoguelikeTheme::Sarkaz) ||
                (mode == RoguelikeMode::FindPlaytime && theme == RoguelikeTheme::JieGarden);

--- a/src/MaaWpfGui/Configuration/Single/MaaTask/RoguelikeTask.cs
+++ b/src/MaaWpfGui/Configuration/Single/MaaTask/RoguelikeTask.cs
@@ -235,6 +235,11 @@ public enum RoguelikeMode
     Exploration = 7,
 
     /// <summary>
+    /// 8 - 第二结局，优先第二结局通关，不期而遇采用保守策略（使用 ending2.json）
+    /// </summary>
+    SecondEnding = 8,
+
+    /// <summary>
     /// 20001 - 刷常乐节点，第一层进洞，找不到需要的节点就重开
     /// </summary>
     FindPlaytime = 20001,

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -196,6 +196,7 @@
     <system:String x:Key="RoguelikeCollectibleModeSquad">烧水使用分队</system:String>
     <system:String x:Key="RoguelikeStrategyMonthlySquad">刷月度小队，尽可能稳定地打更多层数</system:String>
     <system:String x:Key="RoguelikeStrategyDeepExploration">刷深入调查，尽可能稳定地打更多层数</system:String>
+    <system:String x:Key="RoguelikeStrategySecondEnding">第二结局，优先解锁第二结局隐藏奖励</system:String>
     <system:String x:Key="RoguelikeStrategyFindPlaytime">刷常乐节点，第一层进洞，找不到需要的节点就重开</system:String>
     <system:String x:Key="RoguelikeFindPlaytimeTarget">目标常乐节点</system:String>
     <system:String x:Key="RoguelikePlaytimeLing">令 - 掷地有声</system:String>

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/RoguelikeSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/RoguelikeSettingsUserControlModel.cs
@@ -120,6 +120,19 @@ public class RoguelikeSettingsUserControlModel : TaskSettingsViewModel, Roguelik
                 ];
                 break;
 
+            case Theme.Phantom:
+                // Phantom 主题添加第二结局模式
+                RoguelikeModeList =
+                [
+                    new() { Display = LocalizationHelper.GetString("RoguelikeStrategyExp"), Value = Mode.Exp },
+                    new() { Display = LocalizationHelper.GetString("RoguelikeStrategyGold"), Value = Mode.Investment },
+                    new() { Display = LocalizationHelper.GetString("RoguelikeStrategyLastReward"), Value = Mode.Collectible },
+                    new() { Display = LocalizationHelper.GetString("RoguelikeStrategyMonthlySquad"), Value = Mode.Squad },
+                    new() { Display = LocalizationHelper.GetString("RoguelikeStrategyDeepExploration"), Value = Mode.Exploration },
+                    new() { Display = LocalizationHelper.GetString("RoguelikeStrategySecondEnding"), Value = Mode.SecondEnding },
+                ];
+                break;
+
             default:
                 RoguelikeModeList =
                 [


### PR DESCRIPTION
在策略中可以选择二结局

## Sourcery 总结

为 Phantom Roguelike 主题添加专用的「第二结局（Second Ending）」策略模式支持。

新功能：
- 引入专属于 Phantom 主题的 SecondEnding Roguelike 模式，并在策略选择界面中提供该模式。
- 为 Phantom 的 SecondEnding 模式加载单独的遭遇配置文件（`ending2.json`）。

增强改进：
- 更新 Phantom Roguelike 的配置和资源，使其能够识别并处理新的 SecondEnding 模式，包括本地化和任务定义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for a dedicated Second Ending strategy mode for the Phantom roguelike theme.

New Features:
- Introduce a SecondEnding roguelike mode dedicated to the Phantom theme and expose it in the strategy selection UI.
- Load a separate encounter configuration file (ending2.json) for Phantom's SecondEnding mode.

Enhancements:
- Update Phantom roguelike configuration and resources to recognize and handle the new SecondEnding mode, including localization and task definitions.

</details>