### PR TITLE
feat: 为牛牛监控添加保存截图选项

### DIFF
--- a/src/MaaWpfGui/Constants/ConfigurationKeys.cs
+++ b/src/MaaWpfGui/Constants/ConfigurationKeys.cs
@@ -340,6 +340,7 @@ public static class ConfigurationKeys
     public const string GachaShowDisclaimerNoMore = "Gacha.ShowDisclaimerNoMore";
 
     public const string PeepTargetFps = "Peep.TargetFps";
+    public const string PeepCaptureSaveFrequency = "Peep.CaptureSaveFrequency";
 
     public const string GuideStepIndex = "Guide.StepIndex";
 

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -930,6 +930,16 @@ The video aspect ratio needs to be 16:9 without interference factors such as bla
     <system:String x:Key="Peep">Peep</system:String>
     <system:String x:Key="PeepTip">See the world through Pallas?</system:String>
     <system:String x:Key="PeepTargetFps">Target Frame Rate</system:String>
+    <system:String x:Key="PeepCaptureSaveEnabled">Save captured images</system:String>
+    <system:String x:Key="PeepCaptureSaveFrequency">Save Rate</system:String>
+    <system:String x:Key="PeepCaptureSaveTip">When enabled, captured frames will be saved to peep/&lt;timestamp&gt;/ under the application directory. This option is off by default every time the app starts to reduce disk usage.</system:String>
+    <system:String x:Key="PeepCaptureSaveWarning">Enabling this feature may quickly consume disk space. Please set a reasonable save rate and clean up in time!</system:String>
+    <system:String x:Key="PeepCaptureSaveWarningPath">Screenshots will be saved to peep/&lt;timestamp&gt;/ under the application directory.</system:String>
+    <system:String x:Key="PeepCaptureCleanHistory">Clean History</system:String>
+    <system:String x:Key="PeepCaptureCleanSkippedActive">Current Peep images will not be cleaned. Stop Peep and clean again if needed.</system:String>
+    <system:String x:Key="PeepCaptureCleanSucceeded">Cleaned {0} Peep capture folder(s).</system:String>
+    <system:String x:Key="PeepCaptureCleanFailed">Failed to clean Peep capture history.</system:String>
+    <system:String x:Key="PeepCaptureSaveFailed">Failed to save Peep captured image.</system:String>
     <!--  !Peep  -->
     <!--  Minigame  -->
     <system:String x:Key="MiniGameName">Mini Game Name</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -931,6 +931,16 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="Peep">Peep</system:String>
     <system:String x:Key="PeepTip">パラスの目に映る世界を見てみませんか？</system:String>
     <system:String x:Key="PeepTargetFps">目標フレームレート</system:String>
+    <system:String x:Key="PeepCaptureSaveEnabled">キャプチャ画像を保存</system:String>
+    <system:String x:Key="PeepCaptureSaveFrequency">保存頻度</system:String>
+    <system:String x:Key="PeepCaptureSaveTip">有効にすると、キャプチャ画面をアプリケーションフォルダーの peep/&lt;timestamp&gt;/ に保存します。ディスク使用量を抑えるため、アプリ起動時は毎回オフになります。</system:String>
+    <system:String x:Key="PeepCaptureSaveWarning">この機能を有効にすると、ディスク容量を急速に消費する可能性があります。保存頻度を適切に設定し、こまめに整理してください！</system:String>
+    <system:String x:Key="PeepCaptureSaveWarningPath">スクリーンショットはアプリケーションフォルダーの peep/&lt;timestamp&gt;/ に保存されます。</system:String>
+    <system:String x:Key="PeepCaptureCleanHistory">履歴画像を削除</system:String>
+    <system:String x:Key="PeepCaptureCleanSkippedActive">現在の画像は削除されません。必要な場合は Peep を停止してから再度削除してください。</system:String>
+    <system:String x:Key="PeepCaptureCleanSucceeded">{0} 個の Peep キャプチャフォルダーを削除しました。</system:String>
+    <system:String x:Key="PeepCaptureCleanFailed">Peep キャプチャ履歴の削除に失敗しました。</system:String>
+    <system:String x:Key="PeepCaptureSaveFailed">Peep キャプチャ画像の保存に失敗しました。</system:String>
     <!--  !Peep  -->
     <!--  小游戏  -->
     <system:String x:Key="MiniGameName">ミニゲーム名</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -932,6 +932,16 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="Peep">모니터링</system:String>
     <system:String x:Key="PeepTip">팔라스의 눈에 비친 세상을 보시겠어요?</system:String>
     <system:String x:Key="PeepTargetFps">목표 프레임 속도</system:String>
