### PR TITLE
feat: 为干员识别和仓库识别新增多记录管理支持

### DIFF
--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -882,6 +882,12 @@ Right Click: Select Target Process</system:String>
     <system:String x:Key="LastSyncTime">Last Sync Time</system:String>
     <system:String x:Key="DepotRecognitionTip">This function is still in testing. If you encounter any unexpected results, please zip the ｢debug/depot｣ folder in the installation path and submit an issue on GitHub</system:String>
     <system:String x:Key="StartToDepotRecognition">Start to Identify</system:String>
+    <system:String x:Key="DefaultRecordName">Default</system:String>
+    <system:String x:Key="EmptyDepotList">Empty Depot</system:String>
+    <system:String x:Key="EmptyOperBoxList">Empty Operator List</system:String>
+    <system:String x:Key="RecordName">Record Name</system:String>
+    <system:String x:Key="AddRecord">Add</system:String>
+    <system:String x:Key="RenameRecord">Rename</system:String>
     <system:String x:Key="ExportToArkplanner">Arkplanner</system:String>
     <system:String x:Key="ExportToLolicon">Arkntools</system:String>
     <system:String x:Key="ExportToMarkdown">Markdown</system:String>

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -886,6 +886,8 @@ Right Click: Select Target Process</system:String>
     <system:String x:Key="EmptyDepotList">Empty Depot</system:String>
     <system:String x:Key="EmptyOperBoxList">Empty Operator List</system:String>
     <system:String x:Key="RecordName">Record Name</system:String>
+    <system:String x:Key="DepotRecordName">Depot List Name</system:String>
+    <system:String x:Key="OperBoxRecordName">Operator List Name</system:String>
     <system:String x:Key="AddRecord">Add</system:String>
     <system:String x:Key="RenameRecord">Rename</system:String>
     <system:String x:Key="ExportToArkplanner">Arkplanner</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -887,6 +887,8 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="EmptyDepotList">空の倉庫</system:String>
     <system:String x:Key="EmptyOperBoxList">空のオペレーターリスト</system:String>
     <system:String x:Key="RecordName">レコード名</system:String>
+    <system:String x:Key="DepotRecordName">倉庫リスト名</system:String>
+    <system:String x:Key="OperBoxRecordName">オペレーターリスト名</system:String>
     <system:String x:Key="AddRecord">追加</system:String>
     <system:String x:Key="RenameRecord">名前変更</system:String>
     <system:String x:Key="ExportToArkplanner">Arkplanner</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -883,6 +883,12 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="LastSyncTime">前回同期時間</system:String>
     <system:String x:Key="DepotRecognitionTip">この機能はまだテスト版です。エラーが発生/統計情報に問題があれば、debug/depotフォルダを圧縮し、issueを提出してください~</system:String>
     <system:String x:Key="StartToDepotRecognition">認識開始</system:String>
+    <system:String x:Key="DefaultRecordName">デフォルト</system:String>
+    <system:String x:Key="EmptyDepotList">空の倉庫</system:String>
+    <system:String x:Key="EmptyOperBoxList">空のオペレーターリスト</system:String>
+    <system:String x:Key="RecordName">レコード名</system:String>
+    <system:String x:Key="AddRecord">追加</system:String>
+    <system:String x:Key="RenameRecord">名前変更</system:String>
     <system:String x:Key="ExportToArkplanner">Arkplanner</system:String>
     <system:String x:Key="ExportToLolicon">Arkntools</system:String>
     <system:String x:Key="ExportToMarkdown">Markdown</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -888,6 +888,8 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="EmptyDepotList">빈 창고</system:String>
     <system:String x:Key="EmptyOperBoxList">빈 오퍼레이터 목록</system:String>
     <system:String x:Key="RecordName">레코드 이름</system:String>
+    <system:String x:Key="DepotRecordName">창고 목록 이름</system:String>
+    <system:String x:Key="OperBoxRecordName">오퍼레이터 목록 이름</system:String>
     <system:String x:Key="AddRecord">추가</system:String>
     <system:String x:Key="RenameRecord">이름 변경</system:String>
     <system:String x:Key="ExportToArkplanner">Arkplanner</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -884,6 +884,12 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="LastSyncTime">마지막 동기화 시간</system:String>
     <system:String x:Key="DepotRecognitionTip">이 기능은 현재 테스트 중입니다. 내보내기 전 인식 결과가 맞는지 확인 후 사용하세요\n만약 오류가 있다면 MAA 경로 내 debug 폴더 안의 depot 폴더 전체를 압축해서 Github의 issue로 올려주세요</system:String>
     <system:String x:Key="StartToDepotRecognition">인식 시작</system:String>
+    <system:String x:Key="DefaultRecordName">기본</system:String>
+    <system:String x:Key="EmptyDepotList">빈 창고</system:String>
+    <system:String x:Key="EmptyOperBoxList">빈 오퍼레이터 목록</system:String>
+    <system:String x:Key="RecordName">레코드 이름</system:String>
+    <system:String x:Key="AddRecord">추가</system:String>
+    <system:String x:Key="RenameRecord">이름 변경</system:String>
     <system:String x:Key="ExportToArkplanner">Arkplanner</system:String>
     <system:String x:Key="ExportToLolicon">Arkntools</system:String>
     <system:String x:Key="ExportToMarkdown">Markdown</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -883,6 +883,12 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="LastSyncTime">上次同步时间</system:String>
     <system:String x:Key="DepotRecognitionTip">该功能尚处于测试阶段，请检查结果是否准确再行使用。若有误，欢迎打包 debug/depot 文件夹后向我们提交 issue ~</system:String>
     <system:String x:Key="StartToDepotRecognition">开始识别</system:String>
