### PR TITLE
rft: 统一 LocalizationHelper GetString Format

### DIFF
--- a/src/MaaWpfGui/Helper/LocalizationHelper.cs
+++ b/src/MaaWpfGui/Helper/LocalizationHelper.cs
@@ -262,7 +262,7 @@ public static class LocalizationHelper
     /// <param name="key">The key of the string.</param>
     /// <param name="args">The args of string.Format</param>
     /// <returns>The string.Format result.</returns>
-    public static string GetStringFormat(string key, params object[] args)
+    public static string GetStringFormat(string key, params object?[] args)
     {
         if (_culture == "pallas")
         {

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -592,7 +592,7 @@ public class AsstProxy
 
             if (x.IsDeprecated)
             {
-                Instances.TaskQueueViewModel.AddLog(string.Format(LocalizationHelper.GetString("GpuDeprecatedMessage"), description), UiLogColor.Warning);
+                Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetStringFormat("GpuDeprecatedMessage", description), UiLogColor.Warning);
                 _logger.Warning("Using deprecated GPU {0} (Driver {1} {2})", description, version, date);
             }
             else
@@ -607,7 +607,7 @@ public class AsstProxy
                 if (driverDate < twoYearsAgo)
                 {
                     var dateStr = driverDate.ToString("yyyy-MM-dd");
-                    var message = string.Format(LocalizationHelper.GetString("GpuDriverOutdatedMessage"), description, version ?? "Unknown", dateStr);
+                    var message = LocalizationHelper.GetStringFormat("GpuDriverOutdatedMessage", description, version ?? "Unknown", dateStr);
                     Instances.TaskQueueViewModel.AddLog(message, UiLogColor.Warning);
                     _logger.Warning("Using GPU {0} with outdated driver {1} (release date: {2}, over 2 years old)", description, version, dateStr);
                 }
@@ -785,7 +785,7 @@ public class AsstProxy
                     int height = details["details"]?["height"]?.ToObject<int>() ?? 0;
                     var baseMsg = LocalizationHelper.GetString("ResolutionNotSupported");
                     _lastConnectionError = width > 0 && height > 0
-                        ? $"{baseMsg} ({string.Format(LocalizationHelper.GetString("ResolutionNotSupportedCurrentResolution"), width, height)})"
+                        ? $"{baseMsg} ({LocalizationHelper.GetStringFormat("ResolutionNotSupportedCurrentResolution", width, height)})"
                         : baseMsg;
                     Instances.TaskQueueViewModel.AddLog(_lastConnectionError, UiLogColor.Error);
                 }
@@ -920,7 +920,7 @@ public class AsstProxy
                             break;
                     }
 
-                    fastestScreencapStringBuilder.Insert(0, string.Format(LocalizationHelper.GetString("FastestWayToScreencap"), costString, method));
+                    fastestScreencapStringBuilder.Insert(0, LocalizationHelper.GetStringFormat("FastestWayToScreencap", costString, method));
                     var fastestScreencapString = fastestScreencapStringBuilder.ToString();
                     SettingsViewModel.ConnectSettings.ScreencapTestCost = fastestScreencapString;
                     Instances.TaskQueueViewModel.AddLog(fastestScreencapString, color, toolTip: screencapAlternatives.CreateScreencapTooltip());
@@ -944,7 +944,7 @@ public class AsstProxy
                 var screencapCostAvg = details["details"]?["avg"]?.ToString() ?? "???";
                 var screencapCostMax = details["details"]?["max"]?.ToString() ?? "???";
                 var currentTime = DateTimeOffset.Now.ToString("HH:mm:ss");
