### PR TITLE
fix: 修复作业列表连续打普通+突袭时，突袭模式无法借助战的问题

### DIFF
--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -254,28 +254,13 @@ void asst::BattleFormationTask::formation_with_last_opers()
         const std::string& oper_name = it->first;
         const std::string& group_name = it->second;
 
+        // 在当前页查找目标干员（单次遍历，已选中和未选中统一处理）
         const auto oper_in_page_it = std::ranges::find_if(opers_result, [&](const QuickFormationOper& op) {
-            return !op.is_selected && op.text == oper_name;
-        }); // 编队页中的干员
+            return op.text == oper_name;
+        });
         if (oper_in_page_it == opers_result.end()) [[unlikely]] {
-            // 检查该干员是否已经在编队画面上被选中（常见于连续打同一关的普通+突袭）
-            auto already_selected_it = std::ranges::find_if(opers_result, [&](const QuickFormationOper& op) {
-                return op.is_selected && op.text == oper_name;
-            });
-            if (already_selected_it != opers_result.end()) {
-                // 已经在画面上被选中，直接更新状态，无需点击
-                if (try_mark_oper_selected(oper_name, group_name)) {
-                    it = last_formation.erase(it);
-                    continue;
-                }
-                // 干员在画面上已选中但在编队数据中找不到，属于异常状态
-                LogWarn << __FUNCTION__ << "| Oper" << oper_name
-                        << "is selected on page but not found in formation data";
-            }
-            else {
-                Log.warn(__FUNCTION__, "| Oper", oper_name,
-                         "was selected last time, but not found in current page");
-            }
+            Log.warn(__FUNCTION__, "| Oper", oper_name,
+                     "was selected last time, but not found in current page");
             ++it;
             continue; // 该干员找不到, 一页只能放下10个干员, 可能被右侧挡住. 打回到正常编队逻辑
         }
@@ -285,8 +270,11 @@ void asst::BattleFormationTask::formation_with_last_opers()
             continue;
         }
 
-        ctrler()->click(oper_in_page_it->flag_rect);
-        sleep(delay);
+        // 干员在画面上未选中时需要点击选中，已选中则跳过点击（常见于连续打同一关的普通+突袭）
+        if (!oper_in_page_it->is_selected) {
+            ctrler()->click(oper_in_page_it->flag_rect);
+            sleep(delay);
+        }
         it = last_formation.erase(it);
     }
 

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -223,72 +223,70 @@ void asst::BattleFormationTask::formation_with_last_opers()
         formation_view.emplace(group.first, &group.second);
     }
     const int delay = Task.get("BattleQuickFormationOCR")->post_delay;
