### PR TITLE
feat: 为自动公招的输出日志增加已公招次数

### DIFF
--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -1582,6 +1582,7 @@ public class AsstProxy
                             }
 
                             Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("RecruitConfirm"), UiLogColor.Info);
+                            Instances.TaskQueueViewModel.AddLog(string.Format(LocalizationHelper.GetString("RecruitTimesCount"), RecruitConfirmTime), UiLogColor.Info);
                             break;
 
                         case "InfrastDormDoubleConfirmButton":

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -1582,7 +1582,7 @@ public class AsstProxy
                             }
 
                             Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("RecruitConfirm"), UiLogColor.Info);
-                            Instances.TaskQueueViewModel.AddLog(string.Format(LocalizationHelper.GetString("RecruitTimesCount"), RecruitConfirmTime), UiLogColor.Info);
+                            Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetStringFormat("RecruitTimesCount", RecruitConfirmTime), UiLogColor.Info);
                             break;
 
                         case "InfrastDormDoubleConfirmButton":

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -1189,6 +1189,7 @@ Right-click to clear inactive jobs</system:String>
     <system:String x:Key="FightMissionFailedAndStop">Proxy failed too many times, task stopped</system:String>
     <system:String x:Key="LabelsRefreshed">Labels refreshed</system:String>
     <system:String x:Key="RecruitConfirm">Recruit confirm</system:String>
+    <system:String x:Key="RecruitTimesCount">Recruited {0} times</system:String>
     <system:String x:Key="InfrastDormDoubleConfirmed">{key=Operator} conflict</system:String>
     <system:String x:Key="BegunToExplore">Exploration started</system:String>
     <system:String x:Key="RoutingRestartTooManyBattles">Too many battles ahead: {0}, restarting route</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -1190,6 +1190,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="FightMissionFailedAndStop">自動指揮の失敗回数が上限に達したため、任務が停止されました</system:String>
     <system:String x:Key="LabelsRefreshed">タグが更新されました</system:String>
     <system:String x:Key="RecruitConfirm">募集を行いました</system:String>
+    <system:String x:Key="RecruitTimesCount">公開求人 {0} 回</system:String>
     <system:String x:Key="InfrastDormDoubleConfirmed">{key=Operator}が競合しました</system:String>
     <system:String x:Key="BegunToExplore">探索を開始しました</system:String>
     <system:String x:Key="RoutingRestartTooManyBattles">前方の戦闘数：{0}、ルートを再計画します</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -1191,6 +1191,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="FightMissionFailedAndStop">대리 지휘 실패 횟수 초과로 작업을 중단합니다</system:String>
     <system:String x:Key="LabelsRefreshed">태그 갱신 완료</system:String>
     <system:String x:Key="RecruitConfirm">모집 확정</system:String>
+    <system:String x:Key="RecruitTimesCount">공개모집 {0}회</system:String>
     <system:String x:Key="InfrastDormDoubleConfirmed">요구 {key=Operator} 중복(충돌)</system:String>
     <system:String x:Key="BegunToExplore">탐험 시작</system:String>
     <system:String x:Key="RoutingRestartTooManyBattles">작전 노드 개수: {0}, 작전 노드가 너무 많아 재시작합니다</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -1190,6 +1190,7 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="FightMissionFailedAndStop">代理失败次数已达上限，任务已停止</system:String>
     <system:String x:Key="LabelsRefreshed">已刷新标签</system:String>
     <system:String x:Key="RecruitConfirm">已确认招募</system:String>
+    <system:String x:Key="RecruitTimesCount">已公招 {0} 次</system:String>
     <system:String x:Key="InfrastDormDoubleConfirmed">{key=Operator}冲突</system:String>
     <system:String x:Key="BegunToExplore">已开始探索</system:String>
     <system:String x:Key="RoutingRestartTooManyBattles">前方战斗数：{0}，重开路线</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -1190,6 +1190,7 @@ C:\\leidian\\LDPlayer9\n
     <system:String x:Key="FightMissionFailedAndStop">代理失敗次數已達上限，任務已停止</system:String>
     <system:String x:Key="LabelsRefreshed">已刷新標籤</system:String>
     <system:String x:Key="RecruitConfirm">已確認招募</system:String>
+    <system:String x:Key="RecruitTimesCount">已公招 {0} 次</system:String>
     <system:String x:Key="InfrastDormDoubleConfirmed">{key=Operator}衝突</system:String>
     <system:String x:Key="BegunToExplore">已開始探索</system:String>
     <system:String x:Key="RoutingRestartTooManyBattles">前方戰鬥數：{0}，重新規劃路線</system:String>


### PR DESCRIPTION
### 新增  
为自动公招的输出日志增加“已公招n次"输出，方便在刷公招时查看进度  

### 截图  
<img width="236" height="165" alt="image" src="https://github.com/user-attachments/assets/0ecd66e2-479a-4210-b70d-9821d86ef434" />  

### 相关issue  
#16580

## Summary by Sourcery

为自动招募任务添加进度日志，显示招募已执行的次数。

新功能：
- 在确认执行招募时，在任务队列输出中记录自动招募的累计次数。

改进：
- 为所有支持的语言添加用于招募次数日志消息的本地化字符串资源。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add progress logging for automatic recruitment tasks showing how many times recruitment has been executed.

New Features:
- Log the cumulative number of automatic recruitments in the task queue output when recruitment is confirmed.

Enhancements:
- Add localized string resources for the recruitment count log message across all supported languages.

</details>