### PR TITLE
feat: 干员识别支持导出 Json/Markdown/CSV，优化导出按钮布局与交互

### DIFF
--- a/src/MaaWpfGui/Constants/ConfigurationKeys.cs
+++ b/src/MaaWpfGui/Constants/ConfigurationKeys.cs
@@ -337,6 +337,7 @@ public static class ConfigurationKeys
     public const string VersionUpdateDoNotShowUpdate = "VersionUpdate.doNotShowUpdate";
 
     public const string OperBoxData = "OperBox.Data";
+    public const string OperBoxSelectedExportValue = "OperBox.SelectedExportValue";
 
     public const string GachaShowDisclaimerNoMore = "Gacha.ShowDisclaimerNoMore";
 

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -899,6 +899,8 @@ Right Click: Select Target Process</system:String>
     <system:String x:Key="OperBoxNotHaveList">Not owned: {0}</system:String>
     <system:String x:Key="StartToOperBoxRecognition">Start to Identify</system:String>
     <system:String x:Key="OperBoxCopyToClipboard">Copy to Clipboard</system:String>
+    <system:String x:Key="OperBoxExportToClipboard">Clipboard</system:String>
+    <system:String x:Key="OperBoxExportToJson">JSON</system:String>
     <!--  !Operator Recognition  -->
     <!--  Video Recognition  -->
     <system:String x:Key="VideoRecognition">Video</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -900,6 +900,8 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="OperBoxNotHaveList">所有していない: {0}</system:String>
     <system:String x:Key="StartToOperBoxRecognition">認識開始</system:String>
     <system:String x:Key="OperBoxCopyToClipboard">クリップボードにコピー</system:String>
+    <system:String x:Key="OperBoxExportToClipboard">クリップボード</system:String>
+    <system:String x:Key="OperBoxExportToJson">JSON</system:String>
     <!--  !Operator Recognition  -->
     <!--  VideoRecognition  -->
     <system:String x:Key="VideoRecognition">映像</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -901,6 +901,8 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="OperBoxNotHaveList">미보유: {0}</system:String>
     <system:String x:Key="StartToOperBoxRecognition">인식 시작</system:String>
     <system:String x:Key="OperBoxCopyToClipboard">클립보드에 복사</system:String>
+    <system:String x:Key="OperBoxExportToClipboard">클립보드</system:String>
+    <system:String x:Key="OperBoxExportToJson">JSON</system:String>
     <!--  !오퍼레이터 인식  -->
     <!--  영상 인식  -->
     <system:String x:Key="VideoRecognition">영상 인식</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -900,6 +900,8 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="OperBoxNotHaveList">未拥有: {0} 名</system:String>
     <system:String x:Key="StartToOperBoxRecognition">开始识别</system:String>
     <system:String x:Key="OperBoxCopyToClipboard">复制到剪切板</system:String>
+    <system:String x:Key="OperBoxExportToClipboard">剪切板</system:String>
+    <system:String x:Key="OperBoxExportToJson">JSON</system:String>
     <!--  !干员识别  -->
     <!--  视频识别  -->
     <system:String x:Key="VideoRecognition">视频识别</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -900,6 +900,8 @@ C:\\leidian\\LDPlayer9\n
     <system:String x:Key="OperBoxNotHaveList">未擁有：{0} 名</system:String>
     <system:String x:Key="StartToOperBoxRecognition">開始辨識</system:String>
     <system:String x:Key="OperBoxCopyToClipboard">複製到剪貼簿</system:String>
+    <system:String x:Key="OperBoxExportToClipboard">剪貼簿</system:String>
+    <system:String x:Key="OperBoxExportToJson">JSON</system:String>
     <!--  !日誌  -->
     <!--  自動戰鬥  -->
     <system:String x:Key="VideoRecognition">影片辨識</system:String>

--- a/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
@@ -1651,11 +1651,16 @@ public class ToolboxViewModel : Screen
         StartOperBoxRecognitionTask();
     }
 
