### PR TITLE
fix(infrast): 宿舍循环内重置下一步状态，避免跨宿舍串扰

### DIFF
--- a/src/MaaCore/Task/Infrast/InfrastDormTask.cpp
+++ b/src/MaaCore/Task/Infrast/InfrastDormTask.cpp
@@ -31,6 +31,9 @@ bool asst::InfrastDormTask::on_run_fails()
 bool asst::InfrastDormTask::_run()
 {
     for (; m_cur_facility_index < m_max_num_of_dorm; ++m_cur_facility_index) {
+        // 每个宿舍独立下一步状态，避免跨宿舍干扰导致行为异常
+        m_next_step = NextStep::Rest;
+
         if (need_exit()) {
             return false;
         }


### PR DESCRIPTION
在进入每间宿舍时重置 m_next_step（及筛选相关状态），防止上一间宿舍的状态影响后续宿舍选人/蹭信赖流程。

m_next_step 决定宿舍补人时的模式是rest（按心情休息），trust（补信赖），fill（直接补位）···；代码中所有宿舍复用同一个变量，理论上是没有问题的，当前版本基建也不会清空筛选条件，但是宿舍指定选人流程结束会默认按工作状态排序；
这导致如果启用宿舍蹭信赖，当蹭信赖的宿舍不是最后一间宿舍，且后续宿舍存在指定干员入驻，其进入 opers_choose 时，m_next_step仍为trust，而且，根据信赖进行排序只在rest模式结束时进行的操作，这就导致maa会在根据工作状态排序下尝试获取信赖值，最终会得到空值。
同时信赖非空与否是后续一系列行为的判定条件，信赖为空导致maa除获取一些信息外，不会做任何实际操作，就尝试进行下一页划找。
最终导致maa会卡死在宿舍找人中，不断滑向下一页，不中断不退出。

在不修改宿舍具体逻辑的情况下，每间宿舍重置 m_next_step 会导致特定条件下（无指定干员的多间宿舍蹭信赖情况下，在第二间以后）多进行一次信赖排序，其他情况应该不会有明显体感。

#15112

## Summary by Sourcery

错误修复：
- 确保在处理之前，每个宿舍都会将其“下一步模式”重置为默认的休息状态，以避免先前宿舍的状态影响后续的宿舍干员选择和信赖获取流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure each dorm resets its next-step mode to the default rest state before processing to avoid prior dorm state affecting subsequent dorm operator selection and trust farming flows.

</details>