-    for (auto it = last_formation.begin(); !need_exit() && it != last_formation.end();) {
-        const std::string& oper_name = it->first;
-        const std::string& group_name = it->second;
 
-        const auto& oper_in_page_it = std::ranges::find_if(opers_result, [&](const QuickFormationOper& op) {
-            return !op.is_selected && op.text == oper_name;
-        }); // 编队页中的干员
-        if (oper_in_page_it == opers_result.end()) [[unlikely]] {
-            // 检查该干员是否已经在编队画面上被选中（常见于连续打同一关的普通+突袭）
-            const auto& already_selected_it =
-                std::ranges::find_if(opers_result, [&](const QuickFormationOper& op) {
-                    return op.is_selected && op.text == oper_name;
-                });
-            if (already_selected_it != opers_result.end()) {
-                // 已经在画面上被选中，直接更新状态，无需点击
-                auto group_it = formation_view.find(group_name);
-                if (group_it != formation_view.end()) {
-                    auto oper_it = std::ranges::find_if(
-                        *(group_it->second),
-                        [&](battle::OperUsage& op) { return op.name == oper_name; });
-                    if (oper_it != group_it->second->end()) {
-                        oper_it->status = battle::OperStatus::Selected;
-                        m_opers_in_formation->emplace(oper_name, group_name);
-                        json::value info = basic_info_with_what("BattleFormationSelected");
-                        auto& details = info["details"];
-                        details["selected"] = oper_name;
-                        details["group_name"] = group_name;
-                        callback(AsstMsg::SubTaskExtraInfo, info);
-                    }
-                }
-                it = need_formation.erase(it);
-                continue;
-            }
-            Log.warn(__FUNCTION__, "| Oper", oper_name, "was selected last time, but not found in current page");
-            ++it;
-            continue; // 该干员找不到, 一页只能放下10个干员, 可能被右侧挡住. 打回到正常编队逻辑
-        }
-
-        // 直接通过组名从展平的映射中查找
+    // 在 formation_view 中查找干员并标记为已选中的辅助函数
+    auto try_mark_oper_selected = [&](const std::string& oper_name,
+                                      const std::string& group_name) -> bool {
         auto group_it = formation_view.find(group_name);
         if (group_it == formation_view.end()) {
             LogError << __FUNCTION__ << "| Group" << group_name << " not found in formation";
-            ++it;
-            continue;
+            return false;
         }
-
-        // 在找到的组中查找具体的干员
-        auto oper_it =
-            std::ranges::find_if(*(group_it->second), [&](battle::OperUsage& op) { return op.name == oper_name; });
+        auto oper_it = std::ranges::find_if(
+            *(group_it->second),
+            [&](battle::OperUsage& op) { return op.name == oper_name; });
         if (oper_it == group_it->second->end()) {
             LogError << __FUNCTION__ << "| Group" << group_name << ",Oper" << oper_name
                      << "was selected last time, but not found in current pair";
-            ++it;
-            continue; // 很怪, 按理说不会找不到, 有组相同但是找不到干员
+            return false;
         }
-
-        ctrler()->click(oper_in_page_it->flag_rect);
-        sleep(delay);
-
         oper_it->status = battle::OperStatus::Selected;
+        m_opers_in_formation->emplace(oper_name, group_name);
         json::value info = basic_info_with_what("BattleFormationSelected");
         auto& details = info["details"];
         details["selected"] = oper_name;
         details["group_name"] = group_name;
         callback(AsstMsg::SubTaskExtraInfo, info);
-        m_opers_in_formation->emplace(oper_name, group_name);
+        return true;
+    };
+
+    for (auto it = last_formation.begin(); !need_exit() && it != last_formation.end();) {
+        const std::string& oper_name = it->first;
+        const std::string& group_name = it->second;
+
+        const auto oper_in_page_it = std::ranges::find_if(opers_result, [&](const QuickFormationOper& op) {
+            return !op.is_selected && op.text == oper_name;
+        }); // 编队页中的干员
+        if (oper_in_page_it == opers_result.end()) [[unlikely]] {
+            // 检查该干员是否已经在编队画面上被选中（常见于连续打同一关的普通+突袭）
+            auto already_selected_it = std::ranges::find_if(opers_result, [&](const QuickFormationOper& op) {
+                return op.is_selected && op.text == oper_name;
+            });
+            if (already_selected_it != opers_result.end()) {
+                // 已经在画面上被选中，直接更新状态，无需点击
+                if (try_mark_oper_selected(oper_name, group_name)) {
+                    it = last_formation.erase(it);
+                    continue;
+                }
+                // 干员在画面上已选中但在编队数据中找不到，属于异常状态
+                LogWarn << __FUNCTION__ << "| Oper" << oper_name
+                        << "is selected on page but not found in formation data";
+            }
+            else {
+                Log.warn(__FUNCTION__, "| Oper", oper_name,
+                         "was selected last time, but not found in current page");
+            }
+            ++it;
+            continue; // 该干员找不到, 一页只能放下10个干员, 可能被右侧挡住. 打回到正常编队逻辑
+        }
+
+        if (!try_mark_oper_selected(oper_name, group_name)) {
+            ++it;
+            continue;
+        }
+
+        ctrler()->click(oper_in_page_it->flag_rect);
+        sleep(delay);
         it = last_formation.erase(it);
     }
 

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -89,7 +89,13 @@ bool asst::BattleFormationTask::_run()
         save_img(utils::path("debug") / utils::path("other"));
         return false;
     }