+    private const int OperBoxExportClipboard = 0;
+    private const int OperBoxExportJson = 1;
+    private const int OperBoxExportMarkdown = 2;
+    private const int OperBoxExportCsv = 3;
+
     public List<ExportEntry> OperBoxExportOptionList { get; } = [
-        new(LocalizationHelper.GetString("OperBoxExportToClipboard"), 0),
-        new(LocalizationHelper.GetString("OperBoxExportToJson"), 1),
-        new(LocalizationHelper.GetString("ExportToMarkdown"), 2),
-        new(LocalizationHelper.GetString("ExportToCsv"), 3),
+        new(LocalizationHelper.GetString("OperBoxExportToClipboard"), OperBoxExportClipboard),
+        new(LocalizationHelper.GetString("OperBoxExportToJson"), OperBoxExportJson),
+        new(LocalizationHelper.GetString("ExportToMarkdown"), OperBoxExportMarkdown),
+        new(LocalizationHelper.GetString("ExportToCsv"), OperBoxExportCsv),
     ];
 
     private int _selectedOperBoxExportValue = Convert.ToInt32(ConfigurationHelper.GetValue(ConfigurationKeys.OperBoxSelectedExportValue, "0"));
@@ -1675,10 +1680,10 @@ public class ToolboxViewModel : Screen
     {
         switch (_selectedOperBoxExportValue)
         {
-            case 0: ExportOperBoxToClipboard(); break;
-            case 1: ExportOperBoxToJson(); break;
-            case 2: ExportOperBoxToMarkdown(); break;
-            case 3: ExportOperBoxToCsv(); break;
+            case OperBoxExportClipboard: ExportOperBoxToClipboard(); break;
+            case OperBoxExportJson: ExportOperBoxToJson(); break;
+            case OperBoxExportMarkdown: ExportOperBoxToMarkdown(); break;
+            case OperBoxExportCsv: ExportOperBoxToCsv(); break;
         }
     }
 
@@ -1740,7 +1745,7 @@ public class ToolboxViewModel : Screen
         AchievementTrackerHelper.Instance.Unlock(AchievementIds.OperatorRoster);
     }
 
-    private void ExportOperBoxToJson()
+    private void ExportOperBoxToFile(Func<IReadOnlyList<OperBoxData.OperData>, string> contentBuilder, string filter, string defaultExt, string defaultFileName)
     {
         var exportList = BuildOperBoxExportList();
         if (exportList.Count == 0)
@@ -1748,12 +1753,12 @@ public class ToolboxViewModel : Screen
             return;
         }
 
-        var content = JsonConvert.SerializeObject(exportList, Formatting.Indented);
+        var content = contentBuilder(exportList);
 
         var dialog = new Microsoft.Win32.SaveFileDialog {
-            Filter = "JSON files (*.json)|*.json|All files (*.*)|*.*",
-            DefaultExt = ".json",
-            FileName = "Arknights_OperBox_Export.json",
+            Filter = filter,
+            DefaultExt = defaultExt,
+            FileName = defaultFileName,
         };
 
         if (dialog.ShowDialog() != true)
@@ -1764,58 +1769,33 @@ public class ToolboxViewModel : Screen
         File.WriteAllText(dialog.FileName, content, new UTF8Encoding(true));
         Growl.Info(LocalizationHelper.GetString("ExportedToFile"));
         AchievementTrackerHelper.Instance.Unlock(AchievementIds.OperatorRoster);
