### PR TITLE
feat: 为外部通知加入Ntfy通知方式

### DIFF
--- a/src/MaaWpfGui/Constants/ConfigurationKeys.cs
+++ b/src/MaaWpfGui/Constants/ConfigurationKeys.cs
@@ -320,6 +320,9 @@ public static class ConfigurationKeys
     public const string ExternalNotificationQmsgBot = "ExternalNotification.Qmsg.Bot";
     public const string ExternalNotificationGotifyServer = "ExternalNotification.Gotify.Server";
     public const string ExternalNotificationGotifyToken = "ExternalNotification.Gotify.Token";
+    public const string ExternalNotificationNtfyServer = "ExternalNotification.Ntfy.Server";
+    public const string ExternalNotificationNtfyTopic = "ExternalNotification.Ntfy.Topic";
+    public const string ExternalNotificationNtfyToken = "ExternalNotification.Ntfy.Token";
     public const string ExternalNotificationCustomWebhookUrl = "ExternalNotification.CustomWebhook.Url";
     public const string ExternalNotificationCustomWebhookBody = "ExternalNotification.CustomWebhook.Body";
 

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -73,6 +73,9 @@
     <system:String x:Key="ExternalNotificationQmsgBot">Bot QQ</system:String>
     <system:String x:Key="ExternalNotificationGotifyServer">Server URL</system:String>
     <system:String x:Key="ExternalNotificationGotifyToken">Application Token</system:String>
+    <system:String x:Key="ExternalNotificationNtfyServer">Server URL</system:String>
+    <system:String x:Key="ExternalNotificationNtfyTopic">Topic</system:String>
+    <system:String x:Key="ExternalNotificationNtfyToken">Access Token (optional)</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook">Custom Webhook</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhookUrl">Webhook URL</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhookBody">Message body template</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -73,6 +73,9 @@
     <system:String x:Key="ExternalNotificationQmsgBot">ボットを送信するQQ</system:String>
     <system:String x:Key="ExternalNotificationGotifyServer">サーバー URL</system:String>
     <system:String x:Key="ExternalNotificationGotifyToken">アプリケーショントークン</system:String>
+    <system:String x:Key="ExternalNotificationNtfyServer">サーバー URL</system:String>
+    <system:String x:Key="ExternalNotificationNtfyTopic">Topic</system:String>
+    <system:String x:Key="ExternalNotificationNtfyToken">アクセストークン（オプション）</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook">Custom Webhook</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhookUrl">Webhook URL</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhookBody">メッセージ本文</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -73,6 +73,9 @@
     <system:String x:Key="ExternalNotificationQmsgBot">봇 QQ</system:String>
     <system:String x:Key="ExternalNotificationGotifyServer">서버 URL</system:String>
     <system:String x:Key="ExternalNotificationGotifyToken">애플리케이션 토큰</system:String>
+    <system:String x:Key="ExternalNotificationNtfyServer">서버 URL</system:String>
+    <system:String x:Key="ExternalNotificationNtfyTopic">Topic</system:String>
+    <system:String x:Key="ExternalNotificationNtfyToken">액세스 토큰 (선택 사항)</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook">Custom Webhook</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhookUrl">Webhook URL</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhookBody">메시지 본문 템플릿</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -73,6 +73,9 @@
     <system:String x:Key="ExternalNotificationQmsgBot">机器人 QQ</system:String>
     <system:String x:Key="ExternalNotificationGotifyServer">服务器 URL</system:String>
     <system:String x:Key="ExternalNotificationGotifyToken">应用程序令牌</system:String>
+    <system:String x:Key="ExternalNotificationNtfyServer">服务器 URL</system:String>
+    <system:String x:Key="ExternalNotificationNtfyTopic">Topic</system:String>
+    <system:String x:Key="ExternalNotificationNtfyToken">Access Token（可选）</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook">自定义 Webhook</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhookUrl">Webhook URL</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhookBody">消息体模板</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -73,6 +73,9 @@
     <system:String x:Key="ExternalNotificationQmsgBot">機器人 QQ</system:String>
     <system:String x:Key="ExternalNotificationGotifyServer">伺服器 URL</system:String>
     <system:String x:Key="ExternalNotificationGotifyToken">應用程式權杖 (Token)</system:String>
+    <system:String x:Key="ExternalNotificationNtfyServer">伺服器 URL</system:String>
+    <system:String x:Key="ExternalNotificationNtfyTopic">Topic</system:String>
+    <system:String x:Key="ExternalNotificationNtfyToken">Access Token（選用）</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook">自定義 Webhook</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhookUrl">Webhook URL</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhookBody">訊息本文範本</system:String>

--- a/src/MaaWpfGui/Services/Notification/ExternalNotificationService.cs
+++ b/src/MaaWpfGui/Services/Notification/ExternalNotificationService.cs
@@ -44,6 +44,7 @@ public static class ExternalNotificationService
                 "SMTP" => new SmtpNotificationProvider(),
                 "Bark" => new BarkNotificationProvider(Instances.HttpService),
                 "Qmsg" => new QmsgNotificationProvider(Instances.HttpService),