+    <system:String x:Key="DefaultRecordName">默认</system:String>
+    <system:String x:Key="EmptyDepotList">空仓库列表</system:String>
+    <system:String x:Key="EmptyOperBoxList">空干员列表</system:String>
+    <system:String x:Key="RecordName">记录名称</system:String>
+    <system:String x:Key="AddRecord">添加</system:String>
+    <system:String x:Key="RenameRecord">重命名</system:String>
     <system:String x:Key="ExportToArkplanner">企鹅物流刷图规划</system:String>
     <system:String x:Key="ExportToLolicon">明日方舟工具箱</system:String>
     <system:String x:Key="ExportToMarkdown">Markdown</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -887,6 +887,8 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="EmptyDepotList">空仓库列表</system:String>
     <system:String x:Key="EmptyOperBoxList">空干员列表</system:String>
     <system:String x:Key="RecordName">记录名称</system:String>
+    <system:String x:Key="DepotRecordName">仓库列表名称</system:String>
+    <system:String x:Key="OperBoxRecordName">干员列表名称</system:String>
     <system:String x:Key="AddRecord">添加</system:String>
     <system:String x:Key="RenameRecord">重命名</system:String>
     <system:String x:Key="ExportToArkplanner">企鹅物流刷图规划</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -883,6 +883,12 @@ C:\\leidian\\LDPlayer9\n
     <system:String x:Key="LastSyncTime">上次同步時間</system:String>
     <system:String x:Key="DepotRecognitionTip">該功能尚處於測試階段，請檢查結果是否準確再行使用。若有誤，歡迎打包 debug/depot 資料夾後向我們提交 issue ~</system:String>
     <system:String x:Key="StartToDepotRecognition">開始辨識</system:String>
+    <system:String x:Key="DefaultRecordName">預設</system:String>
+    <system:String x:Key="EmptyDepotList">空倉庫列表</system:String>
+    <system:String x:Key="EmptyOperBoxList">空幹員列表</system:String>
+    <system:String x:Key="RecordName">記錄名稱</system:String>
+    <system:String x:Key="AddRecord">新增</system:String>
+    <system:String x:Key="RenameRecord">重新命名</system:String>
     <system:String x:Key="ExportToArkplanner">企鵝物流刷圖規劃</system:String>
     <system:String x:Key="ExportToLolicon">明日方舟工具箱</system:String>
     <system:String x:Key="ExportToMarkdown">Markdown</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -887,6 +887,8 @@ C:\\leidian\\LDPlayer9\n
     <system:String x:Key="EmptyDepotList">空倉庫列表</system:String>
     <system:String x:Key="EmptyOperBoxList">空幹員列表</system:String>
     <system:String x:Key="RecordName">記錄名稱</system:String>
+    <system:String x:Key="DepotRecordName">倉庫列表名稱</system:String>
+    <system:String x:Key="OperBoxRecordName">幹員列表名稱</system:String>
     <system:String x:Key="AddRecord">新增</system:String>
     <system:String x:Key="RenameRecord">重新命名</system:String>
     <system:String x:Key="ExportToArkplanner">企鵝物流刷圖規劃</system:String>

--- a/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
@@ -479,6 +479,32 @@ public class ToolboxViewModel : Screen
         set => SetAndNotify(ref _depotInfo, value);
     }
 
+    public ObservableCollection<DepotRecordItem> DepotRecords { get; } = [];
+
+    private DepotRecordItem? _selectedDepotRecord;
+
+    public DepotRecordItem? SelectedDepotRecord
+    {
+        get => _selectedDepotRecord;
+        set
+        {
+            if (!SetAndNotify(ref _selectedDepotRecord, value) || value == null)
+            {
+                return;
+            }
+
+            ApplyDepotRecord(value);
+        }
+    }
+
+    private string _depotRecordName = string.Empty;
+
+    public string DepotRecordName
+    {
+        get => _depotRecordName;
+        set => SetAndNotify(ref _depotRecordName, value);
+    }
+
     /// <summary>
     /// Gets or sets 上次仓库同步时间（UTC 时间）
     /// </summary>
@@ -580,6 +606,24 @@ public class ToolboxViewModel : Screen
         public string? DisplayCount => Count >= 0 ? Count.FormatNumber(false) : null;
     }
 
