### PR TITLE
rft: 小游戏界面重构，添加分类并优化选择逻辑，添加日志显示

### DIFF
--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -698,7 +698,7 @@ If the game is launched in portrait mode and then switched to landscape, it may 
     <system:String x:Key="Roguelike">{key=AutoRoguelike}</system:String>
     <system:String x:Key="Reclamation">Reclamation Algorithm</system:String>
     <system:String x:Key="UserDataUpdate">Update Doctor Data</system:String>
-    <system:String x:Key="MiniGame">Mini-Games</system:String>
+    <system:String x:Key="MiniGame">Convenience</system:String>
     <system:String x:Key="MiniGameCategoryPermanent">Permanent</system:String>
     <system:String x:Key="MiniGameCategoryCurrentEvent">Current Events</system:String>
     <system:String x:Key="Custom">Custom Task</system:String>

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -698,7 +698,7 @@ If the game is launched in portrait mode and then switched to landscape, it may 
     <system:String x:Key="Roguelike">{key=AutoRoguelike}</system:String>
     <system:String x:Key="Reclamation">Reclamation Algorithm</system:String>
     <system:String x:Key="UserDataUpdate">Update Doctor Data</system:String>
-    <system:String x:Key="MiniGame">Convenience</system:String>
+    <system:String x:Key="MiniGame">Useful Tasks</system:String>
     <system:String x:Key="MiniGameCategoryPermanent">Permanent</system:String>
     <system:String x:Key="MiniGameCategoryCurrentEvent">Current Events</system:String>
     <system:String x:Key="Custom">Custom Task</system:String>

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -699,6 +699,8 @@ If the game is launched in portrait mode and then switched to landscape, it may 
     <system:String x:Key="Reclamation">Reclamation Algorithm</system:String>
     <system:String x:Key="UserDataUpdate">Update Doctor Data</system:String>
     <system:String x:Key="MiniGame">Mini-Games</system:String>
+    <system:String x:Key="MiniGameCategoryPermanent">Permanent</system:String>
+    <system:String x:Key="MiniGameCategoryCurrentEvent">Current Events</system:String>
     <system:String x:Key="Custom">Custom Task</system:String>
     <system:String x:Key="SingleStep">Single-Step Task</system:String>
     <system:String x:Key="ReclamationTheme">Reclamation Algorithm Theme</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -699,7 +699,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="Roguelike">{key=AutoRoguelike}</system:String>
     <system:String x:Key="Reclamation">生息演算</system:String>
     <system:String x:Key="UserDataUpdate">ユーザーデータ更新</system:String>
-    <system:String x:Key="MiniGame">ミニゲーム</system:String>
+    <system:String x:Key="MiniGame">便利機能</system:String>
     <system:String x:Key="MiniGameCategoryPermanent">常設</system:String>
     <system:String x:Key="MiniGameCategoryCurrentEvent">現在のイベント</system:String>
     <system:String x:Key="Custom">カスタムタスク</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -700,6 +700,8 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="Reclamation">生息演算</system:String>
     <system:String x:Key="UserDataUpdate">ユーザーデータ更新</system:String>
     <system:String x:Key="MiniGame">ミニゲーム</system:String>
+    <system:String x:Key="MiniGameCategoryPermanent">常設</system:String>
+    <system:String x:Key="MiniGameCategoryCurrentEvent">現在のイベント</system:String>
     <system:String x:Key="Custom">カスタムタスク</system:String>
     <system:String x:Key="SingleStep">単一ステップタスク</system:String>
     <system:String x:Key="ReclamationTheme">主題</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -700,7 +700,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="Roguelike">{key=AutoRoguelike}</system:String>
     <system:String x:Key="Reclamation">생존 연산</system:String>
     <system:String x:Key="UserDataUpdate">사용자 데이터 업데이트</system:String>