+                "Ntfy" => new NtfyNotificationProvider(Instances.HttpService),
                 _ => new DummyNotificationProvider(),
             };
 

--- a/src/MaaWpfGui/Services/Notification/NtfyNotificationProvider.cs
+++ b/src/MaaWpfGui/Services/Notification/NtfyNotificationProvider.cs
@@ -40,6 +40,7 @@ public class NtfyNotificationProvider(IHttpService httpService) : IExternalNotif
         if (!Uri.TryCreate(server, UriKind.Absolute, out var baseUri) ||
             (baseUri.Scheme != Uri.UriSchemeHttp && baseUri.Scheme != Uri.UriSchemeHttps))
         {
+            _logger.Warning("Failed to send Ntfy notification, invalid server URL: '{Server}'", server);
             return false;
         }
 

--- a/src/MaaWpfGui/Services/Notification/NtfyNotificationProvider.cs
+++ b/src/MaaWpfGui/Services/Notification/NtfyNotificationProvider.cs
@@ -1,0 +1,97 @@
+// <copyright file="NtfyNotificationProvider.cs" company="MaaAssistantArknights">
+// Part of the MaaWpfGui project, maintained by the MaaAssistantArknights team (Maa Team)
+// Copyright (C) 2021-2025 MaaAssistantArknights Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License v3.0 only as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+using MaaWpfGui.Services.Web;
+using MaaWpfGui.ViewModels.UI;
+using Serilog;
+
+namespace MaaWpfGui.Services.Notification;
+
+public class NtfyNotificationProvider(IHttpService httpService) : IExternalNotificationProvider
+{
+    private readonly ILogger _logger = Log.ForContext<NtfyNotificationProvider>();
+
+    public async Task<bool> SendAsync(string title, string content)
+    {
+        var server = SettingsViewModel.ExternalNotificationSettings.NtfyServer;
+        var topic = SettingsViewModel.ExternalNotificationSettings.NtfyTopic;
+
+        if (string.IsNullOrWhiteSpace(server))
+        {
+            _logger.Warning("Failed to send Ntfy notification, server URL is empty");
+            return false;
+        }
+
+        server = server.Trim();
+        if (!Uri.TryCreate(server, UriKind.Absolute, out var baseUri) ||
+            (baseUri.Scheme != Uri.UriSchemeHttp && baseUri.Scheme != Uri.UriSchemeHttps))
+        {
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(topic))
+        {
+            _logger.Warning("Failed to send Ntfy notification, topic is empty");
+            return false;
+        }
+
+        var token = SettingsViewModel.ExternalNotificationSettings.NtfyToken;
+        Dictionary<string, string>? headers = null;
+
+        if (!string.IsNullOrWhiteSpace(token))
+        {
+            headers = new Dictionary<string, string>
+            {
+                { "Authorization", $"Bearer {token.Trim()}" },
+            };
+        }
+
+        try
+        {
+            var response = await httpService.PostAsJsonAsync(
+                baseUri,
+                new NtfyMessage { Topic = topic.Trim(), Title = title, Message = content },
+                headers);
+
+            if (string.IsNullOrEmpty(response))
+            {
+                _logger.Warning("Failed to send Ntfy notification, response is null");
+                return false;
+            }
+
+            _logger.Information("Ntfy notification sent successfully");
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.Error(ex, "Failed to send Ntfy notification");
+            return false;
+        }
+    }
+
+    private class NtfyMessage
+    {
+        [JsonPropertyName("topic")]
+        public string Topic { get; set; } = string.Empty;
+
+        [JsonPropertyName("title")]
+        public string Title { get; set; } = string.Empty;
+
+        [JsonPropertyName("message")]
+        public string Message { get; set; } = string.Empty;
+    }
+}

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/ExternalNotificationSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/ExternalNotificationSettingsUserControlModel.cs
@@ -101,6 +101,7 @@ public class ExternalNotificationSettingsUserControlModel : PropertyChangedBase
             "Bark",
             "Qmsg",
             "Gotify",
+            "Ntfy",
             "Custom Webhook"
         ];
 
@@ -213,6 +214,14 @@ public class ExternalNotificationSettingsUserControlModel : PropertyChangedBase
         set => SetAndNotify(ref _gotifyEnabled, value);
     }
 
+    private bool _ntfyEnabled = false;
+
+    public bool NtfyEnabled
+    {
+        get => _ntfyEnabled;
+        set => SetAndNotify(ref _ntfyEnabled, value);
+    }
+
     private bool _customWebhookEnabled = false;
 
     public bool CustomWebhookEnabled
@@ -232,6 +241,7 @@ public class ExternalNotificationSettingsUserControlModel : PropertyChangedBase
         BarkEnabled = _enabledExternalNotificationProviders.Contains("Bark");
         QmsgEnabled = _enabledExternalNotificationProviders.Contains("Qmsg");
         GotifyEnabled = _enabledExternalNotificationProviders.Contains("Gotify");
