### PR TITLE
feat(wpf): 理智作战所选关卡今日全未开放时增加显眼日志提示

### DIFF
--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -815,6 +815,7 @@ Do not adjust the proxy multiplier setting in the game</system:String>
     <system:String x:Key="Running">Running……</system:String>
     <system:String x:Key="TaskAppend.Skip">{0}: {1} task skip</system:String>
     <system:String x:Key="TaskAppend.Error">{0}: {1} append task failed</system:String>
+    <system:String x:Key="FightStageAllClosed">｢{key=Fight}｣: Selected stage(s) [{0}] not open today. Consider enabling ｢{key=UseAlternateStage}｣ and adding ｢{key=DefaultStage}｣ as fallback to avoid being skipped.</system:String>
     <system:String x:Key="AdbReplacementTips">If nothing happens or appears stuck, please go to ｢{key=Settings} - {key=ConnectionSettings} - {key=ForcedReplaceAdb}｣, or turn on ADB Input (Deprecated).</system:String>
     <system:String x:Key="Waiting">Waiting for the mission completion…</system:String>
     <system:String x:Key="Stopping">Stopping……</system:String>

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -816,6 +816,7 @@ Do not adjust the proxy multiplier setting in the game</system:String>
     <system:String x:Key="TaskAppend.Skip">{0}: {1} task skip</system:String>
     <system:String x:Key="TaskAppend.Error">{0}: {1} append task failed</system:String>
     <system:String x:Key="FightStageAllClosed">｢{key=Fight}｣: Selected stage(s) [{0}] not open today. Consider enabling ｢{key=UseAlternateStage}｣ and adding ｢{key=DefaultStage}｣ as fallback to avoid being skipped.</system:String>
+    <system:String x:Key="FightNoStageConfigured">｢{key=Fight}｣: No stage configured. Please select a stage, or enable ｢{key=UseAlternateStage}｣ and add ｢{key=DefaultStage}｣ as fallback.</system:String>
     <system:String x:Key="AdbReplacementTips">If nothing happens or appears stuck, please go to ｢{key=Settings} - {key=ConnectionSettings} - {key=ForcedReplaceAdb}｣, or turn on ADB Input (Deprecated).</system:String>
     <system:String x:Key="Waiting">Waiting for the mission completion…</system:String>
     <system:String x:Key="Stopping">Stopping……</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -817,6 +817,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="TaskAppend.Skip">{0}: {1} タスクをスキップしました</system:String>
     <system:String x:Key="TaskAppend.Error">{0}: {1} タスクの追加に失敗しました</system:String>
     <system:String x:Key="FightStageAllClosed">｢{key=Fight}｣: 選択したステージ [{0}] は本日開放されていません。｢{key=UseAlternateStage}｣ を有効にし、｢{key=DefaultStage}｣ をフォールバックとして追加することでスキップを防げます。</system:String>
+    <system:String x:Key="FightNoStageConfigured">｢{key=Fight}｣: ステージが設定されていません。ステージを選択するか、｢{key=UseAlternateStage}｣ を有効にして ｢{key=DefaultStage}｣ をフォールバックとして追加してください。</system:String>
     <system:String x:Key="AdbReplacementTips">タスクが応答なしになる場合は、「{key=Settings} - {key=ConnectionSettings} - {key=ForcedReplaceAdb}」、もしくは ADB Input タッチモード をチェックしてください（お勧めしない）。</system:String>
     <system:String x:Key="Waiting">ミッション終了を待っています……</system:String>
     <system:String x:Key="Stopping">動作停止中……</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -816,6 +816,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="Running">動作中……</system:String>
     <system:String x:Key="TaskAppend.Skip">{0}: {1} タスクをスキップしました</system:String>
     <system:String x:Key="TaskAppend.Error">{0}: {1} タスクの追加に失敗しました</system:String>
+    <system:String x:Key="FightStageAllClosed">｢{key=Fight}｣: 選択したステージ [{0}] は本日開放されていません。｢{key=UseAlternateStage}｣ を有効にし、｢{key=DefaultStage}｣ をフォールバックとして追加することでスキップを防げます。</system:String>
     <system:String x:Key="AdbReplacementTips">タスクが応答なしになる場合は、「{key=Settings} - {key=ConnectionSettings} - {key=ForcedReplaceAdb}」、もしくは ADB Input タッチモード をチェックしてください（お勧めしない）。</system:String>
     <system:String x:Key="Waiting">ミッション終了を待っています……</system:String>
     <system:String x:Key="Stopping">動作停止中……</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -817,6 +817,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="Running">실행 중……</system:String>
     <system:String x:Key="TaskAppend.Skip">{0}: {1} 작업 스킵</system:String>
     <system:String x:Key="TaskAppend.Error">{0}: {1} 작업 추가 실패</system:String>
