### PR TITLE
Fix infrast product change taskbased

### DIFF
--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -4900,7 +4900,7 @@
         "template": "ChooseProductList.png",
         "cache": true,
         "roi": [1000, 117, 115, 60],
-        "specificRect": [1030, 180, 80, 80],
+        "specificRect": [1075, 345, 102, 98],
         "maxTimes": 3,
         "next": ["ChooseBattleRecord", "#self"],
         "exceededNext": ["ChooseBattleRecord"]
@@ -4910,7 +4910,7 @@
         "template": "ChooseProductList.png",
         "cache": true,
         "roi": [1000, 117, 115, 60],
-        "specificRect": [1030, 180, 80, 80],
+        "specificRect": [1075, 345, 102, 98],
         "maxTimes": 3,
         "next": ["ChoosePureGoldTab", "#self"],
         "exceededNext": ["ChoosePureGoldTab"]

--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -2930,6 +2930,26 @@
         "template": "InfrastTradeSyntheticJadeFlag.png",
         "roi": [900, 500, 380, 220]
     },
+    "VerifyProductChangedToBattleRecord": {
+        "template": "InfrastMfgDogFoodFlag.png",
+        "roi": [1000, 0, 280, 720]
+    },
+    "VerifyProductChangedToPureGold": {
+        "template": "InfrastMfgPureGoldFlag.png",
+        "roi": [1000, 0, 280, 720]
+    },
+    "VerifyProductChangedToOriginiumShard": {
+        "template": "InfrastMfgOriginStoneFlag.png",
+        "roi": [1000, 0, 280, 720]
+    },
+    "VerifyProductChangedToMoney": {
+        "template": "InfrastTradeMoneyFlag.png",
+        "roi": [900, 500, 380, 220]
+    },
+    "VerifyProductChangedToSyntheticJade": {
+        "template": "InfrastTradeSyntheticJadeFlag.png",
+        "roi": [900, 500, 380, 220]
+    },
     "InfrastAddOperatorMfgGentle": {
         "template": "AddOperatorMfgGentle.png",
         "templThreshold": 0.8,
@@ -4881,7 +4901,9 @@
         "cache": true,
         "roi": [1000, 117, 115, 60],
         "specificRect": [1030, 180, 80, 80],
-        "next": ["ChooseBattleRecord"]
+        "maxTimes": 3,
+        "next": ["ChooseBattleRecord", "#self"],
+        "exceededNext": ["ChooseBattleRecord"]
     },
     "ChangeProductToPureGold": {
         "action": "ClickRect",
@@ -4889,15 +4911,19 @@
         "cache": true,
         "roi": [1000, 117, 115, 60],
         "specificRect": [1030, 180, 80, 80],
-        "next": ["ChoosePureGoldTab"]
+        "maxTimes": 3,
+        "next": ["ChoosePureGoldTab", "#self"],
+        "exceededNext": ["ChoosePureGoldTab"]
     },
     "ChangeProductToOriginiumShard": {
         "action": "ClickRect",
         "template": "ChooseProductList.png",
         "cache": true,
         "roi": [1000, 117, 115, 60],
-        "specificRect": [1030, 180, 80, 80],
-        "next": ["ChooseOriginiumShardTab"]
+        "specificRect": [1075, 345, 102, 98],
+        "maxTimes": 3,
+        "next": ["ChooseOriginiumShardTab", "#self"],
+        "exceededNext": ["ChooseOriginiumShardTab"]
     },
     "GachaOnce": {
         "algorithm": "JustReturn",

--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -2942,14 +2942,6 @@
         "template": "InfrastMfgOriginStoneFlag.png",
         "roi": [1000, 0, 280, 720]
     },
