### PR TITLE
fix: 部分场景下无法自动启动游戏

### DIFF
--- a/src/MaaCore/Controller/AdbController.cpp
+++ b/src/MaaCore/Controller/AdbController.cpp
@@ -1026,7 +1026,13 @@ bool asst::AdbController::connect(const std::string& adb_path, const std::string
 
     // 按需获取display ID 信息
     if (!adb_cfg.display_id.empty()) {
-        auto display_id_ret = call_command(m_conn_ctx.replace_cmd(adb_cfg.display_id));
+        // [PackageName] 不参与 replace_cmd 的统一替换（保留为运行时参数），
+        // 此处 displayId 查询是 connect 阶段唯一需要它的场景，就地显式替换。
+        auto display_id_cmd = utils::string_replace_all(
+            m_conn_ctx.replace_cmd(adb_cfg.display_id),
+            "[PackageName]",
+            m_conn_ctx.package_name);
+        auto display_id_ret = call_command(display_id_cmd);
         if (!display_id_ret) {
             return false;
         }

--- a/src/MaaCore/Controller/AdbController.h
+++ b/src/MaaCore/Controller/AdbController.h
@@ -57,7 +57,6 @@ struct AdbConnectionContext
                 { "[EventId]", event_id },
                 { "[NcPort]", std::to_string(nc_port) },
                 { "[NcAddress]", nc_address },
-                { "[PackageName]", package_name },
             });
     }
 };


### PR DESCRIPTION
1b1bc15aca8859f039cb56f7b79377832c8e6e05 在 AdbConnectionContext::replace_cmd 的统一替换表中加入了 [PackageName]， 导致 m_adb.start / m_adb.stop 在 connect 阶段就被提前替换。当调用方未通过 AsstSetInstanceOption(ClientType, ...) 设置 client_type 时（如 maa-cli 等不感知该 新选项的第三方调用方），m_conn_ctx.package_name 为空字符串，m_adb.start 中的 [PackageName] 被替换为空，后续 start_game(client_type) 内的运行时替换沦为 no-op， 最终启动命令缺失包名导致启动游戏失败。

将 [PackageName] 从统一替换表移除，恢复其作为运行时参数的语义；connect 阶段唯一 需要 [PackageName] 的位置（Androws 的 displayId 查询）改为就地显式替换。

Close #16392

## Summary by Sourcery

Bug Fixes:
- 修复了一个回归问题：由于在 ADB 连接期间包名占位符被过早替换，可能导致游戏无法自动启动。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix a regression where the game could fail to auto-start because the package name placeholder was prematurely replaced during ADB connect.

</details>