### PR TITLE
fix: lower YoStarJP office mini threshold

### DIFF
--- a/resource/global/YoStarJP/resource/tasks/tasks.json
+++ b/resource/global/YoStarJP/resource/tasks/tasks.json
@@ -1211,6 +1211,9 @@
     "InfrastReward": {
         "text": ["受取可", "納品可", "信頼獲得"]
     },
+    "InfrastOfficeMini": {
+        "templThreshold": 0.9
+    },
     "InfrastStationedInfo": {
         "text": ["配属情報"]
     },


### PR DESCRIPTION
## Summary
- Add a YoStarJP override for `InfrastOfficeMini.templThreshold` so the office mini facility can be recognized during base rotation.
- Matches the observed YoStarJP `OfficeMini.png` score around `0.93`, while keeping the change scoped to JP resources.

## Test plan
- `python3 -m json.tool resource/global/YoStarJP/resource/tasks/tasks.json >/dev/null`
- Verified locally with a macOS debug build: `OfficeMini.png` matched with score `0.930173`, `InfrastOfficeTask` completed, and the `Infrast` task chain completed.

Fixes #16389

## Summary by Sourcery

错误修复：
- 降低 YoStarJP OfficeMini 模板匹配阈值，以便正确检测该设施，并使关联的任务链能够完成。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Lower the YoStarJP OfficeMini template matching threshold so the facility is correctly detected and the associated task chain can complete.

</details>