### PR TITLE
feat: 支持通过 Mirror酱 下载时若新版本无增量包则等待后重试

### DIFF
--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -401,6 +401,7 @@ You can cancel this popup by clicking the ｢{key=Settings} - {key=IssueReport}�
     <system:String x:Key="CheckNetworking">Please check your network connection or proxy.</system:String>
     <system:String x:Key="GetReleaseNoteFailed">Failed to get release note.</system:String>
     <system:String x:Key="NewVersionIsBeingBuilt">The new version is being built, please try again later</system:String>
+    <system:String x:Key="MirrorChyanBuildingOta">MirrorChyan is building the OTA incremental update for this version, will automatically retry in 10 seconds</system:String>
     <system:String x:Key="NewVersionNoOtaPackage">A new version has been detected, but no OTA incremental update package is available. The full package will be downloaded. It will keep cache, config, data, debug, achievement (screenshots), background (custom background images), and MAA.Updater.exe. All other files will be moved to the Recycle Bin and .old. Please back them up manually if necessary.</system:String>
     <system:String x:Key="NewVersionDownloadPreparing">Preparing to download update package……</system:String>
     <system:String x:Key="NewVersionDownloadFailedTitle">Download of Update Package Failed</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -401,6 +401,7 @@
     <system:String x:Key="CheckNetworking">ネットワークの接続状況とプロクシの設定を確認してください。</system:String>
     <system:String x:Key="GetReleaseNoteFailed">リリースノートの取得に失敗しました。</system:String>
     <system:String x:Key="NewVersionIsBeingBuilt">新しいバージョンの準備中です。時間をおいてからもう一度実行してください</system:String>
+    <system:String x:Key="MirrorChyanBuildingOta">MirrorChyan がこのバージョンの OTA 増分アップデートをビルド中です。約 10 秒後に自動的に再試行します</system:String>
     <system:String x:Key="NewVersionNoOtaPackage">新しいバージョンが検出されましたが、利用可能な OTA 増分アップデートパッケージはありません。完全パッケージをダウンロードし、cache、config、data、debug、achievement（クリアスクリーンショット）、background（背景画像）、MAA.Updater.exe は保持され、それ以外のファイルはごみ箱と .old に移動されます。必要に応じて手動でバックアップしてください。</system:String>
     <system:String x:Key="NewVersionDownloadPreparing">アップデートパッケージのダウンロードを準備中です……</system:String>
     <system:String x:Key="NewVersionDownloadFailedTitle">アップデートパッケージのダウンロードに失敗しました</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -401,6 +401,7 @@
     <system:String x:Key="CheckNetworking">네트워크 연결이나 프록시를 확인해 주세요.</system:String>
     <system:String x:Key="GetReleaseNoteFailed">릴리즈 노트를 받아오지 못했습니다.</system:String>
     <system:String x:Key="NewVersionIsBeingBuilt">새로운 버전이 빌드되는 중입니다. 다음에 다시 시도해 주세요</system:String>
+    <system:String x:Key="MirrorChyanBuildingOta">MirrorChyan이 이 버전에 대한 OTA 증분 업데이트를 빌드 중입니다. 약 10초 후에 자동으로 다시 시도합니다</system:String>
     <system:String x:Key="NewVersionNoOtaPackage">새 버전이 감지되었지만 사용할 수 있는 OTA 증분 업데이트 패키지가 없습니다. 전체 패키지를 다운로드하며, cache, config, data, debug, achievement(클리어 스크린샷), background(배경 이미지), MAA.Updater.exe 는 유지되고 그 외의 파일은 휴지통과 .old 폴더로 이동합니다. 필요하다면 수동으로 백업해 주세요.</system:String>
     <system:String x:Key="NewVersionDownloadPreparing">업데이트 패키지 다운로드 준비 중……</system:String>
     <system:String x:Key="NewVersionDownloadFailedTitle">업데이트 패키지 다운로드 실패</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -401,6 +401,7 @@
     <system:String x:Key="CheckNetworking">请检查网络连接或代理。</system:String>
     <system:String x:Key="GetReleaseNoteFailed">获取更新信息失败。</system:String>
     <system:String x:Key="NewVersionIsBeingBuilt">我知道你很急但你先别急.jpg</system:String>
