### PR TITLE
feat: 优化芯片掉落显示

### DIFF
--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -795,10 +795,10 @@ Do not adjust the proxy multiplier setting in the game</system:String>
     <system:String x:Key="CATip">CA-5: Skill Summary</system:String>
     <system:String x:Key="LSTip">LS-6: Battle Record</system:String>
     <system:String x:Key="SKTip">SK-5: Carbon</system:String>
-    <system:String x:Key="PR-ATip">PR-A-1/2: Med&amp;Def Chip</system:String>
-    <system:String x:Key="PR-BTip">PR-B-1/2: Cst&amp;Sni Chip</system:String>
-    <system:String x:Key="PR-CTip">PR-C-1/2: Pio&amp;Sup Chip</system:String>
-    <system:String x:Key="PR-DTip">PR-D-1/2: Grd&amp;Spc Chip</system:String>
+    <system:String x:Key="PR-ATip">PR-A-1/2: |Med|&amp;|Def| Chip</system:String>
+    <system:String x:Key="PR-BTip">PR-B-1/2: |Cst|&amp;|Sni| Chip</system:String>
+    <system:String x:Key="PR-CTip">PR-C-1/2: |Pio|&amp;|Sup| Chip</system:String>
+    <system:String x:Key="PR-DTip">PR-D-1/2: |Grd|&amp;|Spc| Chip</system:String>
     <system:String x:Key="Pormpt1">It's Monday: time to clear the Annihilation</system:String>
     <system:String x:Key="Pormpt2">It's Sunday: don't forget about Annihilation</system:String>
     <!--  !FightSettings  -->

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -796,10 +796,10 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="CATip">CA-5：アーツ学</system:String>
     <system:String x:Key="LSTip">LS-6：作戦記録</system:String>
     <system:String x:Key="SKTip">SK-5：炭素材</system:String>
-    <system:String x:Key="PR-ATip">PR-A-1/2：医療&amp;重装SoC</system:String>
-    <system:String x:Key="PR-BTip">PR-B：術師&amp;狙撃SoC</system:String>
-    <system:String x:Key="PR-CTip">PR-C-1/2：先鋒&amp;補助SoC</system:String>
-    <system:String x:Key="PR-DTip">PR-D-1/2：前衛&amp;特殊SoC</system:String>
+    <system:String x:Key="PR-ATip">PR-A-1/2：|医療|&amp;|重装|SoC</system:String>
+    <system:String x:Key="PR-BTip">PR-B：|術師|&amp;|狙撃|SoC</system:String>
+    <system:String x:Key="PR-CTip">PR-C-1/2：|先鋒|&amp;|補助|SoC</system:String>
+    <system:String x:Key="PR-DTip">PR-D-1/2：|前衛|&amp;|特殊|SoC</system:String>
     <system:String x:Key="Pormpt1">月曜です。殲滅作戦がリセットされています〜</system:String>
     <system:String x:Key="Pormpt2">日曜です。殲滅作戦は忘れてないですか〜</system:String>
     <!--  !戦闘設定  -->

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -797,10 +797,10 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="CATip">CA-5: 스킬개론</system:String>
     <system:String x:Key="LSTip">LS-6: 작전기록</system:String>
     <system:String x:Key="SKTip">SK-5: 카본</system:String>
