### PR TITLE
fix(wpf): 远程控制启动任务未记录开始时间

### DIFF
--- a/src/MaaWpfGui/Services/RemoteControl/RemoteControlService.cs
+++ b/src/MaaWpfGui/Services/RemoteControl/RemoteControlService.cs
@@ -732,6 +732,7 @@ public class RemoteControlService
             if (taskRet)
             {
                 Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("Running"));
+                Instances.AsstProxy.StartTaskTime = DateTimeOffset.Now;
             }
             else
             {


### PR DESCRIPTION
## 摘要

修复远程控制运行时完成弹窗的时长显示不正确的问题。

正常的 GUI 启动路径在 `AsstStart()` 成功后，会刷新 `AsstProxy.StartTaskTime`，但远程控制的 `LinkStart()` 路径没有。因此，完成弹窗可能会复用已过时的时间戳，并显示出类似 `16h` 这样不正确的时长。

## 修改内容

在以下文件中，于 `AsstStart()` 成功执行的分支里，添加 `Instances.AsstProxy.StartTaskTime = DateTimeOffset.Now;`：

`src/MaaWpfGui/Services/RemoteControl/RemoteControlService.cs`

## 相关 issue

关闭 #16518

## Summary by Sourcery

Bug Fixes:
- 通过在远程控制的任务开始运行时设置 `StartTaskTime`，纠正完成弹出窗口的持续时间。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct completion popup duration by setting StartTaskTime when remote-controlled tasks start running.

</details>