### PR TITLE
chore: 肉鸽添加怒潮凛冬招募逻辑

### DIFF
--- a/resource/roguelike/JieGarden/recruitment.json
+++ b/resource/roguelike/JieGarden/recruitment.json
@@ -308,6 +308,27 @@
                     ]
                 },
                 {
+                    "name": "怒潮凛冬",
+                    "skill": 2,
+                    "is_key": true,
+                    "is_start": true,
+                    "recruit_priority": 821,
+                    "promote_priority": 801,
+                    "recruit_priority_offsets": [
+                        {
+                            "groups": ["凯尔希", "近卫", "召唤"],
+                            "threshold": 1,
+                            "offset": -210
+                        },
+                        {
+                            "groups": ["元素奶"],
+                            "is_less": true,
+                            "threshold": 1,
+                            "offset": -80
+                        }
+                    ]
+                },
+                {
                     "name": "百炼嘉维尔",
                     "skill": 2,
                     "is_key": true,
@@ -423,7 +444,7 @@
                     "skill_usage": 0,
                     "is_start": true,
                     "is_key": true,
-                    "recruit_priority": 821,
+                    "recruit_priority": 822,
                     "promote_priority": 960,
                     "recruit_priority_offsets": [
                         {
@@ -2895,6 +2916,9 @@
                 },
                 {
                     "name": "乌尔比安"
+                },
+                {
+                    "name": "怒潮凛冬"
                 },
                 {
                     "name": "百炼嘉维尔"

--- a/resource/roguelike/Mizuki/recruitment.json
+++ b/resource/roguelike/Mizuki/recruitment.json
@@ -35,17 +35,52 @@
                     "promote_priority": 600,
                     "recruit_priority_offsets": [
                         {
-                            "groups": ["基石", "召唤", "号角", "地面C"],
+                            "groups": ["百嘉", "基石", "召唤", "号角", "地面C"],
                             "is_less": true,
                             "threshold": 1,
                             "offset": 100,
                             "doc": "地面阻挡输出位≤1时，百炼嘉维尔的招募优先级+100"
                         },
                         {
-                            "groups": ["基石", "召唤", "号角", "地面C"],
+                            "groups": ["百嘉", "基石", "召唤", "号角", "地面C"],
                             "threshold": 3,
                             "offset": -600,
                             "doc": "地面阻挡输出位≥3时，百炼嘉维尔的招募优先级-600"
+                        },
+                        {
+                            "groups": ["百嘉"],
+                            "threshold": 1,
+                            "offset": -1000,
+                            "doc": "为兼容现有作战逻辑，百嘉组仅招募一人"
+                        }
+                    ]
+                },
+                {
+                    "name": "怒潮凛冬",
+                    "skill": 2,
+                    "is_key": true,
+                    "is_start": true,
+                    "recruit_priority": 901,
+                    "promote_priority": 600,
+                    "recruit_priority_offsets": [
+                        {
+                            "groups": ["百嘉", "基石", "召唤", "号角", "地面C"],
+                            "is_less": true,
+                            "threshold": 1,
+                            "offset": 100,
+                            "doc": "地面阻挡输出位≤1时，怒潮凛冬的招募优先级+100"
+                        },
+                        {
+                            "groups": ["百嘉", "基石", "召唤", "号角", "地面C"],
+                            "threshold": 3,
+                            "offset": -600,
+                            "doc": "地面阻挡输出位≥3时，怒潮凛冬的招募优先级-600"
+                        },
+                        {
+                            "groups": ["百嘉"],
+                            "threshold": 1,
+                            "offset": -1000,
+                            "doc": "为兼容现有作战逻辑，百嘉组仅招募一人"
                         }
                     ]
                 }
@@ -2263,6 +2298,9 @@
                 },
                 {
                     "name": "百炼嘉维尔"
+                },
+                {
+                    "name": "怒潮凛冬"
                 },
                 {
                     "name": "Mon3tr"

--- a/resource/roguelike/Phantom/recruitment.json
+++ b/resource/roguelike/Phantom/recruitment.json
@@ -24,7 +24,7 @@
                     "skill_usage": 0,
                     "is_key": true,
                     "is_start": true,
-                    "recruit_priority": 821,
+                    "recruit_priority": 822,
                     "promote_priority": 1001,
                     "promote_priority_when_team_full": 1200,
                     "recruit_priority_offsets": [
@@ -389,6 +389,21 @@
                             "groups": ["凯尔希", "近卫", "召唤"],
                             "threshold": 1,
                             "offset": -210
+                        }
+                    ]
+                },
+                {
+                    "name": "怒潮凛冬",
+                    "skill": 2,
+                    "is_key": true,
+                    "is_start": true,
+                    "recruit_priority": 821,
+                    "promote_priority": 801,
+                    "recruit_priority_offsets": [
+                        {
+                            "groups": ["凯尔希", "近卫", "召唤"],
+                            "threshold": 1,
+                            "offset": -400
                         }
                     ]
                 },
