### PR TITLE
feat:支持了第15~17章关卡的险地/常规模式指定（已添加ROI）

### DIFF
--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -1176,7 +1176,7 @@
         "algorithm": "JustReturn",
         "next": [
             "Fight@UsePrts-Annihilation",
-            "Fight@SwitchToRaidMode",
+            "Fight@SwitchToHardMode",
             "Fight@SwitchToNormalMode",
             "Fight@UsePrts",
             "Fight@UsePrts-StageSN",
@@ -1184,7 +1184,7 @@
             "Fight@PRTS#next"
         ]
     },
-    "SwitchToRaidMode": {
+    "SwitchToHardMode": {
         "Doc": "切换到险地模式（点击险地作战按钮）",
         "algorithm": "OcrDetect",
         "action": "ClickSelf",

--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -1176,11 +1176,35 @@
         "algorithm": "JustReturn",
         "next": [
             "Fight@UsePrts-Annihilation",
+            "Fight@SwitchToRaidMode",
+            "Fight@SwitchToNormalMode",
             "Fight@UsePrts",
             "Fight@UsePrts-StageSN",
             "Fight@StartButton1",
             "Fight@PRTS#next"
         ]
+    },
+    "SwitchToRaidMode": {
+        "Doc": "切换到险地模式（点击险地作战按钮）",
+        "algorithm": "OcrDetect",
+        "action": "ClickSelf",
+        "roi": [614, 626, 218, 72],
+        "text": ["险地作战", "险地"],
+        "maxTimes": 0,
+        "postDelay": 1000,
+        "next": ["UsePrts", "UsePrts-StageSN", "StartButton1"],
+        "exceededNext": ["SwitchToNormalMode", "UsePrts", "UsePrts-StageSN", "StartButton1"]
+    },
+    "SwitchToNormalMode": {
+        "Doc": "切换到常规模式（点击常规作战按钮）",
+        "algorithm": "OcrDetect",
+        "action": "ClickSelf",
+        "roi": [614, 626, 218, 72],
+        "text": ["常规作战", "常规"],
+        "maxTimes": 0,
+        "postDelay": 1000,
+        "next": ["UsePrts", "UsePrts-StageSN", "StartButton1"],
+        "exceededNext": ["UsePrts", "UsePrts-StageSN", "StartButton1"]
     },
     "LastOrCurBattleBegin": {
         "algorithm": "JustReturn",

--- a/src/MaaCore/Task/Fight/StageNavigationTask.cpp
+++ b/src/MaaCore/Task/Fight/StageNavigationTask.cpp
@@ -48,17 +48,24 @@ bool asst::StageNavigationTask::set_stage_name(const std::string& stage_name)
     }
 
     if (!difficulty.empty()) {
-        std::string upper_difficulty = difficulty;
-        upper_difficulty[0] = static_cast<char>(::toupper(upper_difficulty[0]));
-        for (size_t i = 1; i < upper_difficulty.size(); ++i) {
-            upper_difficulty[i] = static_cast<char>(::tolower(upper_difficulty[i]));
+        // 15-17章的hard/normal后缀由FightTask处理，不在这里处理
+        int chapter_num = std::stoi(chapter);
+        if (chapter_num >= 15 && chapter_num <= 17) {
+            Log.info("Chapter 15-17 detected, skip ChapterDifficulty task");
         }
-        static const std::string difficulty_task_prefix = "ChapterDifficulty";
-        m_difficulty_task = difficulty_task_prefix + upper_difficulty;
-        Log.info("difficulty task", m_difficulty_task);
-        if (!Task.get(m_difficulty_task)) {
-            Log.error("difficulty task not exists", m_difficulty_task);
-            return false;
+        else {
+            std::string upper_difficulty = difficulty;
+            upper_difficulty[0] = static_cast<char>(::toupper(upper_difficulty[0]));
+            for (size_t i = 1; i < upper_difficulty.size(); ++i) {
+                upper_difficulty[i] = static_cast<char>(::tolower(upper_difficulty[i]));
+            }
+            static const std::string difficulty_task_prefix = "ChapterDifficulty";
+            m_difficulty_task = difficulty_task_prefix + upper_difficulty;
+            Log.info("difficulty task", m_difficulty_task);
+            if (!Task.get(m_difficulty_task)) {
+                Log.error("difficulty task not exists", m_difficulty_task);
+                return false;
+            }
         }
     }
 

--- a/src/MaaCore/Task/Interface/FightTask.cpp
+++ b/src/MaaCore/Task/Interface/FightTask.cpp
@@ -180,18 +180,18 @@ bool asst::FightTask::set_params(const json::value& params)
 
         if (difficulty == "hard") {
             Log.info("Detected chapter 15-17 hard mode stage:", stage);
-            m_fight_task_ptr->set_times_limit("SwitchToRaidMode", 1);
+            m_fight_task_ptr->set_times_limit("SwitchToHardMode", 1);
             m_fight_task_ptr->set_times_limit("SwitchToNormalMode", 0);
         }
         else if (difficulty == "normal") {
             Log.info("Detected chapter 15-17 normal mode stage:", stage);
-            m_fight_task_ptr->set_times_limit("SwitchToRaidMode", 0);
+            m_fight_task_ptr->set_times_limit("SwitchToHardMode", 0);
             m_fight_task_ptr->set_times_limit("SwitchToNormalMode", 1);
         }
     }
     else {
         // 非15-17章关卡，禁用模式切换任务
-        m_fight_task_ptr->set_times_limit("SwitchToRaidMode", 0);
+        m_fight_task_ptr->set_times_limit("SwitchToHardMode", 0);
         m_fight_task_ptr->set_times_limit("SwitchToNormalMode", 0);
     }
 

--- a/src/MaaCore/Task/Interface/FightTask.cpp
+++ b/src/MaaCore/Task/Interface/FightTask.cpp
@@ -1,6 +1,7 @@
 #include "FightTask.h"
 
 #include <utility>
+#include <regex>
 
 #include "Config/TaskData.h"
 #include "Task/Fight/DrGrandetTaskPlugin.h"
@@ -168,6 +169,31 @@ bool asst::FightTask::set_params(const json::value& params)
     m_sidestory_reopen_task_ptr->set_penguin_id(std::move(penguin_id));
     m_sidestory_reopen_task_ptr->set_enable_yituliu(enable_yituliu);
     m_sidestory_reopen_task_ptr->set_server(server);
+
+    // 检测15-17章带后缀的关卡，启用对应的模式切换任务
+    // 必须放在最后，避免被其他set_times_limit覆盖
+    static const std::regex chapter15to17_regex(R"(^(1[5-7])-\d+-(hard|normal)$)", std::regex::icase);
+    std::smatch match;
+    if (std::regex_match(stage, match, chapter15to17_regex)) {
+        std::string difficulty = match[2].str();
+        std::transform(difficulty.begin(), difficulty.end(), difficulty.begin(), ::tolower);
+
+        if (difficulty == "hard") {
+            Log.info("Detected chapter 15-17 hard mode stage:", stage);
+            m_fight_task_ptr->set_times_limit("SwitchToRaidMode", 1);
+            m_fight_task_ptr->set_times_limit("SwitchToNormalMode", 0);
+        }
+        else if (difficulty == "normal") {
+            Log.info("Detected chapter 15-17 normal mode stage:", stage);
+            m_fight_task_ptr->set_times_limit("SwitchToRaidMode", 0);
+            m_fight_task_ptr->set_times_limit("SwitchToNormalMode", 1);
+        }
+    }
+    else {
+        // 非15-17章关卡，禁用模式切换任务
+        m_fight_task_ptr->set_times_limit("SwitchToRaidMode", 0);
+        m_fight_task_ptr->set_times_limit("SwitchToNormalMode", 0);
+    }
 
     return true;
 }


### PR DESCRIPTION
#16477 
先前的PR由于进行ROI修改前先用merge同步了一下进度，弄出来了一堆merge  commit把PR搞臭了，所以rebase之后重新创建PR，修改与上一个PR一模一样，就是多了两行ROI参数

另附上对上一个PR里面的问题的回复

- 因为我是根据自己的需求来做的更改，我基本只有代理作战需求，自动战斗功能碰得很少，所以确实没想过怎么适配自动战斗切换难度，之后可能也没精力去适配了（悲）
- 导航应该统一由StageNavigationTask.cpp处理这个我确实也想过，但是问题就在于15~17章的难度切换发生在已经点进去关卡之后，如果我对本项目结构没理解错的话，这个时候导航应该已经完成了，毕竟关卡都找到了嘛（当然也不排除我理解得确实不到位...）。这个时机的操作应该已经和切换代理倍率，确认要不要碎石，要不要瞌理智药之类的操作是同等级的了，也就是说，它们都该是fightbegin这个任务序列里的了。再加上我是通过maxTimes:0的默认设置来限制难度切换操作的发生，另一个类似的限制方法就是碎石填充理智操作，所以我很大程度上参考了碎石的解除限制的逻辑来写，而这个逻辑就在fightingTask.cpp里面。综上，我最后实现难度切换，还是觉得需要修改fightingTask.cpp。
- 我本地是先跑过了才敢上传的，我PR comment里面写了我跑的几个典型测试样例，任务都能完成。
- ROI现在已经添加了并且再次测试过了
- 命名不一致的问题希望细说一下

## Summary by Sourcery

通过战斗任务参数而非导航任务，支持第 15–17 章关卡难度选择。

新功能：
- 基于战斗配置中的关卡名称后缀，为第 15–17 章关卡启用普通/困难模式选择。

增强内容：
- 对第 15–17 章跳过通用章节难度导航，将难度处理委托给战斗时的模式切换任务。
- 默认对非第 15–17 章的关卡禁用模式切换任务，以避免意外切换难度。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support chapter 15–17 stage difficulty selection via fight task parameters instead of navigation tasks.

New Features:
- Enable hard/normal mode selection for chapter 15–17 stages based on stage name suffix in fight configuration.

Enhancements:
- Skip generic chapter difficulty navigation for chapter 15–17, delegating difficulty handling to fight-time mode switch tasks.
- Disable mode switch tasks by default for non–chapter 15–17 stages to avoid unintended difficulty toggling.

</details>