### PR TITLE
feat: 重复启动时通过跨进程事件激活主窗口而非弹窗警告

### DIFF
--- a/src/MaaWpfGui/Main/Bootstrapper.cs
+++ b/src/MaaWpfGui/Main/Bootstrapper.cs
@@ -30,6 +30,7 @@ using System.Windows.Threading;
 using GlobalHotKey;
 using MaaWpfGui.Configuration.Factory;
 using MaaWpfGui.Constants;
+using MaaWpfGui.Extensions;
 using MaaWpfGui.Helper;
 using MaaWpfGui.Properties;
 using MaaWpfGui.Services;
@@ -577,7 +578,13 @@ public class Bootstrapper : Bootstrapper<RootViewModel>
         }
     }
 
-    private static string GetSingleInstanceKey() => PathsHelper.BaseDir.Replace("\\", "_").Replace(":", string.Empty);
+    private static string GetSingleInstanceKey()
+    {
+        var normalizedBaseDir = Path.GetFullPath(PathsHelper.BaseDir)
+            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+            .ToUpperInvariant();
+        return normalizedBaseDir.StableHash();
+    }
 
     private static void EnsureInstanceActivationEvent(string activationEventName)
     {

--- a/src/MaaWpfGui/Main/Bootstrapper.cs
+++ b/src/MaaWpfGui/Main/Bootstrapper.cs
@@ -62,6 +62,8 @@ public class Bootstrapper : Bootstrapper<RootViewModel>
 
     private static Mutex _mutex;
     private static bool _hasMutex;
+    private static EventWaitHandle _instanceActivationEvent;
+    private static CancellationTokenSource _instanceActivationListenerCancellation;
 
     public static readonly string UiLogFile = Path.Combine(PathsHelper.DebugDir, "gui.log");
     public static readonly string UiLogBakFile = Path.Combine(PathsHelper.DebugDir, "gui.bak.log");
@@ -540,15 +542,22 @@ public class Bootstrapper : Bootstrapper<RootViewModel>
 
     private static bool HandleMultipleInstances()
     {
-        // 设置互斥量的名称
-        string mutexName = "MAA_" + PathsHelper.BaseDir.Replace("\\", "_").Replace(":", string.Empty);
+        string instanceKey = GetSingleInstanceKey();
+        string mutexName = "MAA_" + instanceKey;
+        string activationEventName = "MAA_SHOW_" + instanceKey;
         _mutex = new Mutex(true, mutexName, out var isOnlyInstance);
 
         try
         {
             if (isOnlyInstance || _mutex.WaitOne(500))
             {
+                EnsureInstanceActivationEvent(activationEventName);
                 return true;
+            }
+
+            if (SignalExistingInstance(activationEventName))
+            {
+                return false;
             }
 
             MessageBoxHelper.Show(LocalizationHelper.GetString("MultiInstanceUnderSamePath"), "MAA", MessageBoxButton.OK, MessageBoxImage.Warning);
@@ -558,6 +567,7 @@ public class Bootstrapper : Bootstrapper<RootViewModel>
         {
             // 上一个程序没有正常释放互斥量
             // 即使捕获到这个异常，此时也已经获得了锁
+            EnsureInstanceActivationEvent(activationEventName);
             return true;
         }
         catch (Exception e)
@@ -565,6 +575,88 @@ public class Bootstrapper : Bootstrapper<RootViewModel>
             MessageBoxHelper.Show(LocalizationHelper.GetString("MultiInstanceUnderSamePath") + e.Message, "MAA", MessageBoxButton.OK, MessageBoxImage.Warning);
             return false;
         }
+    }
+
+    private static string GetSingleInstanceKey() => PathsHelper.BaseDir.Replace("\\", "_").Replace(":", string.Empty);
+
+    private static void EnsureInstanceActivationEvent(string activationEventName)
+    {
+        _instanceActivationEvent ??= new EventWaitHandle(false, EventResetMode.AutoReset, activationEventName);
+    }
+
+    private static bool SignalExistingInstance(string activationEventName)
+    {
+        try
+        {
+            using var activationEvent = EventWaitHandle.OpenExisting(activationEventName);
+            activationEvent.Set();
+            _logger.Information("Secondary launch detected, activation signal sent to existing instance");
+            return true;
+        }
+        catch (WaitHandleCannotBeOpenedException)
+        {
+            _logger.Warning("Secondary launch detected, but no activation listener was available");
+            return false;
+        }
+        catch (Exception e)
+        {
+            _logger.Warning(e, "Failed to signal the existing instance");
+            return false;
+        }
+    }
+
+    private static void StartInstanceActivationListener()
+    {
+        if (_instanceActivationEvent == null || _instanceActivationListenerCancellation != null)
+        {
+            return;
+        }
+
+        _instanceActivationListenerCancellation = new CancellationTokenSource();
+        _ = Task.Run(() => ListenForInstanceActivation(_instanceActivationListenerCancellation.Token));
+    }
+
+    private static void ListenForInstanceActivation(CancellationToken cancellationToken)
+    {
+        if (_instanceActivationEvent == null)
+        {
+            return;
+        }
+
+        WaitHandle[] waitHandles = [_instanceActivationEvent, cancellationToken.WaitHandle];
+
+        try
+        {
+            while (true)
+            {
+                int signaledIndex = WaitHandle.WaitAny(waitHandles);
+                if (signaledIndex != 0)
+                {
+                    return;
+                }
+
+                Application.Current?.Dispatcher.BeginInvoke(new Action(ActivateMainWindow), DispatcherPriority.Normal);
+            }
+        }
+        catch (ObjectDisposedException)
+        {
+            // ignored during shutdown
+        }
+        catch (Exception e)
+        {
+            _logger.Warning(e, "Existing instance activation listener stopped unexpectedly");
+        }
+    }
+
+    private static void ActivateMainWindow()
+    {
+        if (Application.Current == null || Application.Current.IsShuttingDown())
+        {
+            return;
+        }
+
+        Instances.MainWindowManager.Show();
+        _logger.Information("Existing instance window activated by a secondary launch");
     }
 
     public static bool IsUserAdministrator() => new WindowsPrincipal(WindowsIdentity.GetCurrent()).IsInRole(WindowsBuiltInRole.Administrator);
@@ -639,6 +731,7 @@ public class Bootstrapper : Bootstrapper<RootViewModel>
 
         Instances.WindowManager.ShowWindow(rootViewModel);
         Instances.InstantiateOnRootViewDisplayed(Container);
+        StartInstanceActivationListener();
 
         // 如果 IsFirstBootAfterUpdate 从 false 变为 true，说明这次启动只是解压更新包，不用执行后续逻辑
         if (!wasFirstBoot && Instances.VersionUpdateDialogViewModel.IsFirstBootAfterUpdate)
@@ -735,6 +828,13 @@ public class Bootstrapper : Bootstrapper<RootViewModel>
 
     public static void Release()
     {
+        _instanceActivationListenerCancellation?.Cancel();
+        _instanceActivationListenerCancellation?.Dispose();
+        _instanceActivationListenerCancellation = null;
+
+        _instanceActivationEvent?.Dispose();
+        _instanceActivationEvent = null;
+
         ETagCache.Save();
         Instances.SettingsViewModel.Sober();
         Instances.MaaHotKeyManager.Release();


### PR DESCRIPTION
## Summary by Sourcery

通过向现有实例发送信号以激活其主窗口来处理二次启动应用程序的情况，而不是显示重复实例警告对话框。

新功能：
- 当在相同安装路径下启动第二个实例时，支持跨进程激活现有实例的主窗口。

增强改进：
- 引入具名的跨进程事件和后台监听器，用于检测二次启动并将主窗口置于前台。
- 确保在应用程序启动和关闭期间，正确初始化和释放单实例同步原语以及激活监听器相关资源。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle secondary application launches by signaling the existing instance to activate its main window instead of showing a duplicate-instance warning dialog.

New Features:
- Support cross-process activation of the existing main window when a second instance is started under the same installation path.

Enhancements:
- Introduce a named cross-process event and background listener to detect secondary launches and bring the primary window to the foreground.
- Ensure proper initialization and disposal of single-instance synchronization primitives and activation listener resources during app startup and shutdown.

</details>