### PR TITLE
ci: 避免生成不必要的res_updater

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -18,6 +18,7 @@
             "cacheVariables": {
                 "BUILD_WPF_GUI": "ON",
                 "BUILD_DEBUG_DEMO": "ON",
+                "BUILD_RESOURCE_UPDATER": "ON",
                 "INSTALL_RESOURCE": "OFF",
                 "INSTALL_PYTHON": "OFF"
             },
@@ -170,7 +171,8 @@
                 "INSTALL_RESOURCE": "ON",
                 "INSTALL_PYTHON": "ON",
                 "BUILD_WPF_GUI": "OFF",
-                "BUILD_DEBUG_DEMO": "OFF"
+                "BUILD_DEBUG_DEMO": "OFF",
+                "BUILD_RESOURCE_UPDATER": "OFF"
             }
         },
         {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -18,7 +18,6 @@
             "cacheVariables": {
                 "BUILD_WPF_GUI": "ON",
                 "BUILD_DEBUG_DEMO": "ON",
-                "BUILD_RESOURCE_UPDATER": "ON",
                 "INSTALL_RESOURCE": "OFF",
                 "INSTALL_PYTHON": "OFF"
             },

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -178,8 +178,8 @@
         {
             "name": "windows-publish-x64",
             "inherits": [
-                "windows-x64",
-                "publish-base"
+                "publish-base",
+                "windows-x64"
             ],
             "$comment": [
                 "github actions only support Visual Studio 17 2022",
@@ -191,8 +191,8 @@
         {
             "name": "windows-publish-arm64",
             "inherits": [
-                "windows-arm64",
-                "publish-base"
+                "publish-base",
+                "windows-arm64"
             ],
             "$comment": [
                 "github actions only support Visual Studio 17 2022",
@@ -204,32 +204,32 @@
         {
             "name": "linux-publish-x64",
             "inherits": [
-                "linux-x64",
-                "publish-base"
+                "publish-base",
+                "linux-x64"
             ],
             "displayName": "Linux x64 Publish"
         },
         {
             "name": "linux-publish-arm64",
             "inherits": [
-                "linux-arm64",
-                "publish-base"
+                "publish-base",
+                "linux-arm64"
             ],
             "displayName": "Linux arm64 Publish"
         },
         {
             "name": "macos-publish-x64",
             "inherits": [
-                "macos-x64",
-                "publish-base"
+                "publish-base",
+                "macos-x64"
             ],
             "displayName": "macOS x64 Publish"
         },
         {
             "name": "macos-publish-arm64",
             "inherits": [
-                "macos-arm64",
-                "publish-base"
+                "publish-base",
+                "macos-arm64"
             ],
             "displayName": "macOS arm64 Publish"
         },

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -178,8 +178,8 @@
         {
             "name": "windows-publish-x64",
             "inherits": [
-                "publish-base",
-                "windows-x64"
+                "windows-x64",
+                "publish-base"
             ],
             "$comment": [
                 "github actions only support Visual Studio 17 2022",
@@ -191,8 +191,8 @@
         {
             "name": "windows-publish-arm64",
             "inherits": [
-                "publish-base",
-                "windows-arm64"
+                "windows-arm64",
+                "publish-base"
             ],
             "$comment": [
                 "github actions only support Visual Studio 17 2022",
@@ -204,32 +204,32 @@
         {
             "name": "linux-publish-x64",
             "inherits": [
-                "publish-base",
-                "linux-x64"
+                "linux-x64",
+                "publish-base"
             ],
             "displayName": "Linux x64 Publish"
         },
         {
             "name": "linux-publish-arm64",
             "inherits": [
-                "publish-base",
-                "linux-arm64"
+                "linux-arm64",
+                "publish-base"
             ],
             "displayName": "Linux arm64 Publish"
         },
         {
             "name": "macos-publish-x64",
             "inherits": [
-                "publish-base",
-                "macos-x64"
+                "macos-x64",
+                "publish-base"
             ],
             "displayName": "macOS x64 Publish"
         },
         {
             "name": "macos-publish-arm64",
             "inherits": [
-                "publish-base",
-                "macos-arm64"
+                "macos-arm64",
+                "publish-base"
             ],
             "displayName": "macOS arm64 Publish"
         },


### PR DESCRIPTION
res-update-game.yml 中使用ResourceUpdater的自己的cmakelist，上层中似乎不应启用res_updater编译

@soundofautumn 

## Summary by Sourcery

更新 CMake 预设，以避免在 CI 中构建不必要的 `res_updater` 目标，并与专用的 ResourceUpdater CMake 配置保持一致。

Build:
- 调整 CMakePresets 配置，在不需要的情况下禁用或省略 `res_updater` 的构建。

CI:
- 优化 CI 配置，使 `res-update-game` 工作流依赖 ResourceUpdater 自身的 CMakeLists，而不是构建顶层的 `res_updater` 目标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update CMake presets to avoid building the unnecessary res_updater target in CI and align with the dedicated ResourceUpdater CMake configuration.

Build:
- Adjust CMakePresets configuration to disable or omit the res_updater build where it is not required.

CI:
- Refine CI configuration so res-update-game workflow relies on ResourceUpdater’s own CMakeLists instead of building the top-level res_updater target.

</details>