### PR TITLE
傀影主题添加第二结局模式支持

### DIFF
--- a/resource/roguelike/Phantom/encounter/default.json
+++ b/resource/roguelike/Phantom/encounter/default.json
@@ -187,6 +187,12 @@
         },
         {
             "name": "疯狂玩偶-3",
+            "option_num": 2,
+            "choose": 1,
+            "next_event": "疯狂玩偶-4"
+        },
+        {
+            "name": "疯狂玩偶-4",
             "option_num": 1,
             "choose": 1
         },

--- a/resource/roguelike/Phantom/encounter/default.json
+++ b/resource/roguelike/Phantom/encounter/default.json
@@ -165,12 +165,30 @@
         {
             "name": "解脱?",
             "option_num": 2,
-            "choose": 2
+            "choose": 2,
+            "next_event": "解脱?-第二结局"
+        },
+        {
+            "name": "解脱?-第二结局",
+            "option_num": 1,
+            "choose": 1
         },
         {
             "name": "疯狂玩偶",
             "option_num": 2,
-            "choose": 2
+            "choose": 1,
+            "next_event": "疯狂玩偶-2"
+        },
+        {
+            "name": "疯狂玩偶-2",
+            "option_num": 2,
+            "choose": 1,
+            "next_event": "疯狂玩偶-3"
+        },
+        {
+            "name": "疯狂玩偶-3",
+            "option_num": 1,
+            "choose": 1
         },
         {
             "name": "解脱",

--- a/resource/roguelike/Phantom/encounter/ending2.json
+++ b/resource/roguelike/Phantom/encounter/ending2.json
@@ -1,0 +1,11 @@
+{
+    "theme": "Phantom",
+    "mode": [ 8 ],
+    "stage": [
+        {
+            "name": "解脱?",
+            "option_num": 2,
+            "choose": 1
+        }
+    ]
+}

--- a/resource/tasks/Roguelike/Phantom.json
+++ b/resource/tasks/Roguelike/Phantom.json
@@ -205,12 +205,14 @@
         "templThreshold": 0.85
     },
     "Phantom@Roguelike@StageCombatOps": {
+        "template": "Phantom@Roguelike@StageCombatOps.png",
         "templThreshold": 0.9
     },
     "Phantom@Roguelike@StageCombatOpsEnter": {},
     "Phantom@Roguelike@StageDreadfulFoe": {},
     "Phantom@Roguelike@StageDreadfulFoeEnter": {},
     "Phantom@Roguelike@StageEmergencyOps": {
+        "template": "Phantom@Roguelike@StageEmergencyOps.png",
         "templThreshold": 0.9
     },
     "Phantom@Roguelike@StageEmergencyOpsEnter": {},

--- a/resource/tasks/Roguelike/Phantom.json
+++ b/resource/tasks/Roguelike/Phantom.json
@@ -35,7 +35,8 @@
     },
     "Phantom@Roguelike@CloseEvent": {},
     "Phantom@Roguelike@CloseInterview": {
-        "template": "Phantom@Roguelike@StageEncounterSpecialClose.png"
+        "template": "Phantom@Roguelike@StageEncounterSpecialClose.png",
+        "next": ["Phantom@Roguelike@CloseEvent", "Phantom@Roguelike@StrategyChange", "Phantom@Roguelike@NextLevel"]
     },
     "Phantom@Roguelike@Continue": {},
     "Phantom@Roguelike@DeepExploration": {
@@ -355,6 +356,18 @@
         ]
     },
     "Phantom@Roguelike@StrategyChange_mode7": {
+        "text": ["_aggressive", "_pragmatic", "_default"],
+        "ocrReplace": [
+            ["迷雾歧途", "_aggressive"],
+            ["落阳庭院", "_aggressive"],
+            ["故土残躯", "_aggressive"],
+            ["噩梦之始", "_pragmatic"],
+            ["血月长廊", "_pragmatic"],
+            ["渴欲大厅", "_default"]
+        ]
+    },
+    "Phantom@Roguelike@StrategyChange_mode8": {
+        "Doc": "第二结局模式",
         "text": ["_aggressive", "_pragmatic", "_default"],
         "ocrReplace": [
             ["迷雾歧途", "_aggressive"],

--- a/resource/tasks/Roguelike/base.json
+++ b/resource/tasks/Roguelike/base.json
@@ -1768,6 +1768,10 @@
     "Roguelike@StrategyChange_mode7": {
         "baseTask": "Roguelike@StrategyChange_default"
     },
+    "Roguelike@StrategyChange_mode8": {
+        "Doc": "第二结局模式",
+        "baseTask": "Roguelike@StrategyChange_default"
+    },
     "Roguelike@TempRecruitFlag": {
         "roi": [587, 76, 100, 20],
         "templThreshold": 0.5

--- a/src/MaaCore/Config/ResourceLoader.cpp
+++ b/src/MaaCore/Config/ResourceLoader.cpp
@@ -244,11 +244,11 @@ bool asst::ResourceLoader::load(const std::filesystem::path& path)
             "RoguelikeStageEncounterConfig")) {
         return false;
     }
-    // ending2.json for Phantom SecondEnding mode
+    // ending2.json for Phantom SecondEnding mode (non-fatal: optional for other modes)
     if (!load_with_custom.template operator()<RoguelikeStageEncounterConfig>(
             roguelike_path("Phantom", "encounter"_p / "ending2.json"_p),
             "RoguelikeStageEncounterConfig")) {
-        return false;
+        Log.warn(__FUNCTION__, "ending2.json load failed, SecondEnding mode may not work correctly");
     }
 
     // Map Config（仅 Sarkaz 和 JieGarden）

--- a/src/MaaCore/Config/ResourceLoader.cpp
+++ b/src/MaaCore/Config/ResourceLoader.cpp
@@ -244,6 +244,12 @@ bool asst::ResourceLoader::load(const std::filesystem::path& path)
             "RoguelikeStageEncounterConfig")) {
         return false;
     }