+    public class DepotRecordItem : PropertyChangedBase
+    {
+        private string _name = string.Empty;
+
+        [JsonProperty("name")]
+        public string Name
+        {
+            get => _name;
+            set => SetAndNotify(ref _name, value);
+        }
+
+        [JsonProperty("items")]
+        public Dictionary<string, int> Items { get; set; } = [];
+
+        [JsonProperty("syncTime")]
+        public DateTimeOffset? SyncTime { get; set; }
+    }
+
     private void InitializeDepotRowPresentation()
     {
         _depotResult.CollectionChanged += DepotResultCollectionChanged;
@@ -602,19 +646,13 @@ public class ToolboxViewModel : Screen
     /// </summary>
     private void SaveDepotDetails()
     {
-        // 构建简化格式：{"itemId": count}
-        var details = new JObject {
-            ["done"] = true,
-            ["data"] = JObject.FromObject(DepotResult.Where(item => item.Count >= 0).ToDictionary(item => item.Id, item => item.Count)),
-        };
-
-        // 保存同步时间为 UTC（如果有）
-        if (LastDepotSyncTime.HasValue)
+        if (SelectedDepotRecord != null)
         {
-            details["syncTime"] = LastDepotSyncTime.Value.ToLocalTime().ToString("o"); // ISO 8601 格式
+            SelectedDepotRecord.Items = DepotResult.Where(item => item.Count >= 0).ToDictionary(item => item.Id, item => item.Count);
+            SelectedDepotRecord.SyncTime = LastDepotSyncTime;
         }
 
-        JsonDataHelper.Set(JsonDataKey.DepotData, details);
+        SaveDepotRecords();
     }
 
     private void LoadDepotDetails()
@@ -622,19 +660,244 @@ public class ToolboxViewModel : Screen
         var json = JsonDataHelper.Get(JsonDataKey.DepotData, string.Empty);
         if (string.IsNullOrWhiteSpace(json))
         {
+            EnsureDefaultDepotRecord();
             return;
         }
 
         try
         {
-            var details = JObject.Parse(json);
-            DepotParse(details);
+            var root = JObject.Parse(json);
+            if (root["records"] != null)
+            {
+                LoadDepotRecords(root);
+            }
+            else
+            {
+                MigrateDepotFromLegacy(root);
+            }
         }
         catch (Exception ex)
         {
             _logger.Error("parse depot json failed,\n{str}", json, ex);
+            EnsureDefaultDepotRecord();
         }
     }
