### PR TITLE
perf: 日志悬浮窗使用更轻量级实现，降低对目标窗口的影响

### DIFF
--- a/src/MaaWpfGui/NativeMethods.txt
+++ b/src/MaaWpfGui/NativeMethods.txt
@@ -19,12 +19,16 @@ DEVPKEY_Device_DriverVersion
 
 // Window enumeration
 EnumWindows
+GetForegroundWindow
 GetWindowText
 GetWindowTextLengthW
 GetWindowThreadProcessId
+IsIconic
 IsWindowVisible
 GetWindowRect
 SetWindowPos
+ShowWindow
+GetWindow
 SetWinEventHook
 UnhookWinEvent
 GetWindowLong

--- a/src/MaaWpfGui/NativeMethods.txt
+++ b/src/MaaWpfGui/NativeMethods.txt
@@ -28,7 +28,6 @@ IsWindowVisible
 GetWindowRect
 SetWindowPos
 ShowWindow
-GetWindow
 SetWinEventHook
 UnhookWinEvent
 GetWindowLong

--- a/src/MaaWpfGui/Views/UI/OverlayWindow.xaml.cs
+++ b/src/MaaWpfGui/Views/UI/OverlayWindow.xaml.cs
@@ -148,6 +148,13 @@ public partial class OverlayWindow : Window
     private void OnClosed(object? sender, EventArgs e)
     {
         StopWinEventHooks();
+        Interlocked.Increment(ref _zOrderVerificationVersion);
+        _zOrderVerificationCts?.Cancel();
+        _zOrderVerificationCts?.Dispose();
+        _zOrderVerificationCts = null;
+        _overlayHwnd = IntPtr.Zero;
+        _targetHwnd = IntPtr.Zero;
+        _targetPid = 0;
     }
 
     #region Win32
@@ -177,6 +184,7 @@ public partial class OverlayWindow : Window
     private int _forceRecalculateSizeRequested;
     private int _zOrderVerificationVersion;
     private bool _overlayHiddenByTargetState;
+    private CancellationTokenSource? _zOrderVerificationCts = new();
 
     private IntPtr _locationChangeHook = IntPtr.Zero;
     private IntPtr _foregroundHook = IntPtr.Zero;
