### PR TITLE
[codex] fix manual version update when auto-download is disabled

### DIFF
--- a/src/MaaWpfGui/ViewModels/Dialogs/VersionUpdateDialogViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/Dialogs/VersionUpdateDialogViewModel.cs
@@ -554,7 +554,7 @@ public class VersionUpdateDialogViewModel : Screen
     /// 检查更新，并下载更新包。
     /// </summary>
     /// <returns>操作成功返回 <see langword="true"/>，反之则返回 <see langword="false"/>。</returns>
-    public async Task<CheckUpdateRetT> CheckAndDownloadVersionUpdate()
+    public async Task<CheckUpdateRetT> CheckAndDownloadVersionUpdate(bool forceDownload = false)
     {
         try
         {
@@ -568,8 +568,8 @@ public class VersionUpdateDialogViewModel : Screen
             }
 
             return source switch {
-                AppUpdateSource.MaaApi => await HandleUpdateFromMaaApi(),
-                AppUpdateSource.MirrorChyan => await HandleUpdateFromMirrorChyan(),
+                AppUpdateSource.MaaApi => await HandleUpdateFromMaaApi(forceDownload),
+                AppUpdateSource.MirrorChyan => await HandleUpdateFromMirrorChyan(forceDownload),
                 _ => CheckUpdateRetT.UnknownError,
             };
         }
@@ -579,7 +579,12 @@ public class VersionUpdateDialogViewModel : Screen
         }
     }
 
-    private async Task<CheckUpdateRetT> HandleUpdateFromMaaApi()
+    private static bool ShouldDownloadUpdatePackage(bool hasPackage, bool forceDownload)
+    {
+        return hasPackage && (forceDownload || SettingsViewModel.VersionUpdateSettings.AutoDownloadUpdatePackage);
+    }
+
+    private async Task<CheckUpdateRetT> HandleUpdateFromMaaApi(bool forceDownload)
     {
         // 保存新版本的信息
         var name = _latestJson?["name"]?.ToString();
@@ -601,13 +606,13 @@ public class VersionUpdateDialogViewModel : Screen
         UpdateUrl = _latestJson?["html_url"]?.ToString() ?? string.Empty;
 
         bool otaFound = _assetsObject != null;
-        bool goDownload = otaFound && SettingsViewModel.VersionUpdateSettings.AutoDownloadUpdatePackage;
+        bool shouldDownload = ShouldDownloadUpdatePackage(otaFound, forceDownload);
 
-        ShowUpdateInfo(otaFound, LocalizationHelper.GetString("NewVersionFoundButtonGoWebpage"), true);
+        ShowUpdateInfo(otaFound, LocalizationHelper.GetString("NewVersionFoundButtonGoWebpage"), true, shouldDownload);
 
         UpdatePackageName = _assetsObject?["name"]?.ToString() ?? string.Empty;
 
-        if (!goDownload || string.IsNullOrWhiteSpace(UpdatePackageName))
+        if (!shouldDownload || string.IsNullOrWhiteSpace(UpdatePackageName))
         {
             OutputDownloadProgress(string.Empty, downloading: false);
             return CheckUpdateRetT.NoNeedToUpdate;
@@ -730,12 +735,10 @@ public class VersionUpdateDialogViewModel : Screen
         }
     }
 
