### PR TITLE
feat: 仓库识别支持导出 Markdown/CSV，优化导出按钮布局与交互

### DIFF
--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -879,9 +879,13 @@ Right Click: Select Target Process</system:String>
     <system:String x:Key="LastSyncTime">Last Sync Time</system:String>
     <system:String x:Key="DepotRecognitionTip">This function is still in testing. If you encounter any unexpected results, please zip the ｢debug/depot｣ folder in the installation path and submit an issue on GitHub</system:String>
     <system:String x:Key="StartToDepotRecognition">Start to Identify</system:String>
-    <system:String x:Key="ExportToArkplanner">Export to Arkplanner</system:String>
-    <system:String x:Key="ExportToLolicon">Export to Arkntools</system:String>
+    <system:String x:Key="ExportToArkplanner">Arkplanner</system:String>
+    <system:String x:Key="ExportToLolicon">Arkntools</system:String>
+    <system:String x:Key="ExportToMarkdown">Markdown</system:String>
+    <system:String x:Key="ExportToCsv">CSV</system:String>
     <system:String x:Key="CopiedToClipboard">Copied to Clipboard</system:String>
+    <system:String x:Key="ExportedToFile">Exported to file</system:String>
+    <system:String x:Key="ExportTo">Export to:</system:String>
     <!--  !Depot Recognition  -->
     <!--  Operator Recognition  -->
     <system:String x:Key="OperBoxRecognition">{key=Operator}</system:String>

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -886,6 +886,7 @@ Right Click: Select Target Process</system:String>
     <system:String x:Key="CopiedToClipboard">Copied to Clipboard</system:String>
     <system:String x:Key="ExportedToFile">Exported to file</system:String>
     <system:String x:Key="ExportTo">Export to:</system:String>
+    <system:String x:Key="Export">Export</system:String>
     <!--  !Depot Recognition  -->
     <!--  Operator Recognition  -->
     <system:String x:Key="OperBoxRecognition">{key=Operator}</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -887,6 +887,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="CopiedToClipboard">クリップボードへコピー</system:String>
     <system:String x:Key="ExportedToFile">ファイルにエクスポートしました</system:String>
     <system:String x:Key="ExportTo">出力先：</system:String>
+    <system:String x:Key="Export">エクスポート</system:String>
     <!--  !倉庫アイテム認識  -->
     <!--  Operator Recognition  -->
     <system:String x:Key="OperBoxRecognition">{key=Operator}</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -880,9 +880,13 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="LastSyncTime">前回同期時間</system:String>
     <system:String x:Key="DepotRecognitionTip">この機能はまだテスト版です。エラーが発生/統計情報に問題があれば、debug/depotフォルダを圧縮し、issueを提出してください~</system:String>
     <system:String x:Key="StartToDepotRecognition">認識開始</system:String>
-    <system:String x:Key="ExportToArkplanner">Arkplannerへ出力</system:String>
-    <system:String x:Key="ExportToLolicon">Arkntoolsへ出力</system:String>
+    <system:String x:Key="ExportToArkplanner">Arkplanner</system:String>
+    <system:String x:Key="ExportToLolicon">Arkntools</system:String>
+    <system:String x:Key="ExportToMarkdown">Markdown</system:String>
+    <system:String x:Key="ExportToCsv">CSV</system:String>
     <system:String x:Key="CopiedToClipboard">クリップボードへコピー</system:String>
+    <system:String x:Key="ExportedToFile">ファイルにエクスポートしました</system:String>
+    <system:String x:Key="ExportTo">出力先：</system:String>
     <!--  !倉庫アイテム認識  -->
     <!--  Operator Recognition  -->
     <system:String x:Key="OperBoxRecognition">{key=Operator}</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -888,6 +888,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="CopiedToClipboard">클립보드에 복사됨</system:String>
     <system:String x:Key="ExportedToFile">파일로 내보내기 완료</system:String>
     <system:String x:Key="ExportTo">내보내기:</system:String>
