### PR TITLE
feat:order of battle

### DIFF
--- a/src/MaaWpfGui/Configuration/Single/MaaTask/FightTask.cs
+++ b/src/MaaWpfGui/Configuration/Single/MaaTask/FightTask.cs
@@ -124,6 +124,11 @@ public class FightTask : BaseTask, IJsonOnDeserialized
     public bool UseOptionalStage { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether 使用作战序列
+    /// </summary>
+    public bool UseSequenceStage { get; set; }
+
+    /// <summary>
     /// Gets or sets a value indicating whether 允许保存碎石状态
     /// </summary>
     public bool UseStoneAllowSave { get; set; }

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -1052,6 +1052,7 @@ public class AsstProxy
 
                 // UpdateTaskStatus(taskId, TaskStatus.Completed);
                 _tasksStatus.Clear();
+                _taskStageMap.Clear();
                 break;
 
             case AsstMsg.TaskChainError:
@@ -1100,6 +1101,8 @@ public class AsstProxy
                 {
                     // 判断 _latestTaskId 中是否有元素的值和 details["taskid"] 相等，如果有再判断这个 id 对应的任务是否在 _mainTaskTypes 中
                     UpdateTaskStatus(taskId, TaskStatus.Completed);
+                    // Remove any registered stage mapping for this completed task
+                    try { _taskStageMap.Remove(taskId); } catch { }
                     if (_tasksStatus.TryGetValue(taskId, out var taskInfo))
                     {
                         if (_mainTaskTypes.Contains(taskInfo.Type))
@@ -1511,6 +1514,24 @@ public class AsstProxy
 
     private static void ProcSubTaskStart(JObject details)
     {
+        // Try to print executing stage when available
+        try
+        {
+            AsstTaskId taskId = details["taskid"]?.ToObject<AsstTaskId>() ?? 0;
+            if (taskId > 0)
+            {
+                var stage = Instances.AsstProxy.GetRegisteredStage(taskId);
+                if (!string.IsNullOrEmpty(stage))
+                {
+                    Instances.TaskQueueViewModel.AddLog("正在执行：" + stage, UiLogColor.Info);
+                }
+            }
+        }
+        catch
+        {
+            // ignore
+        }
+
         string subTask = details["subtask"]?.ToString() ?? string.Empty;
         switch (subTask)
         {
@@ -1996,7 +2017,7 @@ public class AsstProxy
                     break;
                 }
 
-            case "RecruitTagsRefreshed":
+            case "RecruitTagsRefresshed":
                 {
                     int refreshCount = (int)subTaskDetails!["count"]!;
                     Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("Refreshed") + refreshCount + LocalizationHelper.GetString("UnitTime"));
@@ -2867,7 +2888,35 @@ public class AsstProxy
 
     private readonly ObservableDictionary<AsstTaskId, (TaskType Type, TaskStatus Status)> _tasksStatus = [];
 
+    // Map task id -> human readable stage name for sequence logging
+    private readonly Dictionary<AsstTaskId, string> _taskStageMap = new();
+
     public IReadOnlyDictionary<AsstTaskId, (TaskType Type, TaskStatus Status)> TasksStatus => new Dictionary<AsstTaskId, (TaskType, TaskStatus)>(_tasksStatus);
+
+    /// <summary>
+    /// Registers a mapping from a core task id to a stage name (used for sequence mode logging).
+    /// </summary>
+    public void RegisterTaskStage(AsstTaskId id, string stage)
+    {
+        try
+        {
+            if (id > 0 && !string.IsNullOrWhiteSpace(stage))
+            {
+                _taskStageMap[id] = stage;
+            }
+        }
+        catch
+        {
+            // ignore
+        }
+    }
+    /// <summary>
+    /// Returns a registered stage name for a given task id or null if not registered.
+    /// </summary>
+    public string? GetRegisteredStage(AsstTaskId id)
+    {
+        return id > 0 && _taskStageMap.TryGetValue(id, out var s) ? s : null;
+    }
 
     public delegate void TaskItemStatusDelegate(int taskId, TaskItemStatus status);
 
@@ -2896,6 +2945,19 @@ public class AsstProxy
         if (status == TaskStatus.InProgress)
         {
             TaskSettingVisibilityInfo.Instance.NotifyOfTaskStatus();
+        }
+
+        // When task finished or errored, remove any registered stage mapping to avoid leaks
+        if (status == TaskStatus.Completed || status == TaskStatus.Error)
+        {
+            try
+            {
+                _taskStageMap.Remove(id);
+            }
+            catch
+            {
+                // ignore
+            }
         }
 
         return true;

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -617,6 +617,7 @@ Then delete the entries corresponding to the paths.
     <system:String x:Key="AllowUseStoneSave">Save ｢Use Originium｣</system:String>
     <system:String x:Key="AllowUseStoneSaveWarning">This function is considered dangerous. Pressing the ｢{key=Confirm}｣ button indicates that you understand and are willing to accept the potential risks.</system:String>
     <system:String x:Key="UseAlternateStage">Use alternative stage</system:String>
+    <system:String x:Key="UseSequenceStage">Use combat sequence</system:String>
     <system:String x:Key="UseExpiringMedicine">Unlimited use of expiring (&lt;N hours) sanity potion</system:String>
     <system:String x:Key="UseExpireMedicineForActivity">Use sanity potions that expire this week within 48 hours before the activity ends</system:String>
     <system:String x:Key="NoActivity">No activity</system:String>
@@ -786,6 +787,7 @@ If the number of battles is not enough to complete the set multiplier (such as o
 Do not adjust the proxy multiplier setting in the game</system:String>
     <system:String x:Key="StageSelect">Stage</system:String>
     <system:String x:Key="StageSelect2">Candidates</system:String>
+    <system:String x:Key="StageSelectSequence">Sequence</system:String>
     <system:String x:Key="AddStage">Add candidate</system:String>
     <system:String x:Key="RemainingSanityStage">Remaining Sanity</system:String>
     <system:String x:Key="NoUse">No Use</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -617,6 +617,7 @@ HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Notifications\Settin
     <system:String x:Key="AllowUseStoneSave">源石の数を割る保存状態を許可</system:String>
     <system:String x:Key="AllowUseStoneSaveWarning">この機能は危険な機能と見なされます。「{key=Confirm}」ボタンを押すと、リスクを理解し、受け入れることに同意したと見なされます。</system:String>
     <system:String x:Key="UseAlternateStage">代替ステージを選択可能にする</system:String>
+    <system:String x:Key="UseSequenceStage">戦闘シーケンスを使用する</system:String>
     <system:String x:Key="UseExpiringMedicine">N時間以内に期限が切れる回復剤を無制限に使用</system:String>
     <system:String x:Key="UseExpireMedicineForActivity">今週中に期限切れとなる正気回復ポーションは、アクティビティ終了の48時間以内に使用してください。</system:String>
     <system:String x:Key="NoActivity">活動なし</system:String>
@@ -787,6 +788,7 @@ C:\\leidian\\LDPlayer9
 ゲーム内で代理乗数の設定を調整しません。</system:String>
     <system:String x:Key="StageSelect">ステージ</system:String>
     <system:String x:Key="StageSelect2">代替ステージ</system:String>
+    <system:String x:Key="StageSelectSequence">戦闘シーケンス</system:String>
     <system:String x:Key="AddStage">ステージを追加</system:String>
     <system:String x:Key="RemainingSanityStage">余剰理性の消費</system:String>
     <system:String x:Key="NoUse">使用しない</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -617,6 +617,7 @@ HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Notifications\Settin
     <system:String x:Key="AllowUseStoneSave">순오리지늄 사용 상태 저장 허용</system:String>
     <system:String x:Key="AllowUseStoneSaveWarning">이 기능은 위험할 수 있습니다. ｢{key=Confirm}｣ 버튼을 누르면 잠재적인 위험을 이해하고 감수하는 것으로 간주됩니다.</system:String>
     <system:String x:Key="UseAlternateStage">대체 스테이지 사용</system:String>
+    <system:String x:Key="UseSequenceStage">전투 시퀀스 사용</system:String>
     <system:String x:Key="UseExpiringMedicine">N 시간 미만 이성 회복제 사용</system:String>
     <system:String x:Key="UseExpireMedicineForActivity">이벤트 종료 48시간 전, 이번 주 만료되는 이성 회복제 사용</system:String>
     <system:String x:Key="NoActivity">활동 없음</system:String>
@@ -788,6 +789,7 @@ C:\\leidian\\LDPlayer9
 연속 대리 지휘 횟수를 조정하지 않습니다.</system:String>
     <system:String x:Key="StageSelect">스테이지 선택</system:String>
     <system:String x:Key="StageSelect2">대안</system:String>
+    <system:String x:Key="StageSelectSequence">전투 시퀀스</system:String>
     <system:String x:Key="AddStage">스테이지 추가</system:String>
     <system:String x:Key="RemainingSanityStage">남은 이성</system:String>
     <system:String x:Key="NoUse">미사용</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -617,6 +617,7 @@ HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Notifications\Settin
     <system:String x:Key="AllowUseStoneSave">允许使用源石保存状态</system:String>
     <system:String x:Key="AllowUseStoneSaveWarning">该功能属于危险功能。按下 ｢{key=Confirm}｣ 键即视为你了解并愿意承担可能出现的风险。</system:String>
     <system:String x:Key="UseAlternateStage">使用备选关卡</system:String>
+    <system:String x:Key="UseSequenceStage">使用作战序列</system:String>
     <system:String x:Key="UseExpiringMedicine">无限吃 N 小时内过期的理智药</system:String>
     <system:String x:Key="UseExpireMedicineForActivity">活动结束前 48H 吃当周过期理智药</system:String>
     <system:String x:Key="NoActivity">暂无活动</system:String>
@@ -787,6 +788,7 @@ C:\\leidian\\LDPlayer9。\n
 不调整游戏内代理倍率设定</system:String>
     <system:String x:Key="StageSelect">关卡指定</system:String>
     <system:String x:Key="StageSelect2">候选关卡</system:String>
+    <system:String x:Key="StageSelectSequence">作战序列</system:String>
     <system:String x:Key="AddStage">添加候选</system:String>
     <system:String x:Key="RemainingSanityStage">剩余理智</system:String>
     <system:String x:Key="NoUse">不使用</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -617,6 +617,7 @@ HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Notifications\Settin
     <system:String x:Key="AllowUseStoneSave">允許吃源石保存狀態</system:String>
     <system:String x:Key="AllowUseStoneSaveWarning">該功能屬於危險功能。按下 ｢{key=Confirm}｣ 鍵即視為您了解並願意承擔可能出現的風險。</system:String>
     <system:String x:Key="UseAlternateStage">使用備選關卡</system:String>
+    <system:String x:Key="UseSequenceStage">使用作戰序列</system:String>
     <system:String x:Key="UseExpiringMedicine">無限吃 N 小時內過期的理智藥</system:String>
     <system:String x:Key="UseExpireMedicineForActivity">活動結束前 48H 吃當週過期理智藥</system:String>
     <system:String x:Key="NoActivity">暫無活動</system:String>
@@ -787,6 +788,7 @@ C:\\leidian\\LDPlayer9\n
 不調整遊戲內代理倍率設定</system:String>
     <system:String x:Key="StageSelect">關卡選擇</system:String>
     <system:String x:Key="StageSelect2">備選</system:String>
+    <system:String x:Key="StageSelectSequence">作戰序列</system:String>
     <system:String x:Key="AddStage">新增備選</system:String>
     <system:String x:Key="RemainingSanityStage">剩餘理智</system:String>
     <system:String x:Key="NoUse">不選擇</system:String>

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/FightSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/FightSettingsUserControlModel.cs
@@ -515,10 +515,11 @@ public class FightSettingsUserControlModel : TaskSettingsViewModel, FightSetting
             SetTaskConfig<FightTask>(t => t.UseOptionalStage == value, t => t.UseOptionalStage = value);
             if (value)
             {
+                UseSequenceStage = false;
                 HideUnavailableStage = false;
                 StageResetMode = FightStageResetMode.Ignore;
             }
-            else
+            else if (!ShowStagePlan)
             {
                 var list = StagePlan;
                 if (list.Count == 0)
@@ -534,8 +535,43 @@ public class FightSettingsUserControlModel : TaskSettingsViewModel, FightSetting
                     StagePlan.Add(stage);
                 }
             }
+            NotifyOfPropertyChange(nameof(ShowStagePlan));
         }
     }
+
+    public bool UseSequenceStage
+    {
+        get => GetTaskConfig<FightTask>().UseSequenceStage;
+        set {
+            SetTaskConfig<FightTask>(t => t.UseSequenceStage == value, t => t.UseSequenceStage = value);
+            if (value)
+            {
+                UseAlternateStage = false;
+                HideUnavailableStage = false;
+                StageResetMode = FightStageResetMode.Ignore;
+            }
+            else if (!ShowStagePlan)
+            {
+                var list = StagePlan;
+                if (list.Count == 0)
+                {
+                    var item = new StagePlanItem();
+                    item.PropertyChanged += (_, __) => SaveStagePlan();
+                    StagePlan.Add(item);
+                }
+                else
+                {
+                    var stage = list[0];
+                    StagePlan.Clear();
+                    StagePlan.Add(stage);
+                }
+            }
+            NotifyOfPropertyChange(nameof(ShowStagePlan));
+        }
+    }
+
+    [PropertyDependsOn(nameof(UseAlternateStage), nameof(UseSequenceStage))]
+    public bool ShowStagePlan => UseAlternateStage || UseSequenceStage;
 
     public bool AllowUseStoneSave
     {
@@ -713,7 +749,7 @@ public class FightSettingsUserControlModel : TaskSettingsViewModel, FightSetting
             return;
         }
         using var refresh = new UiRefreshingScope();
-        if (!UseAlternateStage && fight.StagePlan.Count == 0)
+        if (!ShowStagePlan && fight.StagePlan.Count == 0)
         {
             fight.StagePlan.Add(string.Empty);
         }
@@ -1019,12 +1055,6 @@ public class FightSettingsUserControlModel : TaskSettingsViewModel, FightSetting
                 return (null, []);
             }
 
-            string? stage = GetFightStage(fight.StagePlan);
-            if (stage is null)
-            {
-                return (null, []);
-            }
-
             var time = DateTimeOffset.Now;
             var activityExpireIn2Days = false;
             var activityList = Instances.StageManager.ActivityList.Where(ss => ss.Value.Info.StartTimeUtc <= time && time <= ss.Value.Info.ExpireTimeUtc);
@@ -1038,42 +1068,86 @@ public class FightSettingsUserControlModel : TaskSettingsViewModel, FightSetting
             var yjTime = DateTimeOffset.Now.ToYjDateTime().ToLocalTime();
             var daysUntilEndOfWeek = ((7 - (int)yjTime.DayOfWeek + 7) % 7) + 1; // 距离本周结束的天数, 用鹰历计算
             var activityExpireDays = activityExpireIn2Days && fight.UseExpireMedicineForActivity ? daysUntilEndOfWeek : 0;
-            var task = new AsstFightTask() {
-                Stage = stage,
-                Medicine = fight.UseMedicine != false ? fight.MedicineCount : 0,
-                Stone = fight.UseStone != false ? fight.StoneCount : 0,
-                Series = fight.Series,
-                MaxTimes = fight.EnableTimesLimit != false ? fight.TimesLimit : int.MaxValue,
-                MedicineExpireDays = Math.Max(expireDays, activityExpireDays),
-                IsDrGrandet = fight.IsDrGrandet,
-                ReportToPenguin = SettingsViewModel.GameSettings.EnablePenguin,
-                ReportToYituliu = SettingsViewModel.GameSettings.EnableYituliu,
-                PenguinId = SettingsViewModel.GameSettings.PenguinId,
-                YituliuId = SettingsViewModel.GameSettings.PenguinId,
-                ServerType = Instances.SettingsViewModel.ServerType,
-                ClientType = SettingsViewModel.GameSettings.ClientType,
-            };
 
-            if (task.Stage == AnnihilationName && fight.UseCustomAnnihilation)
+            AsstFightTask CreateTaskForStage(string stg, int? timesOverride = null)
             {
-                task.Stage = fight.AnnihilationStage;
+                var task = new AsstFightTask() {
+                    Stage = stg,
+                    Medicine = fight.UseMedicine != false ? fight.MedicineCount : 0,
+                    Stone = fight.UseStone != false ? fight.StoneCount : 0,
+                    Series = fight.Series,
+                    MaxTimes = timesOverride ?? (fight.EnableTimesLimit != false ? fight.TimesLimit : int.MaxValue),
+                    MedicineExpireDays = Math.Max(expireDays, activityExpireDays),
+                    IsDrGrandet = fight.IsDrGrandet,
+                    ReportToPenguin = SettingsViewModel.GameSettings.EnablePenguin,
+                    ReportToYituliu = SettingsViewModel.GameSettings.EnableYituliu,
+                    PenguinId = SettingsViewModel.GameSettings.PenguinId,
+                    YituliuId = SettingsViewModel.GameSettings.PenguinId,
+                    ServerType = Instances.SettingsViewModel.ServerType,
+                    ClientType = SettingsViewModel.GameSettings.ClientType,
+                };
+
+                if (task.Stage == AnnihilationName && fight.UseCustomAnnihilation)
+                {
+                    task.Stage = fight.AnnihilationStage;
+                }
+
+                if (fight.EnableTargetDrop != false && !string.IsNullOrEmpty(fight.DropId))
+                {
+                    task.Drops.Add(fight.DropId, fight.DropCount);
+                }
+
+                return task;
             }
 
-            if (fight.EnableTargetDrop != false && !string.IsNullOrEmpty(fight.DropId))
+            if (fight.UseSequenceStage)
             {
-                task.Drops.Add(fight.DropId, fight.DropCount);
+                List<int> ids = new();
+                bool anySuccess = false;
+                // Append in reverse so the execution order becomes FIFO if core processes tasks LIFO
+                foreach (var stageName in fight.StagePlan.AsEnumerable().Reverse())
+                {
+                    if (string.IsNullOrWhiteSpace(stageName)) continue;
+                    if (Instances.StageManager.IsStageOpen(stageName, Instances.TaskQueueViewModel.CurDayOfWeek))
+                    {
+                        // For sequence mode, run each appended stage once then move to next
+                        var t = CreateTaskForStage(stageName, 1);
+                        if (fight.EnableTimesLimit is not false && fight.Series > 0 && fight.TimesLimit % fight.Series != 0)
+                        {
+                            Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetStringFormat("FightTimesMayNotExhausted", fight.TimesLimit, fight.Series), UiLogColor.Warning);
+                        }
+                        var appendResult = Instances.AsstProxy.AsstAppendTaskWithEncoding(TaskType.Fight, t);
+                        if (appendResult.TaskId > 0)
+                        {
+                            ids.Add(appendResult.TaskId);
+                            anySuccess = true;
+                        }
+                    }
+                }
+                if (!anySuccess) return (null, []);
+                // ids currently in order of appended tasks; return them
+                return (true, ids);
             }