@@ -399,15 +407,39 @@ public partial class OverlayWindow : Window
 
     private void ScheduleSecondaryZOrderVerification()
     {
+        var cts = _zOrderVerificationCts;
+        if (cts == null)
+        {
+            return;
+        }
+
         int version = Interlocked.Increment(ref _zOrderVerificationVersion);
         _ = Task.Run(async () => {
-            await Task.Delay(SecondaryZOrderVerificationDelayMs).ConfigureAwait(false);
+            try
+            {
+                await Task.Delay(SecondaryZOrderVerificationDelayMs, cts.Token).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
+
+            if (cts.IsCancellationRequested)
+            {
+                return;
+            }
+
             if (version != Volatile.Read(ref _zOrderVerificationVersion))
             {
                 return;
             }
 
             Execute.OnUIThread(() => {
+                if (cts.IsCancellationRequested || _overlayHwnd == IntPtr.Zero)
+                {
+                    return;
+                }
+
                 if (version != Volatile.Read(ref _zOrderVerificationVersion))
                 {
                     return;

--- a/src/MaaWpfGui/Views/UI/OverlayWindow.xaml.cs
+++ b/src/MaaWpfGui/Views/UI/OverlayWindow.xaml.cs
@@ -42,10 +42,10 @@ namespace MaaWpfGui.Views.UI;
 public partial class OverlayWindow : Window
 {
     private static readonly ILogger _logger = Log.ForContext<OverlayWindow>();
-    private const int OverlayMarginLeft = 12;
-    private const int OverlayMarginTop = 90;
-    private const int OverlayMarginRight = 12;
-    private const int OverlayMarginBottom = 12;
+    private const double OverlayMarginLeft = 8;
+    private const double OverlayMarginTop = 48;
+    private const double OverlayMarginRight = 8;
+    private const double OverlayMarginBottom = 8;
     private const double OverlayMaxWidth = 250;
 
     // Instance delegate to keep callback alive for this instance; avoids global mapping complexity
@@ -98,7 +98,7 @@ public partial class OverlayWindow : Window
         {
             StopWinEventHook();
             StartWinEventHookForTarget(_targetHwnd);
-            UpdatePosition();
+            UpdatePosition(forceRecalculateSize: true);
         }
 
         // 自动滚动到最新内容：订阅 ItemsControl 的 Items 集合变化
@@ -116,7 +116,7 @@ public partial class OverlayWindow : Window
                         Execute.OnUIThread(() =>
                         {
                             scroll.ScrollToVerticalOffset(scroll.ExtentHeight);
-                            UpdatePosition();
+                            UpdatePosition(forceRecalculateSize: true);
                         });
                     }
                 };
@@ -125,7 +125,7 @@ public partial class OverlayWindow : Window
                     Execute.OnUIThread(() =>
                     {
                         scroll.ScrollToVerticalOffset(scroll.ExtentHeight);
-                        UpdatePosition();
+                        UpdatePosition(forceRecalculateSize: true);
                     });
                 };
             }
@@ -161,6 +161,10 @@ public partial class OverlayWindow : Window
     private IntPtr _targetHwnd = IntPtr.Zero;
     private uint _targetPid = 0;
     private IntPtr _overlayHwnd = IntPtr.Zero;
+    private int _lastTargetWidth = -1;
+    private int _lastTargetHeight = -1;
+    private int _overlayWidth = 1;
+    private int _overlayHeight = 1;
 
     // WinEventHook 用于即时订阅目标窗口的位置/大小变动
     private IntPtr _winEventHook = IntPtr.Zero;
@@ -260,7 +264,7 @@ public partial class OverlayWindow : Window
         }
     }
 
-    private void UpdatePosition()
+    private void UpdatePosition(bool forceRecalculateSize = false)
     {
         if (_targetHwnd == IntPtr.Zero)
         {
@@ -272,45 +276,90 @@ public partial class OverlayWindow : Window
             return;
         }
 
+        int targetWidth = rect.right - rect.left;
+        int targetHeight = rect.bottom - rect.top;
+        bool updateSize = forceRecalculateSize ||
+                          targetWidth != _lastTargetWidth ||
+                          targetHeight != _lastTargetHeight;
+
+        if (updateSize)
+        {
+            RecalculateOverlaySize(rect);
+        }
+
+        MoveOverlay(rect, updateSize);
+
+        _lastTargetWidth = targetWidth;
+        _lastTargetHeight = targetHeight;
+    }
+
+    private void RecalculateOverlaySize(RECT rect)
+    {
         if (FindName("OuterBorder") is not Border border)
         {
             return;
         }
 
-        int overlayWidth = Math.Max(1, (int)Math.Ceiling(border.ActualWidth));
-        int overlayHeight = Math.Max(1, (int)Math.Ceiling(border.ActualHeight));
+        _overlayWidth = Math.Max(1, (int)Math.Ceiling(border.ActualWidth));
+        _overlayHeight = Math.Max(1, (int)Math.Ceiling(border.ActualHeight));
+
         var source = PresentationSource.FromVisual(this);
-        if (source?.CompositionTarget != null)
+        if (source?.CompositionTarget == null)
         {
-            var transform = source.CompositionTarget.TransformFromDevice;
-            var transformToDevice = source.CompositionTarget.TransformToDevice;
-            var topLeft = transform.Transform(new Point(rect.left, rect.top));
-            var bottomRight = transform.Transform(new Point(rect.right, rect.bottom));
-            var newWidthWpf = Math.Max(0, bottomRight.X - topLeft.X);
-            var newHeightWpf = Math.Max(0, bottomRight.Y - topLeft.Y);
-            double availableWidth = Math.Max(0, newWidthWpf - OverlayMarginLeft - OverlayMarginRight);
-            double availableHeight = Math.Max(0, newHeightWpf - OverlayMarginTop - OverlayMarginBottom);
-            border.MaxWidth = Math.Clamp(availableWidth, 0, OverlayMaxWidth);
-            border.MaxHeight = availableHeight;
-
-            border.Measure(new Size(border.MaxWidth, border.MaxHeight));
-            var desiredSizeInPixels = transformToDevice.Transform(new Point(border.DesiredSize.Width, border.DesiredSize.Height));
-            overlayWidth = Math.Max(1, (int)Math.Ceiling(desiredSizeInPixels.X));
-            overlayHeight = Math.Max(1, (int)Math.Ceiling(desiredSizeInPixels.Y));
+            return;
         }
 
-        if (_overlayHwnd != IntPtr.Zero)
-        {
-            int newLeft = rect.left + OverlayMarginLeft;
-            int newTop = rect.top + OverlayMarginTop;
+        var transform = source.CompositionTarget.TransformFromDevice;
+        var transformToDevice = source.CompositionTarget.TransformToDevice;
+        var topLeft = transform.Transform(new Point(rect.left, rect.top));
+        var bottomRight = transform.Transform(new Point(rect.right, rect.bottom));
+        var newWidthWpf = Math.Max(0, bottomRight.X - topLeft.X);
+        var newHeightWpf = Math.Max(0, bottomRight.Y - topLeft.Y);
+        double availableWidth = Math.Max(0, newWidthWpf - OverlayMarginLeft - OverlayMarginRight);
+        double availableHeight = Math.Max(0, newHeightWpf - OverlayMarginTop - OverlayMarginBottom);
+        border.MaxWidth = Math.Clamp(availableWidth, 0, OverlayMaxWidth);
+        border.MaxHeight = availableHeight;
 
-            PInvoke.SetWindowPos(
-                (HWND)_overlayHwnd, (HWND)IntPtr.Zero,
-                newLeft, newTop, overlayWidth, overlayHeight,
-                SET_WINDOW_POS_FLAGS.SWP_NOZORDER |
-                SET_WINDOW_POS_FLAGS.SWP_NOACTIVATE |
-                SET_WINDOW_POS_FLAGS.SWP_NOCOPYBITS);
+        border.Measure(new Size(border.MaxWidth, border.MaxHeight));
+        var desiredSizeInPixels = transformToDevice.Transform(new Point(border.DesiredSize.Width, border.DesiredSize.Height));
+        _overlayWidth = Math.Max(1, (int)Math.Ceiling(desiredSizeInPixels.X));
+        _overlayHeight = Math.Max(1, (int)Math.Ceiling(desiredSizeInPixels.Y));
+    }
+
+    private void MoveOverlay(RECT rect, bool updateSize)
+    {
+        if (_overlayHwnd == IntPtr.Zero)
+        {
+            return;
         }
+
+        var marginInPixels = GetOverlayMarginInPixels();
+        int newLeft = rect.left + marginInPixels.left;
+        int newTop = rect.top + marginInPixels.top;
+        var flags = SET_WINDOW_POS_FLAGS.SWP_NOZORDER |
+                    SET_WINDOW_POS_FLAGS.SWP_NOACTIVATE |
+                    SET_WINDOW_POS_FLAGS.SWP_NOCOPYBITS;
+        if (!updateSize)
+        {
+            flags |= SET_WINDOW_POS_FLAGS.SWP_NOSIZE;
+        }
+
+        PInvoke.SetWindowPos(
+            (HWND)_overlayHwnd, (HWND)IntPtr.Zero,
+            newLeft, newTop, _overlayWidth, _overlayHeight,
+            flags);
+    }
+
+    private (int Left, int Top) GetOverlayMarginInPixels()
+    {
+        var source = PresentationSource.FromVisual(this);
+        if (source?.CompositionTarget == null)
+        {
+            return ((int)Math.Round(OverlayMarginLeft), (int)Math.Round(OverlayMarginTop));
+        }
+
+        var margin = source.CompositionTarget.TransformToDevice.Transform(new Point(OverlayMarginLeft, OverlayMarginTop));
+        return ((int)Math.Round(margin.X), (int)Math.Round(margin.Y));
     }
 
     /// <summary>
@@ -323,7 +372,7 @@ public partial class OverlayWindow : Window
         Opacity = 0;
         Show();
         SetWindowLongPtr((HWND)_overlayHwnd, WINDOW_LONG_PTR_INDEX.GWL_HWNDPARENT, _targetHwnd);
-        UpdatePosition();
+        UpdatePosition(forceRecalculateSize: true);
         Opacity = 1;
     }
 }

--- a/src/MaaWpfGui/Views/UI/OverlayWindow.xaml.cs
+++ b/src/MaaWpfGui/Views/UI/OverlayWindow.xaml.cs
@@ -200,14 +200,15 @@ public partial class OverlayWindow : Window
                 return;
             }
 
