### PR TITLE
rft: 生息演算策略逻辑修改

### DIFF
--- a/src/MaaCore/Task/Interface/ReclamationTask.cpp
+++ b/src/MaaCore/Task/Interface/ReclamationTask.cpp
@@ -7,7 +7,7 @@
 // 通用配置及插件
 #include "Task/Reclamation/ReclamationConfig.h"
 
-// ReclamationMode::ProsperityInSave 专用配置及插件
+// TalesMode::ProsperityInSave 专用配置及插件
 #include "Task/Reclamation/ReclamationCraftTaskPlugin.h"
 
 #include "Utils/Logger.hpp"
@@ -19,7 +19,7 @@ asst::ReclamationTask::ReclamationTask(const AsstCallback& callback, Assistant* 
 {
     LogTraceFunction;
 
-    // ReclamationMode::ProsperityInSave 专用参数
+    // TalesMode::ProsperityInSave 专用参数
     m_reclamation_task_ptr->register_plugin<ReclamationCraftTaskPlugin>(m_config_ptr);
 
     m_subtasks.emplace_back(m_reclamation_task_ptr);
@@ -34,7 +34,7 @@ bool asst::ReclamationTask::set_params(const json::value& params)
     }
 
     const std::string& theme = m_config_ptr->get_theme();
-    const ReclamationMode& mode = m_config_ptr->get_mode();
+    const auto& mode = m_config_ptr->get_mode();
 
     if (theme == ReclamationTheme::Fire) {
         Log.info(__FUNCTION__, "Reclamation Algorithm theme", theme, "is no longer available");
@@ -44,21 +44,23 @@ bool asst::ReclamationTask::set_params(const json::value& params)
 
     m_reclamation_task_ptr->set_times_limit("RA@Store@EnterStore", INT_MAX);
 
-    if (theme == ReclamationTheme::RelaunchAnchor) {
-        const int stage = static_cast<int>(m_config_ptr->get_stage());
-        const std::string task_name = theme + "@RA@PNS-RA" + std::to_string(stage) + "-Entry";
+    if (const auto* ra_mode = std::get_if<RelaunchAnchorMode>(&mode)) {
+        // 重启锚点：根据 mode 选择关卡入口
+        const int stage = static_cast<int>(*ra_mode);
+        const std::string stage_str = (stage == static_cast<int>(RelaunchAnchorMode::RA15)) ? "15" : "1";
+        const std::string task_name = theme + "@RA@PNS-RA" + stage_str + "-Entry";
         m_reclamation_task_ptr->set_tasks({ task_name });
         m_reclamation_task_ptr->set_times_limit("RA@Store@EnterStore", 0);
     }
-    else {
-        switch (mode) {
-        case ReclamationMode::ProsperityNoSave:
+    else if (const auto* tales_mode = std::get_if<TalesMode>(&mode)) {
+        switch (*tales_mode) {
+        case TalesMode::ProsperityNoSave:
             m_reclamation_task_ptr->set_tasks({ theme + "@RA@ProsperityNoSave" });
             if (!params.get("clear_store", false)) {
                 m_reclamation_task_ptr->set_times_limit("RA@Store@EnterStore", 0);
             }
             break;
-        case ReclamationMode::ProsperityInSave:
+        case TalesMode::ProsperityInSave:
             m_reclamation_task_ptr->set_tasks({ theme + "@RA@ProsperityInSave" });
             break;
         }

--- a/src/MaaCore/Task/Reclamation/ReclamationConfig.cpp
+++ b/src/MaaCore/Task/Reclamation/ReclamationConfig.cpp
@@ -16,32 +16,23 @@ bool asst::ReclamationConfig::verify_and_load_params(const json::value& params)
     m_theme = theme;
 
     // Reclamation Algorithm Mode
-    const int modeInt = params.get("mode", static_cast<int>(ReclamationMode::ProsperityInSave));
-    const auto mode = static_cast<ReclamationMode>(modeInt);
+    const int modeInt = params.get("mode", 0);
     if (theme == ReclamationTheme::RelaunchAnchor) {
-        m_mode = ReclamationMode::ProsperityNoSave;
-        if (!params.contains("stage")) {
-            Log.error(__FUNCTION__, "| Missing RelaunchAnchor stage");
+        // 重启锚点：mode 0 = RA-1, mode 1 = RA-15
+        if (modeInt < 0 || modeInt >= static_cast<int>(RelaunchAnchorMode::_Count)) {
+            Log.error(__FUNCTION__, "| Invalid RelaunchAnchor mode", modeInt);
             return false;
         }
-
-        const int stageInt = params.get("stage", -1);
-        if (stageInt == static_cast<int>(RelaunchAnchorStage::RA15)) {
-            m_stage = RelaunchAnchorStage::RA15;
-        } else if (stageInt == static_cast<int>(RelaunchAnchorStage::RA1)) {
-            m_stage = RelaunchAnchorStage::RA1;
-        } else {
-            Log.error(__FUNCTION__, "| Invalid RelaunchAnchor stage", stageInt);
+        m_mode = static_cast<RelaunchAnchorMode>(modeInt);
+    }
+    else {
+        // 沙洲遗闻：mode 0 = 无存档刷繁荣点数, mode 1 = 有存档刷繁荣点数
+        if (modeInt < 0 || modeInt >= static_cast<int>(TalesMode::_Count)) {
+            Log.error(__FUNCTION__, "| Invalid Tales mode", modeInt);
             return false;
         }
-        return true;
+        m_mode = static_cast<TalesMode>(modeInt);
     }
-
-    if (!is_valid_mode(mode, theme)) {
-        Log.error(__FUNCTION__, "| Reclamation Algorithm mode", modeInt, "is incompatible with theme", theme);
-        return false;
-    }
-    m_mode = mode;
 
     return true;
 }

--- a/src/MaaCore/Task/Reclamation/ReclamationConfig.h
+++ b/src/MaaCore/Task/Reclamation/ReclamationConfig.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <variant>
+
 #include <meojson/json.hpp>
 
 namespace asst
@@ -11,17 +13,21 @@ public:
     static constexpr std::string_view RelaunchAnchor = "RelaunchAnchor"; // 重启锚点（RELAUNCH ANCHOR）
 };
 
-enum class ReclamationMode // 对应 Roguelike Mode
+enum class TalesMode
 {
     ProsperityNoSave = 0,  // 0 - 无存档刷繁荣点数
     ProsperityInSave = 1,  // 1 - 有存档刷繁荣点数
+    _Count,
 };
 
-enum class RelaunchAnchorStage
+enum class RelaunchAnchorMode
 {
-    RA1 = 1,   // 1 - RA-1
-    RA15 = 15, // 15 - RA-15
+    RA1 = 0,   // 0 - RA-1
+    RA15 = 1,  // 1 - RA-15
+    _Count,
 };
+
+using ReclamationMode = std::variant<TalesMode, RelaunchAnchorMode>;
 
 enum class ReclamationDifficulty // 对应 Roguelike Difficulty
 {
@@ -43,11 +49,6 @@ public:
         return theme == ReclamationTheme::Tales || theme == ReclamationTheme::RelaunchAnchor;
     }
 
-    static constexpr bool is_valid_mode(const ReclamationMode& mode, [[maybe_unused]] const std::string_view theme)
-    {
-        return mode == ReclamationMode::ProsperityNoSave || mode == ReclamationMode::ProsperityInSave;
-    }
-
     static constexpr bool is_valid_difficulty(const ReclamationDifficulty& difficulty)
     {
         return difficulty == ReclamationDifficulty::Casual || difficulty == ReclamationDifficulty::Standard ||
@@ -60,14 +61,11 @@ public:
 
     [[nodiscard]] const ReclamationMode& get_mode() const { return m_mode; }
 
-    [[nodiscard]] RelaunchAnchorStage get_stage() const { return m_stage; }
-
     [[nodiscard]] ReclamationDifficulty get_difficulty() const { return m_difficulty; }
 
 private:
     std::string m_theme = std::string(ReclamationTheme::Tales);            // 主题
-    ReclamationMode m_mode = ReclamationMode::ProsperityInSave;            // 策略
-    RelaunchAnchorStage m_stage = RelaunchAnchorStage::RA1;                // 关卡
+    ReclamationMode m_mode = TalesMode::ProsperityInSave;                  // 策略
     ReclamationDifficulty m_difficulty = ReclamationDifficulty::Challenge; // 难度模式
 
     // 以下注释列出了插件专用参数, 以便于快速检阅。这些参数的具体声明与使用请参考各插件。

--- a/src/MaaCore/Task/Reclamation/ReclamationCraftTaskPlugin.cpp
+++ b/src/MaaCore/Task/Reclamation/ReclamationCraftTaskPlugin.cpp
@@ -11,7 +11,9 @@ bool asst::ReclamationCraftTaskPlugin::load_params(const json::value& params)
 {
     LogTraceFunction;
 
-    if (const ReclamationMode& mode = m_config->get_mode(); mode != ReclamationMode::ProsperityInSave) {
+    // 仅在沙洲遗闻有存档模式下启用
+    if (!std::holds_alternative<TalesMode>(m_config->get_mode()) ||
+        std::get<TalesMode>(m_config->get_mode()) != TalesMode::ProsperityInSave) {
         return false;
     }
 

--- a/src/MaaCore/Task/Reclamation/ReclamationCraftTaskPlugin.cpp
+++ b/src/MaaCore/Task/Reclamation/ReclamationCraftTaskPlugin.cpp
@@ -12,8 +12,8 @@ bool asst::ReclamationCraftTaskPlugin::load_params(const json::value& params)
     LogTraceFunction;
 
     // 仅在沙洲遗闻有存档模式下启用
-    if (!std::holds_alternative<TalesMode>(m_config->get_mode()) ||
-        std::get<TalesMode>(m_config->get_mode()) != TalesMode::ProsperityInSave) {
+    const auto* tales_mode = std::get_if<TalesMode>(&m_config->get_mode());
+    if (!tales_mode || *tales_mode != TalesMode::ProsperityInSave) {
         return false;
     }
 

--- a/src/MaaWpfGui/Configuration/Single/MaaTask/ReclamationTask.cs
+++ b/src/MaaWpfGui/Configuration/Single/MaaTask/ReclamationTask.cs
@@ -25,9 +25,20 @@ public class ReclamationTask : BaseTask
 
     public ReclamationTheme Theme { get; set; } = ReclamationTheme.Tales;
 
-    public RelaunchAnchorStage Stage { get; set; } = RelaunchAnchorStage.RA1;
-
-    public ReclamationMode Mode { get; set; } = ReclamationMode.Archive;
+    /// <summary>
+    /// Gets or sets 生息演算模式（含义由 Theme 决定）
+    /// <list type="bullet">
+    ///     <item>
+    ///         <term><c>0</c></term>
+    ///         <description>Tales: 无存档刷繁荣点数 / RelaunchAnchor: RA-1</description>
+    ///     </item>
+    ///     <item>
+    ///         <term><c>1</c></term>
+    ///         <description>Tales: 有存档刷繁荣点数 / RelaunchAnchor: RA-15</description>
+    ///     </item>
+    /// </list>
+    /// </summary>
+    public int Mode { get; set; } = 0;
 
     /// <summary>
     /// Gets or sets 要组装的支援道具
@@ -65,28 +76,28 @@ public enum ReclamationTheme
     RelaunchAnchor,
 }
 
-public enum RelaunchAnchorStage
-{
-    /// <summary>
-    /// RA-1
-    /// </summary>
-    RA1 = 1,
-
-    /// <summary>
-    /// RA-15
-    /// </summary>
-    RA15 = 15,
-}
-
-public enum ReclamationMode
+public enum TalesMode
 {
     /// <summary>
     /// 无存档，通过进出关卡刷生息点数
     /// </summary>
-    NoArchive = 0,
+    ProsperityNoSave = 0,
 
     /// <summary>
     /// 有存档，通过组装支援道具刷生息点数
     /// </summary>
-    Archive = 1,
+    ProsperityInSave = 1,
+}
+
+public enum RelaunchAnchorMode
+{
+    /// <summary>
+    /// RA-1
+    /// </summary>
+    RA1 = 0,
+
+    /// <summary>
+    /// RA-15
+    /// </summary>
+    RA15 = 1,
 }

--- a/src/MaaWpfGui/Helper/ConfigConverter.cs
+++ b/src/MaaWpfGui/Helper/ConfigConverter.cs
@@ -411,7 +411,7 @@ public class ConfigConverter
                 ConfigurationHelper.DeleteValue(ConfigurationKeys.RoguelikeStopAtMaxLevel);
 
                 reclamationTask.Theme = ConfigurationHelper.GetValue(ConfigurationKeys.ReclamationTheme, ReclamationTheme.Tales);
-                reclamationTask.Mode = ConfigurationHelper.GetValue(ConfigurationKeys.ReclamationMode, 1);
+                reclamationTask.Mode = ConfigurationHelper.GetValue(ConfigurationKeys.ReclamationMode, (int)TalesMode.ProsperityInSave);
                 reclamationTask.ToolToCraft = ConfigurationHelper.GetValue(ConfigurationKeys.ReclamationToolToCraft, string.Empty).Replace('；', ';').Trim();
                 reclamationTask.IncrementMode = ConfigurationHelper.GetValue(ConfigurationKeys.ReclamationIncrementMode, 0);
                 reclamationTask.MaxCraftCountPerRound = ConfigurationHelper.GetValue(ConfigurationKeys.ReclamationMaxCraftCountPerRound, 16);

--- a/src/MaaWpfGui/Helper/ConfigConverter.cs
+++ b/src/MaaWpfGui/Helper/ConfigConverter.cs
@@ -411,7 +411,7 @@ public class ConfigConverter
                 ConfigurationHelper.DeleteValue(ConfigurationKeys.RoguelikeStopAtMaxLevel);
 
                 reclamationTask.Theme = ConfigurationHelper.GetValue(ConfigurationKeys.ReclamationTheme, ReclamationTheme.Tales);
-                reclamationTask.Mode = ConfigurationHelper.GetValue(ConfigurationKeys.ReclamationMode, ReclamationMode.Archive);
+                reclamationTask.Mode = ConfigurationHelper.GetValue(ConfigurationKeys.ReclamationMode, 1);
                 reclamationTask.ToolToCraft = ConfigurationHelper.GetValue(ConfigurationKeys.ReclamationToolToCraft, string.Empty).Replace('；', ';').Trim();
                 reclamationTask.IncrementMode = ConfigurationHelper.GetValue(ConfigurationKeys.ReclamationIncrementMode, 0);
                 reclamationTask.MaxCraftCountPerRound = ConfigurationHelper.GetValue(ConfigurationKeys.ReclamationMaxCraftCountPerRound, 16);

--- a/src/MaaWpfGui/Models/AsstTasks/AsstReclamationTask.cs
+++ b/src/MaaWpfGui/Models/AsstTasks/AsstReclamationTask.cs
@@ -32,24 +32,9 @@ public class AsstReclamationTask : AsstBaseTask
     public ReclamationTheme Theme { get; set; } = ReclamationTheme.Tales;
 
     /// <summary>
-    /// Gets or sets 生息演算关卡（仅重启锚点）
+    /// Gets or sets 生息演算模式（含义由 Theme 决定）
     /// </summary>
-    public RelaunchAnchorStage Stage { get; set; } = RelaunchAnchorStage.RA1;
-
-    /// <summary>
-    /// Gets or sets 生息演算模式
-    /// <list type="bullet">
-    ///     <item>
-    ///         <term><c>0</c></term>
-    ///         <description>无存档时通过进出关卡刷生息点数</description>
-    ///     </item>
-    ///     <item>
-    ///         <term><c>1</c></term>
-    ///         <description>有存档时通过合成支援道具刷生息点数</description>
-    ///     </item>
-    /// </list>
-    /// </summary>
-    public ReclamationMode Mode { get; set; } = ReclamationMode.Archive;
+    public int Mode { get; set; } = 0;
 
     /// <summary>
     /// Gets or sets 点击类型：0 连点；1 长按
@@ -76,8 +61,7 @@ public class AsstReclamationTask : AsstBaseTask
         var data = new JObject
         {
             ["theme"] = Theme.ToString(),
-            ["stage"] = (int)Stage,
-            ["mode"] = (int)Mode,
+            ["mode"] = Mode,
             ["increment_mode"] = IncrementMode,
             ["num_craft_batches"] = MaxCraftCountPerRound,
             ["tools_to_craft"] = new JArray(ToolToCraft),

--- a/src/MaaWpfGui/Models/TaskSettingVisibilityInfo.cs
+++ b/src/MaaWpfGui/Models/TaskSettingVisibilityInfo.cs
@@ -152,7 +152,30 @@ public class TaskSettingVisibilityInfo : PropertyChangedBase
             _ => throw new NotImplementedException(),
         };
         EnableAdvancedSettings = false;
-        AdvancedSettingsVisibility = !Award && !StartUp && !UserDataUpdate;
+        UpdateAdvancedSettingsVisibility(task);
+    }
+
+    /// <summary>
+    /// 根据当前任务配置刷新高级设置可见性
+    /// </summary>
+    public void RefreshAdvancedSettingsVisibility()
+    {
+        if (CurrentIndex < 0 || CurrentIndex >= ConfigFactory.CurrentConfig.TaskQueue.Count)
+        {
+            return;
+        }
+
+        UpdateAdvancedSettingsVisibility(ConfigFactory.CurrentConfig.TaskQueue[CurrentIndex]);
+    }
+
+    private void UpdateAdvancedSettingsVisibility(BaseTask task)
+    {
+        AdvancedSettingsVisibility = task switch
+        {
+            AwardTask or StartUpTask or UserDataUpdateTask => false,
+            ReclamationTask rt => rt.Theme == ReclamationTheme.Tales,
+            _ => true,
+        };
     }
 
     private void ResetVisible()

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -728,7 +728,9 @@ If the game is launched in portrait mode and then switched to landscape, it may 
     <system:String x:Key="ReclamationThemeFire">Fire Within the Sand</system:String>
     <system:String x:Key="ReclamationThemeTales">Tales Within the Sand</system:String>
     <system:String x:Key="ReclamationThemeRelaunchAnchor">RELAUNCH ANCHOR</system:String>
-    <system:String x:Key="ReclamationStage">Stage Selection</system:String>
+    <system:String x:Key="ReclamationMode">Mode</system:String>
+    <system:String x:Key="ReclamationModeRA1">RA-1</system:String>
+    <system:String x:Key="ReclamationModeRA15">RA-15</system:String>
     <system:String x:Key="ReclamationModeProsperityNoSave">I do not have a save, let's farm prosperity points by repeatedly entering and exiting stages.</system:String>
     <system:String x:Key="ReclamationModeProsperityInSave">I do have a save, let's farm prosperity points by crafting tools.</system:String>
     <system:String x:Key="ReclamationIncrementMode">Increment Mode</system:String>
@@ -1502,6 +1504,7 @@ Note: If you have unlocked technologies related to starting with extra items, pl
 
 Task flow: Automatically use support operator to execute 60-kill mission
     </system:String>
+    <system:String x:Key="ReclamationTipFire">This event has been closed and is no longer available.</system:String>
     <system:String x:Key="ReclamationTipTales" xml:space="preserve">
 The support for reclamation algorithm is still under development at present. Please mind the following:
 

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -729,7 +729,9 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="ReclamationThemeFire">砂中の火</system:String>
     <system:String x:Key="ReclamationThemeTales">熱砂秘聞</system:String>
     <system:String x:Key="ReclamationThemeRelaunchAnchor">RELAUNCH ANCHOR</system:String>
-    <system:String x:Key="ReclamationStage">ステージ選択</system:String>
+    <system:String x:Key="ReclamationMode">モード</system:String>
+    <system:String x:Key="ReclamationModeRA1">RA-1</system:String>
+    <system:String x:Key="ReclamationModeRA15">RA-15</system:String>
     <system:String x:Key="ReclamationModeProsperityNoSave">セーブせずに、出入りを繰り返して生息ポイントを稼ぐ</system:String>
     <system:String x:Key="ReclamationModeProsperityInSave">セーブしながら、支援アイテムを組み立てて生息ポイントを稼ぐ</system:String>
     <system:String x:Key="ReclamationIncrementMode">増加方式</system:String>
@@ -1503,6 +1505,7 @@ DEBUGディレクトリに保存される画像には数量制限があり、超
 
 タスクの流れ： サポートオペレーターを使用して 60 キルミッションを自動実行
     </system:String>
+    <system:String x:Key="ReclamationTipFire">このイベントは終了しており、利用できません</system:String>
     <system:String x:Key="ReclamationTipTales" xml:space="preserve">
 生息演算のサポートはまだ初期段階にありますので、ご利用の際は以下の点にご注意ください：
 

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -730,7 +730,9 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="ReclamationThemeFire">모래 속의 불</system:String>
     <system:String x:Key="ReclamationThemeTales">사막 이야기</system:String>
     <system:String x:Key="ReclamationThemeRelaunchAnchor">RELAUNCH ANCHOR</system:String>
-    <system:String x:Key="ReclamationStage">스테이지 선택</system:String>
+    <system:String x:Key="ReclamationMode">모드</system:String>
+    <system:String x:Key="ReclamationModeRA1">RA-1</system:String>
+    <system:String x:Key="ReclamationModeRA15">RA-15</system:String>
     <system:String x:Key="ReclamationModeProsperityNoSave">세이브 X, 스테이지 반복으로 번영의 선물 획득</system:String>
     <system:String x:Key="ReclamationModeProsperityInSave">세이브 O, 도구 제작으로 번영의 선물 획득</system:String>
     <system:String x:Key="ReclamationIncrementMode">증가 방식</system:String>
@@ -1503,6 +1505,7 @@ DEBUG 디렉토리에 저장된 이미지는 수량 제한이 있으며 초과 �
 
 작업 흐름： 서포트 오퍼레이터를 사용하여 60킬 미션을 자동 실행
     </system:String>
+    <system:String x:Key="ReclamationTipFire">이 이벤트는 종료되어 사용할 수 없습니다</system:String>
     <system:String x:Key="ReclamationTipTales" xml:space="preserve">
 현재 생존 연산 기능은 초기 단계이며, 다음 사항에 주의하세요:
 

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -729,7 +729,9 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="ReclamationThemeFire">沙中之火</system:String>
     <system:String x:Key="ReclamationThemeTales">沙洲遗闻</system:String>
     <system:String x:Key="ReclamationThemeRelaunchAnchor">重启锚点</system:String>
-    <system:String x:Key="ReclamationStage">关卡选择</system:String>
+    <system:String x:Key="ReclamationMode">模式</system:String>
+    <system:String x:Key="ReclamationModeRA1">RA-1</system:String>
+    <system:String x:Key="ReclamationModeRA15">RA-15</system:String>
     <system:String x:Key="ReclamationModeProsperityNoSave">无存档，通过进出关卡刷生息点数</system:String>
     <system:String x:Key="ReclamationModeProsperityInSave">有存档，通过组装支援道具刷生息点数</system:String>
     <system:String x:Key="ReclamationIncrementMode">增加方式</system:String>
@@ -1505,6 +1507,7 @@ DEBUG 目录下保存的图片有数量限制，超出后会自动清理旧图�
 
 任务流程：用圣聆初雪完成 60 杀任务
     </system:String>
+    <system:String x:Key="ReclamationTipFire">该活动已关闭，无法使用</system:String>
     <system:String x:Key="ReclamationTipTales" xml:space="preserve">
 目前生息演算的支持仍处于中期阶段，使用时请注意以下几点：
 

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -729,7 +729,9 @@ C:\\leidian\\LDPlayer9\n
     <system:String x:Key="ReclamationThemeFire">沙中之火</system:String>
     <system:String x:Key="ReclamationThemeTales">沙洲遺聞</system:String>
     <system:String x:Key="ReclamationThemeRelaunchAnchor">重啟錨點</system:String>
-    <system:String x:Key="ReclamationStage">關卡選擇</system:String>
+    <system:String x:Key="ReclamationMode">模式</system:String>
+    <system:String x:Key="ReclamationModeRA1">RA-1</system:String>
+    <system:String x:Key="ReclamationModeRA15">RA-15</system:String>
     <system:String x:Key="ReclamationModeProsperityNoSave">無存檔，透過進出關卡刷生息點數</system:String>
     <system:String x:Key="ReclamationModeProsperityInSave">有存檔，透過組裝支援道具刷生息點數</system:String>
     <system:String x:Key="ReclamationIncrementMode">增加方式</system:String>
@@ -1503,6 +1505,7 @@ DEBUG 目錄下儲存的圖片有數量限制，超出後會自動清理舊圖�
 
 任務流程： 自動借助戰執行 60 殺任務
     </system:String>
+    <system:String x:Key="ReclamationTipFire">該活動已關閉，無法使用</system:String>
     <system:String x:Key="ReclamationTipTales" xml:space="preserve">
 目前生息演算的支援仍處於中期階段，使用時請注意以下幾點：
 

--- a/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
@@ -14,13 +14,13 @@
 #nullable enable
 using System;
 using System.Buffers;
-using System.Text;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
@@ -2316,14 +2316,12 @@ public class ToolboxViewModel : Screen
     public static void UpdateMiniGameTaskList()
     {
         var categorizedItems = Instances.StageManager.MiniGameEntries
-            .Select(t =>
-            {
+            .Select(t => {
                 var isCurrentEvent = t.UtcStartTime != DateTime.MinValue || t.UtcExpireTime != DateTime.MinValue;
                 var category = LocalizationHelper.GetString(isCurrentEvent
                     ? "MiniGameCategoryCurrentEvent"
                     : "MiniGameCategoryPermanent");
-                return new MiniGameCategoryItem
-                {
+                return new MiniGameCategoryItem {
                     Display = string.IsNullOrEmpty(t.DisplayKey)
                         ? t.Display
                         : (LocalizationHelper.TryGetString(t.DisplayKey, out var loc) ? loc : t.Display),
@@ -2333,8 +2331,7 @@ public class ToolboxViewModel : Screen
             })
             .ToList();
 
-        Execute.OnUIThread(() =>
-        {
+        Execute.OnUIThread(() => {
             var toolbox = Instances.ToolboxViewModel;
             if (toolbox == null)
             {
@@ -2369,8 +2366,7 @@ public class ToolboxViewModel : Screen
 
     public string GetMiniGameTask()
     {
-        return MiniGameTaskName switch
-        {
+        return MiniGameTaskName switch {
             "MiniGame@SecretFront" => $"{MiniGameTaskName}@Begin@Ending{SecretFrontEnding}{(string.IsNullOrEmpty(SecretFrontEvent) ? string.Empty : $"@{SecretFrontEvent}")}",
             _ => MiniGameTaskName,
         };

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/ReclamationSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/ReclamationSettingsUserControlModel.cs
@@ -21,8 +21,6 @@ using MaaWpfGui.Utilities;
 using MaaWpfGui.Utilities.ValueType;
 using MaaWpfGui.ViewModels.UI;
 using static MaaWpfGui.Main.AsstProxy;
-using Mode = MaaWpfGui.Configuration.Single.MaaTask.ReclamationMode;
-using Stage = MaaWpfGui.Configuration.Single.MaaTask.RelaunchAnchorStage;
 using Theme = MaaWpfGui.Configuration.Single.MaaTask.ReclamationTheme;
 
 namespace MaaWpfGui.ViewModels.UserControl.TaskQueue;
@@ -54,58 +52,39 @@ public class ReclamationSettingsUserControlModel : TaskSettingsViewModel, Reclam
         get => GetTaskConfig<ReclamationTask>().Theme;
         set => SetTaskConfig<ReclamationTask>(
             t => t.Theme == value,
-            t =>
-            {
+            t => {
                 t.Theme = value;
-                if (value == Theme.RelaunchAnchor) {
-                    t.Mode = Mode.NoArchive;
+                t.Mode = 0; // 切换主题时重置模式
+                if (value == Theme.RelaunchAnchor)
+                {
                     t.ClearStore = false;
                 }
             });
     }
 
     /// <summary>
-    /// Gets the list of reclamation stages for RelaunchAnchor theme.
+    /// Gets 生息演算模式列表（沙洲遗闻专用）
     /// </summary>
-    public List<GenericCombinedData<Stage>> ReclamationStageList { get; } =
+    public List<GenericCombinedData<int>> ReclamationTalesModeList { get; } =
         [
-            new() { Display = "RA-1", Value = Stage.RA1 },
-            new() { Display = "RA-15", Value = Stage.RA15 },
+            new() { Display = LocalizationHelper.GetString("ReclamationModeProsperityNoSave"), Value = (int)TalesMode.ProsperityNoSave },
+            new() { Display = LocalizationHelper.GetString("ReclamationModeProsperityInSave"), Value = (int)TalesMode.ProsperityInSave },
         ];
 
     /// <summary>
-    /// Gets or sets 生息演算关卡选择
+    /// Gets 生息演算模式列表（重启锚点专用）
     /// </summary>
-    public Stage ReclamationStage
-    {
-        get => GetTaskConfig<ReclamationTask>().Stage;
-        set => SetTaskConfig<ReclamationTask>(t => t.Stage == value, t => t.Stage = value);
-    }
-
-    /// <summary>
-    /// Gets the list of reclamation modes.
-    /// </summary>
-    public List<GenericCombinedData<Mode>> ReclamationModeList { get; } =
+    public List<GenericCombinedData<int>> ReclamationRelaunchAnchorModeList { get; } =
         [
-            new() { Display = LocalizationHelper.GetString("ReclamationModeProsperityNoSave"), Value = Mode.NoArchive },
-            new() { Display = LocalizationHelper.GetString("ReclamationModeProsperityInSave"), Value = Mode.Archive },
+            new() { Display = LocalizationHelper.GetString("ReclamationModeRA1"), Value = (int)RelaunchAnchorMode.RA1 },
+            new() { Display = LocalizationHelper.GetString("ReclamationModeRA15"), Value = (int)RelaunchAnchorMode.RA15 },
         ];
 
     /// <summary>
-    /// Gets or sets 策略，无存档刷生息点数 / 有存档刷生息点数
-    /// 可用值包括：
-    /// <list type="bullet">
-    ///     <item>
-    ///         <term><c>0</c></term>
-    ///         <description>无存档时通过进出关卡刷生息点数</description>
-    ///     </item>
-    ///     <item>
-    ///         <term><c>1</c></term>
-    ///         <description>有存档时通过合成支援道具刷生息点数</description>
-    ///     </item>
-    /// </list>
+    /// Gets or sets 生息演算模式（含义由主题决定）
     /// </summary>
-    public Mode ReclamationMode
+    [PropertyDependsOn(nameof(ReclamationTheme))]
+    public int ReclamationMode
     {
         get => GetTaskConfig<ReclamationTask>().Mode;
         set => SetTaskConfig<ReclamationTask>(t => t.Mode == value, t => t.Mode = value);
@@ -162,30 +141,34 @@ public class ReclamationSettingsUserControlModel : TaskSettingsViewModel, Reclam
     /// <summary>
     /// Gets the theme-specific tip text.
     /// </summary>
-    [PropertyDependsOn(nameof(ReclamationTheme), nameof(ReclamationStage))]
+    [PropertyDependsOn(nameof(ReclamationTheme), nameof(ReclamationMode))]
     public string ReclamationTip
     {
-        get
-        {
+        get {
             var theme = ReclamationTheme;
+            var mode = ReclamationMode;
 
-            if (theme == Theme.RelaunchAnchor)
+            switch (theme)
             {
-                var stageTipKey = $"ReclamationTipRelaunchAnchorRA{(int)ReclamationStage}";
-                if (LocalizationHelper.TryGetString(stageTipKey, out var stageTip))
-                {
-                    return stageTip;
-                }
+                case Theme.Fire:
+                    return LocalizationHelper.GetString("ReclamationTipFire");
+                case Theme.RelaunchAnchor:
+                    {
+                        // mode 0 = RA-1, mode 1 = RA-15
+                        var stageNum = mode == (int)RelaunchAnchorMode.RA15 ? 15 : 1;
+                        var stageTipKey = $"ReclamationTipRelaunchAnchorRA{stageNum}";
+                        if (LocalizationHelper.TryGetString(stageTipKey, out var stageTip))
+                        {
+                            return stageTip;
+                        }
 
-                return LocalizationHelper.GetString("ReclamationTipRelaunchAnchorRA1");
-            }
-            else if (theme == Theme.Tales || theme == Theme.Fire)
-            {
-                return LocalizationHelper.GetString("ReclamationTipTales");
-            }
-            else
-            {
-                return string.Empty;
+                        return LocalizationHelper.GetString("ReclamationTipRelaunchAnchorRA1");
+                    }
+
+                case Theme.Tales:
+                    return LocalizationHelper.GetString("ReclamationTipTales");
+                default:
+                    return string.Empty;
             }
         }
     }
@@ -212,7 +195,6 @@ public class ReclamationSettingsUserControlModel : TaskSettingsViewModel, Reclam
             var toolToCraft = !string.IsNullOrEmpty(reclamation.ToolToCraft) ? reclamation.ToolToCraft : LocalizationHelper.GetString("ReclamationToolToCraftPlaceholder", DataHelper.ClientLanguageMapper[SettingsViewModel.GameSettings.ClientType]);
             var task = new AsstReclamationTask() {
                 Theme = reclamation.Theme,
-                Stage = reclamation.Stage,
                 Mode = reclamation.Mode,
                 IncrementMode = reclamation.IncrementMode,
                 MaxCraftCountPerRound = reclamation.MaxCraftCountPerRound,

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/ReclamationSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/ReclamationSettingsUserControlModel.cs
@@ -91,6 +91,20 @@ public class ReclamationSettingsUserControlModel : TaskSettingsViewModel, Reclam
     }
 
     /// <summary>
+    /// Gets a value indicating whether 当前模式为有存档模式（仅对 Tales 主题有意义）
+    /// </summary>
+    [PropertyDependsOn(nameof(ReclamationTheme), nameof(ReclamationMode))]
+    public bool IsProsperityInSaveMode =>
+        ReclamationTheme == Theme.Tales && ReclamationMode == (int)TalesMode.ProsperityInSave;
+
+    /// <summary>
+    /// Gets a value indicating whether 当前模式为无存档模式（仅对 Tales 主题有意义）
+    /// </summary>
+    [PropertyDependsOn(nameof(ReclamationTheme), nameof(ReclamationMode))]
+    public bool IsProsperityNoSaveMode =>
+        ReclamationTheme == Theme.Tales && ReclamationMode == (int)TalesMode.ProsperityNoSave;
+
+    /// <summary>
     /// Gets or sets 要组装的支援道具
     /// </summary>
     public string ReclamationToolToCraft

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/ReclamationSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/ReclamationSettingsUserControlModel.cs
@@ -16,6 +16,7 @@ using System.Collections.Generic;
 using System.Linq;
 using MaaWpfGui.Configuration.Single.MaaTask;
 using MaaWpfGui.Helper;
+using MaaWpfGui.Models;
 using MaaWpfGui.Models.AsstTasks;
 using MaaWpfGui.Utilities;
 using MaaWpfGui.Utilities.ValueType;
@@ -50,16 +51,23 @@ public class ReclamationSettingsUserControlModel : TaskSettingsViewModel, Reclam
     public Theme ReclamationTheme
     {
         get => GetTaskConfig<ReclamationTask>().Theme;
-        set => SetTaskConfig<ReclamationTask>(
-            t => t.Theme == value,
-            t => {
-                t.Theme = value;
-                t.Mode = 0; // 切换主题时重置模式
-                if (value == Theme.RelaunchAnchor)
-                {
-                    t.ClearStore = false;
-                }
-            });
+        set
+        {
+            if (SetTaskConfig<ReclamationTask>(
+                t => t.Theme == value,
+                t => {
+                    t.Theme = value;
+                    t.Mode = 0; // 切换主题时重置模式
+                    if (value == Theme.RelaunchAnchor)
+                    {
+                        t.ClearStore = false;
+                    }
+                }))
+            {
+                // 主题变更后刷新高级设置可见性
+                TaskSettingVisibilityInfo.Instance.RefreshAdvancedSettingsVisibility();
+            }
+        }
     }
 
     /// <summary>

--- a/src/MaaWpfGui/Views/UserControl/TaskQueue/ReclamationSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/TaskQueue/ReclamationSettingsUserControl.xaml
@@ -30,24 +30,24 @@
                 SelectedValuePath="Value" />
             <ComboBox
                 Margin="0,5"
-                hc:InfoElement.Title="{DynamicResource ReclamationStage}"
+                hc:InfoElement.Title="{DynamicResource ReclamationMode}"
                 DisplayMemberPath="Display"
                 IsHitTestVisible="{Binding Idle, Source={x:Static ui_vms:TaskQueueViewModel.TaskSettingDataContext}}"
-                ItemsSource="{Binding ReclamationStageList}"
-                SelectedValue="{Binding ReclamationStage}"
+                ItemsSource="{Binding ReclamationTalesModeList}"
+                SelectedValue="{Binding ReclamationMode}"
                 SelectedValuePath="Value"
-                Visibility="{c:Binding 'ReclamationTheme == task:ReclamationTheme.RelaunchAnchor',
-                                      Source={x:Static taskQueue_vms:ReclamationSettingsUserControlModel.Instance}}" />
+                Visibility="{c:Binding 'ReclamationTheme == task:ReclamationTheme.Tales',
+                                       Source={x:Static taskQueue_vms:ReclamationSettingsUserControlModel.Instance}}" />
             <ComboBox
                 Margin="0,5"
-                hc:InfoElement.Title="{DynamicResource Strategy}"
+                hc:InfoElement.Title="{DynamicResource ReclamationMode}"
                 DisplayMemberPath="Display"
                 IsHitTestVisible="{Binding Idle, Source={x:Static ui_vms:TaskQueueViewModel.TaskSettingDataContext}}"
-                ItemsSource="{Binding ReclamationModeList}"
+                ItemsSource="{Binding ReclamationRelaunchAnchorModeList}"
                 SelectedValue="{Binding ReclamationMode}"
-                Visibility="{c:Binding 'ReclamationTheme != task:ReclamationTheme.RelaunchAnchor',
-                                      Source={x:Static taskQueue_vms:ReclamationSettingsUserControlModel.Instance}}"
-                SelectedValuePath="Value" />
+                SelectedValuePath="Value"
+                Visibility="{c:Binding 'ReclamationTheme == task:ReclamationTheme.RelaunchAnchor',
+                                       Source={x:Static taskQueue_vms:ReclamationSettingsUserControlModel.Instance}}" />
             <controls:TextBlock
                 Margin="5,10,5,10"
                 Style="{StaticResource TextBlockDefault}"
@@ -56,15 +56,14 @@
         </StackPanel>
 
         <StackPanel Visibility="{c:Binding EnableAdvancedSettings, Source={x:Static ui_vms:TaskQueueViewModel.TaskSettingVisibilities}}">
-            <StackPanel Visibility="{c:Binding 'ReclamationTheme != task:ReclamationTheme.RelaunchAnchor',
-                                              Source={x:Static taskQueue_vms:ReclamationSettingsUserControlModel.Instance}}">
+            <StackPanel Visibility="{c:Binding 'ReclamationTheme == task:ReclamationTheme.Tales', Source={x:Static taskQueue_vms:ReclamationSettingsUserControlModel.Instance}}">
                 <TextBox
                     Margin="0,10"
                     VerticalContentAlignment="Center"
                     d:IsEnabled="True"
                     hc:InfoElement.Placeholder="{DynamicResource ReclamationToolToCraftPlaceholder}"
                     hc:InfoElement.Title="{DynamicResource ReclamationToolToCraftTip}"
-                    IsEnabled="{c:Binding 'ReclamationMode == task:ReclamationMode.Archive',
+                    IsEnabled="{c:Binding 'ReclamationMode == 1',
                                           Source={x:Static taskQueue_vms:ReclamationSettingsUserControlModel.Instance}}"
                     Text="{Binding ReclamationToolToCraft}" />
                 <ComboBox
@@ -72,7 +71,7 @@
                     d:IsEnabled="True"
                     hc:InfoElement.Title="{DynamicResource ReclamationIncrementMode}"
                     DisplayMemberPath="Display"
-                    IsEnabled="{c:Binding 'ReclamationMode == task:ReclamationMode.Archive',
+                    IsEnabled="{c:Binding 'ReclamationMode == 1',
                                           Source={x:Static taskQueue_vms:ReclamationSettingsUserControlModel.Instance}}"
                     IsHitTestVisible="{Binding Idle, Source={x:Static ui_vms:TaskQueueViewModel.TaskSettingDataContext}}"
                     ItemsSource="{Binding ReclamationIncrementModeList}"
@@ -82,7 +81,7 @@
                     Margin="0,5"
                     d:IsEnabled="True"
                     hc:InfoElement.Title="{DynamicResource ReclamationMaxCraftCountPerRound}"
-                    IsEnabled="{c:Binding 'ReclamationMode == task:ReclamationMode.Archive',
+                    IsEnabled="{c:Binding 'ReclamationMode == 1',
                                           Source={x:Static taskQueue_vms:ReclamationSettingsUserControlModel.Instance}}"
                     Minimum="0"
                     Value="{Binding ReclamationMaxCraftCountPerRound}" />
@@ -90,7 +89,7 @@
                     Margin="0,10"
                     d:Visibility="Visible"
                     IsChecked="{Binding ReclamationClearStore}"
-                    Visibility="{c:Binding 'ReclamationMode == task:ReclamationMode.NoArchive',
+                    Visibility="{c:Binding 'ReclamationMode == 0',
                                            Source={x:Static taskQueue_vms:ReclamationSettingsUserControlModel.Instance}}">
                     <TextBlock
                         Block.TextAlignment="Left"

--- a/src/MaaWpfGui/Views/UserControl/TaskQueue/ReclamationSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/TaskQueue/ReclamationSettingsUserControl.xaml
@@ -63,7 +63,7 @@
                     d:IsEnabled="True"
                     hc:InfoElement.Placeholder="{DynamicResource ReclamationToolToCraftPlaceholder}"
                     hc:InfoElement.Title="{DynamicResource ReclamationToolToCraftTip}"
-                    IsEnabled="{c:Binding 'ReclamationMode == 1',
+                    IsEnabled="{c:Binding IsProsperityInSaveMode,
                                           Source={x:Static taskQueue_vms:ReclamationSettingsUserControlModel.Instance}}"
                     Text="{Binding ReclamationToolToCraft}" />
                 <ComboBox
@@ -71,7 +71,7 @@
                     d:IsEnabled="True"
                     hc:InfoElement.Title="{DynamicResource ReclamationIncrementMode}"
                     DisplayMemberPath="Display"
-                    IsEnabled="{c:Binding 'ReclamationMode == 1',
+                    IsEnabled="{c:Binding IsProsperityInSaveMode,
                                           Source={x:Static taskQueue_vms:ReclamationSettingsUserControlModel.Instance}}"
                     IsHitTestVisible="{Binding Idle, Source={x:Static ui_vms:TaskQueueViewModel.TaskSettingDataContext}}"
                     ItemsSource="{Binding ReclamationIncrementModeList}"
@@ -81,7 +81,7 @@
                     Margin="0,5"
                     d:IsEnabled="True"
                     hc:InfoElement.Title="{DynamicResource ReclamationMaxCraftCountPerRound}"
-                    IsEnabled="{c:Binding 'ReclamationMode == 1',
+                    IsEnabled="{c:Binding IsProsperityInSaveMode,
                                           Source={x:Static taskQueue_vms:ReclamationSettingsUserControlModel.Instance}}"
                     Minimum="0"
                     Value="{Binding ReclamationMaxCraftCountPerRound}" />
@@ -89,7 +89,7 @@
                     Margin="0,10"
                     d:Visibility="Visible"
                     IsChecked="{Binding ReclamationClearStore}"
-                    Visibility="{c:Binding 'ReclamationMode == 0',
+                    Visibility="{c:Binding IsProsperityNoSaveMode,
                                            Source={x:Static taskQueue_vms:ReclamationSettingsUserControlModel.Instance}}">
                     <TextBlock
                         Block.TextAlignment="Left"


### PR DESCRIPTION
## Summary by Sourcery

统一回收算法模式的处理方式，使在 Tales 和 Relaunch Anchor 中每个主题仅解释一个模式字段，并让 GUI、核心配置以及任务执行逻辑与这一新方案保持一致。

增强内容：
- 用按主题区分的模式（Tales 与 Relaunch Anchor）和任务配置及模型中的单一整数模式值，替代原先分离的回收阶段枚举和模式枚举。
- 更新回收任务配置的解析、校验和执行逻辑，使其依据按主题区分的模式类型进行分支，而不是使用通用的模式/阶段二元组合。
- 在更换主题时重置回收模式，并调整回收设置界面中的提示文案选择及模式列表，以反映新的依赖主题的语义。
- 将回收制作插件限制为仅在 Tales 的“保存进度模式”下运行，并更新配置迁移时的新模式表示的默认值。
- 整理与小游戏任务列表和回收设置相关的部分 UI/ViewModel 代码风格及调用关系。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify reclamation algorithm mode handling so that a single mode field is interpreted per theme for both Tales and Relaunch Anchor, and align GUI, core config, and task execution logic with the new scheme.

Enhancements:
- Replace separate reclamation stage and mode enums with theme-specific modes (Tales vs. Relaunch Anchor) and a single integer mode value in task configs and models.
- Update reclamation task configuration parsing, validation, and execution to branch on theme-specific mode types instead of a generic mode/stage pair.
- Reset reclamation mode when changing theme and adjust tip text selection and mode lists in the reclamation settings UI to reflect the new theme-dependent semantics.
- Restrict the reclamation craft plugin to only run in Tales saved-progress mode and update configuration migration defaults for the new mode representation.
- Tidy up minor UI/view-model code style and wiring related to mini-game task listing and reclamation settings.

</details>