### PR TITLE
fix: 修复剿灭结算时，识别不到合成玉基线

### DIFF
--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -4048,7 +4048,8 @@
         "templThreshold_Doc": "这里用来作为基线间距阈值",
         "specialParams": [100],
         "specialParams_Doc": "基线长度阈值（不小于100）",
-        "colorScales": [[45, 255]],
+        "colorScales": [[30, 255]],
+        "colorScales_Doc": "阈值从45降至30，原值对仅在剿灭Reward出现的暗橙色基线(RGB66,28,11~RGB70,32,15)边缘响应不足",
         "rectMove": [181, 40, 25, 0],
         "rectMove_Doc": "作为hsv阈值使用"
     },

--- a/src/MaaCore/Task/Fight/StageDropsTaskPlugin.cpp
+++ b/src/MaaCore/Task/Fight/StageDropsTaskPlugin.cpp
@@ -18,13 +18,20 @@
 #include "Vision/Miscellaneous/StageDropsImageAnalyzer.h"
 #include "Vision/RegionOCRer.h"
 
+// only use in debugging, not in release
+//#define CUSTOM_TASK_ENABLE_DROPS
+
 bool asst::StageDropsTaskPlugin::verify(AsstMsg msg, const json::value& details) const
 {
     if (msg != AsstMsg::SubTaskCompleted || details.get("subtask", std::string()) != "ProcessTask") {
         return false;
     }
     const std::string task = details.get("details", "task", "");
-    if (task == "Fight@EndOfAction") {
+    if (task == "Fight@EndOfAction"
+#ifdef CUSTOM_TASK_ENABLE_DROPS
+        || task == "EndOfAction"
+#endif
+    ) {
         int64_t last_start_time = status()->get_number(LastStartTimeKey).value_or(0);
         int64_t last_recognize_flag = status()->get_number(RecognitionRestrictionsKey).value_or(0);
         if (last_start_time + RecognitionTimeOffset == last_recognize_flag) {
@@ -34,7 +41,11 @@ bool asst::StageDropsTaskPlugin::verify(AsstMsg msg, const json::value& details)
         m_is_annihilation = false;
         return true;
     }
-    else if (task == "Fight@EndOfActionAnnihilation") {
+    else if (task == "Fight@EndOfActionAnnihilation"
+#ifdef CUSTOM_TASK_ENABLE_DROPS
+        || task == "EndOfActionAnnihilation"
+#endif
+    ) {
         m_is_annihilation = true;
         return true;
     }

--- a/src/MaaCore/Task/Interface/CustomTask.cpp
+++ b/src/MaaCore/Task/Interface/CustomTask.cpp
@@ -6,12 +6,25 @@
 #include "Task/ProcessTask.h"
 #include "Utils/Logger.hpp"
 
+// only use in debugging, not in release
+//#define CUSTOM_TASK_ENABLE_DROPS
+
+#ifdef CUSTOM_TASK_ENABLE_DROPS
+#include "Task/Fight/StageDropsTaskPlugin.h"
+#endif
+
 asst::CustomTask::CustomTask(const AsstCallback& callback, Assistant* inst) :
     InterfaceTask(callback, inst, TaskType),
     m_custom_task_ptr(std::make_shared<ProcessTask>(callback, inst, TaskType))
 {
     LogTraceFunction;
     m_custom_task_ptr->register_plugin<ScreenshotTaskPlugin>();
+
+#ifdef CUSTOM_TASK_ENABLE_DROPS
+    auto drops_plugin = m_custom_task_ptr->register_plugin<StageDropsTaskPlugin>();
+    drops_plugin->set_retry_times(0);
+    Log.info("CustomTask: StageDropsTaskPlugin enabled for debugging");
+#endif
 }
 
 bool asst::CustomTask::set_params(const json::value& params)


### PR DESCRIPTION
<img width="508" height="175" alt="FABI(C}_VIB}7@N5KI51H R" src="https://github.com/user-attachments/assets/1bb987c5-d0cc-41cd-92da-d31045490028" />
这是报告者的掉落图

<img width="630" height="166" alt="628X1BM7GI6$8 4(T%2}Q$0" src="https://github.com/user-attachments/assets/8ecc8d6d-f44b-4540-93bd-8b73ef18f854" />
这是我本机的掉落图

明显看得出我本机的图，报酬二字上方那根线亮一些。

由于在我本机无法复现识别BUG，所以我只能用理论计算值来推断一个阈值。

根据反馈者的图提取出来的RGB值，算法计算出来的灰度是38.7(左)/44(右)。

均低于45的阈值，所以不可能有100像素长的线，于是合成玉基线被过滤掉了。

识别不到基线就不会识别对应的掉落物，就会触发无合成玉掉落导致的退出。

## Summary by Sourcery

将针对湮灭阶段的可选掉落识别处理置于仅调试用的宏之后进行控制，并在启用时将其接入自定义任务。

Enhancements:
- 当启用调试宏时，允许 `StageDropsTaskPlugin` 响应通用的动作结束任务。
- 在 `CustomTask` 中启用可选的 `StageDropsTaskPlugin` 注册，用于调试掉落识别问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Gate optional drop-recognition handling for annihilation stages behind a debug-only macro and wire it into custom tasks when enabled.

Enhancements:
- Allow StageDropsTaskPlugin to respond to generic end-of-action tasks when a debug macro is enabled.
- Enable optional registration of StageDropsTaskPlugin in CustomTask for debugging drop recognition issues.

</details>