### PR TITLE
fix: quick place clues unrelated to vacancy count

### DIFF
--- a/src/MaaCore/Task/Infrast/InfrastReceptionTask.cpp
+++ b/src/MaaCore/Task/Infrast/InfrastReceptionTask.cpp
@@ -184,7 +184,7 @@ bool asst::InfrastReceptionTask::proc_clue_vacancy()
                 int available = 0;
                 if (utils::chars_to_number(ocr_res->text, available)) {
                     Log.info("vacancy_cnt:", vacancy_cnt, ", available:", available);
-                    if (available == vacancy_cnt) {
+                    if (available > 0) {
                         Rect click_rect = confirm_task->roi.move(confirm_task->rect_move);
                         ctrler()->click(click_rect);
                     }


### PR DESCRIPTION
Am I missing something important? Why do we have to wait for the vacancy being == to the owned to place them?

Can't we just always place them in case we have vacancies AND we have owned that are not placed.

This way our friends can send us the missing clues.

## Summary by Sourcery

Bug Fixes:
- 通过在至少有一个空位可用时就允许放置线索，而不是要求空位数量必须与已拥有线索数量完全匹配，修复了线索快速放置在空位数量不完全匹配已拥有线索数量时不会被触发的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix clue quick placement not triggering when vacancy count does not exactly match the number of owned clues by allowing placement whenever at least one vacancy is available.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- 通过在至少有一个空位可用时就允许放置线索，而不是要求空位数量必须与已拥有线索数量完全匹配，修复了线索快速放置在空位数量不完全匹配已拥有线索数量时不会被触发的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix clue quick placement not triggering when vacancy count does not exactly match the number of owned clues by allowing placement whenever at least one vacancy is available.

</details>

</details>