### PR TITLE
feat: 为自动公招的输出日志增加已公招次数

### DIFF
--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -1582,7 +1582,7 @@ public class AsstProxy
                             }
 
                             Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("RecruitConfirm"), UiLogColor.Info);
-                            Instances.TaskQueueViewModel.AddLog("已公招" + RecruitConfirmTime + "次", UiLogColor.Info);
+                            Instances.TaskQueueViewModel.AddLog(string.Format(LocalizationHelper.GetString("RecruitTimesCount"), RecruitConfirmTime), UiLogColor.Info);
                             break;
 
                         case "InfrastDormDoubleConfirmButton":

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -1582,6 +1582,7 @@ public class AsstProxy
                             }
 
                             Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("RecruitConfirm"), UiLogColor.Info);
+                            Instances.TaskQueueViewModel.AddLog("已公招" + RecruitConfirmTime + "次", UiLogColor.Info);
                             break;
 
                         case "InfrastDormDoubleConfirmButton":

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -42,7 +42,7 @@
     <system:String x:Key="ExternalNotificationEnableDetails">Output Detailed Information</system:String>
     <system:String x:Key="ExternalNotificationSendWhenComplete">Send notification when complete</system:String>
     <system:String x:Key="ExternalNotificationSendWhenError">Send notification when task fails</system:String>
-    <system:String x:Key="ExternalNotificationSendWhenStalled">Send notification when task log output stalls</system:String>
+    <system:String x:Key="ExternalNotificationSendWhenTimeout">Send notification when task times out</system:String>
     <system:String x:Key="ExternalNotificationSendSuccess">Send successfully</system:String>
     <system:String x:Key="ExternalNotificationSendFail">Send failed</system:String>
     <system:String x:Key="ExternalNotificationSendTest">Send Test</system:String>
@@ -354,21 +354,21 @@ You can cancel this popup by clicking the ｢{key=Settings} - {key=IssueReport}�
     <system:String x:Key="UpdateSource">Update Source</system:String>
     <system:String x:Key="UpdateSourceTip" xml:space="preserve">
 🌏 Using {key=GlobalSource}:
-    • {key=UpdateCheckNow}: Update checks are provided by the MAA Team, with update packages pulled from GitHub. A direct domestic mirror is also available (limited bandwidth during peak hours)
-    • {key=ResourceUpdate}: Free update checks provided by {key=MirrorChyan}. You can manually click "{key=ResourceUpdate}" in Settings to download from GitHub
+    ● {key=UpdateCheckNow}: Update checks are provided by the MAA Team, with update packages pulled from GitHub. A direct domestic mirror is also available (limited bandwidth during peak hours)
+    ● {key=ResourceUpdate}: Free update checks provided by {key=MirrorChyan}. You can manually click "{key=ResourceUpdate}" in Settings to download from GitHub
 
 🔑 Using {key=MirrorChyan}:
-    • After entering a CDK, automatic updates for both software and resources are enabled
-    • Downloads are prioritized via the high-speed {key=MirrorChyan} CDN for greater stability and speed
+    ● After entering a CDK, automatic updates for both software and resources are enabled
+    ● Downloads are prioritized via the high-speed {key=MirrorChyan} CDN for greater stability and speed
 
 📦 Manual Update:
-    • {key=UpdateCheckNow}: Download a full package or OTA update package and drag it into the app. The app will automatically extract it and clean up old files
-    • {key=ResourceUpdate}: Download the resource package and overwrite the `resource` folder. The package is incremental; do not delete the original folder, or errors may occur
+    ● {key=UpdateCheckNow}: Download a full package or OTA update package and drag it into the app. The app will automatically extract it and clean up old files
+    ● {key=ResourceUpdate}: Download the resource package and overwrite the `resource` folder. The package is incremental; do not delete the original folder, or errors may occur
 
 📄 Update Notes:
-    • {key=UpdateCheckNow}: Includes UI and feature updates. All interface changes and new features are delivered via {key=UpdateCheckNow}
-    • {key=ResourceUpdate}: Includes new stage maps for Auto Battle, drop item icons for recognition, recruitment tags for operator recognition, and other resource data
-    • Navigation Hotfix: Triggered automatically to update main screen prompts and event stage entries. A success message “{key=ApiUpdateSuccess}” will appear in the top right corner
+    ● {key=UpdateCheckNow}: Includes UI and feature updates. All interface changes and new features are delivered via {key=UpdateCheckNow}
+    ● {key=ResourceUpdate}: Includes new stage maps for Auto Battle, drop item icons for recognition, recruitment tags for operator recognition, and other resource data
+    ● Navigation Hotfix: Triggered automatically to update main screen prompts and event stage entries. A success message “{key=ApiUpdateSuccess}” will appear in the top right corner
 </system:String>
     <system:String x:Key="GlobalSource">Global Source</system:String>
     <system:String x:Key="ForceGithubGlobalSource">Force using GitHub</system:String>
@@ -625,7 +625,7 @@ Then delete the entries corresponding to the paths.
     <system:String x:Key="MainViewButtonFeature">Variable function button</system:String>
     <system:String x:Key="CustomStageCode">Manual entry of stage names</system:String>
     <system:String x:Key="CustomStageCodeTip" xml:space="preserve">Support most main stage names + stage names from the original list (e.g. 4-10, AP-5, H10-1-Hard, etc.)
-At the end of the stage, enter ｢Normal/Hard｣ to switch difficulty: Chapters 10-14 use Standard/Adverse, Chapters 15+ use Normal/Raid
+At the end of the stage, enter ｢Normal/Hard｣ to switch between Standard and Adverse environment
 Enter ｢SSReopen-XX｣ once to clear all normal stages with Auto-Deploy in SS rerun events</system:String>
     <system:String x:Key="AutoDetectConnection">Auto detect connection</system:String>
     <system:String x:Key="AutoDetectConnectionNotSupported">Automatic connection detection is not supported for this configuration, please try manually entering the port number</system:String>
@@ -718,15 +718,12 @@ If the game is launched in portrait mode and then switched to landscape, it may 
     <system:String x:Key="Roguelike">{key=AutoRoguelike}</system:String>
     <system:String x:Key="Reclamation">Reclamation Algorithm</system:String>
     <system:String x:Key="UserDataUpdate">Update Doctor Data</system:String>
-    <system:String x:Key="MiniGame">Useful Tasks</system:String>
-    <system:String x:Key="MiniGameCategoryPermanent">Permanent</system:String>
-    <system:String x:Key="MiniGameCategoryCurrentEvent">Current Events</system:String>
+    <system:String x:Key="MiniGame">Mini-Games</system:String>
     <system:String x:Key="Custom">Custom Task</system:String>
     <system:String x:Key="SingleStep">Single-Step Task</system:String>
     <system:String x:Key="ReclamationTheme">Reclamation Algorithm Theme</system:String>
     <system:String x:Key="ReclamationThemeFire">Fire Within the Sand</system:String>
     <system:String x:Key="ReclamationThemeTales">Tales Within the Sand</system:String>
-    <system:String x:Key="ReclamationThemeRelaunchAnchor">RELAUNCH ANCHOR</system:String>
     <system:String x:Key="ReclamationModeProsperityNoSave">I do not have a save, let's farm prosperity points by repeatedly entering and exiting stages.</system:String>
     <system:String x:Key="ReclamationModeProsperityInSave">I do have a save, let's farm prosperity points by crafting tools.</system:String>
     <system:String x:Key="ReclamationIncrementMode">Increment Mode</system:String>
@@ -882,14 +879,9 @@ Right Click: Select Target Process</system:String>
     <system:String x:Key="LastSyncTime">Last Sync Time</system:String>
     <system:String x:Key="DepotRecognitionTip">This function is still in testing. If you encounter any unexpected results, please zip the ｢debug/depot｣ folder in the installation path and submit an issue on GitHub</system:String>
     <system:String x:Key="StartToDepotRecognition">Start to Identify</system:String>
-    <system:String x:Key="ExportToArkplanner">Arkplanner</system:String>
-    <system:String x:Key="ExportToLolicon">Arkntools</system:String>
-    <system:String x:Key="ExportToMarkdown">Markdown</system:String>
-    <system:String x:Key="ExportToCsv">CSV</system:String>
+    <system:String x:Key="ExportToArkplanner">Export to Arkplanner</system:String>
+    <system:String x:Key="ExportToLolicon">Export to Arkntools</system:String>
     <system:String x:Key="CopiedToClipboard">Copied to Clipboard</system:String>
-    <system:String x:Key="ExportedToFile">Exported to file</system:String>
-    <system:String x:Key="ExportTo">Export to:</system:String>
-    <system:String x:Key="Export">Export</system:String>
     <!--  !Depot Recognition  -->
     <!--  Operator Recognition  -->
     <system:String x:Key="OperBoxRecognition">{key=Operator}</system:String>
@@ -1073,14 +1065,14 @@ Right-click to clear inactive jobs</system:String>
         5. When using a support unit, turn off ｢{key=AutoSquad}｣ and ｢{key=UseCopilotList}｣, manually select the {key=Operator}, then start from the squad screen where the "Mission Start" button appears in the bottom right.\n\n
         6. {key=Operator}s marked as "Favorite" may affect ｢{key=AutoSquad}｣ recognition and selection. When using ｢{key=AutoSquad}｣, consider removing favorites, or if errors occur, turn off ｢{key=AutoSquad}｣ and manually supplement the missing {key=Operator}s as prompted.\n\n
         7. In the Copilot workstation, you can paste codes by clicking the paste button on the right side of the input box:\n
-        • Second button = Add a single job.\n
-        • Third button = Add a job set.\n\n
+        ● Second button = Add a single job.\n
+        ● Third button = Add a job set.\n\n
         8. {key=UseCopilotList}:\n
