### PR TITLE
fix: 修复 FFT 路径 masked TM_CCOEFF_NORMED 精度损失导致的误匹配

### DIFF
--- a/src/MaaCore/Vision/MaskedCcoeffMatcher.cpp
+++ b/src/MaaCore/Vision/MaskedCcoeffMatcher.cpp
@@ -143,10 +143,12 @@ std::shared_ptr<const MaskedCcoeffMatcher::DftPlan> MaskedCcoeffMatcher::get_or_
     }
 
     auto dft_plan = std::make_shared<DftPlan>();
-    cv::Mat padded = cv::Mat::zeros(dft_rows, dft_cols, CV_32F);
+    cv::Mat padded = cv::Mat::zeros(dft_rows, dft_cols, CV_64F);
     auto compute_into = [&](const cv::Mat& src, cv::Mat& out) {
-        padded.setTo(0.0f);
-        src.copyTo(padded(cv::Rect(0, 0, src.cols, src.rows)));
+        padded.setTo(0.0);
+        cv::Mat src_d;
+        src.convertTo(src_d, CV_64F);
+        src_d.copyTo(padded(cv::Rect(0, 0, src_d.cols, src_d.rows)));
         cv::dft(padded, out, cv::DFT_COMPLEX_OUTPUT);
     };
 
