### PR TITLE
Feat/copilot plot

### DIFF
--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -3685,11 +3685,13 @@
         "next": ["EndOfPlot"]
     },
     "BattleAvatarDialog": {
-        "doc": "战斗中带头像对话框, 类似于 SkipThePreBattlePlot(可见于画中人关卡) 的, 但是缺少 跳过 按钮",
+        "doc": "战斗中带头像对话框, 类似于 SkipThePreBattlePlot(可见于画中人关卡, 17章主线TR28) 的, 但是缺少 跳过 按钮",
         "action": "ClickSelf",
         "roi": [70, 30, 120, 30],
+        "maxTimes": 5,
         "next": ["BattleAvatarDialog", "Stop"],
-        "rectMove": [125, 20, 200, 60]
+        "rectMove": [125, 20, 200, 60],
+        "specialParams": [98]
     },
     "EndOfPlot": {
         "roi": [520, 0, 243, 206],

--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -4761,8 +4761,8 @@
         "Doc": "20260109 YJWL更新后暂停按钮向右移动约8像素, 且暂停后亮度上限245 (不知道以前是不是也有这个问题)",
         "template": "empty.png",
         "roi": [1178, 33, 53, 39],
-        "specialParams_Doc": "亮度阈值；点的数量",
-        "specialParams": [235, 200]
+        "specialParams_Doc": "亮度阈值; 暂停时阈值; 运行时阈值",
+        "specialParams": [235, 200, 450]
     },
     "BattleSpeedButton": {
         "template": "empty.png",

--- a/src/MaaCore/Task/BattleHelper.cpp
+++ b/src/MaaCore/Task/BattleHelper.cpp
@@ -601,7 +601,7 @@ bool asst::BattleHelper::check_pause_button(const cv::Mat& reusable)
 
     BattlefieldMatcher battle_flag_analyzer_2(image);
     auto battle_result_opt = battle_flag_analyzer_2.analyze();
-    ret &= battle_result_opt && battle_result_opt->pause_button;
+    ret &= battle_result_opt && battle_result_opt->pause_button != BattlefieldMatcher::PauseStatus::Unknown;
     return ret;
 }
 
@@ -646,7 +646,7 @@ bool asst::BattleHelper::check_in_battle(const cv::Mat& reusable, bool weak)
         BattlefieldMatcher analyzer(image);
         auto result = analyzer.analyze();
         m_in_battle = result.has_value();
