### PR TITLE
rft: 重构battle_data, 拆分不同客户端类型干员信息

### DIFF
--- a/src/MaaCore/Common/AsstBattleDef.h
+++ b/src/MaaCore/Common/AsstBattleDef.h
@@ -375,6 +375,7 @@ struct OperProps
     std::string name_jp;
     std::string name_kr;
     std::string name_tw;
+    std::string name_display;
     Role role = Role::Unknown;
     std::array<std::string, 3> ranges;
     int rarity = 0;                  // 稀有度 1-6

--- a/src/MaaCore/Config/Miscellaneous/BattleDataConfig.cpp
+++ b/src/MaaCore/Config/Miscellaneous/BattleDataConfig.cpp
@@ -29,6 +29,8 @@ bool asst::BattleDataConfig::parse(const json::value& json)
         data_ptr->name_jp = name_jp;
         data_ptr->name_kr = name_kr;
         data_ptr->name_tw = name_tw;
+        data_ptr->name_display = char_data_json.get("name_display", "");
+
         static const std::unordered_map<std::string, battle::Role> RoleMap = {
             { "CASTER", battle::Role::Caster },   { "MEDIC", battle::Role::Medic },
             { "PIONEER", battle::Role::Pioneer }, { "SNIPER", battle::Role::Sniper },

--- a/src/MaaCore/Config/Miscellaneous/BattleDataConfig.cpp
+++ b/src/MaaCore/Config/Miscellaneous/BattleDataConfig.cpp
@@ -12,6 +12,9 @@ bool asst::BattleDataConfig::parse(const json::value& json)
     m_ranges.clear();
     m_opers.clear();
     m_drones_confusing.clear();
+    m_opers.clear();
+    m_chars.clear();
+    m_ranges.clear();
     for (const auto& [id, char_data_json] : json.at("chars").as_object()) {
         std::shared_ptr<battle::OperProps> data_ptr = std::make_shared<battle::OperProps>();
         data_ptr->id = id;

--- a/tools/ResourceUpdater/main.cpp
+++ b/tools/ResourceUpdater/main.cpp
@@ -929,11 +929,14 @@ bool update_battle_chars_info(const fs::path& official_dir, const fs::path& over
         json::value char_new_data;
 
         for (auto& [data, name] : chars_json) {
+            if (data.get(id, "name", "_unavailable_") != "_unavailable_") {
             char_new_data[name] = data.get(id, "name", char_data["name"].as_string());
-            if (data.get(id, "name", "_unavailable_") == "_unavailable_") {
+            }
+            else {
                 char_new_data[name + "_unavailable"] = true;
             }
         }
+        char_new_data["name_display"] = char_new_data["name"];
 
         char_new_data["profession"] = char_data["profession"];
         const std::string& default_range = char_data.get("phases", 0, "rangeId", "0-1");
@@ -974,6 +977,7 @@ bool update_battle_chars_info(const fs::path& official_dir, const fs::path& over
     Amiya_data["name_jp"] = "アーミヤ-WARRIOR";
     Amiya_data["name_kr"] = "아미야-WARRIOR";
     Amiya_data["name_tw"] = "阿米婭-WARRIOR";
+    Amiya_data["name_display"] = "阿米娅-WARRIOR";
     Amiya_data["profession"] = "WARRIOR";
     Amiya_data["rangeId"] = json::array { "1-1", "1-1", "1-1" };
     Amiya_data["rarity"] = 5;
@@ -986,6 +990,7 @@ bool update_battle_chars_info(const fs::path& official_dir, const fs::path& over
     Amiya_data3["name_jp"] = "アーミヤ-MEDIC";
     Amiya_data3["name_kr"] = "아미야-MEDIC";
     Amiya_data3["name_tw"] = "阿米婭-MEDIC";
+    Amiya_data3["name_display"] = "阿米娅-MEDIC";
     Amiya_data3["profession"] = "MEDIC";
     Amiya_data3["rangeId"] = json::array { "3-1", "3-3", "3-3" };
     Amiya_data3["rarity"] = 5;
@@ -996,6 +1001,34 @@ bool update_battle_chars_info(const fs::path& official_dir, const fs::path& over
     std::ofstream ofs(out_file, std::ios::out);
     ofs << result.format() << '\n';
     ofs.close();
+
+    std::vector<std::pair<std::string, std::string>> overseas_paths = {
+        { "name_en", "global/YoStarEN/resource/battle_data.json" },
+        { "name_jp", "global/YoStarJP/resource/battle_data.json" },
+        { "name_kr", "global/YoStarKR/resource/battle_data.json" },
+        { "name_tw", "global/txwy/resource/battle_data.json" },
+    };
+
+    for (const auto& [client_name, path] : overseas_paths) {
+        json::value overseas_result;
+        overseas_result["ranges"] = result["ranges"];
+        auto& overseas_chars = overseas_result["chars"];
+
+        for (auto& [id, char_data] : chars.as_object()) {
+            auto name_opt = char_data.find<std::string>(client_name);
+            if (!name_opt) {
+                continue;
+            }
+            auto data = char_data;
+            data.emplace("name_display", *name_opt);
+            overseas_chars.emplace(id, std::move(data));
+        }
+
+        const auto& overseas_file = output_dir / path;
+        std::ofstream overseas_ofs(overseas_file, std::ios::out);
+        overseas_ofs << overseas_result.format() << '\n';
+        overseas_ofs.close();
+    }
 
     return true;
 }

--- a/tools/ResourceUpdater/main.cpp
+++ b/tools/ResourceUpdater/main.cpp
@@ -939,6 +939,7 @@ bool update_battle_chars_info(const fs::path& official_dir, const fs::path& over
         char_new_data["name_display"] = char_new_data["name"];
 
         char_new_data["profession"] = char_data["profession"];
+        char_new_data["subProfessionId"] = char_data["subProfessionId"];
         const std::string& default_range = char_data.get("phases", 0, "rangeId", "0-1");
         char_new_data["rangeId"] = json::array {
             default_range,


### PR DESCRIPTION
拆分不同服务区的角色数据，并添加 `name_display` 作为当前服务器的显示值。

## Summary by Sourcery

更新战斗角色数据的生成与配置，以支持单独的展示名称字段，并为不同地区生成对应的 `battle_data` 输出。

新功能：
- 为干员在战斗数据和配置中新增用于配合本地化名称的展示名称字段。
- 为不同海外客户端生成单独的 `battle_data.json` 文件，并填充相应的本地化展示名称。

改进：
- 在更新战斗角色数据时，对缺失名称条目的情况进行保护处理，并在生成的数据中将此类角色明确标记为不可用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update battle character data generation and configuration to support a separate display name field and generate region-specific battle_data outputs.

New Features:
- Add a display name field for operators in battle data and configuration for use alongside localized names.
- Generate separate battle_data.json files for different overseas clients with appropriate localized display names.

Enhancements:
- Guard battle character updates against unavailable name entries and mark such characters explicitly as unavailable in generated data.

</details>