+
+    private void LoadDepotRecords(JObject root)
+    {
+        DepotRecords.Clear();
+        var records = root["records"] as JArray;
+        if (records != null)
+        {
+            foreach (var record in records)
+            {
+                var item = new DepotRecordItem
+                {
+                    Name = record["name"]?.ToString() ?? LocalizationHelper.GetString("DefaultRecordName"),
+                    Items = (record["items"] as JObject)?.ToObject<Dictionary<string, int>>() ?? [],
+                    SyncTime = record["syncTime"]?.ToObject<DateTimeOffset?>(),
+                };
+                DepotRecords.Add(item);
+            }
+        }
+
+        if (DepotRecords.Count == 0)
+        {
+            EnsureDefaultDepotRecord();
+        }
+
+        var selectedIndex = root["selectedIndex"]?.ToObject<int>() ?? 0;
+        if (selectedIndex >= 0 && selectedIndex < DepotRecords.Count)
+        {
+            SelectedDepotRecord = DepotRecords[selectedIndex];
+        }
+        else
+        {
+            SelectedDepotRecord = DepotRecords[0];
+        }
+    }
+
+    private void MigrateDepotFromLegacy(JObject details)
+    {
+        DepotRecords.Clear();
+        var depotItems = ParseDepotItems(details);
+        var record = new DepotRecordItem
+        {
+            Name = LocalizationHelper.GetString("DefaultRecordName"),
+            Items = depotItems,
+        };
+
+        var syncTimeStr = details["syncTime"]?.ToString(Formatting.None)?.Trim('"');
+        if (!string.IsNullOrEmpty(syncTimeStr) && DateTimeOffset.TryParse(syncTimeStr, null, DateTimeStyles.AssumeUniversal, out var syncTime))
+        {
+            record.SyncTime = syncTime;
+        }
+
+        DepotRecords.Add(record);
+        _selectedDepotRecord = record;
+        DepotParse(details);
+    }
+
+    private static Dictionary<string, int> ParseDepotItems(JObject details)
+    {
+        Dictionary<string, int> depotItems = [];
+        var dataToken = details["data"];
+        if (dataToken is JObject dataObj)
+        {
+            foreach (var prop in dataObj.Properties())
+            {
+                if (int.TryParse(prop.Value.ToString(), out var count))
+                {
+                    depotItems[prop.Name] = count;
+                }
+            }
+        }
+        else if (dataToken?.ToString() is string dataStr && !string.IsNullOrEmpty(dataStr))
+        {
+            try
+            {
+                var dataO = JObject.Parse(dataStr);
+                foreach (var prop in dataO.Properties())
+                {
+                    if (int.TryParse(prop.Value.ToString(), out var count))
+                    {
+                        depotItems[prop.Name] = count;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.Warning(ex, "Failed to parse depot data format");
+            }
+        }
+
+        if (depotItems.Count == 0)
+        {
+            var arkplannerItems = details["arkplanner"]?["object"]?["items"]?.Cast<JObject>() ?? [];
+            foreach (var item in arkplannerItems)
+            {
+                var id = (string?)item["id"];
+                if (string.IsNullOrEmpty(id))
+                {
+                    continue;
+                }
+
+                if (item["have"] != null && int.TryParse(item["have"]?.ToString(), out var count))
+                {
+                    depotItems[id] = count;
+                }
+            }
+        }
+
+        return depotItems;
+    }
+
+    private void EnsureDefaultDepotRecord()
+    {
+        if (DepotRecords.Count == 0)
+        {
+            DepotRecords.Add(new DepotRecordItem { Name = LocalizationHelper.GetString("DefaultRecordName") });
+        }
+
+        SelectedDepotRecord = DepotRecords[0];
+    }
+
+    private void ApplyDepotRecord(DepotRecordItem record)
+    {
+        DepotResult.Clear();
+        foreach (var kvp in record.Items.OrderBy(x => x.Key))
+        {
+            var result = new DepotResultDate
+            {
+                Id = kvp.Key,
+                Name = ItemListHelper.GetItemName(kvp.Key),
+                Image = ItemListHelper.GetItemImage(kvp.Key),
+                Count = kvp.Value,
+            };
+            DepotResult.Add(result);
+        }
+
+        LastDepotSyncTime = record.SyncTime;
+        InvalidateDepotCache();
+        DepotInfo = DepotResult.Count > 0 ? LocalizationHelper.GetString("IdentificationCompleted") : string.Empty;
+        Instances.TaskQueueViewModel.UpdateDatePrompt();
+    }
+
+    private void SaveDepotRecords()
+    {
+        var recordsArray = new JArray();
+        foreach (var record in DepotRecords)
+        {
+            recordsArray.Add(new JObject
+            {
+                ["name"] = record.Name,
+                ["items"] = JObject.FromObject(record.Items),
+                ["syncTime"] = record.SyncTime?.ToLocalTime().ToString("o"),
+            });
+        }
+
+        var root = new JObject
+        {
+            ["records"] = recordsArray,
+            ["selectedIndex"] = DepotRecords.IndexOf(SelectedDepotRecord!),
+        };
+
+        JsonDataHelper.Set(JsonDataKey.DepotData, root);
+    }
+
+    public void AddDepotRecord()
+    {
+        var name = string.IsNullOrWhiteSpace(DepotRecordName) ? LocalizationHelper.GetString("EmptyDepotList") : DepotRecordName.Trim();
+        var record = new DepotRecordItem { Name = name };
+        DepotRecords.Add(record);
+        SelectedDepotRecord = record;
+        SaveDepotRecords();
+        DepotRecordName = string.Empty;
+    }
+
+    public void DeleteDepotRecord(DepotRecordItem? record)
+    {
+        if (record == null || DepotRecords.Count <= 1)
+        {
+            return;
+        }
+
+        var index = DepotRecords.IndexOf(record);
+        DepotRecords.Remove(record);
+
+        if (SelectedDepotRecord == record)
+        {
+            SelectedDepotRecord = DepotRecords[Math.Min(index, DepotRecords.Count - 1)];
+        }
+
+        SaveDepotRecords();
+    }
+
+    public void SelectDepotRecord(DepotRecordItem? record)
+    {
+        if (record == null || record == SelectedDepotRecord)
+        {
+            return;
+        }
+
+        SelectedDepotRecord = record;
+        SaveDepotRecords();
+    }
+
+    public void RenameDepotRecord()
+    {
+        if (SelectedDepotRecord == null || string.IsNullOrWhiteSpace(DepotRecordName))
+        {
+            return;
+        }
+
+        SelectedDepotRecord.Name = DepotRecordName.Trim();
+        SaveDepotRecords();
+        DepotRecordName = string.Empty;
+    }
+
+    [PropertyDependsOn(nameof(SelectedDepotRecord))]
+    public string SelectedDepotRecordName => SelectedDepotRecord?.Name ?? string.Empty;
 
     /// <summary>
     /// Gets 获取 ArkPlanner 导出格式（带缓存）
@@ -1174,6 +1437,86 @@ public class ToolboxViewModel : Screen
         set => SetAndNotify(ref _operBoxInfo, value);
     }
 
+    public ObservableCollection<OperBoxRecordItem> OperBoxRecords { get; } = [];
+
+    private OperBoxRecordItem? _selectedOperBoxRecord;
+
+    public OperBoxRecordItem? SelectedOperBoxRecord
+    {
+        get => _selectedOperBoxRecord;
+        set
+        {
+            if (!SetAndNotify(ref _selectedOperBoxRecord, value) || value == null)
+            {
+                return;
+            }
+
+            ApplyOperBoxRecord(value);
+        }
+    }
+
+    private string _operBoxRecordName = string.Empty;
+
+    public string OperBoxRecordName
+    {
+        get => _operBoxRecordName;
+        set => SetAndNotify(ref _operBoxRecordName, value);
+    }
+
+    public void AddOperBoxRecord()
+    {
+        var name = string.IsNullOrWhiteSpace(OperBoxRecordName) ? LocalizationHelper.GetString("EmptyOperBoxList") : OperBoxRecordName.Trim();
+        var record = new OperBoxRecordItem { Name = name };
+        OperBoxRecords.Add(record);
+        SelectedOperBoxRecord = record;
+        SaveOperBoxRecords();
+        OperBoxRecordName = string.Empty;
+    }
+
+    public void DeleteOperBoxRecord(OperBoxRecordItem? record)
+    {
+        if (record == null || OperBoxRecords.Count <= 1)
+        {
+            return;
+        }
+
+        var index = OperBoxRecords.IndexOf(record);
+        OperBoxRecords.Remove(record);
+
+        if (SelectedOperBoxRecord == record)
+        {
+            SelectedOperBoxRecord = OperBoxRecords[Math.Min(index, OperBoxRecords.Count - 1)];
+        }
+
+        SaveOperBoxRecords();
+    }
+
+    public void SelectOperBoxRecord(OperBoxRecordItem? record)
+    {
+        if (record == null || record == SelectedOperBoxRecord)
+        {
+            return;
+        }
+
+        SelectedOperBoxRecord = record;
+        SaveOperBoxRecords();
+    }
+
+    public void RenameOperBoxRecord()
+    {
+        if (SelectedOperBoxRecord == null || string.IsNullOrWhiteSpace(OperBoxRecordName))
+        {
+            return;
+        }
+
+        SelectedOperBoxRecord.Name = OperBoxRecordName.Trim();
+        SaveOperBoxRecords();
+        OperBoxRecordName = string.Empty;
+    }
+
+    [PropertyDependsOn(nameof(SelectedOperBoxRecord))]
+    public string SelectedOperBoxRecordName => SelectedOperBoxRecord?.Name ?? string.Empty;
+
     /// <summary>
     /// Gets OperBoxDataArray from OperBoxHaveList for backward compatibility
     /// </summary>
@@ -1287,6 +1630,24 @@ public class ToolboxViewModel : Screen
         }
     }
 