-            uint flags = WineventOutOfContext | WineventSkipOwnProcess;
+            uint globalFlags = WineventOutOfContext;
+            uint targetProcessFlags = WineventOutOfContext | WineventSkipOwnProcess;
 
             StopWinEventHooks();
-            _foregroundHook = RegisterWinEventHook(EventSystemForeground, EventSystemForeground, 0, flags, "foreground");
-            _minimizeHook = RegisterWinEventHook(EventSystemMinimizeStart, EventSystemMinimizeEnd, _targetPid, flags, "minimize");
-            _showHideHook = RegisterWinEventHook(EventObjectShow, EventObjectHide, _targetPid, flags, "show/hide");
-            _destroyHook = RegisterWinEventHook(EventObjectDestroy, EventObjectDestroy, _targetPid, flags, "destroy");
-            _locationChangeHook = RegisterWinEventHook(EventObjectLocationChange, EventObjectLocationChange, _targetPid, flags, "location change");
+            _foregroundHook = RegisterWinEventHook(EventSystemForeground, EventSystemForeground, 0, globalFlags, "foreground");
+            _minimizeHook = RegisterWinEventHook(EventSystemMinimizeStart, EventSystemMinimizeEnd, _targetPid, targetProcessFlags, "minimize");
+            _showHideHook = RegisterWinEventHook(EventObjectShow, EventObjectHide, _targetPid, targetProcessFlags, "show/hide");
+            _destroyHook = RegisterWinEventHook(EventObjectDestroy, EventObjectDestroy, _targetPid, targetProcessFlags, "destroy");
+            _locationChangeHook = RegisterWinEventHook(EventObjectLocationChange, EventObjectLocationChange, _targetPid, targetProcessFlags, "location change");
         }
         catch (Exception ex)
         {

--- a/src/MaaWpfGui/Views/UI/OverlayWindow.xaml.cs
+++ b/src/MaaWpfGui/Views/UI/OverlayWindow.xaml.cs
@@ -14,6 +14,7 @@
 using System;
 using System.Collections.Specialized;
 using System.Runtime.InteropServices;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
@@ -116,7 +117,7 @@ public partial class OverlayWindow : Window
                         Execute.OnUIThread(() =>
                         {
                             scroll.ScrollToVerticalOffset(scroll.ExtentHeight);
-                            UpdatePosition(forceRecalculateSize: true);
+                            RequestUpdatePosition(forceRecalculateSize: true);
                         });
                     }
                 };
@@ -125,7 +126,7 @@ public partial class OverlayWindow : Window
                     Execute.OnUIThread(() =>
                     {
                         scroll.ScrollToVerticalOffset(scroll.ExtentHeight);
-                        UpdatePosition(forceRecalculateSize: true);
+                        RequestUpdatePosition(forceRecalculateSize: true);
                     });
                 };
             }