+    <system:String x:Key="MirrorChyanBuildingOta">MirrorChyan 正在为此版本打包 OTA 增量更新包，将在 10 秒后自动重试</system:String>
     <system:String x:Key="NewVersionNoOtaPackage">检测到新版本，但无可用的 OTA 增量更新包。将下载完整包，保留 cache、config、data、debug、achievement（通关截图）、background（背景图）和 MAA.Updater.exe，其余文件将移至回收站及 .old。如有需要请手动备份</system:String>
     <system:String x:Key="NewVersionDownloadPreparing">正在准备下载更新包……</system:String>
     <system:String x:Key="NewVersionDownloadFailedTitle">新版本下载失败</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -401,6 +401,7 @@
     <system:String x:Key="CheckNetworking">請檢查網路連線或 Proxy 代理設定。</system:String>
     <system:String x:Key="GetReleaseNoteFailed">取得更新資訊失敗。</system:String>
     <system:String x:Key="NewVersionIsBeingBuilt">我知道你很急但你先別急.jpg</system:String>
+    <system:String x:Key="MirrorChyanBuildingOta">MirrorChyan 正在為此版本打包 OTA 增量更新檔，將在 10 秒後自動重試</system:String>
     <system:String x:Key="NewVersionNoOtaPackage">偵測到新版本，但無可用的 OTA 增量更新檔案。將下載完整安裝檔案，保留 cache、config、data、debug、achievement（通關截圖）、background（背景圖片）和 MAA.Updater.exe，其餘檔案將移至資源回收桶及 .old，如有需要請手動備份</system:String>
     <system:String x:Key="NewVersionDownloadPreparing">正在準備下載更新檔……</system:String>
     <system:String x:Key="NewVersionDownloadFailedTitle">新版本下載失敗</system:String>

--- a/src/MaaWpfGui/ViewModels/Dialogs/VersionUpdateDialogViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/Dialogs/VersionUpdateDialogViewModel.cs
@@ -957,44 +957,16 @@ public class VersionUpdateDialogViewModel : Screen
 
         var url = $"{MaaUrls.MirrorChyanAppUpdate}?current_version={_curVersion}&cdk={cdk}&user_agent=MaaWpfGui&os=win&arch={arch}&channel={channel}&sp_id={spid}";
 
-        HttpResponseMessage? response = null;
-        try
-        {
-            response = await Instances.HttpService.GetAsync(new(url), uriPartial: UriPartial.Path);
-        }
-        catch (Exception e)
-        {
-            _logger.Error(e, "Failed to send GET request to {Uri}", new Uri(url).GetLeftPart(UriPartial.Path));
-            _logger.Information("current_version: {CurVersion}, cdk: {Mask}, arch: {Arch}, channel: {Channel}", _curVersion, cdk.Mask(), arch, channel);
-        }
-
-        if (response is null)
+        var data = await FetchMirrorChyanJsonAsync(url);
+        if (data is null)
         {
             _logger.Error("mirrorc failed");
+            _logger.Information("current_version: {CurVersion}, cdk: {Mask}, arch: {Arch}, channel: {Channel}", _curVersion, cdk.Mask(), arch, channel);
             SettingsViewModel.VersionUpdateSettings.MirrorChyanCdkFetchFailed = true;
             return CheckUpdateRetT.NetworkError;
         }
 