-                SettingsViewModel.ConnectSettings.ScreencapCost = string.Format(LocalizationHelper.GetString("ScreencapCost"), screencapCostMin, screencapCostAvg, screencapCostMax, currentTime);
+                SettingsViewModel.ConnectSettings.ScreencapCost = LocalizationHelper.GetStringFormat("ScreencapCost", screencapCostMin, screencapCostAvg, screencapCostMax, currentTime);
                 if (!HasPrintedScreencapWarning && int.TryParse(screencapCostAvg, out var screencapCostAvgInt))
                 {
                     static void AddLog(string message, string color)
@@ -958,12 +958,12 @@ public class AsstProxy
                     {
                         // 日志提示
                         case >= 800:
-                            AddLog(string.Format(LocalizationHelper.GetString("FastestWayToScreencapErrorTip"), screencapCostAvgInt), UiLogColor.Warning);
+                            AddLog(LocalizationHelper.GetStringFormat("FastestWayToScreencapErrorTip", screencapCostAvgInt), UiLogColor.Warning);
                             AchievementTrackerHelper.Instance.Unlock(AchievementIds.SnapshotChallenge1);
                             break;
 
                         case >= 400:
-                            AddLog(string.Format(LocalizationHelper.GetString("FastestWayToScreencapWarningTip"), screencapCostAvgInt), UiLogColor.Warning);
+                            AddLog(LocalizationHelper.GetStringFormat("FastestWayToScreencapWarningTip", screencapCostAvgInt), UiLogColor.Warning);
                             AchievementTrackerHelper.Instance.Unlock(AchievementIds.SnapshotChallenge2);
                             break;
 
@@ -1127,7 +1127,7 @@ public class AsstProxy
                     var taskName = task?.NameDisplay ?? $"({LocalizationHelper.GetString(taskChain)})";
                     if (taskChain == "Fight" && FightSetting.SanityReport is not null)
                     {
-                        var sanityLog = "\n" + string.Format(LocalizationHelper.GetString("CurrentSanity"), FightSetting.SanityReport.SanityCurrent, FightSetting.SanityReport.SanityMax);
+                        var sanityLog = "\n" + LocalizationHelper.GetStringFormat("CurrentSanity", FightSetting.SanityReport.SanityCurrent, FightSetting.SanityReport.SanityMax);
                         Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("CompleteTask") + taskName + sanityLog);
 
                         if (FightSetting.SanityReport.SanityCurrent == 0)
@@ -1163,7 +1163,7 @@ public class AsstProxy
                             {
                                 case "TooManyBattlesAhead":
                                     var cost = details["node_cost"]?.ToString() ?? "?";
-                                    msgText = string.Format(LocalizationHelper.GetString("RoutingRestartTooManyBattles"), cost);
+                                    msgText = LocalizationHelper.GetStringFormat("RoutingRestartTooManyBattles", cost);
                                     break;
                             }
 
@@ -1206,7 +1206,7 @@ public class AsstProxy
                     var dateTimeNow = DateTimeOffset.Now;
                     var diffTaskTime = (dateTimeNow - StartTaskTime).ToString(@"h\h\ m\m\ s\s");
 
-                    var allTaskCompleteTitle = string.Format(LocalizationHelper.GetString("AllTasksComplete"), diffTaskTime);
+                    var allTaskCompleteTitle = LocalizationHelper.GetStringFormat("AllTasksComplete", diffTaskTime);
                     var allTaskCompleteMessage = LocalizationHelper.GetString("AllTaskCompleteContent");
                     var sanityReport = LocalizationHelper.GetString("SanityReport");
 
@@ -1217,7 +1217,7 @@ public class AsstProxy
                         .Replace("{Preset}", configurationPreset)
                         .Replace("{TimeDiff}", diffTaskTime);
 
-                    var allTaskCompleteLog = string.Format(LocalizationHelper.GetString("AllTasksComplete"), diffTaskTime);
+                    var allTaskCompleteLog = LocalizationHelper.GetStringFormat("AllTasksComplete", diffTaskTime);
 
                     if (FightSetting.SanityReport is not null)
                     {
@@ -1526,12 +1526,12 @@ public class AsstProxy
                             StringBuilder missionStartLogBuilder = new();
                             if (FightSetting.FightReport is null)
                             {
-                                missionStartLogBuilder.AppendLine(string.Format(LocalizationHelper.GetString("MissionStart.FightTask"), "???", "???"));
+                                missionStartLogBuilder.AppendLine(LocalizationHelper.GetStringFormat("MissionStart.FightTask", "???", "???"));
                             }
                             else
                             {
                                 var times = FightSetting.FightReport.Series == 1 ? $"{FightSetting.FightReport.TimesFinished + 1}" : $"{FightSetting.FightReport.TimesFinished + 1}~{FightSetting.FightReport.TimesFinished + FightSetting.FightReport.Series}";
-                                missionStartLogBuilder.AppendLine(string.Format(LocalizationHelper.GetString("MissionStart.FightTask"), times, FightSetting.FightReport.SanityCost));
+                                missionStartLogBuilder.AppendLine(LocalizationHelper.GetStringFormat("MissionStart.FightTask", times, FightSetting.FightReport.SanityCost));
                             }
 
                             if (FightSetting.SanityReport is not null)
@@ -1940,7 +1940,7 @@ public class AsstProxy
                     var tooltip = Instances.ToolboxViewModel.RecruitResultInlines.CreateTooltip(PlacementMode.Center);
                     if (level >= 5)
                     {
-                        using (var toast = new ToastNotification(string.Format(LocalizationHelper.GetString("RecruitmentOfStar"), level)))
+                        using (var toast = new ToastNotification(LocalizationHelper.GetStringFormat("RecruitmentOfStar", level)))
                         {
                             toast.AppendContentText(new string('★', level)).ShowRecruit(row: 2);
                         }
@@ -1981,7 +1981,7 @@ public class AsstProxy
             case "RecruitSupportOperator":
                 {
                     var name = subTaskDetails!["name"]!.ToString();
-                    Instances.TaskQueueViewModel.AddLog(string.Format(LocalizationHelper.GetString("RecruitSupportOperator"), name), UiLogColor.Info);
+                    Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetStringFormat("RecruitSupportOperator", name), UiLogColor.Info);
                     break;
                 }
 
@@ -2108,15 +2108,15 @@ public class AsstProxy
                     var actionToken = subTaskDetails?["action"];
                     var actionString = actionToken?.ToString() ?? "UnknownAction";
                     Instances.CopilotViewModel.AddLog(
-                        string.Format(
-                            LocalizationHelper.GetString("CurrentSteps"),
+                        LocalizationHelper.GetStringFormat(
+                            "CurrentSteps",
                             LocalizationHelper.GetString(actionString),
                             DataHelper.GetLocalizedCharacterName(target) ?? target));
 
                     var elapsed_time_str = subTaskDetails!["elapsed_time"]?.ToString();
                     if (int.TryParse(elapsed_time_str, out int elapsed_time_int) && elapsed_time_int >= 0)
                     {
-                        Instances.CopilotViewModel.AddLog(string.Format(LocalizationHelper.GetString("ElapsedTime"), elapsed_time_int), UiLogColor.Message);
+                        Instances.CopilotViewModel.AddLog(LocalizationHelper.GetStringFormat("ElapsedTime", elapsed_time_int), UiLogColor.Message);
                     }
 
                     break;
@@ -2128,7 +2128,7 @@ public class AsstProxy
                 break;
 
             case "SSSStage":
-                Instances.CopilotViewModel.AddLog(string.Format(LocalizationHelper.GetString("CurrentStage"), subTaskDetails!["stage"]), UiLogColor.Info);
+                Instances.CopilotViewModel.AddLog(LocalizationHelper.GetStringFormat("CurrentStage", subTaskDetails!["stage"]), UiLogColor.Info);
                 break;
 
             case "SSSSettlement":
@@ -2238,7 +2238,7 @@ public class AsstProxy
 
                         if (FightSetting.Instance.HasTimesLimited != false && FightSetting.FightReport.IsFinished && FightSetting.FightReport.TimesFinished < FightSetting.Instance.MaxTimes)
                         {
-                            Instances.TaskQueueViewModel.AddLog(string.Format(LocalizationHelper.GetString("FightTimesUnused"), FightSetting.FightReport.TimesFinished, FightSetting.FightReport.Series, FightSetting.FightReport.TimesFinished + FightSetting.FightReport.Series, FightSetting.Instance.MaxTimes), UiLogColor.Warning);
+                            Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetStringFormat("FightTimesUnused", FightSetting.FightReport.TimesFinished, FightSetting.FightReport.Series, FightSetting.FightReport.TimesFinished + FightSetting.FightReport.Series, FightSetting.Instance.MaxTimes), UiLogColor.Warning);
                         }
                     }
 
@@ -2547,7 +2547,7 @@ public class AsstProxy
 
         if (foundWindows.Count == 0)
         {
-            error = string.Format(LocalizationHelper.GetString("AttachWindowNotFound"), TargetWindowName);
+            error = LocalizationHelper.GetStringFormat("AttachWindowNotFound", TargetWindowName);
             Instances.TaskQueueViewModel.AddLog(error, UiLogColor.Error);
             _logger.Warning("AttachWindow: No window found with name {WindowName}", TargetWindowName);
             return false;
@@ -2558,13 +2558,13 @@ public class AsstProxy
         if (foundWindows.Count > 1)
         {
             // 找到多个窗口，使用第一个并记录日志
-            var multipleMsg = string.Format(LocalizationHelper.GetString("AttachWindowMultipleFound"), foundWindows.Count, TargetWindowName);
+            var multipleMsg = LocalizationHelper.GetStringFormat("AttachWindowMultipleFound", foundWindows.Count, TargetWindowName);
             Instances.TaskQueueViewModel.AddLog(multipleMsg, UiLogColor.Info);
             _logger.Warning("AttachWindow: Multiple windows found with name {WindowName}, count: {Count}, using first one: {Hwnd}", TargetWindowName, foundWindows.Count, hwnd);
         }
         else
         {
-            var foundMsg = string.Format(LocalizationHelper.GetString("AttachWindowFound"), TargetWindowName);
+            var foundMsg = LocalizationHelper.GetStringFormat("AttachWindowFound", TargetWindowName);
             Instances.TaskQueueViewModel.AddLog(foundMsg, UiLogColor.Info);
             _logger.Information("AttachWindow: Found window \"{WindowName}\" with HWND: {Hwnd}", TargetWindowName, hwnd);
         }

--- a/src/MaaWpfGui/Main/Bootstrapper.cs
+++ b/src/MaaWpfGui/Main/Bootstrapper.cs
@@ -884,7 +884,7 @@ public class Bootstrapper : Bootstrapper<RootViewModel>
         var maxTimeInterval = Math.Max(buildTimeInterval, resourceTimeInterval);
         if (maxTimeInterval > 90)
         {
-            Instances.TaskQueueViewModel.LogItemViewModels.Add(new(string.Format(LocalizationHelper.GetString("Achievement.Martian.ConditionsTip"), (maxTimeInterval / 30.436875).ToString("F2")), UiLogColor.Error));
+            Instances.TaskQueueViewModel.LogItemViewModels.Add(new(LocalizationHelper.GetStringFormat("Achievement.Martian.ConditionsTip", (maxTimeInterval / 30.436875).ToString("F2")), UiLogColor.Error));
         }
     }
 

--- a/src/MaaWpfGui/Models/Copilot/SSSCopilotModel.cs
+++ b/src/MaaWpfGui/Models/Copilot/SSSCopilotModel.cs
@@ -138,7 +138,7 @@ public class SSSCopilotModel : CopilotBase
             output.Add(($"{localizedName}, {LocalizationHelper.GetString("CopilotSkill")} {oper.Skill}", null));
         }
 
-        output.Add((string.Format(LocalizationHelper.GetString("TotalOperatorsCount"), count), null));
+        output.Add((LocalizationHelper.GetStringFormat("TotalOperatorsCount", count), null));
 
         if (ToolMen is not null)
         {

--- a/src/MaaWpfGui/Models/ResourceUpdater.cs
+++ b/src/MaaWpfGui/Models/ResourceUpdater.cs
@@ -258,7 +258,7 @@ public static class ResourceUpdater
 
         releaseNote = LocalizationHelper.FormatVersion(releaseNote, versionTime);
 
-        SettingsViewModel.VersionUpdateSettings.NewResourceFoundInfo = string.Format(LocalizationHelper.GetString("MirrorChyanResourceUpdateShortTip"), releaseNote);
+        SettingsViewModel.VersionUpdateSettings.NewResourceFoundInfo = LocalizationHelper.GetStringFormat("MirrorChyanResourceUpdateShortTip", releaseNote);
 
         if (string.IsNullOrEmpty(cdk))
         {
@@ -282,8 +282,8 @@ public static class ResourceUpdater
             return false;
         }
 
-        ToastNotification.ShowDirect(string.Format(
-            LocalizationHelper.GetString("GameResourceUpdatingMirrorChyan"), releaseNote));
+        ToastNotification.ShowDirect(LocalizationHelper.GetStringFormat(
+            "GameResourceUpdatingMirrorChyan", releaseNote));
 
         const string MirrorchyanZipFile = "MaaResourceMirrorchyan.zip";
         const string ExtractFolder = "MaaResourceMirrorchyan";
@@ -372,7 +372,7 @@ public static class ResourceUpdater
             var (ret, uri, releaseNote) = await CheckFromMirrorChyanAsync();
             if (ret == CheckUpdateRetT.NoMirrorChyanCdk)
             {
-                ToastNotification.ShowDirect(string.Format(LocalizationHelper.GetString("MirrorChyanResourceUpdateTip"), releaseNote));
+                ToastNotification.ShowDirect(LocalizationHelper.GetStringFormat("MirrorChyanResourceUpdateTip", releaseNote));
             }
 
             if (ret != CheckUpdateRetT.OK)

--- a/src/MaaWpfGui/Services/RemoteControl/RemoteControlService.cs
+++ b/src/MaaWpfGui/Services/RemoteControl/RemoteControlService.cs
@@ -331,7 +331,7 @@ public class RemoteControlService
                     {
                         // 一键长草特殊任务
                         await _runningState.UntilIdleAsync();
-                        var startLogStr = string.Format(LocalizationHelper.GetString("RemoteControlReceivedTask"), type, id);
+                        var startLogStr = LocalizationHelper.GetStringFormat("RemoteControlReceivedTask", type, id);
 
                         Instances.TaskQueueViewModel.AddLog(startLogStr);
                         await Execute.OnUIThreadAsync(() => {
@@ -339,7 +339,7 @@ public class RemoteControlService
                         });
                         await _runningState.UntilIdleAsync();
 
-                        var stopLogStr = string.Format(LocalizationHelper.GetString("RemoteControlCompletedTask"), type, id);
+                        var stopLogStr = LocalizationHelper.GetStringFormat("RemoteControlCompletedTask", type, id);
                         Instances.TaskQueueViewModel.AddLog(stopLogStr);
                         break;
                     }
@@ -771,7 +771,7 @@ public class RemoteControlService
             {
                 if (!response.IsSuccessStatusCode)
                 {
-                    var errorMsg = string.Format(LocalizationHelper.GetString("RemoteControlConnectionTestFail"), response.StatusCode);
+                    var errorMsg = LocalizationHelper.GetStringFormat("RemoteControlConnectionTestFail", response.StatusCode);
                     ToastNotification.ShowDirect(errorMsg);
                     return;
                 }
@@ -779,7 +779,7 @@ public class RemoteControlService
             else
             {
                 // 一般来说不会走到这里，因为null response一定会报错
-                var errorMsg = string.Format(LocalizationHelper.GetString("RemoteControlConnectionTestFail"), "Unknown");
+                var errorMsg = LocalizationHelper.GetStringFormat("RemoteControlConnectionTestFail", "Unknown");
                 ToastNotification.ShowDirect(errorMsg);
                 return;
             }
@@ -795,7 +795,7 @@ public class RemoteControlService
                 error = e.InnerException.Message;
             }
 
-            var errorMsg = string.Format(LocalizationHelper.GetString("RemoteControlConnectionTestFail"), error);
+            var errorMsg = LocalizationHelper.GetStringFormat("RemoteControlConnectionTestFail", error);
             ToastNotification.ShowDirect(errorMsg);
         }
     }

