### PR TITLE
test: 添加 StringMisc 的 string_replace_all 与 chars_to_number 测试

### DIFF
--- a/unit_test/CMakeLists.txt
+++ b/unit_test/CMakeLists.txt
@@ -35,3 +35,13 @@ target_link_libraries(maa-algorithm-test PRIVATE Catch2::Catch2WithMain)
 target_include_directories(maa-algorithm-test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src/MaaCore)
 
 catch_discover_tests(maa-algorithm-test TEST_PREFIX "algorithm::")
+
+add_executable(maa-stringmisc-test
+    MaaCore/StringMiscTest.cpp
+)
+
+target_compile_features(maa-stringmisc-test PRIVATE cxx_std_20)
+target_link_libraries(maa-stringmisc-test PRIVATE Catch2::Catch2WithMain)
+target_include_directories(maa-stringmisc-test PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src/MaaCore)
+
+catch_discover_tests(maa-stringmisc-test TEST_PREFIX "stringmisc::")

--- a/unit_test/MaaCore/StringMiscTest.cpp
+++ b/unit_test/MaaCore/StringMiscTest.cpp
@@ -1,0 +1,231 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+#include "Utils/StringMisc.hpp"
+
+using asst::utils::chars_to_number;
+using asst::utils::string_replace_all;
+using asst::utils::string_replace_all_in_place;
+
+// ============================================================================
+// string_replace_all_in_place
+// ============================================================================
+
+TEST_CASE("replace_all replaces single occurrence")
+{
+    std::string s = "hello world";
+    string_replace_all_in_place<std::string>(s, "world", "there");
+    REQUIRE(s == "hello there");
+}
+
+TEST_CASE("replace_all replaces multiple non-overlapping occurrences")
+{
+    std::string s = "foo bar foo baz foo";
+    string_replace_all_in_place<std::string>(s, "foo", "X");
+    REQUIRE(s == "X bar X baz X");
+}
+
+TEST_CASE("replace_all is a no-op when pattern is not found")
+{
+    std::string s = "hello";
+    string_replace_all_in_place<std::string>(s, "xyz", "abc");
+    REQUIRE(s == "hello");
+}
+
+TEST_CASE("replace_all on empty string produces empty string")
+{
+    std::string s;
+    string_replace_all_in_place<std::string>(s, "a", "b");
+    REQUIRE(s.empty());
+}
+
+TEST_CASE("replace_all terminates when replacement contains the pattern")
+{
+    // Classic footgun: if the loop forgets to skip past `to`, replacing
+    // "a" with "aa" in "a" would re-find "a" at the same position and
+    // loop forever.
+    std::string s = "a";
+    string_replace_all_in_place<std::string>(s, "a", "aa");
+    REQUIRE(s == "aa");
+}
+
+TEST_CASE("replace_all expands string correctly when to-contains-from")
+{
+    std::string s = "aaa";
+    string_replace_all_in_place<std::string>(s, "a", "aa");
+    REQUIRE(s == "aaaaaa"); // 3 x 'a' -> 3 x 'aa' = 6 'a's
+}
+
+TEST_CASE("replace_all with overlapping pattern consumes greedily left-to-right")
+{
+    // "aaa" contains "aa" starting at pos 0 and pos 1; greedy left-to-right
+    // match at pos 0 replaces with "b", leaving "ba". Searching from pos 1
+    // finds no more "aa".
+    std::string s = "aaa";
+    string_replace_all_in_place<std::string>(s, "aa", "b");
+    REQUIRE(s == "ba");
+}
+
+TEST_CASE("replace_all with shrinking pattern skips correctly")
+{
+    std::string s = "xxxxx";
+    string_replace_all_in_place<std::string>(s, "xxx", "y");
+    // "xxx" at pos 0 -> "yxx". Advance pos by 1 (length of "y"). Remaining
+    // "xx" has no "xxx" match. Final result: "yxx".
+    REQUIRE(s == "yxx");
+}
+
+TEST_CASE("replace_all works on std::wstring with multi-byte characters")
+{
+    std::wstring s = L"你好世界你好";
+    string_replace_all_in_place<std::wstring>(s, L"你好", L"再见");
+    REQUIRE(s == L"再见世界再见");
+}
+
+TEST_CASE("non-in-place replace_all returns new string without mutating source")
+{
+    const std::string src = "hello world";
+    // Deliberately let template argument deduction pick up `const std::string&`
+    // as StringT so the source is copied rather than moved. Explicitly
+    // specifying `<std::string>` would turn the parameter into an rvalue
+    // reference and reject the const lvalue.
+    std::string_view from { "world" };
+    std::string_view to { "there" };
+    auto result = string_replace_all(src, from, to);
+    REQUIRE(result == "hello there");
+    REQUIRE(src == "hello world");
+}
+
+TEST_CASE("replace_all with initializer_list applies all replacements")
+{
+    std::string s = "ab";
+    string_replace_all_in_place<std::string>(s, { { "a", "x" }, { "b", "y" } });
+    REQUIRE(s == "xy");
+}
+
+TEST_CASE("replace_all initializer_list applies left-to-right, later rules see earlier results")
+{
+    // First rule: a -> b. String becomes "b".
+    // Second rule: b -> c. String becomes "c".
+    // If rules were applied independently to the original string, we'd get "b".
+    std::string s = "a";
+    string_replace_all_in_place<std::string>(s, { { "a", "b" }, { "b", "c" } });
+    REQUIRE(s == "c");
+}
+
+// ============================================================================
+// chars_to_number
+// ============================================================================
+
+TEST_CASE("chars_to_number parses a simple positive integer")
+{
+    int result = 0;
+    REQUIRE(chars_to_number("42", result));
+    REQUIRE(result == 42);
+}
+
+TEST_CASE("chars_to_number parses negative integer")
+{
+    int result = 0;
+    REQUIRE(chars_to_number("-42", result));
+    REQUIRE(result == -42);
+}
+
+TEST_CASE("chars_to_number parses zero")
+{
+    int result = 99;
+    REQUIRE(chars_to_number("0", result));
+    REQUIRE(result == 0);
+}
+
+TEST_CASE("chars_to_number fails on empty string")
+{
+    int result = 99;
+    REQUIRE_FALSE(chars_to_number("", result));
+    // result unchanged per std::from_chars contract; do not assert its value.
+}
+
+TEST_CASE("chars_to_number fails on non-numeric input")
+{
+    int result = 99;
+    REQUIRE_FALSE(chars_to_number("abc", result));
+}
+
+TEST_CASE("chars_to_number does NOT skip leading whitespace (std::from_chars contract)")
+{
+    int result = 99;
+    REQUIRE_FALSE(chars_to_number("  42", result));
+}
+
+TEST_CASE("chars_to_number with default FullMatch=false allows trailing garbage")
+{
+    int result = 0;
+    REQUIRE(chars_to_number("42abc", result));
+    REQUIRE(result == 42);
+}
+
+TEST_CASE("chars_to_number with default FullMatch=false allows trailing whitespace")
+{
+    int result = 0;
+    REQUIRE(chars_to_number("42 ", result));
+    REQUIRE(result == 42);
+}
+
+TEST_CASE("chars_to_number with FullMatch=true rejects trailing garbage")
+{
+    int result = 0;
+    const bool ok = chars_to_number<int, true>("42abc", result);
+    REQUIRE_FALSE(ok);
+}
+
+TEST_CASE("chars_to_number with FullMatch=true rejects trailing whitespace")
+{
+    int result = 0;
+    const bool ok = chars_to_number<int, true>("42 ", result);
+    REQUIRE_FALSE(ok);
+}
+
+TEST_CASE("chars_to_number with FullMatch=true accepts a pure integer")
+{
+    int result = 0;
+    const bool ok = chars_to_number<int, true>("42", result);
+    REQUIRE(ok);
+    REQUIRE(result == 42);
+}
+
+TEST_CASE("chars_to_number reports out-of-range for int8_t overflow")
+{
+    int8_t result = 0;
+    REQUIRE_FALSE(chars_to_number<int8_t>("1000", result));
+}
+
+TEST_CASE("chars_to_number accepts int8_t boundary value")
+{
+    int8_t result = 0;
+    REQUIRE(chars_to_number<int8_t>("127", result));
+    REQUIRE(result == 127);
+}
+
+TEST_CASE("chars_to_number parses large uint64_t value")
+{
+    uint64_t result = 0;
+    REQUIRE(chars_to_number<uint64_t>("9999999999", result));
+    REQUIRE(result == 9999999999ULL);
+}
+
+TEST_CASE("chars_to_number parses a double")
+{
+    double result = 0.0;
+    REQUIRE(chars_to_number<double>("3.14", result));
+    REQUIRE(result == 3.14);
+}
+
+TEST_CASE("chars_to_number parses scientific notation into double")
+{
+    double result = 0.0;
+    REQUIRE(chars_to_number<double>("1e3", result));
+    REQUIRE(result == 1000.0);
+}

