### PR TITLE
fix: stop depot recognition when depot entry fails

### DIFF
--- a/src/MaaCore/Task/Interface/DepotTask.cpp
+++ b/src/MaaCore/Task/Interface/DepotTask.cpp
@@ -7,7 +7,10 @@ asst::DepotTask::DepotTask(const AsstCallback& callback, Assistant* inst) :
     InterfaceTask(callback, inst, TaskType)
 {
     auto enter_task = std::make_shared<ProcessTask>(m_callback, m_inst, TaskType);
-    enter_task->set_tasks({ "DepotBegin" }).set_ignore_error(true);
+    // DepotRecognitionTask assumes we have reached the depot screen. If DepotBegin fails,
+    // scanning may happen on the previous screen and clear a valid depot result.
+    // Keep DepotBegin required, and leave this delay here for the OperBox return path.
+    enter_task->set_tasks({ "DepotBegin" }).set_post_delay("ReturnButton", 1000).set_ignore_error(false);
     m_subtasks.emplace_back(enter_task);
 
     auto recognition_task = std::make_shared<DepotRecognitionTask>(m_callback, m_inst, TaskType);


### PR DESCRIPTION
## Summary

Fixes #16343

This PR prevents `DepotRecognitionTask` from running when `DepotBegin` fails to enter the depot.

Previously, depot recognition could continue from the current screen even if depot entry failed, because `DepotBegin` errors were allowed to be ignored. In that case, `DepotRecognitionTask` could run on an invalid page and emit an empty `DepotInfo`, which then caused the data update flow to proceed with empty depot data.

The fix makes successful depot entry mandatory before depot recognition starts. A short wait is also added for `ReturnButton` in the depot entry flow only, so the UI has time to stabilize after returning from the operator list before matching the depot entry.

## Test

- Built `debug_demo` in `RelWithDebInfo`.
- Ran `OperBox` followed by `Depot`; depot recognition completed with 85 items.
- Ran `Depot` from the settings page; it returned to the home page and completed with 85 items.
- Ran `Depot` from the Android launcher; it stopped before `DepotRecognitionTask` and did not emit empty `DepotInfo`.
- Reproduced the original behavior from the same launcher state: `DepotBegin` failed, but `DepotRecognitionTask` still ran and emitted empty depot data.

## Summary by Sourcery

在运行仓库识别之前，要求仓库录入成功，以避免产生空的仓库数据。

Bug Fixes:
- 通过将 `DepotBegin` 步骤设为必需，防止在仓库录入失败时仍然运行仓库识别。
- 在仓库录入流程中，通过 `ReturnButton` 返回后增加短暂延迟，以确保在进行仓库匹配前 UI 已经稳定。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Require successful depot entry before running depot recognition to avoid emitting empty depot data.

Bug Fixes:
- Prevent depot recognition from running when depot entry fails by making the DepotBegin step mandatory.
- Add a brief delay after returning via the ReturnButton in the depot entry flow to ensure the UI stabilizes before depot matching.

</details>