### PR TITLE
chore: 更新文档中过时的链接

### DIFF
--- a/docs/en-us/protocol/base-scheduling-schema.md
+++ b/docs/en-us/protocol/base-scheduling-schema.md
@@ -137,6 +137,6 @@ Please note that JSON files do not support comments. The comments in this docume
 
 ## Example
 
-[243_layout_3_times_a_day](https://github.com/MaaAssistantArknights/MaaAssistantArknights/blob/master/resource/custom_infrast/243_layout_3_times_a_day.json)
+[243_layout_3_times_a_day](https://github.com/MaaAssistantArknights/MaaAssistantArknights/blob/master-v2/resource/custom_infrast/243_layout_3_times_a_day.json)
 
-[153_layout_3_times_a_day](https://github.com/MaaAssistantArknights/MaaAssistantArknights/blob/master/resource/custom_infrast/153_layout_3_times_a_day.json)
+[153_layout_3_times_a_day](https://github.com/MaaAssistantArknights/MaaAssistantArknights/blob/master-v2/resource/custom_infrast/153_layout_3_times_a_day.json)

--- a/docs/ja-jp/protocol/base-scheduling-schema.md
+++ b/docs/ja-jp/protocol/base-scheduling-schema.md
@@ -147,6 +147,6 @@ JSONファイルはコメントをサポートしていません。テキスト�
 
 ## サンプル
 
-[243 有効率が最も高い 一日三回](https://github.com/MaaAssistantArknights/MaaAssistantArknights/blob/master/resource/custom_infrast/243_layout_3_times_a_day.json)
+[243 有効率が最も高い 一日三回](https://github.com/MaaAssistantArknights/MaaAssistantArknights/blob/master-v2/resource/custom_infrast/243_layout_3_times_a_day.json)
 
-[153 有効率が最も高い 一日三回](https://github.com/MaaAssistantArknights/MaaAssistantArknights/blob/master/resource/custom_infrast/153_layout_3_times_a_day.json)
+[153 有効率が最も高い 一日三回](https://github.com/MaaAssistantArknights/MaaAssistantArknights/blob/master-v2/resource/custom_infrast/153_layout_3_times_a_day.json)

--- a/docs/ko-kr/protocol/base-scheduling-schema.md
+++ b/docs/ko-kr/protocol/base-scheduling-schema.md
@@ -137,6 +137,6 @@ JSON 파일은 주석을 지원하지 않으므로, 텍스트 내의 주석은 �
 
 ## 예시
 
-[243 극한 효율, 하루 3회 교대](https://github.com/MaaAssistantArknights/MaaAssistantArknights/blob/master/resource/custom_infrast/243_layout_3_times_a_day.json)
+[243 극한 효율, 하루 3회 교대](https://github.com/MaaAssistantArknights/MaaAssistantArknights/blob/master-v2/resource/custom_infrast/243_layout_3_times_a_day.json)
 
-[153 극한 효율, 하루 3회 교대](https://github.com/MaaAssistantArknights/MaaAssistantArknights/blob/master/resource/custom_infrast/153_layout_3_times_a_day.json)
+[153 극한 효율, 하루 3회 교대](https://github.com/MaaAssistantArknights/MaaAssistantArknights/blob/master-v2/resource/custom_infrast/153_layout_3_times_a_day.json)

--- a/docs/zh-cn/protocol/base-scheduling-schema.md
+++ b/docs/zh-cn/protocol/base-scheduling-schema.md
@@ -137,6 +137,6 @@ icon: material-symbols:view-quilt-rounded
 
 ## 举例
 
-[243 极限效率，一天三换](https://github.com/MaaAssistantArknights/MaaAssistantArknights/blob/master/resource/custom_infrast/243_layout_3_times_a_day.json)
+[243 极限效率，一天三换](https://github.com/MaaAssistantArknights/MaaAssistantArknights/blob/master-v2/resource/custom_infrast/243_layout_3_times_a_day.json)
 
-[153 极限效率，一天三换](https://github.com/MaaAssistantArknights/MaaAssistantArknights/blob/master/resource/custom_infrast/153_layout_3_times_a_day.json)
+[153 极限效率，一天三换](https://github.com/MaaAssistantArknights/MaaAssistantArknights/blob/master-v2/resource/custom_infrast/153_layout_3_times_a_day.json)

--- a/docs/zh-tw/protocol/base-scheduling-schema.md
+++ b/docs/zh-tw/protocol/base-scheduling-schema.md
@@ -137,6 +137,6 @@ icon: material-symbols:view-quilt-rounded
 
 ## 範例檔案
 
-[243 極限效率，一天三換](https://github.com/MaaAssistantArknights/MaaAssistantArknights/blob/master/resource/custom_infrast/243_layout_3_times_a_day.json)
+[243 極限效率，一天三換](https://github.com/MaaAssistantArknights/MaaAssistantArknights/blob/master-v2/resource/custom_infrast/243_layout_3_times_a_day.json)
 
-[153 極限效率，一天三換](https://github.com/MaaAssistantArknights/MaaAssistantArknights/blob/master/resource/custom_infrast/153_layout_3_times_a_day.json)
+[153 極限效率，一天三換](https://github.com/MaaAssistantArknights/MaaAssistantArknights/blob/master-v2/resource/custom_infrast/153_layout_3_times_a_day.json)


### PR DESCRIPTION
把基建排班文档中的链接从master存档分支改到了v2分支

## Summary by Sourcery

Documentation:
- 在基础调度模式文档中，更新示例 JSON 布局链接，使其在所有本地化版本中都指向 `master-v2` 分支。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Refresh example JSON layout links in base scheduling schema docs to reference the master-v2 branch in all locale variants.

</details>