### PR TITLE
rft: 重构战斗失败识别, 顺带支持沙盘战斗结束

### DIFF
--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -4607,20 +4607,39 @@
         "next": ["BattleStartPlot"],
         "maxTimes": 1
     },
-    "Copilot@ClickCornerUntilEndOfAction": {
+    "Copilot@WaitUntilEndOfAction": {
         "algorithm": "JustReturn",
         "maxTimes": 30,
         "exceededNext": ["Copilot@EndOfAction"],
-        "next": ["Copilot@SkipThePreBattlePlot", "Copilot@EndOfAction", "Copilot@ClickCornerBeforeThreeStars"]
+        "next": [
+            "Copilot@SkipThePreBattlePlot",
+            "Copilot@EndOfAction",
+            "Copilot@EndOfAction-Sandbox",
+            "Copilot@FightMissionFailed",
+            "Copilot@WaitUntilEndOfAction"
+        ]
     },
     "Copilot@SkipThePreBattlePlotConfirm": {
         "template": "SkipThePreBattlePlotConfirm.png",
-        "next": ["Copilot@ClickCornerUntilEndOfAction"]
+        "next": ["Copilot@WaitUntilEndOfAction"]
     },
     "Copilot@EndOfAction": {
         "template": "EndOfAction.png",
         "reduceOtherTimes": [],
         "next": ["Copilot@StageDrops-Stars-3", "Copilot@StageDrops-Stars-Adverse"]
+    },
+    "Copilot@EndOfAction-Sandbox": {
+        "algorithm": "OcrDetect",
+        "text": ["MISSION", "RESULTS"],
+        "roi": [540, 645, 200, 25],
+        "isAscii": true,
+        "ocrReplace": [["l", "I"]],
+        "next": ["Copilot@ClickCornerUntilStartButton"]
+    },
+    "Copilot@FightMissionFailed": {
+        "exceededNext": [],
+        "onErrorNext": [],
+        "next": ["Copilot@EndOfAction", "Copilot@EndOfAction-Sandbox"]
     },
     "Copilot@StageDrops-Stars-3": {
         "Doc": "如果没有三星就终止",
@@ -4631,11 +4650,6 @@
         "Doc": "如果没有三星就终止",
         "template": "StageDrops-Stars-Adverse.png",
         "next": ["Copilot@ClickCornerUntilStartButton"]
-    },
-    "Copilot@ClickCornerBeforeThreeStars": {
-        "Doc": "三星之前",
-        "baseTask": "Copilot@ClickCornerUntilStartButton",
-        "next": ["Copilot@ClickCornerUntilEndOfAction"]
     },
     "Copilot@ClickCornerUntilStartButton": {
         "Doc": "三星之后",

--- a/src/MaaCore/Task/Interface/CopilotTask.cpp
+++ b/src/MaaCore/Task/Interface/CopilotTask.cpp
@@ -173,9 +173,9 @@ bool asst::CopilotTask::set_params(const json::value& params)
              m_stop_task_ptr->set_tasks({ "ClickCornerUntilReturnButton" });
          }
          else {
-             m_stop_task_ptr->set_tasks({ "Copilot@ClickCornerUntilEndOfAction" });
+             m_stop_task_ptr->set_tasks({ "Copilot@WaitUntilEndOfAction" });
          }*/
-        m_stop_task_ptr->set_tasks({ "Copilot@ClickCornerUntilEndOfAction" });
+        m_stop_task_ptr->set_tasks({ "Copilot@WaitUntilEndOfAction" }); // 带三星检查
         m_stop_task_ptr->set_enable(true);
     }
     else if (loop_times > 1) {

--- a/src/MaaCore/Task/Interface/ParadoxCopilotTask.cpp
+++ b/src/MaaCore/Task/Interface/ParadoxCopilotTask.cpp
@@ -15,7 +15,7 @@ asst::ParadoxCopilotTask::ParadoxCopilotTask(const AsstCallback& callback, Assis
 {
     m_paradox_task_ptr->set_battle_task_ptr(m_battle_task_ptr);
     m_battle_task_ptr->set_retry_times(0);
-    m_stop_task_ptr->set_tasks({ "Copilot@ClickCornerUntilEndOfAction" });
+    m_stop_task_ptr->set_tasks({ "Copilot@WaitUntilEndOfAction" });
     m_start_task_ptr->set_tasks({ "BattleStartAll" }).set_retry_times(3).set_ignore_error(false);
 
     /*


### PR DESCRIPTION
<img width="1280" height="720" alt="MuMu-20260503-011727-747" src="https://github.com/user-attachments/assets/2d00668e-2503-4614-bc37-644eb9b7a1d4" />

用的这个mission results，不知道外服显示啥

<img width="721" height="398" alt="image" src="https://github.com/user-attachments/assets/471f167d-d013-484f-84f4-3224c6651b86" />

## Summary by Sourcery

增强功能：
- 将 Copilot 停止任务从“角落点击”方式切换为基于等待的动作结束任务，并在其中加入任务结果和星级检查。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Switch copilot stop tasks from corner-clicking to a wait-based end-of-action task that includes mission result and star checks.

</details>