+    <system:String x:Key="FightStageAllClosed">｢{key=Fight}｣: 선택한 스테이지 [{0}]이(가) 오늘 개방되지 않았습니다. ｢{key=UseAlternateStage}｣을(를) 활성화하고 ｢{key=DefaultStage}｣을(를) 예비로 추가하면 건너뛰기를 방지할 수 있습니다.</system:String>
     <system:String x:Key="AdbReplacementTips">작업이 전혀 반응하지 않을 경우, ｢{key=Settings} - {key=ConnectionSettings} - {key=ForcedReplaceAdb}｣를 사용하거나, 터치 모드에서 ADB Input(권장하지 않음)을 선택해 보세요.</system:String>
     <system:String x:Key="Waiting">전투가 끝나기를 기다리며……</system:String>
     <system:String x:Key="Stopping">중지 중……</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -818,6 +818,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="TaskAppend.Skip">{0}: {1} 작업 스킵</system:String>
     <system:String x:Key="TaskAppend.Error">{0}: {1} 작업 추가 실패</system:String>
     <system:String x:Key="FightStageAllClosed">｢{key=Fight}｣: 선택한 스테이지 [{0}]이(가) 오늘 개방되지 않았습니다. ｢{key=UseAlternateStage}｣을(를) 활성화하고 ｢{key=DefaultStage}｣을(를) 예비로 추가하면 건너뛰기를 방지할 수 있습니다.</system:String>
+    <system:String x:Key="FightNoStageConfigured">｢{key=Fight}｣: 스테이지가 설정되지 않았습니다. 스테이지를 선택하거나 ｢{key=UseAlternateStage}｣을(를) 활성화하고 ｢{key=DefaultStage}｣을(를) 예비로 추가해 주세요.</system:String>
     <system:String x:Key="AdbReplacementTips">작업이 전혀 반응하지 않을 경우, ｢{key=Settings} - {key=ConnectionSettings} - {key=ForcedReplaceAdb}｣를 사용하거나, 터치 모드에서 ADB Input(권장하지 않음)을 선택해 보세요.</system:String>
     <system:String x:Key="Waiting">전투가 끝나기를 기다리며……</system:String>
     <system:String x:Key="Stopping">중지 중……</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -816,6 +816,7 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="Running">正在运行中……</system:String>
     <system:String x:Key="TaskAppend.Skip">{0}: {1} 任务跳过</system:String>
     <system:String x:Key="TaskAppend.Error">{0}: {1} 添加任务失败</system:String>
+    <system:String x:Key="FightStageAllClosed">｢{key=Fight}｣: 所选关卡 [{0}] 今日均未开放。建议勾选 ｢{key=UseAlternateStage}｣ 并添加 ｢{key=DefaultStage}｣ 作为兜底，避免被跳过。</system:String>
     <system:String x:Key="AdbReplacementTips">如果任务完全没有反应，请使用 ｢{key=Settings} - {key=ConnectionSettings} - {key=ForcedReplaceAdb}｣，或触控模式选择 ADB Input（不推荐）。</system:String>
     <system:String x:Key="Waiting">正在等待当前任务结束……</system:String>
     <system:String x:Key="Stopping">正在停止……</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -817,6 +817,7 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="TaskAppend.Skip">{0}: {1} 任务跳过</system:String>
     <system:String x:Key="TaskAppend.Error">{0}: {1} 添加任务失败</system:String>
     <system:String x:Key="FightStageAllClosed">｢{key=Fight}｣: 所选关卡 [{0}] 今日均未开放。建议勾选 ｢{key=UseAlternateStage}｣ 并添加 ｢{key=DefaultStage}｣ 作为兜底，避免被跳过。</system:String>
+    <system:String x:Key="FightNoStageConfigured">｢{key=Fight}｣: 未配置任何关卡。请先选择关卡，或勾选 ｢{key=UseAlternateStage}｣ 并添加 ｢{key=DefaultStage}｣ 作为兜底。</system:String>
     <system:String x:Key="AdbReplacementTips">如果任务完全没有反应，请使用 ｢{key=Settings} - {key=ConnectionSettings} - {key=ForcedReplaceAdb}｣，或触控模式选择 ADB Input（不推荐）。</system:String>
     <system:String x:Key="Waiting">正在等待当前任务结束……</system:String>
     <system:String x:Key="Stopping">正在停止……</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -816,6 +816,7 @@ C:\\leidian\\LDPlayer9\n
     <system:String x:Key="Running">正在執行中……</system:String>
     <system:String x:Key="TaskAppend.Skip">{0}: {1} 任務跳過</system:String>
     <system:String x:Key="TaskAppend.Error">{0}: {1} 新增任務失敗</system:String>
