### PR TITLE
ci: Refactor artifact upload steps in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
         uses: actions/upload-artifact@v7
         if: startsWith(github.ref, 'refs/tags/v')
         with:
-          name: changelog
+          archive: false
           path: CHANGELOG.md
 
   windows:
@@ -206,7 +206,7 @@ jobs:
       - name: Upload PDB files
         uses: actions/upload-artifact@v7
         with:
-          name: MAAComponent-DebugSymbol-win-${{ matrix.arch }}
+          archive: false
           path: install/MAAComponent-DebugSymbol-${{ needs.meta.outputs.tag }}-win-${{ matrix.arch }}.zip
 
       - name: Organize install files
@@ -228,7 +228,7 @@ jobs:
       - name: Upload MAA to GitHub
         uses: actions/upload-artifact@v7
         with:
-          name: MAA-win-${{ matrix.arch }}
+          archive: false
           path: install/MAA-*.zip
 
   ubuntu:
@@ -418,7 +418,7 @@ jobs:
       - name: Upload MAA to GitHub
         uses: actions/upload-artifact@v7
         with:
-          name: MAAComponent-android-${{ matrix.arch }}
+          archive: false
           path: MAAComponent-*.tar.gz
 
   macOS-Core:
@@ -558,7 +558,7 @@ jobs:
       - name: Upload MAA runtime to GitHub
         uses: actions/upload-artifact@v7
         with:
-          name: MAA-macos-runtime-universal
+          archive: false
           path: runtime/MAA-${{ needs.meta.outputs.tag }}-macos-runtime-universal.zip
 
       - name: Build XCFramework


### PR DESCRIPTION
对于那些我觉得是单个文件的部分，actions/upload-artifact 的 `archive` 改成 `false` 了，这样可以直接上传单文件，而不用再被 github 打包一次。

For the parts that I consider to be single files, I changed `archive` in `actions/upload-artifact` to `false`, so they can be uploaded directly as single files without GitHub packaging them again.

## Summary by Sourcery

CI：
- 配置 `upload-artifact` 步骤，直接上传已有的更新日志和发行归档文件，而无需额外使用 GitHub 进行归档。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Configure upload-artifact steps to upload existing changelog and release archives directly without additional GitHub archiving.

</details>