-    private void ShowUpdateInfo(bool otaFound, string? text, bool globalSource)
+    private void ShowUpdateInfo(bool otaFound, string? text, bool globalSource, bool shouldDownload)
     {
-        bool goDownload = otaFound && SettingsViewModel.VersionUpdateSettings.AutoDownloadUpdatePackage;
-
         using var toast = new ToastNotification((otaFound ? LocalizationHelper.GetString("NewVersionFoundTitle") : LocalizationHelper.GetString("NewVersionFoundButNoPackageTitle")) + " : " + UpdateTag);
-        if (goDownload)
+        if (shouldDownload)
         {
             OutputDownloadProgress(LocalizationHelper.GetString("NewVersionDownloadPreparing"), false, globalSource);
             toast.AppendContentText(globalSource
@@ -771,7 +774,7 @@ public class VersionUpdateDialogViewModel : Screen
         toast.ShowUpdateVersion();
     }
 
-    private async Task<CheckUpdateRetT> HandleUpdateFromMirrorChyan()
+    private async Task<CheckUpdateRetT> HandleUpdateFromMirrorChyan(bool forceDownload)
     {
         if (string.IsNullOrEmpty(_mirrorcDownloadUrl))
         {
@@ -782,11 +785,11 @@ public class VersionUpdateDialogViewModel : Screen
         UpdateInfo = _mirrorcReleaseNote ?? string.Empty;
         SettingsViewModel.VersionUpdateSettings.NewVersionFoundInfo = $"{LocalizationHelper.GetString("NewVersionFoundTitle")}: {UpdateTag}";
 
-        bool goDownload = SettingsViewModel.VersionUpdateSettings.AutoDownloadUpdatePackage;
+        bool shouldDownload = ShouldDownloadUpdatePackage(hasPackage: true, forceDownload);
 
-        ShowUpdateInfo(true, LocalizationHelper.GetString("NewVersionFoundButtonGoWebpage"), false);
+        ShowUpdateInfo(true, LocalizationHelper.GetString("NewVersionFoundButtonGoWebpage"), false, shouldDownload);
 
-        if (!goDownload)
+        if (!shouldDownload)
         {
             OutputDownloadProgress(string.Empty, downloading: false);
             return CheckUpdateRetT.NoNeedToUpdate;

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/VersionUpdateSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/VersionUpdateSettingsUserControlModel.cs
@@ -512,7 +512,7 @@ public class VersionUpdateSettingsUserControlModel : PropertyChangedBase
             return;
         }
 
-        var ret = await Instances.VersionUpdateDialogViewModel.CheckAndDownloadVersionUpdate();
+        var ret = await Instances.VersionUpdateDialogViewModel.CheckAndDownloadVersionUpdate(forceDownload: true);
 
         var toastMessage = ret switch {
             VersionUpdateDialogViewModel.CheckUpdateRetT.NoNeedToUpdate => string.Empty,


### PR DESCRIPTION
## Related Issue
- Closes #16126

## Problem
When users disable `AutoDownloadUpdatePackage` in Settings, clicking the manual `Software update` button does not actually update MAA. It only checks for a newer version and then returns without downloading.

## User Impact
This breaks the expected behavior of the manual update flow:
- Resource update can still be performed manually.
- Version update cannot be performed manually once auto-download is off.

## Root Cause
`ManualUpdate()` calls `CheckAndDownloadVersionUpdate()`.
Inside the update pipeline, both Maa API and MirrorChyan branches decide whether to download by checking only `AutoDownloadUpdatePackage`.
So in manual flow with auto-download disabled, the code returns `NoNeedToUpdate` before any download starts.

## Fix
- Added an optional `forceDownload` parameter to `CheckAndDownloadVersionUpdate`.
- Threaded this flag into both source-specific handlers:
  - `HandleUpdateFromMaaApi`
  - `HandleUpdateFromMirrorChyan`
- Updated `ShowUpdateInfo` to use the same effective download decision, so UI/toast state remains consistent.
- Changed `ManualUpdate()` to call `CheckAndDownloadVersionUpdate(forceDownload: true)`.

This preserves existing behavior for startup/scheduled checks while making manual update truly manual and actionable.

## Validation
- Code-path validation by inspection:
  - Manual update now bypasses auto-download gate and enters download flow.
  - Non-manual callers still use default `forceDownload = false` and keep previous semantics.
- Environment limitation:
  - `dotnet` SDK is not available in the current environment, so project build/tests could not be executed here.

## Summary by Sourcery

允许在关闭自动下载的情况下，手动版本更新依然可以下载更新包，同时保持自动检查时的现有行为不变。

Bug Fixes:
- 确保在手动进行版本更新时，无论 `AutoDownloadUpdatePackage` 设置为何，都会触发更新包下载。
- 使更新通知行为在 Maa API 和 MirrorChyan 更新流程中，都与实际的下载决策保持一致。

Enhancements:
- 通过在版本更新来源和界面通知中贯穿“强制下载”选项，统一更新处理逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allow manual version updates to download packages even when automatic download is disabled, while preserving existing behavior for automatic checks.

Bug Fixes:
- Ensure manual version update triggers package download regardless of the AutoDownloadUpdatePackage setting.
- Align update notification behavior with the effective download decision in both Maa API and MirrorChyan update flows.

Enhancements:
- Unify update handling logic by threading a force-download option through version update sources and UI notifications.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

允许在关闭自动下载的情况下，手动版本更新依然可以下载更新包，同时保持自动检查时的现有行为不变。

Bug Fixes:
- 确保在手动进行版本更新时，无论 `AutoDownloadUpdatePackage` 设置为何，都会触发更新包下载。
- 使更新通知行为在 Maa API 和 MirrorChyan 更新流程中，都与实际的下载决策保持一致。

Enhancements:
- 通过在版本更新来源和界面通知中贯穿“强制下载”选项，统一更新处理逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allow manual version updates to download packages even when automatic download is disabled, while preserving existing behavior for automatic checks.

Bug Fixes:
- Ensure manual version update triggers package download regardless of the AutoDownloadUpdatePackage setting.
- Align update notification behavior with the effective download decision in both Maa API and MirrorChyan update flows.

Enhancements:
- Unify update handling logic by threading a force-download option through version update sources and UI notifications.

</details>

</details>