+    <system:String x:Key="FightStageAllClosed">｢{key=Fight}｣: 所選關卡 [{0}] 今日均未開放。建議勾選 ｢{key=UseAlternateStage}｣ 並新增 ｢{key=DefaultStage}｣ 作為備援，避免被跳過。</system:String>
     <system:String x:Key="AdbReplacementTips">如果任務完全沒有反應，請使用 ｢{key=Settings} - {key=ConnectionSettings} - {key=ForcedReplaceAdb}｣，或觸控模式選擇 ADB Input（不推薦）。</system:String>
     <system:String x:Key="Waiting">正在等待目前任務結束……</system:String>
     <system:String x:Key="Stopping">正在停止……</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -817,6 +817,7 @@ C:\\leidian\\LDPlayer9\n
     <system:String x:Key="TaskAppend.Skip">{0}: {1} 任務跳過</system:String>
     <system:String x:Key="TaskAppend.Error">{0}: {1} 新增任務失敗</system:String>
     <system:String x:Key="FightStageAllClosed">｢{key=Fight}｣: 所選關卡 [{0}] 今日均未開放。建議勾選 ｢{key=UseAlternateStage}｣ 並新增 ｢{key=DefaultStage}｣ 作為備援，避免被跳過。</system:String>
+    <system:String x:Key="FightNoStageConfigured">｢{key=Fight}｣: 未設定任何關卡。請先選擇關卡，或勾選 ｢{key=UseAlternateStage}｣ 並新增 ｢{key=DefaultStage}｣ 作為備援。</system:String>
     <system:String x:Key="AdbReplacementTips">如果任務完全沒有反應，請使用 ｢{key=Settings} - {key=ConnectionSettings} - {key=ForcedReplaceAdb}｣，或觸控模式選擇 ADB Input（不推薦）。</system:String>
     <system:String x:Key="Waiting">正在等待目前任務結束……</system:String>
     <system:String x:Key="Stopping">正在停止……</system:String>

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/FightSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/FightSettingsUserControlModel.cs
@@ -1015,9 +1015,10 @@ public class FightSettingsUserControlModel : TaskSettingsViewModel, FightSetting
             if (stage is null)
             {
                 var closedStages = string.Join(", ", fight.StagePlan.Where(s => !string.IsNullOrEmpty(s)));
-                Instances.TaskQueueViewModel.AddLog(
-                    LocalizationHelper.GetStringFormat("FightStageAllClosed", closedStages),
-                    UiLogColor.Warning);
+                var message = string.IsNullOrEmpty(closedStages)
+                    ? LocalizationHelper.GetString("FightNoStageConfigured")
+                    : LocalizationHelper.GetStringFormat("FightStageAllClosed", closedStages);
+                Instances.TaskQueueViewModel.AddLog(message, UiLogColor.Warning);
                 return (null, []);
             }
 

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/FightSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/FightSettingsUserControlModel.cs
@@ -1014,6 +1014,10 @@ public class FightSettingsUserControlModel : TaskSettingsViewModel, FightSetting
             string? stage = GetFightStage(fight.StagePlan);
             if (stage is null)
             {
+                var closedStages = string.Join(", ", fight.StagePlan.Where(s => !string.IsNullOrEmpty(s)));
+                Instances.TaskQueueViewModel.AddLog(
+                    LocalizationHelper.GetStringFormat("FightStageAllClosed", closedStages),
+                    UiLogColor.Warning);
                 return (null, []);
             }
 


### PR DESCRIPTION
点击 Link Start! 后，若「理智作战」或「剩余理智」配置的所有关卡今日均未开放，原本仅以 Info 级别日志 `TaskAppend.Skip` 静默跳过，极易被用户忽略，导致满溢理智无法消耗、时间被白白浪费。

本 PR 在 `FightSettingsUserControlModel.Serialize()` 中检测到该情况时，以 Warning 颜色输出一条显眼提示，告知所选关卡及建议开启「使用备选关卡」+「当前/上次」作为兜底。

- 仅在 Fight 任务已勾选（`IsTaskEnable == true`）且所有候选关卡均今日未开放时触发
- 同时新增 `FightStageAllClosed` 文本键到 5 个 locale（zh-cn / zh-tw / en-us / ja-jp / ko-kr），使用 `{key=...}` 引用现有术语，保证 UI 名称一致
- 不改变任何执行行为，仅让原本静默的 skip 变得可见，不影响现有的「使用备选关卡」「过期关卡重置」等逻辑

ref #16321

## Summary by Sourcery

在所有已配置的理智副本关卡当天都已关闭时，新增一条可见的警告日志，使自动跳过不再是静默进行。

增强内容：
- 在序列化 `FightSettings` 时，当所选战斗关卡在当天全部不可用时记录一条警告日志，但不改变任务执行行为。

文档：
- 在所有支持的语言中新增 `FightStageAllClosed` 本地化字符串，用于描述新的警告消息。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a visible warning log when all configured sanity battle stages are closed for the day so that automatic skipping is no longer silent.

Enhancements:
- Log a warning in FightSettings serialization when the selected fight stages are all unavailable for the current day, without changing task execution behavior.

Documentation:
- Add the FightStageAllClosed localization string in all supported languages to describe the new warning message.

</details>