+    public class OperBoxRecordItem : PropertyChangedBase
+    {
+        private string _name = string.Empty;
+
+        [JsonProperty("name")]
+        public string Name
+        {
+            get => _name;
+            set => SetAndNotify(ref _name, value);
+        }
+
+        [JsonProperty("ownOpers")]
+        public List<OperBoxData.OperData> OwnOpers { get; set; } = [];
+
+        [JsonProperty("syncTime")]
+        public DateTimeOffset? SyncTime { get; set; }
+    }
+
     private const int OperBoxRowSize = 5;
 
     private ObservableCollection<Operator> _operBoxHaveList = [];
@@ -1396,17 +1757,85 @@ public class ToolboxViewModel : Screen
 
     private void SaveOperBoxDetails(List<OperBoxData.OperData> details)
     {
-        var data = new JObject {
-            ["done"] = true,
-            ["own_opers"] = JArray.FromObject(details),
-        };
-
-        if (LastOperBoxSyncTime.HasValue)
+        if (SelectedOperBoxRecord != null)
         {
-            data["syncTime"] = LastOperBoxSyncTime.Value.ToLocalTime().ToString("o");
+            SelectedOperBoxRecord.OwnOpers = details;
+            SelectedOperBoxRecord.SyncTime = LastOperBoxSyncTime;
         }
 
-        JsonDataHelper.Set(JsonDataKey.OperBoxData, data);
+        SaveOperBoxRecords();
+    }
+
+    private void SaveOperBoxRecords()
+    {
+        var recordsArray = new JArray();
+        foreach (var record in OperBoxRecords)
+        {
+            recordsArray.Add(new JObject
+            {
+                ["name"] = record.Name,
+                ["ownOpers"] = JArray.FromObject(record.OwnOpers),
+                ["syncTime"] = record.SyncTime?.ToLocalTime().ToString("o"),
+            });
+        }
+
+        var root = new JObject
+        {
+            ["records"] = recordsArray,
+            ["selectedIndex"] = OperBoxRecords.IndexOf(SelectedOperBoxRecord!),
+        };
+
+        JsonDataHelper.Set(JsonDataKey.OperBoxData, root);
+    }
+
+    private void EnsureDefaultOperBoxRecord()
+    {
+        if (OperBoxRecords.Count == 0)
+        {
+            OperBoxRecords.Add(new OperBoxRecordItem { Name = LocalizationHelper.GetString("DefaultRecordName") });
+        }
+
+        SelectedOperBoxRecord = OperBoxRecords[0];
+    }
+
+    private void ApplyOperBoxRecord(OperBoxRecordItem record)
+    {
+        ClearOperBoxRecognitionData();
+        _tempOperHaveSet = [];
+        _operBoxPotential = null;
+
+        var operDataMap = record.OwnOpers.ToDictionary(o => o.Id);
+        foreach (var (id, oper) in DataHelper.Operators)
+        {
+            if (!DataHelper.IsCharacterAvailableInClient(oper, SettingsViewModel.GameSettings.ClientType))
+            {
+                continue;
+            }
+
+            var name = DataHelper.GetLocalizedCharacterName(oper) ?? "???";
+            if (operDataMap.TryGetValue(id, out var operData))
+            {
+                OperBoxHaveList.Add(new Operator(id, name, oper.Rarity, operData.Elite, operData.Level, operData.Potential));
+
+                if (id == "char_485_pallas")
+                {
+                    AchievementTrackerHelper.Instance.Unlock(AchievementIds.WarehouseKeeper);
+                }
+            }
+            else
+            {
+                OperBoxNotHaveList.Add(new Operator(id, name, oper.Rarity));
+            }
+        }
+
+        SortOperBoxLists();
+
+        if (OperBoxNotHaveList.Count > 0)
+        {
+            OperBoxSelectedIndex = 0;
+        }
+
+        LastOperBoxSyncTime = record.SyncTime;
     }
 
     private void SortOperBoxLists()
@@ -1439,6 +1868,7 @@ public class ToolboxViewModel : Screen
         var json = JsonDataHelper.Get(JsonDataKey.OperBoxData, string.Empty);
         if (string.IsNullOrWhiteSpace(json))
         {
+            EnsureDefaultOperBoxRecord();
             return;
         }
 
@@ -1453,48 +1883,67 @@ public class ToolboxViewModel : Screen
                     .ToList();
                 if (ownOpers is null)
                 {
+                    EnsureDefaultOperBoxRecord();
                     return;
                 }