@@ -165,6 +166,10 @@ public partial class OverlayWindow : Window
     private int _lastTargetHeight = -1;
     private int _overlayWidth = 1;
     private int _overlayHeight = 1;
+    private int _positionUpdateVersion;
+    private int _lastAppliedPositionUpdateVersion;
+    private int _positionUpdateScheduled;
+    private int _forceRecalculateSizeRequested;
 
     // WinEventHook 用于即时订阅目标窗口的位置/大小变动
     private IntPtr _winEventHook = IntPtr.Zero;
@@ -256,11 +261,60 @@ public partial class OverlayWindow : Window
                 return;
             }
 
-            UpdatePosition();
+            RequestUpdatePosition();
         }
         catch (Exception ex)
         {
             _logger.Error(ex, "Exception in WinEventProc (native callback)");
+        }
+    }
+
+    private void RequestUpdatePosition(bool forceRecalculateSize = false)
+    {
+        if (forceRecalculateSize)
+        {
+            Interlocked.Exchange(ref _forceRecalculateSizeRequested, 1);
+        }
+
+        Interlocked.Increment(ref _positionUpdateVersion);
+        if (Interlocked.Exchange(ref _positionUpdateScheduled, 1) != 0)
+        {
+            return;
+        }
+
+        Execute.OnUIThread(ProcessPendingPositionUpdates);
+    }
+
+    private void ProcessPendingPositionUpdates()
+    {
+        try
+        {
+            while (true)
+            {
+                int latestVersion = Volatile.Read(ref _positionUpdateVersion);
+                if (latestVersion == _lastAppliedPositionUpdateVersion)
+                {
+                    break;
+                }
+
+                bool forceRecalculateSize = Interlocked.Exchange(ref _forceRecalculateSizeRequested, 0) != 0;
+                UpdatePosition(forceRecalculateSize);
+                _lastAppliedPositionUpdateVersion = latestVersion;
+
+                if (latestVersion == Volatile.Read(ref _positionUpdateVersion))
+                {
+                    break;
+                }
+            }
+        }
+        finally
+        {
+            Interlocked.Exchange(ref _positionUpdateScheduled, 0);
+            if (Volatile.Read(ref _positionUpdateVersion) != _lastAppliedPositionUpdateVersion &&
+                Interlocked.Exchange(ref _positionUpdateScheduled, 1) == 0)
+            {
+                Execute.OnUIThread(ProcessPendingPositionUpdates);
+            }
         }
     }
 
@@ -334,8 +388,8 @@ public partial class OverlayWindow : Window
         }
 
         var marginInPixels = GetOverlayMarginInPixels();
-        int newLeft = rect.left + marginInPixels.left;
-        int newTop = rect.top + marginInPixels.top;
+        int newLeft = rect.left + marginInPixels.Left;
+        int newTop = rect.top + marginInPixels.Top;
         var flags = SET_WINDOW_POS_FLAGS.SWP_NOZORDER |
                     SET_WINDOW_POS_FLAGS.SWP_NOACTIVATE |
                     SET_WINDOW_POS_FLAGS.SWP_NOCOPYBITS;

--- a/src/MaaWpfGui/Views/UI/OverlayWindow.xaml.cs
+++ b/src/MaaWpfGui/Views/UI/OverlayWindow.xaml.cs
@@ -13,7 +13,6 @@
 
 using System;
 using System.Collections.Specialized;