+    <system:String x:Key="PeepCaptureSaveEnabled">캡처 이미지 저장</system:String>
+    <system:String x:Key="PeepCaptureSaveFrequency">저장 빈도</system:String>
+    <system:String x:Key="PeepCaptureSaveTip">활성화하면 캡처 화면이 애플리케이션 폴더의 peep/&lt;timestamp&gt;/에 저장됩니다. 디스크 사용량을 줄이기 위해 앱을 시작할 때마다 기본적으로 꺼져 있습니다.</system:String>
+    <system:String x:Key="PeepCaptureSaveWarning">이 기능을 활성화하면 디스크 공간이 빠르게 소모될 수 있습니다. 저장 빈도를 적절히 설정하고 제때 정리해 주세요!</system:String>
+    <system:String x:Key="PeepCaptureSaveWarningPath">스크린샷은 애플리케이션 폴더의 peep/&lt;timestamp&gt;/에 저장됩니다.</system:String>
+    <system:String x:Key="PeepCaptureCleanHistory">기록 이미지 정리</system:String>
+    <system:String x:Key="PeepCaptureCleanSkippedActive">현재 이미지가 정리되지 않습니다. 필요한 경우 Peep을 중지한 뒤 다시 정리하세요.</system:String>
+    <system:String x:Key="PeepCaptureCleanSucceeded">Peep 캡처 폴더 {0}개를 정리했습니다.</system:String>
+    <system:String x:Key="PeepCaptureCleanFailed">Peep 캡처 기록 정리에 실패했습니다.</system:String>
+    <system:String x:Key="PeepCaptureSaveFailed">Peep 캡처 이미지 저장에 실패했습니다.</system:String>
     <!--  !Peep  -->
     <!--  미니게임  -->
     <system:String x:Key="MiniGameName">미니게임 이름</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -931,6 +931,16 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="Peep">牛牛监控</system:String>
     <system:String x:Key="PeepTip">看看牛牛眼中的世界？</system:String>
     <system:String x:Key="PeepTargetFps">目标帧率</system:String>
+    <system:String x:Key="PeepCaptureSaveEnabled">保存捕捉图像</system:String>
+    <system:String x:Key="PeepCaptureSaveFrequency">保存频率</system:String>
+    <system:String x:Key="PeepCaptureSaveTip">开启后将自动保存捕捉画面至应用目录下的 peep/&lt;时间戳&gt;/。为降低磁盘占用风险，每次启动应用时默认关闭。</system:String>
+    <system:String x:Key="PeepCaptureSaveWarning">启用此功能可能导致磁盘空间快速消耗，请合理设置保存频率并及时清理！</system:String>
+    <system:String x:Key="PeepCaptureSaveWarningPath">截图将保存至应用目录下的 peep/&lt;时间戳&gt;/。</system:String>
+    <system:String x:Key="PeepCaptureCleanHistory">清理历史图片</system:String>
+    <system:String x:Key="PeepCaptureCleanSkippedActive">当次图片不会被清理，如有需要请在停止后再次清理。</system:String>
+    <system:String x:Key="PeepCaptureCleanSucceeded">已清理 {0} 个牛牛监控历史图片文件夹。</system:String>
+    <system:String x:Key="PeepCaptureCleanFailed">清理牛牛监控历史图片失败。</system:String>
+    <system:String x:Key="PeepCaptureSaveFailed">保存牛牛监控捕捉图像失败。</system:String>
     <!--  !牛牛监控  -->
     <!--  小游戏  -->
     <system:String x:Key="MiniGameName">小游戏名称</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -931,6 +931,16 @@ C:\\leidian\\LDPlayer9\n
     <system:String x:Key="Peep">牛牛監控</system:String>
     <system:String x:Key="PeepTip">看看牛牛眼中的世界？</system:String>
     <system:String x:Key="PeepTargetFps">目標影格率 (FPS)</system:String>