--- a/unit_test/MaaCore/StringMiscTest.cpp
+++ b/unit_test/MaaCore/StringMiscTest.cpp
@@ -209,11 +209,45 @@ TEST_CASE("chars_to_number accepts int8_t boundary value")
     REQUIRE(result == 127);
 }
 
+TEST_CASE("chars_to_number accepts int8_t minimum boundary")
+{
+    int8_t result = 0;
+    REQUIRE(chars_to_number<int8_t>("-128", result));
+    REQUIRE(result == -128);
+}
+
+TEST_CASE("chars_to_number reports out-of-range for int8_t underflow")
+{
+    int8_t result = 0;
+    REQUIRE_FALSE(chars_to_number<int8_t>("-129", result));
+}
+
 TEST_CASE("chars_to_number parses large uint64_t value")
 {
     uint64_t result = 0;
     REQUIRE(chars_to_number<uint64_t>("9999999999", result));
     REQUIRE(result == 9999999999ULL);
+}
+
+TEST_CASE("chars_to_number reports out-of-range for uint64_t overflow")
+{
+    // uint64_t max is 18446744073709551615; the literal below is one past max.
+    uint64_t result = 0;
+    REQUIRE_FALSE(chars_to_number<uint64_t>("18446744073709551616", result));
+}
+
+TEST_CASE("chars_to_number rejects negative input for uint64_t")
+{
+    // std::from_chars treats a leading '-' as invalid for unsigned targets,
+    // rather than wrapping around to the maximum value.
+    uint64_t result = 0;
+    REQUIRE_FALSE(chars_to_number<uint64_t>("-1", result));
+}
+
+TEST_CASE("chars_to_number rejects negative input for uint32_t")
+{
+    uint32_t result = 0;
+    REQUIRE_FALSE(chars_to_number<uint32_t>("-1", result));
 }
 
 TEST_CASE("chars_to_number parses a double")