-        • After selecting a job, verify the stage name below is correct (e.g., CV-EX-1).\n
-        • Add: Left-click for Normal difficulty, right-click for Challenge difficulty.\n
-        • Clear: Left-click to clear all jobs, right-click to remove only inactive jobs.\n
-        • Start from a screen where the target stage name is visible. Cross-chapter navigation is not supported.\n
-        • Execution will stop automatically when sanity is insufficient, battle fails, or fails to achieve a 3★ clear.
+        ● After selecting a job, verify the stage name below is correct (e.g., CV-EX-1).\n
+        ● Add: Left-click for Normal difficulty, right-click for Challenge difficulty.\n
+        ● Clear: Left-click to clear all jobs, right-click to remove only inactive jobs.\n
+        ● Start from a screen where the target stage name is visible. Cross-chapter navigation is not supported.\n
+        ● Execution will stop automatically when sanity is insufficient, battle fails, or fails to achieve a 3★ clear.
     </system:String>
     <system:String x:Key="CopilotFileReadError">Failed to read file!</system:String>
     <system:String x:Key="CopilotNoFound">No corresponding file found!</system:String>
@@ -1187,6 +1179,7 @@ Right-click to clear inactive jobs</system:String>
     <system:String x:Key="FightMissionFailedAndStop">Proxy failed too many times, task stopped</system:String>
     <system:String x:Key="LabelsRefreshed">Labels refreshed</system:String>
     <system:String x:Key="RecruitConfirm">Recruit confirm</system:String>
+    <system:String x:Key="RecruitTimesCount">Recruited {0} time(s)</system:String>
     <system:String x:Key="InfrastDormDoubleConfirmed">{key=Operator} conflict</system:String>
     <system:String x:Key="BegunToExplore">Exploration started</system:String>
     <system:String x:Key="RoutingRestartTooManyBattles">Too many battles ahead: {0}, restarting route</system:String>
@@ -1311,9 +1304,10 @@ Right-click to clear inactive jobs</system:String>
     <system:String x:Key="AttachWindowFailed">AttachWindow failed, please check screencap/input method settings</system:String>
     <system:String x:Key="UseAttachWindowTip">Use Win32 window binding for Arknights PC client instead of ADB connection for emulators or phones</system:String>
     <system:String x:Key="UseAttachWindowWarning" xml:space="preserve">PC connection (experimental feature, stability not guaranteed)
-Due to limited development resources within the MAA Team, this feature is community-maintained and is not continuously supported by the MAA Team. Functionality and stability may fall short of expectations, and issues may not be fixed promptly.
-If you encounter problems that affect usability, we recommend switching to ADB mode with an Android emulator or mobile device for a more stable experience.
-We also always welcome Pull Requests from capable developers to help improve PC support.
+Due to limited development resources within the MAA Team, PC support lacks dedicated maintenance and may experience instability or functional issues:
+● We may not be able to promptly respond to or fix PC-related issues
+● If unavailable, consider switching to ADB mode to connect via Android emulator or mobile device
+● We sincerely welcome Pull Requests from developers to help improve PC support
 
 Before use, please ensure:
 1. MAA is launched with administrator privileges
@@ -1462,20 +1456,6 @@ Cache files (such as maps, operator avatars, etc.) need to be regenerated after 
     <system:String x:Key="AnnouncementNotFinishedConfirm3">Still clicking</system:String>
     <!--  !Announcement  -->
     <!--  Reclamation  -->
-    <system:String x:Key="ReclamationEarlyTipRelaunchAnchor" xml:space="preserve">
-Relaunch Anchor:
-
- Reward estimate: ~159 tokens + coordination points per run, ~3 min per round
-
- Prerequisite (complete once manually):
-  1. Manually enter RA-1, complete the tutorial, and return to the map
-  2. After that, the task can be started when &quot;Start Construction&quot; appears at the bottom-right after clicking RA-1
-
- Note: If you have unlocked technologies related to starting with extra items, please dismantle the facilities in the base that cause starting with extra items, such as Food Supply Stations, Drink Supply Stations, Large Animal Pens, etc.
-
- Task flow:
-  Automatically executes farming, construction, resource delivery, and settlement loop
-    </system:String>
     <system:String x:Key="ReclamationEarlyTip" xml:space="preserve">
 The support for reclamation algorithm is still under development at present. Please mind the following:
 
@@ -1525,8 +1505,7 @@ These locations are too high-level and can lead to file overwrites, config write
     <!--  TimeOutTimer  -->
     <system:String x:Key="TaskTimeoutMinutes">Task timeout duration (minutes)</system:String>
     <system:String x:Key="ReminderIntervalMinutes">Reminder interval (minutes)</system:String>
-    <system:String x:Key="StallTimeoutMinutes">Log output stall timeout (min)</system:String>
-    <system:String x:Key="TaskStallWarning">Task log output has not been updated for {0} minutes (currently stalled for {1} minutes). If there is no further log output for a long time, manual intervention may be required.</system:String>
+    <system:String x:Key="TaskTimeoutWarning">The task has been running for more than {0} minutes (currently running for {1} minutes). If there are no further log updates for a long time, manual intervention may be required.</system:String>
     <!--  !TimeOutTimer  -->
     <!--  Achievement  -->
     <system:String x:Key="AchievementCelebrate">🎉 Achievement Unlocked</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -42,7 +42,7 @@
     <system:String x:Key="ExternalNotificationEnableDetails">詳細情報を出力</system:String>
     <system:String x:Key="ExternalNotificationSendWhenComplete">タスク完了時に通知を送信</system:String>
     <system:String x:Key="ExternalNotificationSendWhenError">タスクが失敗したときに通知を送信</system:String>
-    <system:String x:Key="ExternalNotificationSendWhenStalled">タスクログ出力停滞時に通知を送信</system:String>
+    <system:String x:Key="ExternalNotificationSendWhenTimeout">タスクがタイムアウトしたときに通知を送信する</system:String>
     <system:String x:Key="ExternalNotificationSendSuccess">正常に送信</system:String>
     <system:String x:Key="ExternalNotificationSendFail">送信に失敗しました</system:String>
     <system:String x:Key="ExternalNotificationSendTest">テストを送信する</system:String>
@@ -354,21 +354,21 @@
     <system:String x:Key="UpdateSource">更新ソース</system:String>
     <system:String x:Key="UpdateSourceTip" xml:space="preserve">
 🌏 {key=GlobalSource}を使用：
-    • {key=UpdateCheckNow}：MAA Team による更新確認で、GitHub から更新パッケージを取得します。中国国内向けに直通ミラーも提供されています（ピーク時は帯域制限の可能性あり）
-    • {key=ResourceUpdate}：{key=MirrorChyan} による無料の更新確認が可能。設定画面で「{key=ResourceUpdate}」をクリックして GitHub から手動ダウンロード可能
+    ● {key=UpdateCheckNow}：MAA Team による更新確認で、GitHub から更新パッケージを取得します。中国国内向けに直通ミラーも提供されています（ピーク時は帯域制限の可能性あり）
+    ● {key=ResourceUpdate}：{key=MirrorChyan} による無料の更新確認が可能。設定画面で「{key=ResourceUpdate}」をクリックして GitHub から手動ダウンロード可能
 
 🔑 {key=MirrorChyan}を使用：
-    • CDK を入力すると、ソフトウェアとリソースの自動更新が有効になります
-    • 高速 CDN を通じて {key=MirrorChyan} から優先的にダウンロード、より安定かつ高速
+    ● CDK を入力すると、ソフトウェアとリソースの自動更新が有効になります
+    ● 高速 CDN を通じて {key=MirrorChyan} から優先的にダウンロード、より安定かつ高速
 
 📦 手動更新：
-    • {key=UpdateCheckNow}：完全パッケージまたは OTA 更新パッケージをダウンロードしてアプリにドラッグすると、自動で解凍し古いファイルを整理します
-    • {key=ResourceUpdate}：リソースパックをダウンロードし、resource フォルダに上書きしてください。増分データのため、元のフォルダを削除しないでください
+    ● {key=UpdateCheckNow}：完全パッケージまたは OTA 更新パッケージをダウンロードしてアプリにドラッグすると、自動で解凍し古いファイルを整理します
+    ● {key=ResourceUpdate}：リソースパックをダウンロードし、resource フォルダに上書きしてください。増分データのため、元のフォルダを削除しないでください
 
 📄 更新内容：
-    • {key=UpdateCheckNow}：UI や機能のアップデートを含みます。すべての画面変更や新機能は{key=UpdateCheckNow}経由で提供されます
-    • {key=ResourceUpdate}：自動戦闘用の新ステージ、ドロップ認識用アイコン、公募タグなどの素材データを含みます
-    • ナビホットパッチ：自動でトリガーされ、ホーム画面のヒントやイベントステージ入口を更新します。成功すると右上に「{key=ApiUpdateSuccess}」と表示されます
+    ● {key=UpdateCheckNow}：UI や機能のアップデートを含みます。すべての画面変更や新機能は{key=UpdateCheckNow}経由で提供されます
+    ● {key=ResourceUpdate}：自動戦闘用の新ステージ、ドロップ認識用アイコン、公募タグなどの素材データを含みます
+    ● ナビホットパッチ：自動でトリガーされ、ホーム画面のヒントやイベントステージ入口を更新します。成功すると右上に「{key=ApiUpdateSuccess}」と表示されます
 </system:String>
     <system:String x:Key="GlobalSource">グローバルソース</system:String>
     <system:String x:Key="ForceGithubGlobalSource">GitHub を強制使用</system:String>