-                LoadOperBoxList(ownOpers);
+
+                OperBoxRecords.Clear();
+                OperBoxRecords.Add(new OperBoxRecordItem { Name = LocalizationHelper.GetString("DefaultRecordName"), OwnOpers = ownOpers });
+                SelectedOperBoxRecord = OperBoxRecords[0];
+                SaveOperBoxRecords();
                 return;
             }
             else if (token is JObject details)
             {
-                OperBoxParse(details, updateSyncTime: false);
+                if (details["records"] != null)
+                {
+                    LoadOperBoxRecords(details);
+                }
+                else
+                {
+                    EnsureDefaultOperBoxRecord();
+                    OperBoxParse(details, updateSyncTime: false);
+                }
             }
         }
         catch
         {
-            // 兼容老数据或异常时忽略
+            EnsureDefaultOperBoxRecord();
+        }
+    }
+
+    private void LoadOperBoxRecords(JObject root)
+    {
+        OperBoxRecords.Clear();
+        var records = root["records"] as JArray;
+        if (records != null)
+        {
+            foreach (var record in records)
+            {
+                var ownOpers = (record["ownOpers"] as JArray)?.ToObject<List<OperBoxData.OperData>>() ?? [];
+                var item = new OperBoxRecordItem
+                {
+                    Name = record["name"]?.ToString() ?? LocalizationHelper.GetString("DefaultRecordName"),
+                    OwnOpers = ownOpers,
+                    SyncTime = record["syncTime"]?.ToObject<DateTimeOffset?>(),
+                };
+                OperBoxRecords.Add(item);
+            }
         }
 
-        void LoadOperBoxList(List<OperBoxData.OperData> ownOpers)
+        if (OperBoxRecords.Count == 0)
         {
-            var operDataMap = ownOpers.ToDictionary(o => o.Id);
-            foreach (var (id, oper) in DataHelper.Operators)
-            {
-                if (!DataHelper.IsCharacterAvailableInClient(oper, SettingsViewModel.GameSettings.ClientType))
-                {
-                    continue;
-                }
+            EnsureDefaultOperBoxRecord();
+        }
 
-                var name = DataHelper.GetLocalizedCharacterName(oper) ?? "???";
-                if (operDataMap.TryGetValue(id, out var operData))
-                {
-                    OperBoxHaveList.Add(new Operator(id, name, oper.Rarity, operData.Elite, operData.Level, operData.Potential));
-
-                    if (id == "char_485_pallas")
-                    {
-                        AchievementTrackerHelper.Instance.Unlock(AchievementIds.WarehouseKeeper);
-                    }
-                }
-                else
-                {
-                    OperBoxNotHaveList.Add(new Operator(id, name, oper.Rarity));
-                }
-            }
-
-            SortOperBoxLists();
+        var selectedIndex = root["selectedIndex"]?.ToObject<int>() ?? 0;
+        if (selectedIndex >= 0 && selectedIndex < OperBoxRecords.Count)
+        {
+            SelectedOperBoxRecord = OperBoxRecords[selectedIndex];
+        }
+        else
+        {
+            SelectedOperBoxRecord = OperBoxRecords[0];
         }
     }
 

--- a/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
@@ -773,7 +773,7 @@ public class ToolboxViewModel : Screen
 
         if (depotItems.Count == 0)
         {
-            var arkplannerItems = details["arkplanner"]?["object"]?["items"]?.Cast<JObject>() ?? [];
+            var arkplannerItems = details["arkplanner"]?["object"]?["items"] is JArray itemsArray ? itemsArray.OfType<JObject>() : [];
             foreach (var item in arkplannerItems)
             {
                 var id = (string?)item["id"];
@@ -836,10 +836,12 @@ public class ToolboxViewModel : Screen
             });
         }
 
+        var selectedIndex = SelectedDepotRecord != null ? DepotRecords.IndexOf(SelectedDepotRecord) : 0;
+
         var root = new JObject
         {
             ["records"] = recordsArray,
-            ["selectedIndex"] = DepotRecords.IndexOf(SelectedDepotRecord!),
+            ["selectedIndex"] = Math.Max(0, selectedIndex),
         };
 
         JsonDataHelper.Set(JsonDataKey.DepotData, root);
@@ -1028,7 +1030,7 @@ public class ToolboxViewModel : Screen
         {
             if (depotItems.Count == 0)
             {
-                var arkplannerItems = details["arkplanner"]?["object"]?["items"]?.Cast<JObject>() ?? [];
+                var arkplannerItems = details["arkplanner"]?["object"]?["items"] is JArray itemsArray ? itemsArray.OfType<JObject>() : [];
 
                 foreach (var item in arkplannerItems)
                 {
@@ -1779,10 +1781,12 @@ public class ToolboxViewModel : Screen
             });
         }
 
+        var selectedIndex = SelectedOperBoxRecord != null ? OperBoxRecords.IndexOf(SelectedOperBoxRecord) : 0;
+
         var root = new JObject
         {
             ["records"] = recordsArray,
-            ["selectedIndex"] = OperBoxRecords.IndexOf(SelectedOperBoxRecord!),
+            ["selectedIndex"] = Math.Max(0, selectedIndex),
         };
 
         JsonDataHelper.Set(JsonDataKey.OperBoxData, root);