+    }
+
+    private void ExportOperBoxToJson()
+    {
+        ExportOperBoxToFile(
+            list => JsonConvert.SerializeObject(list, Formatting.Indented),
+            "JSON files (*.json)|*.json|All files (*.*)|*.*",
+            ".json",
+            "Arknights_OperBox_Export.json");
     }
 
     private void ExportOperBoxToMarkdown()
     {
-        var exportList = BuildOperBoxExportList();
-        if (exportList.Count == 0)
-        {
-            return;
-        }
-
-        var content = string.Join(Environment.NewLine, BuildOperBoxMarkdownExportLines(exportList));
-
-        var dialog = new Microsoft.Win32.SaveFileDialog {
-            Filter = "Markdown files (*.md)|*.md|All files (*.*)|*.*",
-            DefaultExt = ".md",
-            FileName = "Arknights_OperBox_Export.md",
-        };
-
-        if (dialog.ShowDialog() != true)
-        {
-            return;
-        }
-
-        File.WriteAllText(dialog.FileName, content, new UTF8Encoding(true));
-        Growl.Info(LocalizationHelper.GetString("ExportedToFile"));
-        AchievementTrackerHelper.Instance.Unlock(AchievementIds.OperatorRoster);
+        ExportOperBoxToFile(
+            list => string.Join(Environment.NewLine, BuildOperBoxMarkdownExportLines(list)),
+            "Markdown files (*.md)|*.md|All files (*.*)|*.*",
+            ".md",
+            "Arknights_OperBox_Export.md");
     }
 
     private void ExportOperBoxToCsv()
     {
-        var exportList = BuildOperBoxExportList();
-        if (exportList.Count == 0)
-        {
-            return;
-        }
-
-        var content = string.Join(Environment.NewLine, BuildOperBoxCsvExportLines(exportList));
-
-        var dialog = new Microsoft.Win32.SaveFileDialog {
-            Filter = "CSV files (*.csv)|*.csv|All files (*.*)|*.*",
-            DefaultExt = ".csv",
-            FileName = "Arknights_OperBox_Export.csv",
-        };
-
-        if (dialog.ShowDialog() != true)
-        {
-            return;
-        }
-
-        File.WriteAllText(dialog.FileName, content, new UTF8Encoding(true));
-        Growl.Info(LocalizationHelper.GetString("ExportedToFile"));
-        AchievementTrackerHelper.Instance.Unlock(AchievementIds.OperatorRoster);
+        ExportOperBoxToFile(
+            list => string.Join(Environment.NewLine, BuildOperBoxCsvExportLines(list)),
+            "CSV files (*.csv)|*.csv|All files (*.*)|*.*",
+            ".csv",
+            "Arknights_OperBox_Export.csv");
     }
 
     private static IEnumerable<string> BuildOperBoxMarkdownExportLines(IReadOnlyList<OperBoxData.OperData> items)

--- a/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
@@ -14,6 +14,7 @@
 #nullable enable
 using System;
 using System.Buffers;
+using System.Text;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
@@ -1650,13 +1651,42 @@ public class ToolboxViewModel : Screen
         StartOperBoxRecognitionTask();
     }
 
+    public List<ExportEntry> OperBoxExportOptionList { get; } = [
+        new(LocalizationHelper.GetString("OperBoxExportToClipboard"), 0),
+        new(LocalizationHelper.GetString("OperBoxExportToJson"), 1),
+        new(LocalizationHelper.GetString("ExportToMarkdown"), 2),
+        new(LocalizationHelper.GetString("ExportToCsv"), 3),
+    ];
+
+    private int _selectedOperBoxExportValue = Convert.ToInt32(ConfigurationHelper.GetValue(ConfigurationKeys.OperBoxSelectedExportValue, "0"));
+
+    public int SelectedOperBoxExportValue
+    {
+        get => _selectedOperBoxExportValue;
+        set {
+            SetAndNotify(ref _selectedOperBoxExportValue, value);
+            ConfigurationHelper.SetValue(ConfigurationKeys.OperBoxSelectedExportValue, value.ToString());
+        }
+    }
+
     // UI 绑定的方法
     [UsedImplicitly]
     public void ExportOperBox()
     {
+        switch (_selectedOperBoxExportValue)
+        {
+            case 0: ExportOperBoxToClipboard(); break;
+            case 1: ExportOperBoxToJson(); break;
+            case 2: ExportOperBoxToMarkdown(); break;
+            case 3: ExportOperBoxToCsv(); break;
+        }
+    }
+
+    private List<OperBoxData.OperData> BuildOperBoxExportList()
+    {
         if (OperBoxHaveList.Count == 0)
         {
-            return;
+            return [];
         }
 
         var exportList = new List<OperBoxData.OperData>();
@@ -1693,10 +1723,124 @@ public class ToolboxViewModel : Screen
             }
         }
 
