### PR TITLE
feat: 点击成就横幅跳转至成就设置，自动打开成就列表并筛选对应成就

### DIFF
--- a/src/MaaWpfGui/Helper/AchievementTrackerHelper.cs
+++ b/src/MaaWpfGui/Helper/AchievementTrackerHelper.cs
@@ -107,9 +107,28 @@ public class AchievementTrackerHelper : PropertyChangedBase
 
     public ICommand SearchCmd { get; }
 
+    private string _searchText = string.Empty;
+
+    public string SearchText
+    {
+        get => _searchText;
+        set => SetAndNotify(ref _searchText, value ?? string.Empty);
+    }
+
+    public void SearchAndSyncText(string text = "")
+    {
+        SearchText = text.Trim();
+        Search(SearchText);
+    }
+
     public void Search(string text = "")
     {
         text = text.Trim();
+        if (!string.Equals(SearchText, text, StringComparison.Ordinal))
+        {
+            SearchText = text;
+        }
+
         if (string.IsNullOrWhiteSpace(text))
         {
             foreach (var achievement in Achievements)
@@ -119,9 +138,14 @@ public class AchievementTrackerHelper : PropertyChangedBase
         }
         else
         {
-            foreach (var (_, value) in Achievements)
+            foreach (var (key, value) in Achievements)
             {
-                value.IsVisibleInSearch = value.Title.Contains(text) || value.Description.Contains(text) || value.Conditions.Contains(text) || value.ReleasePhaseTag.Contains(text);
+                value.IsVisibleInSearch =
+                    key == text ||
+                    value.Title.Contains(text) ||
+                    value.Description.Contains(text) ||
+                    value.Conditions.Contains(text) ||
+                    value.ReleasePhaseTag.Contains(text);
             }
         }
 
@@ -301,39 +325,96 @@ public class AchievementTrackerHelper : PropertyChangedBase
                 return;
             }
 
+            var previousItems = Growl.GrowlPanel?.Children.OfType<UIElement>().ToHashSet() ?? [];
             Growl.Info(info);
-            AttachGrowlClickHandler(info);
+            AttachGrowlClickHandler(info, previousItems);
         });
     }
 
-    private static void AttachGrowlClickHandler(GrowlInfo info)
+    private static void AttachGrowlClickHandler(GrowlInfo info, HashSet<UIElement> previousItems)
     {
-        if (_growlAchievementMap.TryGetValue(info, out var id) &&
-            Growl.GrowlPanel is { } panel && panel.Children.Count > 0)
+        if (!_growlAchievementMap.TryGetValue(info, out var id))
         {
-            var growlItem = panel.Children[panel.Children.Count - 1] as UIElement;
-            if (growlItem != null)
+            return;
+        }
+
+        bool TryAttachToNewItems()
+        {
+            if (Growl.GrowlPanel is not { } panel)
             {
+                return false;
+            }
+
+            bool attached = false;
+            foreach (var growlItem in panel.Children.OfType<UIElement>().Where(item => !previousItems.Contains(item)))
+            {
+                growlItem.RemoveHandler(UIElement.PreviewMouseLeftButtonDownEvent, new MouseButtonEventHandler(OnGrowlItemMouseDown));
                 growlItem.AddHandler(
                     UIElement.PreviewMouseLeftButtonDownEvent,
-                    new MouseButtonEventHandler((_, e) =>
-                    {
-                        var source = e.OriginalSource as DependencyObject;
-                        while (source != null && source != growlItem)
-                        {
-                            if (source is Button)
-                            {
-                                return;
-                            }
-
-                            source = VisualTreeHelper.GetParent(source);
-                        }
-
-                        _growlAchievementMap.Remove(info);
-                        NavigateToAchievement(id);
-                    }),
+                    new MouseButtonEventHandler(OnGrowlItemMouseDown),
                     handledEventsToo: true);
+
+                if (growlItem is FrameworkElement element)
+                {
+                    element.Tag = id;
+                    element.Unloaded -= OnGrowlItemUnloaded;
+                    element.Unloaded += OnGrowlItemUnloaded;
+                }
+
+                attached = true;
             }
+
+            if (attached)
+            {
+                _growlAchievementMap.Remove(info);
+            }
+
+            return attached;
+        }
+
+        if (!TryAttachToNewItems())
+        {
+            Application.Current.Dispatcher.BeginInvoke(
+                DispatcherPriority.Loaded,
+                new Action(() => TryAttachToNewItems()));
+        }
+    }
+
+    private static void OnGrowlItemUnloaded(object sender, RoutedEventArgs e)
+    {
+        if (sender is UIElement growlItem)
+        {
+            growlItem.RemoveHandler(UIElement.PreviewMouseLeftButtonDownEvent, new MouseButtonEventHandler(OnGrowlItemMouseDown));
+        }
+
+        if (sender is FrameworkElement element)
+        {
+            element.Tag = null;
+            element.Unloaded -= OnGrowlItemUnloaded;
+        }
+    }
+
+    private static void OnGrowlItemMouseDown(object sender, MouseButtonEventArgs e)
+    {
+        if (sender is not UIElement growlItem)
+        {
+            return;
+        }
+
+        var source = e.OriginalSource as DependencyObject;
+        while (source != null && source != growlItem)
+        {
+            if (source is Button)
+            {
+                return;
+            }
+
+            source = VisualTreeHelper.GetParent(source);
+        }
+
+        if (sender is FrameworkElement { Tag: string id } && !string.IsNullOrWhiteSpace(id))
+        {
+            NavigateToAchievement(id);
         }
     }
 
