### PR TITLE
修复截图延迟极低时，可能会随机出现，更换产物/订单失败的问题

### DIFF
--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -4688,7 +4688,9 @@
         "action": "ClickSelf",
         "cache": true,
         "roi": [395, 150, 248, 427],
-        "next": ["ChangeOrderConfirm"]
+        "next": ["ChangeOrderConfirm"],
+        "preDelay": 500,
+        "Doc":"加前延时等动画结束再执行点击"
     },
     "ChangeOrderConfirm": {
         "algorithm": "JustReturn",
@@ -4708,7 +4710,9 @@
         "action": "ClickSelf",
         "cache": true,
         "roi": [635, 150, 250, 427],
-        "next": ["ChangeOrderConfirm"]
+        "next": ["ChangeOrderConfirm"],
+        "preDelay": 500,
+        "Doc":"加前延时等动画结束再执行点击"
     },
     "ChooseProductList": {
         "action": "ClickRect",
@@ -4721,7 +4725,7 @@
         "template": "ReplenishToMaxConfirm.png",
         "cache": true,
         "roi": [890, 540, 120, 120],
-        "next": ["ProductFinalConfirm"]
+        "next": ["ProductFinalConfirm", "Stop"]
     },
     "ClickProductMax": {
         "action": "ClickSelf",
@@ -4733,7 +4737,9 @@
         "action": "ClickSelf",
         "cache": true,
         "roi": [240, 255, 190, 195],
-        "next": ["ClickProductMax"]
+        "next": ["ClickProductMax"],
+        "preDelay": 500,
+        "Doc":"加前延时等动画结束再执行点击"
     },
     "ProductFinalConfirm": {
         "action": "ClickSelf",
@@ -4752,7 +4758,9 @@
         "action": "ClickSelf",
         "cache": true,
         "roi": [240, 76, 190, 195],
-        "next": ["ClickProductMax"]
+        "next": ["ClickProductMax"],
+        "preDelay": 500,
+        "Doc":"加前延时等动画结束再执行点击"
     },
     "ChooseOriginiumShardTab": {
         "action": "ClickSelf",
@@ -4764,7 +4772,9 @@
         "action": "ClickSelf",
         "cache": true,
         "roi": [240, 76, 190, 195],
-        "next": ["ClickProductMax"]
+        "next": ["ClickProductMax"],
+        "preDelay": 500,
+        "Doc":"加前延时等动画结束再执行点击"
     },
     "ChangeProductToMiddleBattleRecord": {
         "action": "ClickRect",


### PR DESCRIPTION
fix: 给更换产物/订单的一环任务步骤加延时，避免在极低截图延迟下（5ms)出现更换不成功的情况。
fix: 给ConfirmProductChange任务添加一个stop出口，避免在单独测试更换产物任务时，可能会出现的一个意外报错。

点击更换订单和点击更换产物的时候（见下方两图）会有一个动画时间。

以前cpp代码里，任务执行默认有个500ms延时，可能是现在没有了吧，导致mumu extra模式下，有随机概率卡动画，点击产物会不生效，而且。

大概今年1月份就在我的基建里发现换班出问题了，但是再手动link start一次通常又能换好。

观察一段时间之后，发现能不能换成功都是随机的感觉。

同时，不管换没换对，在基建换班任务执行中，都是返回产物已切换，没有报错的。这个没搞懂怎么回事。

<img width="921" height="517" alt="image" src="https://github.com/user-attachments/assets/5a45910d-8a87-47b8-8695-4e0f4242df8a" />
<img width="918" height="518" alt="image" src="https://github.com/user-attachments/assets/c4132171-4978-4dbd-afbd-a9aaad13b6b0" />


额外加的stop入口是因为在执行自定任务测试的时候发现，如果切换到的产物和当前产物一致，会报错。

正常来说如果产物一致是不会进换产物流程的，所以不影响正常的换班逻辑。

## Summary by Sourcery

为产品/订单变更任务添加时序和控制流调整，以在截图延迟极低的情况下提升可靠性。

Bug Fixes:
- 在产品/订单变更步骤中引入延迟，以防止在截图延迟极低时出现随机失败。
- 为 `ConfirmProductChange` 任务添加停止退出逻辑，以避免在隔离任务测试期间，当目标产品与当前产品相同时出现错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add timing and control-flow adjustments to product/order change tasks to improve reliability under very low screenshot latency.

Bug Fixes:
- Introduce a delay in the product/order change step to prevent random failures when screenshots are taken with extremely low latency.
- Add a stop exit to the ConfirmProductChange task to avoid errors when the target product is the same as the current one during isolated task testing.

</details>