### PR TITLE
fix: yostarJP_infrastControl

### DIFF
--- a/resource/global/YoStarJP/resource/tasks/tasks.json
+++ b/resource/global/YoStarJP/resource/tasks/tasks.json
@@ -1147,6 +1147,18 @@
     "InfrastEnterOperList": {
         "text": ["体力", "休憩中", "仕事中", "配属"]
     },
+    "InfrastControl": {
+        "template": "ControlCenter.png",
+        "maskRange": [1, 255],
+        "roi": [400, 0, 880, 300],
+        "templThreshold": 0.95
+    },
+    "InfrastControlMini": {
+        "template": "ControlCenterMini.png",
+        "maskRange": [1, 255],
+        "roi": [553, 82, 396, 248],
+        "templThreshold": 0.95
+    },
     "SendClues": {
         "doc": "Remove this after 'Quickly place clues' and 'One-tap send duplicate clues' are added (#14966)",
         "roi": [1160, 350, 80, 80]


### PR DESCRIPTION
add InfrastControl,InfrastControlMini to yostarJP tasks.json

## Summary by Sourcery

新功能：
- 在 YoStarJP 的 `tasks.json` 配置中注册 `InfrastControl` 和 `InfrastControlMini` 任务定义。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Register InfrastControl and InfrastControlMini task definitions in the YoStarJP tasks.json configuration.

</details>