### PR TITLE
feat: 争锋频道 绿藤城

### DIFF
--- a/resource/tasks/MiniGame/ALL.json
+++ b/resource/tasks/MiniGame/ALL.json
@@ -4,6 +4,11 @@
         "algorithm": "JustReturn",
         "next": ["MiniGame@ALL@GreenGrass@DuelChannel@Begin"]
     },
+    "MiniGame@ALL@GreenGrass@IvyVine@Begin": {
+        "doc": "争锋频道：绿藤城",
+        "algorithm": "JustReturn",
+        "next": ["MiniGame@ALL@GreenGrass@DuelChannel@Begin"]
+    },
     "MiniGame@ALL@GreenGrass@DuelChannel@Begin": {
         "doc": "争锋频道：青草城",
         "algorithm": "OcrDetect",

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -934,6 +934,8 @@ Only level rewards can be farmed; to get the Engraved Medal, all ｢Key Objectiv
     <system:String x:Key="MiniGame@ALL@GreenGrassTip" xml:space="preserve">Manually skip the tutorial dialogue, then you can exit directly.&#10;Start the task from the event screen (there is a ｢Join Event｣ button in the bottom right corner).&#10;&#10;Follow the Duck Lord's choice.</system:String>
     <system:String x:Key="MiniGame@ALL@HoneyFruit">Duel Channel: Honeydew</system:String>
     <system:String x:Key="MiniGame@ALL@HoneyFruitTip" xml:space="preserve">{key=MiniGame@ALL@GreenGrassTip}</system:String>
+    <system:String x:Key="MiniGame@ALL@IvyVine">Duel Channel: Ivyvine</system:String>
+    <system:String x:Key="MiniGame@ALL@IvyVineTip" xml:space="preserve">{key=MiniGame@ALL@GreenGrassTip}</system:String>
     <system:String x:Key="MiniGame@SecretFront@Ending">Ending</system:String>
     <system:String x:Key="MiniGame@SecretFront@Event">Priority for Series of Events</system:String>
     <system:String x:Key="MiniGame@SecretFront@Event1">Support Platform</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -935,6 +935,8 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="MiniGame@ALL@GreenGrassTip" xml:space="preserve">手動でチュートリアルの会話をスキップし、直接退出することができます。&#10;イベント画面（右下角に「試合観戦」ボタンがあります）でタスクを開始します。&#10;&#10;ダック卿の選択をフォローする。</system:String>
     <system:String x:Key="MiniGame@ALL@HoneyFruit">デュエルチャンネル：ハニーデューシティ</system:String>
     <system:String x:Key="MiniGame@ALL@HoneyFruitTip" xml:space="preserve">{key=MiniGame@ALL@GreenGrassTip}</system:String>
+    <system:String x:Key="MiniGame@ALL@IvyVine">デュエルチャンネル：アイヴィヴァインシティ</system:String>
+    <system:String x:Key="MiniGame@ALL@IvyVineTip" xml:space="preserve">{key=MiniGame@ALL@GreenGrassTip}</system:String>
     <system:String x:Key="MiniGame@SecretFront@Ending">エンディング</system:String>
     <system:String x:Key="MiniGame@SecretFront@Event">シリーズ事件の優先順位</system:String>
     <system:String x:Key="MiniGame@SecretFront@Event1">作戦プラットフォーム支援任務</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -936,6 +936,8 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="MiniGame@ALL@GreenGrassTip" xml:space="preserve">튜토리얼 대화를 수동으로 건너뛴 후, 바로 종료할 수 있어요&#10;이벤트 메인 화면에서 임무를 시작하세요 (오른쪽 아래 ｢경기 진행｣)&#10;&#10;덕로드만 믿고 따라가면 손해는 없을거에요</system:String>
     <system:String x:Key="MiniGame@ALL@HoneyFruit">듀얼 채널: 허니듀</system:String>
     <system:String x:Key="MiniGame@ALL@HoneyFruitTip" xml:space="preserve">{key=MiniGame@ALL@GreenGrassTip}</system:String>
+    <system:String x:Key="MiniGame@ALL@IvyVine">듀얼 채널: 아이비바인</system:String>
+    <system:String x:Key="MiniGame@ALL@IvyVineTip" xml:space="preserve">{key=MiniGame@ALL@GreenGrassTip}</system:String>
     <system:String x:Key="MiniGame@SecretFront@Ending">엔딩</system:String>
     <system:String x:Key="MiniGame@SecretFront@Event">우선 시리즈 사건</system:String>
     <system:String x:Key="MiniGame@SecretFront@Event1">작전 플랫폼 지원</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -935,6 +935,8 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="MiniGame@ALL@GreenGrassTip" xml:space="preserve">手动跳过教程对话，然后可以直接退出。&#10;在活动主界面（右下角有 ｢加入赛事｣ 处）开始任务。&#10;&#10;跟着鸭总喝口汤。</system:String>
     <system:String x:Key="MiniGame@ALL@HoneyFruit">争锋频道：蜜果城</system:String>
     <system:String x:Key="MiniGame@ALL@HoneyFruitTip" xml:space="preserve">手动跳过教程对话，然后可以直接退出。&#10;在活动主界面（右下角有 ｢加入赛事｣ 处）开始任务。&#10;&#10;跟着鸭总喝口汤。</system:String>
+    <system:String x:Key="MiniGame@ALL@IvyVine">争锋频道：绿藤城</system:String>
+    <system:String x:Key="MiniGame@ALL@IvyVineTip" xml:space="preserve">手动跳过教程对话，然后可以直接退出。&#10;在活动主界面（右下角有 ｢加入赛事｣ 处）开始任务。&#10;&#10;跟着鸭总喝口汤。</system:String>
     <system:String x:Key="MiniGame@SecretFront@Ending">结局</system:String>
     <system:String x:Key="MiniGame@SecretFront@Event">优先系列事件</system:String>
     <system:String x:Key="MiniGame@SecretFront@Event1">支援作战平台</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -934,9 +934,9 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="MiniGame@ALL@GreenGrass">争锋频道：青草城</system:String>
     <system:String x:Key="MiniGame@ALL@GreenGrassTip" xml:space="preserve">手动跳过教程对话，然后可以直接退出。&#10;在活动主界面（右下角有 ｢加入赛事｣ 处）开始任务。&#10;&#10;跟着鸭总喝口汤。</system:String>
     <system:String x:Key="MiniGame@ALL@HoneyFruit">争锋频道：蜜果城</system:String>
-    <system:String x:Key="MiniGame@ALL@HoneyFruitTip" xml:space="preserve">手动跳过教程对话，然后可以直接退出。&#10;在活动主界面（右下角有 ｢加入赛事｣ 处）开始任务。&#10;&#10;跟着鸭总喝口汤。</system:String>
+    <system:String x:Key="MiniGame@ALL@HoneyFruitTip" xml:space="preserve">{key=MiniGame@ALL@GreenGrassTip}</system:String>
     <system:String x:Key="MiniGame@ALL@IvyVine">争锋频道：绿藤城</system:String>
-    <system:String x:Key="MiniGame@ALL@IvyVineTip" xml:space="preserve">手动跳过教程对话，然后可以直接退出。&#10;在活动主界面（右下角有 ｢加入赛事｣ 处）开始任务。&#10;&#10;跟着鸭总喝口汤。</system:String>
+    <system:String x:Key="MiniGame@ALL@IvyVineTip" xml:space="preserve">{key=MiniGame@ALL@GreenGrassTip}</system:String>
     <system:String x:Key="MiniGame@SecretFront@Ending">结局</system:String>
     <system:String x:Key="MiniGame@SecretFront@Event">优先系列事件</system:String>
     <system:String x:Key="MiniGame@SecretFront@Event1">支援作战平台</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -935,6 +935,8 @@ C:\\leidian\\LDPlayer9\n
     <system:String x:Key="MiniGame@ALL@GreenGrassTip" xml:space="preserve">手動跳過教學對話，然後可以直接退出。&#10;在活動主介面（右下角有「加入賽事」處）開始任務。&#10;&#10;跟著鴨總喝口湯。</system:String>
     <system:String x:Key="MiniGame@ALL@HoneyFruit">爭鋒頻道：蜜果城</system:String>
     <system:String x:Key="MiniGame@ALL@HoneyFruitTip" xml:space="preserve">{key=MiniGame@ALL@GreenGrassTip}</system:String>
+    <system:String x:Key="MiniGame@ALL@IvyVine">爭鋒頻道：綠藤城</system:String>
+    <system:String x:Key="MiniGame@ALL@IvyVineTip" xml:space="preserve">{key=MiniGame@ALL@GreenGrassTip}</system:String>
     <system:String x:Key="MiniGame@SecretFront@Ending">結局</system:String>
     <system:String x:Key="MiniGame@SecretFront@Event">優先系列事件</system:String>
     <system:String x:Key="MiniGame@SecretFront@Event1">支援作戰平台</system:String>


### PR DESCRIPTION
jp 和 kr 的语言文件去哪了

## Summary by Sourcery

为「争锋频道 绿藤城」功能新增小游戏任务配置，并更新英文和中文本地化资源。

新增功能：
- 在共享的 `ALL.json` 任务文件中引入新的小游戏场景配置。

改进：
- 扩展 `en-us`、`zh-cn` 和 `zh-tw` 本地化资源，以支持与「争锋频道 绿藤城」功能相关的新 UI 文本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add new mini-game task configuration and update English and Chinese localization resources for the 争锋频道 绿藤城 feature.

New Features:
- Introduce configuration for a new mini-game scenario in the shared ALL.json tasks file.

Enhancements:
- Extend en-us, zh-cn, and zh-tw localization resources to support new UI text related to the 争锋频道 绿藤城 feature.

</details>