### PR TITLE
ci: Use v2 logo for AppImage build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,7 +307,7 @@ jobs:
           mkdir -pv release
           mkdir -pv Maa.AppDir/usr/share/maa
           cp -r install/* Maa.AppDir/usr/share/maa/
-          wget -c https://raw.githubusercontent.com/MaaAssistantArknights/design/main/logo/maa-logo_512x512.png -O Maa.AppDir/maa.png
+          wget -c https://raw.githubusercontent.com/MaaAssistantArknights/design/main/v2/icons/maa-logo_512x512.png -O Maa.AppDir/maa.png
           mkdir -pv Maa.AppDir/usr/share/icons/hicolor/512x512/apps/
           cp -v Maa.AppDir/maa.png Maa.AppDir/usr/share/icons/hicolor/512x512/apps/
           cp -v appimage-maa Maa.AppDir/usr/share/maa/maa


### PR DESCRIPTION
https://github.com/MaaAssistantArknights/MaaAssistantArknights/actions/runs/25647098130/job/75278059156
It has failed several times for fetching this file.

## Summary by Sourcery

CI：
- 将 AppImage 构建步骤修改为从 v2 图标路径下载 logo，以避免获取失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Change the AppImage build step to download the logo from the v2 icons path to avoid fetch failures.

</details>