-    formation_with_last_opers();
+    if (verify_and_ensure_page_cleared()) {
+        formation_with_last_opers();
+    }
+    else {
+        // Clear 不可靠，放弃预编队复用，回退到完整编队流程
+        m_opers_in_formation->clear();
+    }
     for (auto& [role, oper_groups] : m_formation) {
         bool need_check =
             std::ranges::any_of(oper_groups, [&](const OperGroup& group) { return has_oper_unchecked(group.second); });
@@ -254,12 +260,8 @@ void asst::BattleFormationTask::formation_with_last_opers()
         const std::string& oper_name = it->first;
         const std::string& group_name = it->second;
 
-        // 按名字定位编队页中的目标干员，不再根据 is_selected 预过滤。
-        // 设计上 enter_selection_page 里的 BattleQuickFormationClear 会在进入前
-        // 清空所有选中态，正常情况下 is_selected 都为 false；但当清空动作未生效
-        // （例如连续打同一关的普通+突袭，游戏保留了上次的选中）时，画面上的干员
-        // 可能已经是选中态，下面会根据实际状态决定是否点击，避免把本来已选中的
-        // 干员反选掉。
+        // 按名字定位编队页中的目标干员。进入前已通过 verify_and_ensure_page_cleared
+        // 确认页面选中态已清空，is_selected 应为 false。
         const auto oper_in_page_it = std::ranges::find_if(
             opers_result,
             [&](const QuickFormationOper& op) { return op.text == oper_name; });
@@ -275,16 +277,8 @@ void asst::BattleFormationTask::formation_with_last_opers()
             continue;
         }
 
-        // 未选中时点击选中；已经是选中态则跳过点击（见上方 Clear 未生效的场景），
-        // 无论是否点击都算本轮命中，后续的选中态校验会再次确认。
-        if (!oper_in_page_it->is_selected) {
-            ctrler()->click(oper_in_page_it->flag_rect);
-            sleep(delay);
-        }
-        else {
-            Log.info(__FUNCTION__, "| Oper", oper_name,
-                     "already selected on page, skip click (Clear may not have taken effect)");
-        }
+        ctrler()->click(oper_in_page_it->flag_rect);
+        sleep(delay);
         it = last_formation.erase(it);
     }
 