-
-            if (fight.EnableTimesLimit is not false && fight.Series > 0 && fight.TimesLimit % fight.Series != 0)
+            else
             {
-                Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetStringFormat("FightTimesMayNotExhausted", fight.TimesLimit, fight.Series), UiLogColor.Warning);
-            }
+                string? stage = GetFightStage(fight.StagePlan);
+                if (stage is null)
+                {
+                    return (null, []);
+                }
+                
+                var task = CreateTaskForStage(stage);
+                if (fight.EnableTimesLimit is not false && fight.Series > 0 && fight.TimesLimit % fight.Series != 0)
+                {
+                    Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetStringFormat("FightTimesMayNotExhausted", fight.TimesLimit, fight.Series), UiLogColor.Warning);
+                }
 
-            return taskId switch {
-                int id when id > 0 => (Instances.AsstProxy.AsstSetTaskParamsEncoded(id, task), [id]),
-                null => FromSingle(Instances.AsstProxy.AsstAppendTaskWithEncoding(TaskType.Fight, task)),
-                _ => (null, []),
-            };
+                return taskId switch {
+                    int id when id > 0 => (Instances.AsstProxy.AsstSetTaskParamsEncoded(id, task), [id]),
+                    null => FromSingle(Instances.AsstProxy.AsstAppendTaskWithEncoding(TaskType.Fight, task)),
+                    _ => (null, []),
+                };
+            }
         }
     }
 }

