### PR TITLE
perf: 优化 masked TM_CCOEFF_NORMED 匹配性能

### DIFF
--- a/src/MaaCore/Config/TemplResource.cpp
+++ b/src/MaaCore/Config/TemplResource.cpp
@@ -99,6 +99,8 @@ bool asst::TemplResource::load(const std::filesystem::path& path)
         return false;
     }
 #endif
+    m_templs.clear();
+    ++m_revision;
     return true;
 }
 

--- a/src/MaaCore/Config/TemplResource.h
+++ b/src/MaaCore/Config/TemplResource.h
@@ -19,10 +19,12 @@ public:
     virtual bool load(const std::filesystem::path& path) override;
 
     const cv::Mat& get_templ(const std::string& name);
+    uint64_t revision() const noexcept { return m_revision; }
 
 private:
     std::unordered_set<std::string> m_load_required;
     std::unordered_map<std::string, cv::Mat> m_templs;
     std::unordered_map<std::string, std::filesystem::path> m_templ_paths;
+    uint64_t m_revision = 0;
 };
 }

--- a/src/MaaCore/Config/TemplResource.h
+++ b/src/MaaCore/Config/TemplResource.h
@@ -2,6 +2,7 @@
 
 #include "AbstractResource.h"
 
+#include <atomic>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -19,12 +20,12 @@ public:
     virtual bool load(const std::filesystem::path& path) override;
 
     const cv::Mat& get_templ(const std::string& name);
-    uint64_t revision() const noexcept { return m_revision; }
+    uint64_t revision() const noexcept { return m_revision.load(std::memory_order_acquire); }
 
 private:
     std::unordered_set<std::string> m_load_required;
     std::unordered_map<std::string, cv::Mat> m_templs;
     std::unordered_map<std::string, std::filesystem::path> m_templ_paths;
-    uint64_t m_revision = 0;
+    std::atomic<uint64_t> m_revision { 0 };
 };
 }

--- a/src/MaaCore/Vision/MaskedCcoeffMatcher.cpp
+++ b/src/MaaCore/Vision/MaskedCcoeffMatcher.cpp
@@ -164,22 +164,30 @@ std::shared_ptr<const MaskedCcoeffMatcher::DftPlan> MaskedCcoeffMatcher::get_or_
 bool MaskedCcoeffMatcher::should_fallback_to_opencv(int mask_pixels, int result_positions)
 {
     // 神秘调参值
-    // - 极小 result + 低 K：稀疏路径整体工作量极小（K 次扫小 result）
-    //   OpenCV 的固定 setup 开销在这一档反而占主导，留给稀疏
-    // - 极小 result + 高 K（图像略大于模板的 case，如 138×130/105×105）
-    //   K 超过稀疏阈值无法走稀疏，FFT 在小 DFT size 上不如opencv快了
-    // - 中等 result 配中等 K：OpenCV 紧凑 SIMD 内核比稀疏路径的多通道宽累加快
-    // - 总工作量 K*result 不大：OpenCV 紧凑 SIMD 常数因子优于稀疏 / FFT
-    //   实测 K*result < 25M 段 100% 退化、> 50M 段几乎全是加速
+    // - 极小 result + 低 K：稀疏路径整体工作量极小，留给 FFT/sparse
+    // - 极小 result + 高 K（如 138×130/105×105）：K 超稀疏阈值，FFT 在小 DFT size 反而不如 OpenCV
+    // - 中等 result 配中等 K：Windows 上 OpenCV 紧凑 SIMD 快；Android 上 OpenCV 慢约 300x，阈值大幅收紧
+
     if (result_positions < 1000 && mask_pixels < 2000) {
         return false;
     }
+
+#ifdef __ANDROID__
+    if (result_positions < 3000 && mask_pixels >= 500) {
+        return true;
+    }
+    if (static_cast<long long>(mask_pixels) * result_positions < 8'000'000LL) {
+        return true;
+    }
+#else
     if (result_positions < 12000 && mask_pixels >= 500) {
         return true;
     }
     if (static_cast<long long>(mask_pixels) * result_positions < 25'000'000LL) {
         return true;
     }
+#endif
+
     return false;
 }
 

