### PR TITLE
Release v6.7.0

### DIFF
--- a/src/MaaWpfGui/Helper/FakeUpdateHelper.cs
+++ b/src/MaaWpfGui/Helper/FakeUpdateHelper.cs
@@ -1,0 +1,60 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using HandyControl.Tools.Command;
+using MaaWpfGui.Helper;
+using MaaWpfGui.Main;
+using Newtonsoft.Json;
+using Stylet;
+
+public class UpdateInfo
+{
+    public string CurrentVersion { get; set; } = string.Empty;
+
+    public string TargetVersion { get; set; } = string.Empty;
+
+    public bool IsUpdated { get; set; } = false;
+
+    public bool IsUpdating { get; set; } = false;
+}
+
+public static class FakeUpdateHelper
+{
+    private const string FileName = "FakeUpdate";
+
+    private static readonly UpdateInfo _updateInfo;
+
+    public static string CurrentVersion => _updateInfo.IsUpdated ? _updateInfo.TargetVersion : _updateInfo.CurrentVersion;
+
+    public static string TargetVersion => _updateInfo.TargetVersion;
+
+    public static bool IsUpdating => _updateInfo.IsUpdating;
+
+    static FakeUpdateHelper()
+    {
+        var updateInfo = JsonDataHelper.Get<UpdateInfo>(FileName);
+        if (updateInfo is null)
+        {
+            updateInfo = new UpdateInfo { CurrentVersion = "v1.0.0", TargetVersion = "v10.0.0" };
+            JsonDataHelper.Set(FileName, updateInfo);
+        }
+
+        _updateInfo = updateInfo;
+    }
+
+    public static void Updating()
+    {
+        _updateInfo.IsUpdating = true;
+        JsonDataHelper.Set(FileName, _updateInfo);
+        Bootstrapper.ShutdownAndRestartWithoutArgs();
+    }
+
+    public static void Updated()
+    {
+        _updateInfo.IsUpdated = true;
+        _updateInfo.IsUpdating = false;
+        JsonDataHelper.Set(FileName, _updateInfo);
+        Bootstrapper.ShutdownAndRestartWithoutArgs();
+    }
+}

--- a/src/MaaWpfGui/Main/Bootstrapper.cs
+++ b/src/MaaWpfGui/Main/Bootstrapper.cs
@@ -611,6 +611,12 @@ public class Bootstrapper : Bootstrapper<RootViewModel>
         Instances.WindowManager.ShowWindow(rootViewModel);
         Instances.InstantiateOnRootViewDisplayed(Container);
 
+        if (FakeUpdateHelper.IsUpdating)
+        {
+            FakeUpdateHelper.Updated();
+            return;
+        }
+
         // 如果 IsFirstBootAfterUpdate 从 false 变为 true，说明这次启动只是解压更新包，不用执行后续逻辑
         if (!wasFirstBoot && Instances.VersionUpdateDialogViewModel.IsFirstBootAfterUpdate)
         {

--- a/src/MaaWpfGui/ViewModels/Dialogs/VersionUpdateDialogViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/Dialogs/VersionUpdateDialogViewModel.cs
@@ -72,10 +72,10 @@ public class VersionUpdateDialogViewModel : Screen
         return Regex.Replace(text, @"([^\[`]|^)@([^\s]+)", "$1[@$2](https://github.com/$2)");
     }
 
-    private readonly string _curVersion = Marshal.PtrToStringAnsi(MaaService.AsstGetVersion()) ?? "0.0.1";
+    private readonly string _curVersion = FakeUpdateHelper.CurrentVersion; // Marshal.PtrToStringAnsi(MaaService.AsstGetVersion()) ?? "0.0.1";
     private string _latestVersion = string.Empty;
 
-    private string _updateTag = ConfigurationHelper.GetGlobalValue(ConfigurationKeys.VersionName, string.Empty);
+    private string _updateTag = FakeUpdateHelper.TargetVersion; // ConfigurationHelper.GetGlobalValue(ConfigurationKeys.VersionName, string.Empty);
 
     /// <summary>
     /// Gets or sets the update tag.
