### PR TITLE
feat: 基建干员自定义进驻时增加按职业筛选功能

### DIFF
--- a/src/MaaCore/Task/Infrast/InfrastAbstractTask.cpp
+++ b/src/MaaCore/Task/Infrast/InfrastAbstractTask.cpp
@@ -17,6 +17,7 @@
 #include "Vision/RegionOCRer.h"
 #include <ranges>
 
+std::once_flag asst::InfrastAbstractTask::m_role_map_init_flag;
 std::unordered_map<std::string, std::string> asst::InfrastAbstractTask::m_oper_role_map;
 
 asst::InfrastAbstractTask::InfrastAbstractTask(
@@ -25,11 +26,7 @@ asst::InfrastAbstractTask::InfrastAbstractTask(
     std::string_view task_chain) :
     AbstractTask(callback, inst, task_chain)
 {
-    static bool loaded = false;
-    if (!loaded) {
-        load_oper_role_map();
-        loaded = true;
-    }
+    std::call_once(m_role_map_init_flag, &InfrastAbstractTask::load_oper_role_map);
     m_retry_times = TaskRetryTimes;
 }
 
@@ -518,7 +515,11 @@ bool asst::InfrastAbstractTask::swipe_and_select_custom_opers_by_role(bool is_do
         // 临时设置要选的名单（仅限该职业）
         room_config.names = std::move(names);
         // 选择干员
-        select_in_current_role(swipe_times);
+        if (!select_in_current_role(swipe_times)) {
+            current_room_config() = std::move(origin_room_config);
+            Log.warn("select oper in current role failed");
+            return false;
+        }
 
         // 收集该职业未被选中的干员（可能因为满员或未找到）
         unselected_names.insert(unselected_names.end(), room_config.names.begin(), room_config.names.end());
@@ -543,7 +544,12 @@ bool asst::InfrastAbstractTask::swipe_and_select_custom_opers_by_role(bool is_do
         room_config.names = std::move(unselected_names);
         room_config.candidates = origin_room_config.candidates; // 恢复candidates
 
-        select_in_current_role(swipe_times); // 最后一次全体查找
+        // 最后一次全体查找
+        if (!select_in_current_role(swipe_times)) {
+            current_room_config() = std::move(origin_room_config);
+            Log.warn("select unselected oper failed");
+            return false;
+        }
     }
 
     // 先按任意其他的tab排序，游戏会自动把已经选中的人放到最前面

--- a/src/MaaCore/Task/Infrast/InfrastAbstractTask.cpp
+++ b/src/MaaCore/Task/Infrast/InfrastAbstractTask.cpp
@@ -17,12 +17,19 @@
 #include "Vision/RegionOCRer.h"
 #include <ranges>
 
+std::unordered_map<std::string, std::string> asst::InfrastAbstractTask::m_oper_role_map;
+
 asst::InfrastAbstractTask::InfrastAbstractTask(
     const AsstCallback& callback,
     Assistant* inst,
     std::string_view task_chain) :
     AbstractTask(callback, inst, task_chain)
 {
+    static bool loaded = false;
+    if (!loaded) {
+        load_oper_role_map();
+        loaded = true;
+    }
     m_retry_times = TaskRetryTimes;
 }
 
@@ -314,7 +321,7 @@ bool asst::InfrastAbstractTask::swipe_and_select_custom_opers(bool is_dorm_order
 
     // 先按任意其他的tab排序，游戏会自动把已经选中的人放到最前面
     // 因为后面autofill要按工作状态排序，所以直接按工作状态排序好了
-    // 然后滑动到最左边，清空一下，在走后面的识别+按序点击逻辑
+    // 然后滑动到最左边，清空一下，再走后面的识别+按序点击逻辑
     if (is_dorm_order) {
         ProcessTask(*this, { "InfrastOperListTabMoodDoubleClick" }).run();
         sleep(200);
@@ -336,6 +343,237 @@ bool asst::InfrastAbstractTask::swipe_and_select_custom_opers(bool is_dorm_order
     if (!room_config.names.empty() || (!is_dorm_order && !select_opers_review(origin_room_config))) {
         // 复核失败，说明current_room_config与OCR识别是不符的，current_room_config是无效信息，还原到用户原来的配置，重选
         current_room_config() = std::move(origin_room_config);
+        return false;
+    }
+
+    return true;
+}
+
+// 将 battle::Role 枚举转为 tasks.json 中的职业后缀（首字母大写）
+std::string asst::InfrastAbstractTask::role_to_suffix(battle::Role role)
+{
+    switch (role) {
+    case battle::Role::Caster:
+        return "Caster";
+    case battle::Role::Medic:
+        return "Medic";
+    case battle::Role::Pioneer:
+        return "Pioneer";
+    case battle::Role::Sniper:
+        return "Sniper";
+    case battle::Role::Special:
+        return "Special";
+    case battle::Role::Support:
+        return "Support";
+    case battle::Role::Tank:
+        return "Tank";
+    case battle::Role::Warrior:
+        return "Warrior";
+    default:
+        return {};
+    }
+}
+
+void asst::InfrastAbstractTask::load_oper_role_map()
+{
+    const auto& all_chars = BattleData.get_all_chars(); // 引用全局实例
+    for (const auto& [id, oper_ptr] : all_chars) {
+        if (oper_ptr->role != battle::Role::Drone) {
+            std::string suffix = role_to_suffix(oper_ptr->role);
+            if (!suffix.empty()) {
+                m_oper_role_map.emplace(oper_ptr->name, std::move(suffix));
+            }
+        }
+    }
+    Log.info("Oper role map built from BattleDataConfig, entries:", m_oper_role_map.size());
+}
+
+bool asst::InfrastAbstractTask::select_in_current_role(int& swipe_times)
+{
+    auto& room_config = current_room_config();
+
+    std::vector<std::string> pre_partial_result;
+    bool retried = false;
+    bool pre_result_no_changes = false;
+    //int swipe_times = 0;
+
+    while (true) {
+        if (need_exit()) {
+            return false;
+        }
+        std::vector<std::string> partial_result;
+        // 选择自定义干员，同时输出每一页的干员列表
+        if (!select_custom_opers(partial_result)) {
+            return false;
+        }
+        // 选完人 / 名单已空
+        if (static_cast<size_t>(room_config.selected) >= max_num_of_opers() ||
+            (room_config.names.empty() && room_config.candidates.empty())) {
+            break;
+        }
+        if (partial_result == pre_partial_result) {
+            if (pre_result_no_changes) {
+                Log.warn("partial result is not changed, reset the page");
+                if (retried) {
+                    Log.error("already retrying");
+                    break;
+                }
+                swipe_to_the_left_of_operlist(swipe_times + 1);
+                swipe_times = 0;
+                retried = true;
+            }
+            else {
+                pre_result_no_changes = true;
+            }
+        }
+        else {
+            pre_result_no_changes = false;
+        }
+        pre_partial_result = partial_result;
+        swipe_of_operlist();
+        ++swipe_times;
+    }
+    return true;
+}
+
+/// @brief 按技能排序->清空干员->选择定制干员->按指定顺序排序
+/// @brief 修改：选择定制干员时，改为先切换到对应职业，再在同职业干员中选择
+/// @param is_dorm_order 当前房间是不是宿舍
+bool asst::InfrastAbstractTask::swipe_and_select_custom_opers_by_role(bool is_dorm_order)
+{
+    LogTraceFunction;
+
+    Log.info("m_oper_role_map size:", m_oper_role_map.size());
+
+    auto& room_config = current_room_config();
+    auto origin_room_config = room_config;
+    {
+        json::value cb_info = basic_info_with_what("CustomInfrastRoomOperators");
+        auto& details = cb_info["details"];
+        details["names"] = json::array(room_config.names);
+        details["candidates"] = json::array(room_config.candidates);
+        callback(AsstMsg::SubTaskExtraInfo, cb_info);
+    }
+
+    if (!is_dorm_order) {
+        ProcessTask(*this, { "InfrastOperListTabSkillUnClicked", "Stop" }).run();
+    }
+    else {
+        ProcessTask(*this, { "InfrastOperListTabMoodDoubleClickWhenUnclicked" }).run();
+    }
+
+    if (max_num_of_opers() > 1) {
+        click_clear_button(); // 先排序后清空，加速干员变化不大时的选择速度
+    }
+    
+    // 用于排序
+    std::vector<std::string> opers_order = room_config.names;
+    opers_order.insert(opers_order.end(), room_config.candidates.cbegin(), room_config.candidates.cend());
+
+    int swipe_times = 0;
+
+    // 按职业分组
+    std::unordered_map<std::string, std::vector<std::string>> role_to_names;
+    std::vector<std::string> unknown_names;
+
+    for (const auto& name : opers_order) {
+        Log.info("Looking for:", name, "| len:", name.size());
+        if (name == "阿米娅") {
+            unknown_names.push_back(name);
+            continue;
+        }
+        auto it = m_oper_role_map.find(name);
+        if (it != m_oper_role_map.end()) {
+            role_to_names[it->second].push_back(name);
+        }
+        else {
+            Log.info("encounter unknown_name:", name);
+            unknown_names.push_back(name);
+        }
+    }
+
+    std::vector<std::string> unselected_names; // 收集未选中的必选干员
+    room_config.candidates.clear();            // 临时清空，防止误选候选
+
+    // 展开职业列表
+    ProcessTask(*this, { "BattleQuickFormationExpandRole" }).set_retry_times(3).run();
+    // 依次处理每个职业
+    for (auto& [role, names] : role_to_names) {
+        if (need_exit()) {
+            return false;
+        }
+
+        Log.info("Using role filter, current role:", role);
+
+        // 点击职业图标
+        if (!ProcessTask(*this, { "BattleQuickFormationRole-" + role }).run()) {
+            Log.warn("Failed to switch to role:", role, ", adding to unselected_names");
+            unknown_names.insert(unknown_names.end(), names.begin(), names.end());
+            continue;
+        }
+        else {
+            Log.info("Switch to role page:", role);
+        }
+
+        // 临时设置要选的名单（仅限该职业）
+        room_config.names = std::move(names);
+        // 选择干员
+        select_in_current_role(swipe_times);
+
+        // 收集该职业未被选中的干员（可能因为满员或未找到）
+        unselected_names.insert(unselected_names.end(), room_config.names.begin(), room_config.names.end());
+        room_config.names.clear();
+
+        // 如果已选满，提前结束
+        if (static_cast<size_t>(room_config.selected) >= max_num_of_opers()) {
+            break;
+        }
+    }
+    // 基建默认收起职业列表
+    close_quick_formation_expand_role();
+
+    // 全体兜底：未知职业 + 未选中干员
+    unselected_names.insert(unselected_names.end(), unknown_names.begin(), unknown_names.end());
+
+    if (!unselected_names.empty() || !origin_room_config.candidates.empty()) {
+        Log.info("add fallback opers");
+        // 切换回“全部”标签
+        ProcessTask(*this, { "BattleQuickFormationRole-All", "BattleQuickFormationRole-All-OCR" }).run();
+
+        room_config.names = std::move(unselected_names);
+        room_config.candidates = origin_room_config.candidates; // 恢复candidates
+
+        select_in_current_role(swipe_times); // 最后一次全体查找
+    }
+
+    // 先按任意其他的tab排序，游戏会自动把已经选中的人放到最前面
+    // 因为后面autofill要按工作状态排序，所以直接按工作状态排序好了
+    // 然后滑动到最左边，清空一下，再走后面的识别+按序点击逻辑
+    if (is_dorm_order) {
+        ProcessTask(*this, { "InfrastOperListTabMoodDoubleClick" }).run();
+        sleep(200);
+    }
+    else {
+        ProcessTask(*this, { "InfrastOperListTabWorkStatusUnClicked" }).run();
+    }
+
+    // 滑动回最左（如果之前有滑动）
+    if (swipe_times) {
+        swipe_to_the_left_of_operlist(swipe_times + 1);
+        swipe_times = 0;
+    }
+
+    // 如果只选了一个人没必要排序
+    if (room_config.sort && room_config.selected > 1) {
+        click_clear_button();
+        order_opers_selection(opers_order);
+    }
+
+    // 复核
+    if (!room_config.names.empty() || (!is_dorm_order && !select_opers_review(origin_room_config))) {
+        // 复核失败，说明current_room_config与OCR识别是不符的，current_room_config是无效信息，还原到用户原来的配置，重选
+        current_room_config() = std::move(origin_room_config);
+        Log.warn("check failed");
         return false;
     }
 
@@ -609,6 +847,8 @@ void asst::InfrastAbstractTask::order_opers_selection(const std::vector<std::str
 void asst::InfrastAbstractTask::close_quick_formation_expand_role() const
 {
     LogTraceFunction;
+    ProcessTask(*this, { "BattleQuickFormationRole-All", "BattleQuickFormationRole-All-OCR", "Stop" }).run();
+    // 这里在收起前先按ALL，保证收起后右上角为“职业”而非具体的职业名
     ProcessTask(*this, { "InfrastCloseQuickFormationExpandRole", "Stop" }).run();
 }
 
@@ -715,7 +955,7 @@ void asst::InfrastAbstractTask::swipe_to_the_left_of_operlist(int loop_times)
               "BattleQuickFormationRole-Special",
               "BattleQuickFormationRole-Support" })
             .run();
-        ProcessTask(*this, { "BattleQuickFormationRole-All", "BattleQuickFormationRole-All-OCR" }).run();
+        //ProcessTask(*this, { "BattleQuickFormationRole-All", "BattleQuickFormationRole-All-OCR" }).run();
         // 基建默认收起
         close_quick_formation_expand_role();
     }

--- a/src/MaaCore/Task/Infrast/InfrastAbstractTask.h
+++ b/src/MaaCore/Task/Infrast/InfrastAbstractTask.h
@@ -4,6 +4,8 @@
 #include "Common/AsstInfrastDef.h"
 #include "Common/AsstTypes.h"
 #include "Task/AbstractTask.h"
+#include "Config/Miscellaneous/BattleDataConfig.h"
+
 
 namespace asst
 {
@@ -55,6 +57,8 @@ protected:
     void set_available_oper_for_group(std::set<std::string> opers);
 
     bool swipe_and_select_custom_opers(bool is_dorm_order = false);
+    bool select_in_current_role(int& swipe_times);
+    bool swipe_and_select_custom_opers_by_role(bool is_dorm_order = false);
     bool select_custom_opers(std::vector<std::string>& partial_result);
     // 扫描当前页满足心情条件的所有干员名
     bool get_opers(std::vector<std::string>& result, double mood = 1);
@@ -86,5 +90,10 @@ protected:
     int m_cur_facility_index = 0;
     bool m_is_custom = false;
     infrast::CustomFacilityConfig m_custom_config;
+
+private:
+    static std::unordered_map<std::string, std::string> m_oper_role_map;
+    static void load_oper_role_map();
+    static std::string role_to_suffix(battle::Role role);
 };
 } // namespace asst

--- a/src/MaaCore/Task/Infrast/InfrastAbstractTask.h
+++ b/src/MaaCore/Task/Infrast/InfrastAbstractTask.h
@@ -92,6 +92,7 @@ protected:
     infrast::CustomFacilityConfig m_custom_config;
 
 private:
+    static std::once_flag m_role_map_init_flag; 
     static std::unordered_map<std::string, std::string> m_oper_role_map;
     static void load_oper_role_map();
     static std::string role_to_suffix(battle::Role role);

--- a/src/MaaCore/Task/Infrast/InfrastControlTask.cpp
+++ b/src/MaaCore/Task/Infrast/InfrastControlTask.cpp
@@ -35,7 +35,7 @@ bool asst::InfrastControlTask::_run()
             return false;
         }
         if (is_use_custom_opers()) {
-            bool name_select_ret = swipe_and_select_custom_opers();
+            bool name_select_ret = swipe_and_select_custom_opers_by_role();
             if (name_select_ret) {
                 break;
             }

--- a/src/MaaCore/Task/Infrast/InfrastDormTask.cpp
+++ b/src/MaaCore/Task/Infrast/InfrastDormTask.cpp
@@ -64,7 +64,7 @@ bool asst::InfrastDormTask::_run()
 
         auto origin_room_config = current_room_config();
         if (is_use_custom_opers()) {
-            swipe_and_select_custom_opers(true);
+            swipe_and_select_custom_opers_by_role(true);
         }
         else {
             click_clear_button(); // 宿舍若未指定干员，则清空后按照原约定逻辑选择干员

--- a/src/MaaCore/Task/Infrast/InfrastOfficeTask.cpp
+++ b/src/MaaCore/Task/Infrast/InfrastOfficeTask.cpp
@@ -33,7 +33,7 @@ bool asst::InfrastOfficeTask::_run()
             return false;
         }
         if (is_use_custom_opers()) {
-            bool name_select_ret = swipe_and_select_custom_opers();
+            bool name_select_ret = swipe_and_select_custom_opers_by_role();
             if (name_select_ret) {
                 break;
             }

--- a/src/MaaCore/Task/Infrast/InfrastPowerTask.cpp
+++ b/src/MaaCore/Task/Infrast/InfrastPowerTask.cpp
@@ -33,7 +33,7 @@ bool asst::InfrastPowerTask::_run()
 
         for (int j = 0; j <= OperSelectRetryTimes; ++j) {
             if (is_use_custom_opers()) {
-                bool name_select_ret = swipe_and_select_custom_opers();
+                bool name_select_ret = swipe_and_select_custom_opers_by_role();
                 if (name_select_ret) {
                     break;
                 }

--- a/src/MaaCore/Task/Infrast/InfrastProcessingTask.cpp
+++ b/src/MaaCore/Task/Infrast/InfrastProcessingTask.cpp
@@ -41,7 +41,7 @@ bool asst::InfrastProcessingTask::_run()
             return false;
         }
         if (is_use_custom_opers()) {
-            bool name_select_ret = swipe_and_select_custom_opers();
+            bool name_select_ret = swipe_and_select_custom_opers_by_role();
             if (name_select_ret) {
                 break;
             }

--- a/src/MaaCore/Task/Infrast/InfrastProductionTask.cpp
+++ b/src/MaaCore/Task/Infrast/InfrastProductionTask.cpp
@@ -227,7 +227,7 @@ bool asst::InfrastProductionTask::shift_facility_list()
                 }
 
                 if (is_use_custom_opers()) {
-                    bool name_select_ret = swipe_and_select_custom_opers();
+                    bool name_select_ret = swipe_and_select_custom_opers_by_role();
                     if (name_select_ret) {
                         break;
                     }

--- a/src/MaaCore/Task/Infrast/InfrastReceptionTask.cpp
+++ b/src/MaaCore/Task/Infrast/InfrastReceptionTask.cpp
@@ -363,7 +363,7 @@ bool asst::InfrastReceptionTask::shift()
         }
 
         if (is_use_custom_opers()) {
-            if (swipe_and_select_custom_opers()) {
+            if (swipe_and_select_custom_opers_by_role()) {
                 break;
             }
             swipe_to_the_left_of_operlist();


### PR DESCRIPTION
### 问题描述
在自定义基建换班时，使用`swipe_and_select_custom_opers` ，以干员基建技能来排序，需要在全部干员滑动以寻找指定的干员，部分情况下，自定义配置中给房间配置的干员可能并没有对应房间的基建技能，如贸易站推进之王（配合摩根）、制造站深海猎人、会客室铃兰（配合忍冬）等，寻找这些干员消耗的时间很长。

### 修改文件

#### 1. `src/MaaCore/Task/Infrast/InfrastAbstractTask.h`
- 新增静态成员 `static std::unordered_map<std::string, std::string> m_oper_role_map`，用于保存干员名 → 职业后缀的映射。
- 新增静态辅助函数 `load_oper_role_map()` 和 `role_to_suffix()`，在首次构造任务时通过 `BattleDataConfig` 构建映射。
- 新增成员函数 `select_in_current_role(int& swipe_times)`，负责在当前职业下内完成滑动与干员选择。
- 新增成员函数 `swipe_and_select_custom_opers_by_role(bool is_dorm_order)`，作为带职业筛选的自定义干员选择入口。

#### 2. `src/MaaCore/Task/Infrast/InfrastAbstractTask.cpp`
- 实现 `load_oper_role_map()`：遍历 `BattleData.get_all_chars()`，将每个干员的 `name` 与转换后的职业后缀（如 `"Caster"`）存入静态映射。
- 实现 `swipe_and_select_custom_opers_by_role()`：
  - 由swipe_and_select_custom_opers()修改。
  - 排序、清空等前置步骤与原函数一致。
  - 将用户配置中的 `names`（必选干员）按职业分组，未知职业及“阿米娅”直接归入待兜底列表。
  - 依次切换到每个职业标签页，使用 `select_in_current_role` 在本职业下选择；未选中的收集到 `unselected_names`。
  - 全部职业处理完后，将未选中的必选干员与原始 `candidates` 合并，切回“全部”标签页执行兜底选择（复用原 while 滑动逻辑）。
  - 最后按原流程进行排序、复位和复核。
- 实现 `select_in_current_role`：复用原有滑动与选择循环，并通过引用参数累积滑动次数。
- 修改 `swipe_to_the_left_of_operlist` 内的职业切换逻辑：不再点击“全部”标签，改为由`close_quick_formation_expand_role`点击。
- 修改 `close_quick_formation_expand_role`：收起前先点击“全部”标签，避免收起后仍显示具体职业名。

#### 3. `src/MaaCore/Task/Infrast/InfrastReceptionTask.cpp`、`src/MaaCore/Task/Infrast/InfrastProductionTask.cpp`等
- 将每类房间的调用 `swipe_and_select_custom_opers`改为`swipe_and_select_custom_opers_by_role` 以启用按职业筛选。

### 测试
测试配置：基建自定义排班中，在房间中配置必选干员与候选干员，如：
```json
"manufacture": [
          {
            "skip": false,
            "product": "Originium Shard",
            "operators": ["多萝西"
            ],
            "candidates": ["赫默","梅尔","淬羽赫默","白面鸮"
            ],
            "sort": false,
            "autofill": false
          },
          {
            "skip": false,
            "product": "Pure Gold",
            "operators": ["迷迭香","至简","斑点"
            ],
            "sort": false,
            "autofill": false
          },
          ...
        ]
```
可以正常放入干员。

## Summary by Sourcery

在基础设施任务中引入基于职业的过滤机制，用于选择自定义干员，以加快并改进跨房间的目标干员选择过程。

新功能：
- 添加一个“感知职业”的自定义干员选择流程，将已配置干员按作战职业分组，并优先在对应职业标签页中进行选择，若未找到则再回退到完整列表中选择。

增强内容：
- 使用 BattleDataConfig 构建并缓存一个从干员名称到作战职业的全局映射，以便在基础设施任务中复用。
- 优化快捷编队的职业标签处理逻辑，确保在自定义选择过程中以及结束后，职业筛选会被正确展开、切换，并最终一致地重置到“All”标签。
- 将所有基础设施房间任务更新为使用新的基于职业的自定义干员选择方法，替代之前仅基于技能的选择方式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce role-based filtering when selecting custom operators in infrastructure tasks to speed up and improve targeted operator selection across rooms.

New Features:
- Add a role-aware custom operator selection flow that groups configured operators by their combat role and selects them within the corresponding role tab before falling back to the full list.

Enhancements:
- Build and cache a global mapping from operator name to combat role using BattleDataConfig for reuse in infrastructure tasks.
- Refine quick formation role tab handling so role filters are expanded, switched, and reset to the All tab consistently during and after custom selection.
- Update all infrastructure room tasks to use the new role-based custom operator selection method instead of the previous skill-only based selection.

</details>