@@ -300,16 +302,18 @@ cv::Mat MaskedCcoeffMatcher::match(
     const int dft_cols = cv::getOptimalDFTSize(I.cols + T.cols - 1);
     const auto dft_plan = get_or_build_dft_plan(cache_key, *template_plan, dft_rows, dft_cols);
 
-    cv::Mat padded(dft_rows, dft_cols, CV_32F, cv::Scalar(0));
-    cv::Mat I_dft(dft_rows, dft_cols, CV_32FC2);
-    cv::Mat spectrum(dft_rows, dft_cols, CV_32FC2);
-    cv::Mat result_buf(dft_rows, dft_cols, CV_32F);
-    cv::Mat sum_MI_buf(rh, rw, CV_32F);
-    cv::Mat sum_MI2_buf(rh, rw, CV_32F);
+    cv::Mat padded(dft_rows, dft_cols, CV_64F, cv::Scalar(0));
+    cv::Mat I_dft(dft_rows, dft_cols, CV_64FC2);
+    cv::Mat spectrum(dft_rows, dft_cols, CV_64FC2);
+    cv::Mat result_buf(dft_rows, dft_cols, CV_64F);
+    cv::Mat sum_MI_buf(rh, rw, CV_64F);
+    cv::Mat sum_MI2_buf(rh, rw, CV_64F);
 
     auto make_dft_into = [&](const cv::Mat& src, cv::Mat& out) {
-        padded.setTo(0.0f);
-        src.copyTo(padded(cv::Rect(0, 0, src.cols, src.rows)));
+        padded.setTo(0.0);
+        cv::Mat src_d;
+        src.convertTo(src_d, CV_64F);
+        src_d.copyTo(padded(cv::Rect(0, 0, src_d.cols, src_d.rows)));
         cv::dft(padded, out, cv::DFT_COMPLEX_OUTPUT);
     };
     auto xcorr_into = [&](const cv::Mat& dft_A, const cv::Mat& dft_B, cv::Mat& out) {
@@ -323,8 +327,8 @@ cv::Mat MaskedCcoeffMatcher::match(
         cv::add(accum, result_buf(cv::Rect(0, 0, rw, rh)), accum);
     };
 
-    cv::Mat numerator = cv::Mat::zeros(rh, rw, CV_32F);
-    cv::Mat sigma_I_sq_d = cv::Mat::zeros(rh, rw, CV_64F); // float64 避免 sum_MI2-sum_MI² 灾难性精度损失
+    cv::Mat numerator = cv::Mat::zeros(rh, rw, CV_64F);
+    cv::Mat sigma_I_sq = cv::Mat::zeros(rh, rw, CV_64F);
 
     // σ_I²(x,y) = Σ_c σ_I_c² = Σ_c [(M ⋆ I_c²) - (M ⋆ I_c)² / N]
     //          = Σ_c (M ⋆ I_c²)        - (1/N) Σ_c (M ⋆ I_c)²
@@ -333,14 +337,11 @@ cv::Mat MaskedCcoeffMatcher::match(
     // 利用卷积对加法线性：Σ_c (M ⋆ I_c²) = M ⋆ (Σ_c I_c²)
     // 在空域里先把三通道平方加起来再做一次卷积，比每通道各做一次再相加少 2 次 FFT + 2 次 IFFT
     // 第二项 Σ_c (M ⋆ I_c)² 因为有平方，不能这样合并（平方对加法非线性），仍逐通道算
-    // 实测 Windows + Android 真 FFT 路径 case 平均 -22%
     cv::Mat I_sq_sum = I_ch[0].mul(I_ch[0]) + I_ch[1].mul(I_ch[1]) + I_ch[2].mul(I_ch[2]);
-    cv::Mat I_sq_sum_dft(dft_rows, dft_cols, CV_32FC2);
+    cv::Mat I_sq_sum_dft(dft_rows, dft_cols, CV_64FC2);
     make_dft_into(I_sq_sum, I_sq_sum_dft);
     xcorr_into(I_sq_sum_dft, dft_plan->M_dft, sum_MI2_buf);
-    cv::Mat sum_MI2_d;
-    sum_MI2_buf.convertTo(sum_MI2_d, CV_64F);
-    cv::add(sigma_I_sq_d, sum_MI2_d, sigma_I_sq_d);
+    cv::add(sigma_I_sq, sum_MI2_buf, sigma_I_sq);
 
     for (int c = 0; c < 3; ++c) {
         make_dft_into(I_ch[c], I_dft);
@@ -350,26 +351,32 @@ cv::Mat MaskedCcoeffMatcher::match(
 
         // sigma_I² 第二项：-Σ_c (sum_MI_c)² / mask_area，逐通道累加
         xcorr_into(I_dft, dft_plan->M_dft, sum_MI_buf);
-        cv::Mat sum_MI_d, var_d;
-        sum_MI_buf.convertTo(sum_MI_d, CV_64F);
-        cv::multiply(sum_MI_d, sum_MI_d, var_d, -1.0 / mask_area);
-        cv::add(sigma_I_sq_d, var_d, sigma_I_sq_d);
+        cv::Mat var_d;
+        cv::multiply(sum_MI_buf, sum_MI_buf, var_d, -1.0 / mask_area);
+        cv::add(sigma_I_sq, var_d, sigma_I_sq);
     }
 
-    cv::Mat sigma_I_sq;
-    sigma_I_sq_d.convertTo(sigma_I_sq, CV_32F);
     cv::max(sigma_I_sq, 0.0, sigma_I_sq);
+    // 图像块方差远低于模板方差时相关系数无定义（均匀区域，分母≈0），直接归零。
+    // 8-bit 图像最小非零单通道方差约为 (K-1)/K ≈ 0.996，阈值 sigma_T_sq*1e-8 远低于此，不影响真实匹配。
+    sigma_I_sq.setTo(0.0, sigma_I_sq < sigma_T_sq * 1e-8);
 
     cv::Mat denom;
     cv::sqrt(sigma_I_sq * sigma_T_sq, denom);
 
     cv::Mat result;
     cv::divide(numerator, denom, result);
-    cv::patchNaNs(result, 0.0);
-    const auto sigma_T_norm = static_cast<float>(std::sqrt(sigma_T_sq));
-    result.setTo(0.0f, denom < sigma_T_norm * 1e-5f);
-    cv::min(result, 1.0f, result);
-    cv::max(result, -1.0f, result);
-    return result;
+    // patchNaNs 不支持 CV_64F，用 CMP_NE 自检替代（NaN != NaN）
+    cv::Mat nan_mask;
+    cv::compare(result, result, nan_mask, cv::CMP_NE);
+    result.setTo(0.0, nan_mask);
+    const double sigma_T_norm = std::sqrt(sigma_T_sq);
+    result.setTo(0.0, denom < sigma_T_norm * 1e-5);
+    cv::min(result, 1.0, result);
+    cv::max(result, -1.0, result);
+
+    cv::Mat result_f32;
+    result.convertTo(result_f32, CV_32F);
+    return result_f32;
 }
 }

--- a/src/MaaCore/Vision/MaskedCcoeffMatcher.cpp
+++ b/src/MaaCore/Vision/MaskedCcoeffMatcher.cpp
@@ -144,9 +144,9 @@ std::shared_ptr<const MaskedCcoeffMatcher::DftPlan> MaskedCcoeffMatcher::get_or_
 
     auto dft_plan = std::make_shared<DftPlan>();
     cv::Mat padded = cv::Mat::zeros(dft_rows, dft_cols, CV_64F);
+    cv::Mat src_d;
     auto compute_into = [&](const cv::Mat& src, cv::Mat& out) {
         padded.setTo(0.0);
-        cv::Mat src_d;
         src.convertTo(src_d, CV_64F);
         src_d.copyTo(padded(cv::Rect(0, 0, src_d.cols, src_d.rows)));
         cv::dft(padded, out, cv::DFT_COMPLEX_OUTPUT);
@@ -308,10 +308,10 @@ cv::Mat MaskedCcoeffMatcher::match(
     cv::Mat result_buf(dft_rows, dft_cols, CV_64F);
     cv::Mat sum_MI_buf(rh, rw, CV_64F);
     cv::Mat sum_MI2_buf(rh, rw, CV_64F);
+    cv::Mat src_d;
 
     auto make_dft_into = [&](const cv::Mat& src, cv::Mat& out) {
         padded.setTo(0.0);
-        cv::Mat src_d;
         src.convertTo(src_d, CV_64F);
         src_d.copyTo(padded(cv::Rect(0, 0, src_d.cols, src_d.rows)));
         cv::dft(padded, out, cv::DFT_COMPLEX_OUTPUT);
@@ -358,8 +358,9 @@ cv::Mat MaskedCcoeffMatcher::match(
 
     cv::max(sigma_I_sq, 0.0, sigma_I_sq);
     // 图像块方差远低于模板方差时相关系数无定义（均匀区域，分母≈0），直接归零。
-    // 8-bit 图像最小非零单通道方差约为 (K-1)/K ≈ 0.996，阈值 sigma_T_sq*1e-8 远低于此，不影响真实匹配。
-    sigma_I_sq.setTo(0.0, sigma_I_sq < sigma_T_sq * 1e-8);
+    // 8-bit 图像最小非零单通道方差约为 (K-1)/K ≈ 0.996，variance_eps 远低于此，不影响真实匹配。
+    const double variance_eps = sigma_T_sq * 1e-8;
+    sigma_I_sq.setTo(0.0, sigma_I_sq < variance_eps);
 
     cv::Mat denom;
     cv::sqrt(sigma_I_sq * sigma_T_sq, denom);


### PR DESCRIPTION
fix https://github.com/MaaAssistantArknights/MaaAssistantArknights/issues/16645

## Summary by Sourcery

提高基于掩膜的 FFT TM_CCOEFF_NORMED 匹配器的数值精度和鲁棒性，以避免在低方差区域出现错误匹配。

Bug Fixes:
- 在整个基于 FFT 的掩膜相关计算流程中使用双精度缓冲区，以在计算掩膜方差和相关得分时减少灾难性抵消。
- 对于近零图像方差区域以及出现 NaN 结果的情况，显式将相关得分置零，以防止无效匹配和误检。

Enhancements:
- 在中间计算中使用 float64 精度，而最终仍以 float32 返回相关性图，以在准确性与输出格式兼容性之间取得平衡。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Increase numerical precision and robustness of the masked FFT-based TM_CCOEFF_NORMED matcher to avoid false matches in low-variance regions.

Bug Fixes:
- Use double-precision buffers throughout the FFT-based masked correlation pipeline to reduce catastrophic cancellation when computing masked variance and correlation scores.
- Explicitly zero out correlation scores in near-zero image variance areas and for NaN results to prevent invalid matches and misdetections.

Enhancements:
- Perform intermediate computations in float64 while returning the final correlation map as float32 to balance accuracy with output format compatibility.

</details>

Bug 修复：
- 在 FFT 相关路径中使用双精度缓冲区，以减少在计算带掩膜方差和相关分数时的灾难性抵消。
- 对接近零图像方差区域和 NaN 结果进行显式处理，将其相关分数置零，以防止产生无效匹配。

增强：
- 在中间计算中使用 float64 提高精度，同时将最终相关图以 float32 返回，以在准确性与输出格式兼容性之间取得更好的平衡。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

提高基于掩膜的 FFT TM_CCOEFF_NORMED 匹配器的数值精度和鲁棒性，以避免在低方差区域出现错误匹配。

Bug Fixes:
- 在整个基于 FFT 的掩膜相关计算流程中使用双精度缓冲区，以在计算掩膜方差和相关得分时减少灾难性抵消。
- 对于近零图像方差区域以及出现 NaN 结果的情况，显式将相关得分置零，以防止无效匹配和误检。

Enhancements:
- 在中间计算中使用 float64 精度，而最终仍以 float32 返回相关性图，以在准确性与输出格式兼容性之间取得平衡。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Increase numerical precision and robustness of the masked FFT-based TM_CCOEFF_NORMED matcher to avoid false matches in low-variance regions.

Bug Fixes:
- Use double-precision buffers throughout the FFT-based masked correlation pipeline to reduce catastrophic cancellation when computing masked variance and correlation scores.
- Explicitly zero out correlation scores in near-zero image variance areas and for NaN results to prevent invalid matches and misdetections.

Enhancements:
- Perform intermediate computations in float64 while returning the final correlation map as float32 to balance accuracy with output format compatibility.

</details>

</details>