@@ -84,12 +84,14 @@ public class VersionUpdateDialogViewModel : Screen
     {
         get => _updateTag;
         set {
-            SetAndNotify(ref _updateTag, value);
-            ConfigurationHelper.SetGlobalValue(ConfigurationKeys.VersionName, value);
+            // SetAndNotify(ref _updateTag, value);
+            // ConfigurationHelper.SetGlobalValue(ConfigurationKeys.VersionName, value);
         }
     }
 
-    private string _updateInfo = ConfigurationHelper.GetGlobalValue(ConfigurationKeys.VersionUpdateBody, string.Empty);
+    private static readonly string _updateInfoFilePath = Path.Combine(PathsHelper.DataDir, "updateInfo.txt");
+
+    private string _updateInfo = File.Exists(_updateInfoFilePath) ? File.ReadAllText(_updateInfoFilePath) : string.Empty; // ConfigurationHelper.GetGlobalValue(ConfigurationKeys.VersionUpdateBody, string.Empty);
 
     // private static readonly MarkdownPipeline s_markdownPipeline = new MarkdownPipelineBuilder().UseXamlSupportedExtensions().Build();
 

--- a/src/MaaWpfGui/ViewModels/UI/RootViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/RootViewModel.cs
@@ -100,7 +100,9 @@ public class RootViewModel : Conductor<Screen>.Collection.OneActive
         set => SetAndNotify(ref _windowTitle, value);
     }
 
-    private string _windowVersionUpdateInfo = string.Empty;
+    private string _windowVersionUpdateInfo = FakeUpdateHelper.CurrentVersion == FakeUpdateHelper.TargetVersion
+        ? string.Empty
+        : $"{LocalizationHelper.GetString("NewVersionFoundTitle")}: {FakeUpdateHelper.TargetVersion}";
 
     /// <summary>
     /// Gets or sets the version update info.

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -995,6 +995,8 @@ public class TaskQueueViewModel : Screen
             }
         }
 
+        // CanShowAutoReload = true;
+
         TaskItemViewModels = [.. taskqueue];
         TaskItemViewModels.CollectionChanged += TaskItemSelectionChanged;
         var taskItem = TaskItemViewModels.ElementAtOrDefault(ConfigFactory.CurrentConfig.TaskSelectedIndex);

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/VersionUpdateSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/VersionUpdateSettingsUserControlModel.cs
@@ -69,7 +69,7 @@ public class VersionUpdateSettingsUserControlModel : PropertyChangedBase
     /// <summary>
     /// Gets the core version.
     /// </summary>
-    public static string CoreVersion { get; } = Marshal.PtrToStringAnsi(MaaService.AsstGetVersion()) ?? "0.0.1";
+    public static string CoreVersion { get; } = FakeUpdateHelper.CurrentVersion; // Marshal.PtrToStringAnsi(MaaService.AsstGetVersion()) ?? "0.0.1";
 
     public static string CoreVersionDisplay => string.Join("\u200B", CoreVersion.ToCharArray());
 
@@ -78,7 +78,7 @@ public class VersionUpdateSettingsUserControlModel : PropertyChangedBase
     /// <summary>
     /// Gets the UI version.
     /// </summary>
-    public static string UiVersion { get; } = _uiVersion == "0.0.1" ? "DEBUG_VERSION" : _uiVersion;
+    public static string UiVersion { get; } = FakeUpdateHelper.CurrentVersion; // _uiVersion == "0.0.1" ? "DEBUG_VERSION" : _uiVersion;
 
     public static string UiVersionDisplay => string.Join("\u200B", UiVersion.ToCharArray());
 
@@ -386,7 +386,7 @@ public class VersionUpdateSettingsUserControlModel : PropertyChangedBase
         OnPropertyChanged(nameof(MirrorChyanCdkExpiredLocalTime));
     }
 
-    private bool _startupUpdateCheck = Convert.ToBoolean(ConfigurationHelper.GetGlobalValue(ConfigurationKeys.StartupUpdateCheck, bool.TrueString));
+    private bool _startupUpdateCheck = false; // Convert.ToBoolean(ConfigurationHelper.GetGlobalValue(ConfigurationKeys.StartupUpdateCheck, bool.TrueString));
 
     // UI 绑定的方法
     [UsedImplicitly]
@@ -453,6 +453,17 @@ public class VersionUpdateSettingsUserControlModel : PropertyChangedBase
         }
     }
 
