### PR TITLE
docs: 将弃用的 demo-wrapper 容器替换为 window 容器，补上了en-us和ja-jp缺失的部分

### DIFF
--- a/docs/en-us/develop/documentation-guidelines.md
+++ b/docs/en-us/develop/documentation-guidelines.md
@@ -39,6 +39,7 @@ Accepted container types and their default titles are as follows:
 - `warning` Warning
 - `danger` Caution
 - `details` Details
+- `window` ==Demo Container==
 
 ### Container Examples
 
@@ -64,6 +65,10 @@ This is a danger container
 
 ::: details
 This is a details container
+:::
+
+::: window
+This is a demo container
 :::
 
 ## Icons

--- a/docs/ja-jp/develop/documentation-guidelines.md
+++ b/docs/ja-jp/develop/documentation-guidelines.md
@@ -39,6 +39,7 @@ icon: jam:write-f
 - `warning` 注意
 - `danger` 警告
 - `details` 詳細
+- `window` ==サンプルコンテナ==
 
 ### コンテナの例
 
@@ -64,6 +65,10 @@ icon: jam:write-f
 
 ::: details
 これは詳細のコンテナです
+:::
+
+::: window
+これはサンプルのコンテナです
 :::
 
 ## アイコン

--- a/docs/ko-kr/develop/documentation-guidelines.md
+++ b/docs/ko-kr/develop/documentation-guidelines.md
@@ -44,7 +44,7 @@ icon: jam:write-f
 - `warning` 주의
 - `danger` 경고
 - `details` 세부 사항
-- `demo-wrapper` ==특수 컨테이너==
+- `window` ==예시 컨테이너==
 
 ### 컨테이너 예시
 
@@ -72,7 +72,7 @@ icon: jam:write-f
 이것은 세부 사항 컨테이너입니다
 :::
 
-::: demo-wrapper
+::: window
 이것은 매우 특별한 컨테이너입니다
 :::
 
@@ -113,7 +113,7 @@ MaaAssistantArknights는 ==많은 돼지들== 에 의해 개발되었습니다
 
 다음과 같은 설정을 사용할 수 있습니다:
 
-::: demo-wrapper
+::: window
 입력:
 
 ```markdown
@@ -192,7 +192,7 @@ MaaAssistantArknights는 ==많은 돼지들== 에 의해 개발되었습니다
 
 마크다운 본문에서 `<ImageGrid>` 컴포넌트를 사용하여 이 메서드를 호출할 수 있으며, 구체적인 구문과 효과는 다음과 같습니다.
 
-::: demo-wrapper
+::: window
 
 구문:
 
@@ -292,7 +292,7 @@ icon: jam:write-f
 - `color` css 스타일 색상 값을 받습니다. 예: `#fff`, `red` 등 (이 옵션은 svg 아이콘에만 유효함)
 - `size` css 스타일 크기 값을 받습니다. 예: `1rem`, `2em`, `100px` 등
 
-::: demo-wrapper 예시
+::: window 예시
 
 입력:
 

--- a/docs/zh-cn/develop/documentation-guidelines.md
+++ b/docs/zh-cn/develop/documentation-guidelines.md
@@ -44,7 +44,7 @@ icon: jam:write-f
 - `warning` 注意
 - `danger` 警告
 - `details` 详情
-- `demo-warpper` ==特殊容器==
+- `window` ==示例容器==
 
 ### 容器示例
 
@@ -72,7 +72,7 @@ icon: jam:write-f
 这是详情容器
 :::
 
-::: demo-wrapper
+::: window
 这是一个很特殊的容器
 :::
 
@@ -113,7 +113,7 @@ MaaAssistantArknights 是由 ==很多猪== 开发的
 
 有以下配置可以使用
 
-::: demo-wrapper
+::: window
 输入：
 
 ```markdown
@@ -192,7 +192,7 @@ MaaAssistantArknights 是由 ==很多猪== 开发的
 
 你可以在 markdown 正文中使用 `<ImageGrid>` 组件来调用该方法，具体的语法和效果如下
 
-::: demo-wrapper
+::: window
 
 这是语法：
 
@@ -292,7 +292,7 @@ icon: jam:write-f
 - `color` 接受 css 风格的颜色值，如 `#fff`，`red` 等（该选项仅对 svg 图标有效）
 - `size` 接受 css 风格的大小，如 `1rem`，`2em`，`100px` 等
 
-::: demo-wrapper 案例
+::: window 案例
 
 输入：
 

--- a/docs/zh-tw/develop/documentation-guidelines.md
+++ b/docs/zh-tw/develop/documentation-guidelines.md
@@ -44,7 +44,7 @@ icon: jam:write-f
 - `warning` 注意
 - `danger` 警告
 - `details` 詳情
-- `demo-warpper` ==特殊容器==
+- `window` ==示例容器==
 
 ### 容器範例
 
@@ -72,7 +72,7 @@ icon: jam:write-f
 這是詳情容器
 :::
 
-::: demo-wrapper
+::: window
 這是一個很特殊的容器
 :::
 
@@ -113,7 +113,7 @@ MaaAssistantArknights 是由 ==很多豬== 開發的
 
 有以下配置可以使用：
 
-::: demo-wrapper
+::: window
 輸入：
 
 ```markdown
@@ -192,7 +192,7 @@ MaaAssistantArknights 是由 ==很多豬== 開發的
 
 您可以在 Markdown 正文中使用 `<ImageGrid>` 元件來呼叫該方法，具體的語法和效果如下：
 
-::: demo-wrapper
+::: window
 
 這是語法：
 
@@ -292,7 +292,7 @@ icon: jam:write-f
 - `color` 接受 CSS 風格的顏色值，如 `#fff`，`red` 等（該選項僅對 SVG 圖示有效）。
 - `size` 接受 CSS 風格的大小，如 `1rem`，`2em`，`100px` 等。
 
-::: demo-wrapper 範例
+::: window 範例
 
 輸入：
 

--- a/docs/zh-tw/develop/documentation-guidelines.md
+++ b/docs/zh-tw/develop/documentation-guidelines.md
@@ -44,7 +44,7 @@ icon: jam:write-f
 - `warning` 注意
 - `danger` 警告
 - `details` 詳情
-- `window` ==示例容器==
+- `window` ==範例容器==
 
 ### 容器範例
 


### PR DESCRIPTION
https://theme-plume.vuejs.press/guide/markdown/window/#doc-changelog

## 来自 Sourcery 的摘要

将文档中已弃用的 `demo-wrapper` 容器引用替换为新的 `window` 容器，并为所有支持的语言补充 `window` 容器的文档说明。

文档：
- 更新 ko-kr、zh-cn 和 zh-tw 的文档规范，在示例和描述中使用 `window` 容器来替代已弃用的 `demo-wrapper` 容器。
- 在 en-us 和 ja-jp 的文档规范中新增 `window` 演示容器类型及其示例用法。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Replace deprecated demo-wrapper container references in documentation with the new window container and document the window container for all supported languages.

Documentation:
- Update ko-kr, zh-cn, and zh-tw documentation guidelines to use the window container in examples and descriptions instead of the deprecated demo-wrapper container.
- Add the window demo container type and example usage to the en-us and ja-jp documentation guidelines.

</details>