### PR TITLE
fix: reset task list skipped styles after stopping

### DIFF
--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -1976,6 +1976,13 @@ public class TaskQueueViewModel : Screen
 
     public void SetStopped()
     {
+        // If this stop comes from an explicit stop flow, reset skipped/temporary
+        // task item states so the task list returns to normal selectable appearance.
+        if (_runningState.GetStopping())
+        {
+            ResetTaskItemStatuses();
+        }
+
         SleepManagement.AllowSleep();
         if (SettingsViewModel.GameSettings.ManualStopWithScript)
         {


### PR DESCRIPTION
## Related Issue
- Closes #16088

## Problem
When stopping a task chain midway, task items that were marked as `Skipped` keep their gray/locked-looking appearance in the task list, which is visually misleading.

## Root Cause
`StatusDisplay` for skipped tasks is only reset at the beginning of the next run (`ResetTaskItemStatuses()`), not when stopping.

## Fix
In `TaskQueueViewModel.SetStopped()`:
- Detect explicit stop flow via `_runningState.GetStopping()`.
- Reset task item statuses immediately with `ResetTaskItemStatuses()` before finalizing stop state.

This makes task items return to normal selectable appearance right after stop.

## Validation
- Code-path validation by inspection:
  - During stop flow (`Stopping == true`), status is reset.
  - Non-stop completion path keeps existing status display behavior.
- Could not run local build/tests in this environment because `dotnet` SDK is unavailable.

## Summary by Sourcery

错误修复：
- 当正在进行显式停止操作时，在 `SetStopped()` 中清除已跳过/临时任务列表的样式，以恢复正常的可选择外观。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Clear skipped/temporary task list styles in SetStopped() when an explicit stop is in progress to restore normal selectable appearance.

</details>