--- a/src/MaaWpfGui/Views/UserControl/TaskQueue/FightSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/TaskQueue/FightSettingsUserControl.xaml
@@ -206,7 +206,7 @@
                         Text="{DynamicResource StageSelect}"
                         TextAlignment="Center"
                         TextWrapping="Wrap"
-                        Visibility="{c:Binding !UseAlternateStage}" />
+                        Visibility="{c:Binding !ShowStagePlan}" />
                     <controls:TextBlock
                         Margin="6,11"
                         HorizontalAlignment="Center"
@@ -215,6 +215,14 @@
                         TextAlignment="Center"
                         TextWrapping="Wrap"
                         Visibility="{c:Binding UseAlternateStage}" />
+                    <controls:TextBlock
+                        Margin="6,11"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Top"
+                        Text="{DynamicResource StageSelectSequence}"
+                        TextAlignment="Center"
+                        TextWrapping="Wrap"
+                        Visibility="{c:Binding UseSequenceStage}" />
                     <controls:TooltipBlock
                         Margin="0,5,6,0"
                         HorizontalAlignment="Right"
@@ -231,20 +239,20 @@
                         Content="{DynamicResource AddStage}"
                         IsHitTestVisible="{c:Binding !IsCurrentTaskRunning,
                                                      Source={x:Static ui_vms:TaskQueueViewModel.TaskSettingVisibilities}}"