-        var jsonStr = await response.Content.ReadAsStringAsync();
-        _logger.Information("{JsonStr}", jsonStr);
-        JObject? data = null;
-        try
-        {
-            data = (JObject?)JsonConvert.DeserializeObject(jsonStr);
-        }
-        catch (Exception ex)
-        {
-            _logger.Error(ex, "Failed to deserialize json");
-        }
-
-        if (data is null)
-        {
-            SettingsViewModel.VersionUpdateSettings.MirrorChyanCdkFetchFailed = true;
-            return CheckUpdateRetT.UnknownError;
-        }
-
         var mirrorChyanCdkExpired = data["data"]?["cdk_expired_time"]?.ToObject<long?>();
-
         if (mirrorChyanCdkExpired.HasValue)
         {
             SettingsViewModel.VersionUpdateSettings.MirrorChyanCdkExpiredTime = mirrorChyanCdkExpired.Value;
@@ -1005,58 +977,10 @@ public class VersionUpdateDialogViewModel : Screen
             SettingsViewModel.VersionUpdateSettings.MirrorChyanCdkFetchFailed = true;
         }
 
-        var errorCode = data["code"]?.ToObject<MirrorChyanErrorCode>() ?? MirrorChyanErrorCode.Undivided;
-        if (errorCode != MirrorChyanErrorCode.Success)
+        var errorResult = HandleMirrorChyanErrorCode(data, mirrorChyanCdkExpired);
+        if (errorResult.HasValue)
         {
-            switch (errorCode)
-            {
-                case MirrorChyanErrorCode.KeyExpired:
-                    ToastNotification.ShowDirect(LocalizationHelper.GetString("MirrorChyanCdkExpired"));
-
-                    SettingsViewModel.VersionUpdateSettings.MirrorChyanCdkFetchFailed = false;
-
-                    // 有人会第一次就填过期的 cdk 吗
-                    if (SettingsViewModel.VersionUpdateSettings.MirrorChyanCdkExpiredTime == 0)
-                    {
-                        SettingsViewModel.VersionUpdateSettings.MirrorChyanCdkExpiredTime = 1;
-                    }
-
-                    // 如果上次查出来的时间比现在的还新，说明换了 cdk，重置过期时间
-                    if (!SettingsViewModel.VersionUpdateSettings.IsMirrorChyanCdkExpired)
-                    {
-                        SettingsViewModel.VersionUpdateSettings.MirrorChyanCdkExpiredTime = mirrorChyanCdkExpired ?? 1;
-                    }
-
-                    break;
-
-                case MirrorChyanErrorCode.KeyInvalid:
-                    ToastNotification.ShowDirect(LocalizationHelper.GetString("MirrorChyanCdkInvalid"));
-                    AchievementTrackerHelper.Instance.Unlock(AchievementIds.MirrorChyanCdkError);
-                    break;
-
-                case MirrorChyanErrorCode.ResourceQuotaExhausted:
-                    ToastNotification.ShowDirect(LocalizationHelper.GetString("MirrorChyanCdkQuotaExhausted"));
-                    break;
-
-                case MirrorChyanErrorCode.KeyMismatched:
-                    ToastNotification.ShowDirect(LocalizationHelper.GetString("MirrorChyanCdkMismatched"));
-                    break;
-
-                case MirrorChyanErrorCode.KeyBlocked:
-                    ToastNotification.ShowDirect(LocalizationHelper.GetString("MirrorChyanCdkBlocked"));
-                    break;
-
-                case MirrorChyanErrorCode.InvalidParams:
-                case MirrorChyanErrorCode.ResourceNotFound:
-                case MirrorChyanErrorCode.InvalidOs:
-                case MirrorChyanErrorCode.InvalidArch:
-                case MirrorChyanErrorCode.InvalidChannel:
-                case MirrorChyanErrorCode.Undivided:
-                    ToastNotification.ShowDirect(data["msg"]?.ToString() ?? LocalizationHelper.GetString("GameResourceFailed"));
-                    break;
-            }
-
-            return CheckUpdateRetT.UnknownError;
+            return errorResult.Value;
         }
 
         var version = data["data"]?["version_name"]?.ToString();