@@ -367,8 +448,9 @@ public class AchievementTrackerHelper : PropertyChangedBase
         Execute.OnUIThread(() => {
             foreach (var info in _pending)
             {
+                var previousItems = Growl.GrowlPanel?.Children.OfType<UIElement>().ToHashSet() ?? [];
                 Growl.Info(info);
-                AttachGrowlClickHandler(info);
+                AttachGrowlClickHandler(info, previousItems);
             }
 
             _pending.Clear();

--- a/src/MaaWpfGui/Helper/AchievementTrackerHelper.cs
+++ b/src/MaaWpfGui/Helper/AchievementTrackerHelper.cs
@@ -16,6 +16,10 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media;
+using System.Windows.Threading;
 using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Input;
@@ -223,6 +227,7 @@ public class AchievementTrackerHelper : PropertyChangedBase
             IconKey = "HangoverGeometry",
             IconBrushKey = achievement.MedalBrushKey,
         };
+        _growlAchievementMap[growlInfo] = id;
         ShowInfo(growlInfo, forceStayOpen: forceStayOpen);
     }
 
@@ -276,6 +281,8 @@ public class AchievementTrackerHelper : PropertyChangedBase
         Save();
     }
 
+    private static readonly Dictionary<GrowlInfo, string> _growlAchievementMap = [];
+
     private static readonly List<GrowlInfo> _pending = [];
 
     public static void ShowInfo(GrowlInfo info, bool forceStayOpen = false)
@@ -295,7 +302,64 @@ public class AchievementTrackerHelper : PropertyChangedBase
             }
 
             Growl.Info(info);
+            AttachGrowlClickHandler(info);
         });
+    }
+
+    private static void AttachGrowlClickHandler(GrowlInfo info)
+    {
+        if (_growlAchievementMap.TryGetValue(info, out var id) &&
+            Growl.GrowlPanel is { } panel && panel.Children.Count > 0)
+        {
+            var growlItem = panel.Children[panel.Children.Count - 1] as UIElement;
+            if (growlItem != null)
+            {
+                growlItem.AddHandler(
+                    UIElement.PreviewMouseLeftButtonDownEvent,
+                    new MouseButtonEventHandler((_, e) =>
+                    {
+                        var source = e.OriginalSource as DependencyObject;
+                        while (source != null && source != growlItem)
+                        {
+                            if (source is Button)
+                            {
+                                return;
+                            }
+
+                            source = VisualTreeHelper.GetParent(source);
+                        }
+
+                        _growlAchievementMap.Remove(info);
+                        NavigateToAchievement(id);
+                    }),
+                    handledEventsToo: true);
+            }
+        }
+    }
+
+    public static void NavigateToAchievement(string id)
+    {
+        if (Instances.SettingsViewModel.Parent is IHaveActiveItem<Screen> conductor)
+        {
+            conductor.ActiveItem = Instances.SettingsViewModel;
+        }
+
+        Application.Current.Dispatcher.BeginInvoke(
+            DispatcherPriority.Loaded,
+            new Action(() =>
+            {
+                var settings = Instances.SettingsViewModel.Settings;
+                for (int i = 0; i < settings.Count; i++)
+                {
+                    if (settings[i].Key == "AchievementSettings")
+                    {
+                        Instances.SettingsViewModel.SelectedIndex = i;
+                        break;
+                    }
+                }
+
+                AchievementSettingsUserControlModel.Instance.OnShowAchievementsClick(id);
+            }));
     }
 
     public static void TryShowPendingGrowls()