-    "VerifyProductChangedToMoney": {
-        "template": "InfrastTradeMoneyFlag.png",
-        "roi": [900, 500, 380, 220]
-    },
-    "VerifyProductChangedToSyntheticJade": {
-        "template": "InfrastTradeSyntheticJadeFlag.png",
-        "roi": [900, 500, 380, 220]
-    },
     "InfrastAddOperatorMfgGentle": {
         "template": "AddOperatorMfgGentle.png",
         "templThreshold": 0.8,

--- a/src/MaaCore/Task/Infrast/InfrastAbstractTask.cpp
+++ b/src/MaaCore/Task/Infrast/InfrastAbstractTask.cpp
@@ -26,6 +26,12 @@ asst::InfrastAbstractTask::InfrastAbstractTask(
     m_retry_times = TaskRetryTimes;
 }
 
+bool asst::InfrastAbstractTask::run()
+{
+    reset_custom_config();
+    return AbstractTask::run();
+}
+
 asst::InfrastAbstractTask& asst::InfrastAbstractTask::set_mood_threshold(double mood_thres) noexcept
 {
     m_mood_threshold = mood_thres;
@@ -61,6 +67,7 @@ std::string asst::InfrastAbstractTask::facility_name() const
 
 void asst::InfrastAbstractTask::set_custom_config(infrast::CustomFacilityConfig config) noexcept
 {
+    m_initial_custom_config = config;
     m_custom_config = std::move(config);
     m_is_custom = true;
 }
@@ -69,6 +76,14 @@ void asst::InfrastAbstractTask::clear_custom_config() noexcept
 {
     m_is_custom = false;
     m_custom_config.clear();
+    m_initial_custom_config.clear();
+}
+
+void asst::InfrastAbstractTask::reset_custom_config() noexcept
+{
+    if (m_is_custom) {
+        m_custom_config = m_initial_custom_config;
+    }
 }
 
 asst::infrast::CustomRoomConfig& asst::InfrastAbstractTask::current_room_config()
@@ -192,6 +207,7 @@ bool asst::InfrastAbstractTask::on_run_fails()
 {
     LogTraceFunction;
 
+    reset_custom_config();
     ProcessTask return_task(*this, { "InfrastBegin" });
     return return_task.run();
 }

--- a/src/MaaCore/Task/Infrast/InfrastAbstractTask.cpp
+++ b/src/MaaCore/Task/Infrast/InfrastAbstractTask.cpp
@@ -81,6 +81,8 @@ void asst::InfrastAbstractTask::clear_custom_config() noexcept
 
 void asst::InfrastAbstractTask::reset_custom_config() noexcept
 {
+    // current_room_config() 返回的是引用；为了避免重复选人，select_custom_opers() 找到一个名字后会 erase。
+    // 所以出错重试前需要恢复原配置，否则下一轮会丢失已经处理过的自定义干员名单。
     if (m_is_custom) {
         m_custom_config = m_initial_custom_config;
     }

--- a/src/MaaCore/Task/Infrast/InfrastAbstractTask.h
+++ b/src/MaaCore/Task/Infrast/InfrastAbstractTask.h
@@ -13,6 +13,7 @@ public:
     InfrastAbstractTask(const AsstCallback& callback, Assistant* inst, std::string_view task_chain);
 
     virtual ~InfrastAbstractTask() override = default;
+    virtual bool run() override;
     InfrastAbstractTask& set_mood_threshold(double mood_thres) noexcept;
 
     virtual json::value basic_info() const override;
@@ -30,6 +31,7 @@ public:
 
 protected:
     virtual bool on_run_fails() override;
+    void reset_custom_config() noexcept;
 
     bool enter_facility(int index = 0);
     // 从刚点进设施的界面，到干员列表页
@@ -86,5 +88,6 @@ protected:
     int m_cur_facility_index = 0;
     bool m_is_custom = false;
     infrast::CustomFacilityConfig m_custom_config;
+    infrast::CustomFacilityConfig m_initial_custom_config;
 };
 } // namespace asst

--- a/src/MaaCore/Task/Infrast/InfrastProductionTask.cpp
+++ b/src/MaaCore/Task/Infrast/InfrastProductionTask.cpp
@@ -75,6 +75,7 @@ bool asst::InfrastProductionTask::change_product()
 {
     auto run_change_task =
         [&](const std::string& task_name, const std::string& product_name, const std::string& verify_task_name) {
+        // 只有切换流程和产物复核都通过，才上报 ProductChanged。
         if (!ProcessTask(*this, { task_name }).run()) {
             Log.error("change product failed", task_name);
             return false;

--- a/src/MaaCore/Task/Infrast/InfrastProductionTask.cpp
+++ b/src/MaaCore/Task/Infrast/InfrastProductionTask.cpp
@@ -71,55 +71,63 @@ void asst::InfrastProductionTask::set_product(std::string product_name) noexcept
     }
 }
 
-void asst::InfrastProductionTask::change_product()
+bool asst::InfrastProductionTask::change_product()
 {
+    auto run_change_task =
+        [&](const std::string& task_name, const std::string& product_name, const std::string& verify_task_name) {
+        if (!ProcessTask(*this, { task_name }).run()) {
+            Log.error("change product failed", task_name);
+            return false;
+        }
+
+        if (!ProcessTask(*this, { verify_task_name }).run()) {
+            Log.error("product verification failed", verify_task_name);
+            return false;
+        }
+
+        json::value callback_info = basic_info_with_what("ProductChanged");
+        callback_info["details"]["product"] = product_name;
+        callback(AsstMsg::SubTaskExtraInfo, callback_info);
+        return true;
+    };
+
     auto customProduct = current_room_config().product;
     switch (customProduct) {
     /*制造站的产品类型*/
     case infrast::CustomRoomConfig::Product::BattleRecord: {
-        ProcessTask(*this, { "ChangeProductToMiddleBattleRecord" }).run();
-        json::value callback_info = basic_info_with_what("ProductChanged");
-        callback_info["details"]["product"] = "MiddleBattleRecord";
-        callback(AsstMsg::SubTaskExtraInfo, callback_info);
-        break;
+        return run_change_task(
+            "ChangeProductToMiddleBattleRecord",
+            "MiddleBattleRecord",
+            "VerifyProductChangedToBattleRecord");
     }
     case infrast::CustomRoomConfig::Product::PureGold: {
-        ProcessTask(*this, { "ChangeProductToPureGold" }).run();
-        json::value callback_info = basic_info_with_what("ProductChanged");
-        callback_info["details"]["product"] = "PureGold";
-        callback(AsstMsg::SubTaskExtraInfo, callback_info);
-        break;
+        return run_change_task("ChangeProductToPureGold", "PureGold", "VerifyProductChangedToPureGold");
     }
     case infrast::CustomRoomConfig::Product::OriginiumShard: {
-        ProcessTask(*this, { "ChangeProductToOriginiumShard" }).run();
-        json::value callback_info = basic_info_with_what("ProductChanged");
-        callback_info["details"]["product"] = "OriginiumShard";
-        callback(AsstMsg::SubTaskExtraInfo, callback_info);
-        break;
+        return run_change_task(
+            "ChangeProductToOriginiumShard",
+            "OriginiumShard",
+            "VerifyProductChangedToOriginiumShard");
     }
     case infrast::CustomRoomConfig::Product::Dualchip: {
-        break;
+        return true;
     }
     /*贸易站的订单类型*/
     case infrast::CustomRoomConfig::Product::LMD: {
-        ProcessTask(*this, { "ChangeToMoneyOrder" }).run();
-        json::value callback_info = basic_info_with_what("ProductChanged");
-        callback_info["details"]["product"] = "Money";
-        callback(AsstMsg::SubTaskExtraInfo, callback_info);
-        break;
+        return run_change_task("ChangeToMoneyOrder", "Money", "VerifyProductChangedToMoney");
     }
     case infrast::CustomRoomConfig::Product::Orundum: {
-        ProcessTask(*this, { "ChangeToSyntheticJadeFlagOrder" }).run();
-        json::value callback_info = basic_info_with_what("ProductChanged");
-        callback_info["details"]["product"] = "SyntheticJade";
-        callback(AsstMsg::SubTaskExtraInfo, callback_info);
-        break;
+        return run_change_task(
+            "ChangeToSyntheticJadeFlagOrder",
+            "SyntheticJade",
+            "VerifyProductChangedToSyntheticJade");
     }
 
     default: {
-        break;
+        return true;
     }
     }
+    return true;
 }
 
 bool asst::InfrastProductionTask::shift_facility_list()
@@ -266,7 +274,9 @@ bool asst::InfrastProductionTask::shift_facility_list()
 
         /*启用自定义基建时，如果产物不一致则直接更换产物*/
         if (m_is_custom && m_is_product_incorrect) {
-            change_product();
+            if (!change_product()) {
+                return false;
+            }
         }
         // 使用无人机
         if (m_is_use_custom_drones) {

--- a/src/MaaCore/Task/Infrast/InfrastProductionTask.cpp
+++ b/src/MaaCore/Task/Infrast/InfrastProductionTask.cpp
@@ -73,8 +73,7 @@ void asst::InfrastProductionTask::set_product(std::string product_name) noexcept
 
 bool asst::InfrastProductionTask::change_product()
 {
-    auto run_change_task =
-        [&](const std::string& task_name, const std::string& product_name, const std::string& verify_task_name) {
+    auto run_change_task = [&](const std::string& task_name, const std::string& verify_task_name) {
         // 只有切换流程和产物复核都通过，才上报 ProductChanged。
         if (!ProcessTask(*this, { task_name }).run()) {
             Log.error("change product failed", task_name);
@@ -86,9 +85,6 @@ bool asst::InfrastProductionTask::change_product()
             return false;
         }
 
-        json::value callback_info = basic_info_with_what("ProductChanged");
-        callback_info["details"]["product"] = product_name;
-        callback(AsstMsg::SubTaskExtraInfo, callback_info);
         return true;
     };
 
@@ -96,36 +92,53 @@ bool asst::InfrastProductionTask::change_product()
     switch (customProduct) {
     /*制造站的产品类型*/
     case infrast::CustomRoomConfig::Product::BattleRecord: {
-        return run_change_task(
-            "ChangeProductToMiddleBattleRecord",
-            "MiddleBattleRecord",
-            "VerifyProductChangedToBattleRecord");
+        if (!run_change_task("ChangeProductToMiddleBattleRecord", "VerifyProductChangedToBattleRecord")) {
+            return false;
+        }
+        json::value callback_info = basic_info_with_what("ProductChanged");
+        callback_info["details"]["product"] = "MiddleBattleRecord";
+        callback(AsstMsg::SubTaskExtraInfo, callback_info);
+        break;
     }
     case infrast::CustomRoomConfig::Product::PureGold: {
-        return run_change_task("ChangeProductToPureGold", "PureGold", "VerifyProductChangedToPureGold");
+        if (!run_change_task("ChangeProductToPureGold", "VerifyProductChangedToPureGold")) {
+            return false;
+        }
+        json::value callback_info = basic_info_with_what("ProductChanged");
+        callback_info["details"]["product"] = "PureGold";
+        callback(AsstMsg::SubTaskExtraInfo, callback_info);
+        break;
     }
     case infrast::CustomRoomConfig::Product::OriginiumShard: {
-        return run_change_task(
-            "ChangeProductToOriginiumShard",
-            "OriginiumShard",
-            "VerifyProductChangedToOriginiumShard");
+        if (!run_change_task("ChangeProductToOriginiumShard", "VerifyProductChangedToOriginiumShard")) {
+            return false;
+        }
+        json::value callback_info = basic_info_with_what("ProductChanged");
+        callback_info["details"]["product"] = "OriginiumShard";
+        callback(AsstMsg::SubTaskExtraInfo, callback_info);
+        break;
     }
     case infrast::CustomRoomConfig::Product::Dualchip: {
-        return true;
+        break;
     }
     /*贸易站的订单类型*/
     case infrast::CustomRoomConfig::Product::LMD: {
-        return run_change_task("ChangeToMoneyOrder", "Money", "VerifyProductChangedToMoney");
+        ProcessTask(*this, { "ChangeToMoneyOrder" }).run();
+        json::value callback_info = basic_info_with_what("ProductChanged");
+        callback_info["details"]["product"] = "Money";
+        callback(AsstMsg::SubTaskExtraInfo, callback_info);
+        break;
     }
     case infrast::CustomRoomConfig::Product::Orundum: {
-        return run_change_task(
-            "ChangeToSyntheticJadeFlagOrder",
-            "SyntheticJade",
-            "VerifyProductChangedToSyntheticJade");
+        ProcessTask(*this, { "ChangeToSyntheticJadeFlagOrder" }).run();
+        json::value callback_info = basic_info_with_what("ProductChanged");
+        callback_info["details"]["product"] = "SyntheticJade";
+        callback(AsstMsg::SubTaskExtraInfo, callback_info);
+        break;
     }
 
     default: {
-        return true;
+        break;
     }
     }
     return true;

--- a/src/MaaCore/Task/Infrast/InfrastProductionTask.h
+++ b/src/MaaCore/Task/Infrast/InfrastProductionTask.h
@@ -45,7 +45,7 @@ protected:
     bool m_skip_shift = false;
 
 protected:
-    void change_product();
+    bool change_product();
     bool m_is_product_incorrect = false;
 };
 }


### PR DESCRIPTION
## 问题

基建自定义换班切换制造站产物时，原流程在产物切换任务失败后仍会无条件上报 `ProductChanged`，并继续处理后续设施。

群里白泽的原始日志中（23:19，制造站 02）：

- 制造站 02 当前产物识别为 `PureGold`，目标为 `Originium Shard`
- 进入 `ChangeProductToOriginiumShard`
- 点击产品列表后，连续多次未识别到 `ChooseOriginiumShardTab`
- `ProcessTask` 已经返回 `SubTaskError`
- 但 `InfrastProductionTask::change_product()` 仍然上报了 `ProductChanged OriginiumShard`
- 随后流程继续进入下一个制造站

这会导致 GUI 显示产物已切换，但游戏内实际产物并没有完成切换。

另外，日志中还观察到一次确认流程已经走到最终确认节点（红勾），但后续界面状态仍不符合预期的情况。该现象的底层原因不易从日志直接确认，但可以通过在上报 `ProductChanged` 前复核最终产物状态来解决。


## fix

- 将 `change_product()` 改为返回true/false。
- 产物切换任务失败时不再无条件上报 `ProductChanged`，交给现有基建重试逻辑处理。
- 新增 `VerifyProductChangedTo*` 任务节点，复用了现有模板检查右侧产品名。
- 只有切换任务和产物复核都成功后，才上报 `ProductChanged`。
- 将制造站产品列表入口点击改为 `maxTimes + #self + exceededNext` 形式。
- 尽可能地少改cpp，只改了bool，加了两个if。
- 调整改产物click的ROI，并3次#self，改了ROI连点是不会误触的。
<img width="204" height="333" alt="image" src="https://github.com/user-attachments/assets/7e1aea6f-6da1-447d-91f2-99c1d4e2ca75" />

同时，在验证失败重试路径时，发现自定义配置fail之后就失效了。因为`current_room_config()` 返回引用，`select_custom_opers()` 每找到一个名字就从配置中移除，避免重复选人。但失败重试时就没法正确选人了。

因此新增初始自定义配置副本，在任务开始和失败重试前恢复 `m_custom_config`。

## 测试

- 本地 RelWithDebInfo 构建通过。
- 通过临时调整ROI来模拟点击后未打开产品列表的情况：
  - `ChangeProductToOriginiumShard` 按任务图重试；
  - 耗尽后等待目标页签失败；
  - `ProcessTask` 返回 `SubTaskError`；
  - 外层记录切换失败，不再上报 `ProductChanged`。
- 正式流程验证：
  - 制造站切换为源石碎片成功；
  - 目标产物模板复核通过后才上报 `ProductChanged`。
- 所有复现和测试我都存有录像，要的话可以发

## logs
[logs.zip](https://github.com/user-attachments/files/28030981/logs.zip)

`test_logs` 包含两组测试日志：
- `bad_roi`
  - 模拟点击产品卡片失败的测试。这里用异常 ROI 让产品列表打不开，用来验证切换失败后不会再误报 `ProductChanged`
  - 关键日志现象包括：`ChangeProductToOriginiumShard` 连续执行到 `max_times`，随后 `ChooseOriginiumShardTab` 仍识别失败，最终出现 `SubTaskError` 和 `change product failed`。

- `originium_shard`
  - 正式修复版本测试。制造站 3、4 切换到源石碎片，验证切换完成后会通过源石碎片模板复核，再上报 `ProductChanged`。
  - 日志中可以看到 `ChangeProductToOriginiumShard` 完成后继续执行 `VerifyProductChangedToOriginiumShard`，匹配到 `InfrastMfgOriginStoneFlag.png` 后才上报 `ProductChanged`。


每个子目录里：

`asst.log` 是核心运行日志。
`callback.log` 是回调/GUI 事件日志。
`task_params.json` 是测试任务参数。
`run_status.json` 是脚本记录的运行结果。

## Summary by Sourcery

通过验证来保护基础设施生产产品变更，并在重试过程中改进自定义配置的处理。

**Bug 修复：**
- 当生产产品变更的子任务或验证失败时，防止报告 `ProductChanged`，而是中止后续的工厂处理。
- 在运行前以及重试时恢复最初的自定义基础设施配置，以确保在发生失败后，操作员的选择保持一致。

**增强功能：**
- 在自定义生产运行期间，要求产品变更任务和变更后验证任务都成功后，才会在回调中发出 `ProductChanged`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Guard infrastructure manufacturing product changes with verification and improve custom configuration handling across retries.

Bug Fixes:
- Prevent reporting ProductChanged when manufacturing product change subtasks or verification fail, aborting further facility processing instead.
- Restore initial custom infrastructure configuration before runs and on retry to ensure operator selection remains consistent after failures.

Enhancements:
- Require both product change and post-change verification tasks to succeed before emitting ProductChanged callbacks during custom manufacturing runs.

</details>