@@ -1070,68 +994,7 @@ public class VersionUpdateDialogViewModel : Screen
             return CheckUpdateRetT.AlreadyLatest;
         }
 
-        if (data["data"]?["update_type"]?.ToObject<string>() == "full")
-        {
-            // MirrorChyan 在收到第一个对应版本的请求后会开始打包 OTA，打包过程中返回完整包
-            // 等待 10s 后重试，通常此时 OTA 包已就绪
-            _logger.Information("MirrorChyan returned full package, OTA may be building. Will retry after 10s.");
-            using (var toast = new ToastNotification(LocalizationHelper.GetString("NewVersionIsBeingBuilt")))
-            {
-                toast.Show(10);
-            }
-
-            Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("NewVersionIsBeingBuilt"), UiLogColor.Info);
-
-            await Task.Delay(10000);
-
-            // 重试请求，检查 OTA 包是否已就绪
-            HttpResponseMessage? retryResponse = null;
-            try
-            {
-                retryResponse = await Instances.HttpService.GetAsync(new(url), uriPartial: UriPartial.Path);
-            }
-            catch (Exception ex)
-            {
-                _logger.Error(ex, "Retry request to MirrorChyan failed.");
-            }
-
-            bool otaReady = false;
-            if (retryResponse != null)
-            {
-                var retryJsonStr = await retryResponse.Content.ReadAsStringAsync();
-                _logger.Information("MirrorChyan retry response: {JsonStr}", retryJsonStr);
-                JObject? retryData = null;
-                try
-                {
-                    retryData = (JObject?)JsonConvert.DeserializeObject(retryJsonStr);
-                }
-                catch (Exception ex)
-                {
-                    _logger.Error(ex, "Failed to deserialize retry json from MirrorChyan");
-                }
-
-                if (retryData != null && retryData["data"]?["update_type"]?.ToObject<string>() != "full")
-                {
-                    // 重试成功，OTA 包已就绪，使用新的响应数据
-                    _logger.Information("MirrorChyan OTA package ready after retry.");
-                    data = retryData;
-                    otaReady = true;
-                }
-            }
-
-            if (!otaReady)
-            {
-                // 重试后仍是完整包或重试失败，走完整包更新途径
-                _logger.Warning("MirrorChyan still returning full package after retry (or retry failed).");
-                _requiresFullPackageConfirmation = true;
-                if (SettingsViewModel.VersionUpdateSettings.AutoDownloadUpdatePackage)
-                {
-                    using var toast = new ToastNotification(LocalizationHelper.GetString("NewVersionNoOtaPackage"));
-                    toast.Show(30);
-                    Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("NewVersionNoOtaPackage"), UiLogColor.Warning);
-                }
-            }
-        }
+        data = await TryWaitForMirrorChyanOtaAsync(url, data);
 
         // 到这里已经确定有新版本了
         _logger.Information("New version found: {Version}", version);
@@ -1147,6 +1010,136 @@ public class VersionUpdateDialogViewModel : Screen
         _mirrorcDownloadUrl = data["data"]?["url"]?.ToString();
 
         return CheckUpdateRetT.OK;