@@ -625,7 +625,7 @@ HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Notifications\Settin
     <system:String x:Key="MainViewButtonFeature">スタート画面に表示する便利ボタン</system:String>
     <system:String x:Key="CustomStageCode">ステージ名を入力する</system:String>
     <system:String x:Key="CustomStageCodeTip" xml:space="preserve">(テスト機能)ステージ名と番号（例: 4-10、AP-5、H10-1-Hardなど）
-の両方がサポートされています。ステージの最後に「Normal/Hard」を入力すると難易度を切り替えできます（10〜14章は標準/厄難、15章以降は通常/険地）</system:String>
+の両方がサポートされています。ステージの最後に「Normal/Hard」を入力することで、標準から強襲/厄難に難易度を切り替えることができます</system:String>
     <!--ワンタイム代理SS一般パスとして「SSReopen-XX」を入力できます</system:String>-->
     <system:String x:Key="AutoDetectConnection">接続自動認識</system:String>
     <system:String x:Key="AutoDetectConnectionNotSupported">この接続構成では自動接続検出はサポートされていません。手動でポート番号を入力してみてください</system:String>
@@ -719,15 +719,12 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="Roguelike">{key=AutoRoguelike}</system:String>
     <system:String x:Key="Reclamation">生息演算</system:String>
     <system:String x:Key="UserDataUpdate">ユーザーデータ更新</system:String>
-    <system:String x:Key="MiniGame">便利機能</system:String>
-    <system:String x:Key="MiniGameCategoryPermanent">常設</system:String>
-    <system:String x:Key="MiniGameCategoryCurrentEvent">現在のイベント</system:String>
+    <system:String x:Key="MiniGame">ミニゲーム</system:String>
     <system:String x:Key="Custom">カスタムタスク</system:String>
     <system:String x:Key="SingleStep">単一ステップタスク</system:String>
     <system:String x:Key="ReclamationTheme">主題</system:String>
     <system:String x:Key="ReclamationThemeFire">砂中の火</system:String>
     <system:String x:Key="ReclamationThemeTales">熱砂秘聞</system:String>
-    <system:String x:Key="ReclamationThemeRelaunchAnchor">RELAUNCH ANCHOR</system:String>
     <system:String x:Key="ReclamationModeProsperityNoSave">セーブせずに、出入りを繰り返して生息ポイントを稼ぐ</system:String>
     <system:String x:Key="ReclamationModeProsperityInSave">セーブしながら、支援アイテムを組み立てて生息ポイントを稼ぐ</system:String>
     <system:String x:Key="ReclamationIncrementMode">増加方式</system:String>
@@ -883,14 +880,9 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="LastSyncTime">前回同期時間</system:String>
     <system:String x:Key="DepotRecognitionTip">この機能はまだテスト版です。エラーが発生/統計情報に問題があれば、debug/depotフォルダを圧縮し、issueを提出してください~</system:String>
     <system:String x:Key="StartToDepotRecognition">認識開始</system:String>
-    <system:String x:Key="ExportToArkplanner">Arkplanner</system:String>
-    <system:String x:Key="ExportToLolicon">Arkntools</system:String>
-    <system:String x:Key="ExportToMarkdown">Markdown</system:String>
-    <system:String x:Key="ExportToCsv">CSV</system:String>
+    <system:String x:Key="ExportToArkplanner">Arkplannerへ出力</system:String>
+    <system:String x:Key="ExportToLolicon">Arkntoolsへ出力</system:String>
     <system:String x:Key="CopiedToClipboard">クリップボードへコピー</system:String>
-    <system:String x:Key="ExportedToFile">ファイルにエクスポートしました</system:String>
-    <system:String x:Key="ExportTo">出力先：</system:String>
-    <system:String x:Key="Export">エクスポート</system:String>
     <!--  !倉庫アイテム認識  -->
     <!--  Operator Recognition  -->
     <system:String x:Key="OperBoxRecognition">{key=Operator}</system:String>
@@ -1074,14 +1066,14 @@ C:\\leidian\\LDPlayer9
         5. サポートを使うときは、「{key=AutoSquad}」と「{key=UseCopilotList}」をオフにし、手動で {key=Operator} を選択した後、編成画面の右下に「行動開始」ボタン画面で開始してください。\n\n
         6. 「戦術要員」機能を有効にすると、「{key=AutoSquad}」の{key=Operator}選択に影響を与える可能性があります。「{key=AutoSquad}」を 使用する際は「戦術要員」をオフにするか、不足している{key=Operator}を手動で補充して編成を完成させることをお勧めします。\n\n
         7. Copilot作業ステーションでは、入力欄の右側にある貼り付けボタンをクリックして、謎のコードを貼り付けることができます：\n
-        • 2番目のボタンをクリック = 割り当てを追加。\n
-        • 3番目のボタンをクリック = 割り当てセットを追加。\n\n
+        ● 2番目のボタンをクリック = 割り当てを追加。\n
+        ● 3番目のボタンをクリック = 割り当てセットを追加。\n\n
         8. {key=UseCopilotList}:\n
-        • 攻略ファイルを選択した後、リストの下のステージ名が正しいことを確認してください（例: CV-EX-1）。 \n
-        • 追加: 左クリックして通常難易度を追加し、右クリックして強襲難易度を追加します。\n
-        • クリア: 左クリックするとリストがクリアされ、右クリックすると非アクティブなタスクのみが削除されます。\n
-        • ターゲットのステージ名が見える画面で起動してください。章間のナビゲーションはサポートされていません。\n
-        • 理性不足の場合、戦闘が失敗した場合、または 3 つ星を解決できない場合、アクションは終了します。
+        ● 攻略ファイルを選択した後、リストの下のステージ名が正しいことを確認してください（例: CV-EX-1）。 \n
+        ● 追加: 左クリックして通常難易度を追加し、右クリックして強襲難易度を追加します。\n
+        ● クリア: 左クリックするとリストがクリアされ、右クリックすると非アクティブなタスクのみが削除されます。\n
+        ● ターゲットのステージ名が見える画面で起動してください。章間のナビゲーションはサポートされていません。\n
+        ● 理性不足の場合、戦闘が失敗した場合、または 3 つ星を解決できない場合、アクションは終了します。
     </system:String>
     <system:String x:Key="CopilotFileReadError">ファイルの読み取りに失敗しました！</system:String>
     <system:String x:Key="CopilotNoFound">対応する攻略ファイルが見つかりません！</system:String>
@@ -1188,6 +1180,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="FightMissionFailedAndStop">自動指揮の失敗回数が上限に達したため、任務が停止されました</system:String>
     <system:String x:Key="LabelsRefreshed">タグが更新されました</system:String>
     <system:String x:Key="RecruitConfirm">募集を行いました</system:String>
+    <system:String x:Key="RecruitTimesCount">公招回数: {0}</system:String>
     <system:String x:Key="InfrastDormDoubleConfirmed">{key=Operator}が競合しました</system:String>
     <system:String x:Key="BegunToExplore">探索を開始しました</system:String>
     <system:String x:Key="RoutingRestartTooManyBattles">前方の戦闘数：{0}、ルートを再計画します</system:String>
@@ -1312,9 +1305,10 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="AttachWindowFailed">AttachWindow の接続に失敗しました。スクリーンキャプチャ/入力方法の設定を確認してください</system:String>
     <system:String x:Key="UseAttachWindowTip">エミュレータや携帯電話への ADB 接続ではなく、アークナイツ PC クライアントに Win32 ウィンドウバインディングを使用します</system:String>
     <system:String x:Key="UseAttachWindowWarning" xml:space="preserve">PC 接続（実験的機能・動作の安定性は保証されません）
-MAA Team の開発リソースが限られているため、この機能はコミュニティによって保守されており、MAA Team が継続的にサポートしているものではありません。機能面や安定性が十分でない場合があり、問題が発生してもすぐには修正できない可能性があります。
-使用に支障が出る問題がある場合は、より安定した利用のために、ADB モードで Android エミュレータまたはモバイルデバイスへ接続することをおすすめします。
-また、PC 対応の改善にご協力いただける開発者の Pull Request はいつでも歓迎しています。
+MAA Team の開発リソースが限られているため、PC 対応は専任のメンテナンスがなく、機能の不具合や動作の不安定が生じる可能性があります：
+● 問題が発生した場合、迅速な対応や修正が難しい場合があります
+● 正常に動作しない場合は、ADB モードで Android エミュレータまたはモバイルデバイスへの接続をご検討ください
+● PC 対応の改善にご協力いただける開発者の Pull Request を心より歓迎いたします
 
 使用前にご確認ください：
 1. MAA を管理者権限で起動してください
@@ -1463,20 +1457,6 @@ DEBUGディレクトリに保存される画像には数量制限があり、超
     <system:String x:Key="AnnouncementNotFinishedConfirm3">まだ押す</system:String>
     <!--  !Announcement  -->
     <!--  Reclamation  -->
-    <system:String x:Key="ReclamationEarlyTipRelaunchAnchor" xml:space="preserve">
-再起の錨：
-
- 報酬目安：1回あたり約159トークン＋統括ポイント、所要時間約3分
-
- 事前準備（手動で1回のみ）：
-  1. 手動でRA-1に入り、チュートリアルを完了してマップに戻る
-  2. 以降、RA-1をクリックした後に右下に「建設開始」が表示されたらタスクを開始可能
-
- 注意：「初期追加携帯アイテム」に関連するテクノロジーをアンロックしている場合、基地内で初期追加携帯アイテムの原因となる施設（食品供給所、飲料供給所、大型獣舎など）を解体してください
-
- タスクの流れ：
-  精耕細作、建設、資源納入、決済を自動実行
-    </system:String>
     <system:String x:Key="ReclamationEarlyTip" xml:space="preserve">
 生息演算のサポートはまだ初期段階にありますので、ご利用の際は以下の点にご注意ください：
 