-    <system:String x:Key="PR-ATip">PR-A-1/2: 메딕&amp;디펜더 칩</system:String>
-    <system:String x:Key="PR-BTip">PR-B-1/2: 캐스터&amp;스나이퍼 칩</system:String>
-    <system:String x:Key="PR-CTip">PR-C-1/2: 뱅가드&amp;서포터 칩</system:String>
-    <system:String x:Key="PR-DTip">PR-D-1/2: 가드&amp;스페셜리스트 칩</system:String>
+    <system:String x:Key="PR-ATip">PR-A-1/2: |메딕|&amp;|디펜더| 칩</system:String>
+    <system:String x:Key="PR-BTip">PR-B-1/2: |캐스터|&amp;|스나이퍼| 칩</system:String>
+    <system:String x:Key="PR-CTip">PR-C-1/2: |뱅가드|&amp;|서포터| 칩</system:String>
+    <system:String x:Key="PR-DTip">PR-D-1/2: |가드|&amp;|스페셜리스트| 칩</system:String>
     <system:String x:Key="Pormpt1">월요일입니다. 섬멸 작전을 잊지 마세요~</system:String>
     <system:String x:Key="Pormpt2">일요일입니다. 섬멸 작전을 잊지 마세요~</system:String>
     <!--  !작전 설정  -->

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -796,10 +796,10 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="CATip">CA-5: 技能</system:String>
     <system:String x:Key="LSTip">LS-6: 经验</system:String>
     <system:String x:Key="SKTip">SK-5: 碳</system:String>
-    <system:String x:Key="PR-ATip">PR-A-1/2: 奶&amp;盾芯片</system:String>
-    <system:String x:Key="PR-BTip">PR-B-1/2: 术&amp;狙芯片</system:String>
-    <system:String x:Key="PR-CTip">PR-C-1/2: 先&amp;辅芯片</system:String>
-    <system:String x:Key="PR-DTip">PR-D-1/2: 近&amp;特芯片</system:String>
+    <system:String x:Key="PR-ATip">PR-A-1/2: |奶|&amp;|盾|芯片</system:String>
+    <system:String x:Key="PR-BTip">PR-B-1/2: |术|&amp;|狙|芯片</system:String>
+    <system:String x:Key="PR-CTip">PR-C-1/2: |先|&amp;|辅|芯片</system:String>
+    <system:String x:Key="PR-DTip">PR-D-1/2: |近|&amp;|特|芯片</system:String>
     <system:String x:Key="Pormpt1">周一了，可以打剿灭了~</system:String>
     <system:String x:Key="Pormpt2">周日了，记得打剿灭哦~</system:String>
     <!--  !战斗设置  -->

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -796,10 +796,10 @@ C:\\leidian\\LDPlayer9\n
     <system:String x:Key="CATip">CA-5: 技能書</system:String>
     <system:String x:Key="LSTip">LS-6: 經驗</system:String>
     <system:String x:Key="SKTip">SK-5: 碳</system:String>
-    <system:String x:Key="PR-ATip">PR-A-1/2: 奶&amp;盾晶片</system:String>
-    <system:String x:Key="PR-BTip">PR-B-1/2: 術&amp;狙晶片</system:String>
-    <system:String x:Key="PR-CTip">PR-C-1/2: 先&amp;輔晶片</system:String>
-    <system:String x:Key="PR-DTip">PR-D-1/2: 近&amp;特晶片</system:String>
+    <system:String x:Key="PR-ATip">PR-A-1/2: |奶|&amp;|盾|晶片</system:String>
+    <system:String x:Key="PR-BTip">PR-B-1/2: |術|&amp;|狙|晶片</system:String>
+    <system:String x:Key="PR-CTip">PR-C-1/2: |先|&amp;|輔|晶片</system:String>
+    <system:String x:Key="PR-DTip">PR-D-1/2: |近|&amp;|特|晶片</system:String>
     <system:String x:Key="Pormpt1">週一了，可以打剿滅了 ~</system:String>
     <system:String x:Key="Pormpt2">週日了，記得打剿滅喔 ~</system:String>
     <!--  !戰鬥設定  -->

--- a/src/MaaWpfGui/Res/Themes/Dark.xaml
+++ b/src/MaaWpfGui/Res/Themes/Dark.xaml
@@ -63,6 +63,12 @@
         <GradientStop Offset="1" Color="#F48FB1" />
     </LinearGradientBrush>
 
