### PR TITLE
fix: baseList 无法编译的问题

### DIFF
--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/RoguelikeSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/RoguelikeSettingsUserControlModel.cs
@@ -109,7 +109,7 @@ public class RoguelikeSettingsUserControlModel : TaskSettingsViewModel, Roguelik
     {
         var roguelikeMode = RoguelikeMode;
 
-        var baseList = new List<ModeItem>
+        var baseList = new List<GenericCombinedData<Mode>>
         {
             new() { Display = LocalizationHelper.GetString("RoguelikeStrategyExp"), Value = Mode.Exp },
             new() { Display = LocalizationHelper.GetString("RoguelikeStrategyGold"), Value = Mode.Investment },
@@ -129,7 +129,7 @@ public class RoguelikeSettingsUserControlModel : TaskSettingsViewModel, Roguelik
                 break;
         }
 
-        RoguelikeModeList = baseList;
+        RoguelikeModeList = new ObservableCollection<GenericCombinedData<Mode>>(baseList);
         RoguelikeMode = RoguelikeModeList.Any(x => x.Value == roguelikeMode) ? roguelikeMode : RoguelikeModeList.First().Value;
     }
 


### PR DESCRIPTION
之前的pull request #16271 导致112行的baseList那里编译出错

## Summary by Sourcery

错误修复：
- 将 roguelike 模式列表类型更正为使用 `GenericCombinedData<Mode>`，并将 `RoguelikeModeList` 初始化为可观察集合。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct the roguelike mode list type to use GenericCombinedData<Mode> and initialize RoguelikeModeList as an observable collection.

</details>