### PR TITLE
fix: 修复蓝叠模拟器关闭失败的问题

### DIFF
--- a/src/MaaWpfGui/Helper/EmulatorHelper.cs
+++ b/src/MaaWpfGui/Helper/EmulatorHelper.cs
@@ -434,30 +434,34 @@ public class EmulatorHelper
         {
             _logger.Error("Failed to get the main module of the emulator process.");
             _logger.Error("{EMessage}", e.Message);
-            return false;
+            processModule = null;
         }
 
-        if (processModule == null)
+        if (processModule != null)
         {
-            return false;
-        }
+            string? emuLocation = processModule.FileName;
+            emuLocation = Path.GetDirectoryName(emuLocation);
+            if (emuLocation != null)
+            {
+                string consolePath = Path.Combine(emuLocation, "bsconsole.exe");
 
-        string? emuLocation = processModule.FileName;
-        emuLocation = Path.GetDirectoryName(emuLocation);
-        if (emuLocation == null)
+                if (File.Exists(consolePath))
+                {
+                    _logger.Information("`{ConsolePath}` has been found. This may be the BlueStacks China emulator, try to kill the emulator by window.", consolePath);
+                    return KillEmulatorByWindow();
+                }
+
+                _logger.Information("`{ConsolePath}` not found. This may be the BlueStacks International emulator, try to kill the emulator by the port.", consolePath);
+            }
+            else
+            {
+                _logger.Information("Failed to get emulator location from MainModule, try to kill the emulator by the port.");
+            }
+        }
+        else
         {
-            return false;
+            _logger.Information("Failed to get MainModule, try to kill the emulator by the port.");
         }
-
-        string consolePath = Path.Combine(emuLocation, "bsconsole.exe");
-
-        if (File.Exists(consolePath))
-        {
-            _logger.Information("`{ConsolePath}` has been found. This may be the BlueStacks China emulator, try to kill the emulator by window.", consolePath);
-            return KillEmulatorByWindow();
-        }
-
-        _logger.Information("`{ConsolePath}` not found. This may be the BlueStacks International emulator, try to kill the emulator by the port.", consolePath);
         if (KillEmulator())
         {
             return true;

--- a/src/MaaWpfGui/MaaWpfGui.csproj
+++ b/src/MaaWpfGui/MaaWpfGui.csproj
@@ -120,7 +120,7 @@
     <PackageReference Include="gong-wpf-dragdrop" Version="4.0.0" />
     <PackageReference Include="HandyControls" Version="3.6.0" />
     <PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
-    <PackageReference Include="MailKit" Version="4.15.1" />
+    <PackageReference Include="MailKit" Version="4.16.0" />
     <PackageReference Include="MdXaml" Version="1.27.0" />
     <PackageReference Include="MdXaml.Html" Version="1.27.0" />
     <PackageReference Include="MdXaml.Plugins" Version="1.27.0" />


### PR DESCRIPTION
### 优化 EmulatorHelper 逻辑并升级 MailKit 依赖

优化了 EmulatorHelper 的异常处理和分支逻辑，提升对不同 BlueStacks 版本的识别与日志记录。将 MailKit 包从 4.15.1 升级至 4.16.0。

修复前遇到的问题：

```log
[2026-04-29 17:28:08.738][INF][TaskQueueViewModel]     <2> Post actions: 退出 模拟器
[2026-04-29 17:28:08.835][ERR][EmulatorHelper]         <2> Failed to get the main module of the emulator process.
[2026-04-29 17:28:08.835][ERR][EmulatorHelper]         <2> 拒绝访问。
[2026-04-29 17:28:08.835][ERR][TaskQueueViewModel]     <2> 模拟器关闭失败
```

修复后问题成功解决：

```log
[2026-04-30 11:38:56.188][INF][TaskQueueViewModel]     <2> Post actions: 退出 模拟器
[2026-04-30 11:38:56.288][ERR][EmulatorHelper]         <2> Failed to get the main module of the emulator process.
[2026-04-30 11:38:56.288][ERR][EmulatorHelper]         <2> 拒绝访问。
[2026-04-30 11:38:56.289][INF][EmulatorHelper]         <2> Failed to get MainModule, try to kill the emulator by the port.
[2026-04-30 11:38:56.289][INF][EmulatorHelper]         <2> address: 127.0.0.1:5555, port: 5555
```

## Summary by Sourcery

改进针对不同 BlueStacks 版本的模拟器关闭处理，并更新邮件相关依赖的版本。

Bug 修复：
- 当无法解析进程的主模块或位置时，确保模拟器关闭逻辑能回退到基于端口的终止方式。

功能增强：
- 优化 BlueStacks 的检测逻辑和日志记录，在尝试关闭时区分中国版和国际版。

构建：
- 将 MailKit 依赖包版本从 4.15.1 升级到 4.16.0。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve emulator shutdown handling for different BlueStacks variants and update a mail dependency version.

Bug Fixes:
- Ensure emulator shutdown falls back to port-based termination when the process main module or location cannot be resolved.

Enhancements:
- Refine BlueStacks detection logic and logging to distinguish between China and international versions when attempting shutdown.

Build:
- Bump MailKit package reference from 4.15.1 to 4.16.0.

</details>