+    <system:String x:Key="Export">내보내기</system:String>
     <!--  !창고 인식  -->
     <!--  오퍼레이터 인식  -->
     <system:String x:Key="OperBoxRecognition">{key=Operator} 인식</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -881,9 +881,13 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="LastSyncTime">마지막 동기화 시간</system:String>
     <system:String x:Key="DepotRecognitionTip">이 기능은 현재 테스트 중입니다. 내보내기 전 인식 결과가 맞는지 확인 후 사용하세요\n만약 오류가 있다면 MAA 경로 내 debug 폴더 안의 depot 폴더 전체를 압축해서 Github의 issue로 올려주세요</system:String>
     <system:String x:Key="StartToDepotRecognition">인식 시작</system:String>
-    <system:String x:Key="ExportToArkplanner">Arkplanner로 내보내기</system:String>
-    <system:String x:Key="ExportToLolicon">Arkntools으로 내보내기</system:String>
+    <system:String x:Key="ExportToArkplanner">Arkplanner</system:String>
+    <system:String x:Key="ExportToLolicon">Arkntools</system:String>
+    <system:String x:Key="ExportToMarkdown">Markdown</system:String>
+    <system:String x:Key="ExportToCsv">CSV</system:String>
     <system:String x:Key="CopiedToClipboard">클립보드에 복사됨</system:String>
+    <system:String x:Key="ExportedToFile">파일로 내보내기 완료</system:String>
+    <system:String x:Key="ExportTo">내보내기:</system:String>
     <!--  !창고 인식  -->
     <!--  오퍼레이터 인식  -->
     <system:String x:Key="OperBoxRecognition">{key=Operator} 인식</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -887,6 +887,7 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="CopiedToClipboard">已复制到剪切板</system:String>
     <system:String x:Key="ExportedToFile">已导出到文件</system:String>
     <system:String x:Key="ExportTo">导出到：</system:String>
+    <system:String x:Key="Export">导出</system:String>
     <!--  !仓库识别  -->
     <!--  干员识别  -->
     <system:String x:Key="OperBoxRecognition">{key=Operator}识别</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -880,9 +880,13 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="LastSyncTime">上次同步时间</system:String>
     <system:String x:Key="DepotRecognitionTip">该功能尚处于测试阶段，请检查结果是否准确再行使用。若有误，欢迎打包 debug/depot 文件夹后向我们提交 issue ~</system:String>
     <system:String x:Key="StartToDepotRecognition">开始识别</system:String>
-    <system:String x:Key="ExportToArkplanner">导出至企鹅物流刷图规划</system:String>
-    <system:String x:Key="ExportToLolicon">导出至明日方舟工具箱</system:String>
+    <system:String x:Key="ExportToArkplanner">企鹅物流刷图规划</system:String>
+    <system:String x:Key="ExportToLolicon">明日方舟工具箱</system:String>
+    <system:String x:Key="ExportToMarkdown">Markdown</system:String>
+    <system:String x:Key="ExportToCsv">CSV</system:String>
     <system:String x:Key="CopiedToClipboard">已复制到剪切板</system:String>
+    <system:String x:Key="ExportedToFile">已导出到文件</system:String>
+    <system:String x:Key="ExportTo">导出到：</system:String>
     <!--  !仓库识别  -->
     <!--  干员识别  -->
     <system:String x:Key="OperBoxRecognition">{key=Operator}识别</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -887,6 +887,7 @@ C:\\leidian\\LDPlayer9\n
     <system:String x:Key="CopiedToClipboard">已複製到剪貼簿</system:String>
     <system:String x:Key="ExportedToFile">已匯出到檔案</system:String>
     <system:String x:Key="ExportTo">匯出到：</system:String>
+    <system:String x:Key="Export">匯出</system:String>
     <!--  !倉庫辨識  -->
     <!--  日誌  -->
     <system:String x:Key="OperBoxRecognition">{key=Operator}辨識</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -880,9 +880,13 @@ C:\\leidian\\LDPlayer9\n
     <system:String x:Key="LastSyncTime">上次同步時間</system:String>
     <system:String x:Key="DepotRecognitionTip">該功能尚處於測試階段，請檢查結果是否準確再行使用。若有誤，歡迎打包 debug/depot 資料夾後向我們提交 issue ~</system:String>
     <system:String x:Key="StartToDepotRecognition">開始辨識</system:String>