+    // ending2.json for Phantom SecondEnding mode
+    if (!load_with_custom.template operator()<RoguelikeStageEncounterConfig>(
+            roguelike_path("Phantom", "encounter"_p / "ending2.json"_p),
+            "RoguelikeStageEncounterConfig")) {
+        return false;
+    }
 
     // Map Config（仅 Sarkaz 和 JieGarden）
     for (auto theme : { "Sarkaz", "JieGarden" }) {

--- a/src/MaaCore/Task/Roguelike/RoguelikeConfig.h
+++ b/src/MaaCore/Task/Roguelike/RoguelikeConfig.h
@@ -30,6 +30,9 @@ enum class RoguelikeMode
     Squad = 6,       // 6 - 月度小队，尽可能稳定地打更多层数，不期而遇采用激进策略
     Exploration = 7, // 7 - 深入调查，尽可能稳定地打更多层数，不期而遇采用激进策略
 
+    // ------------------ 傀影主题专用模式 ------------------
+    SecondEnding = 8, // 8 - 第二结局，优先第二结局通关，不期而遇采用保守策略（使用 ending2.json）
+
     // ------------------ 萨米主题专用模式 ------------------
     CLP_PDS = 5, // 5 - 刷隐藏坍缩范式,以增加坍缩值为最优先目标
 
@@ -94,6 +97,7 @@ public:
     {
         return mode == RoguelikeMode::Exp || mode == RoguelikeMode::Investment || mode == RoguelikeMode::Collectible ||
                mode == RoguelikeMode::Squad || mode == RoguelikeMode::Exploration ||
+               (mode == RoguelikeMode::SecondEnding && theme == RoguelikeTheme::Phantom) ||
                (mode == RoguelikeMode::CLP_PDS && theme == RoguelikeTheme::Sami) ||
                (mode == RoguelikeMode::FastPass && theme == RoguelikeTheme::Sarkaz) ||
                (mode == RoguelikeMode::FindPlaytime && theme == RoguelikeTheme::JieGarden);

--- a/src/MaaCore/Task/Roguelike/RoguelikeStageEncounterTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeStageEncounterTaskPlugin.cpp
@@ -119,8 +119,13 @@ std::optional<std::string> asst::RoguelikeStageEncounterTaskPlugin::handle_singl
 
     auto info = basic_info_with_what("RoguelikeEvent");
     info["details"]["name"] = event.name;
+    info["details"]["option_num"] = event.option_num;
     info["details"]["default_choose"] = event.default_choose;
     info["details"]["choose_option"] = choose_option;
+    // 添加选项文本（如果有）
+    if (!event.option_text.empty()) {
+        info["details"]["option_text"] = json::array(event.option_text);
+    }
     callback(AsstMsg::SubTaskExtraInfo, info);
 
     // 萨卡兹内容拓展 II，#11861

--- a/src/MaaWpfGui/Configuration/Single/MaaTask/RoguelikeTask.cs
+++ b/src/MaaWpfGui/Configuration/Single/MaaTask/RoguelikeTask.cs
@@ -235,6 +235,11 @@ public enum RoguelikeMode
     Exploration = 7,
 
     /// <summary>
+    /// 8 - 第二结局，优先第二结局通关，不期而遇采用保守策略（使用 ending2.json）
+    /// </summary>
+    SecondEnding = 8,
+
+    /// <summary>
     /// 20001 - 刷常乐节点，第一层进洞，找不到需要的节点就重开
     /// </summary>
     FindPlaytime = 20001,

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -2271,6 +2271,48 @@ public class AsstProxy
             case "StageQueueMissionCompleted":
                 Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("StageQueue") + $" {subTaskDetails!["stage_code"]} - {subTaskDetails["stars"]} ★", UiLogColor.Info);
                 break;
+
+            case "RoguelikeEvent":
+                {
+                    var eventName = subTaskDetails?["name"]?.ToString() ?? "Unknown";
+                    var optionNum = (int)(subTaskDetails?["option_num"] ?? 0);
+                    var chooseOption = (int)(subTaskDetails?["choose_option"] ?? 0);
+                    var optionTexts = subTaskDetails?["option_text"] as JArray;
+
+                    string logContent;
+                    if (optionTexts != null && optionTexts.Count > 0) {
+                        var selectedText = chooseOption > 0 && chooseOption <= optionTexts.Count
+                            ? optionTexts[chooseOption - 1]?.ToString()
+                            : "";
+                        logContent = $"[不期而遇] {eventName} - 选择 {chooseOption}/{optionNum}";
+                        if (!string.IsNullOrEmpty(selectedText)) {
+                            logContent += $" \"{selectedText}\"";
+                        }
+                    } else {
+                        logContent = $"[不期而遇] {eventName} - 选择选项 {chooseOption}/{optionNum}";
+                    }
+
+                    Instances.TaskQueueViewModel.AddLog(logContent, UiLogColor.Info);
+                    break;
+                }
+
+            case "RoguelikeEncounterOptions":
+                {
+                    var options = subTaskDetails?["options"] as JArray;
+                    if (options != null && options.Count > 0) {
+                        var sb = new StringBuilder();
+                        sb.AppendLine("[不期而遇选项]");
+                        for (int i = 0; i < options.Count; i++) {
+                            var opt = options[i];
+                            var enabled = opt?["enabled"]?.ToObject<bool>() ?? false;
+                            var text = opt?["text"]?.ToString() ?? "";
+                            sb.AppendFormat("  {0}. [{1}] {2}", i + 1, enabled ? "√" : "×", text);
+                            sb.AppendLine();
+                        }
+                        Instances.TaskQueueViewModel.AddLog(sb.ToString().TrimEnd(), UiLogColor.Info);
+                    }
+                    break;
+                }
         }
     }
 

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -196,6 +196,7 @@
     <system:String x:Key="RoguelikeCollectibleModeSquad">烧水使用分队</system:String>
     <system:String x:Key="RoguelikeStrategyMonthlySquad">刷月度小队，尽可能稳定地打更多层数</system:String>
     <system:String x:Key="RoguelikeStrategyDeepExploration">刷深入调查，尽可能稳定地打更多层数</system:String>