-                        Visibility="{c:Binding UseAlternateStage}" />
+                        Visibility="{c:Binding ShowStagePlan}" />
                 </Grid>
                 <ListBox
                     Grid.Column="1"
-                    MinHeight="{c:Binding 'UseAlternateStage ? 75 : 0'}"
+                    MinHeight="{c:Binding 'ShowStagePlan ? 75 : 0'}"
                     Margin="6,6"
                     Padding="-1"
                     VerticalAlignment="Top"
                     HorizontalContentAlignment="Stretch"
                     d:ItemsSource="{d:SampleData ItemCount=2}"
                     dd:DragDrop.DragDropContext="{Binding RelativeSource={RelativeSource Self}}"
-                    dd:DragDrop.IsDragSource="{Binding UseAlternateStage}"
-                    dd:DragDrop.IsDropTarget="{Binding UseAlternateStage}"
-                    BorderThickness="{c:Binding 'UseAlternateStage ? 1 : 0'}"
+                    dd:DragDrop.IsDragSource="{Binding ShowStagePlan}"
+                    dd:DragDrop.IsDropTarget="{Binding ShowStagePlan}"
+                    BorderThickness="{c:Binding 'ShowStagePlan ? 1 : 0'}"
                     ClipToBounds="False"
                     IsHitTestVisible="{c:Binding !IsCurrentTaskRunning,
                                                  Source={x:Static ui_vms:TaskQueueViewModel.TaskSettingVisibilities}}"