+    <system:String x:Key="PeepCaptureSaveEnabled">儲存擷取圖像</system:String>
+    <system:String x:Key="PeepCaptureSaveFrequency">儲存頻率</system:String>
+    <system:String x:Key="PeepCaptureSaveTip">開啟後將自動儲存擷取畫面至應用程式目錄下的 peep/&lt;時間戳&gt;/。為降低磁碟佔用風險，每次啟動應用程式時預設關閉。</system:String>
+    <system:String x:Key="PeepCaptureSaveWarning">啟用此功能可能導致磁碟空間快速消耗，請合理設定儲存頻率並及時清理！</system:String>
+    <system:String x:Key="PeepCaptureSaveWarningPath">截圖將儲存至應用程式目錄下的 peep/&lt;時間戳&gt;/。</system:String>
+    <system:String x:Key="PeepCaptureCleanHistory">清理歷史圖片</system:String>
+    <system:String x:Key="PeepCaptureCleanSkippedActive">本次圖片不會被清理，如有需要請停止後再次清理。</system:String>
+    <system:String x:Key="PeepCaptureCleanSucceeded">已清理 {0} 個牛牛監控歷史圖片資料夾。</system:String>
+    <system:String x:Key="PeepCaptureCleanFailed">清理牛牛監控歷史圖片失敗。</system:String>
+    <system:String x:Key="PeepCaptureSaveFailed">儲存牛牛監控擷取圖像失敗。</system:String>
     <!--  !牛牛監控  -->
     <!--  小遊戲  -->
     <system:String x:Key="MiniGameName">小遊戲名稱</system:String>

--- a/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
@@ -17,11 +17,13 @@ using System.Buffers;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Documents;
+using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Threading;
 using HandyControl.Controls;
@@ -48,6 +50,9 @@ namespace MaaWpfGui.ViewModels.UI;
 /// </summary>
 public class ToolboxViewModel : Screen
 {
+    private const string PeepCaptureRootDirectoryName = "peep";
+    private const string PeepCaptureTimestampFormat = "yyyyMMdd_HHmmss_fff";
+
     private readonly RunningState _runningState;
     private static readonly ILogger _logger = Log.ForContext<ToolboxViewModel>();
 
@@ -71,6 +76,7 @@ public class ToolboxViewModel : Screen
         };
         _peepImageTimer.Elapsed += PeepImageTimerElapsed;
         _peepImageTimer.Interval = 1000d / PeepTargetFps;
+        PeepCaptureSaveFrequency = _peepCaptureSaveFrequency;
         _gachaTimer.Tick += RefreshGachaTip;
         LoadDepotDetails();
         LoadOperBoxDetails();
@@ -1525,7 +1531,7 @@ public class ToolboxViewModel : Screen
 
         RefreshGachaTip(null, null);
         IsGachaInProgress = true;
-        _ = Peep();
+        _ = Peep(allowCaptureSaving: false);
     }
 
     private void RefreshGachaTip(object? sender, EventArgs? e)
@@ -1656,9 +1662,92 @@ public class ToolboxViewModel : Screen
                 _ => value,
             };
 
-            SetAndNotify(ref _peepTargetFps, value);
+            if (!SetAndNotify(ref _peepTargetFps, value))
+            {
+                return;
+            }
+
             _peepImageTimer.Interval = 1000d / _peepTargetFps;
             ConfigurationHelper.SetValue(ConfigurationKeys.PeepTargetFps, value.ToString());
