### PR TITLE
rft: 干员数据重构, 支持跨职业重名干员

### DIFF
--- a/src/MaaCore/Config/Miscellaneous/AvatarCacheManager.cpp
+++ b/src/MaaCore/Config/Miscellaneous/AvatarCacheManager.cpp
@@ -68,7 +68,7 @@ void asst::AvatarCacheManager::set_avatar(
         return;
     }
 
-    if (BattleData.is_name_invalid(name)) {
+    if (BattleData.is_name_invalid(role, name)) {
         Log.error("invalid name", name);
         return;
     }

--- a/src/MaaCore/Config/Miscellaneous/AvatarCacheManager.cpp
+++ b/src/MaaCore/Config/Miscellaneous/AvatarCacheManager.cpp
@@ -23,15 +23,15 @@ bool asst::AvatarCacheManager::load(const std::filesystem::path& path)
             continue;
         }
         const std::filesystem::path& filepath = entry.path();
-        std::string name = utils::path_to_utf8_string(filepath.stem());
+        std::string id = utils::path_to_utf8_string(filepath.stem());
 
-        auto role = BattleData.get_role(name);
-        if (role == battle::Role::Unknown) {
-            Log.warn("unknown oper", name);
+        const auto& oper_ptr = BattleData.find_oper_by_id(id);
+        if (!oper_ptr) {
+            Log.warn("unknown oper", id);
             continue;
         }
 
-        waiting_to_load[role].emplace(name, filepath);
+        waiting_to_load[oper_ptr->role].emplace(oper_ptr->name, filepath);
     }
 
     m_load_future = std::async(std::launch::async, &AvatarCacheManager::_load, this, std::move(waiting_to_load));
@@ -68,12 +68,13 @@ void asst::AvatarCacheManager::set_avatar(
         return;
     }
 