@@ -602,6 +596,45 @@ std::vector<asst::BattleFormationTask::QuickFormationOper>
 bool asst::BattleFormationTask::enter_selection_page(const cv::Mat& img)
 {
     return ProcessTask(*this, { "BattleQuickFormation" }).set_reusable_image(img).set_retry_times(3).run();
+}
+
+bool asst::BattleFormationTask::verify_and_ensure_page_cleared()
+{
+    LogTraceFunction;
+
+    static constexpr int max_retry_times = 3;
+
+    for (int retry = 0; retry < max_retry_times; ++retry) {
+        const auto& opers_result = analyzer_opers(ctrler()->get_image());
+        if (opers_result.empty()) {
+            return true;
+        }
+
+        bool has_selected = std::ranges::any_of(
+            opers_result,
+            [](const QuickFormationOper& op) { return op.is_selected; });
+
+        if (!has_selected) {
+            return true;
+        }
+
+        Log.info(__FUNCTION__, "| Found pre-selected operators, retrying Clear (attempt",
+                 retry + 1, "/", max_retry_times, ")");
+        ProcessTask(*this, { "BattleQuickFormationClear" }).run();
+    }
+
+    const auto& opers_result = analyzer_opers(ctrler()->get_image());
+    bool has_selected = std::ranges::any_of(
+        opers_result,
+        [](const QuickFormationOper& op) { return op.is_selected; });
+
+    if (has_selected) {
+        Log.warn(__FUNCTION__, "| Page still has pre-selected operators after retries, "
+                 "skipping last formation reuse");
+        return false;
+    }
+
+    return true;
 }
 
 bool asst::BattleFormationTask::select_opers_in_cur_page(const std::vector<OperGroup*>& groups)

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -231,6 +231,31 @@ void asst::BattleFormationTask::formation_with_last_opers()
             return !op.is_selected && op.text == oper_name;
         }); // 编队页中的干员
         if (oper_in_page_it == opers_result.end()) [[unlikely]] {
+            // 检查该干员是否已经在编队画面上被选中（常见于连续打同一关的普通+突袭）
+            const auto& already_selected_it =
+                std::ranges::find_if(opers_result, [&](const QuickFormationOper& op) {
+                    return op.is_selected && op.text == oper_name;
+                });
+            if (already_selected_it != opers_result.end()) {
+                // 已经在画面上被选中，直接更新状态，无需点击
+                auto group_it = formation_view.find(group_name);
+                if (group_it != formation_view.end()) {
+                    auto oper_it = std::ranges::find_if(
+                        *(group_it->second),
+                        [&](battle::OperUsage& op) { return op.name == oper_name; });
+                    if (oper_it != group_it->second->end()) {
+                        oper_it->status = battle::OperStatus::Selected;
+                        m_opers_in_formation->emplace(oper_name, group_name);
+                        json::value info = basic_info_with_what("BattleFormationSelected");
+                        auto& details = info["details"];
+                        details["selected"] = oper_name;
+                        details["group_name"] = group_name;
+                        callback(AsstMsg::SubTaskExtraInfo, info);
+                    }
+                }
+                it = need_formation.erase(it);
+                continue;
+            }
             Log.warn(__FUNCTION__, "| Oper", oper_name, "was selected last time, but not found in current page");
             ++it;
             continue; // 该干员找不到, 一页只能放下10个干员, 可能被右侧挡住. 打回到正常编队逻辑

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -254,10 +254,15 @@ void asst::BattleFormationTask::formation_with_last_opers()
         const std::string& oper_name = it->first;
         const std::string& group_name = it->second;
 
-        // 在当前页查找目标干员（单次遍历，已选中和未选中统一处理）
-        const auto oper_in_page_it = std::ranges::find_if(opers_result, [&](const QuickFormationOper& op) {
-            return op.text == oper_name;
-        });
+        // 按名字定位编队页中的目标干员，不再根据 is_selected 预过滤。
+        // 设计上 enter_selection_page 里的 BattleQuickFormationClear 会在进入前
+        // 清空所有选中态，正常情况下 is_selected 都为 false；但当清空动作未生效
+        // （例如连续打同一关的普通+突袭，游戏保留了上次的选中）时，画面上的干员
+        // 可能已经是选中态，下面会根据实际状态决定是否点击，避免把本来已选中的
+        // 干员反选掉。
+        const auto oper_in_page_it = std::ranges::find_if(
+            opers_result,
+            [&](const QuickFormationOper& op) { return op.text == oper_name; });
         if (oper_in_page_it == opers_result.end()) [[unlikely]] {
             Log.warn(__FUNCTION__, "| Oper", oper_name,
                      "was selected last time, but not found in current page");
@@ -270,10 +275,15 @@ void asst::BattleFormationTask::formation_with_last_opers()
             continue;
         }
 
-        // 干员在画面上未选中时需要点击选中，已选中则跳过点击（常见于连续打同一关的普通+突袭）
+        // 未选中时点击选中；已经是选中态则跳过点击（见上方 Clear 未生效的场景），
+        // 无论是否点击都算本轮命中，后续的选中态校验会再次确认。
         if (!oper_in_page_it->is_selected) {
             ctrler()->click(oper_in_page_it->flag_rect);
             sleep(delay);
+        }
+        else {
+            Log.info(__FUNCTION__, "| Oper", oper_name,
+                     "already selected on page, skip click (Clear may not have taken effect)");
         }
         it = last_formation.erase(it);
     }

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.h
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.h
@@ -98,7 +98,9 @@ protected:
     bool is_formation_valid(const cv::Mat& img) const;
     bool select_formation(int select_index, const cv::Mat& img);
     bool enter_selection_page(const cv::Mat& img = cv::Mat());
-    // 进入快捷编队清空选择后执行，快速选择非干员组的干员
+    // 验证快捷编队页面是否已被清空，未清空则重试 Clear；仍失败返回 false
+    bool verify_and_ensure_page_cleared();
+    // 进入快捷编队且页面已确认清空后执行，快速选择上次编队的干员
     void formation_with_last_opers();
     bool add_formation(battle::Role role, const std::vector<OperGroup*>& oper_group);
     // 追加附加干员（按部署费用等小分类）


### PR DESCRIPTION
formation_with_last_opers() 在查找上次编入的干员时，使用 !op.is_selected 过滤导致已在画面上选中的干员被跳过，状态未更新为 Selected，最终被错误标记为 Missing，使得missing_numbers > 1，不满足借助战条件。

## 由 Sourcery 提供的总结