+            NotifyOfPropertyChange(nameof(PeepCaptureSaveFrequencyMaximum));
+            PeepCaptureSaveFrequency = Math.Min(PeepCaptureSaveFrequency, PeepCaptureSaveFrequencyMaximum);
+        }
+    }
+
+    private bool _peepCaptureSaveEnabled;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to save screenshots captured during Peep.
+    /// </summary>
+    public bool PeepCaptureSaveEnabled
+    {
+        get => _peepCaptureSaveEnabled;
+        set {
+            if (value == _peepCaptureSaveEnabled)
+            {
+                return;
+            }
+
+            if (value && !ConfirmPeepCaptureSaveEnabled())
+            {
+                NotifyOfPropertyChange(nameof(PeepCaptureSaveEnabled));
+                return;
+            }
+
+            if (!SetAndNotify(ref _peepCaptureSaveEnabled, value))
+            {
+                return;
+            }
+
+            if (value)
+            {
+                if (Peeping && !IsGachaInProgress)
+                {
+                    StartPeepCaptureSession(allowCaptureSaving: true);
+                }
+            }
+            else
+            {
+                StopPeepCaptureSession();
+            }
+        }
+    }
+
+    private bool ConfirmPeepCaptureSaveEnabled()
+    {
+        var message = LocalizationHelper.GetString("PeepCaptureSaveWarning")
+            + Environment.NewLine
+            + Environment.NewLine
+            + LocalizationHelper.GetString("PeepCaptureSaveWarningPath");
+
+        // Keep this reverse mapping consistent with GachaAgreeDisclaimer and AllowUseStoneSave warnings.
+        var result = MessageBoxHelper.Show(
+            message,
+            LocalizationHelper.GetString("Warning"),
+            MessageBoxButton.YesNo,
+            MessageBoxImage.Warning,
+            no: LocalizationHelper.GetString("Confirm"),
+            yes: LocalizationHelper.GetString("Cancel"),
+            iconBrushKey: "DangerBrush");
+
+        return result == MessageBoxResult.No;
+    }
+
+    public int PeepCaptureSaveFrequencyMaximum => Math.Max(1, PeepTargetFps);
+
+    private int _peepCaptureSaveFrequency = int.Parse(ConfigurationHelper.GetValue(ConfigurationKeys.PeepCaptureSaveFrequency, "1"));
+
+    public int PeepCaptureSaveFrequency
+    {
+        get => _peepCaptureSaveFrequency;
+        set {
+            value = Math.Clamp(value, 1, PeepCaptureSaveFrequencyMaximum);
+            if (!SetAndNotify(ref _peepCaptureSaveFrequency, value))
+            {
+                return;
+            }
+
+            ConfigurationHelper.SetValue(ConfigurationKeys.PeepCaptureSaveFrequency, value.ToString());
         }
     }
 
@@ -1675,6 +1764,13 @@ public class ToolboxViewModel : Screen
     private const int PeepImageSemaphoreMaxCount = 5;
     private static int _peepImageSemaphoreFailCount = 0;
     private static readonly SemaphoreSlim _peepImageSemaphore = new(_peepImageSemaphoreCurrentCount, PeepImageSemaphoreMaxCount);
+
+    private readonly SemaphoreSlim _peepCaptureSaveSemaphore = new(1, 1);
+    private string? _peepCaptureSessionDir;
+    private string? _peepCaptureRecentSessionDir;
+    private DateTime _lastPeepCaptureSaveTime = DateTime.MinValue;
+    private long _peepCaptureSavedCount;
+    private bool _peepCaptureSaveFailureNotified;
 
     private async void PeepImageTimerElapsed(object? sender, EventArgs? e)
     {
@@ -1741,6 +1837,8 @@ public class ToolboxViewModel : Screen
                 _peepImageCache[index] = AsstProxy.WriteBgrToBitmap(frameData, _peepImageCache[index]);
             });
 
+            TryQueuePeepCaptureSave(frameData);
+
             PeepImage = _peepImageCache[index];
             ArrayPool<byte>.Shared.Return(frameData);
             Interlocked.Exchange(ref _peepImageNewestCount, count);
@@ -1764,6 +1862,273 @@ public class ToolboxViewModel : Screen
         }
     }
 
