### PR TITLE
feat: MAA updater 增加文件被占用时增加重试、互斥量协调与回滚机制

### DIFF
--- a/src/MaaUpdater/main.cpp
+++ b/src/MaaUpdater/main.cpp
@@ -5,7 +5,8 @@
 // Usage:
 //   MAA.Updater.exe <ParentProcessId> <RootDir> <ExtractDir> <BackupDir>
 //                   <PackagePath> <SuccessStatusFile> <FailureStatusFile>
-//                   <RelaunchExecutablePath> <PlanFile> [--show-console]
+//                   <RelaunchExecutablePath> <PlanFile>
+//                   [--instance-key <sha256>] [--show-console]
 //
 // Plan file format (UTF-8 JSON):
 //   { "packageType": "full|ota", "removeList": ["rel/path", ...], "moveList": ["rel/path", ...] }
@@ -94,6 +95,8 @@ static bool LoadPendingUpdatePlan(
     std::string* rawJson = nullptr);
 static void PrintPlanEntries(const std::wstring& title, const std::vector<std::wstring>& entries);
 static int RunPlanParserTest(const std::wstring& initialPlanFile);
+static HANDLE AcquireUpdateMutex(const std::wstring& mutexName);
+static void ReleaseUpdateMutex(HANDLE hMutex);
 
 struct UpdateProgressUi
 {
@@ -135,6 +138,8 @@ static constexpr int PROGRESS_DETAIL_CONTROL_ID = 1002;
 static constexpr int PROGRESS_COUNT_CONTROL_ID = 1003;
 static constexpr int PROGRESS_BAR_CONTROL_ID = 1004;
 static constexpr DWORD LEGACY_DWMWA_USE_IMMERSIVE_DARK_MODE = 19;
+static constexpr wchar_t INSTANCE_KEY_ARG[] = L"--instance-key";
+static constexpr DWORD UPDATE_MUTEX_TIMEOUT_MS = 3000;
 
 #ifndef DWMWA_USE_IMMERSIVE_DARK_MODE
 #define DWMWA_USE_IMMERSIVE_DARK_MODE 20
@@ -1388,6 +1393,54 @@ static int RunPlanParserTest(const std::wstring& initialPlanFile)
 }
 
 // ---------------------------------------------------------------------------
+// Update mutex helpers
+// ---------------------------------------------------------------------------
+
+// Acquires a named system mutex to prevent new MAA instances from starting
+// while the update is in progress. Returns nullptr if the mutex cannot be
+// acquired (e.g. another MAA instance holds the lock).
+static HANDLE AcquireUpdateMutex(const std::wstring& mutexName)
+{
+    HANDLE hMutex = CreateMutexW(nullptr, TRUE, mutexName.c_str());
+    if (hMutex == nullptr) {
+        WriteLog((L"CreateMutexW failed, error=" + std::to_wstring(GetLastError())).c_str());
+        return nullptr;
+    }
+
+    DWORD waitResult = WaitForSingleObject(hMutex, UPDATE_MUTEX_TIMEOUT_MS);
+
+    if (waitResult == WAIT_OBJECT_0) {
+        WriteLog((L"Mutex acquired: " + mutexName).c_str());
+        return hMutex;
+    }
+
+    if (waitResult == WAIT_ABANDONED) {
+        // Previous MAA instance terminated abnormally; we now own the mutex.
+        WriteLog((L"Mutex acquired after WAIT_ABANDONED (previous instance crashed): " + mutexName).c_str());
+        return hMutex;
+    }
+
+    if (waitResult == WAIT_TIMEOUT) {
+        WriteLog((L"Mutex acquisition timed out after " + std::to_wstring(UPDATE_MUTEX_TIMEOUT_MS) + L"ms: " + mutexName).c_str());
+    } else {
+        WriteLog((L"WaitForSingleObject failed, error=" + std::to_wstring(GetLastError())).c_str());
+    }
+
+    CloseHandle(hMutex);
+    return nullptr;
+}
+
+static void ReleaseUpdateMutex(HANDLE hMutex)
+{
+    if (hMutex == nullptr || hMutex == INVALID_HANDLE_VALUE) {
+        return;
+    }
+
+    ReleaseMutex(hMutex);
+    CloseHandle(hMutex);
+}
+
+// ---------------------------------------------------------------------------
 // Entry point
 // ---------------------------------------------------------------------------
 
@@ -1422,6 +1475,14 @@ int wmain(int argc, wchar_t* argv[])
     std::wstring planFile            = argv[9];
     g_writeConsoleLog = HasArgument(argc, argv, L"--show-console");
 
+    std::wstring instanceKey;
+    for (int i = 1; i < argc - 1; ++i) {
+        if (_wcsicmp(argv[i], INSTANCE_KEY_ARG) == 0) {
+            instanceKey = argv[i + 1];
+            break;
+        }
+    }
+
     g_logFile = rootDir + L"\\debug\\pending-update-applier.log";
     RotateLogIfNeeded();
     InitializeProgressUi();
@@ -1437,6 +1498,7 @@ int wmain(int argc, wchar_t* argv[])
     bool shouldRelaunch = false;
     bool success = false;
     std::wstring failureReason;
+    HANDLE hUpdateMutex = nullptr;
 
     // ------------------------------------------------------------------
     // Wait for parent process to exit