修复复用上一场战斗编队时的处理逻辑，使已经出现在编队界面的干员能够被正确识别并复用。

Bug 修复：
- 确保在复用上一次编队时，已经在编队界面中被选中的干员不会被错误地标记为缺失，从而恢复它们作为助战干员的可用性。

增强项：
- 引入一个辅助例程，用于在编队视图中定位并标记已选中的干员，并在编队逻辑中复用该例程，以获得更清晰的控制流程和日志记录。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix handling of reusing the previous battle formation so that operators already present on the formation screen are correctly recognized and reused.

Bug Fixes:
- Ensure operators that are already selected on the formation screen when reusing the last formation are not incorrectly marked as missing, restoring their availability as support units.

Enhancements:
- Introduce a helper routine to locate and mark selected operators within the formation view and reuse it across the formation logic for clearer control flow and logging.

</details>

Bug Fixes（错误修复）:
- 当复用上一次编队时，防止已经在编队界面中选中的干员被错误地标记为缺失，从而恢复其作为助战可借用的资格。

Enhancements（功能增强）:
- 抽取一个辅助方法，用于在编队界面中定位并标记已选中的干员，并在多处代码路径中复用该方法，以使逻辑与日志记录更加清晰。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

修复复用上一场战斗编队时的处理逻辑，使已经出现在编队界面的干员能够被正确识别并复用。

Bug 修复：
- 确保在复用上一次编队时，已经在编队界面中被选中的干员不会被错误地标记为缺失，从而恢复它们作为助战干员的可用性。

增强项：
- 引入一个辅助例程，用于在编队视图中定位并标记已选中的干员，并在编队逻辑中复用该例程，以获得更清晰的控制流程和日志记录。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix handling of reusing the previous battle formation so that operators already present on the formation screen are correctly recognized and reused.

Bug Fixes:
- Ensure operators that are already selected on the formation screen when reusing the last formation are not incorrectly marked as missing, restoring their availability as support units.

Enhancements:
- Introduce a helper routine to locate and mark selected operators within the formation view and reuse it across the formation logic for clearer control flow and logging.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

修复复用上一场战斗编队时的处理逻辑，使已经出现在编队界面的干员能够被正确识别并复用。

Bug 修复：
- 确保在复用上一次编队时，已经在编队界面中被选中的干员不会被错误地标记为缺失，从而恢复它们作为助战干员的可用性。

增强项：
- 引入一个辅助例程，用于在编队视图中定位并标记已选中的干员，并在编队逻辑中复用该例程，以获得更清晰的控制流程和日志记录。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix handling of reusing the previous battle formation so that operators already present on the formation screen are correctly recognized and reused.

Bug Fixes:
- Ensure operators that are already selected on the formation screen when reusing the last formation are not incorrectly marked as missing, restoring their availability as support units.

Enhancements:
- Introduce a helper routine to locate and mark selected operators within the formation view and reuse it across the formation logic for clearer control flow and logging.

</details>

Bug Fixes（错误修复）:
- 当复用上一次编队时，防止已经在编队界面中选中的干员被错误地标记为缺失，从而恢复其作为助战可借用的资格。

Enhancements（功能增强）:
- 抽取一个辅助方法，用于在编队界面中定位并标记已选中的干员，并在多处代码路径中复用该方法，以使逻辑与日志记录更加清晰。

<details>
<summary>Original summary in English</summary>

## 由 Sourcery 提供的总结

修复复用上一场战斗编队时的处理逻辑，使已经出现在编队界面的干员能够被正确识别并复用。

Bug 修复：
- 确保在复用上一次编队时，已经在编队界面中被选中的干员不会被错误地标记为缺失，从而恢复它们作为助战干员的可用性。

增强项：
- 引入一个辅助例程，用于在编队视图中定位并标记已选中的干员，并在编队逻辑中复用该例程，以获得更清晰的控制流程和日志记录。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix handling of reusing the previous battle formation so that operators already present on the formation screen are correctly recognized and reused.

Bug Fixes:
- Ensure operators that are already selected on the formation screen when reusing the last formation are not incorrectly marked as missing, restoring their availability as support units.

Enhancements:
- Introduce a helper routine to locate and mark selected operators within the formation view and reuse it across the formation logic for clearer control flow and logging.

</details>

</details>

</details>