+    <!--  StageItemBrush  -->
+    <SolidColorBrush x:Key="StageItemBrush.Primary" Color="#90CAF9" />
+    <SolidColorBrush x:Key="StageItemBrush.Secondary" Color="#F48FB1" />
+    <SolidColorBrush x:Key="StageItemBrush.Tertiary" Color="#A5D6A7" />
+    <SolidColorBrush x:Key="StageItemBrush.Quaternary" Color="#FFCC80" />
+
     <!--  MdXaml Brush  -->
     <SolidColorBrush x:Key="MdXamlBackground" Color="#2d2d30" />
     <SolidColorBrush x:Key="MdXamlCodeBackground" Color="#161b22" />

--- a/src/MaaWpfGui/Res/Themes/Light.xaml
+++ b/src/MaaWpfGui/Res/Themes/Light.xaml
@@ -44,6 +44,12 @@
         <GradientStop Offset="1" Color="#EC407A" />
     </LinearGradientBrush>
 
+    <!--  StageItemBrush  -->
+    <SolidColorBrush x:Key="StageItemBrush.Primary" Color="#42A5F5" />
+    <SolidColorBrush x:Key="StageItemBrush.Secondary" Color="#EC407A" />
+    <SolidColorBrush x:Key="StageItemBrush.Tertiary" Color="#66BB6A" />
+    <SolidColorBrush x:Key="StageItemBrush.Quaternary" Color="#FFA726" />
+
     <!--  MdXaml Brush  -->
     <SolidColorBrush x:Key="MdXamlBackground" Color="#ffffff" />
     <SolidColorBrush x:Key="MdXamlCodeBackground" Color="#f6f8fa" />

--- a/src/MaaWpfGui/Services/StageManager.cs
+++ b/src/MaaWpfGui/Services/StageManager.cs
@@ -694,7 +694,10 @@ public class StageManager
             // Resource collection tip - only show one
             if (!resourceTipShown && activity is { IsResourceCollection: true, BeingOpen: true })
             {
-                inlines.Insert(0, new LineBreak());
+                if (inlines.Count > 0)
+                {
+                    inlines.Insert(0, new LineBreak());
+                }
                 inlines.Insert(0, new Run($"｢{activity.Tip}｣ {LocalizationHelper.GetString("DaysLeftOpen")}{GetDaysLeftText(activity.UtcExpireTime, now)}"));
                 resourceTipShown = true;
             }

--- a/src/MaaWpfGui/Services/StageManager.cs
+++ b/src/MaaWpfGui/Services/StageManager.cs
@@ -20,6 +20,7 @@ using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using System.Windows.Documents;
 using HandyControl.Controls;
 using HandyControl.Data;
 using MaaWpfGui.Constants.Enums;