-    <system:String x:Key="ExportToArkplanner">匯出到企鵝物流刷圖規劃</system:String>
-    <system:String x:Key="ExportToLolicon">匯出到明日方舟工具箱</system:String>
+    <system:String x:Key="ExportToArkplanner">企鵝物流刷圖規劃</system:String>
+    <system:String x:Key="ExportToLolicon">明日方舟工具箱</system:String>
+    <system:String x:Key="ExportToMarkdown">Markdown</system:String>
+    <system:String x:Key="ExportToCsv">CSV</system:String>
     <system:String x:Key="CopiedToClipboard">已複製到剪貼簿</system:String>
+    <system:String x:Key="ExportedToFile">已匯出到檔案</system:String>
+    <system:String x:Key="ExportTo">匯出到：</system:String>
     <!--  !倉庫辨識  -->
     <!--  日誌  -->
     <system:String x:Key="OperBoxRecognition">{key=Operator}辨識</system:String>

--- a/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
@@ -836,6 +836,35 @@ public class ToolboxViewModel : Screen
         return true;
     }
 
+    public record struct ExportEntry(string Display, int Value);
+
+    public List<ExportEntry> ExportOptionList { get; } = [
+        new(LocalizationHelper.GetString("ExportToArkplanner"), 0),
+        new(LocalizationHelper.GetString("ExportToLolicon"), 1),
+        new(LocalizationHelper.GetString("ExportToMarkdown"), 2),
+        new(LocalizationHelper.GetString("ExportToCsv"), 3),
+    ];
+
+    private int _selectedExportValue;
+
+    public int SelectedExportValue
+    {
+        get => _selectedExportValue;
+        set => SetAndNotify(ref _selectedExportValue, value);
+    }
+
+    [UsedImplicitly]
+    public void ExecuteSelectedExport()
+    {
+        switch (_selectedExportValue)
+        {
+            case 0: ExportToArkplanner(); break;
+            case 1: ExportToLolicon(); break;
+            case 2: ExportToMarkdown(); break;
+            case 3: ExportToCsv(); break;
+        }
+    }
+
     /// <summary>
     /// Export depot info to ArkPlanner.
     /// UI 绑定的方法

--- a/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
@@ -18,7 +18,9 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.Globalization;
+using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
@@ -896,31 +898,7 @@ public class ToolboxViewModel : Screen
     [UsedImplicitly]
     public void ExportToMarkdown()
     {
-        var items = DepotResult.Where(item => item.Count >= 0).ToList();
-        if (items.Count == 0)
-        {
-            return;
-        }
-
-        var lines = new List<string> { "# Arknights Depot Export", string.Empty, "| ID | Name | Count |", "| --- | --- | --- |" };
-        foreach (var item in items)
-        {
-            lines.Add($"| {item.Id} | {item.Name ?? string.Empty} | {item.Count} |");
-        }
-
-        var content = string.Join(Environment.NewLine, lines);
-
-        var dialog = new Microsoft.Win32.SaveFileDialog {
-            Filter = "Markdown files (*.md)|*.md|All files (*.*)|*.*",
-            DefaultExt = ".md",
-            FileName = "Arknights_Depot_Export.md",
-        };
-
-        if (dialog.ShowDialog() == true)
-        {
-            System.IO.File.WriteAllText(dialog.FileName, content);
-            Growl.Info(LocalizationHelper.GetString("ExportedToFile"));
-        }
+        ExportDepot(BuildMarkdownExportLines, "Markdown files (*.md)|*.md|All files (*.*)|*.*", ".md", "Arknights_Depot_Export.md");
     }
 
     /// <summary>