--- a/src/MaaWpfGui/Views/UI/ToolboxView.xaml
+++ b/src/MaaWpfGui/Views/UI/ToolboxView.xaml
@@ -278,6 +278,7 @@
                         <ListBox.ItemContainerStyle>
                             <Style BasedOn="{StaticResource TransparentListBoxItemStyle}" TargetType="{x:Type ListBoxItem}">
                                 <Setter Property="Padding" Value="0" />
+                                <Setter Property="HorizontalContentAlignment" Value="Stretch" />
                             </Style>
                         </ListBox.ItemContainerStyle>
                         <ListBox.ItemTemplate>
@@ -289,7 +290,7 @@
                                     </Grid.ColumnDefinitions>
                                     <controls:TextBlock
                                         Grid.Column="0"
-                                        Margin="10,5"
+                                        Margin="10,5,10,5"
                                         VerticalAlignment="Center"
                                         Text="{Binding Name}"
                                         TextTrimming="CharacterEllipsis" />
@@ -319,7 +320,7 @@
                         <hc:TextBox
                             Grid.Row="0"
                             Height="30"
-                            hc:InfoElement.Placeholder="{DynamicResource RecordName}"
+                            hc:InfoElement.Placeholder="{DynamicResource OperBoxRecordName}"
                             Text="{Binding OperBoxRecordName, UpdateSourceTrigger=PropertyChanged}" />
                         <StackPanel
                             Grid.Row="1"
@@ -575,6 +576,7 @@
                         <ListBox.ItemContainerStyle>
                             <Style BasedOn="{StaticResource TransparentListBoxItemStyle}" TargetType="{x:Type ListBoxItem}">
                                 <Setter Property="Padding" Value="0" />
+                                <Setter Property="HorizontalContentAlignment" Value="Stretch" />
                             </Style>
                         </ListBox.ItemContainerStyle>
                         <ListBox.ItemTemplate>
@@ -586,7 +588,7 @@
                                     </Grid.ColumnDefinitions>
                                     <controls:TextBlock
                                         Grid.Column="0"
-                                        Margin="10,5"
+                                        Margin="10,5,10,5"
                                         VerticalAlignment="Center"
                                         Text="{Binding Name}"
                                         TextTrimming="CharacterEllipsis" />
@@ -616,7 +618,7 @@
                         <hc:TextBox
                             Grid.Row="0"
                             Height="30"
-                            hc:InfoElement.Placeholder="{DynamicResource RecordName}"
+                            hc:InfoElement.Placeholder="{DynamicResource DepotRecordName}"
                             Text="{Binding DepotRecordName, UpdateSourceTrigger=PropertyChanged}" />
                         <StackPanel
                             Grid.Row="1"

--- a/src/MaaWpfGui/Views/UI/ToolboxView.xaml
+++ b/src/MaaWpfGui/Views/UI/ToolboxView.xaml
@@ -258,6 +258,92 @@
         </TabItem>
         <TabItem Header="{DynamicResource OperBoxRecognition}">
             <Grid Margin="20,0,20,20">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="180" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+
+                <Grid Grid.Column="0" Margin="0,0,10,0">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="*" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <ListBox
+                        Grid.Row="0"
+                        Background="{DynamicResource RegionBrushOpacity25}"
+                        BorderBrush="{DynamicResource BorderBrush}"
+                        BorderThickness="1"
+                        ItemsSource="{Binding OperBoxRecords}"
+                        SelectedItem="{Binding SelectedOperBoxRecord}">
+                        <ListBox.ItemContainerStyle>
+                            <Style BasedOn="{StaticResource TransparentListBoxItemStyle}" TargetType="{x:Type ListBoxItem}">
+                                <Setter Property="Padding" Value="0" />
+                            </Style>
+                        </ListBox.ItemContainerStyle>
+                        <ListBox.ItemTemplate>
+                            <DataTemplate>
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition />
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
+                                    <controls:TextBlock
+                                        Grid.Column="0"
+                                        Margin="10,5"
+                                        VerticalAlignment="Center"
+                                        Text="{Binding Name}"
+                                        TextTrimming="CharacterEllipsis" />
+                                    <Button
+                                        Grid.Column="1"
+                                        Width="20"
+                                        Height="20"
+                                        MinWidth="20"
+                                        Padding="0"
+                                        hc:IconElement.Geometry="{StaticResource CloseGeometry}"
+                                        hc:VisualElement.HighlightBackground="Transparent"
+                                        hc:VisualElement.HighlightForeground="{DynamicResource PrimaryBrush}"
+                                        Background="Transparent"
+                                        BorderThickness="0"
+                                        Foreground="{DynamicResource SecondaryTextBrush}"
+                                        Command="{s:Action DeleteOperBoxRecord}"
+                                        CommandParameter="{Binding}" />
+                                </Grid>
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                    </ListBox>
+                    <Grid Grid.Row="1" Margin="0,5,0,0">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <hc:TextBox
+                            Grid.Row="0"
+                            Height="30"
+                            hc:InfoElement.Placeholder="{DynamicResource RecordName}"
+                            Text="{Binding OperBoxRecordName, UpdateSourceTrigger=PropertyChanged}" />
+                        <StackPanel
+                            Grid.Row="1"
+                            Margin="0,5,0,0"
+                            HorizontalAlignment="Center"
+                            Orientation="Horizontal">
+                            <Button
+                                Height="25"
+                                MinWidth="50"
+                                Padding="8,0"
+                                Command="{s:Action AddOperBoxRecord}"
+                                Content="{DynamicResource AddRecord}" />
+                            <Button
+                                Height="25"
+                                MinWidth="50"
+                                Margin="5,0,0,0"
+                                Padding="8,0"
+                                Command="{s:Action RenameOperBoxRecord}"
+                                Content="{DynamicResource RenameRecord}" />
+                        </StackPanel>
+                    </Grid>
+                </Grid>
+
+                <Grid Grid.Column="1">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="Auto" />
@@ -464,10 +550,97 @@
                         Content="{DynamicResource StartToOperBoxRecognition}"
                         IsEnabled="{c:Binding 'Idle and Inited'}" />
                 </StackPanel>