+    private bool _fakeIsCheckingForUpdates = Convert.ToBoolean(ConfigurationHelper.GetGlobalValue(ConfigurationKeys.UpdateAutoCheck, bool.FalseString));
+
+    public bool FakeIsCheckingForUpdates
+    {
+        get => _fakeIsCheckingForUpdates;
+        set
+        {
+            SetAndNotify(ref _fakeIsCheckingForUpdates, value);
+        }
+    }
+
     private bool _isCheckingForUpdates;
 
     /// <summary>
@@ -466,7 +477,7 @@ public class VersionUpdateSettingsUserControlModel : PropertyChangedBase
         }
     }
 
-    private bool _autoDownloadUpdatePackage = Convert.ToBoolean(ConfigurationHelper.GetGlobalValue(ConfigurationKeys.AutoDownloadUpdatePackage, bool.TrueString));
+    private bool _autoDownloadUpdatePackage = false; // Convert.ToBoolean(ConfigurationHelper.GetGlobalValue(ConfigurationKeys.AutoDownloadUpdatePackage, bool.TrueString));
 
     /// <summary>
     /// Gets or sets a value indicating whether to auto download update package.
@@ -501,6 +512,12 @@ public class VersionUpdateSettingsUserControlModel : PropertyChangedBase
     [UsedImplicitly]
     public async Task ManualUpdate()
     {
+        IsCheckingForUpdates = true;
+        await Task.Delay(1000);
+        IsCheckingForUpdates = false;
+        FakeUpdateHelper.Updating();
+        return;
+
         if (IsCheckingForUpdates)
         {
             return;

--- a/src/MaaWpfGui/Views/UserControl/Settings/VersionUpdateSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/Settings/VersionUpdateSettingsUserControl.xaml
@@ -49,7 +49,7 @@
                     HorizontalAlignment="Left"
                     VerticalAlignment="Center"
                     Content="{DynamicResource StartupUpdateCheck}"
-                    IsChecked="{Binding StartupUpdateCheck}"
+                    IsChecked="True"
                     IsEnabled="False" />
                 <StackPanel Margin="8" Orientation="Horizontal">
                     <CheckBox
@@ -64,7 +64,7 @@
                     HorizontalAlignment="Left"
                     VerticalAlignment="Center"
                     Content="{DynamicResource UpdateAutoDownload}"
-                    IsChecked="{Binding AutoDownloadUpdatePackage}" />
+                    IsChecked="{Binding FakeIsCheckingForUpdates}" />
                 <CheckBox
                     Margin="8"
                     HorizontalAlignment="Left"


### PR DESCRIPTION
## Summary by Sourcery

使用新的假更新助手模拟应用版本更新，并暂时绕过真实的更新服务和基于配置驱动的更新流程。

新功能：
- 添加 `FakeUpdateHelper` 工具，用于在重启之间持久化和管理虚构的当前/目标版本以及更新状态。
- 当基于虚构更新信息检测到存在更新的目标版本时，在窗口级别显示通知。

增强：
- 将核心和 UI 的版本显示，以及更新对话框中的当前和目标版本，由原先依赖核心服务和已存配置值改为通过 `FakeUpdateHelper` 进行路由。
- 从本地文件加载版本更新对话框的更新正文文本，而不是从配置存储中读取。
- 对手动更新动作进行短路处理，使用 `FakeUpdateHelper` 和一个短暂的“检查中”状态来模拟完整的更新周期。
- 将 `FakeUpdateHelper` 集成到启动流程中，使应用在启动时能在更新进行中时完成虚构的更新流程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Simulate application version updates using a new fake update helper and temporarily bypass the real update service and configuration-driven update flow.

New Features:
- Add a FakeUpdateHelper utility to persist and manage fake current/target versions and updating state across restarts.
- Display a window-level notification when a newer target version is available based on the fake update information.

Enhancements:
- Route core and UI version display, as well as the update dialog’s current and target version, through FakeUpdateHelper instead of the core service and stored config values.
- Load update body text for the version update dialog from a local file rather than configuration storage.
- Short-circuit the manual update action to simulate an update cycle using FakeUpdateHelper and a brief checking state.
- Integrate FakeUpdateHelper into the bootstrap process so the app completes the fake update flow on startup when an update is in progress.

</details>