### PR TITLE
perf: 移除 NotificationImplWinRT 中二次进入 UI 线程

### DIFF
--- a/src/MaaWpfGui/Helper/Notification/NotificationImplWinRT.cs
+++ b/src/MaaWpfGui/Helper/Notification/NotificationImplWinRT.cs
@@ -12,14 +12,16 @@
 // </copyright>
 
 using System;
-using System.Windows;
 using Microsoft.Toolkit.Uwp.Notifications;
+using Serilog;
 
 namespace MaaWpfGui.Helper.Notification;
 
 internal class NotificationImplWinRT : INotificationPoster, IDisposable
 {
     public event EventHandler<string> ActionActivated;
+
+    private static readonly ILogger _logger = Log.ForContext<NotificationImplWinRT>();
 
     public NotificationImplWinRT()
     {
@@ -42,24 +44,22 @@ internal class NotificationImplWinRT : INotificationPoster, IDisposable
     {
         try
         {
-            Application.Current.Dispatcher.InvokeAsync(() =>
+            var builder = new ToastContentBuilder().AddText(content.Body).AddText(content.Summary);
+
+            foreach (var action in content.Actions)
             {
-                var builder = new ToastContentBuilder().AddText(content.Body).AddText(content.Summary);
+                builder.AddButton(new ToastButton()
+                    .SetContent(action.Label)
+                    .AddArgument(action.Tag));
+            }
 
-                foreach (var action in content.Actions)
-                {
-                    builder.AddButton(new ToastButton()
-                        .SetContent(action.Label)
-                        .AddArgument(action.Tag));
-                }
-
-                builder.GetToastContent().ActivationType = ToastActivationType.Protocol;
-                builder.Show();
-            });
+            builder.GetToastContent().ActivationType = ToastActivationType.Protocol;
+            builder.Show();
         }
-        catch
+        catch (Exception e)
         {
-            // ignored
+            _logger.Error(e, "Failed to Toast Notification.");
         }
     }
 }
+


### PR DESCRIPTION
近期使用发现，运行Windows一段时间，尤其是运行过很多大型程序之后再开启MAA，在MAA弹出系统通知时会卡死，搜寻出多个相同症状的 issues
#16160
#15921
#15542

整理之后发现问题都指向 Toast 通知的封装，故作如下修改，待进一步定位。
1. 现有的错误处理有点简陋，加上一个日志打印。
2. ToastContentBuilder 的使用和 show 都不会阻塞 UI 线程，无需占用 Dispatcher 队列，优化为直接调用。

## Summary by Sourcery

改进 Windows Toast 通知的处理方式，以减少对 UI 线程的阻塞，并便于调试通知失败问题。

Bug 修复：
- 避免通过 WPF Dispatcher 分发 Toast 通知的创建和显示，以防止在显示通知期间可能发生的 UI 线程死锁或卡死。

增强内容：
- 当 Toast 通知无法显示时，添加结构化的错误日志记录，而不是静默吞掉异常。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve Windows toast notification handling to reduce UI thread blocking and aid debugging of notification failures.

Bug Fixes:
- Avoid dispatching toast notification creation and display via the WPF Dispatcher to prevent potential UI thread deadlocks or freezes during notification display.

Enhancements:
- Add structured error logging when toast notifications fail to display, instead of silently swallowing exceptions.

</details>