### PR TITLE
fix: 修复宿舍自定义干员+信赖补位的bug

### DIFF
--- a/resource/global/YoStarEN/resource/tasks/tasks.json
+++ b/resource/global/YoStarEN/resource/tasks/tasks.json
@@ -1260,6 +1260,9 @@
         "fullMatch": true,
         "text": ["Morale", "Resting", "In Use", "Working", "Assign"]
     },
+    "InfrastFilterMenuAllButton": {
+        "text": ["All"]
+    },
     "InfrastConfirmButtonWait": {
         "text": ["Submitting feedback", "to the neural network"],
         "roi": [675, 605, 427, 115]

--- a/resource/global/YoStarJP/resource/tasks/tasks.json
+++ b/resource/global/YoStarJP/resource/tasks/tasks.json
@@ -1220,6 +1220,9 @@
     "InfrastEnterOperList": {
         "text": ["体力", "休憩中", "仕事中", "配属"]
     },
+    "InfrastFilterMenuAllButton": {
+        "text": ["全て"]
+    },
     "InfrastTrainingIdle": {
         "text": ["待機中"],
         "roi": [325, 637, 180, 50]

--- a/resource/global/YoStarKR/resource/tasks/tasks.json
+++ b/resource/global/YoStarKR/resource/tasks/tasks.json
@@ -1322,6 +1322,9 @@
     "InfrastEnterOperList": {
         "text": ["컨디션", "휴식중", "업무중", "배치"]
     },
+    "InfrastFilterMenuAllButton": {
+        "text": ["전부"]
+    },
     "InfrastConfirmButtonWait": {
         "text": ["피드백", "전달"],
         "roi": [700, 620, 400, 80]

--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -2796,15 +2796,30 @@
         "template": ["InfrastFilterMenu.png", "InfrastFilterMenu2.png"],
         "roi": [1050, 0, 230, 100],
         "postDelay": 1000,
-        "next": ["InfrastFilterMenuNotStationedButton", "InfrastFilterMenuNotStationedButtonAlreadyClicked"]
+        "next": ["InfrastFilterMenuNotStationedButton"]
+    },
+    "InfrastFilterMenuNotStationedSelected": {
+        "action": "DoNothing",
+        "template": "InfrastFilterMenu3.png",
+        "roi": [1050, 0, 230, 100],
+        "next": ["Stop"]
     },
     "InfrastFilterMenuNotStationedButton": {
         "action": "ClickSelf",
         "templThreshold": 0.85,
         "roi": [300, 160, 890, 300],
+        "maxTimes": 3,
         "postDelay": 1000,
-        "next_Doc": "国服现在没有 InfrastFilterMenuConfirmButton 了，加个 Stop",
-        "next": ["InfrastFilterMenuConfirmButton", "Stop"]
+        "next": ["InfrastFilterMenuOpenedAfterNotStationedClick"],
+        "onErrorNext": ["Stop"]
+    },
+    "InfrastFilterMenuOpenedAfterNotStationedClick": {
+        "baseTask": "InfrastFilterMenuAllButton",
+        "action": "DoNothing",
+        "Doc": "点击“未进驻”后，通过检测“全部”是否仍可见判断菜单是否还打开；仍可见则补点，消失则认为选择完成。",
+        "postDelay": 300,
+        "next": ["InfrastFilterMenuNotStationedButton"],
+        "onErrorNext": ["Stop"]
     },
     "InfrastFilterMenuNotStationedButtonAlreadyClicked": {
         "roi": [300, 160, 890, 300],
@@ -2823,7 +2838,18 @@
         "action": "ClickSelf",
         "text": ["全部"],
         "roi": [1050, 65, 150, 70],
-        "postDelay": 1000
+        "maxTimes": 3,
+        "postDelay": 1000,
+        "next": ["InfrastFilterMenuAllButtonGone"],
+        "onErrorNext": ["Stop"]
+    },
+    "InfrastFilterMenuAllButtonGone": {
+        "baseTask": "InfrastFilterMenuAllButton",
+        "action": "DoNothing",
+        "Doc": "点击“全部”后，通过检测“全部”是否仍可见判断菜单是否还打开；仍可见则补点，消失则认为取消完成。",
+        "postDelay": 300,
+        "next": ["InfrastFilterMenuAllButton"],
+        "onErrorNext": ["Stop"]
     },
     "InfrastFilterMenuCancelNotStationedButton": {
         "template": "InfrastFilterMenuNotStationedButton.png",

--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -2816,7 +2816,14 @@
         "template": ["InfrastFilterMenu.png", "InfrastFilterMenu3.png"],
         "roi": [1050, 0, 230, 100],
         "postDelay": 1000,
-        "next": ["InfrastFilterMenuCancelNotStationedButtonAlreadyClicked", "InfrastFilterMenuCancelNotStationedButton"]
+        "next": ["InfrastFilterMenuAllButton"]
+    },
+    "InfrastFilterMenuAllButton": {
+        "algorithm": "OcrDetect",
+        "action": "ClickSelf",
+        "text": ["全部"],
+        "roi": [1050, 65, 150, 70],
+        "postDelay": 1000
     },
     "InfrastFilterMenuCancelNotStationedButton": {
         "template": "InfrastFilterMenuNotStationedButton.png",

--- a/src/MaaCore/Task/Infrast/InfrastAbstractTask.cpp
+++ b/src/MaaCore/Task/Infrast/InfrastAbstractTask.cpp
@@ -670,16 +670,24 @@ bool asst::InfrastAbstractTask::click_filter_menu_not_stationed_button()
 {
     LogTraceFunction;
 
-    ProcessTask task(*this, { "InfrastFilterMenuNotStationed" });
-    return task.run();
+    // 如果菜单已经打开，先直接找菜单里的“未进驻”；如果顶部已是“未进驻”选中态，直接成功。
+    // 否则先点击顶部筛选菜单再找“未进驻”。最终必须走到 Stop 才返回 true。
+    ProcessTask task(
+        *this,
+        { "InfrastFilterMenuNotStationedButton",
+          "InfrastFilterMenuNotStationedSelected",
+          "InfrastFilterMenuNotStationed" });
+    return task.run() && task.get_last_task_name() == "Stop";
 }
 
 bool asst::InfrastAbstractTask::click_filter_menu_cancel_not_stationed_button()
 {
     LogTraceFunction;
 
-    ProcessTask task(*this, { "InfrastFilterMenuCancelNotStationed" });
-    return task.run();
+    // 如果菜单已经打开，直接找“全部”；否则先点击顶部筛选菜单再找“全部”。
+    // 最终必须走到 Stop 才算取消成功。
+    ProcessTask task(*this, { "InfrastFilterMenuAllButton", "InfrastFilterMenuCancelNotStationed" });
+    return task.run() && task.get_last_task_name() == "Stop";
 }
 
 bool asst::InfrastAbstractTask::click_confirm_button()

--- a/src/MaaCore/Task/Infrast/InfrastDormTask.cpp
+++ b/src/MaaCore/Task/Infrast/InfrastDormTask.cpp
@@ -55,17 +55,21 @@ bool asst::InfrastDormTask::_run()
         // EDIT: 25.7.17 把未进驻的筛选移到了清空之前，看看会不会有问题
         // 按原来的逻辑先清空再筛选的话，会把第一个宿舍的人隐藏，假设当前只有 20 个人需要回复心情
         // 会导致第宿舍全塞入信赖干员，使得 5 人最后不能休息
+        auto origin_room_config = current_room_config();
+        const bool use_custom_opers = is_use_custom_opers();
+
         Log.trace("m_dorm_notstationed_enabled:", m_dorm_notstationed_enabled);
-        if (m_dorm_notstationed_enabled && !m_if_filter_notstationed_haspressed) {
+        if (m_dorm_notstationed_enabled && !m_if_filter_notstationed_haspressed && !use_custom_opers) {
             Log.trace("click_filter_menu_not_stationed_button");
             click_filter_menu_not_stationed_button();
             m_if_filter_notstationed_haspressed = true;
         }
 
-        auto origin_room_config = current_room_config();
-        if (is_use_custom_opers()) {
+        if (use_custom_opers) {
             // 自定义干员可能正在其他宿舍休息，选择前临时关闭“未进驻”筛选。
             const bool filter_notstationed_before_custom = m_if_filter_notstationed_haspressed;
+            const bool need_notstationed_after_custom =
+                filter_notstationed_before_custom || m_dorm_notstationed_enabled;
             if (filter_notstationed_before_custom) {
                 Log.trace("click_filter_menu_cancel_not_stationed_button");
                 click_filter_menu_cancel_not_stationed_button();
@@ -74,7 +78,7 @@ bool asst::InfrastDormTask::_run()
 
             swipe_and_select_custom_opers(true);
 
-            if (filter_notstationed_before_custom) {
+            if (need_notstationed_after_custom && !m_if_filter_notstationed_haspressed) {
                 Log.trace("click_filter_menu_not_stationed_button");
                 click_filter_menu_not_stationed_button();
                 m_if_filter_notstationed_haspressed = true;

--- a/src/MaaCore/Task/Infrast/InfrastDormTask.cpp
+++ b/src/MaaCore/Task/Infrast/InfrastDormTask.cpp
@@ -10,21 +10,34 @@
 #include "Vision/Matcher.h"
 #include "Vision/RegionOCRer.h"
 
-asst::InfrastDormTask& asst::InfrastDormTask::set_notstationed_enabled(bool dorm_notstationed_enabled) noexcept
+namespace
 {
-    m_dorm_notstationed_enabled = dorm_notstationed_enabled;
+constexpr int OperFullTrustValue = 200;
+// After enough full-trust candidates are seen on one page, trust autofill is
+// considered exhausted and the flow falls back to regular filling.
+constexpr size_t TrustAutofillThreshold = 6;
+// Seeing enough resting entries means the low-mood scan on the current page is
+// effectively finished, so the flow can switch to the next phase.
+constexpr size_t RestingOperCountThreshold = 6;
+// Active facility labels are expected to look like 1F01 or B101.
+constexpr size_t ActiveFacilityNumberLength = 4;
+}
+
+asst::InfrastDormTask& asst::InfrastDormTask::set_notstationed_enabled(bool notstationed_filter_enabled) noexcept
+{
+    m_notstationed_filter_enabled = notstationed_filter_enabled;
     return *this;
 }
 
-asst::InfrastDormTask& asst::InfrastDormTask::set_trust_enabled(bool dorm_trust_enabled) noexcept
+asst::InfrastDormTask& asst::InfrastDormTask::set_trust_enabled(bool trust_autofill_enabled) noexcept
 {
-    m_dorm_trust_enabled = dorm_trust_enabled;
+    m_trust_autofill_enabled = trust_autofill_enabled;
     return *this;
 }
 
 bool asst::InfrastDormTask::on_run_fails()
 {
-    m_if_filter_notstationed_haspressed = false;
+    m_notstationed_filter_active = false;
     return asst::InfrastAbstractTask::on_run_fails();
 }
 
@@ -39,7 +52,6 @@ bool asst::InfrastDormTask::_run()
             continue;
         }
 
-        // 进不去说明设施数量不够
         if (!enter_facility(m_cur_facility_index)) {
             swipe_to_the_left_of_main_ui();
             if (!enter_facility(m_cur_facility_index)) {
@@ -52,95 +64,60 @@ bool asst::InfrastDormTask::_run()
 
         close_quick_formation_expand_role();
 
-        // EDIT: 25.7.17 把未进驻的筛选移到了清空之前，看看会不会有问题
-        // 按原来的逻辑先清空再筛选的话，会把第一个宿舍的人隐藏，假设当前只有 20 个人需要回复心情
-        // 会导致第宿舍全塞入信赖干员，使得 5 人最后不能休息
-        auto origin_room_config = current_room_config();
-        const bool use_custom_opers = is_use_custom_opers();
+        const auto room_config = current_room_config();
+        const bool room_uses_custom_opers = is_use_custom_opers();
 
-        Log.trace("m_dorm_notstationed_enabled:", m_dorm_notstationed_enabled);
-        if (m_dorm_notstationed_enabled && !m_if_filter_notstationed_haspressed && !use_custom_opers) {
-            Log.trace("click_filter_menu_not_stationed_button");
-            // 筛选状态变量只在 helper 确认 UI 操作完成后更新，避免内部状态和真实 UI 脱节。
-            if (!click_filter_menu_not_stationed_button()) {
+        Log.trace("m_notstationed_filter_enabled:", m_notstationed_filter_enabled);
+        if (m_notstationed_filter_enabled && !room_uses_custom_opers) {
+            if (!set_notstationed_filter(true)) {
                 return false;
             }
-            m_if_filter_notstationed_haspressed = true;
         }
 
-        if (use_custom_opers) {
-            // 自定义干员可能正在其他宿舍休息，选择前临时关闭“未进驻”筛选。
-            const bool filter_notstationed_before_custom = m_if_filter_notstationed_haspressed;
-            const bool need_notstationed_after_custom =
-                filter_notstationed_before_custom || m_dorm_notstationed_enabled;
-            if (filter_notstationed_before_custom) {
-                Log.trace("click_filter_menu_cancel_not_stationed_button");
-                if (!click_filter_menu_cancel_not_stationed_button()) {
-                    return false;
-                }
-                m_if_filter_notstationed_haspressed = false;
+        if (room_uses_custom_opers) {
+            // Custom dorm operators may already be resting in other dorms.
+            const bool filter_was_active_before_custom_select = m_notstationed_filter_active;
+            // Restore the room's original filter intent after the temporary custom search.
+            const bool should_restore_notstationed_filter =
+                filter_was_active_before_custom_select || m_notstationed_filter_enabled;
+
+            if (filter_was_active_before_custom_select && !set_notstationed_filter(false)) {
+                return false;
             }
 
             swipe_and_select_custom_opers(true);
 
-            if (need_notstationed_after_custom && !m_if_filter_notstationed_haspressed) {
-                Log.trace("click_filter_menu_not_stationed_button");
-                if (!click_filter_menu_not_stationed_button()) {
-                    return false;
-                }
-                m_if_filter_notstationed_haspressed = true;
+            if (should_restore_notstationed_filter && !set_notstationed_filter(true)) {
+                return false;
             }
 
-            /*
-             * 此处修复前，自定义宿舍干员 + 自动补位同时开启时，
-             * swipe_and_select_custom_opers(true); 会找指定干员并切心情排序。
-             * 但前一个宿舍处理完低心情干员后，
-             * m_next_step 可能已进入 Trust / RestDone，
-             * 进入下一个宿舍时，这个状态没有回到普通心情阶段。
-             * 所以 opers_choose() 会把当前列表当成信赖列表解析，结果读到的 opertrust 是空的
-             * 要么把带数字的干员选上（小车、12F）偶然成功，要么就一直右滑卡死
-             * 修复：信赖补位前切回信赖排序
-             */
-            if (origin_room_config.autofill && m_dorm_trust_enabled &&
-                (m_next_step == NextStep::RestDone || m_next_step == NextStep::Trust)) {
-                Log.trace("click_sort_by_trust_button");
-                if (!click_sort_by_trust_button()) {
-                    return false;
-                }
-            }
-        }
-        else {
-            click_clear_button(); // 宿舍若未指定干员，则清空后按照原约定逻辑选择干员
-        }
-
-        if (!m_is_custom || current_room_config().autofill) {
-            if (!opers_choose(origin_room_config)) {
+            if (!restore_list_sort_for_selection_phase(room_config)) {
                 return false;
             }
         }
-        // else {
-        //     if (!select_opers_review(origin_room_config)) {
-        //         current_room_config() = std::move(origin_room_config);
-        //         return false;
-        //     }
-        // }
+        else {
+            // If no custom dorm operators are configured, clear first and refill by the default flow.
+            click_clear_button();
+        }
+
+        if (!m_is_custom || current_room_config().autofill) {
+            if (!fill_dorm_slots()) {
+                return false;
+            }
+        }
 
         click_confirm_button();
         click_return_button();
 
-        if (m_next_step == NextStep::AllDone) { // 不蹭信赖或所有干员满信赖
-            break;
-        }
     }
     return true;
 }
 
-bool asst::InfrastDormTask::opers_choose(asst::infrast::CustomRoomConfig const& origin_room_config)
+bool asst::InfrastDormTask::fill_dorm_slots()
 {
     size_t num_of_selected = m_is_custom ? current_room_config().selected : 0;
     size_t num_of_fulltrust = 0;
-    bool to_fill = false;
-    int swipe_times [[maybe_unused]] = 0;
+    bool fill_remaining_slots = false;
 
     while (num_of_selected < max_num_of_opers()) {
         if (need_exit()) {
@@ -156,10 +133,10 @@ bool asst::InfrastDormTask::opers_choose(asst::infrast::CustomRoomConfig const& 
             return false;
         }
         oper_analyzer.sort_by_mood();
-        const auto& oper_result = oper_analyzer.get_result();
+        const auto& opers = oper_analyzer.get_result();
 
         size_t num_of_resting = 0;
-        for (const auto& oper : oper_result) {
+        for (const auto& oper : opers) {
             if (need_exit()) {
                 return false;
             }
@@ -167,177 +144,204 @@ bool asst::InfrastDormTask::opers_choose(asst::infrast::CustomRoomConfig const& 
                 Log.info("num_of_selected:", num_of_selected, ", just break");
                 break;
             }
-            if (to_fill) {
+            if (fill_remaining_slots) {
                 if (oper.doing != infrast::Doing::Working && !oper.selected) {
-                    Log.info("to fill");
+                    Log.info("fill remaining slots");
                     ctrler()->click(oper.rect);
                     ++num_of_selected;
                 }
                 continue;
             }
+
             switch (oper.smiley.type) {
             case infrast::SmileyType::Rest:
-                if (m_next_step == NextStep::Fill) {
-                    to_fill = true;
-                    Log.info("set to_fill = true;");
+                if (m_selection_phase == SelectionPhase::FillRemaining) {
+                    fill_remaining_slots = true;
+                    Log.info("switch to fill remaining slots");
                     if (oper.doing != infrast::Doing::Working && !oper.selected) {
-                        Log.info("to fill");
+                        Log.info("fill remaining slots");
                         ctrler()->click(oper.rect);
                         ++num_of_selected;
                     }
                     continue;
                 }
-                // 如果所有心情不满的干员已经放入宿舍，就把信赖不满的干员放入宿舍
-                if (m_dorm_trust_enabled && m_next_step != NextStep::Rest && oper.selected == false &&
-                    oper.doing != infrast::Doing::Working && oper.doing != infrast::Doing::Resting) {
-                    // 获得干员信赖值
+
+                if (m_trust_autofill_enabled && m_selection_phase != SelectionPhase::LowMood &&
+                    !oper.selected && oper.doing != infrast::Doing::Working &&
+                    oper.doing != infrast::Doing::Resting) {
                     RegionOCRer trust_analyzer(oper.name_img);
                     if (!trust_analyzer.analyze()) {
                         Log.trace("ERROR:!trust_analyzer.analyze()");
                         break;
                     }
 
-                    std::string opertrust = trust_analyzer.get_result().text;
-                    boost::regex rule("[^0-9]"); // 只保留数字
-                    opertrust = boost::regex_replace(opertrust, rule, "");
-                    Log.trace("opertrust:", opertrust);
+                    std::string oper_trust_text = trust_analyzer.get_result().text;
+                    boost::regex trust_rule("[^0-9]");
+                    oper_trust_text = boost::regex_replace(oper_trust_text, trust_rule, "");
+                    Log.trace("oper_trust_text:", oper_trust_text);
 
-                    bool if_opertrust_not_full = false;
-                    if (!opertrust.empty()) {
-                        int trust = std::stoi(opertrust);
-                        if (trust < 200) {
-                            if_opertrust_not_full = true;
+                    bool has_incomplete_trust = false;
+                    if (!oper_trust_text.empty()) {
+                        const int trust = std::stoi(oper_trust_text);
+                        if (trust < OperFullTrustValue) {
+                            has_incomplete_trust = true;
                         }
                         else {
-                            num_of_fulltrust++;
+                            ++num_of_fulltrust;
                         }
                     }
-                    if (num_of_fulltrust >= 6) { // 所有干员都满信赖了
+                    if (num_of_fulltrust >= TrustAutofillThreshold) {
                         Log.trace("num_of_fulltrust:", num_of_fulltrust);
-                        m_next_step = NextStep::Fill;
-                        to_fill = true;
-                        if (!m_dorm_notstationed_enabled && m_if_filter_notstationed_haspressed) {
-                            click_filter_menu_cancel_not_stationed_button();
+                        m_selection_phase = SelectionPhase::FillRemaining;
+                        fill_remaining_slots = true;
+                        if (!m_notstationed_filter_enabled && m_notstationed_filter_active) {
+                            set_notstationed_filter(false);
                         }
-                        click_order_by_mood();
+                        switch_to_mood_sort();
                         break;
                     }
 
-                    // 获得干员所在设施
                     RegionOCRer facility_analyzer(oper.facility_img);
                     if (!facility_analyzer.analyze()) {
                         Log.trace("ERROR:!facility_analyzer.analyze()");
                         break;
                     }
 
-                    std::string facilityname = facility_analyzer.get_result().text;
-                    boost::regex rule2("[^BF0-9]"); // 只保留B、F和数字
-                    facilityname = boost::regex_replace(facilityname, rule2, "");
+                    std::string facility_name = facility_analyzer.get_result().text;
+                    boost::regex facility_rule("[^BF0-9]");
+                    facility_name = boost::regex_replace(facility_name, facility_rule, "");
 
-                    Log.trace("facilityname:<" + facilityname + ">");
-                    bool if_oper_not_stationed = facilityname.length() < 4; // 只有形如1F01或B101才是设施标签
+                    Log.trace("facility_name:<" + facility_name + ">");
+                    const bool is_not_stationed = facility_name.length() < ActiveFacilityNumberLength;
 
-                    // 判断要不要把人放进宿舍if_opertrust_not_full && if_oper_not_stationed
-                    if (if_opertrust_not_full && if_oper_not_stationed) {
+                    if (has_incomplete_trust && is_not_stationed) {
                         ctrler()->click(oper.rect);
                         ++num_of_selected;
                     }
                     else {
-                        Log.trace("not put oper in");
+                        Log.trace("skip trust autofill candidate");
                     }
                 }
-                // 如果当前页面休息完成的人数超过5个，说明已经已经把所有心情不满的滑过一遍、没有更多的了
-                else if (++num_of_resting >= 6) {
+                else if (++num_of_resting >= RestingOperCountThreshold) {
                     Log.trace("num_of_resting:", num_of_resting, ", dorm finished");
-                    if (m_dorm_trust_enabled) {
-                        Log.trace("m_dorm_trust_enabled:", m_dorm_trust_enabled);
-                        if (!m_if_filter_notstationed_haspressed) {
-                            Log.trace("click_filter_menu_not_stationed_button");
-                            click_filter_menu_not_stationed_button();
-                            m_if_filter_notstationed_haspressed = true;
-                        }
-                        Log.trace("click_sort_by_trust_button");
-                        click_sort_by_trust_button();
-                        m_next_step = NextStep::RestDone; // 选中未进驻标签并按信赖值排序
+                    if (m_trust_autofill_enabled) {
+                        // We have exhausted the low-mood pass on this page. Switch to the
+                        // trust-autofill view and let the next iteration re-read the list.
+                        switch_to_trust_autofill_phase();
                     }
                     else {
-                        Log.trace("m_dorm_trust_enabled:", m_dorm_trust_enabled);
-                        m_next_step = NextStep::Fill;
-                        // click_filter_menu_cancel_not_stationed_button();
-                        // click_order_by_mood();
+                        m_selection_phase = SelectionPhase::FillRemaining;
                     }
                 }
                 break;
+
             case infrast::SmileyType::Work:
             case infrast::SmileyType::Distract:
-                // 干员没有被选择的情况下，且不在工作，就进驻宿舍
-                if (oper.selected == false && oper.doing != infrast::Doing::Working) {
+                if (!oper.selected && oper.doing != infrast::Doing::Working) {
                     ctrler()->click(oper.rect);
                     ++num_of_selected;
                 }
                 break;
+
             default:
                 break;
             }
-            // 按信赖排序后需要重新识图，中断循环
-            if (m_next_step == NextStep::RestDone) {
+
+            // Sorting changes the visible list order, so stop this pass and OCR again.
+            if (m_selection_phase == SelectionPhase::ResortForTrust) {
                 break;
             }
 
-            // 如果是之前设置的to_fill，走不到这里，一定是当次设置的
-            if (to_fill) {
+            if (fill_remaining_slots) {
                 swipe_of_operlist();
-                ++swipe_times;
                 break;
             }
         }
+
         if (num_of_selected >= max_num_of_opers()) {
             Log.trace("num_of_selected:", num_of_selected, ", just break");
-            // 若当前宿舍已满人，则按信赖排序后不需要跳过滑动列表
-            if (m_next_step == NextStep::RestDone) {
-                m_next_step = NextStep::Trust;
-            }
+            advance_after_trust_sort();
             break;
         }
 
-        // 若当前宿舍未满人，则按信赖排序后需要跳过一次滑动列表
-        if (m_next_step == NextStep::RestDone) {
-            m_next_step = NextStep::Trust;
+        if (m_selection_phase == SelectionPhase::ResortForTrust) {
+            advance_after_trust_sort();
         }
         else {
             swipe_of_operlist();
-            ++swipe_times;
         }
     }
 
     ProcessTask(*this, { "InfrastOperListTabMoodClick", "InfrastOperListTabWorkStatusUnClicked" }).run();
-    // if (swipe_times) swipe_to_the_left_of_operlist(swipe_times + 1);
-    // swipe_times = 0;
-    // bool review = select_opers_review(origin_room_config, num_of_selected);
-    if (m_next_step == NextStep::RestDone || m_next_step == NextStep::Trust) {
+    if (is_in_trust_autofill_phase()) {
         click_sort_by_trust_button();
     }
     else {
         ProcessTask(*this, { "InfrastOperListTabMoodClick" }).run();
     }
-    // if (!review) {
-    //     current_room_config() = origin_room_config;
-    //     return false;
-    // }
-    std::ignore = origin_room_config;
 
     return true;
 }
 
-bool asst::InfrastDormTask::click_order_by_mood()
+bool asst::InfrastDormTask::set_notstationed_filter(bool enabled)
+{
+    if (m_notstationed_filter_active == enabled) {
+        return true;
+    }
+
+    bool success = false;
+    if (enabled) {
+        Log.trace("click_filter_menu_not_stationed_button");
+        success = click_filter_menu_not_stationed_button();
+    }
+    else {
+        Log.trace("click_filter_menu_cancel_not_stationed_button");
+        success = click_filter_menu_cancel_not_stationed_button();
+    }
+
+    if (success) {
+        m_notstationed_filter_active = enabled;
+    }
+
+    return success;
+}
+
+bool asst::InfrastDormTask::restore_list_sort_for_selection_phase(
+    asst::infrast::CustomRoomConfig const& room_config)
+{
+    // Custom dorm selection leaves the list sorted by mood. Restore trust sort
+    // before continuing trust autofill in the same room flow.
+    if (room_config.autofill && m_trust_autofill_enabled && is_in_trust_autofill_phase()) {
+        Log.trace("click_sort_by_trust_button");
+        return click_sort_by_trust_button();
+    }
+
+    return true;
+}
+
+bool asst::InfrastDormTask::switch_to_mood_sort()
 {
     return ProcessTask(*this, { "InfrastOperListTabMoodDoubleClickWhenUnclicked", "Stop" }).run();
 }
 
-// bool asst::InfrastDormTask::click_confirm_button()
-//{
-//     LogTraceFunction;
-//
-//     ProcessTask task(*this, { "InfrastDormConfirmButton" });
-//     return task.run();
-// }
+void asst::InfrastDormTask::switch_to_trust_autofill_phase()
+{
+    Log.trace("m_trust_autofill_enabled:", m_trust_autofill_enabled);
+    set_notstationed_filter(true);
+    Log.trace("click_sort_by_trust_button");
+    click_sort_by_trust_button();
+    m_selection_phase = SelectionPhase::ResortForTrust;
+}
+
+void asst::InfrastDormTask::advance_after_trust_sort()
+{
+    if (m_selection_phase == SelectionPhase::ResortForTrust) {
+        m_selection_phase = SelectionPhase::TrustAutofill;
+    }
+}
+
+bool asst::InfrastDormTask::is_in_trust_autofill_phase() const noexcept
+{
+    return m_selection_phase == SelectionPhase::ResortForTrust ||
+        m_selection_phase == SelectionPhase::TrustAutofill;
+}

--- a/src/MaaCore/Task/Infrast/InfrastDormTask.cpp
+++ b/src/MaaCore/Task/Infrast/InfrastDormTask.cpp
@@ -64,7 +64,22 @@ bool asst::InfrastDormTask::_run()
 
         auto origin_room_config = current_room_config();
         if (is_use_custom_opers()) {
+            // 自定义干员可能正在其他宿舍休息，选择前临时关闭“未进驻”筛选。
+            const bool filter_notstationed_before_custom = m_if_filter_notstationed_haspressed;
+            if (filter_notstationed_before_custom) {
+                Log.trace("click_filter_menu_cancel_not_stationed_button");
+                click_filter_menu_cancel_not_stationed_button();
+                m_if_filter_notstationed_haspressed = false;
+            }
+
             swipe_and_select_custom_opers(true);
+
+            if (filter_notstationed_before_custom) {
+                Log.trace("click_filter_menu_not_stationed_button");
+                click_filter_menu_not_stationed_button();
+                m_if_filter_notstationed_haspressed = true;
+            }
+
             /*
              * 此处修复前，自定义宿舍干员 + 自动补位同时开启时，
              * swipe_and_select_custom_opers(true); 会找指定干员并切心情排序。
@@ -75,7 +90,7 @@ bool asst::InfrastDormTask::_run()
              * 要么把带数字的干员选上（小车、12F）偶然成功，要么就一直右滑卡死
              * 修复：信赖补位前切回信赖排序
              */
-            if (current_room_config().autofill && m_dorm_trust_enabled &&
+            if (origin_room_config.autofill && m_dorm_trust_enabled &&
                 (m_next_step == NextStep::RestDone || m_next_step == NextStep::Trust)) {
                 Log.trace("click_sort_by_trust_button");
                 if (!click_sort_by_trust_button()) {

--- a/src/MaaCore/Task/Infrast/InfrastDormTask.cpp
+++ b/src/MaaCore/Task/Infrast/InfrastDormTask.cpp
@@ -65,6 +65,23 @@ bool asst::InfrastDormTask::_run()
         auto origin_room_config = current_room_config();
         if (is_use_custom_opers()) {
             swipe_and_select_custom_opers(true);
+            /*
+             * 此处修复前，自定义宿舍干员 + 自动补位同时开启时，
+             * swipe_and_select_custom_opers(true); 会找指定干员并切心情排序。
+             * 但前一个宿舍处理完低心情干员后，
+             * m_next_step 可能已进入 Trust / RestDone，
+             * 进入下一个宿舍时，这个状态没有回到普通心情阶段。
+             * 所以 opers_choose() 会把当前列表当成信赖列表解析，结果读到的 opertrust 是空的
+             * 要么把带数字的干员选上（小车、12F）偶然成功，要么就一直右滑卡死
+             * 修复：信赖补位前切回信赖排序
+             */
+            if (current_room_config().autofill && m_dorm_trust_enabled &&
+                (m_next_step == NextStep::RestDone || m_next_step == NextStep::Trust)) {
+                Log.trace("click_sort_by_trust_button");
+                if (!click_sort_by_trust_button()) {
+                    return false;
+                }
+            }
         }
         else {
             click_clear_button(); // 宿舍若未指定干员，则清空后按照原约定逻辑选择干员

--- a/src/MaaCore/Task/Infrast/InfrastDormTask.cpp
+++ b/src/MaaCore/Task/Infrast/InfrastDormTask.cpp
@@ -61,7 +61,10 @@ bool asst::InfrastDormTask::_run()
         Log.trace("m_dorm_notstationed_enabled:", m_dorm_notstationed_enabled);
         if (m_dorm_notstationed_enabled && !m_if_filter_notstationed_haspressed && !use_custom_opers) {
             Log.trace("click_filter_menu_not_stationed_button");
-            click_filter_menu_not_stationed_button();
+            // 筛选状态变量只在 helper 确认 UI 操作完成后更新，避免内部状态和真实 UI 脱节。
+            if (!click_filter_menu_not_stationed_button()) {
+                return false;
+            }
             m_if_filter_notstationed_haspressed = true;
         }
 
@@ -72,7 +75,9 @@ bool asst::InfrastDormTask::_run()
                 filter_notstationed_before_custom || m_dorm_notstationed_enabled;
             if (filter_notstationed_before_custom) {
                 Log.trace("click_filter_menu_cancel_not_stationed_button");
-                click_filter_menu_cancel_not_stationed_button();
+                if (!click_filter_menu_cancel_not_stationed_button()) {
+                    return false;
+                }
                 m_if_filter_notstationed_haspressed = false;
             }
 
@@ -80,7 +85,9 @@ bool asst::InfrastDormTask::_run()
 
             if (need_notstationed_after_custom && !m_if_filter_notstationed_haspressed) {
                 Log.trace("click_filter_menu_not_stationed_button");
-                click_filter_menu_not_stationed_button();
+                if (!click_filter_menu_not_stationed_button()) {
+                    return false;
+                }
                 m_if_filter_notstationed_haspressed = true;
             }
 

--- a/src/MaaCore/Task/Infrast/InfrastDormTask.h
+++ b/src/MaaCore/Task/Infrast/InfrastDormTask.h
@@ -1,4 +1,5 @@
 #pragma once
+
 #include "InfrastAbstractTask.h"
 
 namespace asst
@@ -11,33 +12,36 @@ public:
 
     virtual size_t max_num_of_opers() const noexcept override { return 5ULL; }
 
-    InfrastDormTask& set_notstationed_enabled(bool dorm_notstationed_enabled) noexcept;
-    InfrastDormTask& set_trust_enabled(bool m_dorm_trust_enabled) noexcept;
+    InfrastDormTask& set_notstationed_enabled(bool notstationed_filter_enabled) noexcept;
+    InfrastDormTask& set_trust_enabled(bool trust_autofill_enabled) noexcept;
 
 protected:
     virtual bool on_run_fails() override;
 
 private:
     virtual bool _run() override;
-    // virtual bool click_confirm_button() override;
 
-    bool opers_choose(asst::infrast::CustomRoomConfig const& origin_room_config);
-    bool click_order_by_mood();
+    bool fill_dorm_slots();
+    bool set_notstationed_filter(bool enabled);
+    bool restore_list_sort_for_selection_phase(asst::infrast::CustomRoomConfig const& room_config);
+    bool switch_to_mood_sort();
+    void switch_to_trust_autofill_phase();
+    void advance_after_trust_sort();
+    bool is_in_trust_autofill_phase() const noexcept;
 
-    bool m_dorm_notstationed_enabled = false; // 设置是否启用未进驻筛选
-    bool m_dorm_trust_enabled = true;         // 设置是否启用蹭信赖
-
+    bool m_notstationed_filter_enabled = false;
+    bool m_trust_autofill_enabled = true;
     int m_max_num_of_dorm = 4;
 
-    enum class NextStep
+    enum class SelectionPhase
     {
-        Rest,
-        RestDone,
-        Trust,
-        Fill,
-        AllDone,
+        LowMood,
+        ResortForTrust,
+        TrustAutofill,
+        FillRemaining,
     };
-    NextStep m_next_step = NextStep::Rest;
-    bool m_if_filter_notstationed_haspressed = false;
+
+    SelectionPhase m_selection_phase = SelectionPhase::LowMood;
+    bool m_notstationed_filter_active = false;
 };
-}
+} // namespace asst


### PR DESCRIPTION
## 问题

解决 #16565 中宿舍任务的一部分bug。

在同时开启“自定义宿舍干员”和“自动补位”时，宿舍任务先调用 `swipe_and_select_custom_opers(true)` 查找指定干员，这个流程会把干员列表切回心情排序。

但前一个宿舍处理完低心情干员后，`m_next_step` 可能已经进入 `Trust` / `RestDone`。进入下一个宿舍时，仍会按信赖补位逻辑解析当前列表，导致在心情排序列表中读取信赖值，出现 `opertrust` 为空、反复右滑的问题。

## 修复

在自定义干员选择完成后，如果当前宿舍开启自动补位，且任务已进入信赖补位阶段，则重新切回信赖排序，再继续自动补位。


## 复现与测试
测试配置：无锁定干员；宿舍 1-4 分别指定 `闪灵`、`桃金娘`、`芙蓉`、`小满`； `dorm_trust_enabled=true`， `dorm_notstationed_enabled=false`。

### 复现

修复前，前面的低心情干员选择可以正常进行。宿舍 1 进入干员列表，执行自定义干员选择，并正常补满宿舍：

```text
[2026-05-17 06:17:19.719][INF][Px22484][Tx3828] Assistant::append_callback | SubTaskExtraInfo {"class":"asst::InfrastDormTask","details":{"candidates":[],"facility":"Dorm","index":0,"names":["闪灵"]},"subtask":"InfrastDormTask","taskchain":"Infrast","taskid":1,"uuid":"564688fd8a657262","what":"CustomInfrastRoomOperators"}
[2026-05-17 06:17:42.662][INF][Px22484][Tx3828] num_of_selected: 5 , just break
```

宿舍 2 也能正常进入，指定桃子后，低心情干员处理完，进入信赖补位阶段：

```text
[2026-05-17 06:17:52.262][INF][Px22484][Tx3828] Assistant::append_callback | SubTaskExtraInfo {"class":"asst::InfrastDormTask","details":{"candidates":[],"facility":"Dorm","index":1,"names":["桃金娘"]},"subtask":"InfrastDormTask","taskchain":"Infrast","taskid":1,"uuid":"564688fd8a657262","what":"CustomInfrastRoomOperators"}
[2026-05-17 06:18:15.395][TRC][Px22484][Tx3828] num_of_resting: 6 , dorm finished
[2026-05-17 06:18:15.395][TRC][Px22484][Tx3828] m_dorm_trust_enabled: 1
[2026-05-17 06:18:19.549][TRC][Px22484][Tx3828] click_sort_by_trust_button
[2026-05-17 06:18:22.934][INF][Px22484][Tx3828] num_of_selected: 5 , just break
```

宿舍 3 开始出现问题：自定义选择芙蓉会把列表切回心情排序，但 `m_next_step` 仍按信赖补位解析。前面一段已经读不到信赖值和设施名：

```text
[2026-05-17 06:18:39.786][INF][Px22484][Tx3828] Assistant::append_callback | SubTaskExtraInfo {"class":"asst::InfrastDormTask","details":{"candidates":[],"facility":"Dorm","index":2,"names":["芙蓉"]},"subtask":"InfrastDormTask","taskchain":"Infrast","taskid":1,"uuid":"564688fd8a657262","what":"CustomInfrastRoomOperators"}
[2026-05-17 06:18:39.786][INF][Px22484][Tx3828] {"class":"asst::ProcessTask","cur_task":"","details":{"cur_retry":0,"retry_times":3,"to_be_recognized":["InfrastOperListTabMoodDoubleClickWhenUnclicked"]},"first":["InfrastOperListTabMoodDoubleClickWhenUnclicked"],"pre_task":"","subtask":"ProcessTask","taskchain":"Infrast","taskid":1}
[2026-05-17 06:18:53.337][TRC][Px22484][Tx3828] asst::InfrastOperImageAnalyzer::sort_by_mood | enter
[2026-05-17 06:18:53.337][TRC][Px22484][Tx3828] asst::InfrastOperImageAnalyzer::sort_by_mood | leave, 0 ms
[2026-05-17 06:18:53.349][TRC][Px22484][Tx3828] opertrust: 
[2026-05-17 06:18:53.358][TRC][Px22484][Tx3828] facilityname:<>
[2026-05-17 06:18:53.358][TRC][Px22484][Tx3828] not put oper in
[2026-05-17 06:18:59.730][INF][Px22484][Tx3828] {"class":"asst::ProcessTask","cur_task":"","details":{"cur_retry":0,"retry_times":3,"to_be_recognized":["InfrastOperListSlowlySwipeToTheRight"]},"first":["InfrastOperListSlowlySwipeToTheRight"],"pre_task":"","subtask":"ProcessTask","taskchain":"Infrast","taskid":1}
```

但宿舍 3 最后同样碰巧继续走下去了，因为有小车之类的带数字，被误当作信赖值，然后选中：

```text
[2026-05-17 06:19:50.811][TRC][Px22484][Tx3828] asst::WordOcr [{ text: 12F, rect: [ 0 (84), 0 (1), 38, 19 ], score: 0.981824 }] by OCR Rec , cost 10 ms
[2026-05-17 06:19:50.811][TRC][Px22484][Tx3828] opertrust: 12
[2026-05-17 06:19:50.823][TRC][Px22484][Tx3828] facilityname:<4>
[2026-05-17 06:19:50.823][TRC][Px22484][Tx3828] Click with scaled coordinates (700, 465) 1.5
[2026-05-17 06:19:50.989][TRC][Px22484][Tx3828] asst::WordOcr [{ text: CONFESS-47, rect: [ 0 (0), 0 (1), 122, 19 ], score: 0.958664 }] by OCR Rec , cost 16 ms
[2026-05-17 06:19:50.989][TRC][Px22484][Tx3828] opertrust: 47
[2026-05-17 06:19:51.003][TRC][Px22484][Tx3828] Click with scaled coordinates (995, 112) 1.5
[2026-05-17 06:19:51.232][INF][Px22484][Tx3828] num_of_selected: 5 , just break
```

到宿舍 4 后，同样切回心情排序，但这次没有再碰巧补满，信赖值持续为空并反复右滑：

```text
[2026-05-17 06:20:06.817][INF][Px22484][Tx3828] Assistant::append_callback | SubTaskExtraInfo {"class":"asst::InfrastDormTask","details":{"candidates":[],"facility":"Dorm","index":3,"names":["小满"]},"subtask":"InfrastDormTask","taskchain":"Infrast","taskid":1,"uuid":"564688fd8a657262","what":"CustomInfrastRoomOperators"}
[2026-05-17 06:20:06.817][INF][Px22484][Tx3828] {"class":"asst::ProcessTask","cur_task":"","details":{"cur_retry":0,"retry_times":3,"to_be_recognized":["InfrastOperListTabMoodDoubleClickWhenUnclicked"]},"first":["InfrastOperListTabMoodDoubleClickWhenUnclicked"],"pre_task":"","subtask":"ProcessTask","taskchain":"Infrast","taskid":1}
[2026-05-17 06:20:43.926][TRC][Px22484][Tx3828] opertrust: 
[2026-05-17 06:20:43.939][TRC][Px22484][Tx3828] facilityname:<>
[2026-05-17 06:20:43.939][TRC][Px22484][Tx3828] not put oper in
[2026-05-17 06:21:00.592][INF][Px22484][Tx3828] {"class":"asst::ProcessTask","cur_task":"","details":{"cur_retry":0,"retry_times":3,"to_be_recognized":["InfrastOperListSlowlySwipeToTheRight"]},"first":["InfrastOperListSlowlySwipeToTheRight"],"pre_task":"","subtask":"ProcessTask","taskchain":"Infrast","taskid":1}
[2026-05-17 06:21:06.789][INF][Px22484][Tx3828] {"class":"asst::ProcessTask","cur_task":"","details":{"cur_retry":0,"retry_times":3,"to_be_recognized":["InfrastOperListSlowlySwipeToTheRight"]},"first":["InfrastOperListSlowlySwipeToTheRight"],"pre_task":"","subtask":"ProcessTask","taskchain":"Infrast","taskid":1}
```

### Fix 测试

fix后，低心情选择正常完成：

```text
[2026-05-17 07:28:23.675][INF][Px6532][Tx39829] Assistant::append_callback | SubTaskExtraInfo {"class":"asst::InfrastDormTask","details":{"candidates":[],"facility":"Dorm","index":0,"names":["闪灵"]},"subtask":"InfrastDormTask","taskchain":"Infrast","taskid":1,"uuid":"564688fd8a657262","what":"CustomInfrastRoomOperators"}
[2026-05-17 07:28:37.043][INF][Px6532][Tx39829] num_of_selected: 5 , just break
```

宿舍 2 进入信赖补位阶段后，正常按信赖排序并补满：

```text
[2026-05-17 07:28:45.340][INF][Px6532][Tx39829] Assistant::append_callback | SubTaskExtraInfo {"class":"asst::InfrastDormTask","details":{"candidates":[],"facility":"Dorm","index":1,"names":["桃金娘"]},"subtask":"InfrastDormTask","taskchain":"Infrast","taskid":1,"uuid":"564688fd8a657262","what":"CustomInfrastRoomOperators"}
[2026-05-17 07:28:52.404][TRC][Px6532][Tx39829] num_of_resting: 6 , dorm finished
[2026-05-17 07:28:52.404][TRC][Px6532][Tx39829] m_dorm_trust_enabled: 1
[2026-05-17 07:28:54.681][TRC][Px6532][Tx39829] click_sort_by_trust_button
[2026-05-17 07:28:57.465][INF][Px6532][Tx39829] num_of_selected: 5 , just break
```

宿舍 3 ：

```text
[2026-05-17 07:29:13.319][INF][Px6532][Tx39829] Assistant::append_callback | SubTaskExtraInfo {"class":"asst::InfrastDormTask","details":{"candidates":[],"facility":"Dorm","index":2,"names":["芙蓉"]},"subtask":"InfrastDormTask","taskchain":"Infrast","taskid":1,"uuid":"564688fd8a657262","what":"CustomInfrastRoomOperators"}
[2026-05-17 07:29:25.041][TRC][Px6532][Tx39829] asst::InfrastAbstractTask::swipe_and_select_custom_opers | leave, 11720 ms
[2026-05-17 07:29:25.041][TRC][Px6532][Tx39829] click_sort_by_trust_button
[2026-05-17 07:29:27.919][INF][Px6532][Tx39829] num_of_selected: 5 , just break
```

宿舍 4 ：

```text
[2026-05-17 07:29:43.844][INF][Px6532][Tx39829] Assistant::append_callback | SubTaskExtraInfo {"class":"asst::InfrastDormTask","details":{"candidates":[],"facility":"Dorm","index":3,"names":["小满"]},"subtask":"InfrastDormTask","taskchain":"Infrast","taskid":1,"uuid":"564688fd8a657262","what":"CustomInfrastRoomOperators"}
[2026-05-17 07:29:55.385][TRC][Px6532][Tx39829] asst::InfrastAbstractTask::swipe_and_select_custom_opers | leave, 11541 ms
[2026-05-17 07:29:55.385][TRC][Px6532][Tx39829] click_sort_by_trust_button
[2026-05-17 07:29:58.308][INF][Px6532][Tx39829] num_of_selected: 5 , just break
[2026-05-17 07:30:16.988][INF][Px6532][Tx39829] Assistant::append_callback | TaskChainCompleted {"taskchain":"Infrast","taskid":1,"uuid":"564688fd8a657262"}
[2026-05-17 07:30:16.988][INF][Px6532][Tx39829] Assistant::append_callback | AllTasksCompleted {"finished_tasks":[1],"taskchain":"Infrast","taskid":1,"uuid":"564688fd8a657262"}
```

另外执行了 `MaaCore` 构建验证。

完整log：

复现：
[asst.log](https://github.com/user-attachments/files/27864477/asst.log)

fix：
[asst.log](https://github.com/user-attachments/files/27864531/asst.log)

## Summary by Sourcery

Bug Fixes:
- 通过在继续自动填充之前恢复信赖度排序，防止在自定义干员选择后，由于按心情排序的干员列表被误读而导致的宿舍信赖自动填充错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent dorm trust auto-fill from misreading operator lists sorted by mood after custom operator selection by restoring trust sort before continuing auto-fill.

</details>