### PR TITLE
Release v6.10.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -692,11 +692,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.MISTEOWORKFLOW }}
 
-      - name: Create issue on failure
-        if: failure()
-        uses: actions-cool/issues-helper@v3
-        with:
-          actions: "create-issue"
           title: "Errors occured during release ${{ needs.meta.outputs.tag }}"
           body: |
             ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/release-ota.yml
+++ b/.github/workflows/release-ota.yml
@@ -139,15 +139,6 @@ jobs:
           prerelease: ${{ fromJSON(needs.create-tag.outputs.prerelease) }}
           overwrite: true
 
-      - name: Create issue on failure
-        if: failure()
-        uses: actions-cool/issues-helper@v3
-        with:
-          actions: "create-issue"
-          title: "Failed to make OTA release for Windows"
-          body: |
-            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-
   make-ota-mac:
     name: Build and Upload OTA for macOS
     needs: create-tag
@@ -191,15 +182,6 @@ jobs:
           tag: ${{ needs.create-tag.outputs.release_tag }}
           prerelease: ${{ fromJSON(needs.create-tag.outputs.prerelease) }}
           overwrite: true
-
-      - name: Create issue on failure
-        if: failure()
-        uses: actions-cool/issues-helper@v3
-        with:
-          actions: "create-issue"
-          title: "Failed to make OTA release for macOS"
-          body: |
-            ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
   release:
     name: Publish to Release Mirrors


### PR DESCRIPTION
怎么 [issues-helper](https://github.com/actions-cool/issues-helper) 被 ban 了

## Summary by Sourcery

从 GitHub workflow 中移除使用已弃用的 `issues-helper` action 自动创建 issue 的功能。

CI：
- 在 `release-ota` workflow 中，当 Windows 和 macOS 的 OTA 构建失败时，停止自动创建 GitHub issue。
- 在主 CI workflow 中，当 CI 发布失败时，停止自动创建 GitHub issue。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Remove automatic issue creation using the deprecated issues-helper action from GitHub workflows.

CI:
- Stop creating GitHub issues on OTA build failures for Windows and macOS in the release-ota workflow.
- Stop creating GitHub issues on CI release failures in the main CI workflow.

</details>