-using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
@@ -43,11 +42,23 @@ namespace MaaWpfGui.Views.UI;
 public partial class OverlayWindow : Window
 {
     private static readonly ILogger _logger = Log.ForContext<OverlayWindow>();
+    private static readonly HWND HwndTopmost = (HWND)new IntPtr(-1);
+    private static readonly HWND HwndNotTopmost = (HWND)new IntPtr(-2);
     private const double OverlayMarginLeft = 8;
     private const double OverlayMarginTop = 48;
     private const double OverlayMarginRight = 8;
     private const double OverlayMarginBottom = 8;
     private const double OverlayMaxWidth = 250;
+    private const uint WineventOutOfContext = 0x0000;
+    private const uint WineventSkipOwnProcess = 0x0002;
+    private const uint EventSystemForeground = 0x0003;
+    private const uint EventSystemMinimizeStart = 0x0016;
+    private const uint EventSystemMinimizeEnd = 0x0017;
+    private const uint EventObjectDestroy = 0x8001;
+    private const uint EventObjectShow = 0x8002;
+    private const uint EventObjectHide = 0x8003;
+    private const uint EventObjectLocationChange = 0x800B;
+    private const int ObjidWindow = 0;
 
     // Instance delegate to keep callback alive for this instance; avoids global mapping complexity
     private readonly WINEVENTPROC _winEventProc;
@@ -97,9 +108,9 @@ public partial class OverlayWindow : Window
         // 如果在 OnLoaded 触发时已有目标窗口（例如从配置恢复），立即设置钩子和位置
         if (_targetHwnd != IntPtr.Zero)
         {
-            StopWinEventHook();
-            StartWinEventHookForTarget(_targetHwnd);
-            UpdatePosition(forceRecalculateSize: true);
+            StopWinEventHooks();
+            StartWinEventHooksForTarget(_targetHwnd);
+            SyncOverlayToTargetState(forceRecalculateSize: true);
         }
 
         // 自动滚动到最新内容：订阅 ItemsControl 的 Items 集合变化
@@ -138,22 +149,18 @@ public partial class OverlayWindow : Window
 
     private void OnClosed(object? sender, EventArgs e)
     {
-        StopWinEventHook();
+        StopWinEventHooks();
     }
 
     #region Win32
 
-    // Keep Win32 constants for clarity; underscore naming matches Win32 defines
 #pragma warning disable SA1310 // Field names intentionally contain underscores for Win32 constants
     private const int WS_EX_TRANSPARENT = 0x20;
     private const int WS_EX_LAYERED = 0x80000;
     private const int WS_EX_NOACTIVATE = 0x08000000;
 #pragma warning restore SA1310
 
-    [DllImport("user32.dll", EntryPoint = "SetWindowLongPtrW", SetLastError = true)]
-    private static extern IntPtr SetWindowLongPtr(HWND hWnd, WINDOW_LONG_PTR_INDEX nIndex, IntPtr dwNewLong);
-
-    // Use CsWin32 generated PInvoke wrappers instead of manual DllImport declarations.
+    // Use CsWin32 generated PInvoke wrappers where possible.
     #endregion
 
     /// <summary>
@@ -170,11 +177,15 @@ public partial class OverlayWindow : Window
     private int _lastAppliedPositionUpdateVersion;
     private int _positionUpdateScheduled;
     private int _forceRecalculateSizeRequested;
+    private bool _overlayHiddenByTargetState;
 
-    // WinEventHook 用于即时订阅目标窗口的位置/大小变动
-    private IntPtr _winEventHook = IntPtr.Zero;
+    private IntPtr _locationChangeHook = IntPtr.Zero;
+    private IntPtr _foregroundHook = IntPtr.Zero;
+    private IntPtr _minimizeHook = IntPtr.Zero;
+    private IntPtr _showHideHook = IntPtr.Zero;
+    private IntPtr _destroyHook = IntPtr.Zero;
 
-    private void StartWinEventHookForTarget(IntPtr hwnd)
+    private void StartWinEventHooksForTarget(IntPtr hwnd)
     {
         try
         {
@@ -183,17 +194,6 @@ public partial class OverlayWindow : Window
                 return;
             }
 
-            // 如果已经有钩子，先清理旧的
-            if (_winEventHook != IntPtr.Zero)
-            {
-                StopWinEventHook();
-            }
-
-            const uint WINEVENT_OUTOFCONTEXT = 0x0000;
-            const uint WINEVENT_SKIPOWNPROCESS = 0x0002;
-
-            const uint EVENT_OBJECT_LOCATIONCHANGE = 0x800B;
-
             // 获取目标窗口所属进程 id
             _ = PInvoke.GetWindowThreadProcessId((HWND)hwnd, out _targetPid);
             if (_targetPid == Environment.ProcessId)
@@ -201,51 +201,72 @@ public partial class OverlayWindow : Window
                 return;
             }
 
-            uint flags = WINEVENT_OUTOFCONTEXT | WINEVENT_SKIPOWNPROCESS;
+            uint flags = WineventOutOfContext | WineventSkipOwnProcess;
 
-            // 订阅目标进程的 location change
-            _winEventHook = (IntPtr)PInvoke.SetWinEventHook(EVENT_OBJECT_LOCATIONCHANGE, EVENT_OBJECT_LOCATIONCHANGE, HINSTANCE.Null, _winEventProc, _targetPid, 0, flags);
-            if (_winEventHook == IntPtr.Zero)
-            {
-                _logger.Warning("SetWinEventHook for location change returned null for pid {Pid}", _targetPid);
-            }
+            StopWinEventHooks();
+            _foregroundHook = RegisterWinEventHook(EventSystemForeground, EventSystemForeground, 0, flags, "foreground");
+            _minimizeHook = RegisterWinEventHook(EventSystemMinimizeStart, EventSystemMinimizeEnd, _targetPid, flags, "minimize");
+            _showHideHook = RegisterWinEventHook(EventObjectShow, EventObjectHide, _targetPid, flags, "show/hide");
+            _destroyHook = RegisterWinEventHook(EventObjectDestroy, EventObjectDestroy, _targetPid, flags, "destroy");
+            _locationChangeHook = RegisterWinEventHook(EventObjectLocationChange, EventObjectLocationChange, _targetPid, flags, "location change");
         }
         catch (Exception ex)
         {
-            _logger.Error(ex, "StartWinEventHookForTarget failed");
+            _logger.Error(ex, "StartWinEventHooksForTarget failed");
         }
     }
 
