### PR TITLE
fix: 修复萨米肉鸽装备解析等 10 个 bug

### DIFF
--- a/src/MaaCore/Task/Fight/FightTimesTaskPlugin.cpp
+++ b/src/MaaCore/Task/Fight/FightTimesTaskPlugin.cpp
@@ -165,7 +165,7 @@ std::optional<int> asst::FightTimesTaskPlugin::change_series(int sanity_current,
         m_task_ptr->set_enable(false);
     }
     else if (!ret) {
-        ret = select_series(1);
+        ret = select_series(false);
     }
     return ret;
 }

--- a/src/MaaCore/Task/Fight/MedicineCounterTaskPlugin.cpp
+++ b/src/MaaCore/Task/Fight/MedicineCounterTaskPlugin.cpp
@@ -310,7 +310,7 @@ std::optional<int> asst::MedicineCounterTaskPlugin::get_target_of_sanity(const c
     int num = 0;
     if (!utils::chars_to_number(ocr.get_result().text, num)) {
         Log.error(__FUNCTION__, "unable to change [", ocr.get_result().text, "] into int");
-        return false;
+        return std::nullopt;
     }
     return num;
 }
@@ -333,7 +333,7 @@ std::optional<int> asst::MedicineCounterTaskPlugin::get_maximun_of_sanity(const 
     int num = 0;
     if (!utils::chars_to_number(ocr.get_result().text, num)) {
         Log.error(__FUNCTION__, "unable to change [", ocr.get_result().text, "] into int");
-        return false;
+        return std::nullopt;
     }
     return num;
 }

--- a/src/MaaCore/Task/Roguelike/Sami/RoguelikeFoldartalGainTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/Sami/RoguelikeFoldartalGainTaskPlugin.cpp
@@ -122,7 +122,8 @@ bool asst::RoguelikeFoldartalGainTaskPlugin::gain_stage_award()
 
     auto foldartal = analyzer.get_result().front().text;
     // 深入调查调查装备也使用同一个入口，先分类