@@ -1526,8 +1506,7 @@ MAA を複数開くには、新しい MAA を他のフォルダにコピーし�
     <!--  TimeOutTimer  -->
     <system:String x:Key="TaskTimeoutMinutes">タスクのタイムアウト時間（分）</system:String>
     <system:String x:Key="ReminderIntervalMinutes">リマインダー間隔時間（分）</system:String>
-    <system:String x:Key="StallTimeoutMinutes">ログ出力停滞タイムアウト（分）</system:String>
-    <system:String x:Key="TaskStallWarning">タスクログ出力が {0} 分間更新されていません（現在 {1} 分間停滞）。長時間ログ出力がない場合は、手動での操作が必要になる可能性があります。</system:String>
+    <system:String x:Key="TaskTimeoutWarning">タスクが {0} 分以上実行されています（現在 {1} 分実行中）。長時間ログの更新がない場合、手動で介入する必要があるかもしれません。</system:String>
     <!--  !TimeOutTimer  -->
     <!--  Achievement  -->
     <system:String x:Key="AchievementCelebrate">🎉 実績を獲得した</system:String>
@@ -2016,4 +1995,3 @@ MAA を複数開くには、新しい MAA を他のフォルダにコピーし�
     <system:String x:Key="EmulatorSelectionCancelled">エミュレータの選択がキャンセルされました</system:String>
     <!--  !ItemSelection  -->
 </ResourceDictionary>
-

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -42,7 +42,7 @@
     <system:String x:Key="ExternalNotificationEnableDetails">상세 정보 출력</system:String>
     <system:String x:Key="ExternalNotificationSendWhenComplete">작업 완료 시 알림 전송</system:String>
     <system:String x:Key="ExternalNotificationSendWhenError">작업 실패 시 알림 전송</system:String>
-    <system:String x:Key="ExternalNotificationSendWhenStalled">작업 로그 출력 정지 시 알림 전송</system:String>
+    <system:String x:Key="ExternalNotificationSendWhenTimeout">작업 시간 초과 시 알림 전송</system:String>
     <system:String x:Key="ExternalNotificationSendSuccess">전송 성공</system:String>
     <system:String x:Key="ExternalNotificationSendFail">전송 실패</system:String>
     <system:String x:Key="ExternalNotificationSendTest">테스트</system:String>
@@ -354,21 +354,21 @@
     <system:String x:Key="UpdateSource">업데이트 소스</system:String>
     <system:String x:Key="UpdateSourceTip" xml:space="preserve">
 🌏 {key=GlobalSource} 사용:
-    • {key=UpdateCheckNow}: MAA Team에서 업데이트를 확인하고, GitHub에서 설치 파일을 다운로드합니다. 중국에서는 직접 연결 가능한 미러도 제공됩니다. (대역폭이 제한되어 있으며, 트래픽에 따라 접속이 제한될 수 있습니다)
-    • {key=ResourceUpdate}: {key=MirrorChyan}에서 무료로 업데이트 확인을 제공합니다. 설정에서 "{key=ResourceUpdate}"를 수동으로 클릭하여 GitHub에서 다운로드할 수 있습니다
+    ● {key=UpdateCheckNow}: MAA Team에서 업데이트를 확인하고, GitHub에서 설치 파일을 다운로드합니다. 중국에서는 직접 연결 가능한 미러도 제공됩니다. (대역폭이 제한되어 있으며, 트래픽에 따라 접속이 제한될 수 있습니다)
+    ● {key=ResourceUpdate}: {key=MirrorChyan}에서 무료로 업데이트 확인을 제공합니다. 설정에서 "{key=ResourceUpdate}"를 수동으로 클릭하여 GitHub에서 다운로드할 수 있습니다
 
 🔑 {key=MirrorChyan} 사용:
-    • CDK 입력 시, 소프트웨어와 리소스 모두 자동 업데이트를 지원합니다
-    • {key=MirrorChyan}의 고속 CDN을 통해 우선 다운로드되어 더욱 안정적이고 빠릅니다
+    ● CDK 입력 시, 소프트웨어와 리소스 모두 자동 업데이트를 지원합니다
+    ● {key=MirrorChyan}의 고속 CDN을 통해 우선 다운로드되어 더욱 안정적이고 빠릅니다
 
 📦 수동 업데이트:
-    • {key=UpdateCheckNow}: 전체 패키지 또는 OTA 업데이트 패키지를 다운로드한 뒤 앱으로 드래그하면, 앱이 자동으로 압축을 풀고 오래된 파일을 정리합니다
-    • {key=ResourceUpdate}: 리소스 패키지를 다운로드한 후 resource 폴더에 덮어쓰기하세요. 증분 방식으로 제공되므로 기존 폴더를 삭제하지 마세요. 리소스가 손상될 수 있습니다
+    ● {key=UpdateCheckNow}: 전체 패키지 또는 OTA 업데이트 패키지를 다운로드한 뒤 앱으로 드래그하면, 앱이 자동으로 압축을 풀고 오래된 파일을 정리합니다
+    ● {key=ResourceUpdate}: 리소스 패키지를 다운로드한 후 resource 폴더에 덮어쓰기하세요. 증분 방식으로 제공되므로 기존 폴더를 삭제하지 마세요. 리소스가 손상될 수 있습니다
 
 📄 업데이트 설명:
-    • {key=UpdateCheckNow}: UI 및 기능 업데이트가 포함됩니다. UI 변경 및 새로운 기능은 모두 {key=UpdateCheckNow}를 통해 제공됩니다
-    • {key=ResourceUpdate}: 자동 전투용 신규 스테이지, 드롭 아이콘, 공개모집 태그 등의 리소스 데이터가 포함됩니다
-    • 내비 핫픽스: 자동으로 실행되어 메인 화면 하단의 안내 및 이벤트 스테이지 입구를 업데이트합니다. 성공 시 우측 상단에 “{key=ApiUpdateSuccess}” 메시지가 표시됩니다
+    ● {key=UpdateCheckNow}: UI 및 기능 업데이트가 포함됩니다. UI 변경 및 새로운 기능은 모두 {key=UpdateCheckNow}를 통해 제공됩니다
+    ● {key=ResourceUpdate}: 자동 전투용 신규 스테이지, 드롭 아이콘, 공개모집 태그 등의 리소스 데이터가 포함됩니다
+    ● 내비 핫픽스: 자동으로 실행되어 메인 화면 하단의 안내 및 이벤트 스테이지 입구를 업데이트합니다. 성공 시 우측 상단에 “{key=ApiUpdateSuccess}” 메시지가 표시됩니다
 </system:String>
     <system:String x:Key="GlobalSource">글로벌 소스</system:String>
     <system:String x:Key="ForceGithubGlobalSource">GitHub 강제 사용</system:String>
@@ -625,7 +625,7 @@ HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Notifications\Settin
     <system:String x:Key="MainViewButtonFeature">메인 화면 버튼의 기능</system:String>
     <system:String x:Key="CustomStageCode">스테이지 코드 수동 입력</system:String>
     <system:String x:Key="CustomStageCodeTip" xml:space="preserve">대부분의 기본 스테이지 이름과 원래 스테이지 이름 목록 지원 (예: 4-10, AP-5, H10-1-Hard)
-스테이지 이름 끝에 ｢Normal/Hard｣ 를 입력해 난이도를 전환할 수 있습니다 (10-14장은 표준/재앙, 15장 이후는 일반/험지)
+스테이지 이름 끝에 ｢Normal/Hard｣ 를 입력하여 일반 난이도와 하드 난이도 사이를 전환해야 하는 것을 표시할 수 있습니다
 ｢SSReopen-XX｣ 일회성 프록시 SS 포크의 일반 수준을 입력할 수 있습니다</system:String>
     <system:String x:Key="AutoDetectConnection">연결 자동 감지</system:String>
     <system:String x:Key="AutoDetectConnectionNotSupported">이 연결 구성에서는 자동 연결 감지가 지원되지 않습니다. 수동으로 포트 번호를 입력해보세요</system:String>
@@ -720,15 +720,12 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="Roguelike">{key=AutoRoguelike}</system:String>
     <system:String x:Key="Reclamation">생존 연산</system:String>
     <system:String x:Key="UserDataUpdate">사용자 데이터 업데이트</system:String>
-    <system:String x:Key="MiniGame">편의 기능</system:String>
-    <system:String x:Key="MiniGameCategoryPermanent">상시</system:String>
-    <system:String x:Key="MiniGameCategoryCurrentEvent">현재 이벤트</system:String>
+    <system:String x:Key="MiniGame">미니게임</system:String>
     <system:String x:Key="Custom">커스텀 작업</system:String>
     <system:String x:Key="SingleStep">단일 단계 작업</system:String>
     <system:String x:Key="ReclamationTheme">생존 연산 테마</system:String>
     <system:String x:Key="ReclamationThemeFire">모래 속의 불</system:String>
     <system:String x:Key="ReclamationThemeTales">사막 이야기</system:String>
-    <system:String x:Key="ReclamationThemeRelaunchAnchor">RELAUNCH ANCHOR</system:String>
     <system:String x:Key="ReclamationModeProsperityNoSave">세이브 X, 스테이지 반복으로 번영의 선물 획득</system:String>
     <system:String x:Key="ReclamationModeProsperityInSave">세이브 O, 도구 제작으로 번영의 선물 획득</system:String>
     <system:String x:Key="ReclamationIncrementMode">증가 방식</system:String>
@@ -884,14 +881,9 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="LastSyncTime">마지막 동기화 시간</system:String>
     <system:String x:Key="DepotRecognitionTip">이 기능은 현재 테스트 중입니다. 내보내기 전 인식 결과가 맞는지 확인 후 사용하세요\n만약 오류가 있다면 MAA 경로 내 debug 폴더 안의 depot 폴더 전체를 압축해서 Github의 issue로 올려주세요</system:String>
     <system:String x:Key="StartToDepotRecognition">인식 시작</system:String>
