### PR TITLE
fix: 绿票商店稳定性提升

### DIFF
--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -4971,7 +4971,16 @@
         "action": "ClickSelf",
         "text": ["资质凭证区"],
         "roi": [108, 163, 124, 56],
-        "next": ["Store@EnterTicketStore@LoadingIcon", "GreenTicket@Store@ClickFirstFloor"]
+        "next": ["Store@EnterTicketStore@LoadingIcon", "GreenTicket@Store@ClickFirstFloor", "GreenTicket@Store@SwitchToSecondFloor"]
+    },
+    "GreenTicket@Store@SwitchToSecondFloor": {
+        "doc": "备选方案：点击二层使一层按钮变为灰底，提高一层OCR识别成功率",
+        "algorithm": "OcrDetect",
+        "text": ["2"],
+        "action": "ClickSelf",
+        "isAscii": false,
+        "roi": [262, 364, 38, 58],
+        "next": ["GreenTicket@Store@ClickFirstFloor"]
     },
     "GreenTicket@Store@ClickFirstFloor": {
         "algorithm": "OcrDetect",
@@ -4980,7 +4989,7 @@
         "action": "ClickSelf",
         "roi": [263, 196, 35, 73],
         "sub": ["SlowlySwipeToTheLeft"],
-        "postDelay": 1000,
+        "postDelay": 500,
         "next": ["GreenTicket@Store@ClickItemList#next", "GreenTicket@Store@ClickSecondFloor"]
     },
     "GreenTicket@Store@ClickItem": {
@@ -5074,7 +5083,46 @@
         "maxTimes": 1,
         "sub": ["SlowlySwipeToTheLeft*3"],
         "postDelay": 1000,
-        "next": ["GreenTicket@Store@ClickItemList#next", "Stop"]
+        "next": ["GreenTicket@Store@ClickSecondFloorItemList#next", "Stop"]
+    },
+    "GreenTicket@Store@ClickSecondFloorItemList": {
+        "algorithm": "JustReturn",
+        "next": [
+            "GreenTicket@Store@ClickSecondFloorItem_Headhunting_Permit",
+            "GreenTicket@Store@ClickSecondFloorItem_Recruitment_Permit"
+        ]
+    },
+    "GreenTicket@Store@ClickSecondFloorItem": {
+        "baseTask": "GreenTicket@Store@ClickItem",
+        "template": "empty.png",
+        "next": ["GreenTicket@Store@SecondFloorChooseMaxAmount"]
+    },
+    "GreenTicket@Store@ClickSecondFloorItem_Headhunting_Permit": {
+        "doc": "二层-单抽",
+        "baseTask": "GreenTicket@Store@ClickSecondFloorItem",
+        "template": "items/7003.png"
+    },
+    "GreenTicket@Store@ClickSecondFloorItem_Recruitment_Permit": {
+        "doc": "二层-招募许可",
+        "baseTask": "GreenTicket@Store@ClickSecondFloorItem",
+        "template": "items/7001.png"
+    },
+    "GreenTicket@Store@SecondFloorChooseMaxAmount": {
+        "baseTask": "GreenTicket@Store@ChooseMaxAmount",
+        "next": ["GreenTicket@Store@UnderfundedOCR", "GreenTicket@Store@SecondFloorPurchase"]
+    },
+    "GreenTicket@Store@SecondFloorPurchase": {
+        "baseTask": "GreenTicket@Store@Purchase",
+        "next": ["GreenTicket@Store@SecondFloorPurchasedConfirm"]
+    },
+    "GreenTicket@Store@SecondFloorPurchasedConfirm": {
+        "baseTask": "GreenTicket@Store@PurchasedConfirm",
+        "template": "CreditShop-Bought.png",
+        "next": [
+            "GreenTicket@Store@SecondFloorPurchasedConfirm",
+            "GreenTicket@Store@ClickSecondFloorItemList#next",
+            "Stop"
+        ]
     },
     "YellowTicket@Store@ChooseTicketType": {
         "algorithm": "OcrDetect",


### PR DESCRIPTION
见#16278

OCR对于蓝底白字的数字1，有概率识别不到字符，如果是灰底白字数字1，会好很多，至少我自定任务测试没有发现过识别失败。

所以先点二层，让一层一定是灰底白字，再进行识别。

以上逻辑作为备用逻辑，在1层识别不到的时候才会点击2层，再次识别1层。

2层的购买物调整为单抽券和公招券。

本来想加750绿票的4星兑换券，但是根据小号的情况来看，750绿票还是有点贵了。

## Summary by Sourcery

调整任务配置，以提高在蓝色背景白色文字屏幕上的 OCR 识别可靠性，通过确保在灰色背景图层上执行识别来实现。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust task configuration to improve OCR reliability on blue-background white-text screens by ensuring recognition occurs on a gray-background layer instead.

</details>