### PR TITLE
rft: 外部更新使用分离的 updater

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ if(BUILD_WPF_GUI)
     include_external_msproject(MaaWpfGui ${PROJECT_SOURCE_DIR}/src/MaaWpfGui/MaaWpfGui.csproj)
 
     add_dependencies(MaaWpfGui MaaCore)
+    add_dependencies(MaaWpfGui MAA.Updater)
     if(DEFINED ENV{VSCODE_PID})
         add_custom_target(run-MaaWpfGui
             COMMAND "${CMAKE_BINARY_DIR}/bin/$<CONFIG>/MAA.exe"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,8 @@ target_include_directories(HeaderOnlyLibraries INTERFACE 3rdparty/include)
 add_subdirectory(src/MaaCore)
 
 if(BUILD_WPF_GUI)
+    add_subdirectory(src/MaaUpdater)
+
     include_external_msproject(MaaWpfGui ${PROJECT_SOURCE_DIR}/src/MaaWpfGui/MaaWpfGui.csproj)
 
     add_dependencies(MaaWpfGui MaaCore)

--- a/src/MaaUpdater/CMakeLists.txt
+++ b/src/MaaUpdater/CMakeLists.txt
@@ -1,0 +1,16 @@
+add_executable(MAA.Updater main.cpp)
+set_target_properties(MAA.Updater PROPERTIES OUTPUT_NAME "MAA.Updater")
+
+# Static CRT - no runtime DLL dependency, updater must survive MAA's own runtime being replaced
+set_property(TARGET MAA.Updater PROPERTY
+    MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+
+target_compile_options(MAA.Updater PRIVATE /WX- /W3 /utf-8)
+target_compile_definitions(MAA.Updater PRIVATE UNICODE _UNICODE WIN32_LEAN_AND_MEAN NOMINMAX)
+
+# kernel32: process/file/directory APIs
+# user32:   MessageBoxW for "do not run manually" prompt
+# shell32:  recycle-bin delete via SHFileOperationW
+target_link_libraries(MAA.Updater PRIVATE kernel32 user32 shell32)
+
+install(TARGETS MAA.Updater RUNTIME DESTINATION .)

--- a/src/MaaUpdater/main.cpp
+++ b/src/MaaUpdater/main.cpp
@@ -8,7 +8,7 @@
 //                   <RelaunchExecutablePath> <PlanFile>
 //
 // Plan file format (UTF-8 JSON):
-//   { "removeList": ["rel/path", ...], "moveList": ["rel/path", ...] }
+//   { "packageType": "full|ota", "removeList": ["rel/path", ...], "moveList": ["rel/path", ...] }
 
 #include <windows.h>
 #include <shellapi.h>
@@ -507,6 +507,126 @@ static std::string ParseJsonString(const std::string& json, size_t& pos)
     return result;
 }
 
+static size_t SkipJsonWhitespace(const std::string& json, size_t pos)
+{
+    while (pos < json.size() && (json[pos] == ' ' || json[pos] == '\t' ||
+                                 json[pos] == '\r' || json[pos] == '\n'))
+    {
+        ++pos;
+    }
+    return pos;
+}
+
+// Skips one JSON value starting at `pos` and returns the position right after it.
+static size_t SkipJsonValue(const std::string& json, size_t pos)
+{
+    pos = SkipJsonWhitespace(json, pos);
+    if (pos >= json.size()) return pos;
+
+    char c = json[pos];
+    if (c == '"') {
+        ++pos;
+        ParseJsonString(json, pos);
+        return pos;
+    }
+
+    if (c == '{' || c == '[') {
+        char open = c;
+        char close = (c == '{') ? '}' : ']';
+        int depth = 0;
+        bool inString = false;
+        bool escaped = false;
+
+        for (; pos < json.size(); ++pos) {
+            char ch = json[pos];
+            if (inString) {
+                if (escaped) {
+                    escaped = false;
+                } else if (ch == '\\') {
+                    escaped = true;
+                } else if (ch == '"') {
+                    inString = false;
+                }
+                continue;
+            }
+
+            if (ch == '"') {
+                inString = true;
+                continue;
+            }
+
+            if (ch == open) {
+                ++depth;
+            } else if (ch == close) {
+                --depth;
+                if (depth == 0) {
+                    ++pos;
+                    break;
+                }
+            }
+        }
+
+        return pos;
+    }
+
+    // number / true / false / null
+    while (pos < json.size()) {
+        char ch = json[pos];
+        if (ch == ',' || ch == '}' || ch == ']' || ch == ' ' || ch == '\t' || ch == '\r' || ch == '\n') {
+            break;
+        }
+        ++pos;
+    }
+    return pos;
+}
+
+// Finds `"key": <value>` in the top-level JSON object and returns the start of `<value>`.
+static size_t FindTopLevelJsonValueStartByKey(const std::string& json, const char* key)
+{
+    size_t pos = SkipJsonWhitespace(json, 0);
+    if (pos >= json.size() || json[pos] != '{') return std::string::npos;
+    ++pos;
+
+    while (pos < json.size()) {
+        pos = SkipJsonWhitespace(json, pos);
+        if (pos >= json.size()) return std::string::npos;
+
+        if (json[pos] == ',') {
+            ++pos;
+            continue;
+        }
+
+        if (json[pos] == '}') {
+            return std::string::npos;
+        }
+
+        if (json[pos] != '"') {
+            ++pos;
+            continue;
+        }
+
+        ++pos;
+        std::string currentKey = ParseJsonString(json, pos);
+
+        pos = SkipJsonWhitespace(json, pos);
+        if (pos >= json.size() || json[pos] != ':') {
+            return std::string::npos;
+        }
+
+        ++pos;
+        pos = SkipJsonWhitespace(json, pos);
+        if (pos >= json.size()) return std::string::npos;
+
+        if (currentKey == key) {
+            return pos;
+        }
+
+        pos = SkipJsonValue(json, pos);
+    }
+
+    return std::string::npos;
+}
+
 // Find a JSON array by key name and return its string elements.
 static std::vector<std::wstring> ParseJsonStringArray(
     const std::string& json,
@@ -514,18 +634,8 @@ static std::vector<std::wstring> ParseJsonStringArray(
 {
     std::vector<std::wstring> result;
 
-    // Find "key"
-    std::string needle = std::string("\"") + key + "\"";
-    size_t keyPos = json.find(needle);
-    if (keyPos == std::string::npos) return result;
-
-    size_t pos = keyPos + needle.size();
-
-    // Skip whitespace and colon
-    while (pos < json.size() && (json[pos] == ' ' || json[pos] == '\t' ||
-                                  json[pos] == '\r' || json[pos] == '\n' ||
-                                  json[pos] == ':'))
-        pos++;
+    size_t pos = FindTopLevelJsonValueStartByKey(json, key);
+    if (pos == std::string::npos) return result;
 
     if (pos >= json.size() || json[pos] != '[') return result;
     pos++; // consume '['
@@ -554,17 +664,8 @@ static std::vector<std::wstring> ParseJsonStringArray(
 
 static std::wstring ParseJsonStringProperty(const std::string& json, const char* key)
 {
-    std::string needle = std::string("\"") + key + "\"";
-    size_t keyPos = json.find(needle);
-    if (keyPos == std::string::npos) return {};
-
-    size_t pos = keyPos + needle.size();
-    while (pos < json.size() && (json[pos] == ' ' || json[pos] == '\t' ||
-                                  json[pos] == '\r' || json[pos] == '\n' ||
-                                  json[pos] == ':'))
-    {
-        pos++;
-    }
+    size_t pos = FindTopLevelJsonValueStartByKey(json, key);
+    if (pos == std::string::npos) return {};
 
     if (pos >= json.size() || json[pos] != '"') return {};
 

--- a/src/MaaUpdater/main.cpp
+++ b/src/MaaUpdater/main.cpp
@@ -13,11 +13,13 @@
 #include <windows.h>
 #include <shellapi.h>
 
+#include <cstdarg>
 #include <cassert>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
+#include <limits>
 #include <string>
 #include <vector>
 
@@ -26,6 +28,34 @@
 // ---------------------------------------------------------------------------
 
 static std::wstring g_logFile;
+
+static bool TryConvertWideToUtf8(const std::wstring& wide, std::string& utf8)
+{
+    int utf8Len = WideCharToMultiByte(
+        CP_UTF8,
+        0,
+        wide.c_str(),
+        static_cast<int>(wide.size()),
+        nullptr,
+        0,
+        nullptr,
+        nullptr);
+    if (utf8Len <= 0) {
+        utf8.clear();
+        return false;
+    }
+
+    utf8.assign(static_cast<size_t>(utf8Len), '\0');
+    return WideCharToMultiByte(
+        CP_UTF8,
+        0,
+        wide.c_str(),
+        static_cast<int>(wide.size()),
+        utf8.data(),
+        utf8Len,
+        nullptr,
+        nullptr) == utf8Len;
+}
 
 static void WriteLog(const wchar_t* message)
 {
@@ -58,12 +88,10 @@ static void WriteLog(const wchar_t* message)
     if (hFile == INVALID_HANDLE_VALUE) return;
 
     // Write UTF-8
-    int utf8Len = WideCharToMultiByte(CP_UTF8, 0, line.c_str(), -1, nullptr, 0, nullptr, nullptr);
-    if (utf8Len > 1) {
-        std::string utf8(utf8Len - 1, '\0');
-        WideCharToMultiByte(CP_UTF8, 0, line.c_str(), -1, utf8.data(), utf8Len, nullptr, nullptr);
+    std::string utf8;
+    if (TryConvertWideToUtf8(line, utf8)) {
         DWORD written = 0;
-        WriteFile(hFile, utf8.c_str(), static_cast<DWORD>(utf8.size()), &written, nullptr);
+        WriteFile(hFile, utf8.data(), static_cast<DWORD>(utf8.size()), &written, nullptr);
     }
     CloseHandle(hFile);
 }
@@ -365,7 +393,14 @@ static bool RemoveDirectoryRecursive(const std::wstring& dir)
 // Write a small UTF-8 text file
 // ---------------------------------------------------------------------------
 
+static bool WriteUtf8File(const std::wstring& path, const std::string& content);
+
 static bool WriteUtf8File(const std::wstring& path, const char* content)
+{
+    return WriteUtf8File(path, std::string(content));
+}
+
+static bool WriteUtf8File(const std::wstring& path, const std::string& content)
 {
     EnsureParentDirectory(path);
     HANDLE hFile = CreateFileW(
@@ -375,8 +410,8 @@ static bool WriteUtf8File(const std::wstring& path, const char* content)
     if (hFile == INVALID_HANDLE_VALUE) return false;
 
     DWORD written = 0;
-    DWORD len = static_cast<DWORD>(strlen(content));
-    bool ok = WriteFile(hFile, content, len, &written, nullptr) != FALSE;
+    DWORD len = static_cast<DWORD>(content.size());
+    bool ok = WriteFile(hFile, content.data(), len, &written, nullptr) != FALSE;
     CloseHandle(hFile);
     return ok && written == len;
 }
@@ -394,10 +429,21 @@ static std::string ReadUtf8File(const std::wstring& path)
         nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
     if (hFile == INVALID_HANDLE_VALUE) return {};
 
-    DWORD size = GetFileSize(hFile, nullptr);
-    std::string buf(size, '\0');
+    LARGE_INTEGER size {};
+    if (!GetFileSizeEx(hFile, &size) ||
+        size.QuadPart < 0 ||
+        size.QuadPart > static_cast<LONGLONG>(std::numeric_limits<size_t>::max()))
+    {
+        CloseHandle(hFile);
+        return {};
+    }
+
+    std::string buf(static_cast<size_t>(size.QuadPart), '\0');
     DWORD read = 0;
-    ReadFile(hFile, buf.data(), size, &read, nullptr);
+    if (!ReadFile(hFile, buf.data(), static_cast<DWORD>(buf.size()), &read, nullptr)) {
+        CloseHandle(hFile);
+        return {};
+    }
     CloseHandle(hFile);
     buf.resize(read);
     return buf;
@@ -694,11 +740,9 @@ int wmain(int argc, wchar_t* argv[])
     // ------------------------------------------------------------------
     if (!success && !failureReason.empty()) {
         // Convert wstring reason to UTF-8 for file
-        int utf8Len = WideCharToMultiByte(CP_UTF8, 0, failureReason.c_str(), -1, nullptr, 0, nullptr, nullptr);
-        if (utf8Len > 1) {
-            std::string utf8Reason(utf8Len - 1, '\0');
-            WideCharToMultiByte(CP_UTF8, 0, failureReason.c_str(), -1, utf8Reason.data(), utf8Len, nullptr, nullptr);
-            WriteUtf8File(failureStatusFile, utf8Reason.c_str());
+        std::string utf8Reason;
+        if (TryConvertWideToUtf8(failureReason, utf8Reason)) {
+            WriteUtf8File(failureStatusFile, utf8Reason);
         }
         if (PathExistsW(successStatusFile))
             DeleteFileW(successStatusFile.c_str());

--- a/src/MaaUpdater/main.cpp
+++ b/src/MaaUpdater/main.cpp
@@ -685,8 +685,10 @@ int wmain(int argc, wchar_t* argv[])
         MessageBoxW(
             nullptr,
             L"MAA.Updater.exe 是 MAA 内部使用的更新程序，不应被手动启动。\n\n"
-            L"请直接运行 MAA.exe。",
-            L"MAA 更新程序",
+            L"请直接运行 MAA.exe。\n\n"
+            L"MAA.Updater.exe is an updater used internally by MAA and should not be manually started.\n\n"
+            L"Please run MAA.exe directly.",
+            L"MAA 更新程序 / MAA Updater",
             MB_OK | MB_ICONINFORMATION);
         return 1;
     }

--- a/src/MaaUpdater/main.cpp
+++ b/src/MaaUpdater/main.cpp
@@ -1,0 +1,751 @@
+// MAA.Updater.exe
+// Applies a pending MAA update package after the main MAA process exits.
+// Invoked by MaaWpfGui's PendingUpdateApplier; do NOT run manually.
+//
+// Usage:
+//   MAA.Updater.exe <ParentProcessId> <RootDir> <ExtractDir> <BackupDir>
+//                   <PackagePath> <SuccessStatusFile> <FailureStatusFile>
+//                   <RelaunchExecutablePath> <PlanFile>
+//
+// Plan file format (UTF-8 JSON):
+//   { "removeList": ["rel/path", ...], "moveList": ["rel/path", ...] }
+
+#include <windows.h>
+#include <shellapi.h>
+
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <string>
+#include <vector>
+
+// ---------------------------------------------------------------------------
+// Logging
+// ---------------------------------------------------------------------------
+
+static std::wstring g_logFile;
+
+static void WriteLog(const wchar_t* message)
+{
+    if (g_logFile.empty()) return;
+
+    SYSTEMTIME st {};
+    GetLocalTime(&st);
+
+    wchar_t buf[64];
+    _snwprintf_s(buf, _countof(buf), _TRUNCATE,
+                 L"[%04d-%02d-%02d %02d:%02d:%02d.%03d] ",
+                 st.wYear, st.wMonth, st.wDay,
+                 st.wHour, st.wMinute, st.wSecond, st.wMilliseconds);
+
+    std::wstring line = buf;
+    line += message;
+    line += L"\r\n";
+
+    // Ensure parent directory exists
+    size_t sep = g_logFile.rfind(L'\\');
+    if (sep != std::wstring::npos) {
+        std::wstring dir = g_logFile.substr(0, sep);
+        CreateDirectoryW(dir.c_str(), nullptr);
+    }
+
+    HANDLE hFile = CreateFileW(
+        g_logFile.c_str(),
+        FILE_APPEND_DATA, FILE_SHARE_READ,
+        nullptr, OPEN_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (hFile == INVALID_HANDLE_VALUE) return;
+
+    // Write UTF-8
+    int utf8Len = WideCharToMultiByte(CP_UTF8, 0, line.c_str(), -1, nullptr, 0, nullptr, nullptr);
+    if (utf8Len > 1) {
+        std::string utf8(utf8Len - 1, '\0');
+        WideCharToMultiByte(CP_UTF8, 0, line.c_str(), -1, utf8.data(), utf8Len, nullptr, nullptr);
+        DWORD written = 0;
+        WriteFile(hFile, utf8.c_str(), static_cast<DWORD>(utf8.size()), &written, nullptr);
+    }
+    CloseHandle(hFile);
+}
+
+static void WriteLogF(const wchar_t* fmt, ...)
+{
+    wchar_t buf[2048];
+    va_list args;
+    va_start(args, fmt);
+    _vsnwprintf_s(buf, _countof(buf), _TRUNCATE, fmt, args);
+    va_end(args);
+    WriteLog(buf);
+}
+
+// ---------------------------------------------------------------------------
+// Path utilities
+// ---------------------------------------------------------------------------
+
+static std::wstring EnsureTrailingSeparator(const std::wstring& path)
+{
+    if (!path.empty() && path.back() != L'\\')
+        return path + L'\\';
+    return path;
+}
+
+static std::wstring NormalizeRelativePath(const std::wstring& relativePath)
+{
+    std::wstring normalized = relativePath;
+    for (wchar_t& c : normalized) {
+        if (c == L'/') {
+            c = L'\\';
+        }
+    }
+
+    while (!normalized.empty() && (normalized.back() == L'\\' || normalized.back() == L' ' || normalized.back() == L'\t')) {
+        normalized.pop_back();
+    }
+
+    return normalized;
+}
+
+static bool EqualsIgnoreCase(const std::wstring& left, const wchar_t* right)
+{
+    return _wcsicmp(left.c_str(), right) == 0;
+}
+
+static bool IsRecycleAndReplaceDirectory(const std::wstring& relativePath)
+{
+    std::wstring normalized = NormalizeRelativePath(relativePath);
+    return EqualsIgnoreCase(normalized, L"resource") || EqualsIgnoreCase(normalized, L"externals");
+}
+
+// Resolves `relativePath` under `rootPath`, writes result to `out`.
+// Returns false if the path is rooted, empty, or escapes the root.
+static bool TryResolvePathUnderRoot(
+    const std::wstring& rootPath,
+    const std::wstring& relativePath,
+    std::wstring& out)
+{
+    out.clear();
+
+    // Reject empty or whitespace
+    if (relativePath.empty()) return false;
+    bool allSpace = true;
+    for (wchar_t c : relativePath)
+        if (c != L' ' && c != L'\t') { allSpace = false; break; }
+    if (allSpace) return false;
+
+    // Normalise slashes
+    std::wstring rel = relativePath;
+    for (wchar_t& c : rel)
+        if (c == L'/') c = L'\\';
+
+    // Reject absolute paths
+    if (rel.size() >= 2 && rel[1] == L':') return false;
+    if (!rel.empty() && rel[0] == L'\\') return false;
+
+    // Build candidate and canonicalise
+    std::wstring combined = rootPath + L'\\' + rel;
+    wchar_t full[MAX_PATH * 4];
+    DWORD len = GetFullPathNameW(combined.c_str(), _countof(full), full, nullptr);
+    if (len == 0 || len >= _countof(full)) return false;
+
+    std::wstring candidate = full;
+
+    // Root must be canonical too
+    DWORD rootLen = GetFullPathNameW(rootPath.c_str(), _countof(full), full, nullptr);
+    if (rootLen == 0 || rootLen >= _countof(full)) return false;
+    std::wstring normalRoot = EnsureTrailingSeparator(std::wstring(full));
+
+    // Case-insensitive prefix check
+    if (candidate.size() < normalRoot.size()) return false;
+    if (_wcsnicmp(candidate.c_str(), normalRoot.c_str(), normalRoot.size()) != 0) return false;
+
+    out = candidate;
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// File / directory helpers
+// ---------------------------------------------------------------------------
+
+static void EnsureParentDirectory(const std::wstring& path);
+
+static bool PathExistsW(const std::wstring& path)
+{
+    return GetFileAttributesW(path.c_str()) != INVALID_FILE_ATTRIBUTES;
+}
+
+static bool IsDirectory(const std::wstring& path)
+{
+    DWORD attr = GetFileAttributesW(path.c_str());
+    return attr != INVALID_FILE_ATTRIBUTES && (attr & FILE_ATTRIBUTE_DIRECTORY);
+}
+
+static bool CopyDirectoryRecursive(const std::wstring& sourceDir, const std::wstring& destinationDir)
+{
+    DWORD attr = GetFileAttributesW(sourceDir.c_str());
+    if (attr == INVALID_FILE_ATTRIBUTES || !(attr & FILE_ATTRIBUTE_DIRECTORY)) {
+        return false;
+    }
+
+    CreateDirectoryW(destinationDir.c_str(), nullptr);
+
+    std::wstring pattern = sourceDir + L"\\*";
+    WIN32_FIND_DATAW fd {};
+    HANDLE hFind = FindFirstFileW(pattern.c_str(), &fd);
+    if (hFind == INVALID_HANDLE_VALUE) {
+        return true;
+    }
+
+    do {
+        if (wcscmp(fd.cFileName, L".") == 0 || wcscmp(fd.cFileName, L"..") == 0) {
+            continue;
+        }
+
+        std::wstring sourceChild = sourceDir + L"\\" + fd.cFileName;
+        std::wstring destinationChild = destinationDir + L"\\" + fd.cFileName;
+
+        if (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
+            if (!CopyDirectoryRecursive(sourceChild, destinationChild)) {
+                FindClose(hFind);
+                return false;
+            }
+            continue;
+        }
+
+        EnsureParentDirectory(destinationChild);
+        if (!CopyFileW(sourceChild.c_str(), destinationChild.c_str(), FALSE)) {
+            FindClose(hFind);
+            return false;
+        }
+    } while (FindNextFileW(hFind, &fd));
+
+    FindClose(hFind);
+    return true;
+}
+
+static bool MovePathToRecycleBin(const std::wstring& path)
+{
+    std::wstring doubleNullPath = path;
+    doubleNullPath.push_back(L'\0');
+
+    SHFILEOPSTRUCTW op {};
+    op.wFunc = FO_DELETE;
+    op.pFrom = doubleNullPath.c_str();
+    op.fFlags = FOF_ALLOWUNDO | FOF_NOCONFIRMATION | FOF_NOERRORUI | FOF_SILENT;
+
+    int result = SHFileOperationW(&op);
+    return result == 0 && !op.fAnyOperationsAborted;
+}
+
+static bool CopyPathEntry(const std::wstring& sourcePath, const std::wstring& destinationPath)
+{
+    DWORD attr = GetFileAttributesW(sourcePath.c_str());
+    if (attr == INVALID_FILE_ATTRIBUTES) {
+        return false;
+    }
+
+    if (attr & FILE_ATTRIBUTE_DIRECTORY) {
+        return CopyDirectoryRecursive(sourcePath, destinationPath);
+    }
+
+    EnsureParentDirectory(destinationPath);
+    return CopyFileW(sourcePath.c_str(), destinationPath.c_str(), FALSE) != FALSE;
+}
+
+static void EnsureParentDirectory(const std::wstring& path)
+{
+    size_t sep = path.rfind(L'\\');
+    if (sep == std::wstring::npos) return;
+    std::wstring parent = path.substr(0, sep);
+    if (parent.empty()) return;
+
+    // Recursively create
+    EnsureParentDirectory(parent);
+    CreateDirectoryW(parent.c_str(), nullptr);
+}
+
+static std::wstring CreateArchivedPath(const std::wstring& base)
+{
+    SYSTEMTIME st {};
+    GetLocalTime(&st);
+    wchar_t ts[32];
+    _snwprintf_s(ts, _countof(ts), _TRUNCATE,
+                 L".%04d%02d%02d%02d%02d%02d.",
+                 st.wYear, st.wMonth, st.wDay,
+                 st.wHour, st.wMinute, st.wSecond);
+
+    int index = 0;
+    while (true) {
+        wchar_t idx[16];
+        _itow_s(index, idx, _countof(idx), 10);
+        std::wstring candidate = base + ts + idx;
+        if (!PathExistsW(candidate)) return candidate;
+        index++;
+    }
+}
+
+// Move a file or directory entry (handles cross-volume by CopyFile+Delete for files)
+static bool MovePathEntry(const std::wstring& src, const std::wstring& dst)
+{
+    EnsureParentDirectory(dst);
+
+    DWORD attr = GetFileAttributesW(src.c_str());
+    if (attr == INVALID_FILE_ATTRIBUTES) return false;
+
+    if (attr & FILE_ATTRIBUTE_DIRECTORY) {
+        return MoveFileExW(src.c_str(), dst.c_str(), 0) != FALSE;
+    }
+
+    // Try atomic move first; fall back to copy+delete for cross-volume
+    if (MoveFileExW(src.c_str(), dst.c_str(), MOVEFILE_REPLACE_EXISTING) != FALSE)
+        return true;
+
+    if (!CopyFileW(src.c_str(), dst.c_str(), FALSE)) return false;
+    DeleteFileW(src.c_str());
+    return true;
+}
+
+static void PrepareBackupDestination(const std::wstring& backupPath)
+{
+    EnsureParentDirectory(backupPath);
+    if (!PathExistsW(backupPath)) return;
+
+    std::wstring archived = CreateArchivedPath(backupPath);
+    MovePathEntry(backupPath, archived);
+}
+
+static bool MoveExistingPathToBackup(const std::wstring& src, const std::wstring& backup)
+{
+    PrepareBackupDestination(backup);
+    return MovePathEntry(src, backup);
+}
+
+static bool RecycleAndBackupDirectory(const std::wstring& sourcePath, const std::wstring& backupPath)
+{
+    PrepareBackupDestination(backupPath);
+
+    if (!CopyDirectoryRecursive(sourcePath, backupPath)) {
+        return false;
+    }
+
+    return MovePathToRecycleBin(sourcePath);
+}
+
+static bool RecycleAndBackupPath(const std::wstring& sourcePath, const std::wstring& backupPath)
+{
+    PrepareBackupDestination(backupPath);
+
+    if (!CopyPathEntry(sourcePath, backupPath)) {
+        return false;
+    }
+
+    return MovePathToRecycleBin(sourcePath);
+}
+
+static bool RemoveDirectoryRecursive(const std::wstring& dir)
+{
+    std::wstring pattern = dir + L"\\*";
+    WIN32_FIND_DATAW fd {};
+    HANDLE hFind = FindFirstFileW(pattern.c_str(), &fd);
+    if (hFind != INVALID_HANDLE_VALUE) {
+        do {
+            if (wcscmp(fd.cFileName, L".") == 0 || wcscmp(fd.cFileName, L"..") == 0)
+                continue;
+            std::wstring child = dir + L"\\" + fd.cFileName;
+            if (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
+                RemoveDirectoryRecursive(child);
+            else
+                DeleteFileW(child.c_str());
+        } while (FindNextFileW(hFind, &fd));
+        FindClose(hFind);
+    }
+    return RemoveDirectoryW(dir.c_str()) != FALSE;
+}
+
+// ---------------------------------------------------------------------------
+// Write a small UTF-8 text file
+// ---------------------------------------------------------------------------
+
+static bool WriteUtf8File(const std::wstring& path, const char* content)
+{
+    EnsureParentDirectory(path);
+    HANDLE hFile = CreateFileW(
+        path.c_str(),
+        GENERIC_WRITE, 0,
+        nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (hFile == INVALID_HANDLE_VALUE) return false;
+
+    DWORD written = 0;
+    DWORD len = static_cast<DWORD>(strlen(content));
+    bool ok = WriteFile(hFile, content, len, &written, nullptr) != FALSE;
+    CloseHandle(hFile);
+    return ok && written == len;
+}
+
+// ---------------------------------------------------------------------------
+// Minimal JSON parser for the plan file
+// { "packageType": "full|ota", "removeList": [ "...", ... ], "moveList": [ "...", ... ] }
+// ---------------------------------------------------------------------------
+
+static std::string ReadUtf8File(const std::wstring& path)
+{
+    HANDLE hFile = CreateFileW(
+        path.c_str(),
+        GENERIC_READ, FILE_SHARE_READ,
+        nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (hFile == INVALID_HANDLE_VALUE) return {};
+
+    DWORD size = GetFileSize(hFile, nullptr);
+    std::string buf(size, '\0');
+    DWORD read = 0;
+    ReadFile(hFile, buf.data(), size, &read, nullptr);
+    CloseHandle(hFile);
+    buf.resize(read);
+    return buf;
+}
+
+// Convert a UTF-8 JSON string value to std::wstring.
+// Handles basic \uXXXX, \n, \r, \t, \\, \/
+static std::wstring Utf8ToWide(const std::string& s)
+{
+    if (s.empty()) return {};
+    int len = MultiByteToWideChar(CP_UTF8, 0, s.c_str(), -1, nullptr, 0);
+    if (len <= 1) return {};
+    std::wstring out(len - 1, L'\0');
+    MultiByteToWideChar(CP_UTF8, 0, s.c_str(), -1, out.data(), len);
+    return out;
+}
+
+// Parse a JSON string literal starting at pos (after the opening quote).
+// Advances pos past the closing quote. Returns the raw UTF-8 content.
+static std::string ParseJsonString(const std::string& json, size_t& pos)
+{
+    std::string result;
+    while (pos < json.size()) {
+        char c = json[pos++];
+        if (c == '"') break;
+        if (c == '\\' && pos < json.size()) {
+            char esc = json[pos++];
+            switch (esc) {
+            case '"':  result += '"';  break;
+            case '\\': result += '\\'; break;
+            case '/':  result += '/';  break;
+            case 'n':  result += '\n'; break;
+            case 'r':  result += '\r'; break;
+            case 't':  result += '\t'; break;
+            case 'u': {
+                if (pos + 4 <= json.size()) {
+                    char hex[5] = {};
+                    memcpy(hex, json.c_str() + pos, 4);
+                    pos += 4;
+                    unsigned cp = static_cast<unsigned>(strtoul(hex, nullptr, 16));
+                    // Encode code point as UTF-8
+                    if (cp < 0x80) {
+                        result += static_cast<char>(cp);
+                    } else if (cp < 0x800) {
+                        result += static_cast<char>(0xC0 | (cp >> 6));
+                        result += static_cast<char>(0x80 | (cp & 0x3F));
+                    } else {
+                        result += static_cast<char>(0xE0 | (cp >> 12));
+                        result += static_cast<char>(0x80 | ((cp >> 6) & 0x3F));
+                        result += static_cast<char>(0x80 | (cp & 0x3F));
+                    }
+                }
+                break;
+            }
+            default: result += esc; break;
+            }
+        } else {
+            result += c;
+        }
+    }
+    return result;
+}
+
+// Find a JSON array by key name and return its string elements.
+static std::vector<std::wstring> ParseJsonStringArray(
+    const std::string& json,
+    const char* key)
+{
+    std::vector<std::wstring> result;
+
+    // Find "key"
+    std::string needle = std::string("\"") + key + "\"";
+    size_t keyPos = json.find(needle);
+    if (keyPos == std::string::npos) return result;
+
+    size_t pos = keyPos + needle.size();
+
+    // Skip whitespace and colon
+    while (pos < json.size() && (json[pos] == ' ' || json[pos] == '\t' ||
+                                  json[pos] == '\r' || json[pos] == '\n' ||
+                                  json[pos] == ':'))
+        pos++;
+
+    if (pos >= json.size() || json[pos] != '[') return result;
+    pos++; // consume '['
+
+    // Parse array elements
+    while (pos < json.size()) {
+        // Skip whitespace
+        while (pos < json.size() && (json[pos] == ' ' || json[pos] == '\t' ||
+                                      json[pos] == '\r' || json[pos] == '\n' ||
+                                      json[pos] == ','))
+            pos++;
+
+        if (pos >= json.size()) break;
+        if (json[pos] == ']') break;
+        if (json[pos] == '"') {
+            pos++; // consume opening quote
+            std::string val = ParseJsonString(json, pos);
+            result.push_back(Utf8ToWide(val));
+        } else {
+            pos++;
+        }
+    }
+
+    return result;
+}
+
+static std::wstring ParseJsonStringProperty(const std::string& json, const char* key)
+{
+    std::string needle = std::string("\"") + key + "\"";
+    size_t keyPos = json.find(needle);
+    if (keyPos == std::string::npos) return {};
+
+    size_t pos = keyPos + needle.size();
+    while (pos < json.size() && (json[pos] == ' ' || json[pos] == '\t' ||
+                                  json[pos] == '\r' || json[pos] == '\n' ||
+                                  json[pos] == ':'))
+    {
+        pos++;
+    }
+
+    if (pos >= json.size() || json[pos] != '"') return {};
+
+    pos++;
+    return Utf8ToWide(ParseJsonString(json, pos));
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+int wmain(int argc, wchar_t* argv[])
+{
+    constexpr int REQUIRED_ARGS = 9; // excluding argv[0]
+
+    if (argc - 1 < REQUIRED_ARGS) {
+        MessageBoxW(
+            nullptr,
+            L"MAA.Updater.exe 是 MAA 内部使用的更新程序，不应被手动启动。\n\n"
+            L"请直接运行 MAA.exe。",
+            L"MAA 更新程序",
+            MB_OK | MB_ICONINFORMATION);
+        return 1;
+    }
+
+    DWORD     parentPid              = static_cast<DWORD>(_wtoi(argv[1]));
+    std::wstring rootDir             = argv[2];
+    std::wstring extractDir          = argv[3];
+    std::wstring backupDir           = argv[4];
+    std::wstring packagePath         = argv[5];
+    std::wstring successStatusFile   = argv[6];
+    std::wstring failureStatusFile   = argv[7];
+    std::wstring relaunchExecutable  = argv[8];
+    std::wstring planFile            = argv[9];
+
+    g_logFile = rootDir + L"\\debug\\pending-update-applier.log";
+
+    WriteLog(L"MAA.Updater started (C++ external updater).");
+    WriteLogF(L"ParentPID=%lu RootDir=%s", parentPid, rootDir.c_str());
+    WriteLogF(L"PlanFile=%s ExtractDir=%s", planFile.c_str(), extractDir.c_str());
+
+    bool shouldRelaunch = false;
+    bool success = false;
+    std::wstring failureReason;
+
+    // ------------------------------------------------------------------
+    // Wait for parent process to exit
+    // ------------------------------------------------------------------
+    HANDLE hParent = OpenProcess(SYNCHRONIZE, FALSE, parentPid);
+    if (hParent != nullptr) {
+        WriteLogF(L"Waiting for parent process %lu to exit...", parentPid);
+        WaitForSingleObject(hParent, INFINITE);
+        CloseHandle(hParent);
+        WriteLog(L"Parent process exited.");
+    } else {
+        WriteLogF(L"Could not open parent process %lu (already exited?), continuing.", parentPid);
+    }
+
+    // ------------------------------------------------------------------
+    // Read plan
+    // ------------------------------------------------------------------
+    do {
+        if (!PathExistsW(planFile)) {
+            failureReason = L"Plan file not found: " + planFile;
+            WriteLog(failureReason.c_str());
+            break;
+        }
+
+        std::string planJson = ReadUtf8File(planFile);
+        if (planJson.empty()) {
+            failureReason = L"Plan file is empty or unreadable: " + planFile;
+            WriteLog(failureReason.c_str());
+            break;
+        }
+
+        std::wstring packageType = ParseJsonStringProperty(planJson, "packageType");
+        bool isFullPackage = EqualsIgnoreCase(packageType, L"full");
+        std::vector<std::wstring> removeList = ParseJsonStringArray(planJson, "removeList");
+        std::vector<std::wstring> moveList   = ParseJsonStringArray(planJson, "moveList");
+
+        WriteLogF(L"Plan loaded: packageType=%s removeList=%zu moveList=%zu",
+                  packageType.c_str(), removeList.size(), moveList.size());
+
+        CreateDirectoryW(backupDir.c_str(), nullptr);
+
+        // ---- Remove entries ----
+        for (const std::wstring& rel : removeList) {
+            std::wstring targetPath;
+            if (!TryResolvePathUnderRoot(rootDir, rel, targetPath)) {
+                failureReason = L"Illegal path in removeList: " + rel;
+                WriteLog(failureReason.c_str());
+                goto apply_failed;
+            }
+            if (!PathExistsW(targetPath)) continue;
+
+            std::wstring backupPath;
+            if (!TryResolvePathUnderRoot(backupDir, rel, backupPath)) {
+                failureReason = L"Illegal backup path for removeList: " + rel;
+                WriteLog(failureReason.c_str());
+                goto apply_failed;
+            }
+
+            WriteLogF(L"Removing: %s -> backup %s", targetPath.c_str(), backupPath.c_str());
+            bool backupOk = isFullPackage
+                ? RecycleAndBackupPath(targetPath, backupPath)
+                : MoveExistingPathToBackup(targetPath, backupPath);
+            if (!backupOk) {
+                failureReason = L"Failed to move to backup: " + targetPath;
+                WriteLog(failureReason.c_str());
+                goto apply_failed;
+            }
+        }
+
+        // ---- Move/install entries ----
+        for (const std::wstring& rel : moveList) {
+            std::wstring sourcePath, targetPath, backupPath;
+
+            if (!TryResolvePathUnderRoot(extractDir, rel, sourcePath) ||
+                !TryResolvePathUnderRoot(rootDir,    rel, targetPath) ||
+                !TryResolvePathUnderRoot(backupDir,  rel, backupPath))
+            {
+                failureReason = L"Illegal path in moveList: " + rel;
+                WriteLog(failureReason.c_str());
+                goto apply_failed;
+            }
+
+            if (PathExistsW(targetPath)) {
+                WriteLogF(L"Backing up existing: %s", targetPath.c_str());
+                bool backupOk = IsRecycleAndReplaceDirectory(rel)
+                    ? RecycleAndBackupDirectory(targetPath, backupPath)
+                    : MoveExistingPathToBackup(targetPath, backupPath);
+                if (!backupOk) {
+                    failureReason = L"Failed to backup existing file: " + targetPath;
+                    WriteLog(failureReason.c_str());
+                    goto apply_failed;
+                }
+            }
+
+            WriteLogF(L"Installing: %s -> %s", sourcePath.c_str(), targetPath.c_str());
+            if (!MovePathEntry(sourcePath, targetPath)) {
+                failureReason = L"Failed to move file into place: " + sourcePath;
+                WriteLog(failureReason.c_str());
+                goto apply_failed;
+            }
+        }
+
+        // ---- Cleanup package ----
+        if (PathExistsW(packagePath)) {
+            DeleteFileW(packagePath.c_str());
+            WriteLogF(L"Deleted package: %s", packagePath.c_str());
+        }
+
+        if (PathExistsW(failureStatusFile))
+            DeleteFileW(failureStatusFile.c_str());
+
+        if (WriteUtf8File(successStatusFile, "succeeded")) {
+            WriteLogF(L"Wrote success status: %s", successStatusFile.c_str());
+            success = true;
+            shouldRelaunch = true;
+        } else {
+            failureReason = L"Failed to write success status file: " + successStatusFile;
+            WriteLog(failureReason.c_str());
+        }
+
+        break; // normal exit from do-while
+
+    apply_failed:
+        success = false;
+    } while (false);
+
+    // ------------------------------------------------------------------
+    // On failure: write failure status
+    // ------------------------------------------------------------------
+    if (!success && !failureReason.empty()) {
+        // Convert wstring reason to UTF-8 for file
+        int utf8Len = WideCharToMultiByte(CP_UTF8, 0, failureReason.c_str(), -1, nullptr, 0, nullptr, nullptr);
+        if (utf8Len > 1) {
+            std::string utf8Reason(utf8Len - 1, '\0');
+            WideCharToMultiByte(CP_UTF8, 0, failureReason.c_str(), -1, utf8Reason.data(), utf8Len, nullptr, nullptr);
+            WriteUtf8File(failureStatusFile, utf8Reason.c_str());
+        }
+        if (PathExistsW(successStatusFile))
+            DeleteFileW(successStatusFile.c_str());
+        WriteLogF(L"Update failed: %s", failureReason.c_str());
+    }
+
+    // ------------------------------------------------------------------
+    // Cleanup extract dir and plan file
+    // ------------------------------------------------------------------
+    if (PathExistsW(extractDir)) {
+        WriteLogF(L"Cleaning extract dir: %s", extractDir.c_str());
+        RemoveDirectoryRecursive(extractDir);
+    }
+
+    if (PathExistsW(planFile))
+        DeleteFileW(planFile.c_str());
+
+    // ------------------------------------------------------------------
+    // Relaunch MAA
+    // ------------------------------------------------------------------
+    if (shouldRelaunch && PathExistsW(relaunchExecutable)) {
+        WriteLogF(L"Relaunching: %s", relaunchExecutable.c_str());
+
+        // Find working directory (parent of the executable)
+        std::wstring workDir = relaunchExecutable;
+        size_t sep = workDir.rfind(L'\\');
+        if (sep != std::wstring::npos) workDir = workDir.substr(0, sep);
+
+        STARTUPINFOW si {};
+        si.cb = sizeof(si);
+        PROCESS_INFORMATION pi {};
+        std::wstring cmdLine = L"\"" + relaunchExecutable + L"\"";
+        if (CreateProcessW(
+                relaunchExecutable.c_str(),
+                cmdLine.data(),
+                nullptr, nullptr, FALSE, 0, nullptr,
+                workDir.c_str(),
+                &si, &pi))
+        {
+            CloseHandle(pi.hProcess);
+            CloseHandle(pi.hThread);
+            WriteLog(L"Relaunch successful.");
+        } else {
+            WriteLogF(L"Relaunch failed, error=%lu", GetLastError());
+        }
+    }
+
+    WriteLog(L"MAA.Updater exiting.");
+    return success ? 0 : 2;
+}

--- a/src/MaaWpfGui/MaaWpfGui.csproj
+++ b/src/MaaWpfGui/MaaWpfGui.csproj
@@ -72,7 +72,7 @@
   <PropertyGroup>
     <Authors>MAA Team</Authors>
     <PackageLicenseUrl>https://github.com/MaaAssistantArknights/MaaAssistantArknights/blob/dev-v2/LICENSE</PackageLicenseUrl>
-    <Copyright>Copyright (c) 2021-2025 MAA Team</Copyright>
+    <Copyright>Copyright (c) 2021-2026 MAA Team</Copyright>
     <Description>https://docs.maa.plus/</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryType>git</RepositoryType>

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -399,7 +399,7 @@ You can cancel this popup by clicking the ｢{key=Settings} - {key=IssueReport}�
     <system:String x:Key="CheckNetworking">Please check your network connection or proxy.</system:String>
     <system:String x:Key="GetReleaseNoteFailed">Failed to get release note.</system:String>
     <system:String x:Key="NewVersionIsBeingBuilt">The new version is being built, please try again later</system:String>
-    <system:String x:Key="NewVersionNoOtaPackage">A new version has been detected. But no OTA incremental update package is available. The complete package will be downloaded and the resource folder will be moved to the recycle bin and .old. Please back up manually if necessary.</system:String>
+    <system:String x:Key="NewVersionNoOtaPackage">A new version has been detected, but no OTA incremental update package is available. The full package will be downloaded. The config, data, and debug folders will be kept, and all other files will be moved to the Recycle Bin and .old. Please back them up manually if necessary.</system:String>
     <system:String x:Key="NewVersionDownloadPreparing">Preparing to download update package……</system:String>
     <system:String x:Key="NewVersionDownloadFailedTitle">Download of Update Package Failed</system:String>
     <system:String x:Key="NewVersionDownloadFailedDesc">Please download the zip file manually and place it in the directory</system:String>
@@ -809,7 +809,7 @@ Do not adjust the proxy multiplier setting in the game</system:String>
     <!--  !FightSettings  -->
     <!--  Logs  -->
     <system:String x:Key="VersionMismatch">UI and Core versions mismatch: {0} and {1}, which may cause unpredictable behavior. Please do not manually replace files or occupy files during updates.\n\n{key=FullPackageUpgradeTips}</system:String>
-    <system:String x:Key="FullPackageUpgradeTips">Please download the full package and extract it into a new folder. Do not overwrite the existing installation folder.\nYou may copy the original config and data folders into the new folder to retain your existing settings.</system:String>
+    <system:String x:Key="FullPackageUpgradeTips">Please download the full package and extract it into a new folder. Do not overwrite the existing installation folder.\nYou may copy the original config, data, and debug folders into the new folder to retain your existing settings and logs.</system:String>
     <system:String x:Key="ConnectingToEmulator">Connecting to emulator……</system:String>
     <system:String x:Key="UnselectedTask">Unselected task</system:String>
     <system:String x:Key="Running">Running……</system:String>
@@ -1094,7 +1094,7 @@ Right-click to clear inactive jobs</system:String>
     <system:String x:Key="CopyErrorMessage">Copy error message</system:String>
     <!--  !ErrorView  -->
     <!--  AsstProxy  -->
-    <system:String x:Key="UpdateApplyFailed">The update could not be applied and the current installation may be incomplete. Please download the full package again and migrate your config and data manually as described below.\n\n{key=FullPackageUpgradeTips}</system:String>
+    <system:String x:Key="UpdateApplyFailed">The update could not be applied and the current installation may be incomplete. Please download the full package again and migrate your config, data, and debug folders manually as described below.\n\n{key=FullPackageUpgradeTips}</system:String>
     <system:String x:Key="ResourceBroken">The resources are damaged, please download the full package again.\n\n{key=FullPackageUpgradeTips}</system:String>
     <system:String x:Key="ReplaceAdbNotExists">ADB File NOT existing</system:String>
     <system:String x:Key="AdbDownloadFailedTitle">ADB Download Failed</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -399,7 +399,7 @@
     <system:String x:Key="CheckNetworking">ネットワークの接続状況とプロクシの設定を確認してください。</system:String>
     <system:String x:Key="GetReleaseNoteFailed">リリースノートの取得に失敗しました。</system:String>
     <system:String x:Key="NewVersionIsBeingBuilt">新しいバージョンの準備中です。時間をおいてからもう一度実行してください</system:String>
-    <system:String x:Key="NewVersionNoOtaPackage">新しいバージョンが検出されました。OTA増分アップデートパッケージは利用できません。完全なパッケージがダウンロードされ、リソースフォルダはゴミ箱に移動され、.old ファイルが削除されます。必要に応じて手動でバックアップしてください。</system:String>
+    <system:String x:Key="NewVersionNoOtaPackage">新しいバージョンが検出されましたが、利用可能な OTA 増分アップデートパッケージはありません。完全パッケージをダウンロードし、config、data、debug フォルダーは保持され、それ以外のファイルはごみ箱と .old に移動されます。必要に応じて手動でバックアップしてください。</system:String>
     <system:String x:Key="NewVersionDownloadPreparing">アップデートパッケージのダウンロードを準備中です……</system:String>
     <system:String x:Key="NewVersionDownloadFailedTitle">アップデートパッケージのダウンロードに失敗しました</system:String>
     <system:String x:Key="NewVersionDownloadFailedDesc">ZIPファイルを手動でダウンロードし、ディレクトリに配置してください</system:String>
@@ -810,7 +810,7 @@ C:\\leidian\\LDPlayer9
     <!--  !戦闘設定  -->
     <!--  Logs  -->
     <system:String x:Key="VersionMismatch">UI と Core のバージョンが一致しません: {0} と {1}、予測不可能な動作を引き起こす可能性があります。ファイルを手動で置き換えたり、更新中にファイルを占有しないでください。\n\n{key=FullPackageUpgradeTips}</system:String>
-    <system:String x:Key="FullPackageUpgradeTips">完全パッケージをダウンロードし、既存のフォルダーを上書きせずに新しいフォルダーに解凍してください。\n設定を保持するには、元の config および data フォルダーを新しいフォルダーにコピーしてください。</system:String>
+    <system:String x:Key="FullPackageUpgradeTips">完全パッケージをダウンロードし、既存のフォルダーを上書きせずに新しいフォルダーに解凍してください。\n設定とログを保持するには、元の config、data、および debug フォルダーを新しいフォルダーにコピーしてください。</system:String>
     <system:String x:Key="ConnectingToEmulator">エミュレータ接続中……</system:String>
     <system:String x:Key="UnselectedTask">タスクが選択されていません</system:String>
     <system:String x:Key="Running">動作中……</system:String>
@@ -1095,7 +1095,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="CopyErrorMessage">エラー情報をコピーする</system:String>
     <!--  !ErrorView  -->
     <!--  AsstProxy  -->
-    <system:String x:Key="UpdateApplyFailed">更新の適用に失敗し、現在のインストールが不完全になっている可能性があります。完全パッケージを再ダウンロードし、以下の説明に従って config と data を手動で移行してください。\n\n{key=FullPackageUpgradeTips}</system:String>
+    <system:String x:Key="UpdateApplyFailed">更新の適用に失敗し、現在のインストールが不完全になっている可能性があります。完全パッケージを再ダウンロードし、以下の説明に従って config、data、debug を手動で移行してください。\n\n{key=FullPackageUpgradeTips}</system:String>
     <system:String x:Key="ResourceBroken">リソースファイルが破損しています。完全なパッケージを再度ダウンロードしてください。\n\n{key=FullPackageUpgradeTips}</system:String>
     <system:String x:Key="ReplaceAdbNotExists">ADBファイルが存在しません</system:String>
     <system:String x:Key="AdbDownloadFailedTitle">ADBのダウンロードに失敗しました</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -399,7 +399,7 @@
     <system:String x:Key="CheckNetworking">네트워크 연결이나 프록시를 확인해 주세요.</system:String>
     <system:String x:Key="GetReleaseNoteFailed">릴리즈 노트를 받아오지 못했습니다.</system:String>
     <system:String x:Key="NewVersionIsBeingBuilt">새로운 버전이 빌드되는 중입니다. 다음에 다시 시도해 주세요</system:String>
-    <system:String x:Key="NewVersionNoOtaPackage">새 버전이 감지되었습니다. OTA 증분 업데이트 패키지를 사용할 수 없습니다. 전체 패키지가 다운로드되고 리소스 폴더는 휴지통과 .old 폴더로 이동합니다. 필요한 경우 수동으로 백업해 주세요.</system:String>
+    <system:String x:Key="NewVersionNoOtaPackage">새 버전이 감지되었지만 사용할 수 있는 OTA 증분 업데이트 패키지가 없습니다. 전체 패키지를 다운로드하며, config, data, debug 폴더는 유지되고 그 외의 파일은 휴지통과 .old 폴더로 이동합니다. 필요하다면 수동으로 백업해 주세요.</system:String>
     <system:String x:Key="NewVersionDownloadPreparing">업데이트 패키지 다운로드 준비 중……</system:String>
     <system:String x:Key="NewVersionDownloadFailedTitle">업데이트 패키지 다운로드 실패</system:String>
     <system:String x:Key="NewVersionDownloadFailedDesc">ZIP 파일을 수동으로 다운로드해 폴더 안에 놓아 주세요</system:String>
@@ -811,7 +811,7 @@ C:\\leidian\\LDPlayer9
     <!--  !작전 설정  -->
     <!--  로그  -->
     <system:String x:Key="VersionMismatch">UI와 Core 버전이 일치하지 않습니다: {0} 및 {1}, 예측할 수 없는 동작을 유발할 수 있습니다. 파일을 수동으로 교체하거나 업데이트 중에 파일을 점유하지 마세요.\n\n{key=FullPackageUpgradeTips}</system:String>
-    <system:String x:Key="FullPackageUpgradeTips">전체 패키지를 다운로드하여 기존 폴더를 덮어쓰지 말고 새 폴더에 압축을 푸세요.\n기존 설정을 유지하려면 기존 config 및 data 폴더를 새 폴더로 복사하세요.</system:String>
+    <system:String x:Key="FullPackageUpgradeTips">전체 패키지를 다운로드하여 기존 폴더를 덮어쓰지 말고 새 폴더에 압축을 푸세요.\n기존 설정과 로그를 유지하려면 기존 config, data 및 debug 폴더를 새 폴더로 복사하세요.</system:String>
     <system:String x:Key="ConnectingToEmulator">에뮬레이터에 연결 중……</system:String>
     <system:String x:Key="UnselectedTask">선택된 작업이 없습니다</system:String>
     <system:String x:Key="Running">실행 중……</system:String>
@@ -1096,7 +1096,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="CopyErrorMessage">오류 메시지 복사</system:String>
     <!--  !ErrorView  -->
     <!--  AsstProxy  -->
-    <system:String x:Key="UpdateApplyFailed">업데이트 적용에 실패하여 현재 설치가 불완전할 수 있습니다. 전체 패키지를 다시 다운로드하고, 아래 안내에 따라 config 및 data를 수동으로 옮겨 주세요.\n\n{key=FullPackageUpgradeTips}</system:String>
+    <system:String x:Key="UpdateApplyFailed">업데이트 적용에 실패하여 현재 설치가 불완전할 수 있습니다. 전체 패키지를 다시 다운로드하고, 아래 안내에 따라 config, data 및 debug를 수동으로 옮겨 주세요.\n\n{key=FullPackageUpgradeTips}</system:String>
     <system:String x:Key="ResourceBroken">리소스 파일이 손상되었습니다. 전체 패키지를 다시 다운로드하세요.\n\n{key=FullPackageUpgradeTips}</system:String>
     <system:String x:Key="ReplaceAdbNotExists">ADB 파일이 존재하지 않습니다</system:String>
     <system:String x:Key="AdbDownloadFailedTitle">ADB 다운로드 실패</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -399,7 +399,7 @@
     <system:String x:Key="CheckNetworking">请检查网络连接或代理。</system:String>
     <system:String x:Key="GetReleaseNoteFailed">获取更新信息失败。</system:String>
     <system:String x:Key="NewVersionIsBeingBuilt">我知道你很急但你先别急.jpg</system:String>
-    <system:String x:Key="NewVersionNoOtaPackage">检测到新版本，但无可用的 OTA 增量更新包。将下载完整包并移动 resource 文件夹到回收站及 .old，如有需要请手动备份</system:String>
+    <system:String x:Key="NewVersionNoOtaPackage">检测到新版本，但无可用的 OTA 增量更新包。将下载完整包，保留 config、data 与 debug 文件夹，其余文件将移至回收站及 .old。如有需要请手动备份</system:String>
     <system:String x:Key="NewVersionDownloadPreparing">正在准备下载更新包……</system:String>
     <system:String x:Key="NewVersionDownloadFailedTitle">新版本下载失败</system:String>
     <system:String x:Key="NewVersionDownloadFailedDesc">请尝试手动下载后，将压缩包放到目录下_(:з」∠)_</system:String>
@@ -810,7 +810,7 @@ C:\\leidian\\LDPlayer9。\n
     <!--  !战斗设置  -->
     <!--  日志  -->
     <system:String x:Key="VersionMismatch">UI 和 Core 版本不一致: {0} 和 {1}，可能导致不可预测的行为，请勿手动替换文件或者在更新时占用文件。\n\n{key=FullPackageUpgradeTips}</system:String>
-    <system:String x:Key="FullPackageUpgradeTips">请下载完整包并解压到新的文件夹，切勿直接覆盖原文件夹。\n可将原有的 config 与 data 文件夹复制到新文件夹中，以保留原有配置。</system:String>
+    <system:String x:Key="FullPackageUpgradeTips">请下载完整包并解压到新的文件夹，切勿直接覆盖原文件夹。\n可将原有的 config、data 与 debug 文件夹复制到新文件夹中，以保留原有配置和日志。</system:String>
     <system:String x:Key="ConnectingToEmulator">正在连接模拟器……</system:String>
     <system:String x:Key="UnselectedTask">未选择任务</system:String>
     <system:String x:Key="Running">正在运行中……</system:String>
@@ -1095,7 +1095,7 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="CopyErrorMessage">复制错误信息</system:String>
     <!--  !ErrorDialogView  -->
     <!--  AsstProxy  -->
-    <system:String x:Key="UpdateApplyFailed">更新失败，当前安装可能已不完整。请重新下载完整包，并按下方说明手动迁移配置。\n\n{key=FullPackageUpgradeTips}</system:String>
+    <system:String x:Key="UpdateApplyFailed">更新失败，当前安装可能已不完整。请重新下载完整包，并按下方说明手动迁移 config、data 与 debug。\n\n{key=FullPackageUpgradeTips}</system:String>
     <system:String x:Key="ResourceBroken">资源损坏，请重新下载完整安装包。\n\n{key=FullPackageUpgradeTips}</system:String>
     <system:String x:Key="ReplaceAdbNotExists">ADB 路径不存在</system:String>
     <system:String x:Key="AdbDownloadFailedTitle">ADB 下载失败</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -399,7 +399,7 @@
     <system:String x:Key="CheckNetworking">請檢查網路連線或 Proxy 代理設定。</system:String>
     <system:String x:Key="GetReleaseNoteFailed">取得更新資訊失敗。</system:String>
     <system:String x:Key="NewVersionIsBeingBuilt">我知道你很急但你先別急.jpg</system:String>
-    <system:String x:Key="NewVersionNoOtaPackage">偵測到新版本，但無可用的 OTA 增量更新檔案。將下載完整檔案並將 resource 資料夾移至資源回收桶及 .old，如有需要請手動備份</system:String>
+    <system:String x:Key="NewVersionNoOtaPackage">偵測到新版本，但無可用的 OTA 增量更新檔案。將下載完整安裝檔案，保留 config、data 與 debug 資料夾，其餘檔案將移至資源回收桶及 .old，如有需要請手動備份</system:String>
     <system:String x:Key="NewVersionDownloadPreparing">正在準備下載更新檔……</system:String>
     <system:String x:Key="NewVersionDownloadFailedTitle">新版本下載失敗</system:String>
     <system:String x:Key="NewVersionDownloadFailedDesc">請嘗試手動下載後，將壓縮檔放到目錄下 _(:з」∠)_</system:String>
@@ -810,7 +810,7 @@ C:\\leidian\\LDPlayer9\n
     <!--  !戰鬥設定  -->
     <!--  日誌  -->
     <system:String x:Key="VersionMismatch">UI 和 Core 版本不一致: {0} 和 {1}，可能導致不可預測的行為。請勿手動替換檔案，或在更新時讓檔案處於被佔用狀態。\n\n{key=FullPackageUpgradeTips}</system:String>
-    <system:String x:Key="FullPackageUpgradeTips">請下載完整安裝檔案並解壓縮至新的資料夾中，切勿直接覆蓋原資料夾。\n可將原有的 config 與 data 資料夾複製到新資料夾中，以保留原有設定。</system:String>
+    <system:String x:Key="FullPackageUpgradeTips">請下載完整安裝檔案並解壓縮至新的資料夾中，切勿直接覆蓋原資料夾。\n可將原有的 config、data 與 debug 資料夾複製到新資料夾中，以保留原有設定與日誌。</system:String>
     <system:String x:Key="ConnectingToEmulator">正在連線模擬器……</system:String>
     <system:String x:Key="UnselectedTask">未選擇任務</system:String>
     <system:String x:Key="Running">正在執行中……</system:String>
@@ -1095,7 +1095,7 @@ C:\\leidian\\LDPlayer9\n
     <system:String x:Key="CopyErrorMessage">複製錯誤資訊</system:String>
     <!--  !ErrorView  -->
     <!--  AsstProxy  -->
-    <system:String x:Key="UpdateApplyFailed">更新失敗，目前的安裝可能已不完整。請重新下載完整安裝檔案，並依照下方說明手動搬移 config 與 data。\n\n{key=FullPackageUpgradeTips}</system:String>
+    <system:String x:Key="UpdateApplyFailed">更新失敗，目前的安裝可能已不完整。請重新下載完整安裝檔案，並依照下方說明手動搬移 config、data 與 debug。\n\n{key=FullPackageUpgradeTips}</system:String>
     <system:String x:Key="ResourceBroken">檔案損毀，請重新下載完整安裝檔案。\n\n{key=FullPackageUpgradeTips}</system:String>
     <system:String x:Key="ReplaceAdbNotExists">ADB 路徑不存在</system:String>
     <system:String x:Key="AdbDownloadFailedTitle">ADB 下載失敗</system:String>

--- a/src/MaaWpfGui/Services/PendingUpdateApplier.cs
+++ b/src/MaaWpfGui/Services/PendingUpdateApplier.cs
@@ -48,6 +48,14 @@ internal static partial class PendingUpdateApplier
         "changes.json",
     };
 
+    private static readonly HashSet<string> s_fullPackagePreservedEntries = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "config",
+        "data",
+        "debug",
+        "MAA.Updater.exe",
+    };
+
     private static string DelegatedUpdateSuccessStatusFilePath => Path.Combine(PathsHelper.ConfigDir, "pending-update-success.txt");
 
     private static string DelegatedUpdateFailureStatusFilePath => Path.Combine(PathsHelper.ConfigDir, "pending-update-failure.txt");
@@ -205,12 +213,13 @@ internal static partial class PendingUpdateApplier
             if (!PendingUpdateManifest.HasOtaMetadata(context.ExtractDir))
             {
                 keepExtractDirectory = true;
+                string[] fullPackageMoveEntries = GetFullPackageMoveEntries(context.ExtractDir);
                 return DelegatePendingUpdateApply(
                     context,
                     "full",
                     "full package always replaces runtime files",
-                    Array.Empty<string>(),
-                    GetTopLevelExtractEntries(context.ExtractDir));
+                    GetFullPackageRemoveEntries(context),
+                    fullPackageMoveEntries);
             }
 
             var manifest = PendingUpdateManifest.Load(context.ExtractDir);
@@ -362,27 +371,23 @@ internal static partial class PendingUpdateApplier
         IReadOnlyList<string> removeEntries,
         IReadOnlyList<string> moveEntries)
     {
-        string scriptPath = Path.Combine(Path.GetTempPath(), $"maa-pending-update-{Guid.NewGuid():N}.ps1");
         string planPath = Path.Combine(Path.GetTempPath(), $"maa-pending-update-{Guid.NewGuid():N}.json");
+        string updaterExecutablePath = PrepareDelegatedUpdaterExecutable(context, packageType);
         string relaunchExecutablePath = Path.Combine(context.RootDir, "MAA.exe");
 
-        File.WriteAllText(scriptPath, CreatePendingUpdateScript());
-        File.WriteAllText(planPath, CreatePendingUpdatePlan(removeEntries, moveEntries));
+        File.WriteAllText(planPath, CreatePendingUpdatePlan(packageType, removeEntries, moveEntries));
 
         var startInfo = new ProcessStartInfo
         {
-            FileName = "powershell.exe",
-            UseShellExecute = true,
+            FileName = updaterExecutablePath,
+            UseShellExecute = false,
             CreateNoWindow = true,
-            WindowStyle = ProcessWindowStyle.Hidden,
             WorkingDirectory = context.RootDir,
         };
 
-        startInfo.ArgumentList.Add("-NoProfile");
-        startInfo.ArgumentList.Add("-ExecutionPolicy");
-        startInfo.ArgumentList.Add("Bypass");
-        startInfo.ArgumentList.Add("-File");
-        startInfo.ArgumentList.Add(scriptPath);
+        // Args: <ParentPid> <RootDir> <ExtractDir> <BackupDir>
+        //       <PackagePath> <SuccessStatusFile> <FailureStatusFile>
+        //       <RelaunchExecutablePath> <PlanFile>
         startInfo.ArgumentList.Add(Environment.ProcessId.ToString());
         startInfo.ArgumentList.Add(context.RootDir);
         startInfo.ArgumentList.Add(context.ExtractDir);
@@ -392,7 +397,6 @@ internal static partial class PendingUpdateApplier
         startInfo.ArgumentList.Add(DelegatedUpdateFailureStatusFilePath);
         startInfo.ArgumentList.Add(relaunchExecutablePath);
         startInfo.ArgumentList.Add(planPath);
-        startInfo.ArgumentList.Add(scriptPath);
 
         _logger.Information(
             "Delegating pending update apply to external updater: packageType={PackageType}, rootDir={RootDir}, extractDir={ExtractDir}, packagePath={PackagePath}",
@@ -410,13 +414,31 @@ internal static partial class PendingUpdateApplier
         ZipFile.ExtractToDirectory(packagePath, extractDir, Encoding.Default, overwriteFiles: true);
     }
 
-    private static string CreatePendingUpdatePlan(IReadOnlyList<string> removeEntries, IReadOnlyList<string> moveEntries)
+    private static string CreatePendingUpdatePlan(string packageType, IReadOnlyList<string> removeEntries, IReadOnlyList<string> moveEntries)
     {
         return new JObject
         {
+            ["packageType"] = packageType,
             ["removeList"] = JArray.FromObject(removeEntries),
             ["moveList"] = JArray.FromObject(moveEntries),
         }.ToString();
+    }
+
+    private static string[] GetFullPackageRemoveEntries(PendingUpdateContext context)
+    {
+        HashSet<string> preservedEntries = CreateFullPackagePreservedEntries(context);
+        return [.. Directory.GetFileSystemEntries(context.RootDir)
+            .Select(Path.GetFileName)
+            .OfType<string>()
+            .Where(entry => !string.IsNullOrWhiteSpace(entry) && !preservedEntries.Contains(entry))
+            .Distinct(StringComparer.OrdinalIgnoreCase)];
+    }
+
+    private static string[] GetFullPackageMoveEntries(string extractDir)
+    {
+        return [.. GetTopLevelExtractEntries(extractDir)
+            .Where(entry => !IsFullPackagePreservedEntry(entry))
+            .Distinct(StringComparer.OrdinalIgnoreCase)];
     }
 
     private static string[] GetTopLevelExtractEntries(string extractDir)
@@ -426,6 +448,50 @@ internal static partial class PendingUpdateApplier
             .Select(entry => entry.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar))
             .Where(entry => !string.IsNullOrWhiteSpace(entry) && !IsControlFile(entry))
             .Distinct(StringComparer.OrdinalIgnoreCase)];
+    }
+
+    private static string PrepareDelegatedUpdaterExecutable(PendingUpdateContext context, string packageType)
+    {
+        string updaterExecutablePath = Path.Combine(context.RootDir, "MAA.Updater.exe");
+        if (!string.Equals(packageType, "full", StringComparison.OrdinalIgnoreCase))
+        {
+            return updaterExecutablePath;
+        }
+
+        string extractedUpdaterPath = GetPathUnderRoot(context.ExtractDir, "MAA.Updater.exe");
+        if (!File.Exists(extractedUpdaterPath))
+        {
+            return updaterExecutablePath;
+        }
+
+        EnsureParentDirectory(updaterExecutablePath);
+        File.Copy(extractedUpdaterPath, updaterExecutablePath, overwrite: true);
+        _logger.Information(
+            "Pending update package contains MAA.Updater.exe. Replaced updater before delegation: {UpdaterExecutablePath}",
+            updaterExecutablePath);
+        return updaterExecutablePath;
+    }
+
+    private static HashSet<string> CreateFullPackagePreservedEntries(PendingUpdateContext context)
+    {
+        var preservedEntries = new HashSet<string>(s_fullPackagePreservedEntries, StringComparer.OrdinalIgnoreCase)
+        {
+            Path.GetFileName(context.ExtractDir),
+            Path.GetFileName(context.BackupDir),
+            Path.GetFileName(context.PackagePath),
+        };
+
+        return preservedEntries;
+    }
+
+    private static bool IsFullPackagePreservedEntry(string relativePath)
+    {
+        return s_fullPackagePreservedEntries.Contains(NormalizeRelativePath(relativePath));
+    }
+
+    private static string NormalizeRelativePath(string relativePath)
+    {
+        return relativePath.Trim().Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
     }
 
     private static bool ShouldDelegatePendingOtaApply(PendingUpdateManifest manifest, out string reason)
@@ -457,219 +523,6 @@ internal static partial class PendingUpdateApplier
             : normalizedRelativePath;
 
         return string.Equals(topLevelEntry, "resource", StringComparison.OrdinalIgnoreCase);
-    }
-
-    private static string CreatePendingUpdateScript()
-    {
-        return $$"""
-param(
-    [int]$ParentProcessId,
-    [string]$RootDir,
-    [string]$ExtractDir,
-    [string]$BackupDir,
-    [string]$PackagePath,
-    [string]$SuccessStatusFile,
-    [string]$FailureStatusFile,
-    [string]$RelaunchExecutablePath,
-    [string]$PlanFile,
-    [string]$ScriptPath
-)
-
-$ErrorActionPreference = 'Stop'
-$logFile = Join-Path $RootDir 'debug\pending-update-applier.log'
-$shouldRelaunch = $false
-
-function Write-Log {
-    param([string]$Message)
-
-    $timestamp = Get-Date -Format 'yyyy-MM-dd HH:mm:ss.fff'
-    $directory = Split-Path -Parent $logFile
-    if (-not [string]::IsNullOrEmpty($directory)) {
-        [System.IO.Directory]::CreateDirectory($directory) | Out-Null
-    }
-
-    Add-Content -LiteralPath $logFile -Value "[$timestamp] $Message"
-}
-
-function Ensure-TrailingSeparator {
-    param([string]$Path)
-
-    $separator = [string][System.IO.Path]::DirectorySeparatorChar
-    if ($Path.EndsWith($separator)) {
-        return $Path
-    }
-
-    return $Path + $separator
-}
-
-function Resolve-PathUnderRoot {
-    param(
-        [string]$RootPath,
-        [string]$RelativePath
-    )
-
-    if ([string]::IsNullOrWhiteSpace($RelativePath)) {
-        throw "Illegal path in update package: $RelativePath"
-    }
-
-    $normalizedRelativePath = $RelativePath.Trim().Replace([System.IO.Path]::AltDirectorySeparatorChar, [System.IO.Path]::DirectorySeparatorChar)
-    if ([System.IO.Path]::IsPathRooted($normalizedRelativePath)) {
-        throw "Illegal path in update package: $RelativePath"
-    }
-
-    $normalizedRoot = Ensure-TrailingSeparator ([System.IO.Path]::GetFullPath($RootPath))
-    $candidateFullPath = [System.IO.Path]::GetFullPath([System.IO.Path]::Combine($RootPath, $normalizedRelativePath))
-    if (-not $candidateFullPath.StartsWith($normalizedRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
-        throw "Illegal path in update package: $RelativePath"
-    }
-
-    return $candidateFullPath
-}
-
-function Ensure-ParentDirectory {
-    param([string]$Path)
-
-    $parentDirectory = Split-Path -Parent $Path
-    if (-not [string]::IsNullOrEmpty($parentDirectory)) {
-        [System.IO.Directory]::CreateDirectory($parentDirectory) | Out-Null
-    }
-}
-
-function Move-PathEntry {
-    param(
-        [string]$SourcePath,
-        [string]$DestinationPath
-    )
-
-    Ensure-ParentDirectory $DestinationPath
-
-    if (Test-Path -LiteralPath $SourcePath -PathType Leaf) {
-        [System.IO.File]::Move($SourcePath, $DestinationPath)
-        return
-    }
-
-    if (Test-Path -LiteralPath $SourcePath -PathType Container) {
-        [System.IO.Directory]::Move($SourcePath, $DestinationPath)
-        return
-    }
-
-    throw "Path not found: $SourcePath"
-}
-
-function Create-ArchivedPath {
-    param([string]$Path)
-
-    $index = 0
-    $currentDate = Get-Date -Format 'yyyyMMddHHmmss'
-    $archivedPath = "$Path.$currentDate.$index"
-
-    while (Test-Path -LiteralPath $archivedPath) {
-        $index++
-        $archivedPath = "$Path.$currentDate.$index"
-    }
-
-    return $archivedPath
-}
-
-function Prepare-BackupDestination {
-    param([string]$BackupPath)
-
-    Ensure-ParentDirectory $BackupPath
-    if (-not (Test-Path -LiteralPath $BackupPath)) {
-        return
-    }
-
-    $archivedPath = Create-ArchivedPath $BackupPath
-    Move-PathEntry $BackupPath $archivedPath
-}
-
-function Move-ExistingPathToBackup {
-    param(
-        [string]$SourcePath,
-        [string]$BackupPath
-    )
-
-    Prepare-BackupDestination $BackupPath
-    Move-PathEntry $SourcePath $BackupPath
-}
-
-try {
-    Wait-Process -Id $ParentProcessId -ErrorAction SilentlyContinue
-
-    if (-not (Test-Path -LiteralPath $PlanFile)) {
-        throw "Pending update plan not found: $PlanFile"
-    }
-
-    $plan = [System.IO.File]::ReadAllText($PlanFile, [System.Text.Encoding]::UTF8) | ConvertFrom-Json
-    $removeList = if ($null -eq $plan.removeList) { @() } else { @($plan.removeList) }
-    $moveList = if ($null -eq $plan.moveList) { @() } else { @($plan.moveList) }
-
-    Write-Log "External pending updater started. PlanFile=$PlanFile ExtractDir=$ExtractDir"
-    [System.IO.Directory]::CreateDirectory($BackupDir) | Out-Null
-
-    foreach ($relativePath in $removeList) {
-        $targetPath = Resolve-PathUnderRoot $RootDir $relativePath
-        if (-not (Test-Path -LiteralPath $targetPath)) {
-            continue
-        }
-
-        $backupPath = Resolve-PathUnderRoot $BackupDir $relativePath
-        Move-ExistingPathToBackup $targetPath $backupPath
-    }
-
-    foreach ($relativePath in $moveList) {
-        $sourcePath = Resolve-PathUnderRoot $ExtractDir $relativePath
-        $targetPath = Resolve-PathUnderRoot $RootDir $relativePath
-        $backupPath = Resolve-PathUnderRoot $BackupDir $relativePath
-
-        if (Test-Path -LiteralPath $targetPath) {
-            Move-ExistingPathToBackup $targetPath $backupPath
-        }
-
-        Move-PathEntry $sourcePath $targetPath
-    }
-
-    if (Test-Path -LiteralPath $PackagePath) {
-        Remove-Item -LiteralPath $PackagePath -Force
-    }
-
-    if (Test-Path -LiteralPath $FailureStatusFile) {
-        Remove-Item -LiteralPath $FailureStatusFile -Force
-    }
-
-    Ensure-ParentDirectory $SuccessStatusFile
-    [System.IO.File]::WriteAllText($SuccessStatusFile, 'succeeded', [System.Text.Encoding]::UTF8)
-
-    $shouldRelaunch = $true
-
-    Write-Log 'External pending updater completed successfully.'
-}
-catch {
-    Write-Log ("External pending updater failed: " + $_.Exception)
-    Ensure-ParentDirectory $FailureStatusFile
-    [System.IO.File]::WriteAllText($FailureStatusFile, $_.Exception.ToString(), [System.Text.Encoding]::UTF8)
-    if (Test-Path -LiteralPath $SuccessStatusFile) {
-        Remove-Item -LiteralPath $SuccessStatusFile -Force -ErrorAction SilentlyContinue
-    }
-}
-finally {
-    if (Test-Path -LiteralPath $ExtractDir) {
-        Remove-Item -LiteralPath $ExtractDir -Recurse -Force -ErrorAction SilentlyContinue
-    }
-
-    if (Test-Path -LiteralPath $PlanFile) {
-        Remove-Item -LiteralPath $PlanFile -Force -ErrorAction SilentlyContinue
-    }
-
-    if ($shouldRelaunch -and (Test-Path -LiteralPath $RelaunchExecutablePath)) {
-        Start-Process -FilePath $RelaunchExecutablePath -WorkingDirectory $RootDir
-    }
-
-    if (Test-Path -LiteralPath $ScriptPath) {
-        Remove-Item -LiteralPath $ScriptPath -Force -ErrorAction SilentlyContinue
-    }
-}
-""";
     }
 
     private static void MoveExistingPathToBackup(string sourcePath, string backupPath)

--- a/src/MaaWpfGui/Services/PendingUpdateApplier.cs
+++ b/src/MaaWpfGui/Services/PendingUpdateApplier.cs
@@ -405,6 +405,11 @@ internal static partial class PendingUpdateApplier
             context.ExtractDir,
             context.PackagePath);
 
+        if (!File.Exists(updaterExecutablePath))
+        {
+            throw new FileNotFoundException("MAA.Updater.exe is missing.", updaterExecutablePath);
+        }
+
         Process.Start(startInfo);
         return new(PendingUpdateApplyResult.StatusKind.Delegated);
     }


### PR DESCRIPTION
## Summary by Sourcery

引入一个专用的原生 Windows 更新程序可执行文件，并让 MaaWpfGui 通过基于 JSON 的更新计划，将待处理更新的应用委托给该程序，同时实现更安全的整包处理和备份行为。

新特性：
- 新增独立的 `MAA.Updater` 可执行文件，在主 WPF 进程之外应用待处理更新。

增强：
- 修改委托更新流程，通过包含包类型和文件操作的 JSON 更新计划调用外部更新程序。
- 改进整包更新的处理方式，以保留特定的运行时/配置数据，并允许在委托更新前刷新更新器自身的二进制文件。
- 强化更新应用逻辑，增加更严格的路径校验、备份/回收机制，以及更清晰的委托更新日志记录。

构建：
- 添加 `MaaUpdater` CMake 目标，确保其与 `MaaWpfGui` 一同构建与安装，并使用静态 MSVC 运行时进行链接，以在运行时替换过程中提高稳健性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated native Windows updater executable and wire MaaWpfGui to delegate pending update application to it using a JSON-based plan, with safer full-package handling and backup behavior.

New Features:
- Add a standalone MAA.Updater executable that applies pending updates outside the main WPF process.

Enhancements:
- Change delegated update flow to call the external updater with a JSON plan that includes package type and file operations.
- Improve full-package update handling to preserve specific runtime/config data and allow the updater binary itself to be refreshed before delegation.
- Harden update application logic with stricter path validation, backup/recycle behavior, and clearer logging of delegated updates.

Build:
- Add a MaaUpdater CMake target, ensure it is built and installed alongside MaaWpfGui, and link it with a static MSVC runtime for robustness during runtime replacement.

</details>

新功能：
- 添加独立的 Windows 更新程序二进制文件（MAA.Updater.exe），用于在主 WPF 进程之外执行委托的更新应用。

增强：
- 更改委托更新流程，改为使用包含包类型和文件操作的 JSON 计划来调用专用更新程序可执行文件。
- 优化整包更新处理，以保留特定的 runtime/config 目录和更新程序二进制文件，并允许通过整包来刷新更新程序本身。
- 确保 WPF GUI 构建依赖并安装新的更新程序二进制文件，并使用静态 CRT 链接，以提高运行时替换过程中的健壮性。

构建：
- 添加 CMake 目标和依赖项，以在构建和安装 MaaWpfGui 的同时，构建并安装新的 MAA.Updater 可执行文件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入一个专用的原生 Windows 更新程序可执行文件，并让 MaaWpfGui 通过基于 JSON 的更新计划，将待处理更新的应用委托给该程序，同时实现更安全的整包处理和备份行为。

新特性：
- 新增独立的 `MAA.Updater` 可执行文件，在主 WPF 进程之外应用待处理更新。

增强：
- 修改委托更新流程，通过包含包类型和文件操作的 JSON 更新计划调用外部更新程序。
- 改进整包更新的处理方式，以保留特定的运行时/配置数据，并允许在委托更新前刷新更新器自身的二进制文件。
- 强化更新应用逻辑，增加更严格的路径校验、备份/回收机制，以及更清晰的委托更新日志记录。

构建：
- 添加 `MaaUpdater` CMake 目标，确保其与 `MaaWpfGui` 一同构建与安装，并使用静态 MSVC 运行时进行链接，以在运行时替换过程中提高稳健性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a dedicated native Windows updater executable and wire MaaWpfGui to delegate pending update application to it using a JSON-based plan, with safer full-package handling and backup behavior.

New Features:
- Add a standalone MAA.Updater executable that applies pending updates outside the main WPF process.

Enhancements:
- Change delegated update flow to call the external updater with a JSON plan that includes package type and file operations.
- Improve full-package update handling to preserve specific runtime/config data and allow the updater binary itself to be refreshed before delegation.
- Harden update application logic with stricter path validation, backup/recycle behavior, and clearer logging of delegated updates.

Build:
- Add a MaaUpdater CMake target, ensure it is built and installed alongside MaaWpfGui, and link it with a static MSVC runtime for robustness during runtime replacement.

</details>

</details>