### PR TITLE
fix: 适应两处图标资源文件链接更新

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,7 +307,7 @@ jobs:
           mkdir -pv release
           mkdir -pv Maa.AppDir/usr/share/maa
           cp -r install/* Maa.AppDir/usr/share/maa/
-          wget -c https://raw.githubusercontent.com/MaaAssistantArknights/design/main/logo/maa-logo_512x512.png -O Maa.AppDir/maa.png
+          wget -c https://raw.githubusercontent.com/MaaAssistantArknights/design/main/v1/icons/maa-logo_512x512.png -O Maa.AppDir/maa.png
           mkdir -pv Maa.AppDir/usr/share/icons/hicolor/512x512/apps/
           cp -v Maa.AppDir/maa.png Maa.AppDir/usr/share/icons/hicolor/512x512/apps/
           cp -v appimage-maa Maa.AppDir/usr/share/maa/maa

--- a/src/MaaWpfGui/Services/Notification/BarkNotificationProvider.cs
+++ b/src/MaaWpfGui/Services/Notification/BarkNotificationProvider.cs
@@ -79,7 +79,7 @@ public class BarkNotificationProvider(IHttpService httpService) : IExternalNotif
         public string Group { get; } = "MaaAssistantArknights";
 
         [JsonPropertyName("icon")]
-        public static string Icon { get => "https://cdn.jsdelivr.net/gh/MaaAssistantArknights/design@main/logo/maa-logo_256x256.png"; }
+        public static string Icon { get => "https://cdn.jsdelivr.net/gh/MaaAssistantArknights/design@main/v1/icons/maa-logo_256x256.png"; }
 
         // ReSharper restore UnusedAutoPropertyAccessor.Local
         // ReSharper restore UnusedMember.Local


### PR DESCRIPTION
https://github.com/MaaAssistantArknights/design/pull/2

## Summary by Sourcery

将徽标图标的 URL 更新为设计资源库中的新路径，用于 CI 打包和 Bark 通知。

增强功能：
- 将 Bark 通知图标的 URL 指向设计资源库中更新后的徽标路径。

构建：
- 调整 CI 工作流，从设计资源库中的新徽标路径下载应用图标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update logo icon URLs to match new design repository paths for CI packaging and Bark notifications.

Enhancements:
- Point Bark notification icon URL to the updated logo path in the design repository.

Build:
- Adjust CI workflow to download the application icon from the new logo path in the design repository.

</details>