--- a/src/MaaCore/Vision/MaskedCcoeffMatcher.cpp
+++ b/src/MaaCore/Vision/MaskedCcoeffMatcher.cpp
@@ -290,7 +290,6 @@ cv::Mat MaskedCcoeffMatcher::match(
 
     cv::Mat padded(dft_rows, dft_cols, CV_32F, cv::Scalar(0));
     cv::Mat I_dft(dft_rows, dft_cols, CV_32FC2);
-    cv::Mat I_sq_dft(dft_rows, dft_cols, CV_32FC2);
     cv::Mat spectrum(dft_rows, dft_cols, CV_32FC2);
     cv::Mat result_buf(dft_rows, dft_cols, CV_32F);
     cv::Mat sum_MI_buf(rh, rw, CV_32F);
@@ -312,26 +311,36 @@ cv::Mat MaskedCcoeffMatcher::match(
         cv::add(accum, result_buf(cv::Rect(0, 0, rw, rh)), accum);
     };
 
-    // 图像侧每通道 FFT 只算一次
     cv::Mat numerator = cv::Mat::zeros(rh, rw, CV_32F);
     cv::Mat sigma_I_sq_d = cv::Mat::zeros(rh, rw, CV_64F); // float64 避免 sum_MI2-sum_MI² 灾难性精度损失
 
+    // σ_I²(x,y) = Σ_c σ_I_c² = Σ_c [(M ⋆ I_c²) - (M ⋆ I_c)² / N]
+    //          = Σ_c (M ⋆ I_c²)        - (1/N) Σ_c (M ⋆ I_c)²
+    //          ↑ 把这一项的三通道求和提到卷积外面
+    //
+    // 利用卷积对加法线性：Σ_c (M ⋆ I_c²) = M ⋆ (Σ_c I_c²)
+    // 在空域里先把三通道平方加起来再做一次卷积，比每通道各做一次再相加少 2 次 FFT + 2 次 IFFT
+    // 第二项 Σ_c (M ⋆ I_c)² 因为有平方，不能这样合并（平方对加法非线性），仍逐通道算
+    // 实测 Windows + Android 真 FFT 路径 case 平均 -22%
+    cv::Mat I_sq_sum = I_ch[0].mul(I_ch[0]) + I_ch[1].mul(I_ch[1]) + I_ch[2].mul(I_ch[2]);
+    cv::Mat I_sq_sum_dft(dft_rows, dft_cols, CV_32FC2);
+    make_dft_into(I_sq_sum, I_sq_sum_dft);
+    xcorr_into(I_sq_sum_dft, dft_plan->M_dft, sum_MI2_buf);
+    cv::Mat sum_MI2_d;
+    sum_MI2_buf.convertTo(sum_MI2_d, CV_64F);
+    cv::add(sigma_I_sq_d, sum_MI2_d, sigma_I_sq_d);
+
     for (int c = 0; c < 3; ++c) {
         make_dft_into(I_ch[c], I_dft);
-        make_dft_into(I_ch[c].mul(I_ch[c]), I_sq_dft);
 
         // numerator += xcorr(T'_c, I_c)
         xcorr_add(I_dft, dft_plan->T_prime_dft[c], numerator);
 
-        // σ_I_c²(x,y) = sum_MI2 - sum_MI² / mask_area
-        // 两项量级相近时相减会损失精度，用 float64 累加
+        // sigma_I² 第二项：-Σ_c (sum_MI_c)² / mask_area，逐通道累加
         xcorr_into(I_dft, dft_plan->M_dft, sum_MI_buf);
-        xcorr_into(I_sq_dft, dft_plan->M_dft, sum_MI2_buf);
-        cv::Mat sum_MI_d, sum_MI2_d, var_d;
+        cv::Mat sum_MI_d, var_d;
         sum_MI_buf.convertTo(sum_MI_d, CV_64F);
-        sum_MI2_buf.convertTo(sum_MI2_d, CV_64F);
         cv::multiply(sum_MI_d, sum_MI_d, var_d, -1.0 / mask_area);
-        cv::add(var_d, sum_MI2_d, var_d);
         cv::add(sigma_I_sq_d, var_d, sigma_I_sq_d);
     }
 

--- a/src/MaaCore/Vision/MaskedCcoeffMatcher.cpp
+++ b/src/MaaCore/Vision/MaskedCcoeffMatcher.cpp
@@ -1,0 +1,338 @@
+#include "MaskedCcoeffMatcher.h"
+
+#include "MaaUtils/NoWarningCV.hpp"
+
+#include <array>
+#include <cmath>
+#include <vector>
+
+namespace asst
+{
+namespace
+{
+// 稀疏路径使用的每个有效 mask 像素的条目
+struct SparseEntry
+{
+    int16_t dx, dy;     // 相对模板左上角的偏移
+    float T_prime[3];   // M*(T_c - μT_c)，per-channel
+};
+}
+
+struct MaskedCcoeffMatcher::TemplatePlan
+{
+    cv::Mat M;                                // CV_32F mask, 0 or 1
+    std::array<cv::Mat, 3> T_prime;           // M*(T_c - μT_c)，per-channel
+    double sigma_T_sq = 0.0;
+    double mask_area = 0.0;
+    std::vector<SparseEntry> sparse_entries; // 非零 mask 位置列表
+    int K = 0;                               // sparse_entries.size()
+};
+
+struct MaskedCcoeffMatcher::DftPlan
+{
+    std::array<cv::Mat, 3> T_prime_dft; // FFT(M*(T_c - μT_c))，每通道一个
+    cv::Mat M_dft;                      // FFT(M)
+};
+
+MaskedCcoeffMatcher& MaskedCcoeffMatcher::get_instance()
+{
+    static MaskedCcoeffMatcher instance;
+    return instance;
+}
+
+void MaskedCcoeffMatcher::sync_cache_revision(const uint64_t revision)
+{
+    std::lock_guard<std::mutex> lk(m_cache_mtx);
+    if (m_cache_revision == revision) {
+        return;
+    }
+    m_template_plan_cache.clear();
+    m_dft_plan_cache.clear();
+    m_cache_revision = revision;
+}
+
+void MaskedCcoeffMatcher::fnv1a_update(uint64_t& h, const void* data, size_t size)
+{
+    const auto* ptr = static_cast<const uint8_t*>(data);
+    for (size_t i = 0; i < size; ++i) {
+        h ^= ptr[i];
+        h *= 1099511628211ULL;
+    }
+}
+
+std::string MaskedCcoeffMatcher::make_mat_cache_key(const cv::Mat& mat)
+{
+    uint64_t h = 14695981039346656037ULL;
+    const int meta[] = { mat.rows, mat.cols, mat.type() };
+    fnv1a_update(h, meta, sizeof(meta));
+
+    const size_t row_bytes = static_cast<size_t>(mat.cols) * mat.elemSize();
+    for (int y = 0; y < mat.rows; ++y) {
+        fnv1a_update(h, mat.ptr(y), row_bytes);
+    }
+    return "mat:" + std::to_string(mat.rows) + "x" + std::to_string(mat.cols)
+           + ":" + std::to_string(mat.type()) + ":" + std::to_string(h);
+}
+
+std::shared_ptr<const MaskedCcoeffMatcher::TemplatePlan> MaskedCcoeffMatcher::get_or_build_template_plan(
+    const std::string& cache_key,
+    const cv::Mat& templ_f32,
+    const cv::Mat& mask_f32,
+    int mask_pixels)
+{
+    {
+        std::lock_guard<std::mutex> lk(m_cache_mtx);
+        auto it = m_template_plan_cache.find(cache_key);
+        if (it != m_template_plan_cache.end()) {
+            return it->second;
+        }
+    }
+
+    auto plan = std::make_shared<TemplatePlan>();
+    plan->M = mask_f32;
+    plan->mask_area = mask_pixels;
+    if (plan->mask_area < 1.0) {
+        return {};
+    }
+
+    std::vector<cv::Mat> T_ch(3);
+    cv::split(templ_f32, T_ch);
+
+    for (int c = 0; c < 3; ++c) {
+        const double mu_T = cv::sum(plan->M.mul(T_ch[c]))[0] / plan->mask_area;
+        plan->T_prime[c] = plan->M.mul(T_ch[c] - mu_T);
+        plan->sigma_T_sq += cv::sum(plan->T_prime[c].mul(plan->T_prime[c]))[0];
+    }
+
+    for (int v = 0; v < templ_f32.rows; ++v) {
+        for (int u = 0; u < templ_f32.cols; ++u) {
+            if (plan->M.at<float>(v, u) > 0.5f) {
+                SparseEntry e {};
+                e.dx = static_cast<int16_t>(u);
+                e.dy = static_cast<int16_t>(v);
+                for (int c = 0; c < 3; ++c) {
+                    e.T_prime[c] = plan->T_prime[c].at<float>(v, u);
+                }
+                plan->sparse_entries.push_back(e);
+            }
+        }
+    }
+    plan->K = static_cast<int>(plan->sparse_entries.size());
+
+    std::lock_guard<std::mutex> lk(m_cache_mtx);
+    auto [it, inserted] = m_template_plan_cache.emplace(cache_key, plan);
+    static_cast<void>(inserted);
+    return it->second;
+}
+
+std::shared_ptr<const MaskedCcoeffMatcher::DftPlan> MaskedCcoeffMatcher::get_or_build_dft_plan(
+    const std::string& cache_key,
+    const TemplatePlan& template_plan,
+    int dft_rows,
+    int dft_cols)
+{
+    const std::string dft_key = cache_key + ":dft:" + std::to_string(dft_rows) + "x" + std::to_string(dft_cols);
+    {
+        std::lock_guard<std::mutex> lk(m_cache_mtx);
+        auto it = m_dft_plan_cache.find(dft_key);
+        if (it != m_dft_plan_cache.end()) {
+            return it->second;
+        }
+    }
+
+    auto dft_plan = std::make_shared<DftPlan>();
+    cv::Mat padded = cv::Mat::zeros(dft_rows, dft_cols, CV_32F);
+    auto compute_into = [&](const cv::Mat& src, cv::Mat& out) {
+        padded.setTo(0.0f);
+        src.copyTo(padded(cv::Rect(0, 0, src.cols, src.rows)));
+        cv::dft(padded, out, cv::DFT_COMPLEX_OUTPUT);
+    };
+
+    compute_into(template_plan.M, dft_plan->M_dft);
+    for (int c = 0; c < 3; ++c) {
+        compute_into(template_plan.T_prime[c], dft_plan->T_prime_dft[c]);
+    }
+
+    std::lock_guard<std::mutex> lk(m_cache_mtx);
+    auto [it, inserted] = m_dft_plan_cache.emplace(dft_key, dft_plan);
+    static_cast<void>(inserted);
+    return it->second;
+}
+
+bool MaskedCcoeffMatcher::should_fallback_to_opencv(int mask_pixels, int result_positions)
+{
+    // DFT 的固定成本在输出位置很少、mask 很密时会超过 OpenCV 原路径。
+    static constexpr int OPENCV_DENSE_RESULT_LIMIT = 10'000;
+    return mask_pixels >= 2'000 && result_positions < OPENCV_DENSE_RESULT_LIMIT;
+}
+
+// 用 cv::dft 直接实现，消除冗余 FFT
+//
+// 当前 9 次 matchTemplate 的冗余：
+//   FFT(I_c)  每通道算两次（分别用于 xcorr(T'_c, I_c) 和 xcorr(M, I_c)）
+//   FFT(M)    每通道算两次（分别用于 xcorr(M, I_c) 和 xcorr(M, I_c²)）
+//
+// 优化后：
+//   FFT(I_c) 和 FFT(I_c²) 每通道各算一次并复用
+//   FFT(T'_c) 和 FFT(M) 通过缓存跨调用复用
+//
+// 数学等价于 cv::matchTemplate(image, templ, result, TM_CCOEFF_NORMED, mask)
+cv::Mat MaskedCcoeffMatcher::match(
+    const cv::Mat& image_rgb,      // CV_8UC3
+    const cv::Mat& templ_rgb,      // CV_8UC3
+    const cv::Mat& mask_u8,        // CV_8UC1, 0 or 255
+    const std::string& cache_key,  // 模板侧 FFT 缓存键
+    int mask_pixels)
+{
+    const int rh = image_rgb.rows - templ_rgb.rows + 1;
+    const int rw = image_rgb.cols - templ_rgb.cols + 1;
+    if (rh <= 0 || rw <= 0) return {};
+
+    if (mask_pixels <= 0 || should_fallback_to_opencv(mask_pixels, rh * rw)) {
+        return {};
+    }
+
+    cv::Mat I, T, M;
+    image_rgb.convertTo(I, CV_32F);
+    templ_rgb.convertTo(T, CV_32F);
+    mask_u8.convertTo(M, CV_32F, 1.0 / 255.0);
+
+    const auto template_plan = get_or_build_template_plan(cache_key, T, M, mask_pixels);
+    if (!template_plan) return {};
+
+    const double mask_area = template_plan->mask_area;
+    const double sigma_T_sq = template_plan->sigma_T_sq;
+
+    // 图像通道拆分：稀疏和 FFT 两条路径都需要
+    std::vector<cv::Mat> I_ch(3);
+    cv::split(I, I_ch);
+
+    // ---- 稀疏直接相关（小模板快路径）----------------------
+    // 双重条件：K < SPARSE_K_LIMIT 且总工作量 K×result_positions < SPARSE_WORK_LIMIT。
+    // 仅满足 K 小但结果矩阵极大时（如 49×28 模板/690×434 图）仍走 FFT 路径。
+    static constexpr int SPARSE_K_LIMIT = 2000;
+    static constexpr long long SPARSE_WORK_LIMIT = 30'000'000LL;
+    if (template_plan->K > 0 && template_plan->K < SPARSE_K_LIMIT &&
+        static_cast<long long>(template_plan->K) * rh * rw < SPARSE_WORK_LIMIT) {
+        cv::Mat numerator = cv::Mat::zeros(rh, rw, CV_32F);
+        cv::Mat sum_MI_r = cv::Mat::zeros(rh, rw, CV_32F);
+        cv::Mat sum_MI_g = cv::Mat::zeros(rh, rw, CV_32F);
+        cv::Mat sum_MI_b = cv::Mat::zeros(rh, rw, CV_32F);
+        cv::Mat sum_MI2 = cv::Mat::zeros(rh, rw, CV_32F); // Σ_c I_c²
+
+        for (const auto& e : template_plan->sparse_entries) {
+            for (int y = 0; y < rh; ++y) {
+                const float* Ir = I_ch[0].ptr<float>(y + e.dy) + e.dx;
+                const float* Ig = I_ch[1].ptr<float>(y + e.dy) + e.dx;
+                const float* Ib = I_ch[2].ptr<float>(y + e.dy) + e.dx;
+                float* num_p = numerator.ptr<float>(y);
+                float* smir_p = sum_MI_r.ptr<float>(y);
+                float* smig_p = sum_MI_g.ptr<float>(y);
+                float* smib_p = sum_MI_b.ptr<float>(y);
+                float* smi2_p = sum_MI2.ptr<float>(y);
+
+                // 内层循环：连续内存，编译器向量化
+                for (int x = 0; x < rw; ++x) {
+                    const float r = Ir[x], g = Ig[x], b = Ib[x];
+                    num_p[x] += e.T_prime[0] * r + e.T_prime[1] * g + e.T_prime[2] * b;
+                    smir_p[x] += r;
+                    smig_p[x] += g;
+                    smib_p[x] += b;
+                    smi2_p[x] += r * r + g * g + b * b;
+                }
+            }
+        }
+
+        // sigma_I² = sum_MI2 - (sum_MI_r² + sum_MI_g² + sum_MI_b²) / mask_area
+        cv::Mat sq_sum, sq_g, sq_b;
+        cv::multiply(sum_MI_r, sum_MI_r, sq_sum);
+        cv::multiply(sum_MI_g, sum_MI_g, sq_g);
+        cv::multiply(sum_MI_b, sum_MI_b, sq_b);
+        cv::add(sq_sum, sq_g, sq_sum);
+        cv::add(sq_sum, sq_b, sq_sum);
+        cv::Mat sigma_I_sq;
+        cv::subtract(sum_MI2, sq_sum * (1.0 / mask_area), sigma_I_sq);
+        cv::max(sigma_I_sq, 0.0, sigma_I_sq);
+
+        cv::Mat denom;
+        cv::sqrt(sigma_I_sq * sigma_T_sq, denom);
+        cv::Mat result;
+        cv::divide(numerator, denom, result);
+        cv::patchNaNs(result, 0.0);
+        const float sigma_T_norm = static_cast<float>(std::sqrt(sigma_T_sq));
+        result.setTo(0.0f, denom < sigma_T_norm * 1e-5f);
+        cv::min(result, 1.0f, result);
+        cv::max(result, -1.0f, result);
+        return result;
+    }
+
+    // DFT 的填充尺寸：仅在确认走 FFT 路径后才需要。
+    const int dft_rows = cv::getOptimalDFTSize(I.rows + T.rows - 1);
+    const int dft_cols = cv::getOptimalDFTSize(I.cols + T.cols - 1);
+    const auto dft_plan = get_or_build_dft_plan(cache_key, *template_plan, dft_rows, dft_cols);
+
+    // ---- FFT buffer 仅在确认走 FFT 路径后才分配 ---
+    cv::Mat padded(dft_rows, dft_cols, CV_32F, cv::Scalar(0));
+    cv::Mat I_dft(dft_rows, dft_cols, CV_32FC2);
+    cv::Mat I_sq_dft(dft_rows, dft_cols, CV_32FC2);
+    cv::Mat spectrum(dft_rows, dft_cols, CV_32FC2);
+    cv::Mat result_buf(dft_rows, dft_cols, CV_32F);
+    cv::Mat sum_MI_buf(rh, rw, CV_32F);
+    cv::Mat sum_MI2_buf(rh, rw, CV_32F);
+
+    auto make_dft_into = [&](const cv::Mat& src, cv::Mat& out) {
+        padded.setTo(0.0f);
+        src.copyTo(padded(cv::Rect(0, 0, src.cols, src.rows)));
+        cv::dft(padded, out, cv::DFT_COMPLEX_OUTPUT);
+    };
+    auto xcorr_into = [&](const cv::Mat& dft_A, const cv::Mat& dft_B, cv::Mat& out) {
+        cv::mulSpectrums(dft_A, dft_B, spectrum, 0, true);
+        cv::dft(spectrum, result_buf, cv::DFT_INVERSE | cv::DFT_REAL_OUTPUT | cv::DFT_SCALE);
+        result_buf(cv::Rect(0, 0, rw, rh)).copyTo(out);
+    };
+    auto xcorr_add = [&](const cv::Mat& dft_A, const cv::Mat& dft_B, cv::Mat& accum) {
+        cv::mulSpectrums(dft_A, dft_B, spectrum, 0, true);
+        cv::dft(spectrum, result_buf, cv::DFT_INVERSE | cv::DFT_REAL_OUTPUT | cv::DFT_SCALE);
+        cv::add(accum, result_buf(cv::Rect(0, 0, rw, rh)), accum);
+    };
+
+    // 图像侧每通道 FFT 只算一次
+    cv::Mat numerator = cv::Mat::zeros(rh, rw, CV_32F);
+    cv::Mat sigma_I_sq_d = cv::Mat::zeros(rh, rw, CV_64F); // float64 避免 sum_MI2-sum_MI² 灾难性精度损失
+
+    for (int c = 0; c < 3; ++c) {
+        make_dft_into(I_ch[c], I_dft);
+        make_dft_into(I_ch[c].mul(I_ch[c]), I_sq_dft);
+
+        // numerator += xcorr(T'_c, I_c)
+        xcorr_add(I_dft, dft_plan->T_prime_dft[c], numerator);
+
+        // σ_I_c²(x,y) = sum_MI2 - sum_MI² / mask_area
+        // 两项量级相近时相减会损失精度，用 float64 累加
+        xcorr_into(I_dft, dft_plan->M_dft, sum_MI_buf);
+        xcorr_into(I_sq_dft, dft_plan->M_dft, sum_MI2_buf);
+        cv::Mat sum_MI_d, sum_MI2_d, var_d;
+        sum_MI_buf.convertTo(sum_MI_d, CV_64F);
+        sum_MI2_buf.convertTo(sum_MI2_d, CV_64F);
+        cv::multiply(sum_MI_d, sum_MI_d, var_d, -1.0 / mask_area);
+        cv::add(var_d, sum_MI2_d, var_d);
+        cv::add(sigma_I_sq_d, var_d, sigma_I_sq_d);
+    }
+
+    cv::Mat sigma_I_sq;
+    sigma_I_sq_d.convertTo(sigma_I_sq, CV_32F);
+    cv::max(sigma_I_sq, 0.0, sigma_I_sq);
+
+    cv::Mat denom;
+    cv::sqrt(sigma_I_sq * sigma_T_sq, denom);
+
+    cv::Mat result;
+    cv::divide(numerator, denom, result);
+    cv::patchNaNs(result, 0.0);
+    const float sigma_T_norm = static_cast<float>(std::sqrt(sigma_T_sq));
+    result.setTo(0.0f, denom < sigma_T_norm * 1e-5f);
+    cv::min(result, 1.0f, result);
+    cv::max(result, -1.0f, result);
+    return result;
+}
+}

--- a/src/MaaCore/Vision/MaskedCcoeffMatcher.cpp
+++ b/src/MaaCore/Vision/MaskedCcoeffMatcher.cpp
@@ -3,7 +3,6 @@
 #include "MaaUtils/NoWarningCV.hpp"
 
 #include <array>
-#include <cmath>
 #include <vector>
 
 namespace asst
@@ -42,13 +41,17 @@ MaskedCcoeffMatcher& MaskedCcoeffMatcher::get_instance()
 
 void MaskedCcoeffMatcher::sync_cache_revision(const uint64_t revision)
 {
-    std::lock_guard<std::mutex> lk(m_cache_mtx);
-    if (m_cache_revision == revision) {
+    if (m_cache_revision.load(std::memory_order_acquire) == revision) {
         return;
     }
+    std::lock_guard lk(m_cache_mtx);
+    if (m_cache_revision.load(std::memory_order_relaxed) == revision) {
+        return;
+    }
+    // 清一下缓存
     m_template_plan_cache.clear();
     m_dft_plan_cache.clear();
-    m_cache_revision = revision;
+    m_cache_revision.store(revision, std::memory_order_release);
 }
 
 void MaskedCcoeffMatcher::fnv1a_update(uint64_t& h, const void* data, size_t size)
@@ -70,6 +73,7 @@ std::string MaskedCcoeffMatcher::make_mat_cache_key(const cv::Mat& mat)
     for (int y = 0; y < mat.rows; ++y) {
         fnv1a_update(h, mat.ptr(y), row_bytes);
     }
+    // 捏个hash key
     return "mat:" + std::to_string(mat.rows) + "x" + std::to_string(mat.cols)
            + ":" + std::to_string(mat.type()) + ":" + std::to_string(h);
 }
@@ -81,9 +85,8 @@ std::shared_ptr<const MaskedCcoeffMatcher::TemplatePlan> MaskedCcoeffMatcher::ge
     int mask_pixels)
 {
     {
-        std::lock_guard<std::mutex> lk(m_cache_mtx);
-        auto it = m_template_plan_cache.find(cache_key);
-        if (it != m_template_plan_cache.end()) {
+        std::lock_guard lk(m_cache_mtx);
+        if (const auto it = m_template_plan_cache.find(cache_key); it != m_template_plan_cache.end()) {
             return it->second;
         }
     }
@@ -119,7 +122,7 @@ std::shared_ptr<const MaskedCcoeffMatcher::TemplatePlan> MaskedCcoeffMatcher::ge
     }
     plan->K = static_cast<int>(plan->sparse_entries.size());
 
-    std::lock_guard<std::mutex> lk(m_cache_mtx);
+    std::lock_guard lk(m_cache_mtx);
     auto [it, inserted] = m_template_plan_cache.emplace(cache_key, plan);
     static_cast<void>(inserted);
     return it->second;
@@ -133,9 +136,8 @@ std::shared_ptr<const MaskedCcoeffMatcher::DftPlan> MaskedCcoeffMatcher::get_or_
 {
     const std::string dft_key = cache_key + ":dft:" + std::to_string(dft_rows) + "x" + std::to_string(dft_cols);
     {
-        std::lock_guard<std::mutex> lk(m_cache_mtx);
-        auto it = m_dft_plan_cache.find(dft_key);
-        if (it != m_dft_plan_cache.end()) {
+        std::lock_guard lk(m_cache_mtx);
+        if (const auto it = m_dft_plan_cache.find(dft_key); it != m_dft_plan_cache.end()) {
             return it->second;
         }
     }
@@ -153,7 +155,7 @@ std::shared_ptr<const MaskedCcoeffMatcher::DftPlan> MaskedCcoeffMatcher::get_or_
         compute_into(template_plan.T_prime[c], dft_plan->T_prime_dft[c]);
     }
 
-    std::lock_guard<std::mutex> lk(m_cache_mtx);
+    std::lock_guard lk(m_cache_mtx);
     auto [it, inserted] = m_dft_plan_cache.emplace(dft_key, dft_plan);
     static_cast<void>(inserted);
     return it->second;
@@ -161,9 +163,24 @@ std::shared_ptr<const MaskedCcoeffMatcher::DftPlan> MaskedCcoeffMatcher::get_or_
 
 bool MaskedCcoeffMatcher::should_fallback_to_opencv(int mask_pixels, int result_positions)
 {
-    // DFT 的固定成本在输出位置很少、mask 很密时会超过 OpenCV 原路径。
-    static constexpr int OPENCV_DENSE_RESULT_LIMIT = 10'000;
-    return mask_pixels >= 2'000 && result_positions < OPENCV_DENSE_RESULT_LIMIT;
+    // 神秘调参值
+    // - 极小 result + 低 K：稀疏路径整体工作量极小（K 次扫小 result）
+    //   OpenCV 的固定 setup 开销在这一档反而占主导，留给稀疏
+    // - 极小 result + 高 K（图像略大于模板的 case，如 138×130/105×105）
+    //   K 超过稀疏阈值无法走稀疏，FFT 在小 DFT size 上不如opencv快了
+    // - 中等 result 配中等 K：OpenCV 紧凑 SIMD 内核比稀疏路径的多通道宽累加快
+    // - 总工作量 K*result 不大：OpenCV 紧凑 SIMD 常数因子优于稀疏 / FFT
+    //   实测 K*result < 25M 段 100% 退化、> 50M 段几乎全是加速
+    if (result_positions < 1000 && mask_pixels < 2000) {
+        return false;
+    }
+    if (result_positions < 12000 && mask_pixels >= 500) {
+        return true;
+    }
+    if (static_cast<long long>(mask_pixels) * result_positions < 25'000'000LL) {
+        return true;
+    }
+    return false;
 }
 
 // 用 cv::dft 直接实现，消除冗余 FFT
@@ -176,7 +193,7 @@ bool MaskedCcoeffMatcher::should_fallback_to_opencv(int mask_pixels, int result_
 //   FFT(I_c) 和 FFT(I_c²) 每通道各算一次并复用
 //   FFT(T'_c) 和 FFT(M) 通过缓存跨调用复用
 //
-// 数学等价于 cv::matchTemplate(image, templ, result, TM_CCOEFF_NORMED, mask)
+// 等价于 cv::matchTemplate(image, templ, result, TM_CCOEFF_NORMED, mask)
 cv::Mat MaskedCcoeffMatcher::match(
     const cv::Mat& image_rgb,      // CV_8UC3
     const cv::Mat& templ_rgb,      // CV_8UC3
@@ -207,9 +224,9 @@ cv::Mat MaskedCcoeffMatcher::match(
     std::vector<cv::Mat> I_ch(3);
     cv::split(I, I_ch);
 
-    // ---- 稀疏直接相关（小模板快路径）----------------------
-    // 双重条件：K < SPARSE_K_LIMIT 且总工作量 K×result_positions < SPARSE_WORK_LIMIT。
-    // 仅满足 K 小但结果矩阵极大时（如 49×28 模板/690×434 图）仍走 FFT 路径。
+    // 稀疏直接相关（小模板快路径，比如基建任务中那种就很合适）
+    // 双重条件：K < SPARSE_K_LIMIT 且总工作量 K×result_positions < SPARSE_WORK_LIMIT
+    // 仅满足 K 小但结果矩阵极大时（如 49×28 模板/690×434 图）仍走 FFT 路径
     static constexpr int SPARSE_K_LIMIT = 2000;
     static constexpr long long SPARSE_WORK_LIMIT = 30'000'000LL;
     if (template_plan->K > 0 && template_plan->K < SPARSE_K_LIMIT &&
@@ -220,21 +237,21 @@ cv::Mat MaskedCcoeffMatcher::match(
         cv::Mat sum_MI_b = cv::Mat::zeros(rh, rw, CV_32F);
         cv::Mat sum_MI2 = cv::Mat::zeros(rh, rw, CV_32F); // Σ_c I_c²
 
-        for (const auto& e : template_plan->sparse_entries) {
+        for (const auto& [dx, dy, T_prime] : template_plan->sparse_entries) {
             for (int y = 0; y < rh; ++y) {
-                const float* Ir = I_ch[0].ptr<float>(y + e.dy) + e.dx;
-                const float* Ig = I_ch[1].ptr<float>(y + e.dy) + e.dx;
-                const float* Ib = I_ch[2].ptr<float>(y + e.dy) + e.dx;
-                float* num_p = numerator.ptr<float>(y);
-                float* smir_p = sum_MI_r.ptr<float>(y);
-                float* smig_p = sum_MI_g.ptr<float>(y);
-                float* smib_p = sum_MI_b.ptr<float>(y);
-                float* smi2_p = sum_MI2.ptr<float>(y);
+                const float* Ir = I_ch[0].ptr<float>(y + dy) + dx;
+                const float* Ig = I_ch[1].ptr<float>(y + dy) + dx;
+                const float* Ib = I_ch[2].ptr<float>(y + dy) + dx;
+                auto* num_p = numerator.ptr<float>(y);
+                auto* smir_p = sum_MI_r.ptr<float>(y);
+                auto* smig_p = sum_MI_g.ptr<float>(y);
+                auto* smib_p = sum_MI_b.ptr<float>(y);
+                auto* smi2_p = sum_MI2.ptr<float>(y);
 
-                // 内层循环：连续内存，编译器向量化
+                // 编译器会自动向量化的
                 for (int x = 0; x < rw; ++x) {
                     const float r = Ir[x], g = Ig[x], b = Ib[x];
-                    num_p[x] += e.T_prime[0] * r + e.T_prime[1] * g + e.T_prime[2] * b;
+                    num_p[x] += T_prime[0] * r + T_prime[1] * g + T_prime[2] * b;
                     smir_p[x] += r;
                     smig_p[x] += g;
                     smib_p[x] += b;
@@ -259,19 +276,18 @@ cv::Mat MaskedCcoeffMatcher::match(
         cv::Mat result;
         cv::divide(numerator, denom, result);
         cv::patchNaNs(result, 0.0);
-        const float sigma_T_norm = static_cast<float>(std::sqrt(sigma_T_sq));
+        const auto sigma_T_norm = static_cast<float>(std::sqrt(sigma_T_sq));
         result.setTo(0.0f, denom < sigma_T_norm * 1e-5f);
         cv::min(result, 1.0f, result);
         cv::max(result, -1.0f, result);
         return result;
     }
 
-    // DFT 的填充尺寸：仅在确认走 FFT 路径后才需要。
+    // DFT 的填充尺寸：仅在确认走 FFT 路径后才需要
     const int dft_rows = cv::getOptimalDFTSize(I.rows + T.rows - 1);
     const int dft_cols = cv::getOptimalDFTSize(I.cols + T.cols - 1);
     const auto dft_plan = get_or_build_dft_plan(cache_key, *template_plan, dft_rows, dft_cols);
 
-    // ---- FFT buffer 仅在确认走 FFT 路径后才分配 ---
     cv::Mat padded(dft_rows, dft_cols, CV_32F, cv::Scalar(0));
     cv::Mat I_dft(dft_rows, dft_cols, CV_32FC2);
     cv::Mat I_sq_dft(dft_rows, dft_cols, CV_32FC2);
@@ -329,7 +345,7 @@ cv::Mat MaskedCcoeffMatcher::match(
     cv::Mat result;
     cv::divide(numerator, denom, result);
     cv::patchNaNs(result, 0.0);
-    const float sigma_T_norm = static_cast<float>(std::sqrt(sigma_T_sq));
+    const auto sigma_T_norm = static_cast<float>(std::sqrt(sigma_T_sq));
     result.setTo(0.0f, denom < sigma_T_norm * 1e-5f);
     cv::min(result, 1.0f, result);
     cv::max(result, -1.0f, result);

--- a/src/MaaCore/Vision/MaskedCcoeffMatcher.h
+++ b/src/MaaCore/Vision/MaskedCcoeffMatcher.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "MaaUtils/NoWarningCVMat.hpp"
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
+namespace asst
+{
+class MaskedCcoeffMatcher
+{
+public:
+    static MaskedCcoeffMatcher& get_instance();
+
+    void sync_cache_revision(uint64_t revision);
+    static std::string make_mat_cache_key(const cv::Mat& mat);
+
+    cv::Mat match(
+        const cv::Mat& image_rgb,
+        const cv::Mat& templ_rgb,
+        const cv::Mat& mask_u8,
+        const std::string& cache_key,
+        int mask_pixels);
+
+    static bool should_fallback_to_opencv(int mask_pixels, int result_positions);
+
+private:
+    struct TemplatePlan;
+    struct DftPlan;
+
+    static void fnv1a_update(uint64_t& h, const void* data, size_t size);
+
+    std::shared_ptr<const TemplatePlan> get_or_build_template_plan(
+        const std::string& cache_key,
+        const cv::Mat& templ_f32,
+        const cv::Mat& mask_f32,
+        int mask_pixels);
+
+    std::shared_ptr<const DftPlan> get_or_build_dft_plan(
+        const std::string& cache_key,
+        const TemplatePlan& template_plan,
+        int dft_rows,
+        int dft_cols);
+
+    std::mutex m_cache_mtx;
+    std::unordered_map<std::string, std::shared_ptr<const TemplatePlan>> m_template_plan_cache;
+    std::unordered_map<std::string, std::shared_ptr<const DftPlan>> m_dft_plan_cache;
+    uint64_t m_cache_revision = 0;
+};
+}

--- a/src/MaaCore/Vision/MaskedCcoeffMatcher.h
+++ b/src/MaaCore/Vision/MaskedCcoeffMatcher.h
@@ -2,8 +2,7 @@
 
 #include "MaaUtils/NoWarningCVMat.hpp"
 
-#include <cstddef>
-#include <cstdint>
+#include <atomic>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -49,6 +48,6 @@ private:
     std::mutex m_cache_mtx;
     std::unordered_map<std::string, std::shared_ptr<const TemplatePlan>> m_template_plan_cache;
     std::unordered_map<std::string, std::shared_ptr<const DftPlan>> m_dft_plan_cache;
-    uint64_t m_cache_revision = 0;
+    std::atomic<uint64_t> m_cache_revision { 0 };
 };
 }

--- a/src/MaaCore/Vision/Matcher.cpp
+++ b/src/MaaCore/Vision/Matcher.cpp
@@ -5,12 +5,10 @@
 #include "Config/TaskData.h"
 #include "Config/TemplResource.h"
 #include "MaaUtils/ImageIo.h"
+#include "MaskedCcoeffMatcher.h"
 #include "Utils/DebugImageHelper.hpp"
 #include "Utils/Logger.hpp"
 #include "Utils/StringMisc.hpp"
-
-#include <mutex>
-#include <unordered_map>
 
 using namespace asst;
 
@@ -85,258 +83,12 @@ Matcher::ResultOpt Matcher::analyze() const
     return std::nullopt;
 }
 
-// 模板侧 FFT 缓存
-// 每个 (templ_name, mask_params, dft_size) 只计算一次 FFT(T'_c) 和 FFT(M)。
-// cv::Mat 使用引用计数，缓存存储开销低（不会深拷贝像素数据）。
-
-// 稀疏路径使用的每个有效 mask 像素的条目
-struct SparseEntry
-{
-    int16_t dx, dy;        // 相对模板左上角的偏移
-    float   T_prime[3];    // M*(T_c - μT_c)，per-channel
-};
-
-struct MaskedMatchTemplFFT
-{
-    // FFT 路径
-    std::array<cv::Mat, 3> T_prime_dft; // FFT(M*(T_c - μT_c))，每通道一个
-    cv::Mat                M_dft;       // FFT(M)
-    double                 sigma_T_sq = 0.0;
-    double                 mask_area  = 0.0;
-
-    // 稀疏路径
-    std::vector<SparseEntry> sparse_entries; // 非零 mask 位置列表
-    int K = 0;                               // sparse_entries.size()
-};
-
-static std::mutex s_fft_cache_mtx;
-static std::unordered_map<std::string, MaskedMatchTemplFFT> s_fft_cache;
-
-// 用 cv::dft 直接实现，消除冗余 FFT
-//
-// 当前 9 次 matchTemplate 的冗余：
-//   FFT(I_c)  每通道算两次（分别用于 xcorr(T'_c, I_c) 和 xcorr(M, I_c)）
-//   FFT(M)    每通道算两次（分别用于 xcorr(M, I_c) 和 xcorr(M, I_c²)）
-//
-// 优化后：
-//   FFT(I_c) 和 FFT(I_c²) 每通道各算一次并复用
-//   FFT(T'_c) 和 FFT(M) 通过缓存跨调用复用
-//
-// 数学等价于 cv::matchTemplate(image, templ, result, TM_CCOEFF_NORMED, mask)
-static cv::Mat fast_masked_ccoeff_normed(
-    const cv::Mat& image_rgb,      // CV_8UC3
-    const cv::Mat& templ_rgb,      // CV_8UC3
-    const cv::Mat& mask_u8,        // CV_8UC1, 0 or 255
-    const std::string& cache_key)  // 模板侧 FFT 缓存键
-{
-    cv::Mat I, T, M;
-    image_rgb.convertTo(I, CV_32F);
-    templ_rgb.convertTo(T, CV_32F);
-    mask_u8.convertTo(M, CV_32F, 1.0 / 255.0);
-
-    const int rh = I.rows - T.rows + 1;
-    const int rw = I.cols - T.cols + 1;
-    if (rh <= 0 || rw <= 0) return {};
-
-    // DFT 的填充尺寸：用于 cache key（buffer 延迟到确认走 FFT 路径后再分配）
-    const int dft_rows = cv::getOptimalDFTSize(I.rows + T.rows - 1);
-    const int dft_cols = cv::getOptimalDFTSize(I.cols + T.cols - 1);
-
-    // ---- 读取或计算模板侧 FFT 缓存 ---
-    // key 包含 dft_size，不同图像尺寸会产生不同填充，分开存储
-    const std::string full_key =
-        cache_key + ":" + std::to_string(dft_rows) + "x" + std::to_string(dft_cols);
-
-    MaskedMatchTemplFFT local_cache;
-    {
-        std::lock_guard<std::mutex> lk(s_fft_cache_mtx);
-        auto it = s_fft_cache.find(full_key);
-        if (it != s_fft_cache.end()) {
-            local_cache = it->second; // cv::Mat 浅拷贝，不复制像素
-        }
-    }
-
-    if (local_cache.mask_area < 1.0) {
-        // 缓存未命中，一次性计算 FFT 路径和稀疏路径所需的所有模板侧数据
-        const double mask_area = cv::sum(M)[0];
-        if (mask_area < 1.0) return {};
-
-        local_cache.mask_area = mask_area;
-
-        // cache-miss 时用局部临时 padded，避免为大 DFT buffer 提前分配
-        cv::Mat init_pad = cv::Mat::zeros(dft_rows, dft_cols, CV_32F);
-        auto compute_into = [&](const cv::Mat& src, cv::Mat& out) {
-            init_pad.setTo(0.0f);
-            src.copyTo(init_pad(cv::Rect(0, 0, src.cols, src.rows)));
-            cv::dft(init_pad, out, cv::DFT_COMPLEX_OUTPUT);
-        };
-        compute_into(M, local_cache.M_dft);
-
-        std::vector<cv::Mat> T_ch(3);
-        cv::split(T, T_ch);
-
-        // 先把三通道的 T_prime 全部算出来，后续 FFT 和稀疏都用这批数据
-        std::array<cv::Mat, 3> T_prime_mats;
-        for (int c = 0; c < 3; ++c) {
-            const double mu_T = cv::sum(M.mul(T_ch[c]))[0] / mask_area;
-            T_prime_mats[c]   = M.mul(T_ch[c] - mu_T);
-            local_cache.sigma_T_sq += cv::sum(T_prime_mats[c].mul(T_prime_mats[c]))[0];
-            compute_into(T_prime_mats[c], local_cache.T_prime_dft[c]);
-        }
-
-        // 稀疏路径：收集所有非零 mask 位置及其 T' 值
-        for (int v = 0; v < T.rows; ++v) {
-            for (int u = 0; u < T.cols; ++u) {
-                if (M.at<float>(v, u) > 0.5f) {
-                    SparseEntry e{};
-                    e.dx = static_cast<int16_t>(u);
-                    e.dy = static_cast<int16_t>(v);
-                    for (int c = 0; c < 3; ++c)
-                        e.T_prime[c] = T_prime_mats[c].at<float>(v, u);
-                    local_cache.sparse_entries.push_back(e);
-                }
-            }
-        }
-        local_cache.K = static_cast<int>(local_cache.sparse_entries.size());
-
-        std::lock_guard<std::mutex> lk(s_fft_cache_mtx);
-        s_fft_cache.emplace(full_key, local_cache);
-    }
-
-    const double mask_area  = local_cache.mask_area;
-    const double sigma_T_sq = local_cache.sigma_T_sq;
-
-    // 图像通道拆分：稀疏和 FFT 两条路径都需要
-    std::vector<cv::Mat> I_ch(3);
-    cv::split(I, I_ch);
-
-    // ---- 稀疏直接相关（小模板快路径）----------------------
-    // 双重条件：K < SPARSE_K_LIMIT 且总工作量 K×result_positions < SPARSE_WORK_LIMIT。
-    // 仅满足 K 小但结果矩阵极大时（如 49×28 模板/690×434 图）仍走 FFT 路径。
-    static constexpr int       SPARSE_K_LIMIT    = 2000;
-    static constexpr long long SPARSE_WORK_LIMIT = 30'000'000LL;
-    if (local_cache.K > 0 && local_cache.K < SPARSE_K_LIMIT &&
-        static_cast<long long>(local_cache.K) * rh * rw < SPARSE_WORK_LIMIT) {
-        cv::Mat numerator  = cv::Mat::zeros(rh, rw, CV_32F);
-        cv::Mat sum_MI_r   = cv::Mat::zeros(rh, rw, CV_32F);
-        cv::Mat sum_MI_g   = cv::Mat::zeros(rh, rw, CV_32F);
-        cv::Mat sum_MI_b   = cv::Mat::zeros(rh, rw, CV_32F);
-        cv::Mat sum_MI2    = cv::Mat::zeros(rh, rw, CV_32F); // Σ_c I_c²
-
-        for (const auto& e : local_cache.sparse_entries) {
-            for (int y = 0; y < rh; ++y) {
-                const float* Ir = I_ch[0].ptr<float>(y + e.dy) + e.dx;
-                const float* Ig = I_ch[1].ptr<float>(y + e.dy) + e.dx;
-                const float* Ib = I_ch[2].ptr<float>(y + e.dy) + e.dx;
-                float* num_p  = numerator.ptr<float>(y);
-                float* smir_p = sum_MI_r.ptr<float>(y);
-                float* smig_p = sum_MI_g.ptr<float>(y);
-                float* smib_p = sum_MI_b.ptr<float>(y);
-                float* smi2_p = sum_MI2.ptr<float>(y);
-
-                // 内层循环：连续内存，编译器向量化
-                for (int x = 0; x < rw; ++x) {
-                    const float r = Ir[x], g = Ig[x], b = Ib[x];
-                    num_p[x]  += e.T_prime[0]*r + e.T_prime[1]*g + e.T_prime[2]*b;
-                    smir_p[x] += r;
-                    smig_p[x] += g;
-                    smib_p[x] += b;
-                    smi2_p[x] += r*r + g*g + b*b;
-                }
-            }
-        }
-
-        // sigma_I² = sum_MI2 - (sum_MI_r² + sum_MI_g² + sum_MI_b²) / mask_area
-        cv::Mat sq_sum, sq_g, sq_b;
-        cv::multiply(sum_MI_r, sum_MI_r, sq_sum);
-        cv::multiply(sum_MI_g, sum_MI_g, sq_g);
-        cv::multiply(sum_MI_b, sum_MI_b, sq_b);
-        cv::add(sq_sum, sq_g, sq_sum);
-        cv::add(sq_sum, sq_b, sq_sum);
-        cv::Mat sigma_I_sq;
-        cv::subtract(sum_MI2, sq_sum * (1.0 / mask_area), sigma_I_sq);
-        cv::max(sigma_I_sq, 0.0, sigma_I_sq);
-
-        cv::Mat denom;
-        cv::sqrt(sigma_I_sq * sigma_T_sq, denom);
-        cv::Mat result;
-        cv::divide(numerator, denom, result);
-        cv::patchNaNs(result, 0.0);
-        const float sigma_T_norm = static_cast<float>(std::sqrt(sigma_T_sq));
-        result.setTo(0.0f, denom < sigma_T_norm * 1e-5f);
-        cv::min(result,  1.0f, result);
-        cv::max(result, -1.0f, result);
-        return result;
-    }
-
-    // ---- FFT buffer 仅在确认走 FFT 路径后才分配 ---
-    cv::Mat padded(dft_rows, dft_cols, CV_32F, cv::Scalar(0));
-    cv::Mat I_dft(dft_rows, dft_cols, CV_32FC2);
-    cv::Mat I_sq_dft(dft_rows, dft_cols, CV_32FC2);
-    cv::Mat spectrum(dft_rows, dft_cols, CV_32FC2);
-    cv::Mat result_buf(dft_rows, dft_cols, CV_32F);
-    cv::Mat sum_MI_buf(rh, rw, CV_32F);
-    cv::Mat sum_MI2_buf(rh, rw, CV_32F);
-
-    auto make_dft_into = [&](const cv::Mat& src, cv::Mat& out) {
-        padded.setTo(0.0f);
-        src.copyTo(padded(cv::Rect(0, 0, src.cols, src.rows)));
-        cv::dft(padded, out, cv::DFT_COMPLEX_OUTPUT);
-    };
-    auto xcorr_into = [&](const cv::Mat& dft_A, const cv::Mat& dft_B, cv::Mat& out) {
-        cv::mulSpectrums(dft_A, dft_B, spectrum, 0, true);
-        cv::dft(spectrum, result_buf, cv::DFT_INVERSE | cv::DFT_REAL_OUTPUT | cv::DFT_SCALE);
-        result_buf(cv::Rect(0, 0, rw, rh)).copyTo(out);
-    };
-    auto xcorr_add = [&](const cv::Mat& dft_A, const cv::Mat& dft_B, cv::Mat& accum) {
-        cv::mulSpectrums(dft_A, dft_B, spectrum, 0, true);
-        cv::dft(spectrum, result_buf, cv::DFT_INVERSE | cv::DFT_REAL_OUTPUT | cv::DFT_SCALE);
-        cv::add(accum, result_buf(cv::Rect(0, 0, rw, rh)), accum);
-    };
-
-    // 图像侧每通道 FFT 只算一次
-    cv::Mat numerator     = cv::Mat::zeros(rh, rw, CV_32F);
-    cv::Mat sigma_I_sq_d  = cv::Mat::zeros(rh, rw, CV_64F); // float64 避免 sum_MI2-sum_MI² 灾难性精度损失
-
-    for (int c = 0; c < 3; ++c) {
-        make_dft_into(I_ch[c], I_dft);
-        make_dft_into(I_ch[c].mul(I_ch[c]), I_sq_dft);
-
-        // numerator += xcorr(T'_c, I_c)
-        xcorr_add(I_dft, local_cache.T_prime_dft[c], numerator);
-
-        // σ_I_c²(x,y) = sum_MI2 - sum_MI² / mask_area
-        // 两项量级相近时相减会损失精度，用 float64 累加
-        xcorr_into(I_dft,    local_cache.M_dft, sum_MI_buf);
-        xcorr_into(I_sq_dft, local_cache.M_dft, sum_MI2_buf);
-        cv::Mat sum_MI_d, sum_MI2_d, var_d;
-        sum_MI_buf.convertTo(sum_MI_d,   CV_64F);
-        sum_MI2_buf.convertTo(sum_MI2_d, CV_64F);
-        cv::multiply(sum_MI_d, sum_MI_d, var_d, -1.0 / mask_area);
-        cv::add(var_d, sum_MI2_d, var_d);
-        cv::add(sigma_I_sq_d, var_d, sigma_I_sq_d);
-    }
-
-    cv::Mat sigma_I_sq;
-    sigma_I_sq_d.convertTo(sigma_I_sq, CV_32F);
-    cv::max(sigma_I_sq, 0.0, sigma_I_sq);
-
-    cv::Mat denom;
-    cv::sqrt(sigma_I_sq * sigma_T_sq, denom);
-
-    cv::Mat result;
-    cv::divide(numerator, denom, result);
-    cv::patchNaNs(result, 0.0);
-    const float sigma_T_norm = static_cast<float>(std::sqrt(sigma_T_sq));
-    result.setTo(0.0f, denom < sigma_T_norm * 1e-5f);
-    cv::min(result,  1.0f, result);
-    cv::max(result, -1.0f, result);
-    return result;
-}
-
 std::vector<Matcher::RawResult> Matcher::preproc_and_match(const cv::Mat& image, const MatcherConfig::Params& params)
 {
     std::vector<Matcher::RawResult> results;
+    const uint64_t templ_revision = TemplResource::get_instance().revision();
+    auto& masked_ccoeff_matcher = MaskedCcoeffMatcher::get_instance();
+    masked_ccoeff_matcher.sync_cache_revision(templ_revision);
 
     // Image-side color conversions: compute once, reuse across all templates
     cv::Mat image_match;
@@ -427,7 +179,7 @@ std::vector<Matcher::RawResult> Matcher::preproc_and_match(const cv::Mat& image,
         int match_algorithm = cv::TM_CCOEFF_NORMED;
 
         auto calc_mask = [&templ_name](
-                             const MatchTaskInfo::Ranges mask_ranges,
+                             const MatchTaskInfo::Ranges& mask_ranges,
                              const cv::Mat& templ,
                              const cv::Mat& templ_gray,
                              bool with_close) -> std::optional<cv::Mat> {
@@ -472,34 +224,38 @@ std::vector<Matcher::RawResult> Matcher::preproc_and_match(const cv::Mat& image,
             }
             // mask_src=false 时 mask 完全由模板决定，用 FFT 路径替代标量滑窗
             if (!params.mask_src) {
-                //  cache key：templ_name + mask_ranges 序列化
-                // （mask_src=false 时 mask 由模板+参数唯一确定）
-                // cv::Mat 形式的模板没有文件名，用像素内容 hash 保证 key 唯一
-                std::string fft_key = templ_name;
-                if (fft_key.empty()) {
-                    uint64_t h = 14695981039346656037ULL;
-                    const auto* ptr = templ.data;
-                    const size_t n = static_cast<size_t>(templ.total()) * templ.elemSize();
-                    for (size_t j = 0; j < n; ++j) { h ^= ptr[j]; h *= 1099511628211ULL; }
-                    fft_key = "mat:" + std::to_string(h);
+                const int mask_pixels = cv::countNonZero(mask_opt.value());
+                if (mask_pixels == mask_opt.value().rows * mask_opt.value().cols) {
+                    cv::matchTemplate(image_match, templ_match, matched, match_algorithm);
                 }
-                for (const auto& r : params.mask_ranges) {
-                    if (std::holds_alternative<MatchTaskInfo::GrayRange>(r)) {
-                        const auto& g = std::get<MatchTaskInfo::GrayRange>(r);
-                        fft_key += ":G" + std::to_string(g.first) + '_' + std::to_string(g.second);
-                    }
-                    else if (std::holds_alternative<MatchTaskInfo::ColorRange>(r)) {
-                        const auto& col = std::get<MatchTaskInfo::ColorRange>(r);
-                        fft_key += ":C";
-                        for (auto v : col.first)  fft_key += std::to_string(v) + ',';
-                        fft_key += '_';
-                        for (auto v : col.second) fft_key += std::to_string(v) + ',';
-                    }
+                else if (MaskedCcoeffMatcher::should_fallback_to_opencv(
+                             mask_pixels,
+                             (image_match.rows - templ_match.rows + 1) * (image_match.cols - templ_match.cols + 1))) {
+                    // matched 保持 empty，统一落到下面的 OpenCV masked matchTemplate。
                 }
-                fft_key += params.mask_close ? ":1" : ":0";
+                else {
+                    // cache key：模板身份 + mask_ranges。资源模板绑定 revision；cv::Mat 模板使用 row-wise 内容 hash。
+                    std::string fft_key = templ_name.empty()
+                        ? MaskedCcoeffMatcher::make_mat_cache_key(templ)
+                        : "res:" + std::to_string(templ_revision) + ":" + templ_name;
+                    for (const auto& r : params.mask_ranges) {
+                        if (std::holds_alternative<MatchTaskInfo::GrayRange>(r)) {
+                            const auto& g = std::get<MatchTaskInfo::GrayRange>(r);
+                            fft_key += ":G" + std::to_string(g.first) + '_' + std::to_string(g.second);
+                        }
+                        else if (std::holds_alternative<MatchTaskInfo::ColorRange>(r)) {
+                            const auto& col = std::get<MatchTaskInfo::ColorRange>(r);
+                            fft_key += ":C";
+                            for (auto v : col.first)  fft_key += std::to_string(v) + ',';
+                            fft_key += '_';
+                            for (auto v : col.second) fft_key += std::to_string(v) + ',';
+                        }
+                    }
+                    fft_key += params.mask_close ? ":1" : ":0";
 
-                matched = fast_masked_ccoeff_normed(
-                    image_match, templ_match, mask_opt.value(), fft_key);
+                    matched = masked_ccoeff_matcher.match(
+                        image_match, templ_match, mask_opt.value(), fft_key, mask_pixels);
+                }
             }
             if (matched.empty()) {
                 cv::matchTemplate(image_match, templ_match, matched, match_algorithm, mask_opt.value());

--- a/src/MaaCore/Vision/Matcher.cpp
+++ b/src/MaaCore/Vision/Matcher.cpp
@@ -9,6 +9,9 @@
 #include "Utils/Logger.hpp"
 #include "Utils/StringMisc.hpp"
 
+#include <mutex>
+#include <unordered_map>
+
 using namespace asst;
 
 Matcher::ResultOpt Matcher::analyze() const
@@ -80,6 +83,255 @@ Matcher::ResultOpt Matcher::analyze() const
     }
 
     return std::nullopt;
+}
+
+// 模板侧 FFT 缓存
+// 每个 (templ_name, mask_params, dft_size) 只计算一次 FFT(T'_c) 和 FFT(M)。
+// cv::Mat 使用引用计数，缓存存储开销低（不会深拷贝像素数据）。
+
+// 稀疏路径使用的每个有效 mask 像素的条目
+struct SparseEntry
+{
+    int16_t dx, dy;        // 相对模板左上角的偏移
+    float   T_prime[3];    // M*(T_c - μT_c)，per-channel
+};
+
+struct MaskedMatchTemplFFT
+{
+    // FFT 路径
+    std::array<cv::Mat, 3> T_prime_dft; // FFT(M*(T_c - μT_c))，每通道一个
+    cv::Mat                M_dft;       // FFT(M)
+    double                 sigma_T_sq = 0.0;
+    double                 mask_area  = 0.0;
+
+    // 稀疏路径
+    std::vector<SparseEntry> sparse_entries; // 非零 mask 位置列表
+    int K = 0;                               // sparse_entries.size()
+};
+
+static std::mutex s_fft_cache_mtx;
+static std::unordered_map<std::string, MaskedMatchTemplFFT> s_fft_cache;
+
+// 用 cv::dft 直接实现，消除冗余 FFT
+//
+// 当前 9 次 matchTemplate 的冗余：
+//   FFT(I_c)  每通道算两次（分别用于 xcorr(T'_c, I_c) 和 xcorr(M, I_c)）
+//   FFT(M)    每通道算两次（分别用于 xcorr(M, I_c) 和 xcorr(M, I_c²)）
+//
+// 优化后：
+//   FFT(I_c) 和 FFT(I_c²) 每通道各算一次并复用
+//   FFT(T'_c) 和 FFT(M) 通过缓存跨调用复用
+//
+// 数学等价于 cv::matchTemplate(image, templ, result, TM_CCOEFF_NORMED, mask)
+static cv::Mat fast_masked_ccoeff_normed(
+    const cv::Mat& image_rgb,      // CV_8UC3
+    const cv::Mat& templ_rgb,      // CV_8UC3
+    const cv::Mat& mask_u8,        // CV_8UC1, 0 or 255
+    const std::string& cache_key)  // 模板侧 FFT 缓存键
+{
+    cv::Mat I, T, M;
+    image_rgb.convertTo(I, CV_32F);
+    templ_rgb.convertTo(T, CV_32F);
+    mask_u8.convertTo(M, CV_32F, 1.0 / 255.0);
+
+    const int rh = I.rows - T.rows + 1;
+    const int rw = I.cols - T.cols + 1;
+    if (rh <= 0 || rw <= 0) return {};
+
+    // DFT 的填充尺寸：用于 cache key（buffer 延迟到确认走 FFT 路径后再分配）
+    const int dft_rows = cv::getOptimalDFTSize(I.rows + T.rows - 1);
+    const int dft_cols = cv::getOptimalDFTSize(I.cols + T.cols - 1);
+
+    // ---- 读取或计算模板侧 FFT 缓存 ---
+    // key 包含 dft_size，不同图像尺寸会产生不同填充，分开存储
+    const std::string full_key =
+        cache_key + ":" + std::to_string(dft_rows) + "x" + std::to_string(dft_cols);
+
+    MaskedMatchTemplFFT local_cache;
+    {
+        std::lock_guard<std::mutex> lk(s_fft_cache_mtx);
+        auto it = s_fft_cache.find(full_key);
+        if (it != s_fft_cache.end()) {
+            local_cache = it->second; // cv::Mat 浅拷贝，不复制像素
+        }
+    }
+
+    if (local_cache.mask_area < 1.0) {
+        // 缓存未命中，一次性计算 FFT 路径和稀疏路径所需的所有模板侧数据
+        const double mask_area = cv::sum(M)[0];
+        if (mask_area < 1.0) return {};
+
+        local_cache.mask_area = mask_area;
+
+        // cache-miss 时用局部临时 padded，避免为大 DFT buffer 提前分配
+        cv::Mat init_pad = cv::Mat::zeros(dft_rows, dft_cols, CV_32F);
+        auto compute_into = [&](const cv::Mat& src, cv::Mat& out) {
+            init_pad.setTo(0.0f);
+            src.copyTo(init_pad(cv::Rect(0, 0, src.cols, src.rows)));
+            cv::dft(init_pad, out, cv::DFT_COMPLEX_OUTPUT);
+        };
+        compute_into(M, local_cache.M_dft);
+
+        std::vector<cv::Mat> T_ch(3);
+        cv::split(T, T_ch);
+
+        // 先把三通道的 T_prime 全部算出来，后续 FFT 和稀疏都用这批数据
+        std::array<cv::Mat, 3> T_prime_mats;
+        for (int c = 0; c < 3; ++c) {
+            const double mu_T = cv::sum(M.mul(T_ch[c]))[0] / mask_area;
+            T_prime_mats[c]   = M.mul(T_ch[c] - mu_T);
+            local_cache.sigma_T_sq += cv::sum(T_prime_mats[c].mul(T_prime_mats[c]))[0];
+            compute_into(T_prime_mats[c], local_cache.T_prime_dft[c]);
+        }
+
+        // 稀疏路径：收集所有非零 mask 位置及其 T' 值
+        for (int v = 0; v < T.rows; ++v) {
+            for (int u = 0; u < T.cols; ++u) {
+                if (M.at<float>(v, u) > 0.5f) {
+                    SparseEntry e{};
+                    e.dx = static_cast<int16_t>(u);
+                    e.dy = static_cast<int16_t>(v);
+                    for (int c = 0; c < 3; ++c)
+                        e.T_prime[c] = T_prime_mats[c].at<float>(v, u);
+                    local_cache.sparse_entries.push_back(e);
+                }
+            }
+        }
+        local_cache.K = static_cast<int>(local_cache.sparse_entries.size());
+
+        std::lock_guard<std::mutex> lk(s_fft_cache_mtx);
+        s_fft_cache.emplace(full_key, local_cache);
+    }
+
+    const double mask_area  = local_cache.mask_area;
+    const double sigma_T_sq = local_cache.sigma_T_sq;
+
+    // 图像通道拆分：稀疏和 FFT 两条路径都需要
+    std::vector<cv::Mat> I_ch(3);
+    cv::split(I, I_ch);
+
+    // ---- 稀疏直接相关（小模板快路径）----------------------
+    // 双重条件：K < SPARSE_K_LIMIT 且总工作量 K×result_positions < SPARSE_WORK_LIMIT。
+    // 仅满足 K 小但结果矩阵极大时（如 49×28 模板/690×434 图）仍走 FFT 路径。
+    static constexpr int       SPARSE_K_LIMIT    = 2000;
+    static constexpr long long SPARSE_WORK_LIMIT = 30'000'000LL;
+    if (local_cache.K > 0 && local_cache.K < SPARSE_K_LIMIT &&
+        static_cast<long long>(local_cache.K) * rh * rw < SPARSE_WORK_LIMIT) {
+        cv::Mat numerator  = cv::Mat::zeros(rh, rw, CV_32F);
+        cv::Mat sum_MI_r   = cv::Mat::zeros(rh, rw, CV_32F);
+        cv::Mat sum_MI_g   = cv::Mat::zeros(rh, rw, CV_32F);
+        cv::Mat sum_MI_b   = cv::Mat::zeros(rh, rw, CV_32F);
+        cv::Mat sum_MI2    = cv::Mat::zeros(rh, rw, CV_32F); // Σ_c I_c²
+
+        for (const auto& e : local_cache.sparse_entries) {
+            for (int y = 0; y < rh; ++y) {
+                const float* Ir = I_ch[0].ptr<float>(y + e.dy) + e.dx;
+                const float* Ig = I_ch[1].ptr<float>(y + e.dy) + e.dx;
+                const float* Ib = I_ch[2].ptr<float>(y + e.dy) + e.dx;
+                float* num_p  = numerator.ptr<float>(y);
+                float* smir_p = sum_MI_r.ptr<float>(y);
+                float* smig_p = sum_MI_g.ptr<float>(y);
+                float* smib_p = sum_MI_b.ptr<float>(y);
+                float* smi2_p = sum_MI2.ptr<float>(y);
+
+                // 内层循环：连续内存，编译器向量化
+                for (int x = 0; x < rw; ++x) {
+                    const float r = Ir[x], g = Ig[x], b = Ib[x];
+                    num_p[x]  += e.T_prime[0]*r + e.T_prime[1]*g + e.T_prime[2]*b;
+                    smir_p[x] += r;
+                    smig_p[x] += g;
+                    smib_p[x] += b;
+                    smi2_p[x] += r*r + g*g + b*b;
+                }
+            }
+        }
+
+        // sigma_I² = sum_MI2 - (sum_MI_r² + sum_MI_g² + sum_MI_b²) / mask_area
+        cv::Mat sq_sum, sq_g, sq_b;
+        cv::multiply(sum_MI_r, sum_MI_r, sq_sum);
+        cv::multiply(sum_MI_g, sum_MI_g, sq_g);
+        cv::multiply(sum_MI_b, sum_MI_b, sq_b);
+        cv::add(sq_sum, sq_g, sq_sum);
+        cv::add(sq_sum, sq_b, sq_sum);
+        cv::Mat sigma_I_sq;
+        cv::subtract(sum_MI2, sq_sum * (1.0 / mask_area), sigma_I_sq);
+        cv::max(sigma_I_sq, 0.0, sigma_I_sq);
+
+        cv::Mat denom;
+        cv::sqrt(sigma_I_sq * sigma_T_sq, denom);
+        cv::Mat result;
+        cv::divide(numerator, denom, result);
+        cv::patchNaNs(result, 0.0);
+        const float sigma_T_norm = static_cast<float>(std::sqrt(sigma_T_sq));
+        result.setTo(0.0f, denom < sigma_T_norm * 1e-5f);
+        cv::min(result,  1.0f, result);
+        cv::max(result, -1.0f, result);
+        return result;
+    }
+
+    // ---- FFT buffer 仅在确认走 FFT 路径后才分配 ---
+    cv::Mat padded(dft_rows, dft_cols, CV_32F, cv::Scalar(0));
+    cv::Mat I_dft(dft_rows, dft_cols, CV_32FC2);
+    cv::Mat I_sq_dft(dft_rows, dft_cols, CV_32FC2);
+    cv::Mat spectrum(dft_rows, dft_cols, CV_32FC2);
+    cv::Mat result_buf(dft_rows, dft_cols, CV_32F);
+    cv::Mat sum_MI_buf(rh, rw, CV_32F);
+    cv::Mat sum_MI2_buf(rh, rw, CV_32F);
+
+    auto make_dft_into = [&](const cv::Mat& src, cv::Mat& out) {
+        padded.setTo(0.0f);
+        src.copyTo(padded(cv::Rect(0, 0, src.cols, src.rows)));
+        cv::dft(padded, out, cv::DFT_COMPLEX_OUTPUT);
+    };
+    auto xcorr_into = [&](const cv::Mat& dft_A, const cv::Mat& dft_B, cv::Mat& out) {
+        cv::mulSpectrums(dft_A, dft_B, spectrum, 0, true);
+        cv::dft(spectrum, result_buf, cv::DFT_INVERSE | cv::DFT_REAL_OUTPUT | cv::DFT_SCALE);
+        result_buf(cv::Rect(0, 0, rw, rh)).copyTo(out);
+    };
+    auto xcorr_add = [&](const cv::Mat& dft_A, const cv::Mat& dft_B, cv::Mat& accum) {
+        cv::mulSpectrums(dft_A, dft_B, spectrum, 0, true);
+        cv::dft(spectrum, result_buf, cv::DFT_INVERSE | cv::DFT_REAL_OUTPUT | cv::DFT_SCALE);
+        cv::add(accum, result_buf(cv::Rect(0, 0, rw, rh)), accum);
+    };
+
+    // 图像侧每通道 FFT 只算一次
+    cv::Mat numerator     = cv::Mat::zeros(rh, rw, CV_32F);
+    cv::Mat sigma_I_sq_d  = cv::Mat::zeros(rh, rw, CV_64F); // float64 避免 sum_MI2-sum_MI² 灾难性精度损失
+
+    for (int c = 0; c < 3; ++c) {
+        make_dft_into(I_ch[c], I_dft);
+        make_dft_into(I_ch[c].mul(I_ch[c]), I_sq_dft);
+
+        // numerator += xcorr(T'_c, I_c)
+        xcorr_add(I_dft, local_cache.T_prime_dft[c], numerator);
+
+        // σ_I_c²(x,y) = sum_MI2 - sum_MI² / mask_area
+        // 两项量级相近时相减会损失精度，用 float64 累加
+        xcorr_into(I_dft,    local_cache.M_dft, sum_MI_buf);
+        xcorr_into(I_sq_dft, local_cache.M_dft, sum_MI2_buf);
+        cv::Mat sum_MI_d, sum_MI2_d, var_d;
+        sum_MI_buf.convertTo(sum_MI_d,   CV_64F);
+        sum_MI2_buf.convertTo(sum_MI2_d, CV_64F);
+        cv::multiply(sum_MI_d, sum_MI_d, var_d, -1.0 / mask_area);
+        cv::add(var_d, sum_MI2_d, var_d);
+        cv::add(sigma_I_sq_d, var_d, sigma_I_sq_d);
+    }
+
+    cv::Mat sigma_I_sq;
+    sigma_I_sq_d.convertTo(sigma_I_sq, CV_32F);
+    cv::max(sigma_I_sq, 0.0, sigma_I_sq);
+
+    cv::Mat denom;
+    cv::sqrt(sigma_I_sq * sigma_T_sq, denom);
+
+    cv::Mat result;
+    cv::divide(numerator, denom, result);
+    cv::patchNaNs(result, 0.0);
+    const float sigma_T_norm = static_cast<float>(std::sqrt(sigma_T_sq));
+    result.setTo(0.0f, denom < sigma_T_norm * 1e-5f);
+    cv::min(result,  1.0f, result);
+    cv::max(result, -1.0f, result);
+    return result;
 }
 
 std::vector<Matcher::RawResult> Matcher::preproc_and_match(const cv::Mat& image, const MatcherConfig::Params& params)
@@ -218,7 +470,40 @@ std::vector<Matcher::RawResult> Matcher::preproc_and_match(const cv::Mat& image,
             if (!mask_opt) {
                 return {};
             }
-            cv::matchTemplate(image_match, templ_match, matched, match_algorithm, mask_opt.value());
+            // mask_src=false 时 mask 完全由模板决定，用 FFT 路径替代标量滑窗
+            if (!params.mask_src) {
+                //  cache key：templ_name + mask_ranges 序列化
+                // （mask_src=false 时 mask 由模板+参数唯一确定）
+                // cv::Mat 形式的模板没有文件名，用像素内容 hash 保证 key 唯一
+                std::string fft_key = templ_name;
+                if (fft_key.empty()) {
+                    uint64_t h = 14695981039346656037ULL;
+                    const auto* ptr = templ.data;
+                    const size_t n = static_cast<size_t>(templ.total()) * templ.elemSize();
+                    for (size_t j = 0; j < n; ++j) { h ^= ptr[j]; h *= 1099511628211ULL; }
+                    fft_key = "mat:" + std::to_string(h);
+                }
+                for (const auto& r : params.mask_ranges) {
+                    if (std::holds_alternative<MatchTaskInfo::GrayRange>(r)) {
+                        const auto& g = std::get<MatchTaskInfo::GrayRange>(r);
+                        fft_key += ":G" + std::to_string(g.first) + '_' + std::to_string(g.second);
+                    }
+                    else if (std::holds_alternative<MatchTaskInfo::ColorRange>(r)) {
+                        const auto& col = std::get<MatchTaskInfo::ColorRange>(r);
+                        fft_key += ":C";
+                        for (auto v : col.first)  fft_key += std::to_string(v) + ',';
+                        fft_key += '_';
+                        for (auto v : col.second) fft_key += std::to_string(v) + ',';
+                    }
+                }
+                fft_key += params.mask_close ? ":1" : ":0";
+
+                matched = fast_masked_ccoeff_normed(
+                    image_match, templ_match, mask_opt.value(), fft_key);
+            }
+            if (matched.empty()) {
+                cv::matchTemplate(image_match, templ_match, matched, match_algorithm, mask_opt.value());
+            }
         }
 
         if (method == MatchMethod::RGBCount || method == MatchMethod::HSVCount) {
@@ -232,17 +517,28 @@ std::vector<Matcher::RawResult> Matcher::preproc_and_match(const cv::Mat& image,
 
             cv::threshold(templ_active, templ_active, 1, 1, cv::THRESH_BINARY);
             cv::threshold(image_active, image_active, 1, 1, cv::THRESH_BINARY);
-            // 把 CCORR 当 count 用，计算 image_active 在 templ_active 形状内的像素数量
-            cv::Mat tp, fp;
+            // tp = image_active 与 templ_active 的共激活像素数（TM_CCORR 当 count 用）
+            cv::Mat tp;
             int tp_fn = cv::countNonZero(templ_active);
             cv::matchTemplate(image_active, templ_active, tp, cv::TM_CCORR);
             tp.convertTo(tp, CV_32S);
-            cv::Mat templ_inactive = 1 - templ_active;
-            // TODO: 这里 TP+FP 是 image_active 的 count，可以消掉一个 matchtemplate
-            cv::matchTemplate(image_active, templ_inactive, fp, cv::TM_CCORR);
-            fp.convertTo(fp, CV_32S);
+            // sum_active = 每个窗口内 image_active 的总激活数
+            // 由于 tp + fp = sum_active，用积分图代替第二次 matchTemplate
+            cv::Mat image_active_f;
+            image_active.convertTo(image_active_f, CV_32F);
+            cv::Mat integ;
+            cv::integral(image_active_f, integ, CV_32F);
+            const int kh = templ_active.rows, kw = templ_active.cols;
+            // 四角公式：sum_active[y,x] = integ[y+kh,x+kw] - integ[y,x+kw] - integ[y+kh,x] + integ[y,x]
+            cv::Mat sum_active =
+                integ(cv::Rect(kw, kh, tp.cols, tp.rows))
+                - integ(cv::Rect(0,  kh, tp.cols, tp.rows))
+                - integ(cv::Rect(kw, 0,  tp.cols, tp.rows))
+                + integ(cv::Rect(0,  0,  tp.cols, tp.rows));
+            cv::Mat sum_active_i;
+            sum_active.convertTo(sum_active_i, CV_32S);
             cv::Mat count_result;
-            cv::divide(2 * tp, tp + fp + tp_fn, count_result, 1, CV_32F); // 数色结果为 f1_score
+            cv::divide(2 * tp, sum_active_i + tp_fn, count_result, 1, CV_32F); // 数色结果为 f1_score
 
             if (params.pure_color) {
                 matched = 1.0f;

--- a/src/MaaCore/Vision/Matcher.cpp
+++ b/src/MaaCore/Vision/Matcher.cpp
@@ -20,7 +20,7 @@ Matcher::ResultOpt Matcher::analyze() const
     const auto match_results = preproc_and_match(make_roi(m_image, m_roi), m_params);
 
     for (size_t i = 0; i < match_results.size(); ++i) {
-        const auto& [matched, templ, templ_name] = match_results[i];
+        const auto& [matched, templ, templ_name, path] = match_results[i];
         if (matched.empty()) {
             continue;
         }
@@ -34,8 +34,15 @@ Matcher::ResultOpt Matcher::analyze() const
         Rect rect(max_loc.x + m_roi.x, max_loc.y + m_roi.y, templ.cols, templ.rows);
 
         double threshold = m_params.templ_thres[i];
+        const char* path_tag = path == MatchPath::Optimized ? "optimized" : "opencv";
+        const auto& method_i = m_params.methods.size() > i ? m_params.methods[i] : MatchMethod::Ccoeff;
+        std::string tag = "[";
+        tag += path_tag;
+        if (method_i == MatchMethod::HSVCount) tag += "|hsv";
+        else if (method_i == MatchMethod::RGBCount) tag += "|rgb";
+        tag += "]";
         if (m_log_tracing && max_val > 0.5 && max_val > threshold - 0.2) { // 得分太低的肯定不对，没必要打印
-            Log.trace("match_templ |", templ_name, "score:", max_val, "rect:", rect, "roi:", m_roi);
+            Log.trace("match_templ |", templ_name, tag, "score:", max_val, "rect:", rect, "roi:", m_roi);
 #ifdef ASST_DEBUG
             if (!m_params.methods.empty() && m_params.methods[0] == MatchMethod::HSVCount) {
                 const cv::Rect expanded_roi(
@@ -67,7 +74,7 @@ Matcher::ResultOpt Matcher::analyze() const
 #endif
         }
         else {
-            Log.debug("match_templ |", templ_name, "score:", max_val, "rect:", rect, "roi:", m_roi);
+            Log.debug("match_templ |", templ_name, tag, "score:", max_val, "rect:", rect, "roi:", m_roi);
         }
         if (max_val < threshold) {
             continue;
@@ -153,6 +160,7 @@ std::vector<Matcher::RawResult> Matcher::preproc_and_match(const cv::Mat& image,
         }
 
         cv::Mat matched;
+        auto match_path = MatchPath::OpenCV;
         cv::Mat templ_match, templ_count, templ_gray;
         cv::cvtColor(templ, templ_match, cv::COLOR_BGR2RGB);
         if (!image_gray.empty()) {
@@ -257,10 +265,14 @@ std::vector<Matcher::RawResult> Matcher::preproc_and_match(const cv::Mat& image,
 
                     matched = masked_ccoeff_matcher.match(
                         image_match, templ_match, mask_opt.value(), fft_key, mask_pixels);
+                    if (!matched.empty()) {
+                        match_path = MatchPath::Optimized;
+                    }
                 }
             }
             if (matched.empty()) {
                 cv::matchTemplate(image_match, templ_match, matched, match_algorithm, mask_opt.value());
+                match_path = MatchPath::OpenCV;
             }
         }
 
@@ -304,7 +316,7 @@ std::vector<Matcher::RawResult> Matcher::preproc_and_match(const cv::Mat& image,
 
             cv::multiply(matched, count_result, matched); // 最终结果是数色和模板匹配的点积
         }
-        results.emplace_back(RawResult { .matched = matched, .templ = templ, .templ_name = templ_name });
+        results.emplace_back(RawResult { .matched = matched, .templ = templ, .templ_name = templ_name, .path = match_path });
     }
     return results;
 }

--- a/src/MaaCore/Vision/Matcher.cpp
+++ b/src/MaaCore/Vision/Matcher.cpp
@@ -86,9 +86,6 @@ Matcher::ResultOpt Matcher::analyze() const
 std::vector<Matcher::RawResult> Matcher::preproc_and_match(const cv::Mat& image, const MatcherConfig::Params& params)
 {
     std::vector<Matcher::RawResult> results;
-    const uint64_t templ_revision = TemplResource::get_instance().revision();
-    auto& masked_ccoeff_matcher = MaskedCcoeffMatcher::get_instance();
-    masked_ccoeff_matcher.sync_cache_revision(templ_revision);
 
     // Image-side color conversions: compute once, reuse across all templates
     cv::Mat image_match;
@@ -230,11 +227,16 @@ std::vector<Matcher::RawResult> Matcher::preproc_and_match(const cv::Mat& image,
                 }
                 else if (MaskedCcoeffMatcher::should_fallback_to_opencv(
                              mask_pixels,
-                             (image_match.rows - templ_match.rows + 1) * (image_match.cols - templ_match.cols + 1))) {
-                    // matched 保持 empty，统一落到下面的 OpenCV masked matchTemplate。
+                        (image_match.rows - templ_match.rows + 1) * (image_match.cols - templ_match.cols + 1))) {
+                    // matched 保持 empty，统一落到下面的 OpenCV masked matchTemplate
                 }
                 else {
-                    // cache key：模板身份 + mask_ranges。资源模板绑定 revision；cv::Mat 模板使用 row-wise 内容 hash。
+                    auto& masked_ccoeff_matcher = MaskedCcoeffMatcher::get_instance();
+                    const uint64_t templ_revision = TemplResource::get_instance().revision();
+                    masked_ccoeff_matcher.sync_cache_revision(templ_revision);
+
+                    // cache key：templ_name + mask_ranges
+                    // 资源模板绑定 revision；cv::Mat 模板使用 row-wise 内容 hash
                     std::string fft_key = templ_name.empty()
                         ? MaskedCcoeffMatcher::make_mat_cache_key(templ)
                         : "res:" + std::to_string(templ_revision) + ":" + templ_name;
@@ -285,7 +287,7 @@ std::vector<Matcher::RawResult> Matcher::preproc_and_match(const cv::Mat& image,
             cv::Mat integ;
             cv::integral(image_active_f, integ, CV_32F);
             const int kh = templ_active.rows, kw = templ_active.cols;
-            // 四角公式：sum_active[y,x] = integ[y+kh,x+kw] - integ[y,x+kw] - integ[y+kh,x] + integ[y,x]
+            // sum_active[y,x] = integ[y+kh,x+kw] - integ[y,x+kw] - integ[y+kh,x] + integ[y,x]
             cv::Mat sum_active =
                 integ(cv::Rect(kw, kh, tp.cols, tp.rows))
                 - integ(cv::Rect(0,  kh, tp.cols, tp.rows))

--- a/src/MaaCore/Vision/Matcher.h
+++ b/src/MaaCore/Vision/Matcher.h
@@ -3,8 +3,6 @@
 
 #include "Vision/Config/MatcherConfig.h"
 
-#include "AsstPort.h"
-
 namespace asst
 {
 class Matcher : public VisionHelper, public MatcherConfig
@@ -30,9 +28,7 @@ public:
         std::string templ_name;
     };
 
-    static ASSTAPI_PORT std::vector<RawResult> preproc_and_match(
-        const cv::Mat& image,
-        const MatcherConfig::Params& params);
+    static std::vector<RawResult> preproc_and_match(const cv::Mat& image, const MatcherConfig::Params& params);
 
 protected:
     virtual void _set_roi(const Rect& roi) override { set_roi(roi); }

--- a/src/MaaCore/Vision/Matcher.h
+++ b/src/MaaCore/Vision/Matcher.h
@@ -21,11 +21,18 @@ public:
     const auto& get_result() const noexcept { return m_result; }
 
 public:
+    enum class MatchPath
+    {
+        OpenCV,    // cv::matchTemplate
+        Optimized, // 优化实现
+    };
+
     struct RawResult
     {
         cv::Mat matched;
         cv::Mat templ;
         std::string templ_name;
+        MatchPath path;
     };
 
     static std::vector<RawResult> preproc_and_match(const cv::Mat& image, const MatcherConfig::Params& params);

--- a/src/MaaCore/Vision/Matcher.h
+++ b/src/MaaCore/Vision/Matcher.h
@@ -3,6 +3,8 @@
 
 #include "Vision/Config/MatcherConfig.h"
 
+#include "AsstPort.h"
+
 namespace asst
 {
 class Matcher : public VisionHelper, public MatcherConfig
@@ -28,7 +30,9 @@ public:
         std::string templ_name;
     };
 
-    static std::vector<RawResult> preproc_and_match(const cv::Mat& image, const MatcherConfig::Params& params);
+    static ASSTAPI_PORT std::vector<RawResult> preproc_and_match(
+        const cv::Mat& image,
+        const MatcherConfig::Params& params);
 
 protected:
     virtual void _set_roi(const Rect& roi) override { set_roi(roi); }

--- a/src/MaaCore/Vision/MultiMatcher.cpp
+++ b/src/MaaCore/Vision/MultiMatcher.cpp
@@ -21,7 +21,7 @@ MultiMatcher::ResultsVecOpt MultiMatcher::analyze() const
 
     std::vector<Result> results;
     for (size_t index = 0; index < match_results.size(); ++index) {
-        const auto& [matched, templ, templ_name] = match_results[index];
+        const auto& [matched, templ, templ_name, _] = match_results[index];
         if (matched.empty()) {
             continue;
         }


### PR DESCRIPTION
原 `Matcher::preproc_and_match`  走 mask 的模板匹配都是直接调 ` cv::matchTemplate()`，这条路在大图上挺慢，热点场景都是图固定但是会有调用很多相同的模板，比如基建换人环节找Bskill，就是带mask的模板，模板很小，图相对较大，跑起来就很耗时

 本 PR 把这条路重写了，按 case 尺寸自动选最快的实现

实测的输入case，挑选了一些典型值作为稳定的输入输出  [详细的测试环境和性能分析](https://github.com/Aliothmoon/maa-perf-cases/blob/main/docs/perf-report.md)

把 TM_CCOEFF_NORMED + mask 的公式展开，借 cv::dft + mulSpectrums 把每个通道的 FFT 只算一次然后复用；模板侧的
  FFT(M)、FFT(T'_c) 跨调用缓存，在LoadResource的时候清除缓存

实测主要是一下场景
  - 小到 OpenCV setup 开销都大的 → 稀疏处理
    - 预处理时把模板里所有 mask 非零像素抽出来存成一张表，然后 match 的时候直接按这张表跑，很适合基建那种小图标，周围抠空的 mask
  - 中等尺寸 + 中等 K（OpenCV 紧凑 SIMD 内核刚好快）→ 回退 OpenCV
  - K*result < 25M（实测这段 100% FFT/sparse 都打不过 OpenCV）→ 回退 OpenCV 
  - 大尺寸 + 高 K*result → FFT

FFT转换简单变换了一下，如下公式

$\sum_c (M \ast I_c^2) = M \ast (\sum_c I_c^2)$

减少了运算量

## Summary by Sourcery

使用基于 FFT 和稀疏性的路径优化带掩码的 TM_CCOEFF_NORMED 模板匹配，并添加以模板资源为键的缓存机制。

New Features:
- 引入 `MaskedCcoeffMatcher` 工具，用于实现经过优化的带掩码 TM_CCOEFF_NORMED 匹配，支持稀疏和 FFT 后端以及可复用的模板计划。

Enhancements:
- 将 `Matcher::preproc_and_match` 路由到优化后的匹配器，用于模板驱动的掩码，并在需要时通过启发式自动回退到 OpenCV `matchTemplate`。
- 通过 `ASSTAPI_PORT` 暴露 `Matcher::preproc_and_match` 以供外部使用。
- 在 `TemplResource` 中缓存模板图像并维护修订计数器，在重载时通过缓存失效机制清理缓存，从而实现匹配器端缓存同步。
- 通过将第二次 `matchTemplate` 调用替换为基于积分图的活动像素求和计算，加速 RGB/HSV 统计指标计算。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize masked TM_CCOEFF_NORMED template matching with FFT- and sparsity-based paths and add caching keyed by template resources.

New Features:
- Introduce MaskedCcoeffMatcher utility to implement optimized masked TM_CCOEFF_NORMED matching with sparse and FFT backends and reusable template plans.

Enhancements:
- Route Matcher::preproc_and_match to the optimized matcher for template-driven masks with automatic fallback heuristics to OpenCV matchTemplate.
- Expose Matcher::preproc_and_match via ASSTAPI_PORT for external use.
- Cache template images in TemplResource with a revision counter and clear them with cache invalidation on reload, enabling matcher-side cache synchronization.
- Speed up RGB/HSV counting metrics by replacing a second matchTemplate call with an integral-image based active-pixel sum computation.

</details>

## Summary by Sourcery

通过引入带有缓存机制的专用 FFT/稀疏匹配器，并将其集成到现有的匹配与资源加载流程中，来优化 Matcher 中带掩码模板匹配的性能。

新功能：
- 新增 `MaskedCcoeffMatcher` 工具，用于提供优化的 `TM_CCOEFF_NORMED` 匹配，支持基于稀疏和 FFT 的后端，以及可复用的模板计划。

增强点：
- 当掩码由模板驱动时，将带掩码的 `Matcher::preproc_and_match` 调用经由 `MaskedCcoeffMatcher` 进行路由，并在不利场景中通过启发式回退到 OpenCV 的 `matchTemplate`。
- 通过 `ASSTAPI_PORT` 接口对外暴露 `Matcher::preproc_and_match` 以供外部使用。
- 为 `TemplResource` 增加修订版本跟踪和缓存失效机制，以便在模板发生变化时清除相关匹配器缓存。
- 通过使用基于积分图的有效像素和计算，替换第二次带掩码的 `matchTemplate` 调用，加速 RGB/HSV 计数类指标的计算。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize masked template matching performance in Matcher by introducing a specialized FFT/sparse matcher with caching and integrating it into existing matching and resource-loading flows.

New Features:
- Add MaskedCcoeffMatcher utility to provide optimized TM_CCOEFF_NORMED matching with support for sparse and FFT-based backends and reusable template plans.

Enhancements:
- Route masked Matcher::preproc_and_match calls through MaskedCcoeffMatcher when mask is template-driven, with heuristics to fall back to OpenCV matchTemplate for unfavorable cases.
- Expose Matcher::preproc_and_match through the ASSTAPI_PORT interface for external usage.
- Add revision tracking and cache invalidation to TemplResource so that template changes clear associated matcher caches.
- Speed up RGB/HSV counting metrics by replacing a second masked matchTemplate invocation with an integral-image-based active-pixel sum computation.

</details>