### PR TITLE
feat: 界园肉鸽月度小队和深入调查

### DIFF
--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/RoguelikeSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/RoguelikeSettingsUserControlModel.cs
@@ -109,35 +109,27 @@ public class RoguelikeSettingsUserControlModel : TaskSettingsViewModel, Roguelik
     {
         var roguelikeMode = RoguelikeMode;
 
+        var baseList = new List<ModeItem>
+        {
+            new() { Display = LocalizationHelper.GetString("RoguelikeStrategyExp"), Value = Mode.Exp },
+            new() { Display = LocalizationHelper.GetString("RoguelikeStrategyGold"), Value = Mode.Investment },
+            new() { Display = LocalizationHelper.GetString("RoguelikeStrategyLastReward"), Value = Mode.Collectible },
+            new() { Display = LocalizationHelper.GetString("RoguelikeStrategyMonthlySquad"), Value = Mode.Squad },
+            new() { Display = LocalizationHelper.GetString("RoguelikeStrategyDeepExploration"), Value = Mode.Exploration },
+        };
+
         switch (RoguelikeTheme)
         {
-            case Theme.JieGarden:
-                RoguelikeModeList = [
-                    new() { Display = LocalizationHelper.GetString("RoguelikeStrategyExp"), Value = Mode.Exp },
-                    new() { Display = LocalizationHelper.GetString("RoguelikeStrategyGold"), Value = Mode.Investment },
-                    new() { Display = LocalizationHelper.GetString("RoguelikeStrategyLastReward"), Value = Mode.Collectible },
-                    new() { Display = LocalizationHelper.GetString("RoguelikeStrategyFindPlaytime"), Value = Mode.FindPlaytime },
-                ];
+            case Theme.Sami:
+                baseList.Add(new() { Display = LocalizationHelper.GetString("RoguelikeStrategyCollapse"), Value = Mode.CLP_PDS });
                 break;
 
-            default:
-                RoguelikeModeList =
-                [
-                    new() { Display = LocalizationHelper.GetString("RoguelikeStrategyExp"), Value = Mode.Exp },
-                    new() { Display = LocalizationHelper.GetString("RoguelikeStrategyGold"), Value = Mode.Investment },
-                    new() { Display = LocalizationHelper.GetString("RoguelikeStrategyLastReward"), Value = Mode.Collectible },
-                    new() { Display = LocalizationHelper.GetString("RoguelikeStrategyMonthlySquad"), Value = Mode.Squad },
-                    new() { Display = LocalizationHelper.GetString("RoguelikeStrategyDeepExploration"), Value = Mode.Exploration },
-                ];
-
-                if (RoguelikeTheme == Theme.Sami)
-                {
-                    RoguelikeModeList.Add(new() { Display = LocalizationHelper.GetString("RoguelikeStrategyCollapse"), Value = Mode.CLP_PDS });
-                }
-
+            case Theme.JieGarden:
+                baseList.Add(new() { Display = LocalizationHelper.GetString("RoguelikeStrategyFindPlaytime"), Value = Mode.FindPlaytime });
                 break;
         }
 
+        RoguelikeModeList = baseList;
         RoguelikeMode = RoguelikeModeList.Any(x => x.Value == roguelikeMode) ? roguelikeMode : RoguelikeModeList.First().Value;
     }
 

--- a/src/MaaWpfGui/Views/UserControl/TaskQueue/RoguelikeSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/TaskQueue/RoguelikeSettingsUserControl.xaml
@@ -79,7 +79,9 @@
                 ItemsSource="{Binding RoguelikeSquadList}"
                 MaxDropDownHeight="800"
                 SelectedValue="{Binding RoguelikeSquad}"
-                SelectedValuePath="Value" />
+                SelectedValuePath="Value"
+                Visibility="{c:Binding 'RoguelikeMode != task:RoguelikeMode.Squad and RoguelikeMode != task:RoguelikeMode.Exploration',
+                                       Source={x:Static taskQueue_vms:RoguelikeSettingsUserControlModel.Instance}}" />
             <hc:ComboBox
                 Margin="0,3"
                 hc:InfoElement.Title="{DynamicResource StartingRoles}"
@@ -87,7 +89,9 @@
                 IsHitTestVisible="{Binding Idle, Source={x:Static ui_vms:TaskQueueViewModel.TaskSettingDataContext}}"
                 ItemsSource="{Binding RoguelikeRolesList}"
                 SelectedValue="{Binding RoguelikeRoles}"
-                SelectedValuePath="Value" />
+                SelectedValuePath="Value"
+                Visibility="{c:Binding 'RoguelikeMode != task:RoguelikeMode.Squad and RoguelikeMode != task:RoguelikeMode.Exploration',
+                                       Source={x:Static taskQueue_vms:RoguelikeSettingsUserControlModel.Instance}}" />
             <hc:ComboBox
                 Margin="0,3"
                 d:Visibility="Visible"
@@ -99,7 +103,10 @@
                 SelectedValuePath="Value"
                 Visibility="{c:Binding 'RoguelikeMode == task:RoguelikeMode.FindPlaytime and RoguelikeTheme == task:RoguelikeTheme.JieGarden',
                                        Source={x:Static taskQueue_vms:RoguelikeSettingsUserControlModel.Instance}}" />
-            <StackPanel Margin="0,3">
+            <StackPanel
+                Margin="0,3"
+                Visibility="{c:Binding 'RoguelikeMode != task:RoguelikeMode.Squad and RoguelikeMode != task:RoguelikeMode.Exploration',
+                                       Source={x:Static taskQueue_vms:RoguelikeSettingsUserControlModel.Instance}}">
                 <StackPanel Margin="0,0,0,5" Orientation="Horizontal">
                     <controls:TextBlock Margin="8,0,0,0" Text="{DynamicResource StartingCoreChar}" />
                     <controls:TooltipBlock>


### PR DESCRIPTION
## 来自 Sourcery 的总结

统一 Roguelike 模式列表的构建方式，并根据主题调整可用模式。

增强内容：
- 重构 Roguelike 模式列表的生成逻辑，使用共享的基础列表，并根据不同主题追加特定模式。
- 更新主题处理逻辑，使 Sami 在共享基础选项之上增加 Collapse 策略模式，而 JieGarden 在基础选项之上增加 Find Playtime 模式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify roguelike mode list construction and adjust available modes per theme.

Enhancements:
- Refactor roguelike mode list generation to use a shared base list with theme-specific additions.
- Update theme handling so Sami adds the Collapse strategy mode and JieGarden adds the Find Playtime mode on top of the shared base options.

</details>