### PR TITLE
feat:SendMsg在WindowPos输入下保留窗口原始位置，任务结束时恢复

### DIFF
--- a/src/MaaCore/Assistant.cpp
+++ b/src/MaaCore/Assistant.cpp
@@ -502,6 +502,7 @@ void Assistant::working_proc()
             m_thread_idle = true;
             m_running = false;
             Log.flush();
+            m_ctrler->inactive();
             m_condvar.wait(lock);
             continue;
         }

--- a/src/MaaCore/Controller/Controller.cpp
+++ b/src/MaaCore/Controller/Controller.cpp
@@ -126,6 +126,12 @@ bool asst::Controller::back_to_home()
     m_controller->back_to_home();
     return true;
 }
+bool asst::Controller::inactive()
+{
+    CHECK_EXIST(m_controller, false);
+    return m_controller ? m_controller->inactive() : false;
+}
+
 
 cv::Mat asst::Controller::get_resized_image_cache() const
 {

--- a/src/MaaCore/Controller/Controller.h
+++ b/src/MaaCore/Controller/Controller.h
@@ -97,6 +97,8 @@ public:
     bool press_esc();
     ControlFeat::Feat support_features();
 
+    bool inactive();
+
     std::pair<int, int> get_scale_size() const noexcept;
 
     Controller& operator=(const Controller&) = delete;

--- a/src/MaaCore/Controller/ControllerAPI.h
+++ b/src/MaaCore/Controller/ControllerAPI.h
@@ -69,6 +69,7 @@ public:
     ControllerAPI& operator=(ControllerAPI&&) = delete;
 
     virtual void back_to_home() noexcept {}
+    virtual bool inactive() { return true; }
 };
 
 struct InputEvent

--- a/src/MaaCore/Controller/MaaFwControlUnitInterface.h
+++ b/src/MaaCore/Controller/MaaFwControlUnitInterface.h
@@ -39,6 +39,7 @@ public:
     virtual bool key_down(int key) = 0;
     virtual bool key_up(int key) = 0;
 
+    virtual bool inactive() = 0;
     virtual bool scroll(int dx, int dy) = 0;
 };
 

--- a/src/MaaCore/Controller/Win32Controller.cpp
+++ b/src/MaaCore/Controller/Win32Controller.cpp
@@ -343,6 +343,13 @@ ControlFeat::Feat Win32Controller::support_features() const noexcept
     return ControlFeat::PRECISE_SWIPE;
 }
 
+bool Win32Controller::inactive()
+{
+    LogTraceFunction;
+    auto* unit = static_cast<MaaFwControlUnitAPI*>(m_unit_handle);
+    return unit ? unit->inactive() : false;
+}
+
 std::pair<int, int> Win32Controller::get_screen_res() const noexcept
 {
     return m_screen_size;

--- a/src/MaaCore/Controller/Win32Controller.h
+++ b/src/MaaCore/Controller/Win32Controller.h
@@ -63,6 +63,7 @@ public: // ControllerAPI 接口
     virtual bool inject_input_event(const InputEvent& event) override;
 
     virtual bool press_esc() override;
+    virtual bool inactive() override;
     virtual ControlFeat::Feat support_features() const noexcept override;
 
     virtual std::pair<int, int> get_screen_res() const noexcept override;


### PR DESCRIPTION
### 改动
新增inactive()调用链，使Assistant::working_proc在全部任务完成或手动停止时，能够触发控制器的窗口位置恢复，避免窗口标题栏在任务结束后处于鼠标点击不到的位置  

### 关联MAAfw PR
[feat:将window_pos_saved_标记清除延迟到inactive()](https://github.com/MaaXYZ/MaaFramework/pull/1316)

## Summary by Sourcery

为控制器添加一个非活动（inactivity）钩子，并在助手完成所有任务后调用它，以在工作完成后恢复窗口状态。

新功能：
- 引入 `Controller::inactive` 方法及对应的虚拟 API，用于标识控制器处于非活动状态。
- 扩展 Win32 控制器和 Maa 框架控制单元接口，以从底层控制单元实现新的非活动回调。

改进：
- 当所有任务完成或被手动停止时，从 `Assistant::working_proc` 触发控制器的非活动处理程序，以恢复窗口位置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add an inactivity hook to controllers and invoke it when the assistant finishes all tasks to restore window state after work completion.

New Features:
- Introduce a Controller::inactive method and corresponding virtual API to signal controller inactivity.
- Extend the Win32 controller and Maa framework control unit interface to implement the new inactivity callback from the underlying control unit.

Enhancements:
- Trigger the controller inactivity handler from Assistant::working_proc when all tasks are completed or manually stopped to restore the window position.

</details>