-    private void StopWinEventHook()
+    private IntPtr RegisterWinEventHook(uint eventMin, uint eventMax, uint processId, uint flags, string name)
+    {
+        var hook = (IntPtr)PInvoke.SetWinEventHook(eventMin, eventMax, HINSTANCE.Null, _winEventProc, processId, 0, flags);
+        if (hook == IntPtr.Zero)
+        {
+            _logger.Warning("SetWinEventHook for {Name} returned null for pid {Pid}", name, processId);
+        }
+
+        return hook;
+    }
+
+    private void StopWinEventHooks()
     {
         try
         {
-            if (_winEventHook != IntPtr.Zero)
-            {
-                var toRemove = _winEventHook;
-                try
-                {
-                    PInvoke.UnhookWinEvent((HWINEVENTHOOK)toRemove);
-                }
-                catch (Exception ex)
-                {
-                    _logger.Warning(ex, "UnhookWinEvent failed for hook {Hook}", toRemove);
-                }
-
-                _winEventHook = IntPtr.Zero;
-            }
+            UnhookWinEvent(ref _foregroundHook);
+            UnhookWinEvent(ref _minimizeHook);
+            UnhookWinEvent(ref _showHideHook);
+            UnhookWinEvent(ref _destroyHook);
+            UnhookWinEvent(ref _locationChangeHook);
         }
         catch (Exception ex)
         {
-            _logger.Error(ex, "StopWinEventHook failed");
+            _logger.Error(ex, "StopWinEventHooks failed");
         }
+    }
+
+    private void UnhookWinEvent(ref IntPtr hook)
+    {
+        if (hook == IntPtr.Zero)
+        {
+            return;
+        }
+
+        var toRemove = hook;
+        try
+        {
+            PInvoke.UnhookWinEvent((HWINEVENTHOOK)toRemove);
+        }
+        catch (Exception ex)
+        {
+            _logger.Warning(ex, "UnhookWinEvent failed for hook {Hook}", toRemove);
+        }
+
+        hook = IntPtr.Zero;
     }
 
     private void WinEventProc(HWINEVENTHOOK hWinEventHook, uint eventType, HWND hwnd, int idObject, int idChild, uint dwEventThread, uint dwmsEventTime)
     {
         try
         {
-            // 仅处理顶层窗口位置变化
             if (hwnd == HWND.Null)
             {
                 return;
@@ -256,12 +277,51 @@ public partial class OverlayWindow : Window
                 return;
             }
 
-            if (hwnd != (HWND)_targetHwnd)
+            if (eventType >= EventObjectDestroy && idObject != ObjidWindow)
             {
                 return;
             }
 
-            RequestUpdatePosition();
+            switch (eventType)
+            {
+                case EventSystemForeground:
+                    Execute.OnUIThread(() => UpdateOverlayZOrder(hwnd));
+                    break;
+
+                case EventSystemMinimizeStart:
+                case EventObjectHide:
+                    if (hwnd == (HWND)_targetHwnd)
+                    {
+                        Execute.OnUIThread(HideOverlayForTargetState);
+                    }
+
+                    break;
+
+                case EventSystemMinimizeEnd:
+                case EventObjectShow:
+                    if (hwnd == (HWND)_targetHwnd)
+                    {
+                        Execute.OnUIThread(() => SyncOverlayToTargetState(forceRecalculateSize: true));
+                    }
+
+                    break;
+
+                case EventObjectDestroy:
+                    if (hwnd == (HWND)_targetHwnd)
+                    {
+                        Execute.OnUIThread(HandleTargetDestroyed);
+                    }
+
+                    break;
+
+                case EventObjectLocationChange:
+                    if (hwnd == (HWND)_targetHwnd)
+                    {
+                        RequestUpdatePosition();
+                    }
+
+                    break;
+            }
         }
         catch (Exception ex)
         {
@@ -318,8 +378,92 @@ public partial class OverlayWindow : Window
         }
     }
 
