### PR TITLE
fix: avoid corrupting OCR replace regex with equivalence classes

### DIFF
--- a/src/MaaCore/Vision/Config/OCRerConfig.cpp
+++ b/src/MaaCore/Vision/Config/OCRerConfig.cpp
@@ -3,7 +3,152 @@
 #include "Config/Miscellaneous/OcrConfig.h"
 #include "Config/TaskData.h"
 
+#include <string_view>
+
 using namespace asst;
+
+namespace
+{
+bool starts_with(std::string_view str, size_t pos, std::string_view prefix)
+{
+    return pos + prefix.size() <= str.size() && str.substr(pos, prefix.size()) == prefix;
+}
+
+bool is_regex_special(char ch)
+{
+    static constexpr std::string_view SpecialChars = R"(\.^$|()[]{}*+?)";
+    return SpecialChars.find(ch) != std::string_view::npos;
+}
+
+std::string escape_regex_literal(std::string_view str)
+{
+    std::string result;
+    result.reserve(str.size() * 2);
+    for (char ch : str) {
+        if (is_regex_special(ch)) {
+            result += '\\';
+        }
+        result += ch;
+    }
+    return result;
+}
+
+std::string escape_char_class_literal(std::string_view str)
+{
+    std::string result;
+    result.reserve(str.size() * 2);
+    for (char ch : str) {
+        if (ch == '\\' || ch == ']' || ch == '-' || ch == '^') {
+            result += '\\';
+        }
+        result += ch;
+    }
+    return result;
+}
+
+std::string make_regex_alternation(const auto& eq_class)
+{
+    std::string result = "(?:";
+    for (const auto& elem : eq_class) {
+        result += escape_regex_literal(elem);
+        result += '|';
+    }
+    result.back() = ')';
+    return result;
+}
+
+std::string make_char_class_equivalence(const auto& eq_class)
+{
+    std::string result;
+    for (const auto& elem : eq_class) {
+        result += escape_char_class_literal(elem);
+    }
+    return result;
+}
+
+bool is_char_class_range_endpoint(std::string_view regex, size_t pos, size_t length)
+{
+    const bool is_range_start = pos + length < regex.size() && regex[pos + length] == '-';
+    const bool is_range_end = pos > 0 && regex[pos - 1] == '-';
+    return is_range_start || is_range_end;
+}
+
+std::string process_regex_equivalence_class(std::string_view regex, const auto& eq_classes)
+{
+    std::string result;
+    result.reserve(regex.size());
+
+    // OcrTaskInfo::replace_map keys are regex patterns, not plain text. A blind text replacement here can inject
+    // regex syntax into the wrong context, e.g. "[Oo]" + ["o", "о"] used to become "[O(?:o|о)]", making ':' a
+    // character-class member and replacing time strings like "03:53:4" with "0305304".
+    bool in_char_class = false;
+    bool escaped = false;
+
+    for (size_t i = 0; i < regex.size();) {
+        if (escaped) {
+            result += regex[i++];
+            escaped = false;
+            continue;
+        }
+
+        const char ch = regex[i];
+        if (ch == '\\') {
+            result += ch;
+            escaped = true;
+            ++i;
+            continue;
+        }
+        if (ch == '[') {
+            in_char_class = true;
+            result += ch;
+            ++i;
+            continue;
+        }
+        if (ch == ']' && in_char_class) {
+            in_char_class = false;
+            result += ch;
+            ++i;
+            continue;
+        }
+
+        bool replaced = false;
+        for (const auto& eq_class : eq_classes) {
+            if (eq_class.size() <= 1) {
+                continue;
+            }
+
+            for (const auto& elem : eq_class) {
+                if (elem.empty() || !starts_with(regex, i, elem)) {
+                    continue;
+                }
+
+                if (in_char_class) {
+                    // Inside [...] only literal class members are valid. Outside a class, use alternation.
+                    if (is_char_class_range_endpoint(regex, i, elem.size())) {
+                        break;
+                    }
+                    result += make_char_class_equivalence(eq_class);
+                }
+                else {
+                    result += make_regex_alternation(eq_class);
+                }
+                i += elem.size();
+                replaced = true;
+                break;
+            }
+            if (replaced) {
+                break;
+            }
+        }
+
+        if (!replaced) {
+            result += regex[i++];
+        }
+    }
+
+    return result;
+}
+}
 
 void OCRerConfig::set_params(Params params)
 {
@@ -29,25 +174,10 @@ void OCRerConfig::set_replace(
     m_params.replace.clear();
     m_params.replace.reserve(replace.size());
 
+    auto& ocr_config = OcrConfig::get_instance();
+    const auto eq_classes = ocr_config.get_eq_classes();
     for (auto&& [key, val] : replace) {
-        auto& ocr_config = OcrConfig::get_instance();
-        std::string new_key = key;
-        for (const auto& eq_class : ocr_config.get_eq_classes()) {
-            if (eq_class.size() <= 1) {
-                continue;
-            }
-
-            // eq_class: [s, S] -> regex: "(?:s|S)"
-            std::string eq_classes_regex = "(?:";
-            for (const auto& elem : eq_class) {
-                (eq_classes_regex += elem) += '|';
-            }
-            eq_classes_regex.pop_back();
-            eq_classes_regex += ')';
-            std::ranges::for_each(eq_class, [&](std::string_view elem) {
-                utils::string_replace_all_in_place(new_key, elem, eq_classes_regex);
-            });
-        }
+        std::string new_key = process_regex_equivalence_class(key, eq_classes);
         // do not create new_val as val is user-provided, and can avoid issues like 夕 and katakana タ
         m_params.replace.emplace_back(std::move(new_key), val);
     }


### PR DESCRIPTION
## Summary

Fixes #15084.

`OCRerConfig::set_replace` used to expand OCR equivalence classes with plain string replacement, even though `ocrReplace` keys are regex patterns. This could corrupt character classes such as `[Oo]` into `[O(?:o|?)]`, causing `:` to be matched and time strings like `03:53:4` to become `0305304`.

Make equivalence-class expansion aware of regex character classes. Characters inside `[...]` are added literally, while characters outside a class use non-capturing alternation. Ranges like `[a-z]` are preserved to avoid changing existing regex semantics.

## Test

- `git diff --check`
- Built `src/MaaCore/Vision/Config/OCRerConfig.cpp.obj` in an isolated `build-ocrtest` clang-cl build
- Built `MaaCore` in isolated `build-ocrtest`
- Ran a synthetic OCR regression using the real `PaddleCharOCR` model:
  - old broken regex result: `0305304`
  - fixed OCR postprocess result: `03:53:4`

I did not reproduce or test the issue on the specific affected game client.

## Summary by Sourcery

以可识别正则表达式的方式处理 OCR 等价类扩展，防止在 OCR 替换规则中破坏正则字符类。

Bug Fixes:
- 防止在扩展等价类时破坏 OCR 替换正则键，确保对使用字符类和范围的模式保持正确匹配。

Enhancements:
- 引入支持正则表达式和字符类感知的辅助工具，在不改变现有正则语义的前提下安全地扩展 OCR 等价类。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle OCR equivalence class expansion in regex-aware way to prevent corrupting regex character classes in OCR replacement rules.

Bug Fixes:
- Prevent OCR replace regex keys from being corrupted when expanding equivalence classes, preserving correct matching for patterns that use character classes and ranges.

Enhancements:
- Introduce regex- and character-class–aware helpers for safely expanding OCR equivalence classes without altering existing regex semantics.

</details>