+                </Grid>
             </Grid>
         </TabItem>
         <TabItem Header="{DynamicResource DepotRecognition}">
             <Grid Margin="20,0,20,20">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="180" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+
+                <Grid Grid.Column="0" Margin="0,0,10,0">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="*" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <ListBox
+                        Grid.Row="0"
+                        Background="{DynamicResource RegionBrushOpacity25}"
+                        BorderBrush="{DynamicResource BorderBrush}"
+                        BorderThickness="1"
+                        ItemsSource="{Binding DepotRecords}"
+                        SelectedItem="{Binding SelectedDepotRecord}">
+                        <ListBox.ItemContainerStyle>
+                            <Style BasedOn="{StaticResource TransparentListBoxItemStyle}" TargetType="{x:Type ListBoxItem}">
+                                <Setter Property="Padding" Value="0" />
+                            </Style>
+                        </ListBox.ItemContainerStyle>
+                        <ListBox.ItemTemplate>
+                            <DataTemplate>
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition />
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
+                                    <controls:TextBlock
+                                        Grid.Column="0"
+                                        Margin="10,5"
+                                        VerticalAlignment="Center"
+                                        Text="{Binding Name}"
+                                        TextTrimming="CharacterEllipsis" />
+                                    <Button
+                                        Grid.Column="1"
+                                        Width="20"
+                                        Height="20"
+                                        MinWidth="20"
+                                        Padding="0"
+                                        hc:IconElement.Geometry="{StaticResource CloseGeometry}"
+                                        hc:VisualElement.HighlightBackground="Transparent"
+                                        hc:VisualElement.HighlightForeground="{DynamicResource PrimaryBrush}"
+                                        Background="Transparent"
+                                        BorderThickness="0"
+                                        Foreground="{DynamicResource SecondaryTextBrush}"
+                                        Command="{s:Action DeleteDepotRecord}"
+                                        CommandParameter="{Binding}" />
+                                </Grid>
+                            </DataTemplate>
+                        </ListBox.ItemTemplate>
+                    </ListBox>
+                    <Grid Grid.Row="1" Margin="0,5,0,0">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <hc:TextBox
+                            Grid.Row="0"
+                            Height="30"
+                            hc:InfoElement.Placeholder="{DynamicResource RecordName}"
+                            Text="{Binding DepotRecordName, UpdateSourceTrigger=PropertyChanged}" />
+                        <StackPanel
+                            Grid.Row="1"
+                            Margin="0,5,0,0"
+                            HorizontalAlignment="Center"
+                            Orientation="Horizontal">
+                            <Button
+                                Height="25"
+                                MinWidth="50"
+                                Padding="8,0"
+                                Command="{s:Action AddDepotRecord}"
+                                Content="{DynamicResource AddRecord}" />
+                            <Button
+                                Height="25"
+                                MinWidth="50"
+                                Margin="5,0,0,0"
+                                Padding="8,0"
+                                Command="{s:Action RenameDepotRecord}"
+                                Content="{DynamicResource RenameRecord}" />
+                        </StackPanel>
+                    </Grid>
+                </Grid>
+
+                <Grid Grid.Column="1">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="Auto" />
                     <RowDefinition Height="*" />
@@ -585,6 +758,7 @@
                         Content="{DynamicResource StartToDepotRecognition}"
                         IsEnabled="{c:Binding 'Idle and Inited'}" />
                 </StackPanel>
+                </Grid>
             </Grid>
         </TabItem>
         <!--


### PR DESCRIPTION
### 新增
1. 为干员识别和仓库识别新增多记录管理支持
2. 一键长草/公招识别等部分可以引用用户所选的列表，没有改动指针或源，而是更改源指向的集合中的内容

## Summary by Sourcery

为仓库（depot）和操作员框（operator-box）识别数据添加多记录管理功能，并将现有的单记录存储迁移到新格式。

新功能：
- 支持管理多个命名的仓库记录，提供选择、新建、删除和重命名功能。
- 支持管理多个命名的操作员框记录，提供选择、新建、删除和重命名功能。

改进：
- 将仓库和操作员框数据以记录集合的形式持久化保存，并包含选中记录的索引，同时支持从旧的单记录 JSON 格式迁移。
- 在没有数据或数据无效时初始化默认的仓库和操作员框记录，从而提升识别数据处理的健壮性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add multi-record management for depot and operator-box recognition data and migrate existing single-record storage to the new format.

New Features:
- Support managing multiple named depot records with selection, creation, deletion, and renaming capabilities.
- Support managing multiple named operator-box records with selection, creation, deletion, and renaming capabilities.

Enhancements:
- Persist depot and operator-box data as record collections with selected index, including migration from legacy single-record JSON formats.
- Initialize default depot and operator-box records when no data or invalid data is present, improving robustness of recognition data handling.

</details>