@@ -2634,6 +2649,9 @@
             "opers": [
                 {
                     "name": "“弦惊”"
+                },
+                {
+                    "name": "怒潮凛冬"
                 },
                 {
                     "name": "百炼嘉维尔"

--- a/resource/roguelike/Sami/recruitment.json
+++ b/resource/roguelike/Sami/recruitment.json
@@ -307,6 +307,21 @@
                     ]
                 },
                 {
+                    "name": "怒潮凛冬",
+                    "skill": 2,
+                    "is_key": true,
+                    "is_start": true,
+                    "recruit_priority": 821,
+                    "promote_priority": 801,
+                    "recruit_priority_offsets": [
+                        {
+                            "groups": ["凯尔希", "近卫", "召唤"],
+                            "threshold": 1,
+                            "offset": -210
+                        }
+                    ]
+                },
+                {
                     "name": "百炼嘉维尔",
                     "skill": 2,
                     "is_key": true,
@@ -386,7 +401,7 @@
                     "skill_usage": 0,
                     "is_start": true,
                     "is_key": true,
-                    "recruit_priority": 821,
+                    "recruit_priority": 822,
                     "promote_priority": 960,
                     "recruit_priority_offsets": [
                         {
@@ -2551,6 +2566,9 @@
             "opers": [
                 {
                     "name": "“弦惊”"
+                },
+                {
+                    "name": "怒潮凛冬"
                 },
                 {
                     "name": "百炼嘉维尔"

--- a/resource/roguelike/Sarkaz/recruitment.json
+++ b/resource/roguelike/Sarkaz/recruitment.json
@@ -332,6 +332,27 @@
                     ]
                 },
                 {
+                    "name": "怒潮凛冬",
+                    "skill": 2,
+                    "is_key": true,
+                    "is_start": true,
+                    "recruit_priority": 821,
+                    "promote_priority": 801,
+                    "recruit_priority_offsets": [
+                        {
+                            "groups": ["凯尔希", "近卫", "召唤"],
+                            "threshold": 1,
+                            "offset": -210
+                        },
+                        {
+                            "groups": ["元素奶"],
+                            "is_less": true,
+                            "threshold": 1,
+                            "offset": -80
+                        }
+                    ]
+                },
+                {
                     "name": "百炼嘉维尔",
                     "skill": 2,
                     "is_key": true,
@@ -428,7 +449,7 @@
                     "skill_usage": 0,
                     "is_key": true,
                     "is_start": true,
-                    "recruit_priority": 821,
+                    "recruit_priority": 822,
                     "promote_priority": 960,
                     "recruit_priority_offsets": [
                         {
@@ -2836,6 +2857,9 @@
             "opers": [
                 {
                     "name": "“弦惊”"
+                },
+                {
+                    "name": "怒潮凛冬"
                 },
                 {
                     "name": "百炼嘉维尔"


### PR DESCRIPTION
## 由 Sourcery 提供的总结

增强内容：
- 扩展极光、絮雨、幽灵鲨、萨米以及萨卡兹肉鸽模式的招募配置，以支持新的活动逻辑。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Extend recruitment configuration for JieGarden, Mizuki, Phantom, Sami, and Sarkaz Roguelike modes to support the new event logic.

</details>