### PR TITLE
feat: check "last battle" before full stage navigation (#1179)

### DIFF
--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -1622,6 +1622,27 @@
         "action": "ClickSelf",
         "next": ["UsePrts-Annihilation", "UsePrts", "UsePrts-StageSN", "StartButton1", "#self"]
     },
+    "LastBattleStageName": {
+        "algorithm": "OcrDetect",
+        "action": "DoNothing",
+        "isAscii": true,
+        "fullMatch": true,
+        "text": [],
+        "roi": [916, 430, 249, 60],
+        "ocrReplace": [
+            ["-\\]", "-1"],
+            [" ", ""],
+            ["s", "S"],
+            ["c", "C"],
+            ["o", "O"],
+            ["g", "8"],
+            ["t", "T"],
+            [":", ""],
+            ["'", ""],
+            ["(H\\d+)O(?=-)", "$010"],
+            ["(-\\d+)O", "$010"]
+        ]
+    },
     "RecruitBegin": {
         "algorithm": "JustReturn",
         "next": [

--- a/src/MaaCore/Task/Fight/StageNavigationTask.cpp
+++ b/src/MaaCore/Task/Fight/StageNavigationTask.cpp
@@ -89,7 +89,39 @@ bool asst::StageNavigationTask::_run()
         }
     }
 
+    if (try_last_battle()) {
+        return true;
+    }
+
     return chapter_wayfinding() && swipe_and_find_stage();
+}
+
+bool asst::StageNavigationTask::try_last_battle()
+{
+    LogTraceFunction;
+
+    if (m_stage_code.empty()) {
+        return false;
+    }
+
+    auto image = ctrler()->get_image();
+    OCRer analyzer(image);
+    analyzer.set_task_info("LastBattleStageName");
+
+    if (!analyzer.analyze()) {
+        return false;
+    }
+
+    const auto& results = analyzer.get_result();
+    bool matched = std::ranges::any_of(results, [&](const auto& r) { return r.text == m_stage_code; });
+
+    if (!matched) {
+        Log.info("Last battle stage does not match target", m_stage_code);
+        return false;
+    }
+
+    Log.info("Last battle matches target, using shortcut", m_stage_code);
+    return ProcessTask(*this, { "GoLastBattle" }).set_retry_times(3).run();
 }
 
 void asst::StageNavigationTask::clear() noexcept

--- a/src/MaaCore/Task/Fight/StageNavigationTask.cpp
+++ b/src/MaaCore/Task/Fight/StageNavigationTask.cpp
@@ -100,6 +100,11 @@ bool asst::StageNavigationTask::try_last_battle()
 {
     LogTraceFunction;
 
+    if (m_last_battle_checked) {
+        return false;
+    }
+    m_last_battle_checked = true;
+
     if (m_stage_code.empty()) {
         return false;
     }
@@ -107,16 +112,10 @@ bool asst::StageNavigationTask::try_last_battle()
     auto image = ctrler()->get_image();
     OCRer analyzer(image);
     analyzer.set_task_info("LastBattleStageName");
+    analyzer.set_required({ m_stage_code });
 
     if (!analyzer.analyze()) {
-        return false;
-    }
-
-    const auto& results = analyzer.get_result();
-    bool matched = std::ranges::any_of(results, [&](const auto& r) { return r.text == m_stage_code; });
-
-    if (!matched) {
-        Log.info("Last battle stage does not match target", m_stage_code);
+        Log.info("Last battle OCR failed or stage not found near button", m_stage_code);
         return false;
     }
 
@@ -131,6 +130,7 @@ void asst::StageNavigationTask::clear() noexcept
     m_chapter_task.clear();
     m_difficulty_task.clear();
     m_stage_code.clear();
+    m_last_battle_checked = false;
 }
 
 bool asst::StageNavigationTask::chapter_wayfinding()

