### PR TITLE
chore: 添加贝洛内、怒潮凛冬基建技能数值

### DIFF
--- a/resource/infrast.json
+++ b/resource/infrast.json
@@ -1147,6 +1147,9 @@
         "skills": {
             "bskill_formula_spd_headb1": {
                 "desc": ["进驻制造站时，作战记录类配方的生产力+30%"],
+                "efficient": {
+                    "CombatRecord": 30
+                },
                 "name": ["战阵领袖"],
                 "template": "Bskill_formula_spd_headb1.png"
             },
@@ -1154,6 +1157,9 @@
                 "desc": [
                     "进驻制造站时，作战记录类配方的生产力+30%，当与乌萨斯学生自治团干员在同一个制造站时，作战记录类配方的生产力额外+10%"
                 ],
+                "efficient": {
+                    "CombatRecord": 30
+                },
                 "name": ["情同手足"],
                 "template": "Bskill_formula_spd_headb2.png"
             },
@@ -3600,6 +3606,9 @@
                 "desc": [
                     "进驻贸易站时，订单获取效率+25%；当伺夜在基建内时（不包含副手及活动室使用者），订单获取效率额外+5%"
                 ],
+                "efficient": {
+                    "all": 25
+                },
                 "name": ["家族经营·α"],
                 "template": "Bskill_tra_ord_spd_ext2.png"
             },
@@ -3607,6 +3616,9 @@
                 "desc": [
                     "进驻贸易站时，订单获取效率+30%；当伺夜在基建内时（不包含副手及活动室使用者），订单获取效率额外+10%"
                 ],
+                "efficient": {
+                    "all": 30
+                },
                 "name": ["家族经营·β"],
                 "template": "Bskill_tra_ord_spd_ext3.png"
             },

--- a/resource/infrast.json
+++ b/resource/infrast.json
@@ -1148,7 +1148,7 @@
             "bskill_formula_spd_headb1": {
                 "desc": ["进驻制造站时，作战记录类配方的生产力+30%"],
                 "efficient": {
-                    "CombatRecord": 30
+                    "CombatRecord": 30.1
                 },
                 "name": ["战阵领袖"],
                 "template": "Bskill_formula_spd_headb1.png"
@@ -1158,7 +1158,7 @@
                     "进驻制造站时，作战记录类配方的生产力+30%，当与乌萨斯学生自治团干员在同一个制造站时，作战记录类配方的生产力额外+10%"
                 ],
                 "efficient": {
-                    "CombatRecord": 30
+                    "CombatRecord": 30.1
                 },
                 "name": ["情同手足"],
                 "template": "Bskill_formula_spd_headb2.png"


### PR DESCRIPTION
添加贝洛内、怒潮凛冬基建技能数值

## 由 Sourcery 提供的摘要

在 `infrast.json` 中为新干员 **贝洛内** 和 **怒潮凛冬** 添加基础设施技能数据条目。

新功能：
- 为干员 **贝洛内** 添加基础设施技能配置。
- 为干员 **怒潮凛冬** 添加基础设施技能配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add infrastructure skill data entries for the new operators 贝洛内 and 怒潮凛冬 in infrast.json.

New Features:
- Introduce infrastructure skill configuration for operator 贝洛内.
- Introduce infrastructure skill configuration for operator 怒潮凛冬.

</details>