@@ -254,8 +255,7 @@ public class StageManager
 
     private static List<MiniGameEntry> InitializeDefaultMiniGameEntries()
     {
-        var entries = new List<MiniGameEntry>
-        {
+        var entries = new List<MiniGameEntry> {
             new() { Display = LocalizationHelper.GetString("MiniGameNameSsStore"), Value = "SS@Store@Begin", TipKey = "MiniGameNameSsStoreTip" },
             new() { Display = LocalizationHelper.GetString("MiniGameNameGreenTicketStore"), Value = "GreenTicket@Store@Begin", TipKey = "MiniGameNameGreenTicketStoreTip" },
             new() { Display = LocalizationHelper.GetString("MiniGameNameYellowTicketStore"), Value = "YellowTicket@Store@Begin", TipKey = "MiniGameNameYellowTicketStoreTip" },
@@ -678,12 +678,14 @@ public class StageManager
     /// </summary>
     /// <param name="dayOfWeek">Day of week</param>
     /// <returns>Open stages</returns>
-    public string GetStageTips(DayOfWeek dayOfWeek)
+    public IEnumerable<Inline> GetStageTipsInlines(DayOfWeek dayOfWeek)
     {
-        var lines = new List<string>();
+        var inlines = new List<Inline>();
         var shownSideStories = new HashSet<string>();
         bool resourceTipShown = false;
         DateTime now = DateTime.UtcNow;
+
+        string[] colorKeys = ["StageItemBrush.Primary", "StageItemBrush.Secondary", "StageItemBrush.Tertiary", "StageItemBrush.Quaternary"];
 
         foreach (var stage in _stages.Values.Where(s => s.IsStageOpen(dayOfWeek)))
         {
@@ -692,56 +694,125 @@ public class StageManager
             // Resource collection tip - only show one
             if (!resourceTipShown && activity is { IsResourceCollection: true, BeingOpen: true })
             {
-                // 插入到第一行
-                lines.Insert(0, $"｢{activity.Tip}｣ {LocalizationHelper.GetString("DaysLeftOpen")}{GetDaysLeftText(activity.UtcExpireTime, now)}");
+                inlines.Insert(0, new LineBreak());
+                inlines.Insert(0, new Run($"｢{activity.Tip}｣ {LocalizationHelper.GetString("DaysLeftOpen")}{GetDaysLeftText(activity.UtcExpireTime, now)}"));
                 resourceTipShown = true;
             }
 
             // Side story tips
             if (!string.IsNullOrEmpty(activity?.StageName) && shownSideStories.Add(activity.StageName))
             {
-                lines.Add($"｢{activity.StageName}｣ {LocalizationHelper.GetString("DaysLeftOpen")}{GetDaysLeftText(activity.UtcExpireTime, now)}");
+                if (inlines.Count > 0)
+                {
+                    inlines.Add(new LineBreak());
+                }
+
+                inlines.Add(new Run($"｢{activity.StageName}｣ {LocalizationHelper.GetString("DaysLeftOpen")}{GetDaysLeftText(activity.UtcExpireTime, now)}"));
             }
 
             // Side story Drop item tips
             if (!string.IsNullOrEmpty(stage.Drop))
             {
+                if (inlines.Count > 0)
+                {
+                    inlines.Add(new LineBreak());
+                }
+
                 var str = $"{stage.Value}: {ItemListHelper.GetItemName(stage.Drop) ?? stage.Drop}";
                 var count = Instances.ToolboxViewModel?.DepotResult?.FirstOrDefault(d => d.Id == stage.Drop)?.DisplayCount;
                 if (!string.IsNullOrEmpty(count))
                 {
                     str += $" ({LocalizationHelper.GetString("Inventory")} {count})";
                 }
-
-                lines.Add(str);
+                inlines.Add(new Run(str));
             }
 
             // Normal stage tips
             if (!string.IsNullOrEmpty(stage.Tip))
             {
-                lines.Add(stage.Tip);
+                if (inlines.Count > 0)
+                {
+                    inlines.Add(new LineBreak());
+                }
+
+                if (stage.DropGroups != null && stage.DropGroups.Count > 0 && stage.DropGroups[0].Count >= 2 && stage.Tip.Contains('|'))
+                {
+                    var parts = stage.Tip.Split('|');
+                    if (parts.Length >= 5)
+                    {
+                        inlines.Add(new Run(parts[0]));
+
+                        var run1 = new Run(parts[1]);
+                        string brush1 = colorKeys[0 % colorKeys.Length];
+                        run1.SetResourceReference(TextElement.ForegroundProperty, brush1);
+                        run1.Tag = brush1;
+                        inlines.Add(run1);
+
+                        inlines.Add(new Run(parts[2]));
+
+                        var run2 = new Run(parts[3]);
+                        string brush2 = colorKeys[1 % colorKeys.Length];
+                        run2.SetResourceReference(TextElement.ForegroundProperty, brush2);
+                        run2.Tag = brush2;
+                        inlines.Add(run2);
+
+                        if (!string.IsNullOrEmpty(parts[4]))
+                        {
+                            inlines.Add(new Run(parts[4]));
+                        }
+                    }
+                    else
+                    {
+                        inlines.Add(new Run(stage.Tip.Replace("|", String.Empty)));
+                    }
+                }
+                else
+                {
+                    inlines.Add(new Run(stage.Tip.Replace("|", String.Empty)));
+                }
             }
 
             // Drop groups tips (for chip stages like PR-A-1/2)
             if (stage.DropGroups != null && stage.DropGroups.Count > 0
                 && stage.DropGroups.SelectMany(i => i).Select(dropId => Instances.ToolboxViewModel?.DepotResult?.FirstOrDefault(d => d.Id == dropId)?.Count).Any(x => x >= 0))
             {
-                var groupTexts = new List<string>();
-                foreach (var dropGroup in stage.DropGroups)
+                if (inlines.Count > 0)
                 {
-                    var itemCounts = dropGroup
-                        .Select(dropId => Instances.ToolboxViewModel?.DepotResult?.FirstOrDefault(d => d.Id == dropId)?.DisplayCount ?? "--")
-                        .ToList();
-                    groupTexts.Add(string.Join(" & ", itemCounts));
+                    inlines.Add(new LineBreak());
                 }
 
-                string inventoryLabel = LocalizationHelper.GetString("Inventory");
-                string inventoryText = $" ({inventoryLabel} {string.Join(" / ", groupTexts)})";
-                lines.Add(inventoryText);
+                inlines.Add(new Run($"({LocalizationHelper.GetString("Inventory")} "));
+
+                for (int g = 0; g < stage.DropGroups.Count; g++)
+                {
+                    var dropGroup = stage.DropGroups[g];
+                    if (g > 0)
+                    {
+                        inlines.Add(new Run(" / "));
+                    }
+
+                    for (int i = 0; i < dropGroup.Count; i++)
+                    {
+                        if (i > 0)
+                        {
+                            inlines.Add(new Run(" & "));
+                        }
+
+                        var dropId = dropGroup[i];
+                        string countStr = Instances.ToolboxViewModel?.DepotResult?.FirstOrDefault(d => d.Id == dropId)?.DisplayCount ?? "--";
+
+                        var countRun = new Run(countStr);
+                        string brushKey = colorKeys[i % colorKeys.Length];
+                        countRun.SetResourceReference(TextElement.ForegroundProperty, brushKey);
+                        countRun.Tag = brushKey;
+                        inlines.Add(countRun);
+                    }
+                }
+                inlines.Add(new Run(")"));
             }
         }
 
-        return lines.Count > 0 ? string.Join(Environment.NewLine, lines) : string.Empty;
+        return inlines;
     }
 
     /// <summary>

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -1097,22 +1097,24 @@ public class TaskQueueViewModel : Screen
     // 这个函数被列为public可见，意味着他注入对象前被调用
     public void UpdateDatePrompt()
     {
-        var inlines = new ObservableCollection<Inline>
-        {
-            new Run(LocalizationHelper.GetString("TodaysStageTip") + "\n"),
-        };
-
-        // Open stages today
-        var openStages = Instances.StageManager.GetStageTipsInlines(CurDayOfWeek);
-        if (openStages != null)
-        {
-            foreach (var inline in openStages)
+        Execute.OnUIThread(() => {
+            var inlines = new ObservableCollection<Inline>
             {
-                inlines.Add(inline);
-            }
-        }
+                new Run(LocalizationHelper.GetString("TodaysStageTip") + "\n"),
+            };
 
-        StagesOfTodayInlines = inlines;
+            // Open stages today
+            var openStages = Instances.StageManager.GetStageTipsInlines(CurDayOfWeek);
+            if (openStages != null)
+            {
+                foreach (var inline in openStages)
+                {
+                    inlines.Add(inline);
+                }
+            }
+
+            StagesOfTodayInlines = inlines;
+        });
     }
 
     private ObservableCollection<Inline>? _stagesOfTodayInlines;

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -26,6 +26,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Documents;
 using System.Windows.Media.Imaging;
 using JetBrains.Annotations;
 using MaaWpfGui.Configuration.Factory;
@@ -1096,45 +1097,30 @@ public class TaskQueueViewModel : Screen
     // 这个函数被列为public可见，意味着他注入对象前被调用
     public void UpdateDatePrompt()
     {
-        var builder = new StringBuilder(LocalizationHelper.GetString("TodaysStageTip") + "\n");
-
-        // Closed activity stages
-        /*
-        foreach (var stage in FightTask.Stages)
+        var inlines = new ObservableCollection<Inline>
         {
-            if (stage == null || Instances.StageManager.GetStageInfo(stage).IsActivityClosed() != true)
-            {
-                continue;
-            }
-
-            builder.Append(stage).Append(": ").AppendLine(LocalizationHelper.GetString("ClosedStage"));
-        }*/
+            new Run(LocalizationHelper.GetString("TodaysStageTip") + "\n"),
+        };
 
         // Open stages today
-        var openStages = Instances.StageManager.GetStageTips(CurDayOfWeek);
-        if (!string.IsNullOrEmpty(openStages))
+        var openStages = Instances.StageManager.GetStageTipsInlines(CurDayOfWeek);
+        if (openStages != null)
         {
-            builder.Append(openStages);
+            foreach (var inline in openStages)
+            {
+                inlines.Add(inline);
+            }
         }
 
-        var prompt = builder.ToString();
-        if (StagesOfToday == prompt)
-        {
-            return;
-        }
-
-        StagesOfToday = prompt;
+        StagesOfTodayInlines = inlines;
     }
 
-    private string _stagesOfToday = string.Empty;
+    private ObservableCollection<Inline>? _stagesOfTodayInlines;
 
-    /// <summary>
-    /// Gets or private sets the stages of today.
-    /// </summary>
-    public string StagesOfToday
+    public ObservableCollection<Inline>? StagesOfTodayInlines
     {
-        get => _stagesOfToday;
-        private set => SetAndNotify(ref _stagesOfToday, value);
+        get => _stagesOfTodayInlines;
+        private set => SetAndNotify(ref _stagesOfTodayInlines, value);
     }
 
     public enum LogCardSplitMode

--- a/src/MaaWpfGui/Views/UI/TaskQueueView.xaml
+++ b/src/MaaWpfGui/Views/UI/TaskQueueView.xaml
@@ -572,7 +572,7 @@
                         PanningMode="Both">
                         <controls:TextBlock
                             d:Text="{DynamicResource TodaysStageTip}"
-                            Text="{Binding StagesOfToday}"
+                            controls:TextBlock.BindableInlines="{Binding StagesOfTodayInlines}"
                             TextWrapping="Wrap" />
                     </hc:ScrollViewer>
                     <Border Width="200" Margin="0,10,30,10">


### PR DESCRIPTION
效果：

<img width="143" height="137" alt="image" src="https://github.com/user-attachments/assets/454cd41f-5577-454f-8454-44a4898facc0" />
<img width="139" height="137" alt="image" src="https://github.com/user-attachments/assets/0068c943-d389-4a67-b219-8c48ee917b21" />

## 由 Sourcery 提供的摘要

改进每日关卡提示显示，在任务队列 UI 中支持更丰富、带颜色的芯片掉落信息展示。

增强内容：
- 将关卡提示的生成方式从纯文本改为 WPF inline 元素，以支持结构化格式和按项着色的芯片掉落分组显示。
- 更新任务队列视图模型和绑定逻辑，使其使用基于 inline 的关卡提示，而不是拼接后的字符串。
- 引入用于关卡条目颜色的主题画刷资源，以便在明暗主题下直观地区分不同的芯片掉落。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

通过在任务队列中以结构化、颜色编码的方式显示芯片掉落信息，改进每日关卡提示。

新功能：
- 在任务队列中显示芯片掉落数量，并为每个掉落组和主题使用不同的颜色。

增强：
- 将每日关卡提示渲染为结构化、主题感知的 WPF 内容，同时保留任务队列的增量更新。

杂项：
- 更新所有受支持语言的本地化关卡提示资源。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve daily stage prompts with structured, color-coded chip drop information in the task queue.

New Features:
- Display chip drop counts in the task queue with distinct colors for each drop group and theme.

Enhancements:
- Render daily stage prompts as structured, theme-aware WPF content while preserving incremental task queue updates.

Chores:
- Update localized stage prompt resources across supported languages.

</details>

</details>