### PR TITLE
fix: 剿灭掉落识别不到合成玉时不停止任务

### DIFF
--- a/src/MaaCore/Task/Fight/StageDropsTaskPlugin.cpp
+++ b/src/MaaCore/Task/Fight/StageDropsTaskPlugin.cpp
@@ -207,13 +207,12 @@ bool asst::StageDropsTaskPlugin::recognize_drops()
     }
 
     if (m_is_annihilation) {
-        bool has_orundum = std::ranges::any_of(m_cur_drops, [](const auto& drop) {
+        const bool has_orundum = std::ranges::any_of(m_cur_drops, [](const auto& drop) {
             return drop.item_id == "4003"; // see StageDropType::Reward
         });
         if (!has_orundum) {
-            LogInfo << __FUNCTION__ << "No orundum dropped in annihilation, stopping task";
-            stop_task();
-            return true;
+            LogInfo << __FUNCTION__
+                    << "No orundum (4003) in recognized drops";
         }
 
         RegionOCRer ocr(image);


### PR DESCRIPTION
fix #16715 

这个issue识别不到实际上是baseline没有被算法识别到的问题

但是既然是实际上有掉落，只是没识别到，那么改为不停止任务之后，也会在满周上限之后结束，不会无限循环。

之前task里做了针对新剿灭的保护，应该也不会出现在新剿灭里无限失败导致无限循环打剿灭的问题。

## Summary by Sourcery

错误修复：
- 防止在游戏中存在龙门币掉落但未被识别算法检测到时，歼灭作战任务被过早停止。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent annihilation tasks from prematurely stopping when orundum drops exist in-game but are not detected by the recognition algorithm.

</details>