### PR TITLE
refactor: 让 MaaCore 跨版本增量构建保持缓存稳定

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,25 @@ if(INSTALL_FLATTEN)
 endif()
 
 include(src/MaaUtils/MaaUtils.cmake)
+
+# MAA_VERSION 由 MaaUtils.cmake 通过 add_compile_definitions 设置在 directory scope；
+# MAA 这一侧用 include() 引入 MaaUtils.cmake（文本内联，不创建新 scope），该宏会
+# 随之进入 MaaCore 等下游 TUs 的命令行——MAA_HASH_VERSION 每次变化时所有下游 TUs 命令行
+# 随之变化，git bisect 跨 commit 时 ccache / ninja 增量构建全 miss。
+# 这里直接过滤 directory 的 COMPILE_DEFINITIONS 把该宏从根 scope 移除，再单独以 PRIVATE
+# 形式应用于 MaaUtils target——MaaUtils 内部 TUs 的 per-DLL 版本签名 by-design 行为
+# 保持不变。
+#
+# 注 1：remove_definitions 是为老 API add_definitions 设计的，无法移除
+# add_compile_definitions 加的条目，所以此处直接操作 directory property。
+# 注 2：本 hook 仅处理 directory 级传播。若 MaaUtils 上游将 MAA_VERSION 改为
+# target_compile_definitions PUBLIC/INTERFACE，传播会改经 link 继承通道、绕过本 hook；
+# 届时需追加对 MaaUtils target INTERFACE_COMPILE_DEFINITIONS 的对称过滤。
+get_property(_compile_defs DIRECTORY PROPERTY COMPILE_DEFINITIONS)
+list(FILTER _compile_defs EXCLUDE REGEX "^MAA_VERSION=")
+set_property(DIRECTORY PROPERTY COMPILE_DEFINITIONS "${_compile_defs}")
+target_compile_definitions(MaaUtils PRIVATE MAA_VERSION="${MAA_HASH_VERSION}")
+
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/modules")
 include(${PROJECT_SOURCE_DIR}/cmake/config.cmake)
 include(${PROJECT_SOURCE_DIR}/cmake/utils.cmake)

--- a/src/MaaCore/AsstCaller.cpp
+++ b/src/MaaCore/AsstCaller.cpp
@@ -11,6 +11,7 @@
 #include "Config/ResourceLoader.h"
 #include "Utils/Logger.hpp"
 #include "Utils/WorkingDir.hpp"
+#include "Version.h"
 
 static constexpr AsstSize NullSize = static_cast<AsstSize>(-1);
 static constexpr AsstId InvalidId = 0;
@@ -319,7 +320,7 @@ AsstSize AsstGetNullSize()
 
 const char* AsstGetVersion()
 {
-    return MAA_VERSION;
+    return asst::maa_version();
 }
 
 void AsstLog(const char* level, const char* message)

--- a/src/MaaCore/CMakeLists.txt
+++ b/src/MaaCore/CMakeLists.txt
@@ -9,7 +9,12 @@ if(WITH_MAC_SCK)
     endif()
 endif()
 
-add_library(MaaCore SHARED ${maa_src})
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/Version.cpp.in
+    ${CMAKE_CURRENT_BINARY_DIR}/Version.cpp
+    @ONLY)
+
+add_library(MaaCore SHARED ${maa_src} ${CMAKE_CURRENT_BINARY_DIR}/Version.cpp)
 
 if(WITH_EMULATOR_EXTRAS)
     if(EXISTS ${PROJECT_SOURCE_DIR}/3rdparty/EmulatorExtras/Mumu)

--- a/src/MaaCore/Task/Fight/StageDropsTaskPlugin.cpp
+++ b/src/MaaCore/Task/Fight/StageDropsTaskPlugin.cpp
@@ -14,6 +14,7 @@
 #include "Task/ProcessTask.h"
 #include "Task/ReportDataTask.h"
 #include "Utils/Logger.hpp"
+#include "Version.h"
 #include "Vision/Matcher.h"
 #include "Vision/Miscellaneous/StageDropsImageAnalyzer.h"
 #include "Vision/RegionOCRer.h"
@@ -409,14 +410,14 @@ bool asst::StageDropsTaskPlugin::upload_to_server(const std::string& subtask, Re
         all_drops.emplace(std::move(format_drop));
     }
     body["source"] = UploadDataSource;
-    body["version"] = MAA_VERSION;
+    body["version"] = asst::maa_version();
 
     std::unordered_map<std::string, std::string> extra_headers;
     if (!m_penguin_id.empty()) {
         extra_headers.insert({ "authorization", "PenguinID " + m_penguin_id });
     }
 