-    if (BattleData.is_name_invalid(role, name)) {
+    const auto& oper_ptr = BattleData.find_oper(role, name);
+    if (!oper_ptr) {
         Log.error("invalid name", name);
         return;
     }
 
-    auto path = m_save_path / utils::path(name + CacheExtension);
+    auto path = m_save_path / utils::path(oper_ptr->id + CacheExtension);
     Log.info(path.lexically_relative(UserDir.get()));
 
     MAA_NS::imwrite(path, avatar);

--- a/src/MaaCore/Config/Miscellaneous/BattleDataConfig.cpp
+++ b/src/MaaCore/Config/Miscellaneous/BattleDataConfig.cpp
@@ -15,11 +15,11 @@ bool asst::BattleDataConfig::parse(const json::value& json)
     for (const auto& [id, char_data_json] : json.at("chars").as_object()) {
         std::shared_ptr<battle::OperProps> data_ptr = std::make_shared<battle::OperProps>();
         data_ptr->id = id;
-        std::string name = char_data_json.at("name").as_string();
-        std::string name_en = char_data_json.at("name_en").as_string();
-        std::string name_jp = char_data_json.at("name_jp").as_string();
-        std::string name_kr = char_data_json.at("name_kr").as_string();
-        std::string name_tw = char_data_json.at("name_tw").as_string();
+        std::string name = char_data_json.get("name", "");
+        std::string name_en = char_data_json.get("name_en", "");
+        std::string name_jp = char_data_json.get("name_jp", "");
+        std::string name_kr = char_data_json.get("name_kr", "");
+        std::string name_tw = char_data_json.get("name_tw", "");
 
         data_ptr->name = name;
         data_ptr->name_en = name_en;
@@ -33,7 +33,7 @@ bool asst::BattleDataConfig::parse(const json::value& json)
             { "TANK", battle::Role::Tank },       { "WARRIOR", battle::Role::Warrior },
         };
 
-        if (auto iter = RoleMap.find(char_data_json.at("profession").as_string()); iter == RoleMap.cend()) {
+        if (auto iter = RoleMap.find(char_data_json.get("profession", "")); iter == RoleMap.cend()) {
             data_ptr->role = battle::Role::Drone;
         }
         else {
@@ -52,8 +52,8 @@ bool asst::BattleDataConfig::parse(const json::value& json)
             { "RANGED", battle::LocationType::Ranged },
             { "ALL", battle::LocationType::All },
         };
-        if (auto iter = PositionMap.find(char_data_json.at("position").as_string()); iter == PositionMap.cend()) {
-            Log.warn("Unknown position", char_data_json.at("position").as_string());
+        if (auto iter = PositionMap.find(char_data_json.get("position", "")); iter == PositionMap.cend()) {
+            Log.warn("Unknown position", char_data_json.get("position", ""));
             data_ptr->location_type = battle::LocationType::Invalid;
         }
         else {

--- a/src/MaaCore/Config/Miscellaneous/BattleDataConfig.cpp
+++ b/src/MaaCore/Config/Miscellaneous/BattleDataConfig.cpp
@@ -7,7 +7,6 @@
 bool asst::BattleDataConfig::parse(const json::value& json)
 {
     LogTraceFunction;
-    m_drones_confusing.clear();
     for (const auto& [id, char_data_json] : json.at("chars").as_object()) {
         battle::OperProps data;
         data.id = id;
@@ -63,12 +62,15 @@ bool asst::BattleDataConfig::parse(const json::value& json)
             for (const auto& token : *tokens_opt) {
                 data.tokens.emplace_back(token.as_string());
                 if (tokens_opt->size() > 1) {
-                    m_drones_confusing.emplace_back(token.as_string());
+                    m_drones_confusing.emplace(token.as_string());
                 }
             }
         }
 
-        m_chars.emplace(std::move(name), std::move(data));
+        std::string oper_id = data.id;
+        std::shared_ptr<battle::OperProps> props_ptr = std::make_shared<battle::OperProps>(std::move(data));
+        m_chars_by_role[props_ptr->role].insert_or_assign(std::move(name), props_ptr);
+        m_chars.emplace(std::move(oper_id), std::move(props_ptr));
     }
     for (const auto& [id, points_json] : json.at("ranges").as_object()) {
         battle::AttackRange points;

--- a/src/MaaCore/Config/Miscellaneous/BattleDataConfig.cpp
+++ b/src/MaaCore/Config/Miscellaneous/BattleDataConfig.cpp
@@ -8,19 +8,19 @@ bool asst::BattleDataConfig::parse(const json::value& json)
 {
     LogTraceFunction;
     for (const auto& [id, char_data_json] : json.at("chars").as_object()) {
-        battle::OperProps data;
-        data.id = id;
+        std::shared_ptr<battle::OperProps> data_ptr = std::make_shared<battle::OperProps>();
+        data_ptr->id = id;
         std::string name = char_data_json.at("name").as_string();
         std::string name_en = char_data_json.at("name_en").as_string();
         std::string name_jp = char_data_json.at("name_jp").as_string();
         std::string name_kr = char_data_json.at("name_kr").as_string();
         std::string name_tw = char_data_json.at("name_tw").as_string();
 
-        data.name = name;
-        data.name_en = name_en;
-        data.name_jp = name_jp;
-        data.name_kr = name_kr;
-        data.name_tw = name_tw;
+        data_ptr->name = name;
+        data_ptr->name_en = name_en;
+        data_ptr->name_jp = name_jp;
+        data_ptr->name_kr = name_kr;
+        data_ptr->name_tw = name_tw;
         static const std::unordered_map<std::string, battle::Role> RoleMap = {
             { "CASTER", battle::Role::Caster },   { "MEDIC", battle::Role::Medic },
             { "PIONEER", battle::Role::Pioneer }, { "SNIPER", battle::Role::Sniper },
@@ -29,16 +29,16 @@ bool asst::BattleDataConfig::parse(const json::value& json)
         };
 
         if (auto iter = RoleMap.find(char_data_json.at("profession").as_string()); iter == RoleMap.cend()) {
-            data.role = battle::Role::Drone;
+            data_ptr->role = battle::Role::Drone;
         }
         else {
-            data.role = iter->second;
+            data_ptr->role = iter->second;
             m_opers.emplace(name); // 所有干员名
         }
 
         const auto& ranges_json = char_data_json.at("rangeId").as_array();
-        for (size_t i = 0; i != data.ranges.size(); ++i) {
-            data.ranges.at(i) = ranges_json.at(i).as_string();
+        for (size_t i = 0; i != data_ptr->ranges.size(); ++i) {
+            data_ptr->ranges.at(i) = ranges_json.at(i).as_string();
         }
 
         static const std::unordered_map<std::string, battle::LocationType> PositionMap = {
@@ -49,28 +49,25 @@ bool asst::BattleDataConfig::parse(const json::value& json)
         };
         if (auto iter = PositionMap.find(char_data_json.at("position").as_string()); iter == PositionMap.cend()) {
             Log.warn("Unknown position", char_data_json.at("position").as_string());
-            data.location_type = battle::LocationType::Invalid;
+            data_ptr->location_type = battle::LocationType::Invalid;
         }
         else {
-            data.location_type = iter->second;
+            data_ptr->location_type = iter->second;
         }
 
         const auto& rarity = char_data_json.at("rarity").as_integer();
-        data.rarity = rarity;
-
+        data_ptr->rarity = rarity;
         if (auto tokens_opt = char_data_json.find<json::array>("tokens")) {
             for (const auto& token : *tokens_opt) {
-                data.tokens.emplace_back(token.as_string());
+                data_ptr->tokens.emplace_back(token.as_string());
                 if (tokens_opt->size() > 1) {
                     m_drones_confusing.emplace(token.as_string());
                 }
             }
         }
 
-        std::string oper_id = data.id;
-        std::shared_ptr<battle::OperProps> props_ptr = std::make_shared<battle::OperProps>(std::move(data));
-        m_chars_by_role[props_ptr->role].insert_or_assign(std::move(name), props_ptr);
-        m_chars.emplace(std::move(oper_id), std::move(props_ptr));
+        m_chars_by_role[data_ptr->role].emplace(data_ptr->id, data_ptr);
+        m_chars.emplace(data_ptr->id, std::move(data_ptr));
     }
     for (const auto& [id, points_json] : json.at("ranges").as_object()) {
         battle::AttackRange points;

--- a/src/MaaCore/Config/Miscellaneous/BattleDataConfig.cpp
+++ b/src/MaaCore/Config/Miscellaneous/BattleDataConfig.cpp
@@ -7,6 +7,11 @@
 bool asst::BattleDataConfig::parse(const json::value& json)
 {
     LogTraceFunction;
+    m_chars_by_role.clear();
+    m_chars.clear();
+    m_ranges.clear();
+    m_opers.clear();
+    m_drones_confusing.clear();
     for (const auto& [id, char_data_json] : json.at("chars").as_object()) {
         std::shared_ptr<battle::OperProps> data_ptr = std::make_shared<battle::OperProps>();
         data_ptr->id = id;

--- a/src/MaaCore/Config/Miscellaneous/BattleDataConfig.h
+++ b/src/MaaCore/Config/Miscellaneous/BattleDataConfig.h
@@ -3,6 +3,7 @@
 
 #include "Common/AsstBattleDef.h"
 #include "Common/AsstTypes.h"
+#include <ranges>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -17,57 +18,104 @@ public:
 
     const std::string get_id(const std::string& name) const
     {
-        auto iter = m_chars.find(name);
-        if (iter == m_chars.cend()) {
-            return EmptyId;
+        if (const auto props = find_oper(name); props != nullptr) {
+            return props->id;
         }
-        return iter->second.id;
+        return EmptyId;
     }
 
-    const std::string get_en(const std::string& name) const { return m_chars.find(name)->second.name_en; }
+    const std::string get_id(battle::Role role, const std::string& name) const
+    {
+        if (const auto props = find_oper(role, name); props != nullptr) {
+            return props->id;
+        }
+        return EmptyId;
+    }
 
-    const std::string get_jp(const std::string& name) const { return m_chars.find(name)->second.name_jp; }
+    const std::shared_ptr<battle::OperProps> find_oper(const std::string& name) const
+    {
+        if (name.empty()) {
+            return nullptr;
+        }
 
-    const std::string get_kr(const std::string& name) const { return m_chars.find(name)->second.name_kr; }
+        // compatible with old logic: if multiple roles have the same name, return the first one found in m_chars.
+        if (auto it = std::ranges::find_if(m_chars, [&name](const auto& pair) { return pair.second->name == name; });
+            it != m_chars.cend()) {
+            return it->second;
+        }
+        return nullptr;
+    }
 
-    const std::string get_tw(const std::string& name) const { return m_chars.find(name)->second.name_tw; }
+    const std::shared_ptr<battle::OperProps> find_oper(battle::Role role, const std::string& name) const
+    {
+        if (name.empty()) {
+            return nullptr;
+        }
+        auto role_it = m_chars_by_role.find(role);
+        if (role_it == m_chars_by_role.cend()) {
+            return nullptr;
+        }
+        auto char_it = role_it->second.find(name);
+        if (char_it == role_it->second.cend()) {
+            return nullptr;
+        }
+        return char_it->second;
+    }
 
     battle::Role get_role(const std::string& name) const
     {
-        auto iter = m_chars.find(name);
-        if (iter == m_chars.cend()) {
+        if (name.empty()) {
             return battle::Role::Unknown;
         }
-        return iter->second.role;
-    }
 
-    int get_rarity(const std::string& name) const
-    {
-        auto iter = m_chars.find(name);
-        if (iter == m_chars.cend()) {
-            return 0;
+        // compatible with old logic: if multiple roles have the same name, return the first one found in m_chars.
+        static constexpr battle::Role kRoleOrder[] = { battle::Role::Caster,  battle::Role::Medic,
+                                                       battle::Role::Pioneer, battle::Role::Warrior,
+                                                       battle::Role::Special, battle::Role::Tank,
+                                                       battle::Role::Sniper,  battle::Role::Support,
+                                                       battle::Role::Drone };
+        for (const battle::Role role : kRoleOrder) {
+            if (find_oper(role, name) != nullptr) {
+                return role;
+            }
         }
-        return iter->second.rarity;
+        return battle::Role::Unknown;
     }
 
+    int get_rarity(battle::Role role, const std::string& name) const
+    {
+        if (const auto props = find_oper(role, name); props != nullptr) {
+            return props->rarity;
+        }
+        return 0;
+    }
+
+    // Legacy wrapper (name-only). If name is ambiguous across roles, returns 0.
+    int get_rarity(const std::string& name) const { return get_rarity(get_role(name), name); }
+
+    battle::LocationType get_location_type(battle::Role role, const std::string& name) const
+    {
+        if (const auto props = find_oper(role, name); props != nullptr) {
+            return props->location_type;
+        }
+        return battle::LocationType::Invalid;
+    }
+
+    // Legacy wrapper (name-only). If name is ambiguous across roles, returns LocationType::Invalid.
     battle::LocationType get_location_type(const std::string& name) const
     {
-        auto iter = m_chars.find(name);
-        if (iter == m_chars.cend()) {
-            return battle::LocationType::Invalid;
-        }
-        return iter->second.location_type;
+        return get_location_type(get_role(name), name);
     }
 
     static inline const battle::AttackRange& EmptyRange { { 0, 0 } };
 
-    const battle::AttackRange& get_range(const std::string& name, size_t index) const
+    const battle::AttackRange& get_range(battle::Role role, const std::string& name, size_t index) const
     {
-        auto char_iter = m_chars.find(name);
-        if (char_iter == m_chars.cend()) {
+        const auto props = find_oper(role, name);
+        if (props == nullptr) {
             return EmptyRange;
         }
-        const auto& ranges = char_iter->second.ranges;
+        const auto& ranges = props->ranges;
         if (index >= ranges.size()) {
             if (ranges.empty()) {
                 return EmptyRange;
@@ -83,30 +131,55 @@ public:
         return range_iter->second;
     }
 
-    const std::vector<std::string>& get_tokens(const std::string& name) const
+    // Legacy wrapper (name-only). If name is ambiguous across roles, returns EmptyRange.
+    const battle::AttackRange& get_range(const std::string& name, size_t index) const
     {
-        auto char_iter = m_chars.find(name);
-        if (char_iter == m_chars.cend()) {
-            static const std::vector<std::string> Empty;
-            return Empty;
-        }
-        return char_iter->second.tokens;
+        return get_range(get_role(name), name, index);
     }
 
-    bool is_name_invalid(const std::string& name) const { return name.empty() || m_chars.find(name) == m_chars.cend(); }
+    const std::vector<std::string>& get_tokens(battle::Role role, const std::string& name) const
+    {
+        if (const auto props = find_oper(role, name); props != nullptr) {
+            return props->tokens;
+        }
+        static const std::vector<std::string> Empty;
+        return Empty;
+    }
+
+    // Legacy wrapper (name-only). If name is ambiguous across roles, returns empty token list.
+    const std::vector<std::string>& get_tokens(const std::string& name) const
+    {
+        return get_tokens(get_role(name), name);
+    }
+
+    bool is_name_invalid(battle::Role role, const std::string& name) const
+    {
+        return name.empty() || get_id(role, name).empty();
+    }
+
+    // Legacy wrapper (name-only). If name is ambiguous across roles, returns true.
+    bool is_name_invalid(const std::string& name) const { return name.empty() || find_oper(name) == nullptr; }
 
     const std::unordered_set<std::string>& get_all_oper_names() const noexcept { return m_opers; }
 
-    const std::vector<std::string>& get_drones_confusing() const noexcept { return m_drones_confusing; }
+    const std::unordered_map<std::string, std::shared_ptr<battle::OperProps>>& get_all_opers() const noexcept
+    {
+        return m_chars;
+    }
+
+    const std::unordered_set<std::string>& get_drones_confusing() const noexcept { return m_drones_confusing; }
 
 protected:
     virtual bool parse(const json::value& json) override;
 
 private:
-    std::unordered_map<std::string, battle::OperProps> m_chars;
+    // role -> (name -> pointer to m_chars[id].second)
+    std::map<battle::Role, std::unordered_map<std::string, std::shared_ptr<battle::OperProps>>> m_chars_by_role;
+    std::unordered_map<std::string, std::shared_ptr<battle::OperProps>> m_chars; // id -> oper
+
     std::unordered_map<std::string, battle::AttackRange> m_ranges;
     std::unordered_set<std::string> m_opers;
-    std::vector<std::string> m_drones_confusing; // 容易混淆的召唤物（同一个干员的多个召唤物
+    std::unordered_set<std::string> m_drones_confusing; // confused summons: multiple summons of same oper
 };
 
 inline static auto& BattleData = BattleDataConfig::get_instance();

--- a/src/MaaCore/Config/Miscellaneous/BattleDataConfig.h
+++ b/src/MaaCore/Config/Miscellaneous/BattleDataConfig.h
@@ -18,7 +18,7 @@ public:
 
     const std::string get_id(const std::string& name) const
     {
-        if (const auto props = find_oper(name); props != nullptr) {
+        if (const auto& props = find_oper(name); props != nullptr) {
             return props->id;
         }
         return EmptyId;
@@ -26,7 +26,7 @@ public:
 
     const std::string get_id(battle::Role role, const std::string& name) const
     {
-        if (const auto props = find_oper(role, name); props != nullptr) {
+        if (const auto& props = find_oper(role, name); props != nullptr) {
             return props->id;
         }
         return EmptyId;
@@ -39,8 +39,8 @@ public:
         }
 
         // compatible with old logic: if multiple roles have the same name, return the first one found in m_chars.
-        if (auto it = std::ranges::find_if(m_chars, [&name](const auto& pair) { return pair.second->name == name; });
-            it != m_chars.cend()) {
+        auto it = std::ranges::find_if(m_chars, [&name](const auto& pair) { return pair.second->name == name; });
+        if (it != m_chars.cend()) {
             return it->second;
         }
         return nullptr;
@@ -55,11 +55,26 @@ public:
         if (role_it == m_chars_by_role.cend()) {
             return nullptr;
         }
-        auto char_it = role_it->second.find(name);
-        if (char_it == role_it->second.cend()) {
+        auto oper_it = std::ranges::find_if(role_it->second, [&name](const auto& pair) {
+            return pair.second->name == name;
+        });
+        if (oper_it != role_it->second.cend()) {
+            return oper_it->second;
+        }
+        return nullptr;
+    }
+
+    const std::shared_ptr<battle::OperProps> find_oper_by_id(const std::string& id) const
+    {
+        if (id.empty()) {
             return nullptr;
         }
-        return char_it->second;
+
+        if (auto it = std::ranges::find_if(m_chars, [&id](const auto& pair) { return pair.second->id == id; });
+            it != m_chars.cend()) {
+            return it->second;
+        }
+        return nullptr;
     }
 
     battle::Role get_role(const std::string& name) const
@@ -69,33 +84,33 @@ public:
         }
 
         // compatible with old logic: if multiple roles have the same name, return the first one found in m_chars.
-        static constexpr battle::Role kRoleOrder[] = { battle::Role::Caster,  battle::Role::Medic,
-                                                       battle::Role::Pioneer, battle::Role::Warrior,
-                                                       battle::Role::Special, battle::Role::Tank,
-                                                       battle::Role::Sniper,  battle::Role::Support,
-                                                       battle::Role::Drone };
-        for (const battle::Role role : kRoleOrder) {
-            if (find_oper(role, name) != nullptr) {
-                return role;
-            }
+        const auto& oper_it = find_oper(name);
+        if (oper_it) {
+            return oper_it->role;
         }
         return battle::Role::Unknown;
     }
 
     int get_rarity(battle::Role role, const std::string& name) const
     {
-        if (const auto props = find_oper(role, name); props != nullptr) {
-            return props->rarity;
+        if (const auto& oper = find_oper(role, name); oper != nullptr) {
+            return oper->rarity;
         }
         return 0;
     }
 
     // Legacy wrapper (name-only). If name is ambiguous across roles, returns 0.
-    int get_rarity(const std::string& name) const { return get_rarity(get_role(name), name); }
+    int get_rarity(const std::string& name) const
+    {
+        if (const auto& oper = find_oper(name); oper != nullptr) {
+            return oper->rarity;
+        }
+        return 0;
+    }
 
     battle::LocationType get_location_type(battle::Role role, const std::string& name) const
     {
-        if (const auto props = find_oper(role, name); props != nullptr) {
+        if (const auto& props = find_oper(role, name); props != nullptr) {
             return props->location_type;
         }
         return battle::LocationType::Invalid;
@@ -111,7 +126,7 @@ public:
 
     const battle::AttackRange& get_range(battle::Role role, const std::string& name, size_t index) const
     {
-        const auto props = find_oper(role, name);
+        const auto& props = find_oper(role, name);
         if (props == nullptr) {
             return EmptyRange;
         }
@@ -139,7 +154,7 @@ public:
 
     const std::vector<std::string>& get_tokens(battle::Role role, const std::string& name) const
     {
-        if (const auto props = find_oper(role, name); props != nullptr) {
+        if (const auto& props = find_oper(role, name); props != nullptr) {
             return props->tokens;
         }
         static const std::vector<std::string> Empty;
@@ -162,7 +177,7 @@ public:
 
     const std::unordered_set<std::string>& get_all_oper_names() const noexcept { return m_opers; }
 
-    const std::unordered_map<std::string, std::shared_ptr<battle::OperProps>>& get_all_opers() const noexcept
+    const std::unordered_map<std::string, std::shared_ptr<battle::OperProps>>& get_all_chars() const noexcept
     {
         return m_chars;
     }
@@ -173,8 +188,8 @@ protected:
     virtual bool parse(const json::value& json) override;
 
 private:
-    // role -> (name -> pointer to m_chars[id].second)
-    std::map<battle::Role, std::unordered_map<std::string, std::shared_ptr<battle::OperProps>>> m_chars_by_role;
+    std::map<battle::Role, std::unordered_map<std::string, std::shared_ptr<battle::OperProps>>>
+        m_chars_by_role;                                                         // role -> (name -> oper)
     std::unordered_map<std::string, std::shared_ptr<battle::OperProps>> m_chars; // id -> oper
 
     std::unordered_map<std::string, battle::AttackRange> m_ranges;

--- a/src/MaaCore/Config/Miscellaneous/BattleDataConfig.h
+++ b/src/MaaCore/Config/Miscellaneous/BattleDataConfig.h
@@ -55,9 +55,8 @@ public:
         if (role_it == m_chars_by_role.cend()) {
             return nullptr;
         }
-        auto oper_it = std::ranges::find_if(role_it->second, [&name](const auto& pair) {
-            return pair.second->name == name;
-        });
+        auto oper_it =
+            std::ranges::find_if(role_it->second, [&name](const auto& pair) { return pair.second->name == name; });
         if (oper_it != role_it->second.cend()) {
             return oper_it->second;
         }
@@ -70,8 +69,8 @@ public:
             return nullptr;
         }
 
-        if (auto it = std::ranges::find_if(m_chars, [&id](const auto& pair) { return pair.second->id == id; });
-            it != m_chars.cend()) {
+        auto it = m_chars.find(id);
+        if (it != m_chars.cend()) {
             return it->second;
         }
         return nullptr;
@@ -119,7 +118,10 @@ public:
     // Legacy wrapper (name-only). If name is ambiguous across roles, returns LocationType::Invalid.
     battle::LocationType get_location_type(const std::string& name) const
     {
-        return get_location_type(get_role(name), name);
+        if (const auto& props = find_oper(name); props != nullptr) {
+            return props->location_type;
+        }
+        return battle::LocationType::Invalid;
     }
 
     static inline const battle::AttackRange& EmptyRange { { 0, 0 } };
@@ -169,7 +171,7 @@ public:
 
     bool is_name_invalid(battle::Role role, const std::string& name) const
     {
-        return name.empty() || get_id(role, name).empty();
+        return name.empty() || find_oper(role, name) == nullptr;
     }
 
     // Legacy wrapper (name-only). If name is ambiguous across roles, returns true.

--- a/src/MaaCore/Config/Miscellaneous/CopilotConfig.cpp
+++ b/src/MaaCore/Config/Miscellaneous/CopilotConfig.cpp
@@ -57,7 +57,7 @@ asst::battle::copilot::OperUsageGroups asst::CopilotConfig::parse_groups(const j
             oper.skill_usage = static_cast<battle::SkillUsage>(oper_info.get("skill_usage", 0));
             oper.skill_times = oper_info.get("skill_times", 1); // 使用技能的次数，默认为 1，兼容曾经的作业
 
-            int rarity = BattleDataConfig::get_instance().get_rarity(oper.name); // 修复旧作业中不合理的技能选择
+            int rarity = BattleDataConfig::get_instance().get_rarity(oper.name); // 兼容古早旧作业中非法的技能选择
             if (oper.skill == 3 && rarity < 6) {
                 LogError << __FUNCTION__ << "| Oper " << oper.name << " with rarity " << rarity
                          << " cannot use skill index 3, set to 0.";
@@ -100,7 +100,7 @@ asst::battle::copilot::OperUsageGroups asst::CopilotConfig::parse_groups(const j
                 oper.skill_usage = static_cast<battle::SkillUsage>(oper_info.get("skill_usage", 0));
                 oper.skill_times = oper_info.get("skill_times", 1); // 使用技能的次数，默认为 1，兼容曾经的作业
 
-                int rarity = BattleDataConfig::get_instance().get_rarity(oper.name); // 修复旧作业中不合理的技能选择
+                int rarity = BattleDataConfig::get_instance().get_rarity(oper.name); // 兼容古早旧作业中非法的技能选择
                 if (oper.skill == 3 && rarity < 6) {
                     LogError << __FUNCTION__ << "| Oper " << oper.name << " with rarity " << rarity
                              << " cannot use skill index 3, set to 0.";

--- a/src/MaaCore/Task/BattleHelper.cpp
+++ b/src/MaaCore/Task/BattleHelper.cpp
@@ -146,7 +146,7 @@ bool asst::BattleHelper::update_deployment_(
     // 设置干员名与部署位类型（近战/远程）
     auto set_oper_name = [&](DeploymentOper& oper, const std::string& name) {
         oper.name = name;
-        oper.location_type = BattleData.get_location_type(name);
+        oper.location_type = BattleData.get_location_type(oper.role, name);
         oper.is_usual_location = battle::get_role_usual_location(oper.role) == oper.location_type;
     };
 
@@ -222,7 +222,7 @@ bool asst::BattleHelper::update_deployment_(
 
             name_image = m_inst_helper.ctrler()->get_image();
 
-            std::string name = analyze_detail_page_oper_name(name_image);
+            std::string name = analyze_detail_page_oper_name(name_image, oper.role);
             // 这时候即使名字不合法也只能凑合用了，但是为空还是不行的
             if (name.empty()) {
                 Log.error("name is empty");
@@ -1035,7 +1035,7 @@ bool asst::BattleHelper::move_camera(const std::pair<double, double>& delta)
     return update_deployment(true);
 }
 
-std::string asst::BattleHelper::analyze_detail_page_oper_name(const cv::Mat& image)
+std::string asst::BattleHelper::analyze_detail_page_oper_name(const cv::Mat& image, battle::Role role)
 {
     const auto& replace_task = Task.get<OcrTaskInfo>("CharsNameOcrReplace");
     const auto& task = Task.get<OcrTaskInfo>(oper_name_ocr_task_name());
@@ -1053,7 +1053,7 @@ std::string asst::BattleHelper::analyze_detail_page_oper_name(const cv::Mat& ima
     preproc_analyzer.set_replace(replace_task->replace_map, replace_task->replace_full);
     auto preproc_result_opt = preproc_analyzer.analyze();
 
-    if (preproc_result_opt && !BattleData.is_name_invalid(preproc_result_opt->text)) {
+    if (preproc_result_opt && !BattleData.is_name_invalid(role, preproc_result_opt->text)) {
         return preproc_result_opt->text;
     }
 
@@ -1068,7 +1068,7 @@ std::string asst::BattleHelper::analyze_detail_page_oper_name(const cv::Mat& ima
     sort_by_score_(*det_result_opt);
     const auto& det_name = det_result_opt->front().text;
 
-    if (!BattleData.is_name_invalid(det_name)) {
+    if (!BattleData.is_name_invalid(role, det_name)) {
         return det_name;
     }
 

--- a/src/MaaCore/Task/BattleHelper.h
+++ b/src/MaaCore/Task/BattleHelper.h
@@ -96,7 +96,7 @@ protected:
         double radian = 0);
     bool move_camera(const std::pair<double, double>& delta);
 
-    std::string analyze_detail_page_oper_name(const cv::Mat& image);
+    std::string analyze_detail_page_oper_name(const cv::Mat& image, battle::Role role);
     std::optional<Rect> get_oper_rect_on_deployment(const std::string& name) const;
 
     int elapsed_time();

--- a/src/MaaCore/Task/Miscellaneous/OperBoxRecognitionTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/OperBoxRecognitionTask.cpp
@@ -73,15 +73,16 @@ void asst::OperBoxRecognitionTask::callback_analyze_result(bool done)
 
     for (const auto& name : all_oper_names) {
         bool own = m_own_opers.contains(name);
+        const auto& props = BattleData.find_oper(name);
         all_opers.emplace_back(
             json::object {
-                { "id", BattleData.get_id(name) },
+                { "id", props ? props->id : "" },
                 { "name", name },
-                { "name_en", BattleData.get_en(name) },
-                { "name_jp", BattleData.get_jp(name) },
-                { "name_kr", BattleData.get_kr(name) },
-                { "name_tw", BattleData.get_tw(name) },
-                { "rarity", BattleData.get_rarity(name) },
+                { "name_en", props ? props->name_en : "" },
+                { "name_jp", props ? props->name_jp : "" },
+                { "name_kr", props ? props->name_kr : "" },
+                { "name_tw", props ? props->name_tw : "" },
+                { "rarity", props ? props->rarity : 0 },
                 { "own", own }, // 在m_own_opers中重复
             });
     }

--- a/src/MaaCore/Task/Miscellaneous/OperBoxRecognitionTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/OperBoxRecognitionTask.cpp
@@ -1,8 +1,7 @@
 #include "OperBoxRecognitionTask.h"
 
-#include <ranges>
-
 #include <future>
+#include <ranges>
 
 #include "Config/Miscellaneous/BattleDataConfig.h"
 #include "Config/TaskData.h"
@@ -63,7 +62,7 @@ void asst::OperBoxRecognitionTask::callback_analyze_result(bool done)
 {
     LogTraceFunction;
     // 获取所有干员名
-    const auto& all_oper_names = BattleData.get_all_oper_names();
+    const auto& all_chars = BattleData.get_all_chars();
 
     json::value info = basic_info_with_what("OperBoxInfo");
     auto& details = info["details"];
@@ -71,13 +70,15 @@ void asst::OperBoxRecognitionTask::callback_analyze_result(bool done)
     auto& all_opers = details["all_opers"].as_array();
     auto& own_opers = details["own_opers"].as_array();
 
-    for (const auto& name : all_oper_names) {
-        bool own = m_own_opers.contains(name);
-        const auto& props = BattleData.find_oper(name);
+    for (const auto& chars : all_chars | std::ranges::views::filter([](const auto& pair) {
+                                 return pair.second->role != battle::Role::Drone;
+                             })) {
+        const auto& props = chars.second;
+        bool own = m_own_opers.contains(props->name);
         all_opers.emplace_back(
             json::object {
                 { "id", props ? props->id : "" },
-                { "name", name },
+                { "name", props->name },
                 { "name_en", props ? props->name_en : "" },
                 { "name_jp", props ? props->name_jp : "" },
                 { "name_kr", props ? props->name_kr : "" },

--- a/src/MaaCore/Task/Miscellaneous/ParadoxRecognitionTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/ParadoxRecognitionTask.cpp
@@ -37,7 +37,7 @@ bool asst::ParadoxRecognitionTask::_run()
     LogInfo << __FUNCTION__ << "navigate name:" << m_navigate_name;
     m_paradox_opers.erase(m_paradox_opers.begin());
 
-    const auto& all_oper_names = BattleData.get_all_opers();
+    const auto& all_oper_names = BattleData.get_all_chars();
     const auto& it = std::find_if(all_oper_names.begin(), all_oper_names.end(), [&](const auto& pair) {
         return pair.first.ends_with(m_navigate_name); // 应该没重复吧
     });

--- a/src/MaaCore/Task/Miscellaneous/ParadoxRecognitionTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/ParadoxRecognitionTask.cpp
@@ -37,18 +37,16 @@ bool asst::ParadoxRecognitionTask::_run()
     LogInfo << __FUNCTION__ << "navigate name:" << m_navigate_name;
     m_paradox_opers.erase(m_paradox_opers.begin());
 
-    const auto& all_oper_names = BattleData.get_all_oper_names();
-    const auto& it = std::find_if(all_oper_names.begin(), all_oper_names.end(), [&](const std::string& name) {
-        return BattleData.get_id(name).ends_with(m_navigate_name); // 应该没重复吧
+    const auto& all_oper_names = BattleData.get_all_opers();
+    const auto& it = std::find_if(all_oper_names.begin(), all_oper_names.end(), [&](const auto& pair) {
+        return pair.first.ends_with(m_navigate_name); // 应该没重复吧
     });
 
     if (it != all_oper_names.end()) {
-        const auto& name = *it;
-        m_oper_name = { name,
-                        BattleData.get_en(name),
-                        BattleData.get_jp(name),
-                        BattleData.get_kr(name),
-                        BattleData.get_tw(name) };
+        m_oper_name = {
+            it->second->role,    it->second->rarity,  it->second->name,    it->second->name_en,
+            it->second->name_jp, it->second->name_kr, it->second->name_tw,
+        };
     }
 
     // 设置技能
@@ -66,15 +64,12 @@ bool asst::ParadoxRecognitionTask::_run()
     }
 
     return_initial_oper(); // 回干员列表（默认在最左侧）
-    const auto& name = m_oper_name.name;
-    const auto role = BattleData.get_role(name);
-    if (!click_role_table(role)) {
+    if (!click_role_table(m_oper_name.role)) {
         return_initial_oper();
     }
 
-    const auto rarity = BattleData.get_rarity(name);
     if (swipe_and_analyze()) {
-        enter_paradox(m_skill_num, rarity);
+        enter_paradox(m_skill_num, m_oper_name.rarity);
     }
 
     return true;

--- a/src/MaaCore/Task/Miscellaneous/ParadoxRecognitionTask.h
+++ b/src/MaaCore/Task/Miscellaneous/ParadoxRecognitionTask.h
@@ -13,6 +13,8 @@ class ParadoxRecognitionTask : public AbstractTask
 private:
     struct OperName
     {
+        battle::Role role = battle::Role::Unknown;
+        int rarity;
         std::string name;
         std::string name_en;
         std::string name_jp;

--- a/src/MaaCore/Task/Miscellaneous/ParadoxRecognitionTask.h
+++ b/src/MaaCore/Task/Miscellaneous/ParadoxRecognitionTask.h
@@ -14,7 +14,7 @@ private:
     struct OperName
     {
         battle::Role role = battle::Role::Unknown;
-        int rarity;
+        int rarity = 0;
         std::string name;
         std::string name_en;
         std::string name_jp;

--- a/src/MaaCore/Vision/Miscellaneous/OperBoxImageAnalyzer.cpp
+++ b/src/MaaCore/Vision/Miscellaneous/OperBoxImageAnalyzer.cpp
@@ -124,9 +124,10 @@ bool asst::OperBoxImageAnalyzer::opers_analyze()
         const std::string& name = oper.text;
 
         OperBoxInfo box;
-        box.id = BattleData.get_id(name);
+        const auto& oper_data = BattleData.find_oper(name);
+        box.id = oper_data ? oper_data->id : "";
         box.name = name;
-        box.rarity = BattleData.get_rarity(name);
+        box.rarity = oper_data ? oper_data->rarity : 0;
 
         box.rect = flag_rect;
         box.own = true;


### PR DESCRIPTION
## Summary by Sourcery

重构干员元数据，以支持基于职业感知的查找，并区分不同职业中同名干员。

新功能：
- 新增基于职业感知的干员查找 API，支持通过「职业 + 名字」或唯一干员 ID 进行查询。

错误修复：
- 确保战斗逻辑、头像缓存、OCR 名字识别以及悖论模拟识别均使用基于职业感知的干员查询，以避免将同名干员误认为同一人。

优化改进：
- 引入共享的干员元数据访问器，用以替代分散的逐字段 getter，并更新相关任务以使用统一的元数据。
- 将令人困惑的无人机追踪数据结构由 `vector` 改为 `unordered_set`，以消除重复项并使意图更加清晰。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor operator metadata to support role-aware lookup and disambiguate same-name operators across professions.

New Features:
- Add role-aware operator lookup APIs allowing queries by profession plus name or by unique operator ID.

Bug Fixes:
- Ensure battle logic, avatar caching, OCR name recognition, and paradox recognition use role-aware operator queries to avoid misidentifying operators with shared names.

Enhancements:
- Introduce shared operator metadata accessors to replace scattered per-field getters and update tasks to consume the unified metadata.
- Change confusing drone tracking from a vector to an unordered_set to eliminate duplicates and clarify intent.

</details>

新功能：
- 支持通过“职业 + 名称”两种维度查询干员数据，以区分在不同职业中同名的干员。

错误修复：
- 在战斗、头像和 OCR 流程中使用具备职业感知的查询方式，防止在多个职业共享同名干员时错误识别干员及其属性。

优化完善：
- 提供统一的访问器以获取所有干员元数据，并更新任务与分析器以使用共享的干员属性，而非逐字段的 getter。
- 将令人困惑的无人机跟踪结构由 vector 改为 set，以避免重复并使意图更加清晰。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

重构干员元数据，以支持基于职业感知的查找，并区分不同职业中同名干员。

新功能：
- 新增基于职业感知的干员查找 API，支持通过「职业 + 名字」或唯一干员 ID 进行查询。

错误修复：
- 确保战斗逻辑、头像缓存、OCR 名字识别以及悖论模拟识别均使用基于职业感知的干员查询，以避免将同名干员误认为同一人。

优化改进：
- 引入共享的干员元数据访问器，用以替代分散的逐字段 getter，并更新相关任务以使用统一的元数据。
- 将令人困惑的无人机追踪数据结构由 `vector` 改为 `unordered_set`，以消除重复项并使意图更加清晰。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor operator metadata to support role-aware lookup and disambiguate same-name operators across professions.

New Features:
- Add role-aware operator lookup APIs allowing queries by profession plus name or by unique operator ID.

Bug Fixes:
- Ensure battle logic, avatar caching, OCR name recognition, and paradox recognition use role-aware operator queries to avoid misidentifying operators with shared names.

Enhancements:
- Introduce shared operator metadata accessors to replace scattered per-field getters and update tasks to consume the unified metadata.
- Change confusing drone tracking from a vector to an unordered_set to eliminate duplicates and clarify intent.

</details>

</details>