### PR TITLE
chore: 重新将natvis添加到MaaCore

### DIFF
--- a/src/MaaCore/CMakeLists.txt
+++ b/src/MaaCore/CMakeLists.txt
@@ -45,7 +45,7 @@ if(APPLE AND WITH_MAC_SCK)
 endif()
 
 if(MSVC)
-    target_sources(MaaCore PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/meojson.natvis")
+    set_target_properties(MaaCore PROPERTIES VS_DEBUGGER_VISUALIZER "${CMAKE_CURRENT_SOURCE_DIR}/meojson.natvis")
 endif()
 
 file(GLOB_RECURSE MaaCore_PUBLIC_HEADERS ${PROJECT_SOURCE_DIR}/include/*.h)

--- a/src/MaaCore/CMakeLists.txt
+++ b/src/MaaCore/CMakeLists.txt
@@ -44,6 +44,10 @@ if(APPLE AND WITH_MAC_SCK)
                                   "-framework ScreenCaptureKit")
 endif()
 
+if(MSVC)
+    target_sources(MaaCore PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/meojson.natvis")
+endif()
+
 file(GLOB_RECURSE MaaCore_PUBLIC_HEADERS ${PROJECT_SOURCE_DIR}/include/*.h)
 target_sources(MaaCore PUBLIC ${MaaCore_PUBLIC_HEADERS})
 set_target_properties(MaaCore PROPERTIES PUBLIC_HEADER "${MaaCore_PUBLIC_HEADERS}")


### PR DESCRIPTION
## Summary by Sourcery

Build:
- 在使用 MSVC 构建时，将 `meojson.natvis` 作为 MaaCore 目标的私有源文件包含进去。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Include meojson.natvis as a private source of the MaaCore target when building with MSVC.

</details>