### PR DESCRIPTION
延续 #16245 的 Utils 测试模式，给 `Utils/StringMisc.hpp` 里两个有边界陷阱的函数补测试。

## 改动

- 新文件 `unit_test/MaaCore/StringMiscTest.cpp`，28 个 TEST_CASE：
  - `string_replace_all_in_place` / `string_replace_all` — 覆盖"to 包含 from"死循环、overlap 贪心匹配、缩短替换、空串、宽字符、`initializer_list` 顺序应用
  - `chars_to_number` — 覆盖 `FullMatch=true` 严格模式 vs 默认允许尾部垃圾、`int8_t` 溢出、`uint64_t` 大数、`double` 科学计数法
- `unit_test/CMakeLists.txt` 新增 `maa-stringmisc-test` target，和 `maa-algorithm-test` 同一个模式

## 验证

本地 macOS + AppleClang 21：
- `cmake --build build` 通过，零 warning
- `./build/maa-stringmisc-test` 全通过（39 assertions in 28 test cases）
- ctest 全 green

## Mutation 抽查

为确认测试不是 tautological，手工改源码验证：把 `if constexpr (FullMatch)` 改成 `if constexpr (false)` → 对应 2 个 FullMatch=true 的 test 立刻红掉 ✓

## Summary by Sourcery

为 StringMisc 工具添加单元测试，并将其接入单元测试构建目标。

Build:
- 在 unit_test 的 CMake 配置中添加 `maa-stringmisc-test` 可执行目标，方式与现有的 `maa-algorithm-test` 设置保持一致。

Tests:
- 为 `string_replace_all` / `string_replace_all_in_place` 添加全面的 Catch2 测试，覆盖重叠模式、包含自身的替换、宽字符串以及 `initializer_list` 规则等边界情况。
- 为 `chars_to_number` 添加测试，覆盖空和无效输入、空白字符处理、严格的 FullMatch 模式、整数溢出边界、大无符号整数，以及浮点数/科学计数法解析。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add unit tests for StringMisc utilities and wire them into the unit test build target.

Build:
- Add maa-stringmisc-test executable target to unit_test CMake configuration, mirroring the existing maa-algorithm-test setup.

Tests:
- Add comprehensive Catch2 tests for string_replace_all/string_replace_all_in_place covering edge cases like overlapping patterns, self-containing replacements, wide strings, and initializer_list rules.
- Add tests for chars_to_number covering empty and invalid input, whitespace handling, strict FullMatch mode, integer overflow boundaries, large unsigned integers, and floating-point/scientific notation parsing.

</details>