### PR TITLE
fix: 修改recruit_one的返回值，适配更精细的招募计数(#16355)

### DIFF
--- a/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.cpp
@@ -229,9 +229,7 @@ bool asst::AutoRecruitTask::_run()
 
     bool try_use_expedited = m_use_expedited;
 
-    // m_cur_times means how many times has the confirm button been pressed, NOT expedited plans
-    // used
-    while (m_cur_times != m_max_times) {
+    while (m_cur_times < m_max_times) {
         auto start_rect = try_get_start_button(ctrler()->get_image());
         if (start_rect) {
             if (need_exit()) {
@@ -240,10 +238,14 @@ bool asst::AutoRecruitTask::_run()
             if (m_slot_fail >= slot_retry_limit) {
                 return false;
             }
-            if (recruit_one(start_rect.value())) {
+            auto result = recruit_one(start_rect.value());
+            // confirmed: real recruitment done, advance m_cur_times
+            // skipped:   slot marked in m_force_skipped, try next slot without changing counters
+            // failed:    recognition error / no permit / etc., bump m_slot_fail for retry limiting
+            if (result == recruit_result::confirmed) {
                 ++m_cur_times;
             }
-            else {
+            else if (result == recruit_result::failed) {
                 ++m_slot_fail;
             }
             if (!m_has_permit && (!m_force_refresh || !m_has_refresh)) {
@@ -319,12 +321,14 @@ std::optional<asst::Rect> asst::AutoRecruitTask::try_get_start_button(const cv::
     return iter->rect;
 }
 
-/// open a pending recruit slot, set timer and tags then confirm, or leave the slot doing nothing
-/// return false if:
-/// - recognition failed
-/// - timer or tags corrupted
-/// - failed to confirm
-bool asst::AutoRecruitTask::recruit_one(const Rect& button)
+/// Open a pending recruit slot, analyze tags, set timer and tags, then confirm or skip.
+/// Returns:
+/// - confirmed: RecruitConfirm was executed successfully
+/// - skipped:   slot intentionally skipped (special/robot tag, level-based force skip, or
+///              no recruit permit); slot is added to m_force_skipped so the loop tries the
+///              next slot without changing any counters
+/// - failed:    recognition error, timer mismatch, confirm failure, or exit requested
+asst::AutoRecruitTask::recruit_result asst::AutoRecruitTask::recruit_one(const Rect& button)
 {
     LogTraceFunction;
 
@@ -337,7 +341,6 @@ bool asst::AutoRecruitTask::recruit_one(const Rect& button)
     sleep(delay);
 
     if (!calc_result.success) {
-        // recognition failed, perhaps opening the slot again would not help
         {
             json::value info = basic_info();
             info["what"] = "RecruitError";
@@ -347,26 +350,23 @@ bool asst::AutoRecruitTask::recruit_one(const Rect& button)
         if (!ProcessTask(*this, { "RecruitContinue", "Return" }).run()) {
             m_force_skipped.emplace(slot_index_from_rect(button));
         }
-        return false;
+        return recruit_result::failed;
     }
 
     if (calc_result.for_special_tags_skip || calc_result.for_robot_tags_skip) {
-        // Mark the slot as completed and return
-        // without incrementing the count
         m_force_skipped.emplace(slot_index_from_rect(button));
         click_return_button();
-        return true;
+        return recruit_result::skipped;
     }
 
     if (calc_result.force_skip) {
-        // mark the slot as completed and return
         m_force_skipped.emplace(slot_index_from_rect(button));
         click_return_button();
-        return true;
+        return recruit_result::skipped;
     }
 
     if (need_exit()) {
-        return false;
+        return recruit_result::failed;
     }
 
     if (m_set_time && !check_timer(calc_result.recruitment_time)) {
@@ -376,22 +376,22 @@ bool asst::AutoRecruitTask::recruit_one(const Rect& button)
         // return and try later
         Log.info("Timer of this slot has not been reduced as expected.");
         click_return_button();
-        return false;
+        return recruit_result::failed;
     }
 
     // TODO: count blue pixels and compare with number of selected tags desired
 
     if (need_exit()) {
-        return false;
+        return recruit_result::failed;
     }
 
     if (!confirm()) {
         Log.info("Failed to confirm current recruit config.");
         click_return_button();
-        return false;
+        return recruit_result::failed;
     }
 
-    return true;
+    return recruit_result::confirmed;
 }
 
 // set recruit timer and tags only

--- a/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.h
+++ b/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.h
@@ -45,8 +45,10 @@ protected:
         return (std::find(m_confirm_level.begin(), m_confirm_level.end(), (-1)) != m_confirm_level.end());
     }
 
+    enum class recruit_result { confirmed, skipped, failed };
+
     std::optional<Rect> try_get_start_button(const cv::Mat&);
-    bool recruit_one(const Rect&);
+    recruit_result recruit_one(const Rect&);
     bool check_recruit_home_page();
     bool recruit_begin();
     bool check_timer(int);


### PR DESCRIPTION
见#16355

把recruit_one返回值改成枚举，比之前多了一个状态，外层就好判断了。

以前是设定招1次，遇上保留的槽位就结束了
现在是遇上保留的槽位会跳过，尝试在下一个槽位执行招募。

## Summary by Sourcery

优化自动招募循环控制，以区分成功招募、故意跳过的空位以及失败情况，从而更准确地处理招募计数和重试上限。

Bug Fixes:
- 确保预留或强制跳过的招募空位在被跳过时不会增加招募计数，同时仍然允许后续空位继续处理。
- 通过将识别或确认失败显式标记为失败，防止其被误认为是成功招募。

Enhancements:
- 为 `recruit_one` 引入 `recruit_result` 枚举返回类型，以表示“已确认”“已跳过”和“失败”三种结果，而不是使用布尔标志。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine auto-recruit loop control to distinguish between successful recruits, intentionally skipped slots, and failures so that recruitment counts and retry limits are handled more accurately.

Bug Fixes:
- Ensure reserved or force-skipped recruit slots are skipped without advancing the recruit count while still allowing subsequent slots to be processed.
- Prevent recognition or confirmation failures from being mistaken for successful recruits by explicitly tracking them as failures.

Enhancements:
- Introduce a recruit_result enum return type for recruit_one to represent confirmed, skipped, and failed outcomes instead of a boolean flag.

</details>