### PR TITLE
docs: add FAQ guidance for Windows Defender false positives

### DIFF
--- a/docs/en-us/manual/faq.md
+++ b/docs/en-us/manual/faq.md
@@ -56,7 +56,7 @@ Due to runtime libraries and system components requiring Windows 10 or above, MA
 
 ### Flagged by Windows Defender / antivirus software (PUA / malware)
 
-- First verify the download source. Only use official channels (official website, GitHub Releases, Winget, or official community file distribution), and make sure you downloaded the full package (for example, `MAA-<version>-win-x64.zip`).
+- First verify the download source. Only use official channels (official website, GitHub Releases, Winget, or official community distribution channels), and make sure you downloaded the full package (for example, `MAA-<version>-win-x64.zip`).
 - Automation tools may trigger heuristic detections in some antivirus engines. A detection result does not always mean the program is malicious.
 - If the source is trusted, submit a false-positive sample to the security vendor and wait for signature updates.
 - While waiting, you can temporarily add the MAA installation directory to antivirus allowlists. Avoid disabling real-time protection entirely.

--- a/docs/en-us/manual/faq.md
+++ b/docs/en-us/manual/faq.md
@@ -54,6 +54,13 @@ For Windows N/KN (European/Korean versions), you also need to install the [Media
 
 Due to runtime libraries and system components requiring Windows 10 or above, MAA no longer supports Windows 7/8/8.1 systems.
 
+### Flagged by Windows Defender / antivirus software (PUA / malware)
+
+- First verify the download source. Only use official channels (official website, GitHub Releases, Winget, or official community file distribution), and make sure you downloaded the full package (for example, `MAA-<version>-win-x64.zip`).
+- Automation tools may trigger heuristic detections in some antivirus engines. A detection result does not always mean the program is malicious.
+- If the source is trusted, submit a false-positive sample to the security vendor and wait for signature updates.
+- While waiting, you can temporarily add the MAA installation directory to antivirus allowlists. Avoid disabling real-time protection entirely.
+
 ## Connection errors
 
 ### Verify ADB and connection address are correct

--- a/docs/zh-cn/manual/faq.md
+++ b/docs/zh-cn/manual/faq.md
@@ -54,6 +54,13 @@ winget install "Microsoft.VCRedist.2015+.x64" --override "/repair /passive /nore
 
 由于 MAA 依赖的运行库和系统组件要求 Windows 10 及以上版本，MAA 不再支持 Windows 7 / 8 / 8.1 系统。
 
+### 被 Windows Defender / 杀毒软件误报（PUA / 病毒）
+
+- 请先确认下载来源可信，仅使用官网、GitHub Releases、Winget 或官方群文件；并确认下载的是完整安装包（如 `MAA-<版本>-win-x64.zip`）。
+- 自动化工具可能会触发部分杀毒软件的启发式检测，出现误报并不一定代表软件存在恶意行为。
+- 若确认来源可信，建议向对应安全厂商提交误报样本，等待其病毒库修正。
+- 在等待修正期间，可临时将 MAA 安装目录加入杀毒软件白名单；不建议直接关闭系统实时防护。
+
 ## 连接错误
 
 ### 确认 ADB 及连接地址正确


### PR DESCRIPTION
## Related Issue
- Closes #16097

## What was changed
Added FAQ guidance for Windows Defender/antivirus false positives in both Chinese and English docs:
- docs/zh-cn/manual/faq.md
- docs/en-us/manual/faq.md

The new section explains:
- Use official download channels and full package naming to reduce risk of tampered binaries.
- Why heuristic detections may produce false positives for automation tools.
- Submitting false-positive samples to antivirus vendors.
- Temporary allowlist workaround without disabling real-time protection.

## Why
Issue #16097 reports Windows Defender/VT detections and asks for false-positive handling guidance. This PR adds a stable FAQ reference maintainers can point users to.

## Validation
- Docs-only change.
- Verified markdown renders as normal heading + bullet sections in both language files.

## Summary by Sourcery

文档：
- 新增英文和中文的常见问题（FAQ）条目，说明如何处理 Windows Defender 和其他杀毒软件的误报检测，包括安全下载来源、启发式检测的背景说明、向厂商报告的方法，以及临时加入允许列表的步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Add FAQ entries in English and Chinese explaining how to handle Windows Defender and antivirus false-positive detections, including safe download sources, heuristic detection context, vendor reporting, and temporary allowlisting.

</details>