-    <system:String x:Key="ExportToArkplanner">Arkplanner</system:String>
-    <system:String x:Key="ExportToLolicon">Arkntools</system:String>
-    <system:String x:Key="ExportToMarkdown">Markdown</system:String>
-    <system:String x:Key="ExportToCsv">CSV</system:String>
+    <system:String x:Key="ExportToArkplanner">Arkplanner로 내보내기</system:String>
+    <system:String x:Key="ExportToLolicon">Arkntools으로 내보내기</system:String>
     <system:String x:Key="CopiedToClipboard">클립보드에 복사됨</system:String>
-    <system:String x:Key="ExportedToFile">파일로 내보내기 완료</system:String>
-    <system:String x:Key="ExportTo">내보내기:</system:String>
-    <system:String x:Key="Export">내보내기</system:String>
     <!--  !창고 인식  -->
     <!--  오퍼레이터 인식  -->
     <system:String x:Key="OperBoxRecognition">{key=Operator} 인식</system:String>
@@ -1075,14 +1067,14 @@ C:\\leidian\\LDPlayer9
         5. 지원유닛을 사용할 때는 ｢{key=AutoSquad}｣ 및 ｢{key=UseCopilotList}｣를 끄고, 수동으로 오퍼레이터를 선택한 다음, 우측 하단에 ｢작전 개시｣ 버튼이 나타나는 분대 화면에서 시작하세요.\n\n
         6. ｢선호｣로 표시된 오퍼레이터는 ｢{key=AutoSquad}｣ 인식 및 선택에 영향을 줄 수 있습니다. ｢{key=AutoSquad}｣ 사용 시, 선호 표시를 해제하거나 오류 발생 시 ｢{key=AutoSquad}｣를 끄고 안내에 따라 누락된 오퍼레이터를 수동으로 편성하는 것을 고려하세요.\n\n
         7. 자동지휘 작업 공간에서, 입력 상자 오른쪽의 붙여넣기 버튼을 클릭하여 코드를 붙여넣을 수 있습니다:\n
-        • 두 번째 버튼을 왼쪽 클릭 = 작업 추가.\n
-        • 세 번째 버튼을 클릭 = 작업 목록 추가.\n\n
+        ● 두 번째 버튼을 왼쪽 클릭 = 작업 추가.\n
+        ● 세 번째 버튼을 클릭 = 작업 목록 추가.\n\n
         8. {key=UseCopilotList}:\n
-        • 작업 선택 후, 아래의 스테이지 이름이 올바른지 확인하세요 (예: CV-EX-1).\n
-        • 추가: 좌클릭은 일반, 우클릭은 하드 모드입니다.\n
-        • 지우기: 좌클릭은 전체 삭제, 우클릭은 비활성 작업만 삭제합니다.\n
-        • 목표 스테이지 이름이 보이는 화면에서 시작하세요. 챕터 간 이동은 지원되지 않습니다.\n
-        • 이성 부족, 작전 실패, 또는 3성 클리어 실패 시 작전이 자동으로 중지됩니다.
+        ● 작업 선택 후, 아래의 스테이지 이름이 올바른지 확인하세요 (예: CV-EX-1).\n
+        ● 추가: 좌클릭은 일반, 우클릭은 하드 모드입니다.\n
+        ● 지우기: 좌클릭은 전체 삭제, 우클릭은 비활성 작업만 삭제합니다.\n
+        ● 목표 스테이지 이름이 보이는 화면에서 시작하세요. 챕터 간 이동은 지원되지 않습니다.\n
+        ● 이성 부족, 작전 실패, 또는 3성 클리어 실패 시 작전이 자동으로 중지됩니다.
     </system:String>
     <system:String x:Key="CopilotFileReadError">파일을 읽지 못했습니다!</system:String>
     <system:String x:Key="CopilotNoFound">해당 파일을 찾을 수 없습니다!</system:String>
@@ -1189,6 +1181,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="FightMissionFailedAndStop">대리 지휘 실패 횟수 초과로 작업을 중단합니다</system:String>
     <system:String x:Key="LabelsRefreshed">태그 갱신 완료</system:String>
     <system:String x:Key="RecruitConfirm">모집 확정</system:String>
+    <system:String x:Key="RecruitTimesCount">공개모집 {0}회</system:String>
     <system:String x:Key="InfrastDormDoubleConfirmed">요구 {key=Operator} 중복(충돌)</system:String>
     <system:String x:Key="BegunToExplore">탐험 시작</system:String>
     <system:String x:Key="RoutingRestartTooManyBattles">작전 노드 개수: {0}, 작전 노드가 너무 많아 재시작합니다</system:String>
@@ -1313,9 +1306,10 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="AttachWindowFailed">AttachWindow 연결에 실패했습니다. 스크린샷/입력 방법 설정을 확인하세요</system:String>
     <system:String x:Key="UseAttachWindowTip">에뮬레이터나 휴대폰용 ADB 연결 대신 명일방주 PC 클라이언트에 Win32 창 바인딩을 사용합니다</system:String>
     <system:String x:Key="UseAttachWindowWarning" xml:space="preserve">PC 연결 (실험적 기능이며 안정성은 보장되지 않습니다)
-MAA Team의 개발 여력이 제한되어 있어 이 기능은 커뮤니티에서 유지보수하고 있으며, MAA Team이 지속적으로 지원하는 기능은 아닙니다. 기능이나 안정성이 기대에 못 미칠 수 있고, 문제가 발생해도 빠르게 수정되지 않을 수 있습니다.
-사용에 지장을 주는 문제가 있다면, 더 안정적인 사용을 위해 ADB 모드로 Android 에뮬레이터 또는 모바일 기기에 연결하는 것을 권장합니다.
-또한 PC 지원 개선에 기여할 수 있는 개발자의 Pull Request는 언제나 환영합니다.
+MAA Team의 개발 인력이 제한되어 있어 PC 지원은 전담 관리가 부족하며, 기능 오류나 불안정한 동작이 발생할 수 있습니다:
+● 문제 발생 시 신속한 대응이나 수정이 어려울 수 있습니다
+● 정상 작동하지 않을 경우, ADB 모드로 Android 에뮬레이터 또는 모바일 기기 연결을 권장합니다
+● PC 지원 개선을 위한 개발자의 Pull Request를 진심으로 환영합니다
 
 사용 전 확인 사항:
 1. MAA를 관리자 권한으로 실행해야 합니다
@@ -1464,19 +1458,6 @@ DEBUG 디렉토리에 저장된 이미지는 수량 제한이 있으며 초과 �
     <system:String x:Key="AnnouncementNotFinishedConfirm3">계속 누르네</system:String>
     <!--  !Announcement  -->
     <!--  Reclamation  -->
-    <system:String x:Key="ReclamationEarlyTipRelaunchAnchor" xml:space="preserve">
-재시작 앵커：
-
- 수익 참고: 회당 약 159토큰 + 통괄 포인트, 소요 시간 약 3분
-
- 사전 준비 (수동으로 1회만)：
-  1. 수동으로 RA-1에 진입하여 튜토리얼을 완료하고 맵으로 돌아옵니다
-  2. 이후 RA-1 클릭 후 오른쪽 아래에 "건설 시작"이 나타나면 작업을 시작할 수 있습니다
-
- 참고: 초기 추가 아이템 휴대 관련 기술을 해제한 경우, 기지 내에서 초기 추가 아이템을 휴대하게 하는 시설(식품 공급소, 음료 공급소, 대형 축사 등)을 철거하세요
-
- 작업 흐름：
-  정경세작, 건설, 자원 납품, 결제를 자동 실행</system:String>
     <system:String x:Key="ReclamationEarlyTip" xml:space="preserve">
 현재 생존 연산 기능은 초기 단계이며, 다음 사항에 주의하세요:
 
@@ -1526,8 +1507,7 @@ MAA를 독립된 새 폴더에 압축 해제하거나, MAA에 속하지 않는 D
     <!--  TimeOutTimer  -->
     <system:String x:Key="TaskTimeoutMinutes">작업 타임아웃 시간 (분)</system:String>
     <system:String x:Key="ReminderIntervalMinutes">알림 간격 (분)</system:String>
-    <system:String x:Key="StallTimeoutMinutes">로그 출력 정지 타임아웃 (분)</system:String>
-    <system:String x:Key="TaskStallWarning">작업 로그 출력이 {0}분 동안 업데이트되지 않았습니다(현재 {1}분 정지). 오랫동안 로그 출력이 없으면 수동 개입이 필요할 수 있습니다.</system:String>
+    <system:String x:Key="TaskTimeoutWarning">작업이 {0}분을 초과하여 {1}분째 실행 중입니다\n장시간 로그의 갱신이 없다면 수동 조작이 필요할 수 있습니다</system:String>
     <!--  !TimeOutTimer  -->
     <!--  Achievement  -->
     <system:String x:Key="AchievementCelebrate">🎉 도전과제 달성</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -42,7 +42,7 @@
     <system:String x:Key="ExternalNotificationEnableDetails">输出详细信息</system:String>
     <system:String x:Key="ExternalNotificationSendWhenComplete">任务完成后发送通知</system:String>
     <system:String x:Key="ExternalNotificationSendWhenError">任务出错时发送通知</system:String>
-    <system:String x:Key="ExternalNotificationSendWhenStalled">任务日志输出停滞时发送通知</system:String>
+    <system:String x:Key="ExternalNotificationSendWhenTimeout">任务超时时发送通知</system:String>
     <system:String x:Key="ExternalNotificationSendSuccess">发送成功</system:String>
     <system:String x:Key="ExternalNotificationSendFail">发送失败</system:String>
     <system:String x:Key="ExternalNotificationSendTest">发送测试</system:String>
