### PR TITLE
fix: 修复仓库入口在返回主页时因延迟误触的问题

### DIFF
--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -4221,14 +4221,57 @@
     },
     "DepotBegin": {
         "algorithm": "JustReturn",
-        "next": ["Depot", "DepotMaterialTab", "DepotAllTab", "DepotMaterialTabClicked", "Depot@ReturnButtons#next"]
+        "next": [
+            "Depot",
+            "DepotMaterialTab",
+            "DepotAllTab",
+            "DepotMaterialTabClicked",
+            "Depot@ReturnButtons#next"
+        ]
+    },
+    "DepotUnexpectedReturn": {
+        "template": ["Return.png", "Return-White.png"],
+        "templThreshold": [0.7, 0.7],
+        "action": "ClickSelf",
+        "roi": [0, 0, 180, 80],
+        "next": ["DepotHomeWait"]
     },
     "Depot": {
         "action": "DoNothing",
         "template": "SwitchTheme@ToggleSettingsMenu.png",
         "roi": [227, 327, 159, 152],
+        "next": ["DepotHomeWait"]
+    },
+    "DepotHomeWait": {
+        "algorithm": "JustReturn",
+        "postDelay": 500,
+        "next": ["DepotHomeMaybe#next"],
+        "onErrorNext": ["Depot@ReturnButtons#next"]
+    },
+    "DepotHomeMaybe": {
+        "algorithm": "JustReturn",
+        "next": ["DepotUnexpectedReturn", "DepotHomeConfirmed", "Depot@CloseAnnos#next"]
+    },
+    "DepotHomeConfirmed": {
+        "action": "DoNothing",
+        "template": "SwitchTheme@ToggleSettingsMenu.png",
+        "roi": [227, 327, 159, 152],
         "sub": ["Depot-Entry"],
-        "next": ["DepotMaterialTab"]
+        "maxTimes": 2,
+        "exceededNext": ["Depot@ReturnButtons#next"],
+        "next": ["DepotAfterEntry#next"],
+        "onErrorNext": ["Depot@ReturnButtons#next"]
+    },
+    "DepotAfterEntry": {
+        "algorithm": "JustReturn",
+        "next": [
+            "DepotMaterialTab",
+            "DepotAllTab",
+            "DepotMaterialTabClicked",
+            "DepotUnexpectedReturn",
+            "DepotHomeConfirmed",
+            "Depot@CloseAnnos#next"
+        ]
     },
     "DepotAllTab": {
         "action": "ClickSelf",

--- a/src/MaaCore/Task/Interface/DepotTask.cpp
+++ b/src/MaaCore/Task/Interface/DepotTask.cpp
@@ -7,7 +7,9 @@ asst::DepotTask::DepotTask(const AsstCallback& callback, Assistant* inst) :
     InterfaceTask(callback, inst, TaskType)
 {
     auto enter_task = std::make_shared<ProcessTask>(m_callback, m_inst, TaskType);
-    enter_task->set_tasks({ "DepotBegin" }).set_ignore_error(true);
+    // DepotRecognitionTask assumes we have reached the depot screen. If DepotBegin fails,
+    // scanning on the previous screen may clear a valid depot result.
+    enter_task->set_tasks({ "DepotBegin" }).set_ignore_error(false);
     m_subtasks.emplace_back(enter_task);
 
     auto recognition_task = std::make_shared<DepotRecognitionTask>(m_callback, m_inst, TaskType);


### PR DESCRIPTION
## 问题

修复 #16343。

仓库任务从非主页界面启动，或在有前置任务后需要先通过 `ReturnButtons` 返回主页时，严重延迟或截图滞后可能导致第一次主页识别后，MAA继续使用过期状态执行仓库入口点击。实际界面如果已经被后续点击带到设置、邮件或资讯页，仍可能按“识别到主页”逻辑继续点击仓库入口，最终等不到仓库标签而fail。

相关讨论见 #16442。

## 修改

这次保留原有的 `ReturnButtons` 返回方式，只在第一次识别到主页后增加一次短delay和double check：

- `Depot` 首次识别到主页后，不再立即执行 `Depot-Entry`；
- 进入 `DepotHomeWait` 等待 500ms；
- 通过 `DepotHomeMaybe` 重新判断当前状态；
- 如果进入设置页、邮件页等带返回键的页面，使用 `DepotUnexpectedReturn` 点返回；
- 如果仍确认是主页，再由 `DepotHomeConfirmed` 执行 `Depot-Entry`；
- 如果遇到启动资讯页/公告页，复用原有的 `Depot@CloseAnnos#next` 处理；
- 进入仓库后通过 `DepotAfterEntry` 检查是否到达仓库标签页。

同时将 `DepotTask` 的入口任务改为set_ignore_error(false)。因为`DepotRecognitionTask` 依赖已经进入仓库页面的前提，如果入口流程失败，继续识别错误页面没有意义。

## 关于等待时间

这里的 500ms 等待并非假定某一次返回点击已经被模拟器响应，也不是把问题改成固定等待。它的作用是在第一次识别到主页后，避免立刻复用可能滞后的画面继续点击仓库入口，给下一次截图确认留出间隔。

真正的恢复逻辑依赖后续状态判断。`DepotHomeMaybe` 会重新确认当前界面，如果此时已经进入设置、邮件或资讯页，会先走对应恢复；`DepotAfterEntry` 也会在点击仓库入口后再次检查是否真的到达仓库标签页。

因此这个改动不能解决极端持续卡顿下所有截图/输入积压问题，但可以避免原流程在第一次疑似主页命中后立即沿可能的过期状态继续执行。如果整个链路一直极端滞后，最终仍可能 fail。

## 测试

本地使用 MuMu，从干员页面启动 Depot 任务并手动模拟误触，覆盖了以下情况：

- 返回主页后进入资讯页，可以通过原有公告关闭流程关闭后重新进入仓库；
[depot-info-20260516-055303.log](https://github.com/user-attachments/files/27822349/depot-info-20260516-055303.log)

https://github.com/user-attachments/assets/29975350-7b62-474f-ae08-5b017700ee12


- 返回主页后进入设置页，可以通过 `Return-White.png` 返回并重新进入仓库；
[depot-settings-20260516-055414.log](https://github.com/user-attachments/files/27822676/depot-settings-20260516-055414.log)

https://github.com/user-attachments/assets/82a5661c-c321-49aa-a229-f95fbf2614cf


- 返回主页后进入邮件页，可以通过 `Return-White.png` 返回并重新进入仓库。
[depot-mail-20260516-055445.log](https://github.com/user-attachments/files/27822678/depot-mail-20260516-055445.log)

https://github.com/user-attachments/assets/51ee9637-727f-4d57-a759-1f712636c326



以上场景最终均完成仓库识别，任务结束为 `TaskChainCompleted`。

## Summary by Sourcery

改进仓库任务进入流程，避免在从非首页返回时由于首页识别结果过期而导致错误操作，进而无法成功进入仓库。

Bug Fixes:
- 防止在从其他页面返回后，由于截图延迟导致首页识别结果过期，引发仓库任务误触、失败的问题。

Enhancements:
- 当初始进入仓库的操作序列未能成功进入仓库页面时，让仓库进入任务明确失败，而不是忽略错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve the depot task entry flow to avoid acting on stale home-screen recognition and failing to enter the depot when returning from non-home pages.

Bug Fixes:
- Prevent depot tasks from mis-clicking and failing when delayed screenshots cause stale home-screen recognition after returning from other pages.

Enhancements:
- Make the depot entry task fail explicitly instead of ignoring errors when the initial depot entry sequence does not reach the depot screen.

</details>