### PR TITLE
fix: 生息演算 5.1 更新后无法使用无存档刷分

### DIFF
--- a/resource/tasks/RA/Tales.json
+++ b/resource/tasks/RA/Tales.json
@@ -526,12 +526,17 @@
         "template": "DialogueLog.png",
         "roi": [27, 14, 64, 51],
         "sub": ["Tales@RA@PNS-OpeningDialogueClick*10"],
-        "next": ["Tales@RA@PNS-OpeningDialogue", "Tales@RA@PNS-LeaveBaseCamp"]
+        "next": ["Tales@RA@PNS-OpeningDialogue", "Tales@RA@PNS-ResourceGained", "Tales@RA@PNS-LeaveBaseCamp"]
     },
     "Tales@RA@PNS-OpeningDialogueClick": {
         "algorithm": "JustReturn",
         "action": "ClickRect",
         "specificRect": [901, 422, 360, 51]
+    },
+    "Tales@RA@PNS-ResourceGained": {
+        "doc": "获得物资, 点击 <点击空白处继续> 文字位置",
+        "baseTask": "Tales@RA@ResourceGained",
+        "next": ["#self", "Tales@RA@PNS-LeaveBaseCamp"]
     },
     "Tales@RA@PNS-ProsperityBelowLimit": {
         "doc": "已完成生存周期, 生息点数未达到上限, 点击 <点击任意处继续> 文字位置",

--- a/resource/tasks/RA/Tales.json
+++ b/resource/tasks/RA/Tales.json
@@ -536,7 +536,7 @@
     "Tales@RA@PNS-ResourceGained": {
         "doc": "获得物资, 点击 <点击空白处继续> 文字位置",
         "baseTask": "Tales@RA@ResourceGained",
-        "next": ["#self", "Tales@RA@PNS-LeaveBaseCamp"]
+        "next": ["Tales@RA@PNS-OpeningDialogue#next"]
     },
     "Tales@RA@PNS-ProsperityBelowLimit": {
         "doc": "已完成生存周期, 生息点数未达到上限, 点击 <点击任意处继续> 文字位置",


### PR DESCRIPTION
还没测过，不知道好不好使

## Summary by Sourcery

错误修复：
- 在 5.1 更新之后，恢复对在生息演算中进行无存档刷分运行的支持。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Restore support for running no-save score farming in 生息演算 after the 5.1 update.

</details>