+        NtfyEnabled = _enabledExternalNotificationProviders.Contains("Ntfy");
         CustomWebhookEnabled = _enabledExternalNotificationProviders.Contains("Custom Webhook");
     }
 
@@ -536,6 +546,45 @@ public class ExternalNotificationSettingsUserControlModel : PropertyChangedBase
             SetAndNotify(ref _gotifyToken, value);
             var encryptedValue = SimpleEncryptionHelper.Encrypt(value);
             ConfigurationHelper.SetValue(ConfigurationKeys.ExternalNotificationGotifyToken, encryptedValue);
+        }
+    }
+
+    private string _ntfyServer = SimpleEncryptionHelper.Decrypt(ConfigurationHelper.GetValue(ConfigurationKeys.ExternalNotificationNtfyServer, "https://ntfy.sh"), "https://ntfy.sh");
+
+    public string NtfyServer
+    {
+        get => _ntfyServer;
+        set
+        {
+            SetAndNotify(ref _ntfyServer, value);
+            var encryptedValue = SimpleEncryptionHelper.Encrypt(value);
+            ConfigurationHelper.SetValue(ConfigurationKeys.ExternalNotificationNtfyServer, encryptedValue);
+        }
+    }
+
+    private string _ntfyTopic = SimpleEncryptionHelper.Decrypt(ConfigurationHelper.GetValue(ConfigurationKeys.ExternalNotificationNtfyTopic, string.Empty));
+
+    public string NtfyTopic
+    {
+        get => _ntfyTopic;
+        set
+        {
+            SetAndNotify(ref _ntfyTopic, value);
+            var encryptedValue = SimpleEncryptionHelper.Encrypt(value);
+            ConfigurationHelper.SetValue(ConfigurationKeys.ExternalNotificationNtfyTopic, encryptedValue);
+        }
+    }
+
+    private string _ntfyToken = SimpleEncryptionHelper.Decrypt(ConfigurationHelper.GetValue(ConfigurationKeys.ExternalNotificationNtfyToken, string.Empty));
+
+    public string NtfyToken
+    {
+        get => _ntfyToken;
+        set
+        {
+            SetAndNotify(ref _ntfyToken, value);
+            var encryptedValue = SimpleEncryptionHelper.Encrypt(value);
+            ConfigurationHelper.SetValue(ConfigurationKeys.ExternalNotificationNtfyToken, encryptedValue);
         }
     }
 

--- a/src/MaaWpfGui/Views/UserControl/Settings/ExternalNotificationSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/Settings/ExternalNotificationSettingsUserControl.xaml
@@ -30,6 +30,7 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
         <!--<controls:TextBlock
@@ -487,6 +488,36 @@
 
         <StackPanel
             Grid.Row="11"
+            Orientation="Vertical"
+            Visibility="{c:Binding NtfyEnabled}">
+            <hc:Divider Content="Ntfy" />
+            <hc:TextBox
+                x:Name="NtfyServer"
+                Width="400"
+                Height="30"
+                Margin="10"
+                hc:InfoElement.Title="{DynamicResource ExternalNotificationNtfyServer}"
+                Text="{c:Binding NtfyServer}" />
+            <hc:TextBox
+                x:Name="NtfyTopic"
+                Width="400"
+                Height="30"
+                Margin="10"
+                hc:InfoElement.Title="{DynamicResource ExternalNotificationNtfyTopic}"
+                Text="{c:Binding NtfyTopic}" />
+            <hc:PasswordBox
+                x:Name="NtfyToken"
+                Width="400"
+                Height="30"
+                Margin="10"
+                hc:InfoElement.Title="{DynamicResource ExternalNotificationNtfyToken}"
+                IsSafeEnabled="False"
+                ShowEyeButton="True"
+                UnsafePassword="{c:Binding NtfyToken}" />
+        </StackPanel>
+
+        <StackPanel
+            Grid.Row="12"
             Orientation="Vertical"
             Visibility="{c:Binding CustomWebhookEnabled}">
             <hc:Divider Content="{DynamicResource ExternalNotificationCustomWebhook}" />


### PR DESCRIPTION
### 新增  
为外部通知加入Ntfy通知方式

## Summary by Sourcery

将 Ntfy 添加为新的外部通知提供程序，并将其接入现有的通知系统和设置界面。

新功能：
- 引入 Ntfy 作为可配置的外部通知提供程序，与现有通知渠道并行使用。
- 通过配置键和加密存储持久化保存 Ntfy 的服务器、主题和令牌设置。

增强内容：
- 将 Ntfy 集成到外部通知服务选择中，并在设置界面中接入对应的本地化资源。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add Ntfy as a new external notification provider and wire it into the existing notification system and settings UI.

New Features:
- Introduce Ntfy as a configurable external notification provider alongside existing channels.
- Persist Ntfy server, topic, and token settings via configuration keys and encrypted storage.

Enhancements:
- Integrate Ntfy into the external notification service selection and localization resources for the settings UI.

</details>