### PR TITLE
rft(wpf): RunningState更新

### DIFF
--- a/src/MaaWpfGui/States/RunningState.cs
+++ b/src/MaaWpfGui/States/RunningState.cs
@@ -25,14 +25,14 @@ namespace MaaWpfGui.States;
 
 public class RunningState
 {
-    public class RunningStateChangedEventArgs(bool idle, bool inited, bool stopping) : EventArgs
+    public class RunningStateChangedEventArgs(StateSnapshot oldState, bool idle, bool inited, bool stopping) : EventArgs
     {
-        public bool Idle { get; } = idle;
+        public StateSnapshot OldState { get; } = oldState;
 
-        public bool Inited { get; } = inited;
-
-        public bool Stopping { get; } = stopping;
+        public StateSnapshot NewState => new(idle, inited, stopping);
     }
+
+    public record StateSnapshot(bool Idle, bool Inited, bool Stopping);
 
     private static RunningState? _instance;
     private static readonly ILogger _logger = Log.Logger.ForContext<RunningState>();
@@ -142,8 +142,8 @@ public class RunningState
                 return;
             }
 
+            var oldState = new StateSnapshot(_idle, _inited, _stopping);
             _idle = value;
-
             if (value)
             {
                 StopTimeoutTimer();
@@ -155,7 +155,7 @@ public class RunningState
                 SleepManagement.BlockSleep();
             }
 
-            RaiseStateChanged();
+            RaiseStateChanged(oldState);
         }
     }
 
@@ -175,8 +175,9 @@ public class RunningState
         set {
             if (_inited != value)
             {
+                var oldState = new StateSnapshot(_idle, _inited, _stopping);
                 _inited = value;
-                RaiseStateChanged();
+                RaiseStateChanged(oldState);
             }
         }
     }
@@ -197,8 +198,9 @@ public class RunningState
         set {
             if (_stopping != value)
             {
+                var oldState = new StateSnapshot(_idle, _inited, _stopping);
                 _stopping = value;
-                RaiseStateChanged();
+                RaiseStateChanged(oldState);
             }
         }
     }
@@ -213,9 +215,9 @@ public class RunningState
 
     public event EventHandler<RunningStateChangedEventArgs>? StateChanged;
 
-    private void RaiseStateChanged()
+    private void RaiseStateChanged(StateSnapshot oldState)
     {
-        StateChanged?.Invoke(this, new(_idle, _inited, _stopping));
+        StateChanged?.Invoke(this, new(oldState, _idle, _inited, _stopping));
     }
 
     /// <summary>

--- a/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
@@ -116,9 +116,9 @@ public partial class CopilotViewModel : Screen
         AddLog(LocalizationHelper.GetString("CopilotTip"), showTime: false);
         _runningState = RunningState.Instance;
         _runningState.StateChanged += (_, e) => {
-            Idle = e.Idle;
-            Inited = e.Inited;
-            Stopping = e.Stopping;
+            Idle = e.NewState.Idle;
+            Inited = e.NewState.Inited;
+            Stopping = e.NewState.Stopping;
         };
 
         var copilotTaskList = ConfigurationHelper.GetValue(ConfigurationKeys.CopilotTaskList, string.Empty);

--- a/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
@@ -136,7 +136,7 @@ public class SettingsViewModel : Screen
 
         _runningState = RunningState.Instance;
         _runningState.StateChanged += (_, e) => {
-            Idle = e.Idle;
+            Idle = e.NewState.Idle;
 
             // Inited = e.Inited;
             // Stopping = e.Stopping;

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -610,7 +610,6 @@ public class TaskQueueViewModel : Screen
                 Instances.Data.ClearCache();
             }
         };