@@ -327,7 +335,7 @@
                                                 <MultiDataTrigger>
                                                     <MultiDataTrigger.Conditions>
                                                         <Condition Binding="{Binding IsMouseOver, ElementName=StageItemGrid}" Value="True" />
-                                                        <Condition Binding="{c:Binding DataContext.UseAlternateStage, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type UserControl}}}" Value="True" />
+                                                        <Condition Binding="{c:Binding DataContext.ShowStagePlan, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type UserControl}}}" Value="True" />
                                                     </MultiDataTrigger.Conditions>
                                                     <Setter Property="Visibility" Value="Visible" />
                                                 </MultiDataTrigger>
@@ -454,6 +462,10 @@
                 Margin="0,10"
                 Content="{DynamicResource UseAlternateStage}"
                 IsChecked="{Binding UseAlternateStage}" />
+            <CheckBox
+                Margin="0,10"
+                Content="{DynamicResource UseSequenceStage}"
+                IsChecked="{Binding UseSequenceStage}" />
             <CheckBox
                 Margin="0,10"
                 Content="{DynamicResource HideUnavailableStage}"


### PR DESCRIPTION
理智作战新增自定义作战序列功能，可以在高级设置开启后回到一般设置里面点击候选即可往队列里面添加关卡，每个关卡默认一次，从下到上执行作战序列