@@ -354,21 +354,21 @@
     <system:String x:Key="UpdateSource">更新源</system:String>
     <system:String x:Key="UpdateSourceTip" xml:space="preserve">
 🌏 使用{key=GlobalSource}：
-    • {key=UpdateCheckNow}：由 MAA Team 提供更新检测，从 GitHub 拉取更新包，国内同步提供直连镜像（带宽有限，高峰期可能受限）
-    • {key=ResourceUpdate}：由 {key=MirrorChyan} 提供免费的更新检测，可手动在设置中点击 ｢{key=ResourceUpdate}｣ 从 GitHub 下载
+    ● {key=UpdateCheckNow}：由 MAA Team 提供更新检测，从 GitHub 拉取更新包，国内同步提供直连镜像（带宽有限，高峰期可能受限）
+    ● {key=ResourceUpdate}：由 {key=MirrorChyan} 提供免费的更新检测，可手动在设置中点击 ｢{key=ResourceUpdate}｣ 从 GitHub 下载
 
 🔑 使用 {key=MirrorChyan}：
-    • 填写 CDK 后，支持软件与资源的自动更新
-    • 优先通过 {key=MirrorChyan} 高速 CDN 下载，更稳定快速
+    ● 填写 CDK 后，支持软件与资源的自动更新
+    ● 优先通过 {key=MirrorChyan} 高速 CDN 下载，更稳定快速
 
 📦 手动更新：
-    • {key=UpdateCheckNow}：下载完整包或 OTA 更新包后拖入应用内，程序会自动解压并清理旧文件
-    • {key=ResourceUpdate}：下载资源包后覆盖 resource 文件夹。资源为增量内容，请勿删除原文件夹，会资源损坏
+    ● {key=UpdateCheckNow}：下载完整包或 OTA 更新包后拖入应用内，程序会自动解压并清理旧文件
+    ● {key=ResourceUpdate}：下载资源包后覆盖 resource 文件夹。资源为增量内容，请勿删除原文件夹，会资源损坏
 
 📄 更新说明：
-    • {key=UpdateCheckNow}：包含界面与功能更新。界面改动、新功能需通过{key=UpdateCheckNow}获得
-    • {key=ResourceUpdate}：包含自动战斗新关卡、掉落识别图标、公招干员标签等素材数据
-    • 导航热更：自动触发，用于更新主界面提示与活动关卡入口。成功后右上角会显示「{key=ApiUpdateSuccess}」
+    ● {key=UpdateCheckNow}：包含界面与功能更新。界面改动、新功能需通过{key=UpdateCheckNow}获得
+    ● {key=ResourceUpdate}：包含自动战斗新关卡、掉落识别图标、公招干员标签等素材数据
+    ● 导航热更：自动触发，用于更新主界面提示与活动关卡入口。成功后右上角会显示「{key=ApiUpdateSuccess}」
 </system:String>
     <system:String x:Key="GlobalSource">海外源</system:String>
     <system:String x:Key="ForceGithubGlobalSource">强制使用 GitHub</system:String>
@@ -624,8 +624,8 @@ HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Notifications\Settin
     <system:String x:Key="HideSeries">隐藏代理倍率</system:String>
     <system:String x:Key="MainViewButtonFeature">主界面可选择按钮功能</system:String>
     <system:String x:Key="CustomStageCode">手动输入关卡名</system:String>
-    <system:String x:Key="CustomStageCodeTip" xml:space="preserve">支持大部分主线关卡名与原列表的关卡名（如 4-10、AP-5、H10-1-Hard）
-可在关卡结尾输入 ｢Normal/Hard｣ 切换难度：10-14 章对应标准/磨难，15 章及以后对应常规/险地
+    <system:String x:Key="CustomStageCodeTip" xml:space="preserve">支持大部分主线关卡名与原列表的关卡名（如4-10、AP-5、H10-1-Hard）
+可在关卡结尾输入 ｢Normal/Hard｣ 表示需要切换标准与磨难难度
 可输入 ｢SSReopen-XX｣ 一次性代理 SS 复刻的普通关</system:String>
     <system:String x:Key="AutoDetectConnection">自动检测连接</system:String>
     <system:String x:Key="AutoDetectConnectionNotSupported">该连接配置不支持自动检测连接，请尝试手动填写端口号</system:String>
@@ -719,15 +719,12 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="Roguelike">{key=AutoRoguelike}</system:String>
     <system:String x:Key="Reclamation">生息演算</system:String>
     <system:String x:Key="UserDataUpdate">更新数据</system:String>
-    <system:String x:Key="MiniGame">便捷功能</system:String>
-    <system:String x:Key="MiniGameCategoryPermanent">常驻活动</system:String>
-    <system:String x:Key="MiniGameCategoryCurrentEvent">当期活动</system:String>
+    <system:String x:Key="MiniGame">小游戏</system:String>
     <system:String x:Key="Custom">自定任务</system:String>
     <system:String x:Key="SingleStep">单步任务</system:String>
     <system:String x:Key="ReclamationTheme">生息演算主题</system:String>
     <system:String x:Key="ReclamationThemeFire">沙中之火</system:String>
     <system:String x:Key="ReclamationThemeTales">沙洲遗闻</system:String>
-    <system:String x:Key="ReclamationThemeRelaunchAnchor">重启锚点</system:String>
     <system:String x:Key="ReclamationModeProsperityNoSave">无存档，通过进出关卡刷生息点数</system:String>
     <system:String x:Key="ReclamationModeProsperityInSave">有存档，通过组装支援道具刷生息点数</system:String>
     <system:String x:Key="ReclamationIncrementMode">增加方式</system:String>
@@ -883,14 +880,9 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="LastSyncTime">上次同步时间</system:String>
     <system:String x:Key="DepotRecognitionTip">该功能尚处于测试阶段，请检查结果是否准确再行使用。若有误，欢迎打包 debug/depot 文件夹后向我们提交 issue ~</system:String>
     <system:String x:Key="StartToDepotRecognition">开始识别</system:String>
-    <system:String x:Key="ExportToArkplanner">企鹅物流刷图规划</system:String>
-    <system:String x:Key="ExportToLolicon">明日方舟工具箱</system:String>
-    <system:String x:Key="ExportToMarkdown">Markdown</system:String>
-    <system:String x:Key="ExportToCsv">CSV</system:String>
+    <system:String x:Key="ExportToArkplanner">导出至企鹅物流刷图规划</system:String>
+    <system:String x:Key="ExportToLolicon">导出至明日方舟工具箱</system:String>
     <system:String x:Key="CopiedToClipboard">已复制到剪切板</system:String>
-    <system:String x:Key="ExportedToFile">已导出到文件</system:String>
-    <system:String x:Key="ExportTo">导出到：</system:String>
-    <system:String x:Key="Export">导出</system:String>
     <!--  !仓库识别  -->
     <!--  干员识别  -->
     <system:String x:Key="OperBoxRecognition">{key=Operator}识别</system:String>
@@ -1074,14 +1066,14 @@ C:\\leidian\\LDPlayer9。\n
         5. 使用好友助战时，请关闭 ｢{key=AutoSquad}｣ 和 ｢{key=UseCopilotList}｣，手动选择{key=Operator}后，在编队界面右下角存在 ｢开始行动｣ 按钮界面启动。\n\n
         6. {key=Operator}若被标记为 ｢特别关注｣，可能影响 ｢{key=AutoSquad}｣ 的识别与选择。建议使用 ｢{key=AutoSquad}｣ 时移除关注，或在报错后关闭 ｢{key=AutoSquad}｣，根据提示手动补充缺失的{key=Operator}。\n\n
         7. Copilot 作业站的神秘代码可通过输入框右侧的粘贴按钮粘贴：\n
-        • 单击第 2 个按钮 = 添加作业。\n
-        • 单击第 3 个按钮 = 添加作业集。\n\n
+        ● 单击第 2 个按钮 = 添加作业。\n
+        ● 单击第 3 个按钮 = 添加作业集。\n\n
         8. {key=UseCopilotList}:\n
-        • 选择作业后，检查下方关卡名是否正确 (例: CV-EX-1)。\n
-        • 添加: 左键 = 普通难度，右键 = 突袭难度。\n
-        • 清除: 左键 = 全部清空，右键 = 仅移除未激活任务。\n
-        • 请在能看到目标关卡名的界面启动，不支持跨章节导航。\n
-        • 遇到理智不足、战斗失败、未能三星结算时将自动中止。
+        ● 选择作业后，检查下方关卡名是否正确 (例: CV-EX-1)。\n
+        ● 添加: 左键 = 普通难度，右键 = 突袭难度。\n
+        ● 清除: 左键 = 全部清空，右键 = 仅移除未激活任务。\n
+        ● 请在能看到目标关卡名的界面启动，不支持跨章节导航。\n
+        ● 遇到理智不足、战斗失败、未能三星结算时将自动中止。
     </system:String>
     <system:String x:Key="CopilotFileReadError">读取文件失败！</system:String>
     <system:String x:Key="CopilotNoFound">未找到对应作业！</system:String>
@@ -1188,6 +1180,7 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="FightMissionFailedAndStop">代理失败次数已达上限，任务已停止</system:String>
     <system:String x:Key="LabelsRefreshed">已刷新标签</system:String>
     <system:String x:Key="RecruitConfirm">已确认招募</system:String>
+    <system:String x:Key="RecruitTimesCount">已公招 {0} 次</system:String>
     <system:String x:Key="InfrastDormDoubleConfirmed">{key=Operator}冲突</system:String>
     <system:String x:Key="BegunToExplore">已开始探索</system:String>
     <system:String x:Key="RoutingRestartTooManyBattles">前方战斗数：{0}，重开路线</system:String>