-        _runningState.SetIdle(true);
         _runningState.TimeoutOccurred += RunningState_TimeOut;
 
         if (Instances.VersionUpdateDialogViewModel.IsDebugVersion() || File.Exists("DEBUG") || File.Exists("DEBUG.txt"))

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -600,16 +600,17 @@ public class TaskQueueViewModel : Screen
     {
         _runningState = RunningState.Instance;
         _runningState.StateChanged += (_, e) => {
-            Idle = e.Idle;
-            Inited = e.Inited;
-            Stopping = e.Stopping;
+            Idle = e.NewState.Idle;
+            Inited = e.NewState.Inited;
+            Stopping = e.NewState.Stopping;
 
-            Instances.SettingsViewModel.Idle = e.Idle;
-            if (!e.Idle)
+            Instances.SettingsViewModel.Idle = e.NewState.Idle;
+            if (!e.NewState.Idle)
             {
                 Instances.Data.ClearCache();
             }
         };
+        _runningState.SetIdle(true);
         _runningState.TimeoutOccurred += RunningState_TimeOut;
 
         if (Instances.VersionUpdateDialogViewModel.IsDebugVersion() || File.Exists("DEBUG") || File.Exists("DEBUG.txt"))

--- a/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
@@ -63,11 +63,11 @@ public class ToolboxViewModel : Screen
         DisplayName = LocalizationHelper.GetString("Toolbox");
         _runningState = RunningState.Instance;
         _runningState.StateChanged += (__, e) => {
-            Idle = e.Idle;
-            Inited = e.Inited;
-            Stopping = e.Stopping;
+            Idle = e.NewState.Idle;
+            Inited = e.NewState.Inited;
+            Stopping = e.NewState.Stopping;
 
-            if (e.Stopping && Peeping && !IsPeepTransitioning)
+            if (e.NewState.Stopping && Peeping && !IsPeepTransitioning)
             {
                 _ = Peep();
             }

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/FightSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/FightSettingsUserControlModel.cs
@@ -895,6 +895,8 @@ public class FightSettingsUserControlModel : TaskSettingsViewModel, FightSetting
 
     #endregion 关卡列表更新
 
+    #region Data Class
+
     public class SanityInfo
     {
         [JsonProperty("current_sanity")]
@@ -921,6 +923,10 @@ public class FightSettingsUserControlModel : TaskSettingsViewModel, FightSetting
         [JsonProperty("finished")]
         public bool IsFinished { get; set; }
     }
+
+    #endregion Data Class
+
+    #region UI Item
 
     public class WeeklyScheduleItem(DayOfWeek dayOfWeek) : PropertyChangedBase
     {
@@ -976,6 +982,8 @@ public class FightSettingsUserControlModel : TaskSettingsViewModel, FightSetting
         // 仅供 ComboBox本身 和 手写Stage的TextBlock 绑定使用
         public bool IsOpen { get => field; set => SetAndNotify(ref field, value); } = Instances.TaskQueueViewModel.IsStageOpen(stage);
     }
+
+    #endregion UI Item
 
     private struct UiRefreshingScope : IDisposable
     {


### PR DESCRIPTION
## Summary by Sourcery

跟踪并公开先前和当前的运行状态快照，并更新 WPF 视图模型以使用新的状态表示形式，同时对视图模型结构进行一些小幅清理。

**新功能：**
- 添加 `StateSnapshot` 记录，并在 `RunningStateChangedEventArgs` 中包含先前状态，以向监听者提供旧的和新的运行状态值。

**增强改进：**
- 更新 `TaskQueueViewModel` 和 `CopilotViewModel`，以绑定到基于 `StateSnapshot` 的 `RunningState` 更改事件，并在订阅时初始化空闲状态。
- 将 `FightSettingsUserControlModel` 中的数据和 UI 项嵌套类分组到专门的区域中，以获得更清晰的结构。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Track and expose both previous and current running state snapshots, and update WPF view models to consume the new state representation while doing minor view model structuring cleanups.

New Features:
- Add a StateSnapshot record and include the previous state in RunningStateChangedEventArgs to provide old and new running state values to listeners.

Enhancements:
- Update TaskQueueViewModel and CopilotViewModel to bind to the new StateSnapshot-based RunningState change event and initialize idle state on subscription.
- Group data and UI item nested classes in FightSettingsUserControlModel into dedicated regions for clearer structure.

</details>