@@ -930,12 +908,47 @@ public class ToolboxViewModel : Screen
     [UsedImplicitly]
     public void ExportToCsv()
     {
+        ExportDepot(BuildCsvExportLines, "CSV files (*.csv)|*.csv|All files (*.*)|*.*", ".csv", "Arknights_Depot_Export.csv");
+    }
+
+    private void ExportDepot(Func<IReadOnlyList<DepotResultDate>, IEnumerable<string>> lineBuilder, string filter, string defaultExt, string defaultFileName)
+    {
         var items = DepotResult.Where(item => item.Count >= 0).ToList();
         if (items.Count == 0)
         {
             return;
         }
 
+        var content = string.Join(Environment.NewLine, lineBuilder(items));
+
+        var dialog = new Microsoft.Win32.SaveFileDialog {
+            Filter = filter,
+            DefaultExt = defaultExt,
+            FileName = defaultFileName,
+        };
+
+        if (dialog.ShowDialog() != true)
+        {
+            return;
+        }
+
+        File.WriteAllText(dialog.FileName, content);
+        Growl.Info(LocalizationHelper.GetString("ExportedToFile"));
+    }
+
+    private static IEnumerable<string> BuildMarkdownExportLines(IReadOnlyList<DepotResultDate> items)
+    {
+        var lines = new List<string> { "# Arknights Depot Export", string.Empty, "| ID | Name | Count |", "| --- | --- | --- |" };
+        foreach (var item in items)
+        {
+            lines.Add($"| {item.Id} | {item.Name ?? string.Empty} | {item.Count} |");
+        }
+
+        return lines;
+    }
+
+    private static IEnumerable<string> BuildCsvExportLines(IReadOnlyList<DepotResultDate> items)
+    {
         var lines = new List<string> { "ID,Name,Count" };
         foreach (var item in items)
         {
@@ -948,19 +961,7 @@ public class ToolboxViewModel : Screen
             lines.Add($"{item.Id},{name},{item.Count}");
         }
 
-        var content = string.Join(Environment.NewLine, lines);
-
-        var dialog = new Microsoft.Win32.SaveFileDialog {
-            Filter = "CSV files (*.csv)|*.csv|All files (*.*)|*.*",
-            DefaultExt = ".csv",
-            FileName = "Arknights_Depot_Export.csv",
-        };
-
-        if (dialog.ShowDialog() == true)
-        {
-            System.IO.File.WriteAllText(dialog.FileName, content, new System.Text.UTF8Encoding(true));
-            Growl.Info(LocalizationHelper.GetString("ExportedToFile"));
-        }
+        return lines;
     }
 
     /*

--- a/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
@@ -845,7 +845,7 @@ public class ToolboxViewModel : Screen
     {
         Clipboard.Clear();
         Clipboard.SetDataObject(ArkPlannerResult);
-        DepotInfo = LocalizationHelper.GetString("CopiedToClipboard");
+        Growl.Info(LocalizationHelper.GetString("CopiedToClipboard"));
     }
 
     /// <summary>
@@ -857,7 +857,81 @@ public class ToolboxViewModel : Screen
     {
         Clipboard.Clear();
         Clipboard.SetDataObject(LoliconResult);
-        DepotInfo = LocalizationHelper.GetString("CopiedToClipboard");
+        Growl.Info(LocalizationHelper.GetString("CopiedToClipboard"));
+    }
+
+    /// <summary>
+    /// Export depot info to Markdown file.
+    /// UI 绑定的方法
+    /// </summary>
+    [UsedImplicitly]
+    public void ExportToMarkdown()
+    {
+        var items = DepotResult.Where(item => item.Count >= 0).ToList();
+        if (items.Count == 0)
+        {
+            return;
+        }
+
+        var lines = new List<string> { "# Arknights Depot Export", string.Empty, "| ID | Name | Count |", "| --- | --- | --- |" };
+        foreach (var item in items)
+        {
+            lines.Add($"| {item.Id} | {item.Name ?? string.Empty} | {item.Count} |");
+        }
+
+        var content = string.Join(Environment.NewLine, lines);
+
+        var dialog = new Microsoft.Win32.SaveFileDialog {
+            Filter = "Markdown files (*.md)|*.md|All files (*.*)|*.*",
+            DefaultExt = ".md",
+            FileName = "Arknights_Depot_Export.md",
+        };
+
+        if (dialog.ShowDialog() == true)
+        {
+            System.IO.File.WriteAllText(dialog.FileName, content);
+            Growl.Info(LocalizationHelper.GetString("ExportedToFile"));
+        }
+    }
+
+    /// <summary>
+    /// Export depot info to CSV file.
+    /// UI 绑定的方法
+    /// </summary>
+    [UsedImplicitly]
+    public void ExportToCsv()
+    {
+        var items = DepotResult.Where(item => item.Count >= 0).ToList();
+        if (items.Count == 0)
+        {
+            return;
+        }
+
+        var lines = new List<string> { "ID,Name,Count" };
+        foreach (var item in items)
+        {
+            var name = item.Name ?? string.Empty;
+            if (name.Contains(',') || name.Contains('"') || name.Contains('\n'))
+            {
+                name = "\"" + name.Replace("\"", "\"\"") + "\"";
+            }
+
+            lines.Add($"{item.Id},{name},{item.Count}");
+        }
+
+        var content = string.Join(Environment.NewLine, lines);
+
+        var dialog = new Microsoft.Win32.SaveFileDialog {
+            Filter = "CSV files (*.csv)|*.csv|All files (*.*)|*.*",
+            DefaultExt = ".csv",
+            FileName = "Arknights_Depot_Export.csv",
+        };
+
+        if (dialog.ShowDialog() == true)
+        {
+            System.IO.File.WriteAllText(dialog.FileName, content, new System.Text.UTF8Encoding(true));
+            Growl.Info(LocalizationHelper.GetString("ExportedToFile"));
+        }
     }
 
     /*

--- a/src/MaaWpfGui/Views/UI/ToolboxView.xaml
+++ b/src/MaaWpfGui/Views/UI/ToolboxView.xaml
@@ -559,66 +559,26 @@
                     HorizontalAlignment="Center"
                     VerticalAlignment="Center"
                     Orientation="Horizontal">
-                    <controls:TextBlock
-                        Margin="0,0,10,0"
-                        VerticalAlignment="Center"
-                        FontWeight="Bold"
-                        Text="{DynamicResource ExportTo}" />
-                    <Grid VerticalAlignment="Center">
-                        <Grid.RowDefinitions>
-                            <RowDefinition Height="Auto" />
-                            <RowDefinition Height="Auto" />
-                        </Grid.RowDefinitions>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="Auto" />
-                            <ColumnDefinition Width="Auto" />
-                        </Grid.ColumnDefinitions>
+                    <StackPanel VerticalAlignment="Center">
+                        <ComboBox
+                            Width="160"
+                            hc:TitleElement.Title="{DynamicResource ExportTo}"
+                            DisplayMemberPath="Display"
+                            ItemsSource="{Binding ExportOptionList}"
+                            SelectedValue="{Binding SelectedExportValue}"
+                            SelectedValuePath="Value" />
                         <Button
-                            Grid.Row="0"
-                            Grid.Column="0"
-                            Width="150"
-                            Height="50"
-                            Margin="0,0,5,5"
+                            Width="160"
+                            Height="30"
+                            Margin="0,5,0,0"
                             HorizontalAlignment="Center"
-                            VerticalAlignment="Center"
-                            Command="{s:Action ExportToArkplanner}"
-                            Content="{DynamicResource ExportToArkplanner}" />
-                        <Button
-                            Grid.Row="0"
-                            Grid.Column="1"
-                            Width="150"
-                            Height="50"
-                            Margin="5,0,0,5"
-                            HorizontalAlignment="Center"
-                            VerticalAlignment="Center"
-                            Command="{s:Action ExportToLolicon}"
-                            Content="{DynamicResource ExportToLolicon}" />
-                        <Button
-                            Grid.Row="1"
-                            Grid.Column="0"
-                            Width="150"
-                            Height="50"
-                            Margin="0,5,5,0"
-                            HorizontalAlignment="Center"
-                            VerticalAlignment="Center"
-                            Command="{s:Action ExportToMarkdown}"
-                            Content="{DynamicResource ExportToMarkdown}" />
-                        <Button
-                            Grid.Row="1"
-                            Grid.Column="1"
-                            Width="150"
-                            Height="50"
-                            Margin="5,5,0,0"
-                            HorizontalAlignment="Center"
-                            VerticalAlignment="Center"
-                            Command="{s:Action ExportToCsv}"
-                            Content="{DynamicResource ExportToCsv}" />
-                    </Grid>
+                            Command="{s:Action ExecuteSelectedExport}"
+                            Content="{DynamicResource Export}" />
+                    </StackPanel>
                     <Button
                         Width="180"
-                        Height="70"
+                        Height="80"
                         Margin="20,0,0,0"
-                        HorizontalAlignment="Center"
                         VerticalAlignment="Center"
                         Command="{s:Action StartDepot}"
                         Content="{DynamicResource StartToDepotRecognition}"

--- a/src/MaaWpfGui/Views/UI/ToolboxView.xaml
+++ b/src/MaaWpfGui/Views/UI/ToolboxView.xaml
@@ -558,30 +558,66 @@
                     Margin="0,10,0,0"
                     HorizontalAlignment="Center"
                     VerticalAlignment="Center"
-                    IsEnabled="{Binding Idle}"
                     Orientation="Horizontal">
-                    <Button
-                        Width="180"
-                        Height="70"
-                        Margin="30,0"
-                        HorizontalAlignment="Center"
+                    <controls:TextBlock
+                        Margin="0,0,10,0"
                         VerticalAlignment="Center"
-                        Command="{s:Action ExportToArkplanner}"
-                        Content="{DynamicResource ExportToArkplanner}"
-                        IsEnabled="{Binding Idle}" />
+                        FontWeight="Bold"
+                        Text="{DynamicResource ExportTo}" />
+                    <Grid VerticalAlignment="Center">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <Button
+                            Grid.Row="0"
+                            Grid.Column="0"
+                            Width="150"
+                            Height="50"
+                            Margin="0,0,5,5"
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center"
+                            Command="{s:Action ExportToArkplanner}"
+                            Content="{DynamicResource ExportToArkplanner}" />
+                        <Button
+                            Grid.Row="0"
+                            Grid.Column="1"
+                            Width="150"
+                            Height="50"
+                            Margin="5,0,0,5"
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center"
+                            Command="{s:Action ExportToLolicon}"
+                            Content="{DynamicResource ExportToLolicon}" />
+                        <Button
+                            Grid.Row="1"
+                            Grid.Column="0"
+                            Width="150"
+                            Height="50"
+                            Margin="0,5,5,0"
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center"
+                            Command="{s:Action ExportToMarkdown}"
+                            Content="{DynamicResource ExportToMarkdown}" />
+                        <Button
+                            Grid.Row="1"
+                            Grid.Column="1"
+                            Width="150"
+                            Height="50"
+                            Margin="5,5,0,0"
+                            HorizontalAlignment="Center"
+                            VerticalAlignment="Center"
+                            Command="{s:Action ExportToCsv}"
+                            Content="{DynamicResource ExportToCsv}" />
+                    </Grid>
                     <Button
                         Width="180"
                         Height="70"
-                        Margin="30,0"
-                        HorizontalAlignment="Center"
-                        VerticalAlignment="Center"
-                        Command="{s:Action ExportToLolicon}"
-                        Content="{DynamicResource ExportToLolicon}"
-                        IsEnabled="{Binding Idle}" />
-                    <Button
-                        Width="180"
-                        Height="70"
-                        Margin="30,0"
+                        Margin="20,0,0,0"
                         HorizontalAlignment="Center"
                         VerticalAlignment="Center"
                         Command="{s:Action StartDepot}"


### PR DESCRIPTION
### 改动  
- 仓库识别新增导出至 Markdown与CSV本地文件功能
- 优化导出按钮布局与交互
- 移除导出按钮的 Idle 状态限制，任务运行时仍可导出
- 复制到剪切板后弹出横幅提示

### 相关issue  
#16257

## Summary by Sourcery

为仓库识别新增导出选项，并改善剪贴板/导出相关的用户反馈。

New Features:
- 支持将仓库识别结果导出为本地 Markdown 文件。
- 支持将仓库识别结果导出为本地 CSV 文件。

Enhancements:
- 在将仓库数据复制到剪贴板或导出到文件时，显示非侵入式通知。
- 更新工具箱 UI 布局和本地化文案，以呈现新的 Markdown/CSV 导出选项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add new export options for depot recognition and improve clipboard/export user feedback.

New Features:
- Support exporting depot recognition results to local Markdown files.
- Support exporting depot recognition results to local CSV files.

Enhancements:
- Show non-intrusive notifications when depot data is copied to the clipboard or exported to a file.
- Update toolbox UI layout and localization strings to surface the new Markdown/CSV export options.

</details>