@@ -1311,10 +1304,11 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="RestartAsAdminFailed">请手动以管理员身份运行 MAA</system:String>
     <system:String x:Key="AttachWindowFailed">AttachWindow 绑定窗口失败，请检查截图/输入方式配置</system:String>
     <system:String x:Key="UseAttachWindowTip">使用 Win32 窗口绑定明日方舟 PC 端，而非 ADB 连接模拟器或手机</system:String>
-    <system:String x:Key="UseAttachWindowWarning" xml:space="preserve">连接 PC 端（实验性）
-由于 MAA Team 开发人手有限，此功能由社区维护，非 MAA Team 持续支持，功能和稳定性可能不尽如人意，遇到问题时也可能无法第一时间修复。
-如遇到影响使用的问题，建议改用 ADB 连接 Android 模拟器或移动设备，获得更稳定的体验。
-我们也始终欢迎有能力的开发者参与贡献提交 Pull Request，共同完善 PC 端支持。
+    <system:String x:Key="UseAttachWindowWarning" xml:space="preserve">连接 PC 端（实验性功能，稳定性无法保证）
+由于 MAA Team 开发人手有限，PC 端功能长期缺乏专人维护，可能存在功能异常或运行不稳定等问题：
+● 遇到问题时，我们可能无法及时响应或修复
+● 若无法正常使用，建议切换至 ADB 模式连接 Android 模拟器或移动设备
+● 诚挚欢迎有开发能力的用户提交 Pull Request，共同完善 PC 端支持
 
 使用前请确认：
 1. 需要以管理员身份启动 MAA
@@ -1463,20 +1457,6 @@ DEBUG 目录下保存的图片有数量限制，超出后会自动清理旧图�
     <system:String x:Key="AnnouncementNotFinishedConfirm3">还点</system:String>
     <!--  !Announcement  -->
     <!--  Reclamation  -->
-    <system:String x:Key="ReclamationEarlyTipRelaunchAnchor" xml:space="preserve">
-重启锚点：
-
- 收益参考：每把约 159 代币 + 统筹点数，单轮耗时约 3 分钟
-
- 前置步骤（手动完成一次）：
-  1. 手动进入 RA-1，完成新手教程，直到回到大地图
-  2. 之后每次任务均可在 RA-1 右下角出现“开启建设”时启动
-
- 注意：如果已解锁开局额外携带物品的相关科技，请将基地内会导致开局额外携带物品的设施拆除，如食品供给站、饮品供给站、大型兽栏等
-
- 任务流程：
-  自动执行精耕细作、建设、交付资源、结算循环
-    </system:String>
     <system:String x:Key="ReclamationEarlyTip" xml:space="preserve">
 目前生息演算的支持仍处于中期阶段，使用时请注意以下几点：
 
@@ -1525,9 +1505,8 @@ DEBUG 目录下保存的图片有数量限制，超出后会自动清理旧图�
     <!--  !SimpleEncryptionHelper  -->
     <!--  TimeOutTimer  -->
     <system:String x:Key="TaskTimeoutMinutes">任务超时时间（分钟）</system:String>
-    <system:String x:Key="ReminderIntervalMinutes">通知间隔时间（分钟）</system:String>
-    <system:String x:Key="StallTimeoutMinutes">日志输出停滞超时时间（分钟）</system:String>
-    <system:String x:Key="TaskStallWarning">任务日志输出已超过 {0} 分钟无更新（当前已停滞 {1} 分钟）。如果长时间无进一步日志输出，可能需要手动干预。</system:String>
+    <system:String x:Key="ReminderIntervalMinutes">提醒间隔时间（分钟）</system:String>
+    <system:String x:Key="TaskTimeoutWarning">任务已运行超过 {0} 分钟（当前已运行 {1} 分钟）。如果长时间无进一步日志更新，可能需要手动干预。</system:String>
     <!--  !TimeOutTimer  -->
     <!--  Achievement  -->
     <system:String x:Key="AchievementCelebrate">🎉 达成成就</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -42,7 +42,7 @@
     <system:String x:Key="ExternalNotificationEnableDetails">輸出詳細資訊</system:String>
     <system:String x:Key="ExternalNotificationSendWhenComplete">任務完成後發送通知</system:String>
     <system:String x:Key="ExternalNotificationSendWhenError">任務出錯時發送通知</system:String>
-    <system:String x:Key="ExternalNotificationSendWhenStalled">任務日誌輸出停滯時發送通知</system:String>
+    <system:String x:Key="ExternalNotificationSendWhenTimeout">任務逾時時發送通知</system:String>
     <system:String x:Key="ExternalNotificationSendSuccess">發送成功</system:String>
     <system:String x:Key="ExternalNotificationSendFail">發送失敗</system:String>
     <system:String x:Key="ExternalNotificationSendTest">發送測試</system:String>
@@ -354,21 +354,21 @@
     <system:String x:Key="UpdateSource">更新來源</system:String>
     <system:String x:Key="UpdateSourceTip" xml:space="preserve">
 🌏 使用 {key=GlobalSource}：
-    • {key=UpdateCheckNow}：由 MAA Team 提供更新偵測，從 GitHub 下載更新壓縮檔案，中國國內同步提供直連鏡像站（頻寬有限，高峰時段可能受限）
-    • {key=ResourceUpdate}：由 {key=MirrorChyan} 提供免費的更新偵測，可手動在設定中點擊「{key=ResourceUpdate}」從 GitHub 下載
+    ● {key=UpdateCheckNow}：由 MAA Team 提供更新偵測，從 GitHub 下載更新壓縮檔案，中國國內同步提供直連鏡像站（頻寬有限，高峰時段可能受限）
+    ● {key=ResourceUpdate}：由 {key=MirrorChyan} 提供免費的更新偵測，可手動在設定中點擊「{key=ResourceUpdate}」從 GitHub 下載
 
 🔑 使用 {key=MirrorChyan}：
-    • 填寫 CDK 後，支援軟體與資源的自動更新
-    • 優先透過 {key=MirrorChyan} 高速 CDN 下載，更穩定快速
+    ● 填寫 CDK 後，支援軟體與資源的自動更新
+    ● 優先透過 {key=MirrorChyan} 高速 CDN 下載，更穩定快速
 
 📦 手動更新：
-    • {key=UpdateCheckNow}：下載完整檔案或 OTA 更新檔後拖入應用程式，程式會自動解壓縮並清理舊檔案
-    • {key=ResourceUpdate}：下載資源檔案後覆蓋 resource 資料夾。資源為增量內容，請勿刪除原資料夾，否則會資源損壞
+    ● {key=UpdateCheckNow}：下載完整檔案或 OTA 更新檔後拖入應用程式，程式會自動解壓縮並清理舊檔案
+    ● {key=ResourceUpdate}：下載資源檔案後覆蓋 resource 資料夾。資源為增量內容，請勿刪除原資料夾，否則會資源損壞
 
 📄 更新說明：
-    • {key=UpdateCheckNow}：包含介面與功能更新。介面改動、新功能需透過 {key=UpdateCheckNow} 取得
-    • {key=ResourceUpdate}：包含自動作戰新關卡、掉落辨識圖示、公招幹員標籤等素材資料
-    • 導航熱更新：自動觸發，用於更新主介面提示與活動關卡入口。成功後右上角會顯示「{key=ApiUpdateSuccess}」
+    ● {key=UpdateCheckNow}：包含介面與功能更新。介面改動、新功能需透過 {key=UpdateCheckNow} 取得
+    ● {key=ResourceUpdate}：包含自動作戰新關卡、掉落辨識圖示、公招幹員標籤等素材資料
+    ● 導航熱更新：自動觸發，用於更新主介面提示與活動關卡入口。成功後右上角會顯示「{key=ApiUpdateSuccess}」
 </system:String>
     <system:String x:Key="GlobalSource">全域來源</system:String>
     <system:String x:Key="ForceGithubGlobalSource">強制使用 GitHub</system:String>
@@ -625,7 +625,7 @@ HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Notifications\Settin
     <system:String x:Key="MainViewButtonFeature">主介面可選擇按鈕功能</system:String>
     <system:String x:Key="CustomStageCode">手動輸入關卡名稱</system:String>
     <system:String x:Key="CustomStageCodeTip" xml:space="preserve">支援大部分主線關卡名稱與原清單的關卡名稱（如 4-10、AP-5、H10-1-Hard）
-可在關卡結尾輸入 ｢Normal/Hard｣ 切換難度：10-14 章對應標準/磨難，15 章及以後對應常規/險地
+可在關卡結尾輸入 ｢Normal/Hard｣ 表示需要切換標準與磨難難度
 可輸入 ｢SSReopen-XX｣ 一次性代理 SS 複刻的普通關</system:String>
     <system:String x:Key="AutoDetectConnection">自動偵測連線</system:String>
     <system:String x:Key="AutoDetectConnectionNotSupported">該連線配置不支援自動偵測連線，請嘗試手動填寫通訊埠編號</system:String>
@@ -719,15 +719,12 @@ C:\\leidian\\LDPlayer9\n
     <system:String x:Key="Roguelike">{key=AutoRoguelike}</system:String>
     <system:String x:Key="Reclamation">生息演算</system:String>
     <system:String x:Key="UserDataUpdate">更新使用者資料</system:String>