-    std::string version = MAA_VERSION;
+    std::string version = asst::maa_version();
     if (version.find("DEBUG_VERSION") != std::string::npos) {
         version = "dev";
     }

--- a/src/MaaCore/Task/Fight/StageQueueMissionCompletedTaskPlugin.cpp
+++ b/src/MaaCore/Task/Fight/StageQueueMissionCompletedTaskPlugin.cpp
@@ -6,6 +6,7 @@
 #include "MaaUtils/ImageIo.h"
 #include "StageDropsTaskPlugin.h"
 #include "Utils/Logger.hpp"
+#include "Version.h"
 #include "Vision/Matcher.h"
 #include "Vision/Miscellaneous/StageDropsImageAnalyzer.h"
 #include "Vision/RegionOCRer.h"
@@ -206,14 +207,14 @@ void asst::StageQueueMissionCompletedTaskPlugin::upload_to_penguin(std::string s
         all_drops.emplace(std::move(format_drop));
     }
     body["source"] = UploadDataSource;
-    body["version"] = MAA_VERSION;
+    body["version"] = asst::maa_version();
 
     std::unordered_map<std::string, std::string> extra_headers;
     if (!m_penguin_id.empty()) {
         extra_headers.insert({ "authorization", "PenguinID " + m_penguin_id });
     }
 
-    std::string version = MAA_VERSION;
+    std::string version = asst::maa_version();
     if (version.find("DEBUG_VERSION") != std::string::npos) {
         version = "dev";
     }

--- a/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.cpp
@@ -7,6 +7,7 @@
 #include "Task/ProcessTask.h"
 #include "Task/ReportDataTask.h"
 #include "Utils/Logger.hpp"
+#include "Version.h"
 #include "Vision/Miscellaneous/RecruitImageAnalyzer.h"
 #include "Vision/MultiMatcher.h"
 #include "Vision/OCRer.h"
@@ -985,14 +986,14 @@ void asst::AutoRecruitTask::upload_to_penguin(Rng&& tags)
             });
     }
     body["source"] = UploadDataSource;
-    body["version"] = MAA_VERSION;
+    body["version"] = asst::maa_version();
 
     std::unordered_map<std::string, std::string> extra_headers;
     if (!m_penguin_id.empty()) {
         extra_headers = { { "authorization", "PenguinID " + m_penguin_id } };
     }
 
-    std::string version = MAA_VERSION;
+    std::string version = asst::maa_version();
     if (version.find("DEBUG_VERSION") != std::string::npos) {
         version = "dev";
     }
@@ -1022,7 +1023,7 @@ void asst::AutoRecruitTask::upload_to_yituliu(const json::value& details)
     json::value body = details;
     body["server"] = m_server;
     body["source"] = UploadDataSource;