@@ -1457,6 +1519,27 @@ int wmain(int argc, wchar_t* argv[])
         SetProgressUiStatus(
             L"正在准备更新... | Preparing update...",
             L"主程序已退出，开始读取更新计划 | Main process already exited, reading update plan");
+    }
+
+    // ------------------------------------------------------------------
+    // Acquire update mutex to prevent new MAA instances from starting
+    // ------------------------------------------------------------------
+    if (!instanceKey.empty()) {
+        std::wstring mutexName = L"MAA_" + instanceKey;
+        hUpdateMutex = AcquireUpdateMutex(mutexName);
+        if (hUpdateMutex == nullptr) {
+            failureReason =
+                L"检测到另一个 MAA 实例正在运行，无法执行更新。请关闭所有 MAA 窗口后重试。\n\n"
+                L"Another MAA instance is running. Please close all MAA windows and try again.";
+            WriteLog(failureReason.c_str());
+            SetProgressUiStatus(
+                L"无法继续更新 | Update blocked",
+                L"检测到另一个 MAA 实例正在运行 | Another MAA instance is running");
+        } else {
+            WriteLog(L"Update mutex acquired, preventing new MAA instances from starting.");
+        }
+    } else {
+        WriteLog(L"No instance key provided, update mutex will not be used.");
     }
 
     if (IsDriveRootDirectory(rootDir)) {
@@ -1638,6 +1721,15 @@ int wmain(int argc, wchar_t* argv[])
 
     if (PathExistsW(planFile))
         DeleteFileW(planFile.c_str());
+
+    // ------------------------------------------------------------------
+    // Release update mutex
+    // ------------------------------------------------------------------
+    if (hUpdateMutex != nullptr) {
+        ReleaseUpdateMutex(hUpdateMutex);
+        hUpdateMutex = nullptr;
+        WriteLog(L"Update mutex released.");
+    }
 
     // ------------------------------------------------------------------
     // Relaunch MAA

--- a/src/MaaUpdater/main.cpp
+++ b/src/MaaUpdater/main.cpp
@@ -6,7 +6,7 @@
 //   MAA.Updater.exe <ParentProcessId> <RootDir> <ExtractDir> <BackupDir>
 //                   <PackagePath> <SuccessStatusFile> <FailureStatusFile>
 //                   <RelaunchExecutablePath> <PlanFile>
-//                   [--instance-key <sha256>] [--show-console]
+//                   [--mutex-name <name>] [--show-console]
 //
 // Plan file format (UTF-8 JSON):
 //   { "packageType": "full|ota", "removeList": ["rel/path", ...], "moveList": ["rel/path", ...] }
@@ -146,7 +146,7 @@ static constexpr int PROGRESS_DETAIL_CONTROL_ID = 1002;
 static constexpr int PROGRESS_COUNT_CONTROL_ID = 1003;
 static constexpr int PROGRESS_BAR_CONTROL_ID = 1004;
 static constexpr DWORD LEGACY_DWMWA_USE_IMMERSIVE_DARK_MODE = 19;
-static constexpr wchar_t INSTANCE_KEY_ARG[] = L"--instance-key";
+static constexpr wchar_t MUTEX_NAME_ARG[] = L"--mutex-name";
 static constexpr DWORD UPDATE_MUTEX_TIMEOUT_MS = 3000;
 #define PENDING_DELETE_SUFFIX L".pendingdelete"
 static constexpr int FILE_OP_MAX_RETRIES = 5;
@@ -1826,10 +1826,10 @@ int wmain(int argc, wchar_t* argv[])
     std::wstring planFile            = argv[9];
     g_writeConsoleLog = HasArgument(argc, argv, L"--show-console");
 
-    std::wstring instanceKey;
+    std::wstring mutexName;
     for (int i = 1; i < argc - 1; ++i) {
-        if (_wcsicmp(argv[i], INSTANCE_KEY_ARG) == 0) {
-            instanceKey = argv[i + 1];
+        if (_wcsicmp(argv[i], MUTEX_NAME_ARG) == 0) {
+            mutexName = argv[i + 1];
             break;
         }
     }
@@ -1875,8 +1875,7 @@ int wmain(int argc, wchar_t* argv[])
     // ------------------------------------------------------------------
     // Acquire update mutex to prevent new MAA instances from starting
     // ------------------------------------------------------------------
-    if (!instanceKey.empty()) {
-        std::wstring mutexName = L"MAA_" + instanceKey;
+    if (!mutexName.empty()) {
         hUpdateMutex = AcquireUpdateMutex(mutexName);
         if (hUpdateMutex == nullptr) {
             failureReason =
@@ -1893,7 +1892,7 @@ int wmain(int argc, wchar_t* argv[])
         // Clean up any .pendingdelete files left from a previous interrupted update
         CleanupPendingDeleteFiles(rootDir);
     } else {
-        WriteLog(L"No instance key provided, update mutex will not be used.");
+        WriteLog(L"No mutex name provided, update mutex will not be used.");
     }
 
     if (IsDriveRootDirectory(rootDir)) {

--- a/src/MaaUpdater/main.cpp
+++ b/src/MaaUpdater/main.cpp
@@ -74,7 +74,6 @@ static void PrepareBackupDestination(const std::wstring& backupPath);
 static bool MoveExistingPathToBackup(const std::wstring& src, const std::wstring& backup);
 static bool RecycleAndBackupDirectory(const std::wstring& sourcePath, const std::wstring& backupPath);
 static bool RecycleAndBackupPath(const std::wstring& sourcePath, const std::wstring& backupPath);
-static bool RemoveDirectoryRecursive(const std::wstring& dir);
 
 static bool WriteUtf8File(const std::wstring& path, const char* content);
 static bool WriteUtf8File(const std::wstring& path, const std::string& content);
@@ -1090,26 +1089,6 @@ static bool RecycleAndBackupPath(const std::wstring& sourcePath, const std::wstr
     }
 
     return ForceDeleteFile(sourcePath);
-}
-
-static bool RemoveDirectoryRecursive(const std::wstring& dir)
-{
-    std::wstring pattern = dir + L"\\*";
-    WIN32_FIND_DATAW fd {};
-    HANDLE hFind = FindFirstFileW(pattern.c_str(), &fd);
-    if (hFind != INVALID_HANDLE_VALUE) {
-        do {
-            if (wcscmp(fd.cFileName, L".") == 0 || wcscmp(fd.cFileName, L"..") == 0)
-                continue;
-            std::wstring child = dir + L"\\" + fd.cFileName;
-            if (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
-                ForceRemoveDirectoryRecursive(child);
-            else
-                ForceDeleteFile(child);
-        } while (FindNextFileW(hFind, &fd));
-        FindClose(hFind);
-    }
-    return RemoveDirectoryW(dir.c_str()) != FALSE || !PathExistsW(dir);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/MaaUpdater/main.cpp
+++ b/src/MaaUpdater/main.cpp
@@ -22,8 +22,8 @@
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
+#include <functional>
 #include <iostream>
-#include <limits>
 #include <string>
 #include <vector>
 
@@ -98,6 +98,14 @@ static int RunPlanParserTest(const std::wstring& initialPlanFile);
 static HANDLE AcquireUpdateMutex(const std::wstring& mutexName);
 static void ReleaseUpdateMutex(HANDLE hMutex);
 
+// Retry and force-delete helpers
+static bool RetryFileOp(const std::function<bool()>& op, int maxAttempts = 5, DWORD initialDelayMs = 200);
+static std::wstring RenameLockedFile(const std::wstring& path);
+static bool ForceDeleteFile(const std::wstring& path);
+static bool ForceRemoveDirectoryRecursive(const std::wstring& dir);
+static bool InstallFileAtomic(const std::wstring& sourcePath, const std::wstring& targetPath, const std::wstring& backupDirForFailedAtomic);
+static void CleanupPendingDeleteFiles(const std::wstring& rootDir);
+
 struct UpdateProgressUi
 {
     bool enabled = false;
@@ -140,6 +148,9 @@ static constexpr int PROGRESS_BAR_CONTROL_ID = 1004;
 static constexpr DWORD LEGACY_DWMWA_USE_IMMERSIVE_DARK_MODE = 19;
 static constexpr wchar_t INSTANCE_KEY_ARG[] = L"--instance-key";
 static constexpr DWORD UPDATE_MUTEX_TIMEOUT_MS = 3000;
+#define PENDING_DELETE_SUFFIX L".pendingdelete"
+static constexpr int FILE_OP_MAX_RETRIES = 5;
+static constexpr DWORD FILE_OP_INITIAL_DELAY_MS = 200;
 
 #ifndef DWMWA_USE_IMMERSIVE_DARK_MODE
 #define DWMWA_USE_IMMERSIVE_DARK_MODE 20
@@ -940,7 +951,8 @@ static std::wstring CreateArchivedPath(const std::wstring& base)
     }
 }
 
-// Move a file or directory entry (handles cross-volume by CopyFile+Delete for files)
+// Move a file or directory entry (handles cross-volume by CopyFile+Delete for files).
+// Uses retry and rename fallback for locked files.
 static bool MovePathEntry(const std::wstring& src, const std::wstring& dst)
 {
     EnsureParentDirectory(dst);
@@ -949,16 +961,57 @@ static bool MovePathEntry(const std::wstring& src, const std::wstring& dst)
     if (attr == INVALID_FILE_ATTRIBUTES) return false;
 
     if (attr & FILE_ATTRIBUTE_DIRECTORY) {
-        return MoveFileExW(src.c_str(), dst.c_str(), 0) != FALSE;
+        auto moveOp = [&]() -> bool {
+            return MoveFileExW(src.c_str(), dst.c_str(), 0) != FALSE;
+        };
+        return RetryFileOp(moveOp, FILE_OP_MAX_RETRIES, FILE_OP_INITIAL_DELAY_MS);
     }
 
-    // Try atomic move first; fall back to copy+delete for cross-volume
-    if (MoveFileExW(src.c_str(), dst.c_str(), MOVEFILE_REPLACE_EXISTING) != FALSE)
-        return true;
+    // For files: try atomic move first; fall back to copy+delete
+    {
+        auto moveOp = [&]() -> bool {
+            return MoveFileExW(src.c_str(), dst.c_str(), MOVEFILE_REPLACE_EXISTING) != FALSE;
+        };
 
-    if (!CopyFileW(src.c_str(), dst.c_str(), FALSE)) return false;
-    DeleteFileW(src.c_str());
-    return true;
+        if (RetryFileOp(moveOp, FILE_OP_MAX_RETRIES, FILE_OP_INITIAL_DELAY_MS)) {
+            return true;
+        }
+    }
+
+    // Move failed (likely the source file is locked). Try copy+force-delete.
+    WriteLogF(L"MovePathEntry: move failed, falling back to copy+delete for: %ls", src.c_str());
+    {
+        auto copyOp = [&]() -> bool {
+            return CopyFileW(src.c_str(), dst.c_str(), FALSE) != FALSE;
+        };
+
+        if (RetryFileOp(copyOp, 3, 500)) {
+            // Copy succeeded; force-delete the source
+            ForceDeleteFile(src);
+            return true;
+        }
+    }
+
+    // Copy also failed. As a last resort, try to rename the source out of the way
+    // and then do a fresh copy to the destination.
+    WriteLogF(L"MovePathEntry: copy+delete failed, trying rename-and-copy for: %ls", src.c_str());
+    {
+        std::wstring renamed = RenameLockedFile(src);
+        if (!renamed.empty()) {
+            // The original path is now free; copy the renamed file to destination
+            auto copyOp = [&]() -> bool {
+                return CopyFileW(renamed.c_str(), dst.c_str(), FALSE) != FALSE;
+            };
+
+            if (RetryFileOp(copyOp, 3, 500)) {
+                WriteLogF(L"MovePathEntry: rename-and-copy succeeded: %ls", src.c_str());
+                return true;
+            }
+        }
+    }
+
+    WriteLogF(L"MovePathEntry: all strategies failed for src=%ls, dst=%ls", src.c_str(), dst.c_str());
+    return false;
 }
 
 static void PrepareBackupDestination(const std::wstring& backupPath)
@@ -973,29 +1026,70 @@ static void PrepareBackupDestination(const std::wstring& backupPath)
 static bool MoveExistingPathToBackup(const std::wstring& src, const std::wstring& backup)
 {
     PrepareBackupDestination(backup);
-    return MovePathEntry(src, backup);
+
+    // First try: normal move with retry
+    if (MovePathEntry(src, backup)) {
+        return true;
+    }
+
+    // Second try: copy to backup, then force-delete the source
+    WriteLogF(L"MoveExistingPathToBackup: move failed, trying copy+delete for: %ls", src.c_str());
+    {
+        auto copyOp = [&]() -> bool {
+            return CopyPathEntry(src, backup) != FALSE;
+        };
+
+        if (RetryFileOp(copyOp, 3, 500)) {
+            // Copy succeeded; now remove the source
+            ForceDeleteFile(src);
+            return true;
+        }
+    }
+
+    WriteLogF(L"MoveExistingPathToBackup: all strategies failed for: %ls", src.c_str());
+    return false;
 }
 
 static bool RecycleAndBackupDirectory(const std::wstring& sourcePath, const std::wstring& backupPath)
 {
     PrepareBackupDestination(backupPath);
 
-    if (!CopyDirectoryRecursive(sourcePath, backupPath)) {
-        return false;
+    {
+        auto copyOp = [&]() -> bool {
+            return CopyDirectoryRecursive(sourcePath, backupPath) != FALSE;
+        };
+        if (!RetryFileOp(copyOp, 3, 500)) {
+            return false;
+        }
     }
 
-    return MovePathToRecycleBin(sourcePath);
+    // Try recycle bin first, fall back to force-delete
+    if (MovePathToRecycleBin(sourcePath)) {
+        return true;
+    }
+
+    return ForceRemoveDirectoryRecursive(sourcePath);
 }
 
 static bool RecycleAndBackupPath(const std::wstring& sourcePath, const std::wstring& backupPath)
 {
     PrepareBackupDestination(backupPath);
 
-    if (!CopyPathEntry(sourcePath, backupPath)) {
-        return false;
+    {
+        auto copyOp = [&]() -> bool {
+            return CopyPathEntry(sourcePath, backupPath) != FALSE;
+        };
+        if (!RetryFileOp(copyOp, 3, 500)) {
+            return false;
+        }
     }
 
-    return MovePathToRecycleBin(sourcePath);
+    // Try recycle bin first, fall back to force-delete
+    if (MovePathToRecycleBin(sourcePath)) {
+        return true;
+    }
+
+    return ForceDeleteFile(sourcePath);
 }
 
 static bool RemoveDirectoryRecursive(const std::wstring& dir)
@@ -1009,13 +1103,13 @@ static bool RemoveDirectoryRecursive(const std::wstring& dir)
                 continue;
             std::wstring child = dir + L"\\" + fd.cFileName;
             if (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)
-                RemoveDirectoryRecursive(child);
+                ForceRemoveDirectoryRecursive(child);
             else
-                DeleteFileW(child.c_str());
+                ForceDeleteFile(child);
         } while (FindNextFileW(hFind, &fd));
         FindClose(hFind);
     }
-    return RemoveDirectoryW(dir.c_str()) != FALSE;
+    return RemoveDirectoryW(dir.c_str()) != FALSE || !PathExistsW(dir);
 }
 
 // ---------------------------------------------------------------------------
@@ -1441,6 +1535,263 @@ static void ReleaseUpdateMutex(HANDLE hMutex)
 }
 
 // ---------------------------------------------------------------------------
+// Retry and force-delete helpers
+// ---------------------------------------------------------------------------
+
+// Retries a file operation with exponential backoff on lock-related errors.
+// Returns true if the operation eventually succeeded.
+// Does NOT retry on non-lock errors (ERROR_FILE_NOT_FOUND, etc.).
+static bool RetryFileOp(const std::function<bool()>& op, int maxAttempts, DWORD initialDelayMs)
+{
+    for (int attempt = 1; attempt <= maxAttempts; ++attempt) {
+        if (op()) {
+            return true;
+        }
+
+        DWORD error = GetLastError();
+        if (error != ERROR_SHARING_VIOLATION && error != ERROR_LOCK_VIOLATION &&
+            error != ERROR_ACCESS_DENIED) {
+            // Not a transient locking error — no point retrying.
+            return false;
+        }
+
+        if (attempt < maxAttempts) {
+            DWORD delay = initialDelayMs * static_cast<DWORD>(1 << (attempt - 1));
+            WriteLogF(L"RetryFileOp: attempt %d/%d failed (error=%u), retrying in %u ms",
+                      attempt, maxAttempts, error, delay);
+            Sleep(delay);
+        }
+    }
+
+    return false;
+}
+
+// Renames a locked file to a unique name with .pendingdelete suffix.
+// This works on NTFS even when the file is open with FILE_SHARE_DELETE.
+// Returns the new path on success, or an empty string on failure.
+static std::wstring RenameLockedFile(const std::wstring& path)
+{
+    // Generate a unique suffix using tick count + a counter
+    static volatile LONG s_renameCounter = 0;
+    DWORD tick = GetTickCount();
+    LONG counter = InterlockedIncrement(&s_renameCounter);
+    wchar_t suffix[64];
+    _snwprintf_s(suffix, _countof(suffix), _TRUNCATE,
+                 L".%08x%04x" PENDING_DELETE_SUFFIX, tick, static_cast<WORD>(counter & 0xFFFF));
+
+    std::wstring newPath = path + suffix;
+
+    // Try the rename; if it fails (e.g. path already exists), append more entropy
+    for (int attempt = 0; attempt < 10; ++attempt) {
+        if (MoveFileExW(path.c_str(), newPath.c_str(), MOVEFILE_REPLACE_EXISTING) != FALSE) {
+            WriteLogF(L"Renamed locked file: %ls -> %ls", path.c_str(), newPath.c_str());
+            return newPath;
+        }
+
+        // With MOVEFILE_REPLACE_EXISTING the only likely reason is sharing-violation
+        // on the source. Give it a brief retry.
+        Sleep(100);
+        std::wstring retryPath = newPath + L"." + std::to_wstring(attempt);
+        newPath = retryPath;
+    }
+
+    WriteLogF(L"Failed to rename locked file after 10 attempts: %ls", path.c_str());
+    return {};
+}
+
+// Attempts to delete a file through multiple escalation layers:
+//   1. Normal DeleteFileW + retry
+//   2. Rename the file out of the way, then delete
+//   3. Schedule for deletion on next reboot (MOVEFILE_DELAY_UNTIL_REBOOT)
+// Returns true if the file is no longer present at the original path.
+static bool ForceDeleteFile(const std::wstring& path)
+{
+    // --- Layer 1: Normal delete with retry ---
+    auto deleteOp = [&]() -> bool {
+        return DeleteFileW(path.c_str()) != FALSE;
+    };
+
+    if (RetryFileOp(deleteOp, FILE_OP_MAX_RETRIES, FILE_OP_INITIAL_DELAY_MS)) {
+        WriteLogF(L"Deleted file: %ls", path.c_str());
+        return true;
+    }
+
+    if (!PathExistsW(path)) {
+        return true; // already gone
+    }
+
+    // --- Layer 2: Rename then delete ---
+    std::wstring renamed = RenameLockedFile(path);
+    if (!renamed.empty()) {
+        // The rename succeeded; now try to delete the renamed file
+        RetryFileOp([&]() -> bool { return DeleteFileW(renamed.c_str()) != FALSE; },
+                    3, 500);
+        if (PathExistsW(renamed)) {
+            WriteLogF(L"Renamed file could not be deleted immediately (will remain as .pendingdelete): %ls",
+                      renamed.c_str());
+        }
+        // Even if we couldn't delete the renamed file, the original path is now free.
+        WriteLogF(L"File vacated via rename: %ls -> %ls", path.c_str(), renamed.c_str());
+        return true;
+    }
+
+    // --- Layer 3: Schedule for deletion on next reboot ---
+    if (MoveFileExW(path.c_str(), nullptr, MOVEFILE_DELAY_UNTIL_REBOOT) != FALSE) {
+        WriteLogF(L"Scheduled file for deletion on next reboot: %ls", path.c_str());
+        return true;
+    }
+
+    WriteLogF(L"All deletion strategies failed for: %ls (error=%u)", path.c_str(), GetLastError());
+    return false;
+}
+
+// Recursively removes a directory, using ForceDeleteFile for each file.
+static bool ForceRemoveDirectoryRecursive(const std::wstring& dir)
+{
+    std::wstring pattern = dir + L"\\*";
+    WIN32_FIND_DATAW fd {};
+    HANDLE hFind = FindFirstFileW(pattern.c_str(), &fd);
+    if (hFind != INVALID_HANDLE_VALUE) {
+        do {
+            if (wcscmp(fd.cFileName, L".") == 0 || wcscmp(fd.cFileName, L"..") == 0)
+                continue;
+            std::wstring child = dir + L"\\" + fd.cFileName;
+            if (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
+                ForceRemoveDirectoryRecursive(child);
+            } else {
+                ForceDeleteFile(child);
+            }
+        } while (FindNextFileW(hFind, &fd));
+        FindClose(hFind);
+    }
+    return RemoveDirectoryW(dir.c_str()) != FALSE || !PathExistsW(dir);
+}
+
+// Atomically installs a file from sourcePath to targetPath.
+// Uses ReplaceFileW which handles locked target files better than
+// a separate copy-then-delete cycle.
+// If ReplaceFileW fails, falls back to copy-then-move with retry.
+static bool InstallFileAtomic(const std::wstring& sourcePath,
+                               const std::wstring& targetPath,
+                               const std::wstring& backupDirForFailedAtomic)
+{
+    EnsureParentDirectory(targetPath);
+
+    // Generate a temporary path alongside the target
+    DWORD tick = GetTickCount();
+    std::wstring tempPath = targetPath + L"." + std::to_wstring(tick) + L".tmpinstall";
+
+    // Copy source to the temp location first
+    {
+        DWORD attr = GetFileAttributesW(sourcePath.c_str());
+        if (attr == INVALID_FILE_ATTRIBUTES) {
+            WriteLogF(L"InstallFileAtomic: source not found: %ls", sourcePath.c_str());
+            return false;
+        }
+
+        auto copyOp = [&]() -> bool {
+            return CopyFileW(sourcePath.c_str(), tempPath.c_str(), FALSE) != FALSE;
+        };
+
+        if (!RetryFileOp(copyOp, FILE_OP_MAX_RETRIES, FILE_OP_INITIAL_DELAY_MS)) {
+            WriteLogF(L"InstallFileAtomic: failed to copy to temp: %ls (error=%u)",
+                      tempPath.c_str(), GetLastError());
+            // Clean up the temp file if it exists
+            DeleteFileW(tempPath.c_str());
+            return false;
+        }
+    }
+
+    // --- Try ReplaceFileW (atomic swap) ---
+    // backupDirForFailedAtomic is unused by ReplaceFileW itself; we pass nullptr
+    // because we already have a proper backup in the backupDir. ReplaceFileW's
+    // backup is only used as a last-resort safety net.
+    {
+        auto replaceOp = [&]() -> bool {
+            // ReplaceFileW(replaced, replacement, backup, flags, exclude, reserved)
+            return ReplaceFileW(targetPath.c_str(),
+                                tempPath.c_str(),
+                                nullptr, // no additional backup needed
+                                REPLACEFILE_IGNORE_MERGE_ERRORS | REPLACEFILE_WRITE_THROUGH,
+                                nullptr, nullptr) != FALSE;
+        };
+
+        if (RetryFileOp(replaceOp, 3, 500)) {
+            WriteLogF(L"InstallFileAtomic: ReplaceFileW succeeded: %ls", targetPath.c_str());
+            return true;
+        }
+    }
+
+    // --- ReplaceFileW failed; fall back to copy-then-rename ---
+    WriteLogF(L"InstallFileAtomic: ReplaceFileW failed, falling back to MoveFileEx for: %ls",
+              targetPath.c_str());
+
+    // If the target exists and is locked, try to rename it out of the way
+    if (PathExistsW(targetPath)) {
+        std::wstring renamed = RenameLockedFile(targetPath);
+        if (!renamed.empty()) {
+            // Target path is now free; move temp into place
+            if (MoveFileExW(tempPath.c_str(), targetPath.c_str(), MOVEFILE_REPLACE_EXISTING) != FALSE) {
+                WriteLogF(L"InstallFileAtomic: installed after renaming locked target: %ls", targetPath.c_str());
+                return true;
+            }
+        }
+    }
+
+    // Last resort: direct move with retry
+    auto moveOp = [&]() -> bool {
+        return MoveFileExW(tempPath.c_str(), targetPath.c_str(), MOVEFILE_REPLACE_EXISTING) != FALSE;
+    };
+
+    if (RetryFileOp(moveOp, FILE_OP_MAX_RETRIES, FILE_OP_INITIAL_DELAY_MS)) {
+        WriteLogF(L"InstallFileAtomic: move succeeded: %ls", targetPath.c_str());
+        return true;
+    }
+
+    // Clean up temp file
+    DeleteFileW(tempPath.c_str());
+    WriteLogF(L"InstallFileAtomic: all strategies failed for: %ls", targetPath.c_str());
+    return false;
+}
+
+// Scans rootDir and deletes any remaining .pendingdelete files left
+// from a previous interrupted update.
+static void CleanupPendingDeleteFiles(const std::wstring& rootDir)
+{
+    std::wstring pattern = rootDir + L"\\*" + PENDING_DELETE_SUFFIX;
+    int cleanedCount = 0;
+
+    WIN32_FIND_DATAW fd {};
+    HANDLE hFind = FindFirstFileW(pattern.c_str(), &fd);
+    if (hFind == INVALID_HANDLE_VALUE) {
+        return;
+    }
+
+    do {
+        if (fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
+            continue;
+        }
+
+        std::wstring filePath = rootDir + L"\\" + fd.cFileName;
+        auto deleteOp = [&]() -> bool {
+            return DeleteFileW(filePath.c_str()) != FALSE;
+        };
+
+        if (RetryFileOp(deleteOp, 3, 500)) {
+            ++cleanedCount;
+        } else {
+            WriteLogF(L"Could not clean up pending-delete file: %ls", filePath.c_str());
+        }
+    } while (FindNextFileW(hFind, &fd));
+
+    FindClose(hFind);
+
+    if (cleanedCount > 0) {
+        WriteLogF(L"Cleaned up %d pending-delete file(s).", cleanedCount);
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Entry point
 // ---------------------------------------------------------------------------
 
@@ -1538,6 +1889,9 @@ int wmain(int argc, wchar_t* argv[])
         } else {
             WriteLog(L"Update mutex acquired, preventing new MAA instances from starting.");
         }
+
+        // Clean up any .pendingdelete files left from a previous interrupted update
+        CleanupPendingDeleteFiles(rootDir);
     } else {
         WriteLog(L"No instance key provided, update mutex will not be used.");
     }
@@ -1658,7 +2012,25 @@ int wmain(int argc, wchar_t* argv[])
             }
 
             WriteLog((L"Installing new file: " + sourcePath + L" -> " + targetPath).c_str());
-            if (!MovePathEntry(sourcePath, targetPath)) {
+
+            bool installOk = false;
+            DWORD sourceAttr = GetFileAttributesW(sourcePath.c_str());
+            bool isSourceFile = (sourceAttr != INVALID_FILE_ATTRIBUTES) &&
+                                !(sourceAttr & FILE_ATTRIBUTE_DIRECTORY);
+
+            if (isSourceFile) {
+                // Use atomic file replacement for individual files
+                installOk = InstallFileAtomic(sourcePath, targetPath, backupDir);
+            } else {
+                // Directories: use the original move logic
+                auto moveOp = [&]() -> bool {
+                    return MoveFileExW(sourcePath.c_str(), targetPath.c_str(),
+                                       MOVEFILE_REPLACE_EXISTING) != FALSE;
+                };
+                installOk = RetryFileOp(moveOp, FILE_OP_MAX_RETRIES, FILE_OP_INITIAL_DELAY_MS);
+            }
+
+            if (!installOk) {
                 failureReason = L"Failed to move file into place: " + sourcePath;
                 WriteLog(failureReason.c_str());
                 goto apply_failed;
@@ -1694,6 +2066,31 @@ int wmain(int argc, wchar_t* argv[])
 
     apply_failed:
         success = false;
+
+        // Attempt rollback: restore files that were already backed up
+        WriteLog(L"Update failed, attempting rollback from backup directory.");
+        for (const std::wstring& rel : removeList) {
+            std::wstring targetPath, backupPath;
+            if (!TryResolvePathUnderRoot(rootDir, rel, targetPath) ||
+                !TryResolvePathUnderRoot(backupDir, rel, backupPath)) {
+                continue;
+            }
+            if (PathExistsW(backupPath) && !PathExistsW(targetPath)) {
+                WriteLog((L"Rollback: restoring " + backupPath + L" -> " + targetPath).c_str());
+                MovePathEntry(backupPath, targetPath);
+            }
+        }
+        for (const std::wstring& rel : moveList) {
+            std::wstring targetPath, backupPath;
+            if (!TryResolvePathUnderRoot(rootDir, rel, targetPath) ||
+                !TryResolvePathUnderRoot(backupDir, rel, backupPath)) {
+                continue;
+            }
+            if (PathExistsW(backupPath) && !PathExistsW(targetPath)) {
+                WriteLog((L"Rollback: restoring " + backupPath + L" -> " + targetPath).c_str());
+                MovePathEntry(backupPath, targetPath);
+            }
+        }
     } while (false);
 
     // ------------------------------------------------------------------
@@ -1716,7 +2113,7 @@ int wmain(int argc, wchar_t* argv[])
     // ------------------------------------------------------------------
     if (PathExistsW(extractDir)) {
         WriteLog((L"Cleaning extract directory: " + extractDir).c_str());
-        RemoveDirectoryRecursive(extractDir);
+        ForceRemoveDirectoryRecursive(extractDir);
     }
 
     if (PathExistsW(planFile))

--- a/src/MaaWpfGui/Main/Bootstrapper.cs
+++ b/src/MaaWpfGui/Main/Bootstrapper.cs
@@ -674,7 +674,7 @@ public class Bootstrapper : Bootstrapper<RootViewModel>
 
     private static bool HandleMultipleInstances()
     {
-        string instanceKey = GetSingleInstanceKey();
+        string instanceKey = InstanceKey;
         string mutexName = "MAA_" + instanceKey;
         string activationEventName = "MAA_SHOW_" + instanceKey;
         _mutex = new Mutex(true, mutexName, out var isOnlyInstance);
@@ -709,12 +709,15 @@ public class Bootstrapper : Bootstrapper<RootViewModel>
         }
     }
 
-    private static string GetSingleInstanceKey()
+    public static string InstanceKey
     {
-        var normalizedBaseDir = Path.GetFullPath(PathsHelper.BaseDir)
-            .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
-            .ToUpperInvariant();
-        return normalizedBaseDir.StableHash();
+        get
+        {
+            var normalizedBaseDir = Path.GetFullPath(PathsHelper.BaseDir)
+                .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                .ToUpperInvariant();
+            return normalizedBaseDir.StableHash();
+        }
     }
 
     private static void EnsureInstanceActivationEvent(string activationEventName)

--- a/src/MaaWpfGui/Main/Bootstrapper.cs
+++ b/src/MaaWpfGui/Main/Bootstrapper.cs
@@ -674,10 +674,8 @@ public class Bootstrapper : Bootstrapper<RootViewModel>
 
     private static bool HandleMultipleInstances()
     {
-        string instanceKey = InstanceKey;
-        string mutexName = "MAA_" + instanceKey;
-        string activationEventName = "MAA_SHOW_" + instanceKey;
-        _mutex = new Mutex(true, mutexName, out var isOnlyInstance);
+        string activationEventName = "MAA_SHOW_" + InstanceKey;
+        _mutex = new Mutex(true, MutexName, out var isOnlyInstance);
 
         try
         {
@@ -719,6 +717,8 @@ public class Bootstrapper : Bootstrapper<RootViewModel>
             return normalizedBaseDir.StableHash();
         }
     }
+
+    public static string MutexName => "MAA_" + InstanceKey;
 
     private static void EnsureInstanceActivationEvent(string activationEventName)
     {

--- a/src/MaaWpfGui/Services/PendingUpdateApplier.cs
+++ b/src/MaaWpfGui/Services/PendingUpdateApplier.cs
@@ -462,7 +462,7 @@ internal static partial class PendingUpdateApplier
         // Args: <ParentPid> <RootDir> <ExtractDir> <BackupDir>
         //       <PackagePath> <SuccessStatusFile> <FailureStatusFile>
         //       <RelaunchExecutablePath> <PlanFile>
-        //       [--instance-key <key>] [--show-console]
+        //       [--mutex-name <name>] [--show-console]
         startInfo.ArgumentList.Add(Environment.ProcessId.ToString());
         startInfo.ArgumentList.Add(context.RootDir);
         startInfo.ArgumentList.Add(context.ExtractDir);
@@ -472,8 +472,8 @@ internal static partial class PendingUpdateApplier
         startInfo.ArgumentList.Add(DelegatedUpdateFailureStatusFilePath);
         startInfo.ArgumentList.Add(relaunchExecutablePath);
         startInfo.ArgumentList.Add(planPath);
-        startInfo.ArgumentList.Add("--instance-key");
-        startInfo.ArgumentList.Add(Bootstrapper.InstanceKey);
+        startInfo.ArgumentList.Add("--mutex-name");
+        startInfo.ArgumentList.Add(Bootstrapper.MutexName);
         if (showUpdaterConsole)
         {
             startInfo.ArgumentList.Add("--show-console");

--- a/src/MaaWpfGui/Services/PendingUpdateApplier.cs
+++ b/src/MaaWpfGui/Services/PendingUpdateApplier.cs
@@ -23,6 +23,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using MaaWpfGui.Constants;
 using MaaWpfGui.Helper;
+using MaaWpfGui.Main;
 using Newtonsoft.Json.Linq;
 using Semver;
 using Serilog;
@@ -460,7 +461,8 @@ internal static partial class PendingUpdateApplier
 
         // Args: <ParentPid> <RootDir> <ExtractDir> <BackupDir>
         //       <PackagePath> <SuccessStatusFile> <FailureStatusFile>
-        //       <RelaunchExecutablePath> <PlanFile> [--show-console]
+        //       <RelaunchExecutablePath> <PlanFile>
+        //       [--instance-key <key>] [--show-console]
         startInfo.ArgumentList.Add(Environment.ProcessId.ToString());
         startInfo.ArgumentList.Add(context.RootDir);
         startInfo.ArgumentList.Add(context.ExtractDir);
@@ -470,6 +472,8 @@ internal static partial class PendingUpdateApplier
         startInfo.ArgumentList.Add(DelegatedUpdateFailureStatusFilePath);
         startInfo.ArgumentList.Add(relaunchExecutablePath);
         startInfo.ArgumentList.Add(planPath);
+        startInfo.ArgumentList.Add("--instance-key");
+        startInfo.ArgumentList.Add(Bootstrapper.InstanceKey);
         if (showUpdaterConsole)
         {
             startInfo.ArgumentList.Add("--show-console");


### PR DESCRIPTION
解决updater启动时有可能遇到被maa占用MAA.deps.json导致更新失败的问题
<img width="532" height="183" alt="image" src="https://github.com/user-attachments/assets/3be61d0b-2d71-470f-8ae2-aca22aebf069" />


## Summary by Sourcery

在 WPF 客户端和更新程序之间共享一个命名互斥量（mutex），从而在有其他 MAA 实例正在运行时阻止更新，并由更新程序本身阻止新的实例启动。

New Features:
- 从 WPF 客户端向更新程序传递一个针对每次安装都稳定不变的实例键值（instance key），以便它们可以就共享互斥量名称进行协调。
- 将 WPF 客户端的单实例键值公开为公共属性，以便其他组件复用。

Enhancements:
- 在更新程序中添加互斥量获取与释放逻辑，在更新处理期间持有共享实例锁，并在发现有其他实例正在运行时优雅地失败退出。
- 扩展更新程序和 WPF 的参数/用法文档，说明新的可选参数 `--instance-key`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Share a named mutex between the WPF client and updater so that updates are blocked while another MAA instance is running and the updater itself prevents new instances from starting.

New Features:
- Pass a stable per-installation instance key from the WPF client to the updater so they can coordinate on a shared mutex name.
- Expose the WPF client's single-instance key as a public property for reuse by other components.

Enhancements:
- Add mutex acquisition and release logic to the updater to hold the shared instance lock during update processing and fail gracefully if another instance is running.
- Extend updater and WPF argument/usage documentation to describe the new optional --instance-key parameter.

</details>