### PR TITLE
feat(wpf): 非法Enum值将使用属性设置的默认值作为替代

### DIFF
--- a/src/MaaWpfGui/Configuration/Converter/FightTaskStageResetModeConverter.cs
+++ b/src/MaaWpfGui/Configuration/Converter/FightTaskStageResetModeConverter.cs
@@ -55,7 +55,7 @@ internal class FightTaskStageResetModeConverter : JsonConverter<Root>
                         var task = rootObj.Configurations[configName].TaskQueue[taskIndex];
                         if (task is FightTask fightTask)
                         {
-                            if (!taskElement.TryGetProperty("StageResetMode", out _))
+                            if (!taskElement.TryGetProperty("StageResetMode", out var mode) || !Enum.TryParse<FightStageResetMode>(mode.GetString(), out var _))
                             {
                                 if (fightTask.HideUnavailableStage)
                                 {

--- a/src/MaaWpfGui/Configuration/Converter/InvalidEnumValueRemoveConverter.cs
+++ b/src/MaaWpfGui/Configuration/Converter/InvalidEnumValueRemoveConverter.cs
@@ -1,0 +1,222 @@
+// <copyright file="InvalidEnumValueRemoveConverter.cs" company="MaaAssistantArknights">
+// Part of the MaaWpfGui project, maintained by the MaaAssistantArknights team (Maa Team)
+// Copyright (C) 2021-2025 MaaAssistantArknights Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License v3.0 only as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY
+// </copyright>
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
+using Serilog;
+
+namespace MaaWpfGui.Configuration.Converter;
+
+internal sealed class InvalidEnumValueRemoveConverter : JsonConverter<Root>
+{
+    private readonly ILogger _logger = Log.ForContext<InvalidEnumValueRemoveConverter>();
+
+    public override Root? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType != JsonTokenType.StartObject)
+        {
+            throw new JsonException("Expected StartObject token");
+        }
+
+        using var jsonDoc = JsonDocument.ParseValue(ref reader);
+        string json = jsonDoc.RootElement.GetRawText();
+        try
+        {
+            return JsonSerializer.Deserialize<Root>(json, GetOptionsWithoutThisConverter(options));
+        }
+        catch (JsonException ex) when (IsRecoverableInvalidEnumFailure(ex))
+        {
+            var node = JsonNode.Parse(json);
+            if (node is not JsonObject rootObj)
+            {
+                throw new JsonException("Root configuration JSON must be a JSON object.", ex);
+            }
+
+            if (!TryRemovePropertyByMetadataPath(rootObj, ex.Path))
+            {
+                throw;
+            }
+
+            _logger.Warning(ex, "Invalid enum in configuration JSON at path {Path}; removed property and retrying deserialization once", ex.Path);
+
+            var obj = JsonSerializer.Deserialize<Root>(rootObj.ToJsonString(), GetOptionsWithoutThisConverter(options));
+            _logger.Information("Deserialization succeeded after removing invalid enum property at path {Path}", ex.Path);
+            return obj;
+        }
+    }
+
+    public override void Write(Utf8JsonWriter writer, Root value, JsonSerializerOptions options)
+    {
+        JsonSerializer.Serialize(writer, value, GetOptionsWithoutThisConverter(options)); // 使用默认序列化
+    }
+
+    private static bool IsRecoverableInvalidEnumFailure(JsonException ex)
+    {
+        if (string.IsNullOrWhiteSpace(ex.Path))
+        {
+            return false;
+        }
+
+        var text = ex.ToString();
+        return text.Contains("could not be converted", StringComparison.OrdinalIgnoreCase) && text.Contains("Enum", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static bool TryRemovePropertyByMetadataPath(JsonObject root, string? path)
+    {
+        if (string.IsNullOrEmpty(path))
+        {
+            return false;
+        }
+
+        var segments = new List<string>();
+        if (!TryParseJsonExceptionPath(path, segments) || segments.Count == 0)
+        {
+            return false;
+        }
+
+        JsonNode? parent = root;
+        for (int i = 0; i < segments.Count - 1; i++)
+        {
+            parent = NavigateJsonPathSegment(parent, segments[i]);
+            if (parent is null)
+            {
+                return false;
+            }
+        }
+
+        var leaf = segments[^1];
+        return parent is JsonObject leafObject && leafObject.Remove(leaf);
+    }
+
+    private static JsonNode? NavigateJsonPathSegment(JsonNode? current, string segment)
+    {
+        return current switch {
+            JsonObject obj => obj[segment],
+            JsonArray arr when int.TryParse(segment, out var idx) && idx >= 0 && idx < arr.Count => arr[idx],
+            _ => null,
+        };
+    }
+
+    /// <summary>
+    /// 解析 <see cref="JsonException.Path"/> 风格路径（如 <c>$.Configurations.default.TaskQueue[0].StageResetMode</c>）。
+    /// </summary>
+    private static bool TryParseJsonExceptionPath(string path, List<string> segments)
+    {
+        segments.Clear();
+        if (path.Length == 0 || path[0] != '$')
+        {
+            return false;
+        }
+
+        var i = 1;
+        if (i < path.Length && path[i] == '.')
+        {
+            i++;
+        }
+
+        while (i < path.Length)
+        {
+            if (path[i] == '.')
+            {
+                i++;
+                continue;
+            }
+
+            if (path[i] == '[')
+            {
+                i++;
+                if (i >= path.Length)
+                {
+                    return false;
+                }
+
+                if (path[i] == '\'' || path[i] == '"')
+                {
+                    var q = path[i++];
+                    var start = i;
+                    while (i < path.Length && path[i] != q)
+                    {
+                        i++;
+                    }
+
+                    if (i >= path.Length)
+                    {
+                        return false;
+                    }
+
+                    segments.Add(path.Substring(start, i - start));
+                    i++;
+                    if (i < path.Length && path[i] == ']')
+                    {
+                        i++;
+                    }
+                }
+                else
+                {
+                    var start = i;
+                    while (i < path.Length && path[i] != ']')
+                    {
+                        i++;
+                    }
+
+                    if (i >= path.Length)
+                    {
+                        return false;
+                    }
+
+                    segments.Add(path.Substring(start, i - start).Trim());
+                }
+
+                if (i < path.Length && path[i] == ']')
+                {
+                    i++;
+                }
+            }
+            else
+            {
+                var start = i;
+                while (i < path.Length && path[i] != '.' && path[i] != '[')
+                {
+                    i++;
+                }
+
+                var name = path.Substring(start, i - start);
+                if (name.Length > 0)
+                {
+                    segments.Add(name);
+                }
+            }
+        }
+
+        return segments.Count > 0;
+    }
+
+    /// <summary>
+    /// 获取不包含当前 Converter 的 JsonSerializerOptions，避免无限递归
+    /// </summary>
+    private static JsonSerializerOptions GetOptionsWithoutThisConverter(JsonSerializerOptions options)
+    {
+        var newOptions = new JsonSerializerOptions(options);
+        for (int i = newOptions.Converters.Count - 1; i >= 0; i--)
+        {
+            if (newOptions.Converters[i] is InvalidEnumValueRemoveConverter)
+            {
+                newOptions.Converters.RemoveAt(i);
+            }
+        }
+        return newOptions;
+    }
+}

--- a/src/MaaWpfGui/Configuration/Factory/ConfigFactory.cs
+++ b/src/MaaWpfGui/Configuration/Factory/ConfigFactory.cs
@@ -61,7 +61,7 @@ public static class ConfigFactory
     // ReSharper disable once EventNeverSubscribedTo.Global
     public static event ConfigurationUpdateEventHandler? ConfigurationUpdateEvent;
 
-    private static readonly JsonSerializerOptions _options = new() { WriteIndented = true, Converters = { new JsonStringEnumConverter(), new FightTaskStageResetModeInvalidToIgnoreConverter(), new FightTaskStageResetModeConverter() }, Encoder = JavaScriptEncoder.Create(UnicodeRanges.All), DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull };
+    private static readonly JsonSerializerOptions _options = new() { WriteIndented = true, Converters = { new FightTaskStageResetModeConverter(), new InvalidEnumValueRemoveConverter(), new JsonStringEnumConverter(), new FightTaskStageResetModeInvalidToIgnoreConverter() }, Encoder = JavaScriptEncoder.Create(UnicodeRanges.All), DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull };
 
     // TODO: 参考 ConfigurationHelper ，拆几个函数出来
     private static readonly Lazy<Root> _rootConfig = new(() => {


### PR DESCRIPTION
## Summary by Sourcery

在配置 JSON 中更稳健地处理无效的枚举值，以防止反序列化失败，并改用默认或回退行为。

Bug 修复：
- 将缺失或无法解析的 `FightTask.StageResetMode` 值视为不存在，使任务可以回退到其默认行为。
- 当配置反序列化过程中因无效枚举值导致 `JsonException` 时，通过移除有问题的属性并重试一次来恢复。

增强功能：
- 引入一个根级别的 JSON 转换器，用于检测并移除具有无效枚举值的属性，同时记录恢复过程的日志。
- 调整 JSON 序列化器选项的顺序，确保自定义转换器在通用枚举处理之前运行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle invalid enum values in configuration JSON more robustly to prevent deserialization failures and use default or fallback behavior instead.

Bug Fixes:
- Treat missing or unparsable FightTask.StageResetMode values as absent so that the task falls back to its default behavior.
- Recover from JsonException caused by invalid enum values during configuration deserialization by removing the offending property and retrying once.

Enhancements:
- Introduce a Root-level JSON converter that detects and strips properties with invalid enum values while logging the recovery process.
- Adjust JSON serializer options ordering to ensure custom converters run before generic enum handling.

</details>