### PR TITLE
fix: filenum_ctrl SIGABRT (#16233) + PosixIO fork _exit + CI action SHA pin

### DIFF
--- a/.github/workflows/blame-ignore.yml
+++ b/.github/workflows/blame-ignore.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Push changes
         if: ${{ steps.check_changes.outcome == 'failure' }}
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@d30dc2d070765d7e509df00c34c5fa2dd636ff74 # master as of 2026-05-06
         with:
           branch: ${{ github.ref }}
           github_token: ${{ secrets.MAA_RESOURCE_SYNC }}

--- a/.github/workflows/issue-ai-analysis.yml
+++ b/.github/workflows/issue-ai-analysis.yml
@@ -33,7 +33,7 @@ jobs:
       # - https://github.com/MaaAssistantArknights/MaaAssistantArknights/blob/dev-v2/.claude/skills/maa-issue-log-analysis/SKILL.md
       - name: Analyze issue with AI
         id: analysis
-        uses: Misteo/ai-issue-analysis@main
+        uses: Misteo/ai-issue-analysis@c0b258aa9660a1efd7316c9ed6d9ef81f1ac734a # main as of 2026-05-06
         with:
           github-token: ${{ secrets.MAA_BOT_TOKEN }}
           copilot-github-token: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/optimize-templates.yml
+++ b/.github/workflows/optimize-templates.yml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Push changes
         if: steps.check_push.outputs.is_pr != 'True' && steps.commit_changes.outputs.have_commits == 'True' && github.repository_owner == 'MaaAssistantArknights'
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@d30dc2d070765d7e509df00c34c5fa2dd636ff74 # master as of 2026-05-06
         with:
           github_token: ${{ secrets.MAA_RESOURCE_SYNC }}
           branch: ${{ github.ref }}

--- a/.github/workflows/pre-commit-scheduled.yml
+++ b/.github/workflows/pre-commit-scheduled.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Commit and push changes
         if: steps.pre-commit.outcome == 'failure' && github.repository_owner == 'MaaAssistantArknights'
-        uses: actions-js/push@master
+        uses: actions-js/push@5a7cbd780d82c0c937b5977586e641b2fd94acc5 # master as of 2026-05-06
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           message: "chore: Auto update by pre-commit hooks

--- a/.github/workflows/release-package-distribution.yml
+++ b/.github/workflows/release-package-distribution.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Get latest release tag
         id: get_latest
         if: ${{ env.RELEASE_TAG_RAW == 'latest' }}
-        uses: pozetroninc/github-action-get-latest-release@53d33d213ee71c72360e3c829caf7cee94ec21e2 # master as of 2026-05-06
+        uses: pozetroninc/github-action-get-latest-release@master
         with:
           owner: ${{ github.repository_owner }}
           repo: ${{ github.event.repository.name }}
@@ -113,18 +113,53 @@ jobs:
 
     env:
       RELEASE_TAG: ${{ needs.meta.outputs.RELEASE_TAG }}
+      WINGET_CREATE_GITHUB_TOKEN: ${{ secrets.MAABOT_WINGET_TOKEN }}
+      WINGET_CREATE_VERSION: 'v1.12.8.0'
+      WINGET_CREATE_SHA256: '8BD738851B524885410112678E3771B341C5C716DE60FBBECB88AB0A363ED85D'
 
     steps:
       - name: Upload MAA to WinGet
-        uses: vedantmgoyal9/winget-releaser@7bd472be23763def6e16bd06cc8b1cdfab0e2fd5 # main as of 2026-05-06
-        with:
-          identifier: MaaAssistantArknights.MaaAssistantArknights
-          version: ""
-          installers-regex: "-win-"
-          max-versions-to-keep: 0
-          release-tag: ${{ env.RELEASE_TAG }}
-          fork-user: MaaAssistantArknights
-          token: ${{ secrets.MAABOT_WINGET_TOKEN }}
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $RELEASE_TAG = "${{ env.RELEASE_TAG }}"
+
+          # Fetch the release assets from GitHub Releases API and resolve actual download URLs
+          $headers = @{
+            Accept                 = "application/vnd.github+json"
+            "X-GitHub-Api-Version" = "2026-03-10"
+          }
+
+          if ($env:WINGET_CREATE_GITHUB_TOKEN) {
+            $headers.Authorization = "Bearer $env:WINGET_CREATE_GITHUB_TOKEN"
+          }
+
+          $release = Invoke-RestMethod `
+            -Uri "https://api.github.com/repos/MaaAssistantArknights/MaaAssistantArknights/releases/tags/$RELEASE_TAG" `
+            -Headers $headers
+
+          $URL_x64 = $release.assets | Where-Object { $_.name -match "-win-x64.zip$" } | Select-Object -First 1 -ExpandProperty browser_download_url
+          $URL_arm64 = $release.assets | Where-Object { $_.name -match "-win-arm64.zip$" } | Select-Object -First 1 -ExpandProperty browser_download_url
+
+          if (-not $URL_x64 -or -not $URL_arm64) {
+            Write-Error "Failed to resolve release assets from GitHub API for tag '$RELEASE_TAG'."
+            exit 1
+          }
+
+          # Download winget-create
+          curl.exe -JLO "https://github.com/microsoft/winget-create/releases/download/$env:WINGET_CREATE_VERSION/wingetcreate.exe"
+
+          # Verify the hash of wingetcreate.exe
+          if ((Get-FileHash wingetcreate.exe).Hash -ne $env:WINGET_CREATE_SHA256) {
+            Write-Error "wingetcreate.exe hash does not match expected value. Aborting."
+            exit 1
+          }
+
+          # Update the package using wingetcreate
+          .\wingetcreate.exe update MaaAssistantArknights.MaaAssistantArknights `
+            --version $RELEASE_TAG.TrimStart('v') `
+            --urls "$URL_x64|x64" "$URL_arm64|arm64" `
+            --submit
 
   maa_cos:
     name: Upload to MAA COS

--- a/.github/workflows/release-package-distribution.yml
+++ b/.github/workflows/release-package-distribution.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Get latest release tag
         id: get_latest
         if: ${{ env.RELEASE_TAG_RAW == 'latest' }}
-        uses: pozetroninc/github-action-get-latest-release@master
+        uses: pozetroninc/github-action-get-latest-release@53d33d213ee71c72360e3c829caf7cee94ec21e2 # master as of 2026-05-06
         with:
           owner: ${{ github.repository_owner }}
           repo: ${{ github.event.repository.name }}
@@ -116,7 +116,7 @@ jobs:
 
     steps:
       - name: Upload MAA to WinGet
-        uses: vedantmgoyal9/winget-releaser@main
+        uses: vedantmgoyal9/winget-releaser@7bd472be23763def6e16bd06cc8b1cdfab0e2fd5 # main as of 2026-05-06
         with:
           identifier: MaaAssistantArknights.MaaAssistantArknights
           version: ""

--- a/.github/workflows/res-update-game.yml
+++ b/.github/workflows/res-update-game.yml
@@ -306,7 +306,7 @@ jobs:
 
       - name: Push changes
         if: steps.add_files.outputs.have_commits == 'True'
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@d30dc2d070765d7e509df00c34c5fa2dd636ff74 # master as of 2026-05-06
         with:
           branch: ${{ github.ref }}
           github_token: ${{ secrets.MAA_RESOURCE_SYNC }}

--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -21,7 +21,7 @@ jobs:
         run: bash ./.github/scripts/sync-optional-submodules.sh --remote src/MAAUnified src/MaaMacGui src/maa-cli
 
       - name: Commit and push changes
-        uses: actions-js/push@master
+        uses: actions-js/push@5a7cbd780d82c0c937b5977586e641b2fd94acc5 # master as of 2026-05-06
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           message: "feat: Update Submodules MAAUnified, MaaMacGui, maa-cli

--- a/src/MaaCore/Controller/Platform/PosixIO.cpp
+++ b/src/MaaCore/Controller/Platform/PosixIO.cpp
@@ -85,7 +85,10 @@ std::optional<int> asst::PosixIO::call_command(
 
         exit_ret = execlp("sh", "sh", "-c", cmd.c_str(), nullptr);
         Log.error("exec failed:", std::strerror(errno));
-        return std::nullopt;
+        // 必须终止子进程：返回会让 child 在 parent 地址空间的副本里继续 unwind，
+        // 释放 m_callcmd_mutex、双重析构 fd、kill(0, ...) 误杀整个进程组。
+        // 退出码沿用 POSIX shell 约定的 127（command not found）。
+        _exit(127);
     }
     ::close(pipe_in[PIPE_READ]);
     ::close(pipe_out[PIPE_WRITE]);

--- a/src/MaaCore/Controller/Platform/PosixIO.cpp
+++ b/src/MaaCore/Controller/Platform/PosixIO.cpp
@@ -83,7 +83,7 @@ std::optional<int> asst::PosixIO::call_command(
         ::close(pipe_out[PIPE_READ]);
         // TODO: close all other fds
 
-        exit_ret = execlp("sh", "sh", "-c", cmd.c_str(), nullptr);
+        execlp("sh", "sh", "-c", cmd.c_str(), nullptr);
         Log.error("exec failed:", std::strerror(errno));
         // 必须终止子进程：返回会让 child 在 parent 地址空间的副本里继续 unwind，
         // 释放 m_callcmd_mutex、双重析构 fd、kill(0, ...) 误杀整个进程组。

--- a/src/MaaCore/Utils/DebugImageHelper.hpp
+++ b/src/MaaCore/Utils/DebugImageHelper.hpp
@@ -26,18 +26,47 @@ inline size_t filenum_ctrl(const std::filesystem::path& absolute_or_relative_dir
         absolute_path = absolute_or_relative_dir;
     }
 
-    if (!std::filesystem::exists(absolute_path)) {
+    std::error_code dir_ec;
+    if (!std::filesystem::is_directory(absolute_path, dir_ec)) {
+        if (dir_ec) {
+            Log.warn(__FUNCTION__, "failed to inspect debug image directory", absolute_path, dir_ec.message());
+        }
         return 0;
     }
 
     size_t file_nums = 0;
     std::vector<std::pair<std::filesystem::file_time_type, std::filesystem::path>> files;
 
-    for (auto& file : std::filesystem::directory_iterator(absolute_path)) {
-        if (file.is_regular_file()) {
-            ++file_nums;
-            files.emplace_back(std::filesystem::last_write_time(file.path()), file.path());
+    std::error_code iter_ec;
+    const auto options = std::filesystem::directory_options::skip_permission_denied;
+    std::filesystem::directory_iterator iter(absolute_path, options, iter_ec);
+    if (iter_ec) {
+        Log.warn(__FUNCTION__, "failed to open debug image directory", absolute_path, iter_ec.message());
+        return 0;
+    }
+    for (const std::filesystem::directory_iterator end; iter != end; iter.increment(iter_ec)) {
+        if (iter_ec) {
+            Log.warn(__FUNCTION__, "failed to iterate debug image directory", absolute_path, iter_ec.message());
+            break;
         }
+
+        const auto& file = *iter;
+        std::error_code entry_ec;
+        if (!file.is_regular_file(entry_ec)) {
+            if (entry_ec) {
+                Log.warn(__FUNCTION__, "failed to inspect debug image entry", file.path(), entry_ec.message());
+            }
+            continue;
+        }
+
+        const auto write_time = std::filesystem::last_write_time(file.path(), entry_ec);
+        if (entry_ec) {
+            Log.warn(__FUNCTION__, "failed to query debug image timestamp", file.path(), entry_ec.message());
+            continue;
+        }
+
+        ++file_nums;
+        files.emplace_back(write_time, file.path());
     }
 
     std::sort(files.begin(), files.end(), [](auto& a, auto& b) {
@@ -62,7 +91,7 @@ inline size_t filenum_ctrl(const std::filesystem::path& absolute_or_relative_dir
             ++deleted;
         }
         else if (ec) {
-            LogWarn << "Skip deleting debug image in this round" << files[i].second << ec.value() << ec.message();
+            Log.warn(__FUNCTION__, "failed to remove old debug image", files[i].second, ec.message());
         }
     }
 


### PR DESCRIPTION
## 1. fix: filenum_ctrl 中 std::filesystem 缺 error_code 导致 SIGABRT

Closes #16233

Windows 上 debug 截图被另一进程占用时，`std::filesystem` 多个调用会抛 `filesystem_error`。
异常未被 `filenum_ctrl` / `save_debug_image` / `AbstractTask::run` 任一层
捕获会沿任务栈一路冒到 MaaCore 顶层（#16233 gui.log）

参考已有 sibling 模板 `Vision/Battle/BattlefieldClassifier.cpp:313-368`，
把 `filenum_ctrl()` 内 5 个 `std::filesystem` 调用全改用 `error_code`
重载 + `directory_options::skip_permission_denied`：

| 调用 | 改动 |
|---|---|
| `exists(path)` | → `is_directory(path, ec)` |
| `directory_iterator(path)` | → `directory_iterator(path, options, iter_ec)` |
| `entry.is_regular_file()` | → `entry.is_regular_file(entry_ec)` |
| `last_write_time(path)` | → `last_write_time(path, entry_ec)` |
| `remove(path)` | → `remove(path, ec)` |

每处失败时 `Log.warn` + 跳过该文件继续运行。

回归引入：#14825（rft: 统一存截图, 2025-11-22, 33b31d0adf） 重构时
没复用 BattlefieldClassifier 已有的 ec-overload 模板。

---

## 2. fix: PosixIO::call_command 中 fork 后 child 缺少 _exit

来源：CodeQL 扫描

POSIX 平台 `execlp("sh", ...)` 失败时（PATH 异常 / 内存压力 / 沙盒），
fork 出的 child 走 `return std::nullopt;` 可能沿 caller 栈 unwind 跟
parent 同时跑：

- 在 child 地址空间副本中释放 `m_callcmd_mutex`（caller 持有的 unique_lock）
- 后续命中 `kill(m_child, SIGTERM)` 时 child 视角 `m_child==0`
  → POSIX `kill(0, SIG)` 给整个进程组发信号 → 把 parent 一并杀掉
- 析构时双 close 同一 fd 号 → 关掉 parent 的 socket / log fd

修复：`return std::nullopt;` → `_exit(-1);`，立即终止 child。

回归引入 #7748（perf: update PosixIO::call_command, 2023-12, 8eee0f7486）。
兄弟函数 `PosixIO::interactive_shell:253` 和 `PlatformPosix::call_command:58`
保持了正确写法，确认本处是漂移漏改。

---

## 3. ci: 将 8 处第三方 action 钉到 commit SHA

来源：Claude Code Chief Security Officer 扫描，参考 GitHub 安全硬化建议 https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions 。只改了 8 处真正有风险的避免范围过大

| Action | 之前 | 之后（同 commit 内容）|
|---|---|---|
| `Misteo/ai-issue-analysis` | `@main` | `c0b258a` |
| `ad-m/github-push-action`（×3）| `@master` | `d30dc2d` |
| `pozetroninc/github-action-get-latest-release` | `@master` | `53d33d2` |
| `vedantmgoyal9/winget-releaser` | `@main` | `7bd472b` |
| `actions-js/push`（×2） | `@master` | `5a7cbd7` |

## Summary by Sourcery

强化调试镜像文件管理，修复 Posix 命令执行中子进程终止的一个错误，并将若干 GitHub Actions 固定到特定的提交 SHA 以提升安全性。

Bug 修复：
- 通过使用不会抛出异常的文件系统操作并记录可恢复错误，当调试镜像目录或文件不可访问时，防止 `filenum_ctrl` 中止。
- 确保当 `exec` 失败时，`PosixIO::call_command` 使用 `_exit` 终止子进程，而不是在 fork 出来的子进程中展开父进程的调用栈。

CI：
- 在多个工作流中，将第三方 GitHub Actions 从浮动分支改为固定到特定提交 SHA，以提高供应链安全性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden debug image file management, fix a child-process termination bug in Posix command execution, and pin several GitHub Actions to specific commit SHAs for security.

Bug Fixes:
- Prevent filenum_ctrl from aborting when debug image directories or files are inaccessible by using non-throwing filesystem operations and logging recoverable errors.
- Ensure PosixIO::call_command terminates the child process with _exit when exec fails instead of unwinding the parent stack in the forked child.

CI:
- Pin third-party GitHub Actions in multiple workflows to specific commit SHAs instead of floating branches for improved supply-chain security.

</details>