## Summary by Sourcery

为配置和执行自定义战斗关卡序列提供支持，并改进战斗任务的任务-关卡日志记录。

新功能:
- 允许配置和运行一系列战斗关卡，这些关卡会被追加到任务队列中并按顺序执行，每个关卡默认运行一次。

错误修复:
- 确保在交替模式与序列关卡模式之间切换，以及在未配置任何关卡时，关卡计划初始化都能一致工作。
- 将公招标签刷新事件处理的键与底层任务附加信息事件名对齐，以确保日志能够正确输出。

增强改进:
- 在战斗设置 UI 中，为交替模式与序列关卡模式引入共享的关卡计划可见性标志。
- 重构战斗任务创建逻辑，在为单关卡或序列关卡生成任务时复用通用配置。
- 针对每个核心任务跟踪并记录可读的关卡名称，使在子任务开始时可以显示当前正在执行的关卡，并在任务或任务链完成时清理相关映射。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for configuring and executing a custom battle stage sequence and improve task-stage logging for fight tasks.

New Features:
- Allow configuring and running a sequence of fight stages that are appended to the task queue and executed in order, with each stage run once by default.

Bug Fixes:
- Ensure stage plan initialization works consistently when toggling between alternate and sequence stage modes and when no stages are configured.
- Align recruit tag refresh event handling key with the underlying task extra info event name to ensure logs are emitted correctly.

Enhancements:
- Introduce a shared stage plan visibility flag across alternate and sequence stage modes in the fight settings UI.
- Refactor fight task creation to reuse common configuration when generating tasks for single or sequenced stages.
- Track and log the human-readable stage name per core task so the currently executing stage is displayed when subtasks start, and clean up mappings when tasks or task chains complete.

</details>