-    <system:String x:Key="MiniGame">미니게임</system:String>
+    <system:String x:Key="MiniGame">편의 기능</system:String>
     <system:String x:Key="MiniGameCategoryPermanent">상시</system:String>
     <system:String x:Key="MiniGameCategoryCurrentEvent">현재 이벤트</system:String>
     <system:String x:Key="Custom">커스텀 작업</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -701,6 +701,8 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="Reclamation">생존 연산</system:String>
     <system:String x:Key="UserDataUpdate">사용자 데이터 업데이트</system:String>
     <system:String x:Key="MiniGame">미니게임</system:String>
+    <system:String x:Key="MiniGameCategoryPermanent">상시</system:String>
+    <system:String x:Key="MiniGameCategoryCurrentEvent">현재 이벤트</system:String>
     <system:String x:Key="Custom">커스텀 작업</system:String>
     <system:String x:Key="SingleStep">단일 단계 작업</system:String>
     <system:String x:Key="ReclamationTheme">생존 연산 테마</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -699,7 +699,7 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="Roguelike">{key=AutoRoguelike}</system:String>
     <system:String x:Key="Reclamation">生息演算</system:String>
     <system:String x:Key="UserDataUpdate">更新数据</system:String>
-    <system:String x:Key="MiniGame">小游戏</system:String>
+    <system:String x:Key="MiniGame">便捷功能</system:String>
     <system:String x:Key="MiniGameCategoryPermanent">常驻活动</system:String>
     <system:String x:Key="MiniGameCategoryCurrentEvent">当期活动</system:String>
     <system:String x:Key="Custom">自定任务</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -700,6 +700,8 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="Reclamation">生息演算</system:String>
     <system:String x:Key="UserDataUpdate">更新数据</system:String>
     <system:String x:Key="MiniGame">小游戏</system:String>
+    <system:String x:Key="MiniGameCategoryPermanent">常驻活动</system:String>
+    <system:String x:Key="MiniGameCategoryCurrentEvent">当期活动</system:String>
     <system:String x:Key="Custom">自定任务</system:String>
     <system:String x:Key="SingleStep">单步任务</system:String>
     <system:String x:Key="ReclamationTheme">生息演算主题</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -699,9 +699,9 @@ C:\\leidian\\LDPlayer9\n
     <system:String x:Key="Roguelike">{key=AutoRoguelike}</system:String>
     <system:String x:Key="Reclamation">生息演算</system:String>
     <system:String x:Key="UserDataUpdate">更新使用者資料</system:String>
-    <system:String x:Key="MiniGame">便捷功能</system:String>
+    <system:String x:Key="MiniGame">快捷功能</system:String>
     <system:String x:Key="MiniGameCategoryPermanent">常駐</system:String>
-    <system:String x:Key="MiniGameCategoryCurrentEvent">當前活動</system:String>
+    <system:String x:Key="MiniGameCategoryCurrentEvent">目前活動</system:String>
     <system:String x:Key="Custom">自定義任務</system:String>
     <system:String x:Key="SingleStep">單步任務</system:String>
     <system:String x:Key="ReclamationTheme">生息演算主題</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -699,7 +699,7 @@ C:\\leidian\\LDPlayer9\n
     <system:String x:Key="Roguelike">{key=AutoRoguelike}</system:String>
     <system:String x:Key="Reclamation">生息演算</system:String>
     <system:String x:Key="UserDataUpdate">更新使用者資料</system:String>
-    <system:String x:Key="MiniGame">小遊戲</system:String>
+    <system:String x:Key="MiniGame">便捷功能</system:String>
     <system:String x:Key="MiniGameCategoryPermanent">常駐</system:String>
     <system:String x:Key="MiniGameCategoryCurrentEvent">當前活動</system:String>
     <system:String x:Key="Custom">自定義任務</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -700,6 +700,8 @@ C:\\leidian\\LDPlayer9\n
     <system:String x:Key="Reclamation">生息演算</system:String>
     <system:String x:Key="UserDataUpdate">更新使用者資料</system:String>
     <system:String x:Key="MiniGame">小遊戲</system:String>
+    <system:String x:Key="MiniGameCategoryPermanent">常駐</system:String>
+    <system:String x:Key="MiniGameCategoryCurrentEvent">當前活動</system:String>
     <system:String x:Key="Custom">自定義任務</system:String>
     <system:String x:Key="SingleStep">單步任務</system:String>
     <system:String x:Key="ReclamationTheme">生息演算主題</system:String>