-        if (m_in_battle && !result->pause_button) {
+        if (m_in_battle && result->pause_button == BattlefieldMatcher::PauseStatus::Unknown) {
             if (check_skip_plot_button(image)) {
                 if (m_in_speedup && !check_in_speedup()) {
                     speed_up(); // 跳过剧情会退出2倍速

--- a/src/MaaCore/Task/BattleHelper.cpp
+++ b/src/MaaCore/Task/BattleHelper.cpp
@@ -621,14 +621,39 @@ bool asst::BattleHelper::check_skip_plot_button(const cv::Mat& reusable)
 bool asst::BattleHelper::check_avatar_dialog(const cv::Mat& reusable)
 {
     cv::Mat image = reusable.empty() ? m_inst_helper.ctrler()->get_image() : reusable;
-
+    const static auto& task = Task.get("BattleAvatarDialog");
+    const static double threshold = task->special_params[0] / 100.0;
     Matcher battle_plot_analyzer(image);
-    battle_plot_analyzer.set_task_info("BattleAvatarDialog");
+    battle_plot_analyzer.set_task_info(task);
     bool ret = battle_plot_analyzer.analyze().has_value();
-    if (ret) {
-        ProcessTask(this_task(), { "BattleAvatarDialog" }).run();
+    if (!ret) {
+        return false;
     }
-    return ret;
+
+    ProcessTask(this_task(), { "BattleAvatarDialog" }).run();
+    const auto match_rect = battle_plot_analyzer.get_result().rect.move(task->rect_move);
+
+    cv::Mat image2 = m_inst_helper.ctrler()->get_image();
+    int retry = 100;
+    while (!m_inst_helper.need_exit() && retry > 0) {
+        Matcher matcher(image2);
+        matcher.set_templ(make_roi(image, match_rect));
+        matcher.set_roi(match_rect);
+        matcher.set_threshold(threshold);
+        matcher.set_method(MatchMethod::Ccoeff);
+        if (matcher.analyze()) {
+            LogInfo << __FUNCTION__ << "still in dialog, but not detected change, maybe need deploy or skill";
+            break;
+        }
+        --retry;
+        ret = ProcessTask(this_task(), { "BattleAvatarDialog" }).run();
+        if (!ret) {
+            break;
+        }
+        image = image2;
+        image2 = m_inst_helper.ctrler()->get_image();
+    }
+    return true;
 }
 
 bool asst::BattleHelper::check_in_speedup(const cv::Mat& reusable)
@@ -655,13 +680,13 @@ bool asst::BattleHelper::check_in_battle(const cv::Mat& reusable, bool weak)
             else if (check_avatar_dialog(image)) {
                 if (m_in_speedup && !check_in_speedup()) {
                     speed_up(); // 跳过剧情会退出2倍速
-                    m_inst_helper.sleep(Config.get_options().task_delay);
-                    int times = 0;
-                    while (times < 20 && !m_inst_helper.need_exit() && !check_in_speedup()) {
-                        speed_up(); // 跳过剧情会退出2倍速
-                        m_inst_helper.sleep(Config.get_options().task_delay);
-                        times++;
-                    }
+                }
+            }
+        }
+        else if (m_in_battle && result->pause_button == BattlefieldMatcher::PauseStatus::Pausing) {
+            if (check_avatar_dialog(image)) {
+                if (m_in_speedup && !check_in_speedup()) {
+                    speed_up(); // 跳过剧情会退出2倍速
                 }
             }
         }

--- a/src/MaaCore/Task/Experiment/CombatRecordRecognitionTask.cpp
+++ b/src/MaaCore/Task/Experiment/CombatRecordRecognitionTask.cpp
@@ -248,7 +248,7 @@ bool asst::CombatRecordRecognitionTask::analyze_deployment()
 
         oper_analyzer.set_image(frame);
         auto oper_result_opt = oper_analyzer.analyze();
-        bool analyzed = oper_result_opt && oper_result_opt->pause_button;
+        bool analyzed = oper_result_opt && oper_result_opt->pause_button != BattlefieldMatcher::PauseStatus::Unknown;
         if (analyzed) {
             m_battle_start_frame = i;
             deployment = std::move(oper_result_opt->deployment);
@@ -390,7 +390,7 @@ bool asst::CombatRecordRecognitionTask::slice_video()
             pre_distance = distance;
         }
 
-        bool oper_is_clicked = !result_opt->speed_button || !result_opt->pause_button;
+        bool oper_is_clicked = !result_opt->speed_button || result_opt->pause_button == BattlefieldMatcher::PauseStatus::Unknown;
         bool oper_auto_retreat =
             in_segment && continuity && !m_clips.empty() && cur_opers.size() != m_clips.back().deployment.size();
 

--- a/src/MaaCore/Task/Miscellaneous/BattleProcessTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleProcessTask.cpp
@@ -462,6 +462,9 @@ bool asst::BattleProcessTask::wait_condition(const Action& action)
         const std::string& name = get_name_from_group(action.name);
         update_image_if_empty();
         while (!need_exit()) {
+            if (!check_in_battle(image)) {
+                return false;
+            }
             if (!update_deployment(false, image)) {
                 return false;
             }

--- a/src/MaaCore/Vision/Battle/BattlefieldMatcher.cpp
+++ b/src/MaaCore/Vision/Battle/BattlefieldMatcher.cpp
@@ -37,7 +37,7 @@ BattlefieldMatcher::ResultOpt BattlefieldMatcher::analyze() const
 
     if (m_object_of_interest.flag) {
         result.pause_button = pause_button_analyze();
-        if (!result.pause_button && !hp_flag_analyze() && !kills_flag_analyze() && !cost_symbol_analyze()) {
+        if (result.pause_button == PauseStatus::Unknown && !hp_flag_analyze() && !kills_flag_analyze() && !cost_symbol_analyze()) {
             // flag 表明当前画面是在战斗场景的，不在的就没必要识别了
             return std::nullopt;
         }
@@ -440,7 +440,7 @@ bool asst::BattlefieldMatcher::hit_costs_cache() const
     return mark > threshold;
 }
 
-bool BattlefieldMatcher::pause_button_analyze() const
+asst::BattlefieldMatcher::PauseStatus BattlefieldMatcher::pause_button_analyze() const
 {
     auto task_ptr = Task.get("BattleHasStarted");
     cv::Mat roi = m_image(make_rect<cv::Rect>(task_ptr->roi));
@@ -450,14 +450,22 @@ bool BattlefieldMatcher::pause_button_analyze() const
     const int value_threshold = task_ptr->special_params[0];
     cv::threshold(roi_gray, bin, value_threshold, 255, cv::THRESH_BINARY);
     int count = cv::countNonZero(bin);
-    const int count_threshold = task_ptr->special_params[1];
-    Log.trace(__FUNCTION__, "count", count, "threshold", count_threshold);
+    const int threshold_base = task_ptr->special_params[1];
+    const int threshold_high = task_ptr->special_params[2];
+    Log.trace(__FUNCTION__, "count", count, "threshold", threshold_base, ",", threshold_high);
 
+    PauseStatus status = PauseStatus::Unknown;
+    if (count >= threshold_high) {
+        status = PauseStatus::Running;
+    }
+    else if (count >= threshold_base) {
+        status = PauseStatus::Pausing;
+    }
 #ifdef ASST_DEBUG
     cv::rectangle(m_image_draw, make_rect<cv::Rect>(task_ptr->roi), cv::Scalar(0, 0, 255), 2);
     cv::putText(
         m_image_draw,
-        std::to_string(count) + "/" + std::to_string(count_threshold),
+        std::to_string(count) + "/" + std::to_string(threshold_base) + "," + std::to_string(threshold_high),
         cv::Point(task_ptr->roi.x, task_ptr->roi.y + task_ptr->roi.height + 10),
         cv::FONT_HERSHEY_PLAIN,
         1.2,
@@ -465,7 +473,7 @@ bool BattlefieldMatcher::pause_button_analyze() const
         2);
 #endif
 
-    return count > count_threshold;
+    return status;
 }
 
 bool BattlefieldMatcher::in_detail_analyze() const

--- a/src/MaaCore/Vision/Battle/BattlefieldMatcher.h
+++ b/src/MaaCore/Vision/Battle/BattlefieldMatcher.h
@@ -26,6 +26,13 @@ public:
         HitCache = 2, // 图像命中缓存, 不进行识别
     };
 
+    enum PauseStatus
+    {
+        Unknown = 0, // 没有找到暂停按钮
+        Pausing = 1, // 暂停中
+        Running = 2, // 运行中
+    };
+
     template <typename T>
     struct MatchResult
     {
@@ -42,7 +49,7 @@ public:
 
         // bool in_detail = false;
         bool speed_button = false;
-        bool pause_button = false;
+        asst::BattlefieldMatcher::PauseStatus pause_button = PauseStatus::Unknown;
     };
 
     using ResultOpt = std::optional<Result>;
@@ -59,7 +66,7 @@ public:
 protected:
     bool hp_flag_analyze() const;
     bool kills_flag_analyze() const;
-    bool pause_button_analyze() const;
+    asst::BattlefieldMatcher::PauseStatus pause_button_analyze() const;
 
     std::vector<battle::DeploymentOper> deployment_analyze() const; // 识别干员
     battle::Role oper_role_analyze(const Rect& roi) const;


### PR DESCRIPTION
<img width="1920" height="864" alt="7c8ddfee01e44629ba4ff282bd0d12be" src="https://github.com/user-attachments/assets/fa02a0c3-9fb1-43a1-a065-7e49a868abca" />

应对↑类剧情操作。1a30f9a7dddb58c7f4d7b35523d2fa05d3e1346d 临时额外添加检查，感觉上是要拆分update_deployment和check_in_battle流程，先check处理

后续还需要添加指定slot进行部署

## Summary by Sourcery

优化战斗状态处理和对话流程，更好地区分暂停条件，并更可靠地处理战斗中的干员对话和部署。

Bug 修复：
- 将暂停按钮状态视为三态值，用于区分运行中、已暂停和未知状态，防止错误地将战斗场景分类。
- 改进干员对话处理逻辑，通过反复处理对话直到检测到视觉变化，避免在需要额外操作（如部署或技能）时卡住。
- 确保部署等待条件会验证游戏是否仍处于战斗中，只有在仍在战斗时才更新部署，避免在非战斗状态下执行操作。

增强功能：
- 引入 `PauseStatus` 枚举，并更新暂停按钮分析逻辑，使其根据可配置阈值返回更丰富的状态信息。
- 调整战斗中检测和战斗记录识别逻辑，使用新的 `PauseStatus` 状态以更准确地检测交互，包括游戏处于暂停时的情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine battle state handling and dialog processing to better distinguish pause conditions and handle in-battle avatar dialogs and deployments more reliably.

Bug Fixes:
- Treat the pause button state as a tri-state value to distinguish between running, paused, and unknown, preventing misclassification of battle scenes.
- Improve avatar dialog handling by repeatedly processing dialog until a visual change is detected, avoiding getting stuck when additional actions like deployment or skills are required.
- Ensure deployment wait conditions validate that the game is still in battle before updating deployment, avoiding operations when not in combat.

Enhancements:
- Introduce a PauseStatus enum and update pause button analysis to return a richer state based on configurable thresholds.
- Adjust in-battle checks and combat record recognition logic to use the new PauseStatus states for more accurate interaction detection, including when the game is paused.

</details>