### PR TITLE
fix: 向左调宽了信用商店OCR区域

### DIFF
--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -2229,7 +2229,7 @@
         "algorithm": "OcrDetect",
         "isAscii": true,
         "text": [],
-        "roi": [1147, 26, 57, 27]
+        "roi": [1136, 26, 57, 27]
     },
     "CreditShop-DiscountOcr": {
         "algorithm": "OcrDetect",


### PR DESCRIPTION
## 问题 
#16395 表示信用商店信用点识别容易漏千位数。 日志中 CreditShoppingTask::credit_ocr() 多次识别到 396、356、276、296，导致后续与 MaxCredit = 300 比较时，把实际大于 1000 的信用值误判成接近或低于保留阈值  

## 解决
对问题截图按 ROI 倒推并绘制蒙版后可以直观看到：
旧 ROI [1147, 26, 57, 27] -> 1080p 约 [1720, 39, 86, 40]
新 ROI [1136, 26, 57, 27] -> 1080p 约 [1704, 39, 86, 40]

图中红框为旧 ROI，如果有微小扰动确实有概率漏千位数。绿线为调整后的 ROI 边界。绿色右边界未绘制且上下为错位示意，本次修改只调整 left，top / width / height 均保持不变。
<img width="726" height="447" alt="ROI 对照裁剪" src="https://github.com/user-attachments/assets/b9db27aa-5397-4b4f-8bf9-5eda75b1f3ae" />

## Summary by Sourcery

Bug Fixes:
- 通过在任务配置中更新 OCR 区域坐标，减少积分商城中积分数值识别错误的情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Reduce credit value misrecognition in the credit shop by updating the OCR region coordinates in task configuration.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- 通过在任务配置中更新 OCR 区域坐标，减少积分商城中积分数值识别错误的情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Reduce credit value misrecognition in the credit shop by updating the OCR region coordinates in task configuration.

</details>

</details>