-    <system:String x:Key="MiniGame">快捷功能</system:String>
-    <system:String x:Key="MiniGameCategoryPermanent">常駐</system:String>
-    <system:String x:Key="MiniGameCategoryCurrentEvent">目前活動</system:String>
+    <system:String x:Key="MiniGame">小遊戲</system:String>
     <system:String x:Key="Custom">自定義任務</system:String>
     <system:String x:Key="SingleStep">單步任務</system:String>
     <system:String x:Key="ReclamationTheme">生息演算主題</system:String>
     <system:String x:Key="ReclamationThemeFire">沙中之火</system:String>
     <system:String x:Key="ReclamationThemeTales">沙洲遺聞</system:String>
-    <system:String x:Key="ReclamationThemeRelaunchAnchor">重啟錨點</system:String>
     <system:String x:Key="ReclamationModeProsperityNoSave">無存檔，透過進出關卡刷生息點數</system:String>
     <system:String x:Key="ReclamationModeProsperityInSave">有存檔，透過組裝支援道具刷生息點數</system:String>
     <system:String x:Key="ReclamationIncrementMode">增加方式</system:String>
@@ -883,14 +880,9 @@ C:\\leidian\\LDPlayer9\n
     <system:String x:Key="LastSyncTime">上次同步時間</system:String>
     <system:String x:Key="DepotRecognitionTip">該功能尚處於測試階段，請檢查結果是否準確再行使用。若有誤，歡迎打包 debug/depot 資料夾後向我們提交 issue ~</system:String>
     <system:String x:Key="StartToDepotRecognition">開始辨識</system:String>
-    <system:String x:Key="ExportToArkplanner">企鵝物流刷圖規劃</system:String>
-    <system:String x:Key="ExportToLolicon">明日方舟工具箱</system:String>
-    <system:String x:Key="ExportToMarkdown">Markdown</system:String>
-    <system:String x:Key="ExportToCsv">CSV</system:String>
+    <system:String x:Key="ExportToArkplanner">匯出到企鵝物流刷圖規劃</system:String>
+    <system:String x:Key="ExportToLolicon">匯出到明日方舟工具箱</system:String>
     <system:String x:Key="CopiedToClipboard">已複製到剪貼簿</system:String>
-    <system:String x:Key="ExportedToFile">已匯出到檔案</system:String>
-    <system:String x:Key="ExportTo">匯出到：</system:String>
-    <system:String x:Key="Export">匯出</system:String>
     <!--  !倉庫辨識  -->
     <!--  日誌  -->
     <system:String x:Key="OperBoxRecognition">{key=Operator}辨識</system:String>
@@ -1074,14 +1066,14 @@ C:\\leidian\\LDPlayer9\n
         5. 使用好友助戰時，請關閉 ｢{key=AutoSquad}｣ 和 ｢{key=UseCopilotList}｣，手動選擇{key=Operator}後，在編隊介面右下角顯示 ｢開始行動｣ 按鈕的畫面啟動。\n\n
         6. {key=Operator}若被標記為 ｢特別關注｣，可能影響 ｢{key=AutoSquad}｣ 的辨識與選擇。建議使用 ｢{key=AutoSquad}｣ 時移除特別關注，或在報錯後關閉 ｢{key=AutoSquad}｣，並依據提示手動補充缺少的{key=Operator}。\n\n
         7. Copilot 作業站的神秘代碼可透過輸入框右側的貼上按鈕貼上：\n
-        • 點選第 2 個按鈕 = 新增作業。\n
-        • 點選第 3 個按鈕 = 新增作業集。\n\n
+        ● 點選第 2 個按鈕 = 新增作業。\n
+        ● 點選第 3 個按鈕 = 新增作業集。\n\n
         8. {key=UseCopilotList}：\n
-        • 選擇作業後，檢查下方關卡名稱是否正確 (例: CV-EX-1)。\n
-        • 加入：左鍵 = 普通難度，右鍵 = 突襲難度。\n
-        • 清除：左鍵 = 全部清空，右鍵 = 僅移除未啟用任務。\n
-        • 請在能看到目標關卡名稱的介面啟動，不支援跨章節導航。\n
-        • 遇到理智不足、戰鬥失敗、未能三星結算時將會自動中止。
+        ● 選擇作業後，檢查下方關卡名稱是否正確 (例: CV-EX-1)。\n
+        ● 加入：左鍵 = 普通難度，右鍵 = 突襲難度。\n
+        ● 清除：左鍵 = 全部清空，右鍵 = 僅移除未啟用任務。\n
+        ● 請在能看到目標關卡名稱的介面啟動，不支援跨章節導航。\n
+        ● 遇到理智不足、戰鬥失敗、未能三星結算時將會自動中止。
     </system:String>
     <system:String x:Key="CopilotFileReadError">讀取檔案失敗！</system:String>
     <system:String x:Key="CopilotNoFound">未找到對應作業！</system:String>
@@ -1188,6 +1180,7 @@ C:\\leidian\\LDPlayer9\n
     <system:String x:Key="FightMissionFailedAndStop">代理失敗次數已達上限，任務已停止</system:String>
     <system:String x:Key="LabelsRefreshed">已刷新標籤</system:String>
     <system:String x:Key="RecruitConfirm">已確認招募</system:String>
+    <system:String x:Key="RecruitTimesCount">已公招 {0} 次</system:String>
     <system:String x:Key="InfrastDormDoubleConfirmed">{key=Operator}衝突</system:String>
     <system:String x:Key="BegunToExplore">已開始探索</system:String>
     <system:String x:Key="RoutingRestartTooManyBattles">前方戰鬥數：{0}，重新規劃路線</system:String>
@@ -1312,9 +1305,10 @@ C:\\leidian\\LDPlayer9\n
     <system:String x:Key="AttachWindowFailed">AttachWindow 綁定視窗失敗，請檢查截圖/輸入方式配置</system:String>
     <system:String x:Key="UseAttachWindowTip">使用 Win32 視窗綁定明日方舟 PC 端，而非 ADB 連接模擬器或手機</system:String>
     <system:String x:Key="UseAttachWindowWarning" xml:space="preserve">連接 PC 端（實驗性功能，穩定性無法保證）
-由於 MAA Team 開發人手有限，此功能由社群維護，並非由 MAA Team 持續支援，功能與穩定性可能不盡理想，遇到問題時也可能無法第一時間修復。
-如遇到影響使用的問題，建議改用 ADB 連接 Android 模擬器或行動裝置，以獲得更穩定的體驗。
-我們也始終歡迎有能力的開發者參與貢獻並提交 Pull Request，共同完善 PC 端支援。
+由於 MAA Team 開發人手有限，PC 端功能長期缺乏專人維護，可能存在功能異常或運行不穩定等問題：
+● 遇到問題時，我們可能無法及時回應或修復
+● 若無法正常使用，建議切換至 ADB 模式連接 Android 模擬器或行動裝置
+● 誠摯歡迎有開發能力的用戶提交 Pull Request，共同完善 PC 端支援
 
 使用前請確認：
 1. 需以系統管理員身分啟動 MAA
@@ -1463,20 +1457,6 @@ DEBUG 目錄下儲存的圖片有數量限制，超出後會自動清理舊圖�
     <system:String x:Key="AnnouncementNotFinishedConfirm3">還點</system:String>
     <!--  !Announcement  -->
     <!--  Reclamation  -->
-    <system:String x:Key="ReclamationEarlyTipRelaunchAnchor" xml:space="preserve">
-重啟錨點：
-
- 收益參考：每把約 159 代幣 + 統籌點數，單輪耗時約 3 分
-
- 前置步驟（手動完成一次）：
-  1. 手動進入 RA-1，完成新手教學，直到回到大地圖
-  2. 之後每次任務均可在 RA-1 右下角出現「開啟建設」時啟動
-
- 注意：如果已解鎖開局額外攜帶物品的相關科技，請將基地內會導致開局額外攜帶物品的設施拆除，如食品供給站、飲品供給站、大型獸欄等
-
- 任務流程：
-  自動執行精耕細作、建設、交付資源、結算循環
-    </system:String>
     <system:String x:Key="ReclamationEarlyTip" xml:space="preserve">
 目前生息演算的支援仍處於中期階段，使用時請注意以下幾點：
 
@@ -1525,9 +1505,8 @@ DEBUG 目錄下儲存的圖片有數量限制，超出後會自動清理舊圖�
     <!--  !SimpleEncryptionHelper  -->
     <!--  TimeOutTimer  -->
     <system:String x:Key="TaskTimeoutMinutes">任務逾時時間（分鐘）</system:String>
-    <system:String x:Key="ReminderIntervalMinutes">通知間隔時間（分鐘）</system:String>
-    <system:String x:Key="StallTimeoutMinutes">日誌輸出停滯超時時間（分鐘）</system:String>
-    <system:String x:Key="TaskStallWarning">任務日誌輸出已超過 {0} 分鐘無更新（當前已停滯 {1} 分鐘）。如果長時間無進一步日誌輸出，可能需要手動干預。</system:String>
+    <system:String x:Key="ReminderIntervalMinutes">提醒間隔時間（分鐘）</system:String>
+    <system:String x:Key="TaskTimeoutWarning">任務已執行超過 {0} 分鐘（目前已執行 {1} 分鐘）。若長時間無進一步日誌更新，可能需要手動干預。</system:String>
     <!--  !TimeOutTimer  -->
     <!--  Achievement  -->
     <system:String x:Key="AchievementCelebrate">🎉 達成成就</system:String>


### PR DESCRIPTION
### 新增  
为自动公招的输出日志增加“已公招n次"输出，方便在刷公招时查看进度  

### 截图  
<img width="236" height="165" alt="image" src="https://github.com/user-attachments/assets/0ecd66e2-479a-4210-b70d-9821d86ef434" />  

### 相关issue  
#16580

## 由 Sourcery 提供的摘要

新功能：
- 在任务队列日志输出中显示当前已完成的自动招募数量。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Display the current count of completed automatic recruitments in the task queue log output.

</details>