@@ -304,6 +368,7 @@ public class AchievementTrackerHelper : PropertyChangedBase
             foreach (var info in _pending)
             {
                 Growl.Info(info);
+                AttachGrowlClickHandler(info);
             }
 
             _pending.Clear();

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/AchievementSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/AchievementSettingsUserControlModel.cs
@@ -110,7 +110,7 @@ public class AchievementSettingsUserControlModel : PropertyChangedBase
 
     private static AchievementListDialogView? _achievementsWindow;
 
-    public void OnShowAchievementsClick(string achievementId = null)
+    public void OnShowAchievementsClick(string? achievementId = null)
     {
         AchievementTrackerHelper.Instance.Unlock(AchievementIds.AchievementObserver);
         if (_achievementsWindow is null)
@@ -128,7 +128,7 @@ public class AchievementSettingsUserControlModel : PropertyChangedBase
 
         if (achievementId != null)
         {
-            _achievementsWindow.ScrollToAchievement(achievementId);
+            AchievementTrackerHelper.Instance.SearchAndSyncText(achievementId);
         }
     }
 

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/AchievementSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/AchievementSettingsUserControlModel.cs
@@ -108,9 +108,9 @@ public class AchievementSettingsUserControlModel : PropertyChangedBase
         }
     }
 
-    private static Window? _achievementsWindow;
+    private static AchievementListDialogView? _achievementsWindow;
 
-    public void OnShowAchievementsClick()
+    public void OnShowAchievementsClick(string achievementId = null)
     {
         AchievementTrackerHelper.Instance.Unlock(AchievementIds.AchievementObserver);
         if (_achievementsWindow is null)
@@ -125,6 +125,11 @@ public class AchievementSettingsUserControlModel : PropertyChangedBase
         }
 
         WindowManager.ShowWindow(_achievementsWindow);
+
+        if (achievementId != null)
+        {
+            _achievementsWindow.ScrollToAchievement(achievementId);
+        }
     }
 
     private int _clickCount = 0;

--- a/src/MaaWpfGui/Views/Dialogs/AchievementListDialogView.xaml
+++ b/src/MaaWpfGui/Views/Dialogs/AchievementListDialogView.xaml
@@ -13,6 +13,7 @@
     Background="{DynamicResource MdXamlBackground}">
     <Grid>
         <ListBox
+            x:Name="AchievementListBox"
             Margin="0,0,10,0"
             Background="{DynamicResource MdXamlBackground}"
             BorderThickness="0"

--- a/src/MaaWpfGui/Views/Dialogs/AchievementListDialogView.xaml
+++ b/src/MaaWpfGui/Views/Dialogs/AchievementListDialogView.xaml
@@ -130,7 +130,8 @@
             VerticalAlignment="Top"
             Background="{DynamicResource MouseOverRegionBrushOpacity75}"
             Command="{Binding SearchCmd, Source={x:Static helper:AchievementTrackerHelper.Instance}}"
-            CommandParameter="{Binding Text, RelativeSource={RelativeSource Self}}"
+            CommandParameter="{Binding SearchText, Source={x:Static helper:AchievementTrackerHelper.Instance}}"
+            Text="{Binding SearchText, Source={x:Static helper:AchievementTrackerHelper.Instance}, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
             IsRealTime="True" />
     </Grid>
 </hc:Window>

--- a/src/MaaWpfGui/Views/Dialogs/AchievementListDialogView.xaml.cs
+++ b/src/MaaWpfGui/Views/Dialogs/AchievementListDialogView.xaml.cs
@@ -12,6 +12,7 @@
 // </copyright>
 
 using System.ComponentModel;
+using System.Windows;
 using MaaWpfGui.Helper;
 
 namespace MaaWpfGui.Views.Dialogs;