+    }
+
+    /// <summary>
+    /// 向 MirrorChyan 发送 GET 请求并解析 JSON 响应。
+    /// </summary>
+    /// <returns>解析成功返回 JObject，失败返回 null。</returns>
+    private static async Task<JObject?> FetchMirrorChyanJsonAsync(string url)
+    {
+        HttpResponseMessage? response = null;
+        try
+        {
+            response = await Instances.HttpService.GetAsync(new(url), uriPartial: UriPartial.Path);
+        }
+        catch (Exception ex)
+        {
+            _logger.Error(ex, "Failed to send GET request to {Uri}", new Uri(url).GetLeftPart(UriPartial.Path));
+            return null;
+        }
+
+        var jsonStr = await response.Content.ReadAsStringAsync();
+        _logger.Information("{JsonStr}", jsonStr);
+        try
+        {
+            return (JObject?)JsonConvert.DeserializeObject(jsonStr);
+        }
+        catch (Exception ex)
+        {
+            _logger.Error(ex, "Failed to deserialize json from MirrorChyan");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// 处理 MirrorChyan 错误码，显示对应的 Toast 提示。
+    /// </summary>
+    /// <returns>成功（无需处理）返回 null，出错返回 CheckUpdateRetT.UnknownError。</returns>
+    private static CheckUpdateRetT? HandleMirrorChyanErrorCode(JObject data, long? mirrorChyanCdkExpired)
+    {
+        var errorCode = data["code"]?.ToObject<MirrorChyanErrorCode>() ?? MirrorChyanErrorCode.Undivided;
+        if (errorCode == MirrorChyanErrorCode.Success)
+        {
+            return null;
+        }
+
+        switch (errorCode)
+        {
+            case MirrorChyanErrorCode.KeyExpired:
+                ToastNotification.ShowDirect(LocalizationHelper.GetString("MirrorChyanCdkExpired"));
+                SettingsViewModel.VersionUpdateSettings.MirrorChyanCdkFetchFailed = false;
+
+                // 有人会第一次就填过期的 cdk 吗
+                if (SettingsViewModel.VersionUpdateSettings.MirrorChyanCdkExpiredTime == 0)
+                {
+                    SettingsViewModel.VersionUpdateSettings.MirrorChyanCdkExpiredTime = 1;
+                }
+
+                // 如果上次查出来的时间比现在的还新，说明换了 cdk，重置过期时间
+                if (!SettingsViewModel.VersionUpdateSettings.IsMirrorChyanCdkExpired)
+                {
+                    SettingsViewModel.VersionUpdateSettings.MirrorChyanCdkExpiredTime = mirrorChyanCdkExpired ?? 1;
+                }
+
+                break;
+
+            case MirrorChyanErrorCode.KeyInvalid:
+                ToastNotification.ShowDirect(LocalizationHelper.GetString("MirrorChyanCdkInvalid"));
+                AchievementTrackerHelper.Instance.Unlock(AchievementIds.MirrorChyanCdkError);
+                break;
+
+            case MirrorChyanErrorCode.ResourceQuotaExhausted:
+                ToastNotification.ShowDirect(LocalizationHelper.GetString("MirrorChyanCdkQuotaExhausted"));
+                break;
+
+            case MirrorChyanErrorCode.KeyMismatched:
+                ToastNotification.ShowDirect(LocalizationHelper.GetString("MirrorChyanCdkMismatched"));
+                break;
+
+            case MirrorChyanErrorCode.KeyBlocked:
+                ToastNotification.ShowDirect(LocalizationHelper.GetString("MirrorChyanCdkBlocked"));
+                break;
+
+            case MirrorChyanErrorCode.InvalidParams:
+            case MirrorChyanErrorCode.ResourceNotFound:
+            case MirrorChyanErrorCode.InvalidOs:
+            case MirrorChyanErrorCode.InvalidArch:
+            case MirrorChyanErrorCode.InvalidChannel:
+            case MirrorChyanErrorCode.Undivided:
+                ToastNotification.ShowDirect(data["msg"]?.ToString() ?? LocalizationHelper.GetString("GameResourceFailed"));
+                break;
+        }
+
+        return CheckUpdateRetT.UnknownError;
+    }
+
+    /// <summary>
+    /// MirrorChyan 在收到首个请求后会开始打包 OTA，打包过程中返回完整包。
+    /// 等待 10s 后重试，通常此时 OTA 包已就绪；若重试后仍为完整包则走完整包更新途径。
+    /// </summary>
+    private async Task<JObject> TryWaitForMirrorChyanOtaAsync(string url, JObject data)
+    {
+        if (data["data"]?["update_type"]?.ToObject<string>() != "full")
+        {
+            return data;
+        }
+
+        _logger.Information("MirrorChyan returned full package, OTA may be building. Will retry after 10s.");
+        ToastNotification.ShowDirect(LocalizationHelper.GetString("MirrorChyanBuildingOta"));
+        Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("NewVersionIsBeingBuilt"), UiLogColor.Info);
+
+        await Task.Delay(10000);
+
+        // 重试请求，检查 OTA 包是否已就绪
+        var retryData = await FetchMirrorChyanJsonAsync(url);
+        if (retryData != null && retryData["data"]?["update_type"]?.ToObject<string>() != "full")
+        {
+            // 重试成功，OTA 包已就绪，使用新的响应数据
+            _logger.Information("MirrorChyan OTA package ready after retry.");
+            return retryData;
+        }
+
+        // 重试后仍是完整包或重试失败，走完整包更新途径
+        _logger.Warning("MirrorChyan still returning full package after retry (or retry failed).");
+        _requiresFullPackageConfirmation = true;
+        if (SettingsViewModel.VersionUpdateSettings.AutoDownloadUpdatePackage)
+        {
+            ToastNotification.ShowDirect(LocalizationHelper.GetString("NewVersionNoOtaPackage"));
+            Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("NewVersionNoOtaPackage"), UiLogColor.Warning);
+        }
+
+        return data;
     }
 
     private bool NeedToUpdate(string latestVersion)