+    /// <summary>
+    /// 为牛牛监控页的 Peep 功能启动一个新的截图保存会话
+    /// </summary>
+    /// <param name="allowCaptureSaving">是否允许保存截图（会检查 PeepCaptureSaveEnabled）</param>
+    private void StartPeepCaptureSession(bool allowCaptureSaving)
+    {
+        if (!allowCaptureSaving || !PeepCaptureSaveEnabled)
+        {
+            StopPeepCaptureSession();
+            return;
+        }
+
+        if (!string.IsNullOrEmpty(_peepCaptureSessionDir))
+        {
+            return;
+        }
+
+        _peepCaptureSaveFailureNotified = false;
+
+        try
+        {
+            var rootDir = GetPeepCaptureRootDir();
+            var sessionDir = Path.Combine(rootDir, DateTime.Now.ToString(PeepCaptureTimestampFormat, CultureInfo.InvariantCulture));
+            Directory.CreateDirectory(sessionDir);
+            _peepCaptureSessionDir = sessionDir;
+            _peepCaptureRecentSessionDir = null;
+            _lastPeepCaptureSaveTime = DateTime.MinValue;
+            Interlocked.Exchange(ref _peepCaptureSavedCount, 0);
+        }
+        catch (Exception ex)
+        {
+            _logger.Warning(ex, "Failed to start Peep capture save session.");
+            Growl.Warning(LocalizationHelper.GetString("PeepCaptureSaveFailed"));
+        }
+    }
+
+    /// <summary>
+    /// 停止 Peep 截图保存会话并重置相关状态
+    /// </summary>
+    private void StopPeepCaptureSession()
+    {
+        if (!string.IsNullOrEmpty(_peepCaptureSessionDir))
+        {
+            _peepCaptureRecentSessionDir = _peepCaptureSessionDir;
+        }
+
+        _peepCaptureSessionDir = null;
+        _lastPeepCaptureSaveTime = DateTime.MinValue;
+        Interlocked.Exchange(ref _peepCaptureSavedCount, 0);
+    }
+
+    /// <summary>
+    /// 尝试将当前帧数据加入截图保存队列
+    /// </summary>
+    /// <param name="frameData">当前帧数据</param>
+    private void TryQueuePeepCaptureSave(byte[] frameData)
+    {
+        var sessionDir = _peepCaptureSessionDir;
+        if (!PeepCaptureSaveEnabled || string.IsNullOrEmpty(sessionDir))
+        {
+            return;
+        }
+
+        var now = DateTime.UtcNow;
+        var interval = TimeSpan.FromSeconds(1d / Math.Max(1, PeepCaptureSaveFrequency));
+        if (now - _lastPeepCaptureSaveTime < interval)
+        {
+            return;
+        }
+
+        if (!_peepCaptureSaveSemaphore.Wait(0))
+        {
+            return;
+        }
+
+        const int FrameSize = AsstProxy.ScreencapWidth * AsstProxy.ScreencapHeight * AsstProxy.ScreencapChannels;
+        if (frameData.Length < FrameSize)
+        {
+            _peepCaptureSaveSemaphore.Release();
+            _logger.Warning("Peep capture frame data is too small to save: {Size}", frameData.Length);
+            return;
+        }
+
+        _lastPeepCaptureSaveTime = now;
+        var snapshot = ArrayPool<byte>.Shared.Rent(FrameSize);
+        Buffer.BlockCopy(frameData, 0, snapshot, 0, FrameSize);
+        var sequence = Interlocked.Increment(ref _peepCaptureSavedCount);
+        _ = Task.Run(() => SavePeepCaptureImage(sessionDir, snapshot, sequence, now));
+    }
+
+    /// <summary>
+    /// 将截图数据保存为 PNG 文件
+    /// </summary> <param name="sessionDir">当前截图保存会话的目录</param>
+    /// <param name="bgrData">截图的 BGR 数据</param>
+    /// <param name="sequence">当前截图的序列号</param> <param name="timestampUtc">当前截图的 UTC 时间戳</param>
+    private void SavePeepCaptureImage(string sessionDir, byte[] bgrData, long sequence, DateTime timestampUtc)
+    {
+        try
+        {
+            Directory.CreateDirectory(sessionDir);
+            var timestamp = timestampUtc.ToLocalTime().ToString(PeepCaptureTimestampFormat, CultureInfo.InvariantCulture);
+            var fileName = $"{sequence:D6}_{timestamp}.png";
+            var filePath = Path.Combine(sessionDir, fileName);
+            var bitmap = BitmapSource.Create(
+                AsstProxy.ScreencapWidth,
+                AsstProxy.ScreencapHeight,
+                96,
+                96,
+                PixelFormats.Bgr24,
+                null,
+                bgrData,
+                AsstProxy.ScreencapWidth * AsstProxy.ScreencapChannels);
+            bitmap.Freeze();
+
+            using var stream = new FileStream(filePath, FileMode.CreateNew, FileAccess.Write, FileShare.Read);
+            var encoder = new PngBitmapEncoder();
+            encoder.Frames.Add(BitmapFrame.Create(bitmap));
+            encoder.Save(stream);
+        }
+        catch (Exception ex)
+        {
+            _logger.Warning(ex, "Failed to save Peep capture image.");
+            if (!_peepCaptureSaveFailureNotified)
+            {
+                _peepCaptureSaveFailureNotified = true;
+                _ = Execute.OnUIThreadAsync(() => Growl.Warning(LocalizationHelper.GetString("PeepCaptureSaveFailed")));
+            }
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(bgrData);
+            _peepCaptureSaveSemaphore.Release();
+        }
+    }
+
+    /// <summary>
+    /// 清理 Peep 截图保存历史，保留当前会话（如果有）以避免误删正在保存的截图
+    /// </summary> <returns>Task</returns>
+    public async Task CleanPeepCaptureHistory()
+    {
+        var rootDir = GetPeepCaptureRootDir();
+        var activeSessionDir = Peeping && !string.IsNullOrEmpty(_peepCaptureSessionDir)
+            ? Path.GetFullPath(_peepCaptureSessionDir)
+            : null;
+        var recentSessionDir = !string.IsNullOrEmpty(_peepCaptureRecentSessionDir)
+            ? Path.GetFullPath(_peepCaptureRecentSessionDir)
+            : null;
+
+        try
+        {
+            await _peepCaptureSaveSemaphore.WaitAsync();
+            try
+            {
+                var deletedCount = await Task.Run(() => CleanPeepCaptureHistoryCore(rootDir, activeSessionDir, recentSessionDir));
+                if (activeSessionDir is not null || recentSessionDir is not null)
+                {
+                    Growl.Info(LocalizationHelper.GetString("PeepCaptureCleanSkippedActive"));
+                }
+
+                Growl.Success(LocalizationHelper.GetStringFormat("PeepCaptureCleanSucceeded", deletedCount));
+            }
+            finally
+            {
+                var currentRecentSessionDir = _peepCaptureRecentSessionDir;
+                if (recentSessionDir is not null
+                    && currentRecentSessionDir is not null
+                    && string.Equals(NormalizeDirectoryPath(recentSessionDir), NormalizeDirectoryPath(currentRecentSessionDir), StringComparison.OrdinalIgnoreCase))
+                {
+                    _peepCaptureRecentSessionDir = null;
+                }
+
+                _peepCaptureSaveSemaphore.Release();
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.Warning(ex, "Failed to clean Peep capture history.");
+            Growl.Warning(LocalizationHelper.GetString("PeepCaptureCleanFailed"));
+        }
+    }
+
+    /// <summary>
+    /// 清理 Peep 截图保存历史的核心逻辑，删除 rootDir 下除保留会话以外的所有符合命名格式的子目录
+    /// </summary>
+    /// <param name="rootDir">Peep 截图保存根目录</param>
+    /// <param name="activeSessionDir">当前活跃的截图保存会话目录（如果有且 Peep 正在进行中，否则为 null）</param>
+    /// <param name="recentSessionDir">最近停止的截图保存会话目录（如果有）</param>
+    /// <returns>被删除的目录数量</returns>
+    private static int CleanPeepCaptureHistoryCore(string rootDir, string? activeSessionDir, string? recentSessionDir)
+    {
+        if (!Directory.Exists(rootDir))
+        {
+            return 0;
+        }
+
+        var rootFullPath = NormalizeDirectoryPath(rootDir);
+        var skippedSessionDirs = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (activeSessionDir is not null)
+        {
+            skippedSessionDirs.Add(NormalizeDirectoryPath(activeSessionDir));
+        }
+
+        if (recentSessionDir is not null)
+        {
+            skippedSessionDirs.Add(NormalizeDirectoryPath(recentSessionDir));
+        }
+
+        var deletedCount = 0;
+        var failures = new List<Exception>();
+        foreach (var dir in Directory.EnumerateDirectories(rootFullPath))
+        {
+            var fullPath = NormalizeDirectoryPath(dir);
+            if (!IsPathUnderDirectory(fullPath, rootFullPath) || skippedSessionDirs.Contains(fullPath))
+            {
+                continue;
+            }
+
+            var dirName = Path.GetFileName(fullPath.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar));
+            if (!DateTime.TryParseExact(dirName, PeepCaptureTimestampFormat, CultureInfo.InvariantCulture, DateTimeStyles.None, out _))
+            {
+                continue;
+            }
+
+            try
+            {
+                Directory.Delete(fullPath, recursive: true);
+                deletedCount++;
+            }
+            catch (Exception ex)
+            {
+                failures.Add(new IOException($"Failed to delete Peep capture directory: {fullPath}", ex));
+            }
+        }
+
+        if (failures.Count > 0)
+        {
+            throw new AggregateException("Failed to delete one or more Peep capture directories.", failures);
+        }
+
+        return deletedCount;
+    }
+
+    /// <summary>
+    /// 获取 Peep 截图保存根目录
+    /// </summary>
+    /// <returns>Peep 截图保存根目录的完整路径</returns>
+    private static string GetPeepCaptureRootDir()
+    {
+        return Path.Combine(PathsHelper.BaseDir, PeepCaptureRootDirectoryName);
+    }
+
+    /// <summary>
+    /// 规范目录路径，确保路径以目录分隔符结尾，并转换为绝对路径
+    /// </summary> <param name="path">要规范化的目录路径</param>
+    private static string NormalizeDirectoryPath(string path)
+    {
+        return Path.GetFullPath(path).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar) + Path.DirectorySeparatorChar;
+    }
+
+    // 判断路径是否在指定目录下，比较时会规范化路径并忽略大小写
+    private static bool IsPathUnderDirectory(string path, string directory)
+    {
+        var normalizedPath = NormalizeDirectoryPath(path);
+        var normalizedDirectory = NormalizeDirectoryPath(directory);
+        return normalizedPath.StartsWith(normalizedDirectory, StringComparison.OrdinalIgnoreCase);
+    }
+
     private bool _isPeepTransitioning;
 
     public bool IsPeepTransitioning