-    body["version"] = MAA_VERSION;
+    body["version"] = asst::maa_version();
     body["uuid"] = m_yituliu_id;
 
     if (!m_report_yituliu_task_ptr) {

--- a/src/MaaCore/Utils/Logger.hpp
+++ b/src/MaaCore/Utils/Logger.hpp
@@ -25,6 +25,7 @@
 #include "Meta.hpp"
 #include "NullStreambuf.hpp"
 #include "Platform.hpp"
+#include "Version.h"
 #include "WorkingDir.hpp"
 
 #if defined(__APPLE__) || defined(__linux__)
@@ -833,7 +834,7 @@ private:
     {
         trace("-----------------------------");
         trace("MaaCore Process Start");
-        trace("Version", MAA_VERSION);
+        trace("Version", maa_version());
         trace("Built at", __DATE__, __TIME__);
         trace("User Dir", m_directory);
         trace("-----------------------------");
@@ -881,7 +882,7 @@ private:
         try {
             auto& logger = Logger::get_instance();
             logger.error("=== UNHANDLED EXCEPTION ===");
-            logger.error("Version", MAA_VERSION);
+            logger.error("Version", maa_version());
             logger.error("Built at", __DATE__, __TIME__);
             logger.error("User Dir", UserDir.get());
             logger.error("============================");
@@ -934,7 +935,7 @@ private:
             }
 
             logger.error("=== FATAL ERROR ===");
-            logger.error("Version", MAA_VERSION);
+            logger.error("Version", maa_version());
             logger.error("Built at", __DATE__, __TIME__);
             logger.error("User Dir", UserDir.get());
             logger.error("Unhandled exception caught:", exception_info);

--- a/src/MaaCore/Version.cpp.in
+++ b/src/MaaCore/Version.cpp.in
@@ -1,0 +1,9 @@
+#include "Version.h"
+
+namespace asst
+{
+const char* maa_version() noexcept
+{
+    return "@MAA_HASH_VERSION@";
+}
+} // namespace asst

--- a/src/MaaCore/Version.h
+++ b/src/MaaCore/Version.h
@@ -1,0 +1,6 @@
+#pragma once
+
+namespace asst
+{
+const char* maa_version() noexcept;
+} // namespace asst


### PR DESCRIPTION
## 问题

`include(src/MaaUtils/MaaUtils.cmake)`（CMakeLists.txt:22）通过文本内联，把 MaaUtils 内部的 `add_compile_definitions(MAA_VERSION="${MAA_HASH_VERSION}")` 引入 MAA 根 scope，进而向所有下游 TU 命令行广播。`Logger.hpp` 等被广泛 include 的头文件又直接以宏形式使用它。结果：MAA_HASH_VERSION 一变（本地切换 git tag、执行 `git bisect`、`git checkout` 历史 commit），所有 TU 的编译命令行随之变化——ninja 据此判定 200+ TU dirty，需要全量重编；ccache 层面预处理输出同样发生变化，缓存键全部失效。

## 改动

把 MAA_VERSION 宏的 scope 从 MAA 根目录隔离到 MaaUtils target 自己；MaaCore 用 `configure_file` 在 build 目录生成自己的 Version.cpp，暴露 `asst::maa_version()` 函数——调用方编译输出与版本字符串无关。

| 文件                                                       | 改动                                                                                                                                                                      |
| ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `CMakeLists.txt`                                           | `include(MaaUtils.cmake)` 后过滤 directory `COMPILE_DEFINITIONS` 中的 `MAA_VERSION=` 项，再以 `target_compile_definitions(MaaUtils PRIVATE ...)` 单独应用于 MaaUtils target |
| `src/MaaCore/Version.h`（新建）                            | 声明 `asst::maa_version()`                                                                                                                                                |
| `src/MaaCore/Version.cpp.in`（新建）                       | 模板，含 `@MAA_HASH_VERSION@` 占位符                                                                                                                                      |
| `src/MaaCore/CMakeLists.txt`                               | `configure_file` 生成 Version.cpp 并加入 `add_library`                                                                                                                    |
| `src/MaaCore/{AsstCaller.cpp, Utils/Logger.hpp, Task/...}` | 11 处 `MAA_VERSION` 替换为 `asst::maa_version()`（5 个文件）                                                                                                              |

净改动：9 文件，+49 -12 行。

## 行为兼容性

`asst::maa_version()` 返回值与原 `MAA_VERSION` 宏展开值完全相同（包括默认 `"DEBUG_VERSION"`）。`AutoRecruitTask.cpp` / `StageDropsTaskPlugin.cpp` / `StageQueueMissionCompletedTaskPlugin.cpp` 中的 `version.find("DEBUG_VERSION")` 检测继续工作；`AsstGetVersion()` 公开 C API 行为不变，下游绑定（C# WPF / Python / maa-cli 等）不受影响。

## 实际价值

让 `git bisect` 跨版本范围真正可用。准备本 PR 期间借助同一套机制 bisect 出了导致部分调用方启动游戏失败的 commit 1b1bc15aca（fix 已在 #16422 合并），过程跨越 49 个候选 commit；若无此优化每个 step 均需全量重编（约 3 分钟），整个流程接近一小时。

**补充说明**：本 commit 自包含、改动很小（只涉及 cmake 与 Version 设施，不依赖任何外部 commit 状态），**可以通过 `rebase -i` 移动到任意历史位置**。如果想 bisect 历史范围 `A..HEAD` 但本 commit 当前位于该范围内较晚位置（或尚未合并）：

```bash
git rebase -i A
# 在编辑器中将本 commit 的 pick 行移至顶部（紧跟 A 之后）
# 保存退出，rebase 重放完成后本 commit 已位于 A+1
git bisect start HEAD A
```

`A..HEAD` 范围内每个 bisect candidate 的 tree 都包含本 commit 引入的 cmake 配置，逐步 bisect 均能命中增量构建。bisect 完成后舍弃这次本地 rebase 即可。即便本 commit 合并后时日已久，第三方贡献者仍可通过 `rebase -i` 将其注入任意历史区间，获得 cross-version cache hit。