+        return exportList;
+    }
+
+    private void ExportOperBoxToClipboard()
+    {
+        var exportList = BuildOperBoxExportList();
+        if (exportList.Count == 0)
+        {
+            return;
+        }
+
         Clipboard.Clear();
         Clipboard.SetDataObject(JsonConvert.SerializeObject(exportList, Formatting.Indented));
-        OperBoxInfo = LocalizationHelper.GetString("CopiedToClipboard");
+        Growl.Info(LocalizationHelper.GetString("CopiedToClipboard"));
         AchievementTrackerHelper.Instance.Unlock(AchievementIds.OperatorRoster);
+    }
+
+    private void ExportOperBoxToJson()
+    {
+        var exportList = BuildOperBoxExportList();
+        if (exportList.Count == 0)
+        {
+            return;
+        }
+
+        var content = JsonConvert.SerializeObject(exportList, Formatting.Indented);
+
+        var dialog = new Microsoft.Win32.SaveFileDialog {
+            Filter = "JSON files (*.json)|*.json|All files (*.*)|*.*",
+            DefaultExt = ".json",
+            FileName = "Arknights_OperBox_Export.json",
+        };
+
+        if (dialog.ShowDialog() != true)
+        {
+            return;
+        }
+
+        File.WriteAllText(dialog.FileName, content, new UTF8Encoding(true));
+        Growl.Info(LocalizationHelper.GetString("ExportedToFile"));
+        AchievementTrackerHelper.Instance.Unlock(AchievementIds.OperatorRoster);
+    }
+
+    private void ExportOperBoxToMarkdown()
+    {
+        var exportList = BuildOperBoxExportList();
+        if (exportList.Count == 0)
+        {
+            return;
+        }
+
+        var content = string.Join(Environment.NewLine, BuildOperBoxMarkdownExportLines(exportList));
+
+        var dialog = new Microsoft.Win32.SaveFileDialog {
+            Filter = "Markdown files (*.md)|*.md|All files (*.*)|*.*",
+            DefaultExt = ".md",
+            FileName = "Arknights_OperBox_Export.md",
+        };
+
+        if (dialog.ShowDialog() != true)
+        {
+            return;
+        }
+
+        File.WriteAllText(dialog.FileName, content, new UTF8Encoding(true));
+        Growl.Info(LocalizationHelper.GetString("ExportedToFile"));
+        AchievementTrackerHelper.Instance.Unlock(AchievementIds.OperatorRoster);
+    }
+
+    private void ExportOperBoxToCsv()
+    {
+        var exportList = BuildOperBoxExportList();
+        if (exportList.Count == 0)
+        {
+            return;
+        }
+
+        var content = string.Join(Environment.NewLine, BuildOperBoxCsvExportLines(exportList));
+
+        var dialog = new Microsoft.Win32.SaveFileDialog {
+            Filter = "CSV files (*.csv)|*.csv|All files (*.*)|*.*",
+            DefaultExt = ".csv",
+            FileName = "Arknights_OperBox_Export.csv",
+        };
+
+        if (dialog.ShowDialog() != true)
+        {
+            return;
+        }
+
+        File.WriteAllText(dialog.FileName, content, new UTF8Encoding(true));
+        Growl.Info(LocalizationHelper.GetString("ExportedToFile"));
+        AchievementTrackerHelper.Instance.Unlock(AchievementIds.OperatorRoster);
+    }
+
+    private static IEnumerable<string> BuildOperBoxMarkdownExportLines(IReadOnlyList<OperBoxData.OperData> items)
+    {
+        yield return "| 干员 | 干员id | 星级 | 精英化等级 | 等级 | 是否拥有 | 潜能 |";
+        yield return "| :-- | :-- | :-- | :-- | :-- | :-- | :-- |";
+        foreach (var item in items)
+        {
+            yield return $"| {item.Name} | {item.Id} | {item.Rarity} | {item.Elite} | {item.Level} | {(item.Own ? "是" : "否")} | {item.Potential} |";
+        }
+    }
+
+    private static IEnumerable<string> BuildOperBoxCsvExportLines(IReadOnlyList<OperBoxData.OperData> items)
+    {
+        yield return "干员,干员id,星级,精英化等级,等级,是否拥有,潜能";
+        foreach (var item in items)
+        {
+            var name = item.Name ?? string.Empty;
+            if (name.Contains(',') || name.Contains('"') || name.Contains('\n'))
+            {
+                name = "\"" + name.Replace("\"", "\"\"") + "\"";
+            }
+
+            yield return $"{name},{item.Id},{item.Rarity},{item.Elite},{item.Level},{(item.Own ? "是" : "否")},{item.Potential}";
+        }
     }
 
     #endregion OperBox