--- a/src/MaaWpfGui/ViewModels/Dialogs/VersionUpdateDialogViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/Dialogs/VersionUpdateDialogViewModel.cs
@@ -1018,26 +1018,24 @@ public class VersionUpdateDialogViewModel : Screen
     /// <returns>解析成功返回 JObject，失败返回 null。</returns>
     private static async Task<JObject?> FetchMirrorChyanJsonAsync(string url)
     {
-        HttpResponseMessage? response = null;
         try
         {
-            response = await Instances.HttpService.GetAsync(new(url), uriPartial: UriPartial.Path);
+            using var response = await Instances.HttpService.GetAsync(new(url), uriPartial: UriPartial.Path);
+            var jsonStr = await response.Content.ReadAsStringAsync();
+            _logger.Information("{JsonStr}", jsonStr);
+            try
+            {
+                return (JObject?)JsonConvert.DeserializeObject(jsonStr);
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "Failed to deserialize json from MirrorChyan");
+                return null;
+            }
         }
         catch (Exception ex)
         {
             _logger.Error(ex, "Failed to send GET request to {Uri}", new Uri(url).GetLeftPart(UriPartial.Path));
-            return null;
-        }
-
-        var jsonStr = await response.Content.ReadAsStringAsync();
-        _logger.Information("{JsonStr}", jsonStr);
-        try
-        {
-            return (JObject?)JsonConvert.DeserializeObject(jsonStr);
-        }
-        catch (Exception ex)
-        {
-            _logger.Error(ex, "Failed to deserialize json from MirrorChyan");
             return null;
         }
     }

