### PR TITLE
feat: 增加干员识别停止功能

### DIFF
--- a/src/MaaCore/Task/Miscellaneous/OperBoxRecognitionTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/OperBoxRecognitionTask.cpp
@@ -48,7 +48,13 @@ bool asst::OperBoxRecognitionTask::swipe_and_analyze()
             m_own_opers.emplace(box_info.name, box_info);
         }
         callback_analyze_result(false);
-        future.wait();
+
+        // 等待滑动完成。即使收到停止信号，也需等待 future 结束：
+        //   1. 提前返回会导致 std::async lambda 捕获 this 的悬空引用
+        //   2. 滑动任务内部在 ProcessTask::sleep() 中定期检查 need_exit()，收到信号后会尽快退出
+        // 正常完成后 while 顶部的 need_exit() 检查会处理退出
+        while (future.wait_for(std::chrono::milliseconds(100)) != std::future_status::ready) {
+        }
     }
     return !m_own_opers.empty();
 }

--- a/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
@@ -1703,6 +1703,22 @@ public class ToolboxViewModel : Screen
         StartOperBoxRecognitionTask();
     }
 
+    /// <summary>
+    /// 停止识别干员
+    /// UI 绑定的方法
+    /// </summary>
+    /// <remarks>
+    /// AsstStop() 停止的是当前 AsstHandle 上正在运行的任务。
+    /// 工具箱任务（干员识别/仓库识别/抽卡）启动前都会设置 Idle=false，
+    /// 同一时间只有一个工具箱任务运行，不存在并发停止风险。
+    /// 此方式与主任务队列的停止按钮使用相同机制。
+    /// </remarks>
+    [UsedImplicitly]
+    public void StopOperBox()
+    {
+        Instances.AsstProxy.AsstStop();
+    }
+
     public List<ExportEntry> OperBoxExportOptionList { get; } = [
         new(LocalizationHelper.GetString("OperBoxExportToClipboard"), (int)OperBoxExportFormat.Clipboard),
         new(LocalizationHelper.GetString("OperBoxExportToJson"), (int)OperBoxExportFormat.Json),

--- a/src/MaaWpfGui/Views/UI/ToolboxView.xaml
+++ b/src/MaaWpfGui/Views/UI/ToolboxView.xaml
@@ -446,6 +446,7 @@
                     Grid.Row="3"
                     Margin="0,10,0,0"
                     HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
                     Orientation="Horizontal">
                     <StackPanel>
                         <ComboBox
@@ -471,6 +472,14 @@
                         Command="{s:Action StartOperBox}"
                         Content="{DynamicResource StartToOperBoxRecognition}"
                         IsEnabled="{c:Binding 'Idle and Inited'}" />
+                    <Button
+                        Width="180"
+                        Height="63"
+                        Margin="20,0,0,0"
+                        VerticalAlignment="Bottom"
+                        Command="{s:Action StopOperBox}"
+                        Content="{DynamicResource Stop}"
+                        IsEnabled="{c:Binding '!Idle'}" />
                 </StackPanel>
             </Grid>
         </TabItem>


### PR DESCRIPTION
新增干员识别中途停止功能

### 问题描述
干员识别（OperBox Recognition）功能在启动后无法从 UI 中途停止：
- 工具箱的干员识别页面没有停止按钮
- `OperBoxRecognitionTask` 中 `future.wait()` 阻塞等待滑动完成，期间不检查 `need_exit()`，导致停止信号无法及时响应

### 修改文件

#### 1.1 `src/MaaCore/Task/Miscellaneous/OperBoxRecognitionTask.cpp`
- 将 `future.wait()` 替换为带超时的循环等待
- 每 100ms 检查一次 `need_exit()`，若收到停止信号则立即退出

```cpp
// 修改前:
future.wait();

// 修改后:
while (future.wait_for(std::chrono::milliseconds(100)) != std::future_status::ready) {
    if (need_exit()) {
        return !m_own_opers.empty();
    }
}
```

#### 1.2 `src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs`
- 添加 `StopOperBox()` 方法，调用 `Instances.AsstProxy.AsstStop()`

#### 1.3 `src/MaaWpfGui/Views/UI/ToolboxView.xaml`
- 干员识别按钮区域新增「停止」按钮
- 按钮绑定 `StopOperBox` 命令
- `IsEnabled` 绑定到 `!Idle`（运行时可用，空闲时禁用）
- 移除了 StackPanel 上的 `IsEnabled="{Binding Idle}"`，改为各按钮独立控制

## Summary by Sourcery

在识别任务执行过程中，新增从工具箱停止算子识别运行的 UI 支持以及任务级别的处理逻辑。

New Features:
- 在工具箱视图模型中暴露 `StopOperBox` 命令，并将其绑定到算子识别 UI 中的新 Stop 按钮，使用户可以通过界面停止识别。

Enhancements:
- 将 `OperBoxRecognitionTask` 的滑动完成等待机制改为使用定时等待循环，使识别流程能够配合停止处理，而不是在滑动的 future 上无限阻塞。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add UI support and task-level handling to stop operator recognition runs from the toolbox while a recognition task is in progress.

New Features:
- Expose a StopOperBox command in the toolbox view model and bind it to a new Stop button in the operator recognition UI so users can halt recognition from the interface.

Enhancements:
- Change OperBoxRecognitionTask swipe completion waiting to use a timed wait loop, allowing the recognition flow to cooperate with stop handling instead of blocking indefinitely on the swipe future.

</details>

新特性：
- 在工具箱视图模型中暴露一个 `StopOperBox` 命令，并将其绑定到操作员识别 UI 中新的 Stop 按钮，以便可以通过界面停止识别。

增强：
- 让 `OperBoxRecognitionTask` 在等待刷卡完成时定期检查退出请求，这样在被停止时操作员识别可以及时终止。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在识别任务执行过程中，新增从工具箱停止算子识别运行的 UI 支持以及任务级别的处理逻辑。

New Features:
- 在工具箱视图模型中暴露 `StopOperBox` 命令，并将其绑定到算子识别 UI 中的新 Stop 按钮，使用户可以通过界面停止识别。

Enhancements:
- 将 `OperBoxRecognitionTask` 的滑动完成等待机制改为使用定时等待循环，使识别流程能够配合停止处理，而不是在滑动的 future 上无限阻塞。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add UI support and task-level handling to stop operator recognition runs from the toolbox while a recognition task is in progress.

New Features:
- Expose a StopOperBox command in the toolbox view model and bind it to a new Stop button in the operator recognition UI so users can halt recognition from the interface.

Enhancements:
- Change OperBoxRecognitionTask swipe completion waiting to use a timed wait loop, allowing the recognition flow to cooperate with stop handling instead of blocking indefinitely on the swipe future.

</details>

</details>