--- a/src/MaaWpfGui/Views/UI/ToolboxView.xaml
+++ b/src/MaaWpfGui/Views/UI/ToolboxView.xaml
@@ -442,38 +442,49 @@
                         </ListBox>
                     </TabItem>
                 </TabControl>
-                <StackPanel
+                <Grid
                     Grid.Row="3"
                     Margin="0,10,0,0"
                     HorizontalAlignment="Center"
-                    VerticalAlignment="Center"
-                    IsEnabled="{Binding Idle}"
-                    Orientation="Horizontal">
-                    <StackPanel VerticalAlignment="Center">
-                        <ComboBox
-                            Width="160"
-                            hc:TitleElement.Title="{DynamicResource ExportTo}"
-                            DisplayMemberPath="Display"
-                            ItemsSource="{Binding OperBoxExportOptionList}"
-                            SelectedValue="{Binding SelectedOperBoxExportValue}"
-                            SelectedValuePath="Value" />
+                    IsEnabled="{Binding Idle}">
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="Auto" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <controls:TextBlock
+                        Grid.Row="0"
+                        Width="160"
+                        Margin="0,0,0,4"
+                        HorizontalAlignment="Left"
+                        Text="{DynamicResource ExportTo}" />
+                    <StackPanel
+                        Grid.Row="1"
+                        Orientation="Horizontal">
+                        <StackPanel VerticalAlignment="Top">
+                            <ComboBox
+                                Width="160"
+                                DisplayMemberPath="Display"
+                                ItemsSource="{Binding OperBoxExportOptionList}"
+                                SelectedValue="{Binding SelectedOperBoxExportValue}"
+                                SelectedValuePath="Value" />
+                            <Button
+                                Width="160"
+                                Height="30"
+                                Margin="0,5,0,0"
+                                HorizontalAlignment="Center"
+                                Command="{s:Action ExportOperBox}"
+                                Content="{DynamicResource Export}" />
+                        </StackPanel>
                         <Button
-                            Width="160"
-                            Height="30"
-                            Margin="0,5,0,0"
-                            HorizontalAlignment="Center"
-                            Command="{s:Action ExportOperBox}"
-                            Content="{DynamicResource Export}" />
+                            Width="180"
+                            Height="63"
+                            Margin="20,0,0,0"
+                            VerticalAlignment="Top"
+                            Command="{s:Action StartOperBox}"
+                            Content="{DynamicResource StartToOperBoxRecognition}"
+                            IsEnabled="{c:Binding 'Idle and Inited'}" />
                     </StackPanel>
-                    <Button
-                        Width="180"
-                        Height="80"
-                        Margin="20,0,0,0"
-                        VerticalAlignment="Center"
-                        Command="{s:Action StartOperBox}"
-                        Content="{DynamicResource StartToOperBoxRecognition}"
-                        IsEnabled="{c:Binding 'Idle and Inited'}" />
-                </StackPanel>
+                </Grid>
             </Grid>
         </TabItem>
         <TabItem Header="{DynamicResource DepotRecognition}">