--- a/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
@@ -1860,8 +1860,7 @@ public class ToolboxViewModel : Screen
     public MiniGameCategoryItem? SelectedMiniGameItem
     {
         get => _selectedMiniGameItem;
-        set
-        {
+        set {
             if (!SetAndNotify(ref _selectedMiniGameItem, value) || value == null)
             {
                 return;
@@ -1919,8 +1918,7 @@ public class ToolboxViewModel : Screen
     public string MiniGameTaskName
     {
         get => _miniGameTaskName;
-        set
-        {
+        set {
             SetAndNotify(ref _miniGameTaskName, value);
             ConfigurationHelper.SetGlobalValue(ConfigurationKeys.MiniGameTaskName, value);
             MiniGameTip = GetMiniGameTip(value);
@@ -1940,8 +1938,7 @@ public class ToolboxViewModel : Screen
 
     public string MiniGameTip
     {
-        get
-        {
+        get {
             _miniGameTip ??= GetMiniGameTip(MiniGameTaskName);
             return _miniGameTip;
         }
@@ -1961,16 +1958,19 @@ public class ToolboxViewModel : Screen
             return LocalizationHelper.GetString("MiniGameNameEmptyTip");
         }
 
+        // 优先使用 TipKey 的本地化
         if (!string.IsNullOrEmpty(entry.TipKey) && LocalizationHelper.TryGetString(entry.TipKey, out var tipFromKey))
         {
             return tipFromKey;
         }
 
+        // 然后使用 explicit Tip
         if (!string.IsNullOrEmpty(entry.Tip))
         {
             return entry.Tip;
         }
 
+        // 若不存在 Tip，再尝试使用 DisplayKey + "Tip" 的约定键
         if (!string.IsNullOrEmpty(entry.DisplayKey))
         {
             var displayTipKey = entry.DisplayKey + "Tip";
@@ -1979,6 +1979,7 @@ public class ToolboxViewModel : Screen
                 return displayTip;
             }
 
+            // 最后回退为 Display 的本地化或原始 Display
             if (LocalizationHelper.TryGetString(entry.DisplayKey, out var displayLoc))
             {
                 return displayLoc;
@@ -2000,8 +2001,7 @@ public class ToolboxViewModel : Screen
     public string SecretFrontEnding
     {
         get => _secretFrontEnding;
-        set
-        {
+        set {
             SetAndNotify(ref _secretFrontEnding, value);
             ConfigurationHelper.SetValue(ConfigurationKeys.MiniGameSecretFrontEnding, value);
         }
@@ -2020,8 +2020,7 @@ public class ToolboxViewModel : Screen
     public string SecretFrontEvent
     {
         get => _secretFrontEvent;
-        set
-        {
+        set {
             SetAndNotify(ref _secretFrontEvent, value);
             ConfigurationHelper.SetValue(ConfigurationKeys.MiniGameSecretFrontEvent, value);
         }

--- a/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
@@ -1842,20 +1842,75 @@ public class ToolboxViewModel : Screen
 
     #region MiniGame
 
-    public static ObservableCollection<MiniGameEntry> MiniGameTaskList { get; } = [];
+    public class MiniGameCategoryItem : PropertyChangedBase
+    {
+        public string Display { get; set; } = string.Empty;
+
+        public string Value { get; set; } = string.Empty;
+
+        public string Category { get; set; } = string.Empty;
+
+        public bool IsSecretFront => Value == "MiniGame@SecretFront";
+    }
+
+    public ObservableCollection<MiniGameCategoryItem> MiniGameCategoryItems { get; } = [];
+
+    private MiniGameCategoryItem? _selectedMiniGameItem;
+
+    public MiniGameCategoryItem? SelectedMiniGameItem
+    {
+        get => _selectedMiniGameItem;
+        set
+        {
+            if (!SetAndNotify(ref _selectedMiniGameItem, value) || value == null)
+            {
+                return;
+            }
+
+            MiniGameTaskName = value.Value;
+            ClearMiniGameLogs();
+        }
+    }
 
     public static void UpdateMiniGameTaskList()
     {
-        var tasks = Instances.StageManager.MiniGameEntries
-            .Select(t => new MiniGameEntry { Display = t.Display, DisplayKey = t.DisplayKey, Value = t.Value, Tip = t.Tip, TipKey = t.TipKey })
+        var categorizedItems = Instances.StageManager.MiniGameEntries
+            .Select(t =>
+            {
+                var isCurrentEvent = t.UtcStartTime != DateTime.MinValue || t.UtcExpireTime != DateTime.MinValue;
+                var category = LocalizationHelper.GetString(isCurrentEvent
+                    ? "MiniGameCategoryCurrentEvent"
+                    : "MiniGameCategoryPermanent");
+                return new MiniGameCategoryItem
+                {
+                    Display = string.IsNullOrEmpty(t.DisplayKey)
+                        ? t.Display
+                        : (LocalizationHelper.TryGetString(t.DisplayKey, out var loc) ? loc : t.Display),
+                    Value = t.Value,
+                    Category = category,
+                };
+            })
             .ToList();
 
-        Execute.OnUIThread(() => {
-            MiniGameTaskList.Clear();
-            foreach (var task in tasks)
+        Execute.OnUIThread(() =>
+        {
+            var toolbox = Instances.ToolboxViewModel;
+            if (toolbox == null)
             {
-                MiniGameTaskList.Add(task);
+                return;
             }
+
+            var prevSelected = toolbox.SelectedMiniGameItem?.Value;
+
+            toolbox.MiniGameCategoryItems.Clear();
+            foreach (var item in categorizedItems)
+            {
+                toolbox.MiniGameCategoryItems.Add(item);
+            }
+
+            toolbox.SelectedMiniGameItem = toolbox.MiniGameCategoryItems
+                .FirstOrDefault(i => i.Value == prevSelected)
+                ?? toolbox.MiniGameCategoryItems.FirstOrDefault();
         });
     }
 
@@ -1864,7 +1919,8 @@ public class ToolboxViewModel : Screen
     public string MiniGameTaskName
     {
         get => _miniGameTaskName;
-        set {
+        set
+        {
             SetAndNotify(ref _miniGameTaskName, value);
             ConfigurationHelper.SetGlobalValue(ConfigurationKeys.MiniGameTaskName, value);
             MiniGameTip = GetMiniGameTip(value);
@@ -1873,7 +1929,8 @@ public class ToolboxViewModel : Screen
 
     public string GetMiniGameTask()
     {
-        return MiniGameTaskName switch {
+        return MiniGameTaskName switch
+        {
             "MiniGame@SecretFront" => $"{MiniGameTaskName}@Begin@Ending{SecretFrontEnding}{(string.IsNullOrEmpty(SecretFrontEvent) ? string.Empty : $"@{SecretFrontEvent}")}",
             _ => MiniGameTaskName,
         };
@@ -1883,7 +1940,8 @@ public class ToolboxViewModel : Screen
 
     public string MiniGameTip
     {
-        get {
+        get
+        {
             _miniGameTip ??= GetMiniGameTip(MiniGameTaskName);
             return _miniGameTip;
         }
@@ -1903,19 +1961,16 @@ public class ToolboxViewModel : Screen
             return LocalizationHelper.GetString("MiniGameNameEmptyTip");
         }
 
-        // 优先使用 TipKey 的本地化
         if (!string.IsNullOrEmpty(entry.TipKey) && LocalizationHelper.TryGetString(entry.TipKey, out var tipFromKey))
         {
             return tipFromKey;
         }
 
-        // 然后使用 explicit Tip
         if (!string.IsNullOrEmpty(entry.Tip))
         {
             return entry.Tip;
         }
 
-        // 若不存在 Tip，再尝试使用 DisplayKey + "Tip" 的约定键
         if (!string.IsNullOrEmpty(entry.DisplayKey))
         {
             var displayTipKey = entry.DisplayKey + "Tip";
@@ -1924,7 +1979,6 @@ public class ToolboxViewModel : Screen
                 return displayTip;
             }
 
-            // 最后回退为 Display 的本地化或原始 Display
             if (LocalizationHelper.TryGetString(entry.DisplayKey, out var displayLoc))
             {
                 return displayLoc;
@@ -1946,13 +2000,15 @@ public class ToolboxViewModel : Screen
     public string SecretFrontEnding
     {
         get => _secretFrontEnding;
-        set {
+        set
+        {
             SetAndNotify(ref _secretFrontEnding, value);
             ConfigurationHelper.SetValue(ConfigurationKeys.MiniGameSecretFrontEnding, value);
         }
     }
 
-    public List<GenericCombinedData<string>> SecretFrontEventList { get; set; } = [
+    public List<GenericCombinedData<string>> SecretFrontEventList { get; set; } =
+    [
         new GenericCombinedData<string> { Display = LocalizationHelper.GetString("NotSelected"), Value = string.Empty },
         new GenericCombinedData<string> { Display = LocalizationHelper.GetString("MiniGame@SecretFront@Event1"), Value = "支援作战平台" },
         new GenericCombinedData<string> { Display = LocalizationHelper.GetString("MiniGame@SecretFront@Event2"), Value = "游侠" },
@@ -1964,10 +2020,40 @@ public class ToolboxViewModel : Screen
     public string SecretFrontEvent
     {
         get => _secretFrontEvent;
-        set {
+        set
+        {
             SetAndNotify(ref _secretFrontEvent, value);
             ConfigurationHelper.SetValue(ConfigurationKeys.MiniGameSecretFrontEvent, value);
         }
+    }
+
+    public class MiniGameLogItem : PropertyChangedBase
+    {
+        public string Time { get; set; } = string.Empty;
+
+        public string Content { get; set; } = string.Empty;
+
+        public string Color { get; set; } = UiLogColor.Info;
+    }
+
+    public ObservableCollection<MiniGameLogItem> MiniGameLogs { get; } = [];
+
+    public void AddMiniGameLog(string content, string color = UiLogColor.Info)
+    {
+        Execute.OnUIThread(() =>
+        {
+            MiniGameLogs.Add(new MiniGameLogItem
+            {
+                Time = DateTime.Now.ToString("HH:mm:ss"),
+                Content = content,
+                Color = color,
+            });
+        });
+    }
+
+    public void ClearMiniGameLogs()
+    {
+        Execute.OnUIThread(() => MiniGameLogs.Clear());
     }
 
     public void StartMiniGame()
@@ -1984,12 +2070,19 @@ public class ToolboxViewModel : Screen
         }
 
         _runningState.SetIdle(false);
+
+        ClearMiniGameLogs();
+        AddMiniGameLog("正在连接...", UiLogColor.Message);
         string errMsg = string.Empty;
         bool caught = await Task.Run(() => Instances.AsstProxy.AsstConnect(ref errMsg));
         if (!caught)
         {
+            AddMiniGameLog($"连接失败: {errMsg}", UiLogColor.Error);
             _runningState.SetIdle(true);
+            return;
         }
+
+        AddMiniGameLog("连接成功", UiLogColor.Success);
 
         if (_runningState.GetStopping())
         {
@@ -1997,9 +2090,12 @@ public class ToolboxViewModel : Screen
             return;
         }
 
+        var taskName = SelectedMiniGameItem?.Display ?? GetMiniGameTask();
+        AddMiniGameLog($"开始运行: {taskName}", UiLogColor.Info);
         caught = Instances.AsstProxy.AsstMiniGame(GetMiniGameTask());
         if (!caught)
         {
+            AddMiniGameLog("运行失败", UiLogColor.Error);
             _runningState.SetIdle(true);
         }
         else

--- a/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
@@ -2071,17 +2071,15 @@ public class ToolboxViewModel : Screen
         _runningState.SetIdle(false);
 
         ClearMiniGameLogs();
-        AddMiniGameLog("正在连接...", UiLogColor.Message);
+        AddMiniGameLog(LocalizationHelper.GetString("ConnectingToEmulator"), UiLogColor.Message);
         string errMsg = string.Empty;
         bool caught = await Task.Run(() => Instances.AsstProxy.AsstConnect(ref errMsg));
         if (!caught)
         {
-            AddMiniGameLog($"连接失败: {errMsg}", UiLogColor.Error);
+            AddMiniGameLog(errMsg, UiLogColor.Error);
             _runningState.SetIdle(true);
             return;
         }
-
-        AddMiniGameLog("连接成功", UiLogColor.Success);
 
         if (_runningState.GetStopping())
         {
@@ -2089,12 +2087,9 @@ public class ToolboxViewModel : Screen
             return;
         }
 
-        var taskName = SelectedMiniGameItem?.Display ?? GetMiniGameTask();
-        AddMiniGameLog($"开始运行: {taskName}", UiLogColor.Info);
         caught = Instances.AsstProxy.AsstMiniGame(GetMiniGameTask());
         if (!caught)
         {
-            AddMiniGameLog("运行失败", UiLogColor.Error);
             _runningState.SetIdle(true);
         }
         else

--- a/src/MaaWpfGui/Views/UI/ToolboxView.xaml
+++ b/src/MaaWpfGui/Views/UI/ToolboxView.xaml
@@ -8,6 +8,7 @@
     xmlns:hc="https://handyorg.github.io/handycontrol"
     xmlns:helper="clr-namespace:MaaWpfGui.Helper"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:properties="clr-namespace:MaaWpfGui.Styles.Properties"
     xmlns:s="https://github.com/canton7/Stylet"
     xmlns:uiBehaviors="clr-namespace:MaaWpfGui.Extensions.UIBehaviors"
     xmlns:ui_vms="clr-namespace:MaaWpfGui.ViewModels.UI"
@@ -756,52 +757,157 @@
             </Grid>
         </TabItem>
         <TabItem Header="{DynamicResource MiniGame}">
-            <Grid Margin="20,0,20,0">
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="Auto" />
-                    <RowDefinition Height="*" />
-                    <RowDefinition Height="100" />
-                </Grid.RowDefinitions>
-                <ComboBox
-                    Margin="10,0"
-                    hc:TitleElement.Title="{DynamicResource MiniGameName}"
-                    DisplayMemberPath="Display"
-                    IsEnabled="{Binding Idle}"
-                    ItemsSource="{Binding MiniGameTaskList}"
-                    SelectedValue="{Binding MiniGameTaskName}"
-                    SelectedValuePath="Value" />
-                <Grid Grid.Row="1" IsEnabled="{Binding Idle}">
-                    <Grid Visibility="{c:Binding 'MiniGameTaskName == &quot;MiniGame@SecretFront&quot;'}">
-                        <Grid.RowDefinitions>
-                            <RowDefinition />
-                            <RowDefinition />
-                        </Grid.RowDefinitions>
-                        <ComboBox
-                            Margin="10,10,10,0"
-                            hc:TitleElement.Title="{DynamicResource MiniGame@SecretFront@Ending}"
-                            ItemsSource="{Binding SecretFrontEndingList}"
-                            SelectedValue="{Binding SecretFrontEnding}" />
-                        <ComboBox
-                            Grid.Row="1"
-                            Margin="10,10,10,0"
-                            hc:TitleElement.Title="{DynamicResource MiniGame@SecretFront@Event}"
-                            DisplayMemberPath="Display"
-                            ItemsSource="{Binding SecretFrontEventList}"
-                            SelectedValue="{Binding SecretFrontEvent}"
-                            SelectedValuePath="Value" />
-                    </Grid>
-
+            <Grid Margin="20,0,20,20">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="200" />
+                    <ColumnDefinition Width="300" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <Grid Grid.Column="0" Margin="10">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="*" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Grid.Resources>
+                        <CollectionViewSource x:Key="CategorizedMiniGames" Source="{Binding MiniGameCategoryItems}">
+                            <CollectionViewSource.GroupDescriptions>
+                                <PropertyGroupDescription PropertyName="Category" />
+                            </CollectionViewSource.GroupDescriptions>
+                        </CollectionViewSource>
+                    </Grid.Resources>
+                    <Border
+                        Grid.Row="0"
+                        Background="{DynamicResource RegionBrushOpacity25}"
+                        BorderBrush="{DynamicResource BorderBrush}"
+                        BorderThickness="1"
+                        CornerRadius="4">
+                        <ListBox
+                            Margin="0"
+                            Background="Transparent"
+                            BorderThickness="0"
+                            IsEnabled="{Binding Idle}"
+                            IsSynchronizedWithCurrentItem="True"
+                            ItemsSource="{Binding Source={StaticResource CategorizedMiniGames}}"
+                            SelectedItem="{Binding SelectedMiniGameItem}"
+                            Style="{StaticResource MaaListBoxDefaultStyle}">
+                            <ListBox.ItemTemplate>
+                                <DataTemplate>
+                                    <TextBlock
+                                        Margin="5,0"
+                                        Text="{Binding Display}"
+                                        TextTrimming="CharacterEllipsis" />
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                            <ListBox.GroupStyle>
+                                <GroupStyle>
+                                    <GroupStyle.HeaderTemplate>
+                                        <DataTemplate>
+                                            <Border
+                                                Padding="8,4"
+                                                Background="{DynamicResource RegionBrushOpacity50}"
+                                                BorderBrush="{DynamicResource BorderBrush}"
+                                                BorderThickness="0,0,0,1">
+                                                <controls:TextBlock FontWeight="Bold" Text="{Binding Name}" />
+                                            </Border>
+                                        </DataTemplate>
+                                    </GroupStyle.HeaderTemplate>
+                                </GroupStyle>
+                            </ListBox.GroupStyle>
+                        </ListBox>
+                    </Border>
+                    <Button
+                        Grid.Row="1"
+                        Width="160"
+                        Height="60"
+                        Margin="0,20,0,0"
+                        HorizontalAlignment="Center"
+                        Command="{s:Action StartMiniGame}"
+                        Content="{c:Binding 'Idle ? &quot;Link Start!&quot; : &quot;Stop!&quot;'}"
+                        IsEnabled="{c:Binding 'Inited and !Stopping'}" />
                 </Grid>
-                <controls:TextBlock Grid.Row="2" Text="{Binding MiniGameTip}" />
-                <Button
-                    Grid.Row="3"
-                    Width="100"
-                    Height="50"
-                    Margin="10"
-                    Command="{s:Action StartMiniGame}"
-                    Content="{c:Binding 'Idle ? &quot;Link Start!&quot; : &quot;Stop!&quot;'}"
-                    IsEnabled="{c:Binding 'Inited and !Stopping'}" />
+                <Grid Grid.Column="1" Margin="50,50,30,10" IsEnabled="{Binding Idle}" VerticalAlignment="Top">
+                    <Grid Visibility="{c:Binding 'SelectedMiniGameItem != null'}">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="*" />
+                        </Grid.RowDefinitions>
+                        <Grid Visibility="{c:Binding 'SelectedMiniGameItem.IsSecretFront'}">
+                            <Grid.RowDefinitions>
+                                <RowDefinition />
+                                <RowDefinition />
+                            </Grid.RowDefinitions>
+                            <ComboBox
+                                Margin="10,0,10,0"
+                                hc:TitleElement.Title="{DynamicResource MiniGame@SecretFront@Ending}"
+                                ItemsSource="{Binding SecretFrontEndingList}"
+                                SelectedValue="{Binding SecretFrontEnding}" />
+                            <ComboBox
+                                Grid.Row="1"
+                                Margin="10,10,10,10"
+                                hc:TitleElement.Title="{DynamicResource MiniGame@SecretFront@Event}"
+                                DisplayMemberPath="Display"
+                                ItemsSource="{Binding SecretFrontEventList}"
+                                SelectedValue="{Binding SecretFrontEvent}"
+                                SelectedValuePath="Value" />
+                        </Grid>
+                        <controls:TextBlock
+                            Grid.Row="1"
+                            Margin="10,0,10,10"
+                            Text="{Binding MiniGameTip}"
+                            TextWrapping="Wrap" />
+                    </Grid>
+                </Grid>
+                <Grid
+                    Grid.Column="2"
+                    Margin="10,10,0,10"
+                    HorizontalAlignment="Stretch"
+                    VerticalAlignment="Top">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="*" />
+                    </Grid.RowDefinitions>
+                    <hc:ScrollViewer
+                        Grid.Row="0"
+                        HorizontalAlignment="Stretch"
+                        VerticalAlignment="Stretch"
+                        properties:AutoScroll.AutoScroll="True"
+                        HorizontalScrollBarVisibility="Disabled"
+                        IsInertiaEnabled="True"
+                        PanningMode="Both">
+                        <Grid>
+                            <ItemsControl
+                                HorizontalAlignment="Stretch"
+                                VerticalAlignment="Stretch"
+                                ItemsSource="{Binding MiniGameLogs}">
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <Grid>
+                                            <Grid.ColumnDefinitions>
+                                                <ColumnDefinition Width="Auto" />
+                                                <ColumnDefinition Width="*" />
+                                            </Grid.ColumnDefinitions>
+                                            <controls:TextBlock
+                                                Grid.Column="0"
+                                                Margin="0,5,10,5"
+                                                VerticalAlignment="Top"
+                                                Foreground="{DynamicResource TraceLogBrush}"
+                                                Text="{Binding Time}" />
+                                            <Grid
+                                                Grid.Column="1"
+                                                Margin="0,5"
+                                                HorizontalAlignment="Left">
+                                                <controls:TextBlock
+                                                    ForegroundKey="{Binding Color}"
+                                                    Text="{Binding Content}"
+                                                    TextWrapping="Wrap" />
+                                            </Grid>
+                                        </Grid>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </Grid>
+                    </hc:ScrollViewer>
+                </Grid>
             </Grid>
         </TabItem>
     </TabControl>


### PR DESCRIPTION
<img width="1248" height="948" alt="QQ_1778079644390" src="https://github.com/user-attachments/assets/d63a6663-d846-4f05-9a01-58ee3b5558ca" />

## Summary by Sourcery

重构小游戏 UI，以支持按类别进行选择，并在窗口中记录连接和运行状态的日志。

新功能：
- 在工具箱 UI 中引入分类的小游戏条目，将当前活动与常驻内容区分开来。
- 添加小游戏日志面板，以时间戳和不同严重程度的颜色记录连接、启动和错误状态消息。

改进：
- 在任务列表刷新时持久化并恢复所选的小游戏，并在选择变化时清除相关日志。
- 优化小游戏提示解析和选择逻辑，并使 UI 绑定与新的基于类别的模型保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the mini-game UI to support categorized selection and in-window logging of connection and run status.

New Features:
- Introduce categorized mini-game entries distinguishing current events from permanent content in the toolbox UI.
- Add a mini-game log panel that records connection, start, and error status messages with timestamps and severity colors.

Enhancements:
- Persist and restore the selected mini-game when the task list is refreshed, clearing related logs on selection change.
- Improve mini-game tip resolution and selection logic while aligning the UI bindings with the new category-based model.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

重构小游戏 UI，以支持按类别进行选择，并在窗口中记录连接和运行状态的日志。

新功能：
- 在工具箱 UI 中引入分类的小游戏条目，将当前活动与常驻内容区分开来。
- 添加小游戏日志面板，以时间戳和不同严重程度的颜色记录连接、启动和错误状态消息。

改进：
- 在任务列表刷新时持久化并恢复所选的小游戏，并在选择变化时清除相关日志。
- 优化小游戏提示解析和选择逻辑，并使 UI 绑定与新的基于类别的模型保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the mini-game UI to support categorized selection and in-window logging of connection and run status.

New Features:
- Introduce categorized mini-game entries distinguishing current events from permanent content in the toolbox UI.
- Add a mini-game log panel that records connection, start, and error status messages with timestamps and severity colors.

Enhancements:
- Persist and restore the selected mini-game when the task list is refreshed, clearing related logs on selection change.
- Improve mini-game tip resolution and selection logic while aligning the UI bindings with the new category-based model.

</details>

</details>