-    if (foldartal != "雷达" || "留声机" || "景观" || "LUD" || "踢脚" || "自走车") {
+    if (foldartal != "雷达" && foldartal != "留声机" && foldartal != "景观" && foldartal != "LUD"
+        && foldartal != "踢脚" && foldartal != "自走车") {
         gain_foldartal(std::move(foldartal));
     }
     if (m_ocr_after_combat) {

--- a/src/MaaCore/Task/Roguelike/Sami/RoguelikeFoldartalUseTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/Sami/RoguelikeFoldartalUseTaskPlugin.cpp
@@ -29,8 +29,8 @@ bool asst::RoguelikeFoldartalUseTaskPlugin::verify(const AsstMsg msg, const json
         task_view.remove_prefix(task_name_pre.length());
     }
     // 不知道是不是不对纵向节点用比较好，先写上
-    task_name_pre = "task_name_pre";
-    if (task_view.starts_with("Vertical")) {
+    task_name_pre = "Vertical";
+    if (task_view.starts_with(task_name_pre)) {
         task_view.remove_prefix(task_name_pre.length());
     }
     const std::string task_name_suf = "AI6";

--- a/src/MaaCore/Vision/Battle/BattlefieldClassifier.cpp
+++ b/src/MaaCore/Vision/Battle/BattlefieldClassifier.cpp
@@ -230,7 +230,7 @@ BattlefieldClassifier::DeployDirectionResult BattlefieldClassifier::deploy_direc
 
     auto memory_info = Ort::MemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeCPU);
     constexpr int64_t batch_size = 1;
-    std::array<int64_t, 4> input_shape { batch_size, image.channels(), image.cols, image.rows };
+    std::array<int64_t, 4> input_shape { batch_size, image.channels(), image.rows, image.cols };
 
     Ort::Value input_tensor = Ort::Value::CreateTensor<float>(
         memory_info,

--- a/src/MaaCore/Vision/Battle/BattlefieldDetector.cpp
+++ b/src/MaaCore/Vision/Battle/BattlefieldDetector.cpp
@@ -43,7 +43,7 @@ std::vector<BattlefieldDetector::OperatorResult> BattlefieldDetector::operator_a
 
     auto memory_info = Ort::MemoryInfo::CreateCpu(OrtDeviceAllocator, OrtMemTypeCPU);
     constexpr int64_t batch_size = 1;
-    std::array<int64_t, 4> input_shape { batch_size, image.channels(), image.cols, image.rows };
+    std::array<int64_t, 4> input_shape { batch_size, image.channels(), image.rows, image.cols };
 
     Ort::Value input_tensor = Ort::Value::CreateTensor<float>(
         memory_info,

--- a/src/MaaCore/Vision/Miscellaneous/PixelAnalyzer.h
+++ b/src/MaaCore/Vision/Miscellaneous/PixelAnalyzer.h
@@ -28,7 +28,7 @@ public:
 
     void set_gray_lb(const int gray_lb) { m_gray_lb = gray_lb; }
 
-    void set_gray_ub(const int gray_ub) { m_ub = gray_ub; }
+    void set_gray_ub(const int gray_ub) { m_gray_ub = gray_ub; }
 
     void set_lb(const std::array<int, 3>& lb) { m_lb = cv::Scalar(lb[0], lb[1], lb[2]); }
 

--- a/src/MaaCore/Vision/Roguelike/RoguelikeRecruitSupportAnalyzer.cpp
+++ b/src/MaaCore/Vision/Roguelike/RoguelikeRecruitSupportAnalyzer.cpp
@@ -131,9 +131,9 @@ bool asst::RoguelikeRecruitSupportAnalyzer::analyze()
             boost::smatch match_results;
             if (boost::regex_search(result.text, match_results, boost::regex("[0-9]{2}:[0-9]{2}:[0-9]{2}"))) {
                 const auto& match_str = match_results[0].str();
-                const auto& hour = std::atoi(match_str.substr(2).c_str());
+                const auto& hour = std::atoi(match_str.substr(0, 2).c_str());
                 const auto& min = std::atoi(match_str.substr(3, 2).c_str());
-                const auto& sec = std::atoi(match_str.substr(7, 2).c_str());
+                const auto& sec = std::atoi(match_str.substr(6, 2).c_str());
                 m_refresh_result = { result.rect, true, 3600 * hour + 60 * min + sec };
                 return true;
             }

--- a/src/MaaCore/Vision/VisionHelper.cpp
+++ b/src/MaaCore/Vision/VisionHelper.cpp
@@ -64,12 +64,14 @@ Rect asst::VisionHelper::correct_rect(const Rect& rect, const Rect& main_roi)
         res.height = rect.height + rect.y;
     }
     if (res.x < main_roi.x) {
+        const int dx = main_roi.x - res.x;
         res.x = main_roi.x;
-        res.width = res.width - (main_roi.x - res.x);
+        res.width -= dx;
     }
     if (res.y < main_roi.y) {
+        const int dy = main_roi.y - res.y;
         res.y = main_roi.y;
-        res.height = res.height - (main_roi.y - res.y);
+        res.height -= dy;
     }
     if (res.x + res.width > main_roi.x + main_roi.width) {
         res.width = main_roi.x + main_roi.width - res.x;


### PR DESCRIPTION
> rebase 后版本：原 9 个 commit 已通过 #16332 合入，已 drop。本 PR 现在只含 10 个新 fix。详见底部更正说明。

改进了 Claude Code 的 review 方法，对仓库进行了更详细的扫描后人工逐条确认不是游戏机制或作者意图，得到 10 项 correctness 修复。所有改动按 commit 独立分割，可单独回退。

## 高严重性 — 直接影响功能（6 项）

### 萨米肉鸽

**`72e9526762` `RoguelikeFoldartalGainTaskPlugin::gain_stage_award` `||` 链恒为 true**
```cpp
if (foldartal != "雷达" || "留声机" || "景观" || "LUD" || "踢脚" || "自走车")
```
C++ 解析为 `(foldartal != "雷达") || ("留声机") || ...`，5 个字符串字面量是 `const char*`，非空指针视为 `true`，整个表达式恒真，所有 OCR 文字都被存入 `foldartal_list`。

**为什么不是游戏机制：** 注释 `// 深入调查调查装备也使用同一个入口，先分类` 明示要排除这 6 个装备名（雷达/留声机等是萨米深入调查事件的装备，不是密文板）；混入会导致 use 阶段查找密文板时找到不存在的 "留声机"。blame 显示是 BxFS 2025-02-25 引入分类时的笔误。

修法：改 `&&` 链做逐项排除。

---

**`8b89352c7b` `RoguelikeFoldartalUseTaskPlugin::verify` 把变量名当字面量赋值**
```cpp
task_name_pre = "task_name_pre";   // ← 字面量恰好等于变量名
if (task_view.starts_with("Vertical")) {
    task_view.remove_prefix(task_name_pre.length());   // 删 13 字符而非 8
}
```
`task_name_pre` 被赋成长度 13 的字面量，`remove_prefix(13)` 把 `"Vertical"` 后多砍 5 字符，下游 `task_view == "CombatOps"` 全部失败 → 萨米纵向节点不会触发密文板使用。

**为什么不是游戏机制：** 同函数 line 28 已对横向节点 `task_name_pre` 做了"匹配再删除"；line 33 `starts_with("Vertical")` 表明意图是 `"Vertical"`；注释 `// 不知道是不是不对纵向节点用比较好，先写上` 是 work-in-progress 笔误。

修法：`task_name_pre = "Vertical"` 让 starts_with 与 length 一致。

### 理智作战 / 连战

**`3e62a78ad2` `MedicineCounterTaskPlugin::get_target_of_sanity / get_maximun_of_sanity` `return false` 隐式转 `optional<int>{0}`**
```cpp
std::optional<int> get_target_of_sanity(...) {
    if (!utils::chars_to_number(ocr.get_result().text, num)) {
        return false;          // ← bool→int(0)→optional<int>{0}
    }
    return num;
}
```
OCR 失败时返回的 optional **是 has_value 的**，里面装着 0。调用方 `analyze_sanity` 通过两个 has_value 判断，进入 `*target >= *max` 即 `0 >= 0 = true` 的"理智溢出"分支。最坏路径（`m_reduce_when_exceed = true`）：reduce 循环把 `using_count` 减到 0 → line 134 注释 `// 糊个屎, 假装吃了药` 直接 `m_has_used_medicine = true` 并通知 FightTimes 跳过吃药 → **整次理智作战用户没吃任何一瓶药**。博朗台模式路径表现为"停在吃药界面迟迟不吃药"。

**为什么不是有意：** 函数签名 `std::optional<int>` 明确表达"OCR 可能失败时返回 nullopt"；同函数 line 299/322（OCR 整体失败那行）已有 `return std::nullopt;`，证明这才是预期写法。**关联 issue #16061** "理智作战使用药剂停住不吃药"（v6.6.0-beta.1，博朗台模式）的现象正是本 bug 的博朗台路径。

修法：两处 `return false;` 改 `return std::nullopt;`。

**Refs #16061**

---

**`912a3f18d2` `FightTimesTaskPlugin::change_series` fallback 调到 int 重载**
```cpp
auto ret = select_series(true);   // line 163: optional<int>(bool) 重载
else if (!ret) {
    ret = select_series(1);       // line 168: 字面量 1 → bool(int) 重载！
}
```
两个重载并存（`FightTimesTaskPlugin.h:64-65`）：`std::optional<int> select_series(bool)` 与 `bool select_series(int)`。字面量 `1` 是 `int`，精确匹配 int 重载返回 `bool`；赋给 `optional<int>` 触发 `bool→int→optional<int>{0/1}` 隐式转换，`ret` 永远 has_value。调用方 `if (change_series(...))` 用 `optional::operator bool` 只看 has_value，**误判为切换成功**。

**为什么不是有意：** 同函数 line 151 已有 `return select_series(false); // 调整到剩余次数`——是放弃 available_only 限制走"选剩余次数"的标准 fallback；line 168 显然想做同样的事但把 `false` 写成了 `1`。

修法：`select_series(false)` 让两次调用语义一致。

### 招募刷新

**`5b5d0c3355` `RoguelikeRecruitSupportAnalyzer::analyze` HH:MM:SS substr 偏移**
```cpp
boost::regex_search(result.text, match_results, boost::regex("[0-9]{2}:[0-9]{2}:[0-9]{2}"))
const auto& hour = std::atoi(match_str.substr(2).c_str());      // ← 应是 (0,2)
const auto& sec  = std::atoi(match_str.substr(7, 2).c_str());   // ← 应是 (6,2)
```
`"12:34:56"` 索引 `0=1, 1=2, 2=:, 3=3, 4=4, 5=:, 6=5, 7=6`。`substr(2)` 从冒号开始 → `hour = 0`；`substr(7, 2)` 只取 1 字节 `"6"` → `sec` 是个位数。比如 CD `01:23:45` 当前算 `0*3600 + 23*60 + 5 = 1385` 秒，正确应是 `5025` 秒——少算近 1 小时。

**为什么不是中文格式：** regex `[0-9]{2}:[0-9]{2}:[0-9]{2}` 用的是 ASCII 半角冒号，匹配成功时 `match_str` 必为严格 8 字节 `HH:MM:SS`；如果游戏是 `12时34分56秒` 本地化格式，regex 根本不匹配，函数 line 142 提前 return false，根本走不到 substr。Line 137 `3600 * hour + 60 * min + sec` 也是标准时分秒换算。

修法：偏移改 `(0,2)`、`(3,2)`、`(6,2)`。

## 中等严重性 — 性能/精度受损（1 项）

**`c24cfee5c8` `BattlefieldClassifier::skill_ready_analyze` CHW 数据用 HWC 索引归一化**
```cpp
std::vector<float> input = image_to_tensor(cropped_image);   // CHW 输出
for (size_t i = 0; i < input.size(); i++) {
    int channel = i % 3;       // ← HWC 假设
    input[i] = (input[i] - mean[channel]) / std[channel];
}
```
`OnnxHelper::image_to_tensor` 显式 `hwc_to_chw`，输出是 CHW（先所有 R 像素，再 G，再 B）。`i % 3` 是 HWC 索引（R, G, B, R, G, B...），跟实际数据布局不匹配。三通道 mean/std 数值接近，错位归一化在统计上影响小，模型仍能跑但精度有损。

**为什么不是魔改 PyTorch / ONNX：** `grep -r "Ort::" src/MaaCore` 全部是微软官方 ONNX Runtime C++ API，没有 fork；模型 `resource/onnx/skill_ready_cls.onnx` 是标准 PyTorch 默认 NCHW 导出；`image_to_tensor` 函数名直接告诉你内部调用 `hwc_to_chw`，意图就是产出 CHW；紧接的 `input_shape{batch, channels, cols, rows}` 也按 NCHW 排序。这段归一化是 Plumess 2025-04-29 加的（model 在 2023-04 就有了），照搬 PyTorch tutorial 上 HWC 归一化但没注意上游已经 transpose 过了。

**关联 issue：**
- **#10799** "协助收集训练集 重训 skill_ready 模型"（OPEN）—— 维护者在收集数据想重训模型，但模型本身可能没问题，问题是推理时 mean/std 错位
- **#14438** "干员部署在最上方一行... 无法正确识别技能充能"（CLOSED）—— 表面是 UI 遮挡，但 CHW/HWC 错位会放大模型对边缘 case 的敏感性

修法：`int channel = i / plane_size`（plane_size = cols × rows）真正的 CHW 索引。

**Refs #10799 #14438**

## 低严重性 — 潜伏 / 防御性 cleanup（3 项）

**`01c3cdc25e` `BattlefieldClassifier / BattlefieldDetector` ONNX `input_shape` (W, H) → (H, W)** — 3 处全写成 `(N, C, W, H)`，标准应是 `(N, C, H, W)`。当前所有输入方形（64×64、96×96、640×640），bug 不显形。修法防止换非方形模型时炸。**为什么不是自定义 YOLO：** 同 #1 验证——用的是标准 ONNX Runtime，模型是标准 PyTorch 导出。

**`212406fc71` `VisionHelper::correct_rect(Rect, Rect)` 左/上越界裁剪 no-op** — `res.width = res.width - (main_roi.x - res.x)` 在 `res.x = main_roi.x` 之后算，差值恒为 0。**对比同函数 line 60** 处理 `res.x < 0` 时用了原始 `rect.x`：`res.width = rect.width + rect.x`——pattern 应一致。触发面极窄：只有 `RegionOCRer.cpp:41` 一处用 (Rect, Rect) 重载；其余 12+ 处都用 (Rect, cv::Mat) 重载（line 83+ 有 `std::clamp` 二次保险）。

**`ee89532e13` `BattleHelper::register_deployed_oper` Point 给 string-keyed map 赋值** — `m_last_use_skill_time.emplace(loc, ...)` 走 `Point::explicit operator std::string()` 编译通过但插入 `"(x, y)"` key；`use_all_ready_skill` 全用 `[name]` 读。`operator[]` 兜底默认构造，**功能影响接近零**——只是 map 多个永不被读的死条目。修法用 `name` 让对称 pattern 完整。

**`ca38bea86f` `PixelAnalyzer::set_gray_ub` 复制粘贴写到错字段** — `m_ub`（`cv::Scalar`） 应是 `m_gray_ub`（`int`）。grep 全仓库无人调用，潜伏 bug。

## 关联 issue

| Issue | 状态 | 修复 commit | 关联 |
|---|---|---|---|
| #16061 "理智作战使用药剂停住不吃药" | CLOSED | \`3e62a78ad2\` | 直接（博朗台路径） |
| #10799 "协助收集训练集 重训 skill_ready 模型" | OPEN | \`c24cfee5c8\` | 间接（精度根因之一） |
| #14438 "干员部署在最上方一行... 无法正确识别技能充能" | CLOSED | \`c24cfee5c8\` | 间接（边缘 case 敏感性） |

## 更正说明

抱歉，初次提交时未先 fetch upstream，把 PR #16332 squash 合入 dev-v2 的原 9 个 commit（back_to_home / MumuExtras reload / d_size / PlayToolsController swipe / m_task_id / OcrPack rec_label / RoguelikeStageEncounter / AsstDestroy / AvatarCacheManager pragma）一起带了过来。已 rebase 到最新 upstream/dev-v2，重复内容自动 drop，本 PR 现在只含 10 个新 fix。