@@ -32,5 +33,32 @@ public partial class AchievementListDialogView
     {
         // 关闭窗口时执行一次空搜索，重置可见性
         AchievementTrackerHelper.Instance.Search();
+    }
+
+    public void ScrollToAchievement(string id)
+    {
+        if (!IsLoaded)
+        {
+            Loaded += OnLoadedForScroll;
+            _pendingScrollAchievementId = id;
+            return;
+        }
+
+        if (AchievementTrackerHelper.Instance.VisibleAchievements.TryGetValue(id, out var achievement))
+        {
+            AchievementListBox.ScrollIntoView(achievement);
+        }
+    }
+
+    private string _pendingScrollAchievementId;
+
+    private void OnLoadedForScroll(object sender, RoutedEventArgs e)
+    {
+        Loaded -= OnLoadedForScroll;
+        if (_pendingScrollAchievementId != null)
+        {
+            ScrollToAchievement(_pendingScrollAchievementId);
+            _pendingScrollAchievementId = null;
+        }
     }
 }

--- a/src/MaaWpfGui/Views/Dialogs/AchievementListDialogView.xaml.cs
+++ b/src/MaaWpfGui/Views/Dialogs/AchievementListDialogView.xaml.cs
@@ -12,7 +12,6 @@
 // </copyright>
 
 using System.ComponentModel;
-using System.Windows;
 using MaaWpfGui.Helper;
 
 namespace MaaWpfGui.Views.Dialogs;
@@ -35,30 +34,4 @@ public partial class AchievementListDialogView
         AchievementTrackerHelper.Instance.Search();
     }
 
-    public void ScrollToAchievement(string id)
-    {
-        if (!IsLoaded)
-        {
-            Loaded += OnLoadedForScroll;
-            _pendingScrollAchievementId = id;
-            return;
-        }
-
-        if (AchievementTrackerHelper.Instance.VisibleAchievements.TryGetValue(id, out var achievement))
-        {
-            AchievementListBox.ScrollIntoView(achievement);
-        }
-    }
-
-    private string _pendingScrollAchievementId;
-
-    private void OnLoadedForScroll(object sender, RoutedEventArgs e)
-    {
-        Loaded -= OnLoadedForScroll;
-        if (_pendingScrollAchievementId != null)
-        {
-            ScrollToAchievement(_pendingScrollAchievementId);
-            _pendingScrollAchievementId = null;
-        }
-    }
 }

--- a/src/MaaWpfGui/Views/UI/RootView.xaml
+++ b/src/MaaWpfGui/Views/UI/RootView.xaml
@@ -199,7 +199,7 @@
                     d:Height="200"
                     d:Width="100"
                     VerticalScrollBarVisibility="Hidden">
-                    <StackPanel Margin="0,0,0,5" hc:Growl.GrowlParent="True" />
+                    <StackPanel x:Name="AchievementGrowlPanel" Margin="0,0,0,5" hc:Growl.GrowlParent="True" />
                 </ScrollViewer>
                 <hc:GifImage
                     Width="100"

--- a/src/MaaWpfGui/Views/UI/RootView.xaml.cs
+++ b/src/MaaWpfGui/Views/UI/RootView.xaml.cs
@@ -1,0 +1,22 @@
+// <copyright file="RootView.xaml.cs" company="MaaAssistantArknights">
+// Part of the MaaWpfGui project, maintained by the MaaAssistantArknights team (Maa Team)
+// Copyright (C) 2021-2025 MaaAssistantArknights Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License v3.0 only as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY
+// </copyright>
+
+namespace MaaWpfGui.Views.UI;
+
+public partial class RootView
+{
+    public RootView()
+    {
+        InitializeComponent();
+    }
+}


### PR DESCRIPTION
### 改动
可以通过点击右上角弹出的成就横幅跳转至成就设置，并自动打开成就列表并筛选对应成就

## Summary by Sourcery

为成就通知横幅添加导航功能，可跳转到对应的设置部分和成就列表条目。

New Features:
- 允许点击成就的提示（growl）横幅，以打开成就设置页面，并聚焦到相关成就。
- 使成就列表对话框在打开时或加载完成后，可以直接滚动到指定成就。

Enhancements:
- 跟踪提示（growl）通知，将其与特定成就关联起来，并绑定点击处理程序，同时不影响现有按钮的行为。
- 引入一个 `RootView` 代码隐藏文件，用于初始化根视图组件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add navigation from achievement notification banners to the corresponding settings section and achievement list entry.

New Features:
- Allow clicking achievement growl banners to open the achievement settings page focused on the relevant achievement.
- Enable the achievement list dialog to scroll directly to a specific achievement when opened or once loaded.

Enhancements:
- Track growl notifications to associate them with specific achievements and wire up click handlers without interfering with existing buttons.
- Introduce a RootView code-behind file to initialize the root view component.

</details>