--- a/src/MaaWpfGui/Views/UI/ToolboxView.xaml
+++ b/src/MaaWpfGui/Views/UI/ToolboxView.xaml
@@ -445,8 +445,7 @@
                 <Grid
                     Grid.Row="3"
                     Margin="0,10,0,0"
-                    HorizontalAlignment="Center"
-                    IsEnabled="{Binding Idle}">
+                    HorizontalAlignment="Center">
                     <Grid.RowDefinitions>
                         <RowDefinition Height="Auto" />
                         <RowDefinition Height="Auto" />

--- a/src/MaaWpfGui/Views/UI/ToolboxView.xaml
+++ b/src/MaaWpfGui/Views/UI/ToolboxView.xaml
@@ -449,17 +449,27 @@
                     VerticalAlignment="Center"
                     IsEnabled="{Binding Idle}"
                     Orientation="Horizontal">
+                    <StackPanel VerticalAlignment="Center">
+                        <ComboBox
+                            Width="160"
+                            hc:TitleElement.Title="{DynamicResource ExportTo}"
+                            DisplayMemberPath="Display"
+                            ItemsSource="{Binding OperBoxExportOptionList}"
+                            SelectedValue="{Binding SelectedOperBoxExportValue}"
+                            SelectedValuePath="Value" />
+                        <Button
+                            Width="160"
+                            Height="30"
+                            Margin="0,5,0,0"
+                            HorizontalAlignment="Center"
+                            Command="{s:Action ExportOperBox}"
+                            Content="{DynamicResource Export}" />
+                    </StackPanel>
                     <Button
                         Width="180"
-                        Height="70"
-                        Margin="30,0"
-                        Command="{s:Action ExportOperBox}"
-                        Content="{DynamicResource OperBoxCopyToClipboard}"
-                        IsEnabled="{Binding Idle}" />
-                    <Button
-                        Width="180"
-                        Height="70"
-                        Margin="30,0"
+                        Height="80"
+                        Margin="20,0,0,0"
+                        VerticalAlignment="Center"
                         Command="{s:Action StartOperBox}"
                         Content="{DynamicResource StartToOperBoxRecognition}"
                         IsEnabled="{c:Binding 'Idle and Inited'}" />


### PR DESCRIPTION
### 新增  
1. 干员识别支持导出 Json/Markdown/CSV文件
2. 优化导出按钮布局与交互
3. 任务运行时也可以导出列表了  

### 截图 
<img width="783" height="662" alt="image" src="https://github.com/user-attachments/assets/bc4536ba-1041-4ca3-b0a1-a5a321d55fde" />  
  
### 重要事项
**我没有牛牛😭**

## Summary by Sourcery

为算子框识别结果新增多种导出格式和导出方式选择，并优化导出界面。

New Features:
- 支持将算子框识别数据导出为 JSON 文件。
- 支持将算子框识别数据导出为 Markdown 文件。
- 支持将算子框识别数据导出为 CSV 文件。
- 在配置中持久化上一次选择的算子框导出格式。

Enhancements:
- 通过用户可选择的导出格式，将单一导出操作路由到不同的导出方式，从而优化算子框导出交互。
- 通过对剪贴板导出和文件导出使用通知反馈，提升算子框导出时的用户反馈体验。
- 更新算子框工具箱的 UI 布局和本地化资源，以便在所有受支持语言中呈现新的导出选项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add multiple export formats and selection for operator box recognition results and refine the export UI.

New Features:
- Support exporting operator box recognition data as JSON files.
- Support exporting operator box recognition data as Markdown files.
- Support exporting operator box recognition data as CSV files.
- Persist the last selected operator box export format in configuration.

Enhancements:
- Refine the operator box export interaction by routing a single export action through a user-selectable export format.
- Improve user feedback on operator box export by using notifications for clipboard and file exports.
- Update operator box toolbox UI layout and localization resources to surface the new export options across supported languages.

</details>