--- a/src/MaaCore/Task/Fight/StageNavigationTask.h
+++ b/src/MaaCore/Task/Fight/StageNavigationTask.h
@@ -22,6 +22,7 @@ protected:
     virtual bool _run() override;
     void clear() noexcept;
 
+    bool try_last_battle();
     bool chapter_wayfinding();
     bool swipe_and_find_stage();
 

--- a/src/MaaCore/Task/Fight/StageNavigationTask.h
+++ b/src/MaaCore/Task/Fight/StageNavigationTask.h
@@ -22,9 +22,12 @@ protected:
     virtual bool _run() override;
     void clear() noexcept;
 
-    bool try_last_battle();
     bool chapter_wayfinding();
     bool swipe_and_find_stage();
+
+private:
+    bool try_last_battle();
+    bool m_last_battle_checked = false;
 
     // 是否有定义任务名的Task
     bool m_is_directly = false;


### PR DESCRIPTION
## Summary

Closes #1179

指定关卡时，在进行完整章节导航之前，先 OCR 识别终端界面"前往上一次作战"按钮附近的关卡名。如果匹配目标关卡，直接点击按钮跳过导航，大幅减少反复刷同一关卡时的操作时间。

### 改动

- **`resource/tasks/tasks.json`**: 新增 `LastBattleStageName` OCR 任务，用于识别"上次作战"区域的关卡名
- **`StageNavigationTask.cpp`**: 新增 `try_last_battle()` 方法，在 `_run()` 中优先尝试快速路径
- **`StageNavigationTask.h`**: 声明 `try_last_battle()`


```
StageNavigationTask::_run()
  ├─ try_last_battle()  ← 新增
  │   ├─ OCR 读取"上次作战"区域的关卡名
  │   ├─ 匹配 m_stage_code → 点击 GoLastBattle → return true
  │   └─ 不匹配 → return false
  └─ chapter_wayfinding() + swipe_and_find_stage()  ← 原有流程（fallback）
```

### Note

- `LastBattleStageName` 的 ROI `[916, 430, 249, 60]` 是根据 `GoLastBattle` 按钮位置推算的，**需要实际截图验证**，可能需要调整

### Test

- [x] macOS arm64 编译通过
- [ ] 指定关卡 = 上次作战关卡 → 跳过导航直接开始
- [ ] 指定关卡 ≠ 上次作战关卡 → 正常导航
- [ ] 不指定关卡（stage 为空）→ 行为不变
- [ ] 首次进入终端（无"上次作战"按钮）→ 正常导航

## Sourcery 摘要

当终端的上次战斗入口与请求的关卡匹配时，通过该入口跳过关卡导航流程。

新功能：
- 添加 OCR 支持，用于识别终端上次战斗入口附近此前游玩的关卡。

增强功能：
- 当上次战斗快捷入口与请求的关卡匹配时使用该入口，同时保留现有的完整导航流程作为回退方案，并维持难度选择行为。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

允许关卡导航在回退到完整导航流程之前，使用终端中匹配的最后战斗快捷方式。

新功能：
- 添加 OCR 支持，用于识别终端最后战斗快捷方式中显示的关卡。

增强功能：
- 当最后战斗快捷方式与请求的关卡匹配时使用该快捷方式，同时保留完整的关卡导航作为回退方案，并保持难度选择行为不变。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Allow stage navigation to use the terminal’s matching last-battle shortcut before falling back to the full navigation flow.

New Features:
- Add OCR support for identifying the stage shown in the terminal’s last-battle shortcut.

Enhancements:
- Use the last-battle shortcut when it matches the requested stage, while retaining full stage navigation as a fallback and preserving difficulty-selection behavior.

</details>

</details>

新功能：
- 添加通过 OCR 读取上次战斗关卡名称的支持，并在其与目标关卡匹配时使用 `GoLastBattle` 快捷方式。

改进：
- 优化 `StageNavigationTask`，当上次战斗关卡与请求的关卡相同时，优先走更快速的短路路径，否则回退到现有的导航流程。

<details>
<summary>Original summary in English</summary>



</details>