@@ -1777,6 +2142,19 @@ public class ToolboxViewModel : Screen
     /// </summary>
     /// <returns>Task</returns>
     public async Task Peep()
+    {
+        await Peep(allowCaptureSaving: true);
+    }
+
+    [UsedImplicitly]
+
+    // 专为抽卡界面使用的 Peep 方法，不保存截图
+    public async Task GachaPeep()
+    {
+        await Peep(allowCaptureSaving: false);
+    }
+
+    private async Task Peep(bool allowCaptureSaving)
     {
         if (IsPeepTransitioning)
         {
@@ -1792,6 +2170,7 @@ public class ToolboxViewModel : Screen
             {
                 Peeping = false;
                 _peepImageTimer.Stop();
+                StopPeepCaptureSession();
                 Array.Fill(_peepImageCache, null);
 
                 // 由 Peep() 方法启动的 Peep 也需要停止，Block 不会自动停止
@@ -1827,6 +2206,7 @@ public class ToolboxViewModel : Screen
                 IsPeepInProgress = true;
             }
 
+            StartPeepCaptureSession(allowCaptureSaving);
             PeepScreenFpf = 0;
             _peepImageCount = 0;
             _peepImageNewestCount = 0;

--- a/src/MaaWpfGui/Views/UI/ToolboxView.xaml
+++ b/src/MaaWpfGui/Views/UI/ToolboxView.xaml
@@ -677,7 +677,7 @@
                         Width="180"
                         Height="70"
                         Margin="10"
-                        Command="{s:Action Peep}"
+                        Command="{s:Action GachaPeep}"
                         Content="{c:Binding '!Peeping ? &quot;Peep!&quot; : (IsGachaInProgress ? &quot;Stop!!!!!&quot; : &quot;Stop!&quot;)'}"
                         FontSize="16"
                         IsEnabled="{c:Binding '!IsPeepTransitioning and Inited'}" />
@@ -752,6 +752,32 @@
                         Maximum="600"
                         Minimum="1"
                         Value="{Binding PeepTargetFps, UpdateSourceTrigger=PropertyChanged}" />
+                    <CheckBox
+                        Margin="10"
+                        VerticalAlignment="Center"
+                        IsChecked="{Binding PeepCaptureSaveEnabled}"
+                        ToolTip="{DynamicResource PeepCaptureSaveTip}">
+                        <TextBlock Text="{DynamicResource PeepCaptureSaveEnabled}" TextWrapping="Wrap" />
+                    </CheckBox>
+                    <hc:NumericUpDown
+                        MinWidth="50"
+                        VerticalAlignment="Center"
+                        HorizontalContentAlignment="Center"
+                        d:Value="1"
+                        hc:TitleElement.HorizontalAlignment="Center"
+                        hc:TitleElement.Title="{DynamicResource PeepCaptureSaveFrequency}"
+                        hc:TitleElement.TitlePlacement="Top"
+                        IsEnabled="{Binding PeepCaptureSaveEnabled}"
+                        Maximum="{Binding PeepCaptureSaveFrequencyMaximum}"
+                        Minimum="1"
+                        Value="{Binding PeepCaptureSaveFrequency, UpdateSourceTrigger=PropertyChanged}" />
+                    <Button
+                        Width="150"
+                        Height="70"
+                        Margin="10"
+                        Command="{s:Action CleanPeepCaptureHistory}"
+                        Content="{DynamicResource PeepCaptureCleanHistory}"
+                        FontSize="16" />
                 </StackPanel>
             </Grid>
         </TabItem>


### PR DESCRIPTION
### 改动 
1. 为“牛牛监控”新增保存截图的选项，支持保存频率调节（不超过目标帧率）。默认保存在根目录的peep/<保存开始时间戳>下，并添加一键清空已保存截图的按钮。 
3. 将“牛牛抽卡”中的 Peep 独立出来，默认不开启截图保存，不受监控页的选项调节。

## Summary by Sourcery

为 Peep 监控新增可配置的截图保存功能，并将其与扭蛋场景中的 Peep 使用分离。

New Features:
- 引入可选的 Peep 截图保存模式，并提供与监控功能绑定的可调保存频率。
- 将 Peep 截图保存频率持久化到配置中，并将截图保存到带时间戳的 peep 目录下。
- 新增一键操作，用于清除历史 Peep 截图记录，同时在有活动会话时保留当前会话的截图。

Enhancements:
- 在更新 Peep 目标 FPS 时，确保对最大截图保存频率进行约束并保持同步。
- 将扭蛋场景中的 Peep 使用与监控 Peep 分离，使扭蛋运行时不会触发截图保存。
- 新增本地化 UI 文本和控制项，用于在各支持语言中配置 Peep 截图保存、保存频率以及清理行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable screenshot saving for Peep monitoring and separate it from gacha Peep usage.

New Features:
- Introduce an optional Peep screenshot saving mode with adjustable save frequency tied to the monitoring feature.
- Persist Peep capture save frequency in configuration and store captures under a timestamped peep directory.
- Add a one-click action to clear historical Peep screenshot captures while preserving the current session if active.

Enhancements:
- Ensure Peep target FPS updates constrain and synchronize the maximum screenshot save frequency.
- Separate gacha Peep usage from monitoring Peep so gacha runs without triggering screenshot saving.
- Add localized UI text and controls to configure Peep capture saving, frequency, and cleanup across supported languages.

</details>