+    <system:String x:Key="RoguelikeStrategySecondEnding">第二结局，优先解锁第二结局隐藏奖励</system:String>
     <system:String x:Key="RoguelikeStrategyFindPlaytime">刷常乐节点，第一层进洞，找不到需要的节点就重开</system:String>
     <system:String x:Key="RoguelikeFindPlaytimeTarget">目标常乐节点</system:String>
     <system:String x:Key="RoguelikePlaytimeLing">令 - 掷地有声</system:String>

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/RoguelikeSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/RoguelikeSettingsUserControlModel.cs
@@ -109,6 +109,16 @@ public class RoguelikeSettingsUserControlModel : TaskSettingsViewModel, Roguelik
     {
         var roguelikeMode = RoguelikeMode;
 
+        // 通用模式列表（Phantom 和其他主题共用）
+        List<GenericCombinedData<Mode>> commonModes =
+        [
+            new() { Display = LocalizationHelper.GetString("RoguelikeStrategyExp"), Value = Mode.Exp },
+            new() { Display = LocalizationHelper.GetString("RoguelikeStrategyGold"), Value = Mode.Investment },
+            new() { Display = LocalizationHelper.GetString("RoguelikeStrategyLastReward"), Value = Mode.Collectible },
+            new() { Display = LocalizationHelper.GetString("RoguelikeStrategyMonthlySquad"), Value = Mode.Squad },
+            new() { Display = LocalizationHelper.GetString("RoguelikeStrategyDeepExploration"), Value = Mode.Exploration },
+        ];
+
         switch (RoguelikeTheme)
         {
             case Theme.JieGarden:
@@ -121,27 +131,16 @@ public class RoguelikeSettingsUserControlModel : TaskSettingsViewModel, Roguelik
                 break;
 
             case Theme.Phantom:
-                // Phantom 主题添加第二结局模式
+                // Phantom 主题在通用列表基础上添加第二结局模式
                 RoguelikeModeList =
                 [
-                    new() { Display = LocalizationHelper.GetString("RoguelikeStrategyExp"), Value = Mode.Exp },
-                    new() { Display = LocalizationHelper.GetString("RoguelikeStrategyGold"), Value = Mode.Investment },
-                    new() { Display = LocalizationHelper.GetString("RoguelikeStrategyLastReward"), Value = Mode.Collectible },
-                    new() { Display = LocalizationHelper.GetString("RoguelikeStrategyMonthlySquad"), Value = Mode.Squad },
-                    new() { Display = LocalizationHelper.GetString("RoguelikeStrategyDeepExploration"), Value = Mode.Exploration },
+                    .. commonModes,
                     new() { Display = LocalizationHelper.GetString("RoguelikeStrategySecondEnding"), Value = Mode.SecondEnding },
                 ];
                 break;
 
             default:
-                RoguelikeModeList =
-                [
-                    new() { Display = LocalizationHelper.GetString("RoguelikeStrategyExp"), Value = Mode.Exp },
-                    new() { Display = LocalizationHelper.GetString("RoguelikeStrategyGold"), Value = Mode.Investment },
-                    new() { Display = LocalizationHelper.GetString("RoguelikeStrategyLastReward"), Value = Mode.Collectible },
-                    new() { Display = LocalizationHelper.GetString("RoguelikeStrategyMonthlySquad"), Value = Mode.Squad },
-                    new() { Display = LocalizationHelper.GetString("RoguelikeStrategyDeepExploration"), Value = Mode.Exploration },
-                ];
+                RoguelikeModeList = [.. commonModes];
 
                 if (RoguelikeTheme == Theme.Sami)
                 {

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/RoguelikeSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/RoguelikeSettingsUserControlModel.cs
@@ -120,6 +120,19 @@ public class RoguelikeSettingsUserControlModel : TaskSettingsViewModel, Roguelik
                 ];
                 break;
 
+            case Theme.Phantom:
+                // Phantom 主题添加第二结局模式
+                RoguelikeModeList =
+                [
+                    new() { Display = LocalizationHelper.GetString("RoguelikeStrategyExp"), Value = Mode.Exp },
+                    new() { Display = LocalizationHelper.GetString("RoguelikeStrategyGold"), Value = Mode.Investment },
+                    new() { Display = LocalizationHelper.GetString("RoguelikeStrategyLastReward"), Value = Mode.Collectible },
+                    new() { Display = LocalizationHelper.GetString("RoguelikeStrategyMonthlySquad"), Value = Mode.Squad },
+                    new() { Display = LocalizationHelper.GetString("RoguelikeStrategyDeepExploration"), Value = Mode.Exploration },
+                    new() { Display = LocalizationHelper.GetString("RoguelikeStrategySecondEnding"), Value = Mode.SecondEnding },
+                ];
+                break;
+
             default:
                 RoguelikeModeList =
                 [


### PR DESCRIPTION
已经在本地测试过，可以正常拿到二结局相关道具

## Summary by Sourcery

为 Phantom 类 Rogue 模式添加第二结局模式支持，并改进 Rogue 遭遇日志与配置。

新功能：
- 引入 Phantom 专用的 SecondEnding Rogue 模式，在遭遇策略上更保守，并优先追求第二结局。
- 为第二结局模式加载并使用单独的 Phantom 遭遇配置文件 `ending2.json`。
- 在 WPF 界面模式列表和本地化资源中暴露新的 SecondEnding Rogue 模式。

增强改进：
- 扩展 Rogue 遭遇的额外信息回调和界面日志，加入遭遇名称、选项数量、已选选项以及选项文本。
- 重构 Rogue 模式列表的构建方式，在主题之间共享通用模式的同时添加 Phantom 专属条目。
- 更新 Phantom Rogue 基础配置和遭遇配置文件，使其与新的第二结局模式行为保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for a Phantom roguelike second-ending mode and improve roguelike encounter logging and configuration.

New Features:
- Introduce a Phantom-specific SecondEnding roguelike mode that prioritizes the second ending with conservative encounter strategy.
- Load and use a dedicated Phantom encounter configuration file (ending2.json) for the second-ending mode.
- Expose the new SecondEnding roguelike mode in the WPF UI mode list and localization resources.

Enhancements:
- Extend roguelike encounter extra-info callbacks and UI logging to include encounter names, option counts, selected options, and option texts.
- Refactor roguelike mode list construction to share common modes across themes while adding Phantom-specific entries.
- Update Phantom roguelike base and encounter configuration files to align with the new second-ending mode behavior.

</details>