--- a/src/MaaWpfGui/States/RunningState.cs
+++ b/src/MaaWpfGui/States/RunningState.cs
@@ -174,8 +174,8 @@ public class RunningState
         _stallTimer.Stop();
         _stallAccumulatedCount++;
         var accumulatedMinutes = StallTimeoutMinutes + ((_stallAccumulatedCount - 1) * ReminderIntervalMinutes);
-        var message = string.Format(
-            LocalizationHelper.GetString("TaskStallWarning"),
+        var message = LocalizationHelper.GetStringFormat(
+            "TaskStallWarning",
             StallTimeoutMinutes,
             accumulatedMinutes);
         StallOccurred?.Invoke(this, message);

--- a/src/MaaWpfGui/ViewModels/Dialogs/VersionUpdateDialogViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/Dialogs/VersionUpdateDialogViewModel.cs
@@ -750,7 +750,7 @@ public class VersionUpdateDialogViewModel : Screen
             : GetPlannedUpdatePackagePath(packagePath);
 
         MessageBoxResult result = MessageBoxHelper.Show(
-            string.Format(LocalizationHelper.GetString("PendingFullUpdateManualConfirmDesc"), baseDir, normalizedPackagePath),
+            LocalizationHelper.GetStringFormat("PendingFullUpdateManualConfirmDesc", baseDir, normalizedPackagePath),
             LocalizationHelper.GetString("PendingFullUpdateManualConfirmTitle"),
             MessageBoxButton.YesNo,
             MessageBoxImage.Warning,

--- a/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
@@ -1631,7 +1631,7 @@ public partial class CopilotViewModel : Screen
         var stageId = mapInfo?.StageId;
         if (mapInfo is null)
         {
-            AddLog(string.Format(LocalizationHelper.GetString("CopilotStageNameNotFound"), stageCode), UiLogColor.Error, showTime: false);
+            AddLog(LocalizationHelper.GetStringFormat("CopilotStageNameNotFound", stageCode), UiLogColor.Error, showTime: false);
             return false;
         }
 
@@ -2252,7 +2252,7 @@ public partial class CopilotViewModel : Screen
         {
             if (!DataHelper.Operators.Any(op => op.Value.Name == DataHelper.GetLocalizedCharacterName(task.Name, "zh-cn")))
             {
-                AddLog(string.Format(LocalizationHelper.GetString("CopilotIllegalOperName"), task.Name), UiLogColor.Error, showTime: false);
+                AddLog(LocalizationHelper.GetStringFormat("CopilotIllegalOperName", task.Name), UiLogColor.Error, showTime: false);
                 _ = Task.Run(ResourceUpdater.ResourceUpdateAndReloadAsync);
                 AchievementTrackerHelper.Instance.Unlock(AchievementIds.MapOutdated);
                 ok = false;

--- a/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
@@ -564,7 +564,7 @@ public class SettingsViewModel : Screen
 
             var growlInfo = new GrowlInfo {
                 IsCustom = true,
-                Message = string.Format(LocalizationHelper.GetString("AddConfigSuccess"), NewConfigurationName),
+                Message = LocalizationHelper.GetStringFormat("AddConfigSuccess", NewConfigurationName),
                 IconKey = "HangoverGeometry",
                 IconBrushKey = "PallasBrush",
             };
@@ -576,7 +576,7 @@ public class SettingsViewModel : Screen
             ConfigFactory.DeleteConfiguration(NewConfigurationName);
             var growlInfo = new GrowlInfo {
                 IsCustom = true,
-                Message = string.Format(LocalizationHelper.GetString("ConfigExists"), NewConfigurationName),
+                Message = LocalizationHelper.GetStringFormat("ConfigExists", NewConfigurationName),
                 IconKey = "HangoverGeometry",
                 IconBrushKey = "PallasBrush",
             };

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -1427,7 +1427,7 @@ public class TaskQueueViewModel : Screen
 
         var taskType = ConfigFactory.CurrentConfig.TaskQueue[taskItem.Index].TaskType;
         var result = MessageBoxHelper.Show(
-            string.Format(LocalizationHelper.GetString("ConfirmDeleteTaskMessage"), $"{taskItem.Index + 1}-{LocalizationHelper.GetString(taskType.ToString())}", taskItem.Name),
+            LocalizationHelper.GetStringFormat("ConfirmDeleteTaskMessage", $"{taskItem.Index + 1}-{LocalizationHelper.GetString(taskType.ToString())}", taskItem.Name),
             LocalizationHelper.GetString("ConfirmDeleteTask"),
             MessageBoxButton.YesNo,
             MessageBoxImage.Question);
@@ -1438,7 +1438,7 @@ public class TaskQueueViewModel : Screen
             if (index < ConfigFactory.CurrentConfig.TaskQueue.Count)
             {
                 TaskItemViewModels.RemoveAt(index);
-                AddLog(string.Format(LocalizationHelper.GetString("TaskDeleted"), taskItem.Name), UiLogColor.Info);
+                AddLog(LocalizationHelper.GetStringFormat("TaskDeleted", taskItem.Name), UiLogColor.Info);
                 AchievementTrackerHelper.Instance.Unlock(AchievementIds.QueueSimplifier);
             }
         }
@@ -1756,8 +1756,8 @@ public class TaskQueueViewModel : Screen
         if (maxTimeInterval > 90)
         {
             AddLog(
-                string.Format(
-                    LocalizationHelper.GetString("Achievement.Martian.ConditionsTip"),
+                LocalizationHelper.GetStringFormat(
+                    "Achievement.Martian.ConditionsTip",
                     Math.Round(maxTimeInterval / 30, 1)),
                 UiLogColor.Error);
         }

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/ConnectSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/ConnectSettingsUserControlModel.cs
@@ -262,7 +262,7 @@ public class ConnectSettingsUserControlModel : PropertyChangedBase
 
     public string ScreencapTestCost { get; set; } = string.Empty;
 
-    private string _screencapCost = string.Format(LocalizationHelper.GetString("ScreencapCost"), "---", "---", "---", "---");
+    private string _screencapCost = LocalizationHelper.GetStringFormat("ScreencapCost", "---", "---", "---", "---");
 
     public string ScreencapCost
     {

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/VersionUpdateSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/VersionUpdateSettingsUserControlModel.cs
@@ -359,7 +359,7 @@ public class VersionUpdateSettingsUserControlModel : PropertyChangedBase
         MirrorChyanCdkExpiredTime != 0
         ? IsMirrorChyanCdkExpired
             ? LocalizationHelper.GetString("MirrorChyanCdkExpired")
-            : string.Format(LocalizationHelper.GetString("MirrorChyanCdkRemainingDays"),
+            : LocalizationHelper.GetStringFormat("MirrorChyanCdkRemainingDays",
                             MirrorChyanCdkRemaining.TotalDays.ToString("F1"))
         : string.Empty;
 

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/RoguelikeSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/RoguelikeSettingsUserControlModel.cs
@@ -854,11 +854,11 @@ public class RoguelikeSettingsUserControlModel : TaskSettingsViewModel, Roguelik
                 break;
 
             case "RoguelikeInvestmentReachLimit":
-                Instances.TaskQueueViewModel.AddLog(string.Format(LocalizationHelper.GetString("RoguelikeInvestmentReachLimit"), subTaskDetails!["limit"]), UiLogColor.Info);
+                Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetStringFormat("RoguelikeInvestmentReachLimit", subTaskDetails!["limit"]), UiLogColor.Info);
                 break;
 
             case "RoguelikeInvestment":
-                Instances.TaskQueueViewModel.AddLog(string.Format(LocalizationHelper.GetString("RoguelikeInvestment"), subTaskDetails!["count"], subTaskDetails["total"], subTaskDetails["deposit"]), UiLogColor.Info);
+                Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetStringFormat("RoguelikeInvestment", subTaskDetails!["count"], subTaskDetails["total"], subTaskDetails["deposit"]), UiLogColor.Info);
                 AchievementTrackerHelper.Instance.SetProgress(AchievementIds.RoguelikeGoldMax, (int)subTaskDetails["deposit"]!);
                 break;
 
@@ -881,8 +881,8 @@ public class RoguelikeSettingsUserControlModel : TaskSettingsViewModel, Roguelik
                         }
                     }
 
-                    var roguelikeInfo = string.Format(
-                        LocalizationHelper.GetString("RoguelikeSettlement"),
+                    var roguelikeInfo = LocalizationHelper.GetStringFormat(
+                        "RoguelikeSettlement",
                         pass ? "✓" : "✗",
                         report["floor"],
                         report["step"],
@@ -936,14 +936,14 @@ public class RoguelikeSettingsUserControlModel : TaskSettingsViewModel, Roguelik
                 var options = (subTaskDetails!["options"]! as JArray) ?? [];
                 var logLines = new List<string>
                 {
-                    string.Format(LocalizationHelper.GetString("RoguelikeEncounterOptions"), options.Count, UiLogColor.EventIS),
+                    LocalizationHelper.GetStringFormat("RoguelikeEncounterOptions", options.Count, UiLogColor.EventIS),
                 };
 
                 foreach (var option in options)
                 {
                     string messageKey = option["enabled"]!.Value<bool>() ? "RoguelikeEncounterEnabledOption" : "RoguelikeEncounterDisabledOption";
                     var text = option["text"]!.ToString();
-                    logLines.Add(string.Format(LocalizationHelper.GetString(messageKey), text));
+                    logLines.Add(LocalizationHelper.GetStringFormat(messageKey, text));
                 }
 
                 Instances.TaskQueueViewModel.AddLog(string.Join("\n", logLines), UiLogColor.EventIS, updateCardImage: true);
@@ -971,7 +971,7 @@ public class RoguelikeSettingsUserControlModel : TaskSettingsViewModel, Roguelik
             case "RoguelikeCoppersRecognitionError":
                 {
                     var recognizedName = subTaskDetails!["recognized_name"]?.ToString() ?? "Unknown";
-                    var message = string.Format(LocalizationHelper.GetString("RoguelikeCoppersRecognitionError"), recognizedName);
+                    var message = LocalizationHelper.GetStringFormat("RoguelikeCoppersRecognitionError", recognizedName);
                     Instances.TaskQueueViewModel.AddLog(message, UiLogColor.Error);
                     break;
                 }
@@ -980,7 +980,7 @@ public class RoguelikeSettingsUserControlModel : TaskSettingsViewModel, Roguelik
                 {
                     var toDiscard = subTaskDetails!["to_discard"]?.ToString() ?? "Unknown";
                     var toPickup = subTaskDetails["to_pickup"]?.ToString() ?? "Unknown";
-                    var message = string.Format(LocalizationHelper.GetString("RoguelikeCoppersExchange"), toDiscard, toPickup);
+                    var message = LocalizationHelper.GetStringFormat("RoguelikeCoppersExchange", toDiscard, toPickup);
                     Instances.TaskQueueViewModel.AddLog(message, UiLogColor.EventIS);
                     break;
                 }
@@ -998,7 +998,7 @@ public class RoguelikeSettingsUserControlModel : TaskSettingsViewModel, Roguelik
                         "Nian" => LocalizationHelper.GetString("RoguelikePlaytimeNian"),
                         _ => targetSubtype ?? "Unknown",
                     };
-                    Instances.TaskQueueViewModel.AddLog(string.Format(LocalizationHelper.GetString("RoguelikeJieGardenTargetFound"), localizedTarget), UiLogColor.Success);
+                    Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetStringFormat("RoguelikeJieGardenTargetFound", localizedTarget), UiLogColor.Success);
                     break;
                 }
 
@@ -1025,19 +1025,19 @@ public class RoguelikeSettingsUserControlModel : TaskSettingsViewModel, Roguelik
                 string prev = subTaskDetails["prev"]?.ToString() ?? "UnKnown";
                 if (deepen_or_weaken == 1 && prev == string.Empty)
                 {
-                    Instances.TaskQueueViewModel.AddLog(string.Format(LocalizationHelper.GetString("RoguelikeGainParadigm"), cur), UiLogColor.Info);
+                    Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetStringFormat("RoguelikeGainParadigm", cur), UiLogColor.Info);
                 }
                 else if (deepen_or_weaken == 1 && prev != string.Empty)
                 {
-                    Instances.TaskQueueViewModel.AddLog(string.Format(LocalizationHelper.GetString("RoguelikeDeepenParadigm"), cur, prev), UiLogColor.Info);
+                    Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetStringFormat("RoguelikeDeepenParadigm", cur, prev), UiLogColor.Info);
                 }
                 else if (deepen_or_weaken == -1 && cur == string.Empty)
                 {
-                    Instances.TaskQueueViewModel.AddLog(string.Format(LocalizationHelper.GetString("RoguelikeLoseParadigm"), string.Empty, prev), UiLogColor.Info);
+                    Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetStringFormat("RoguelikeLoseParadigm", string.Empty, prev), UiLogColor.Info);
                 }
                 else if (deepen_or_weaken == -1 && cur != string.Empty)
                 {
-                    Instances.TaskQueueViewModel.AddLog(string.Format(LocalizationHelper.GetString("RoguelikeWeakenParadigm"), cur, prev), UiLogColor.Info);
+                    Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetStringFormat("RoguelikeWeakenParadigm", cur, prev), UiLogColor.Info);
                 }
 
                 break;


### PR DESCRIPTION
## Summary by Sourcery

通过将外部的 `string.Format` 调用替换为 `LocalizationHelper.GetStringFormat` 辅助方法，并扩展其参数类型以接受可空对象，统一本地化字符串格式化方式。

增强内容：
- 通过将 `string.Format(LocalizationHelper.GetString(...), ...)` 这类直接调用模式替换为 `LocalizationHelper.GetStringFormat`，在 UI 日志、通知和对话框消息中统一 `LocalizationHelper` 的使用方式。
- 更新 `LocalizationHelper.GetStringFormat` 以接受可为空的格式化参数，从而实现更安全、更灵活的字符串格式化。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify localized string formatting by replacing external string.Format calls with the LocalizationHelper.GetStringFormat helper and widening its parameter type to accept nullable objects.

Enhancements:
- Standardize usage of LocalizationHelper by replacing direct string.Format(LocalizationHelper.GetString(...), ...) patterns with LocalizationHelper.GetStringFormat across UI logging, notifications, and dialog messages.
- Update LocalizationHelper.GetStringFormat to accept nullable format arguments for safer and more flexible formatting.

</details>