### PR TITLE
feat: SendMsg在WindowPos输入下保留窗口原始位置，任务结束时恢复

### DIFF
--- a/src/MaaCore/Assistant.cpp
+++ b/src/MaaCore/Assistant.cpp
@@ -512,6 +512,10 @@ void Assistant::working_proc()
             continue;
         }
 
+        if (finished_tasks.empty()) {
+            m_ctrler->save_window_pos();
+        }
+
         m_running = true;
         const auto [id, task_ptr] = m_tasks_list.front();
         lock.unlock();
@@ -537,11 +541,13 @@ void Assistant::working_proc()
         append_callback(msg, callback_json);
 
         if (m_thread_idle) {
+            m_ctrler->restore_window_pos();
             finished_tasks.clear();
             continue;
         }
 
         if (m_tasks_list.empty()) {
+            m_ctrler->restore_window_pos();
             callback_json["finished_tasks"] = json::array(finished_tasks);
             append_callback(AsstMsg::AllTasksCompleted, callback_json);
             finished_tasks.clear();
@@ -553,6 +559,7 @@ void Assistant::working_proc()
         m_condvar.wait_for(lock, std::chrono::milliseconds(delay), [&]() -> bool { return m_thread_idle; });
 
         if (m_thread_idle) {
+            m_ctrler->restore_window_pos();
             append_callback(AsstMsg::TaskChainStopped, callback_json);
         }
     }

--- a/src/MaaCore/Controller/Controller.cpp
+++ b/src/MaaCore/Controller/Controller.cpp
@@ -474,6 +474,26 @@ cv::Mat asst::Controller::get_image_cache() const
     return get_resized_image_cache();
 }
 
+void asst::Controller::save_window_pos()
+{
+#ifdef _WIN32
+    auto* win32_ctrl = dynamic_cast<Win32Controller*>(m_controller.get());
+    if (win32_ctrl) {
+        win32_ctrl->save_window_pos();
+    }
+#endif
+}
+
+void asst::Controller::restore_window_pos()
+{
+#ifdef _WIN32
+    auto* win32_ctrl = dynamic_cast<Win32Controller*>(m_controller.get());
+    if (win32_ctrl) {
+        win32_ctrl->restore_window_pos();
+    }
+#endif
+}
+
 bool asst::Controller::screencap(bool allow_reconnect)
 {
     CHECK_EXIST(m_controller, false);

--- a/src/MaaCore/Controller/Controller.h
+++ b/src/MaaCore/Controller/Controller.h
@@ -99,6 +99,9 @@ public:
     bool press_esc();
     ControlFeat::Feat support_features();
 
+    void save_window_pos();
+    void restore_window_pos();
+
     std::pair<int, int> get_scale_size() const noexcept;
 
     Controller& operator=(const Controller&) = delete;

--- a/src/MaaCore/Controller/Win32Controller.cpp
+++ b/src/MaaCore/Controller/Win32Controller.cpp
@@ -446,7 +446,7 @@ void Win32Controller::save_window_pos()
 {
     LogTraceFunction;
 
-    if (!(m_mouse_method & Win32Input::SendMessageWithWindowPos)) {
+    if (!(m_mouse_method & Win32Input::SendMessageWithWindowPos) || m_window_pos_saved) {
         return;
     }
 

--- a/src/MaaCore/Controller/Win32Controller.cpp
+++ b/src/MaaCore/Controller/Win32Controller.cpp
@@ -442,6 +442,49 @@ bool Win32Controller::unit_click_key(int key)
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
     return unit->key_up(key);
 }
+void Win32Controller::save_window_pos()
+{
+    LogTraceFunction;
+
+    if (!(m_mouse_method & Win32Input::SendMessageWithWindowPos)) {
+        return;
+    }
+
+    HWND hwnd = static_cast<HWND>(m_hwnd);
+    if (!hwnd || !IsWindow(hwnd)) {
+        return;
+    }
+
+    if (GetWindowRect(hwnd, &m_saved_window_rect)) {
+        m_window_pos_saved = true;
+        Log.info("Saved window position:", m_saved_window_rect.left, m_saved_window_rect.top);
+    }
+}
+
+void Win32Controller::restore_window_pos()
+{
+    LogTraceFunction;
+
+    if (!m_window_pos_saved) {
+        return;
+    }
+
+    m_window_pos_saved = false;
+
+    HWND hwnd = static_cast<HWND>(m_hwnd);
+    if (!hwnd || !IsWindow(hwnd)) {
+        return;
+    }
+
+    int x = m_saved_window_rect.left;
+    int y = m_saved_window_rect.top;
+    int width = m_saved_window_rect.right - m_saved_window_rect.left;
+    int height = m_saved_window_rect.bottom - m_saved_window_rect.top;
+
+    SetWindowPos(hwnd, nullptr, x, y, width, height, SWP_NOZORDER | SWP_NOACTIVATE);
+    Log.info("Restored window position:", x, y);
+}
+
 } // namespace asst
 
 #endif // _WIN32

--- a/src/MaaCore/Controller/Win32Controller.h
+++ b/src/MaaCore/Controller/Win32Controller.h
@@ -96,6 +96,13 @@ private:
     Win32ScreencapMethod m_screencap_method = Win32Screencap::None;
     Win32InputMethod m_mouse_method = Win32Input::None;
     Win32InputMethod m_keyboard_method = Win32Input::None;
+
+    RECT m_saved_window_rect {};
+    bool m_window_pos_saved = false;
+
+public:
+    void save_window_pos();
+    void restore_window_pos();
 };
 } // namespace asst
 


### PR DESCRIPTION
现在不依赖maafw的改动了，全部任务完成或手动停止时，能够恢复窗口位置，避免窗口标题栏在任务结束后处于鼠标点击不到的位置

## Summary by Sourcery

在任务执行过程中，当使用带有窗口位置输入的 `SendMessage` 时，为 Win32 控制器保留并恢复原始窗口位置。

新功能：
- 在 `Win32Controller` 和 `Controller` 上新增 API，用于在 Windows 上保存和恢复被控窗口的位置。
- 在任务运行开始时触发窗口位置的保存，并在所有任务完成、线程变为空闲或任务链被停止时恢复窗口位置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Preserve and restore the original window position for Win32 controllers when using SendMessage with window-position input during task execution.

New Features:
- Add APIs on Win32Controller and Controller to save and restore the controlled window position on Windows.
- Trigger window position saving at the start of a task run and restoration when all tasks finish, the thread becomes idle, or the task chain is stopped.

</details>