### PR TITLE
fix: macOS PlayTools/SCK 几处小修正

### DIFF
--- a/src/MaaCore/Config/Miscellaneous/OcrPack.cpp
+++ b/src/MaaCore/Config/Miscellaneous/OcrPack.cpp
@@ -204,7 +204,7 @@ bool asst::OcrPack::check_and_load()
     rec_option.UseCpu();
     det_option.SetCpuThreadNum(cpu_threads);
     rec_option.SetCpuThreadNum(cpu_threads);
-    Log.info("FastDeploy macOS mode with rec", cpu_threads, "CPU threads");
+    Log.info("FastDeploy macOS mode with", cpu_threads, "CPU threads");
 #else
     det_option.UseCpu();
     rec_option.UseCpu();

--- a/src/MaaCore/Controller/MacSCKHelper.mm
+++ b/src/MaaCore/Controller/MacSCKHelper.mm
@@ -82,7 +82,18 @@ struct asst::MacSCKHelper::Impl {
 asst::MacSCKHelper::Impl::~Impl()
 {
     if (m_stream) {
-        [m_stream stopCaptureWithCompletionHandler:nil];
+        auto sem = dispatch_semaphore_create(0);
+        [m_stream stopCaptureWithCompletionHandler:^(NSError* _Nullable error) {
+            if (error) {
+                Log.error("Error stopping capture:", error.localizedDescription.UTF8String);
+            }
+            dispatch_semaphore_signal(sem);
+        }];
+
+        dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW, 3 * NSEC_PER_SEC);
+        dispatch_semaphore_wait(sem, timeout);
+        dispatch_release(sem);
+
         [m_stream release];
         m_stream = nil;
     }

--- a/src/MaaCore/Controller/PlayToolsController.cpp
+++ b/src/MaaCore/Controller/PlayToolsController.cpp
@@ -96,7 +96,7 @@ bool asst::PlayToolsController::screencap(cv::Mat& image_payload, bool allow_rec
 
 bool asst::PlayToolsController::screencap_rgba(cv::Mat& image_payload, bool allow_reconnect [[maybe_unused]])
 {
-    open();
+    if (!open()) return false;
     uint32_t image_size = 0;
 
     try {
@@ -131,7 +131,7 @@ bool asst::PlayToolsController::screencap_rgba(cv::Mat& image_payload, bool allo
 
 bool asst::PlayToolsController::screencap_bgr(cv::Mat& image_payload, bool allow_reconnect [[maybe_unused]])
 {
-    open();
+    if (!open()) return false;
     std::array<uint32_t, 3> header;
 
     try {
@@ -169,7 +169,7 @@ bool asst::PlayToolsController::screencap_bgr(cv::Mat& image_payload, bool allow
 
 bool asst::PlayToolsController::start_game(const std::string& client_type [[maybe_unused]])
 {
-    Log.info("InputText is not supported on iOS");
+    Log.info("StartGame is not supported on PlayTools");
     return true;
 }
 
@@ -423,7 +423,7 @@ bool asst::PlayToolsController::fetch_screen_res()
 
 bool asst::PlayToolsController::toucher_commit(const TouchPhase phase, const Point& p, const int delay)
 {
-    open();
+    if (!open()) return false;
     uint16_t x = socket_ops::host_to_network_short(static_cast<uint16_t>(p.x));
     uint16_t y = socket_ops::host_to_network_short(static_cast<uint16_t>(p.y));
     uint8_t payload[5] = { static_cast<uint8_t>(phase), 0, 0, 0, 0 };


### PR DESCRIPTION
读代码的时候顺手发现的几个小问题，都在 macOS 相关的路径上：

1. **PlayToolsController**: `screencap_rgba`、`screencap_bgr`、`toucher_commit` 三处裸调了 `open()` 没检查返回值。连接断了之后继续往 socket 写数据，虽然外面有 try-catch 兜底，但语义上应该直接 return false

2. **PlayToolsController**: `start_game()` 的日志写的是 "InputText is not supported on iOS"，看着像是从 `input()` 复制过来忘了改

3. **OcrPack**: macOS 分支的日志 `"FastDeploy macOS mode with rec N CPU threads"`，现在 det 和 rec 都走 CPU 了，"rec" 是之前只禁用 rec CoreML 时留下的

4. **MacSCKHelper**: 析构函数里 `stopCaptureWithCompletionHandler:nil` 是异步的，但紧接着就 release 了 stream/output/queue。如果刚好有一帧回调在 dispatch queue 里排队，就会踩到已释放的内存。改成用信号量等 stop 完成再释放，超时 3 秒兜底（和 init/capture 一致）

## Summary by Sourcery

修复 macOS 特有的 PlayTools 和屏幕捕获行为，并澄清相关日志。

错误修复：
- 在 `screencap_rgba`、`screencap_bgr` 和 `toucher_commit` 中，当 `socket open()` 失败时，阻止 `PlayToolsController` 继续执行，以避免向已关闭的连接写入数据。
- 确保 `MacSCKHelper` 在释放资源前等待捕获流完全停止，以避免在排队的帧回调中发生 use-after-free 崩溃。

增强改进：
- 明确 `PlayToolsController start_game` 的日志消息，以准确描述在 PlayTools 上不受支持的行为。
- 调整 macOS `OcrPack` 日志，体现现在检测和识别都在 CPU 上运行，而不仅仅是识别。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix macOS-specific PlayTools and screen capture behavior and clarify related logging.

Bug Fixes:
- Prevent PlayToolsController from proceeding when socket open() fails in screencap_rgba, screencap_bgr, and toucher_commit to avoid writing to a closed connection.
- Ensure MacSCKHelper waits for the capture stream to fully stop before releasing resources to avoid use-after-free crashes in queued frame callbacks.

Enhancements:
- Clarify PlayToolsController start_game log message to accurately describe unsupported behavior on PlayTools.
- Adjust macOS OcrPack logging to reflect that both detection and recognition now run on CPU, not just recognition.

</details>