+    private void SyncOverlayToTargetState(bool forceRecalculateSize = false)
+    {
+        if (!ShouldShowOverlay())
+        {
+            HideOverlayForTargetState();
+            return;
+        }
+
+        ShowOverlayForTargetState();
+        UpdatePosition(forceRecalculateSize);
+        UpdateOverlayZOrder(PInvoke.GetForegroundWindow());
+    }
+
+    private bool ShouldShowOverlay()
+    {
+        return _overlayHwnd != IntPtr.Zero &&
+               _targetHwnd != IntPtr.Zero &&
+               PInvoke.IsWindowVisible((HWND)_targetHwnd) &&
+               !PInvoke.IsIconic((HWND)_targetHwnd);
+    }
+
+    private void ShowOverlayForTargetState()
+    {
+        if (_overlayHwnd == IntPtr.Zero || !_overlayHiddenByTargetState)
+        {
+            return;
+        }
+
+        _overlayHiddenByTargetState = false;
+        PInvoke.ShowWindow((HWND)_overlayHwnd, SHOW_WINDOW_CMD.SW_SHOWNOACTIVATE);
+    }
+
+    private void HideOverlayForTargetState()
+    {
+        if (_overlayHwnd == IntPtr.Zero || _overlayHiddenByTargetState)
+        {
+            return;
+        }
+
+        _overlayHiddenByTargetState = true;
+        PInvoke.ShowWindow((HWND)_overlayHwnd, SHOW_WINDOW_CMD.SW_HIDE);
+    }
+
+    private void UpdateOverlayZOrder(HWND foregroundWindow)
+    {
+        if (_overlayHwnd == IntPtr.Zero || _targetHwnd == IntPtr.Zero || _overlayHiddenByTargetState)
+        {
+            return;
+        }
+
+        var flags = SET_WINDOW_POS_FLAGS.SWP_NOMOVE |
+                    SET_WINDOW_POS_FLAGS.SWP_NOSIZE |
+                    SET_WINDOW_POS_FLAGS.SWP_NOACTIVATE;
+        if (foregroundWindow == (HWND)_targetHwnd)
+        {
+            PInvoke.SetWindowPos((HWND)_overlayHwnd, HwndTopmost, 0, 0, 0, 0, flags);
+            return;
+        }
+
+        if (foregroundWindow == HWND.Null || foregroundWindow == (HWND)_overlayHwnd)
+        {
+            return;
+        }
+
+        PInvoke.SetWindowPos((HWND)_overlayHwnd, HwndNotTopmost, 0, 0, 0, 0, flags);
+        PInvoke.SetWindowPos(foregroundWindow, (HWND)IntPtr.Zero, 0, 0, 0, 0, flags);
+    }
+
+    private void HandleTargetDestroyed()
+    {
+        HideOverlayForTargetState();
+        StopWinEventHooks();
+        _targetHwnd = IntPtr.Zero;
+        _targetPid = 0;
+    }
+
     private void UpdatePosition(bool forceRecalculateSize = false)
     {
+        if (!ShouldShowOverlay())
+        {
+            HideOverlayForTargetState();
+            return;
+        }
+
+        ShowOverlayForTargetState();
+
         if (_targetHwnd == IntPtr.Zero)
         {
             return;
@@ -425,8 +569,7 @@ public partial class OverlayWindow : Window
     {
         Opacity = 0;
         Show();
-        SetWindowLongPtr((HWND)_overlayHwnd, WINDOW_LONG_PTR_INDEX.GWL_HWNDPARENT, _targetHwnd);
-        UpdatePosition(forceRecalculateSize: true);
+        SyncOverlayToTargetState(forceRecalculateSize: true);
         Opacity = 1;
     }
 }

--- a/src/MaaWpfGui/Views/UI/OverlayWindow.xaml.cs
+++ b/src/MaaWpfGui/Views/UI/OverlayWindow.xaml.cs
@@ -42,6 +42,7 @@ namespace MaaWpfGui.Views.UI;
 public partial class OverlayWindow : Window
 {
     private static readonly ILogger _logger = Log.ForContext<OverlayWindow>();
+    private static readonly HWND HwndTop = (HWND)IntPtr.Zero;
     private static readonly HWND HwndTopmost = (HWND)new IntPtr(-1);
     private static readonly HWND HwndNotTopmost = (HWND)new IntPtr(-2);
     private const double OverlayMarginLeft = 8;
@@ -49,6 +50,7 @@ public partial class OverlayWindow : Window
     private const double OverlayMarginRight = 8;
     private const double OverlayMarginBottom = 8;
     private const double OverlayMaxWidth = 250;
+    private const int SecondaryZOrderVerificationDelayMs = 75;
     private const uint WineventOutOfContext = 0x0000;
     private const uint WineventSkipOwnProcess = 0x0002;
     private const uint EventSystemForeground = 0x0003;
@@ -121,21 +123,17 @@ public partial class OverlayWindow : Window
                 itemsCtrl.Items is INotifyCollectionChanged coll)
             {
                 Execute.OnUIThread(() => scroll.ScrollToVerticalOffset(scroll.ExtentHeight));
-                coll.CollectionChanged += (s2, ev2) =>
-                {
+                coll.CollectionChanged += (s2, ev2) => {
                     if (ev2.Action == NotifyCollectionChangedAction.Add)
                     {
-                        Execute.OnUIThread(() =>
-                        {
+                        Execute.OnUIThread(() => {
                             scroll.ScrollToVerticalOffset(scroll.ExtentHeight);
                             RequestUpdatePosition(forceRecalculateSize: true);
                         });
                     }
                 };
-                scroll.SizeChanged += (s2, ev2) =>
-                {
-                    Execute.OnUIThread(() =>
-                    {
+                scroll.SizeChanged += (s2, ev2) => {
+                    Execute.OnUIThread(() => {
                         scroll.ScrollToVerticalOffset(scroll.ExtentHeight);
                         RequestUpdatePosition(forceRecalculateSize: true);
                     });
@@ -177,6 +175,7 @@ public partial class OverlayWindow : Window
     private int _lastAppliedPositionUpdateVersion;
     private int _positionUpdateScheduled;
     private int _forceRecalculateSizeRequested;
+    private int _zOrderVerificationVersion;
     private bool _overlayHiddenByTargetState;
 
     private IntPtr _locationChangeHook = IntPtr.Zero;
@@ -285,7 +284,10 @@ public partial class OverlayWindow : Window
             switch (eventType)
             {
                 case EventSystemForeground:
-                    Execute.OnUIThread(() => UpdateOverlayZOrder(hwnd));
+                    Execute.OnUIThread(() => {
+                        UpdateOverlayZOrder(hwnd);
+                        ScheduleSecondaryZOrderVerification();
+                    });
                     break;
 
                 case EventSystemMinimizeStart:
@@ -301,7 +303,10 @@ public partial class OverlayWindow : Window
                 case EventObjectShow:
                     if (hwnd == (HWND)_targetHwnd)
                     {
-                        Execute.OnUIThread(() => SyncOverlayToTargetState(forceRecalculateSize: true));
+                        Execute.OnUIThread(() => {
+                            SyncOverlayToTargetState(forceRecalculateSize: true);
+                            ScheduleSecondaryZOrderVerification();
+                        });
                     }
 
                     break;
@@ -391,6 +396,27 @@ public partial class OverlayWindow : Window
         UpdateOverlayZOrder(PInvoke.GetForegroundWindow());
     }
 
+    private void ScheduleSecondaryZOrderVerification()
+    {
+        int version = Interlocked.Increment(ref _zOrderVerificationVersion);
+        _ = Task.Run(async () => {
+            await Task.Delay(SecondaryZOrderVerificationDelayMs).ConfigureAwait(false);
+            if (version != Volatile.Read(ref _zOrderVerificationVersion))
+            {
+                return;
+            }
+
+            Execute.OnUIThread(() => {
+                if (version != Volatile.Read(ref _zOrderVerificationVersion))
+                {
+                    return;
+                }
+
+                UpdateOverlayZOrder(PInvoke.GetForegroundWindow());
+            });
+        });
+    }
+
     private bool ShouldShowOverlay()
     {
         return _overlayHwnd != IntPtr.Zero &&
@@ -428,12 +454,9 @@ public partial class OverlayWindow : Window
             return;
         }
 
-        var flags = SET_WINDOW_POS_FLAGS.SWP_NOMOVE |
-                    SET_WINDOW_POS_FLAGS.SWP_NOSIZE |
-                    SET_WINDOW_POS_FLAGS.SWP_NOACTIVATE;
         if (foregroundWindow == (HWND)_targetHwnd)
         {
-            PInvoke.SetWindowPos((HWND)_overlayHwnd, HwndTopmost, 0, 0, 0, 0, flags);
+            SetOverlayTopmostState(true);
             return;
         }
 
@@ -442,8 +465,32 @@ public partial class OverlayWindow : Window
             return;
         }
 
-        PInvoke.SetWindowPos((HWND)_overlayHwnd, HwndNotTopmost, 0, 0, 0, 0, flags);
-        PInvoke.SetWindowPos(foregroundWindow, (HWND)IntPtr.Zero, 0, 0, 0, 0, flags);
+        SetOverlayTopmostState(false);
+        PInvoke.SetWindowPos(foregroundWindow, HwndTop, 0, 0, 0, 0, GetZOrderOnlyFlags());
+    }
+
+    private void SetOverlayTopmostState(bool topmost)
+    {
+        if (_overlayHwnd == IntPtr.Zero)
+        {
+            return;
+        }
+
+        PInvoke.SetWindowPos(
+            (HWND)_overlayHwnd,
+            topmost ? HwndTopmost : HwndNotTopmost,
+            0,
+            0,
+            0,
+            0,
+            GetZOrderOnlyFlags());
+    }
+
+    private static SET_WINDOW_POS_FLAGS GetZOrderOnlyFlags()
+    {
+        return SET_WINDOW_POS_FLAGS.SWP_NOMOVE |
+               SET_WINDOW_POS_FLAGS.SWP_NOSIZE |
+               SET_WINDOW_POS_FLAGS.SWP_NOACTIVATE;
     }
 
     private void HandleTargetDestroyed()
@@ -486,6 +533,7 @@ public partial class OverlayWindow : Window
         }
 
         MoveOverlay(rect, updateSize);
+        UpdateOverlayZOrder(PInvoke.GetForegroundWindow());
 
         _lastTargetWidth = targetWidth;
         _lastTargetHeight = targetHeight;


### PR DESCRIPTION


https://github.com/user-attachments/assets/5062d5d3-2665-4336-9639-c5531060f8f8



## 由 Sourcery 提供的总结

优化叠加日志窗口的行为，在保持其位置和层级正确的同时，尽量减少对目标窗口的影响。

改进点：
- 将单一的 WinEvent 钩子替换为一组有针对性的钩子，用于前台、最小化、显示/隐藏、销毁以及位置变更等事件，以更好地跟踪目标窗口状态。
- 引入带防抖和版本控制的叠加层位置与尺寸更新机制，以在目标窗口频繁移动或调整大小时减少重复工作。
- 调整叠加层的边距、尺寸计算逻辑以及支持 DPI 感知的像素计算，使叠加层在目标窗口区域内更加紧凑地适配。
- 新增逻辑以同步叠加层与目标窗口的可见性和 Z 轴顺序，包括正确处理最小化、隐藏和销毁等情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize the overlay log window behavior to reduce its impact on the target window while keeping it correctly positioned and layered.

Enhancements:
- Replace the single WinEvent hook with a set of targeted hooks for foreground, minimize, show/hide, destroy, and location change events to better track the target window state.
- Introduce debounced, versioned overlay position and size updates to minimize redundant work when the target window moves or resizes frequently.
- Adjust overlay margins, sizing logic, and DPI-aware pixel calculations so the overlay fits more compactly within the target window area.
- Add logic to synchronize overlay visibility and z-order with the target window, including correct handling of minimization, hiding, and destruction.

</details>