--- a/src/MaaWpfGui/ViewModels/Dialogs/VersionUpdateDialogViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/Dialogs/VersionUpdateDialogViewModel.cs
@@ -1072,14 +1072,64 @@ public class VersionUpdateDialogViewModel : Screen
 
         if (data["data"]?["update_type"]?.ToObject<string>() == "full")
         {
-            _requiresFullPackageConfirmation = true;
-
-            if (SettingsViewModel.VersionUpdateSettings.AutoDownloadUpdatePackage)
+            // MirrorChyan 在收到第一个对应版本的请求后会开始打包 OTA，打包过程中返回完整包
+            // 等待 10s 后重试，通常此时 OTA 包已就绪
+            _logger.Information("MirrorChyan returned full package, OTA may be building. Will retry after 10s.");
+            using (var toast = new ToastNotification(LocalizationHelper.GetString("NewVersionIsBeingBuilt")))
             {
-                using var toast = new ToastNotification(LocalizationHelper.GetString("NewVersionNoOtaPackage"));
-                toast.Show(30);
-                _logger.Warning("No OTA package found, but full package found.");
-                Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("NewVersionNoOtaPackage"), UiLogColor.Warning);
+                toast.Show(10);
+            }
+
+            Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("NewVersionIsBeingBuilt"), UiLogColor.Info);
+
+            await Task.Delay(10000);
+
+            // 重试请求，检查 OTA 包是否已就绪
+            HttpResponseMessage? retryResponse = null;
+            try
+            {
+                retryResponse = await Instances.HttpService.GetAsync(new(url), uriPartial: UriPartial.Path);
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "Retry request to MirrorChyan failed.");
+            }
+
+            bool otaReady = false;
+            if (retryResponse != null)
+            {
+                var retryJsonStr = await retryResponse.Content.ReadAsStringAsync();
+                _logger.Information("MirrorChyan retry response: {JsonStr}", retryJsonStr);
+                JObject? retryData = null;
+                try
+                {
+                    retryData = (JObject?)JsonConvert.DeserializeObject(retryJsonStr);
+                }
+                catch (Exception ex)
+                {
+                    _logger.Error(ex, "Failed to deserialize retry json from MirrorChyan");
+                }
+
+                if (retryData != null && retryData["data"]?["update_type"]?.ToObject<string>() != "full")
+                {
+                    // 重试成功，OTA 包已就绪，使用新的响应数据
+                    _logger.Information("MirrorChyan OTA package ready after retry.");
+                    data = retryData;
+                    otaReady = true;
+                }
+            }
+
+            if (!otaReady)
+            {
+                // 重试后仍是完整包或重试失败，走完整包更新途径
+                _logger.Warning("MirrorChyan still returning full package after retry (or retry failed).");
+                _requiresFullPackageConfirmation = true;
+                if (SettingsViewModel.VersionUpdateSettings.AutoDownloadUpdatePackage)
+                {
+                    using var toast = new ToastNotification(LocalizationHelper.GetString("NewVersionNoOtaPackage"));
+                    toast.Show(30);
+                    Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("NewVersionNoOtaPackage"), UiLogColor.Warning);
+                }
             }
         }
 


### PR DESCRIPTION
## Summary by Sourcery

为 MirrorChyan OTA 更新新增等待与重试支持：当初始仅有整包可用时，可以等待 OTA 包上线后再使用。同时重构 MirrorChyan 更新检查逻辑，以提升复用性和错误处理能力。

新功能：
- 支持在延迟一段时间后重试 MirrorChyan 更新检查，这样当 OTA 包变得可用时可以使用 OTA 包，而不是立即回退到整包。

改进：
- 将 MirrorChyan 的 HTTP 请求和 JSON 解析抽取到一个共享的辅助工具中，以集中管理日志与错误处理。
- 将 MirrorChyan 的错误码处理抽取到专用辅助工具中，以简化更新检查流程，并在不同分支中保持 toast 和设置更新行为的一致性。

文档：
- 更新本地化字符串，以支持在所有受支持语言中新增 MirrorChyan OTA 构建与重试相关的用户通知。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for waiting and retrying MirrorChyan OTA updates when only a full package is initially available, while refactoring the MirrorChyan update-check logic for better reuse and error handling.

New Features:
- Support retrying MirrorChyan update checks after a delay so that OTA packages can be used when they become available instead of immediately falling back to full packages.

Enhancements:
- Extract MirrorChyan HTTP request and JSON parsing into a shared helper to centralize logging and error handling.
- Extract MirrorChyan error-code handling into a dedicated helper to simplify the update check flow and keep toast/setting updates consistent across paths.

Documentation:
- Update localized strings for the new MirrorChyan OTA-building and retry user notifications across supported languages.

</details>