### PR TITLE
fix(remote-control): 远控 LinkStart-Combat 兼容「剩余理智」

### DIFF
--- a/src/MaaWpfGui/Services/RemoteControl/RemoteControlService.cs
+++ b/src/MaaWpfGui/Services/RemoteControl/RemoteControlService.cs
@@ -413,12 +413,7 @@ public class RemoteControlService
                     break;
                 case "Settings-Stage1":
                     await Execute.OnUIThreadAsync(() => {
-                        if (TaskQueueViewModel.FightTask.StagePlan.Count != 1)
-                        {
-                            TaskQueueViewModel.FightTask.StagePlan.Clear();
-                            TaskQueueViewModel.FightTask.StagePlan.Add(new());
-                        }
-                        TaskQueueViewModel.FightTask.StagePlan[0].Stage = data;
+                        Instances.TaskQueueViewModel.TryApplyRemoteFightStage(data ?? string.Empty);
                     });
                     break;
                 default:
@@ -546,7 +541,7 @@ public class RemoteControlService
     /// <para>注意以下特点:</para>
     /// <para>- 可以在非UI线程执行。</para>
     /// <para>- 不调用StartScript。</para>
-    /// <para>- 不使用Model里的列表。</para>
+    /// <para>- 子任务序列化走 TaskQueue 队列项与 LinkStartWithTasks 相同路径，不再要求队列中仅存在单个 FightTask。</para>
     /// <para>- 在结尾添加对RunningStatus的等待。</para>
     /// <para>若"一键长草"功能在未来有更新，此方法也应进行相应的同步更新，但需确保上述特点保持不变。</para>
     /// </remarks>
@@ -590,133 +585,77 @@ public class RemoteControlService
 
             bool taskRet = true;
 
-            // 直接遍历TaskItemViewModels里面的内容，是排序后的
-            // 20260112 status102: 先做兼容处理
+            // 与 TaskQueueViewModel.LinkStartWithTasks 一致：按队列项序列化；远控子任务无视「整类未勾选」时回退为全部同类型项
             int count = 0;
+            var viewModel = Instances.TaskQueueViewModel;
             foreach (var item in originalNames)
             {
-                ++count;
-                switch (item)
+                var queueTasks = TaskQueueViewModel.GetTasksForRemoteSubTask(item).ToList();
+                if (queueTasks.Count == 0)
                 {
-                    case "Base":
-                        {
-                            var tasks = ConfigFactory.CurrentConfig.TaskQueue.OfType<InfrastTask>().ToList();
-                            if (tasks.Count == 1)
-                            {
-                                taskRet &= InfrastSettingsUserControlModel.Instance.SerializeTask(tasks[0]).IsSuccess ?? false;
-                                break;
-                            }
-
-                            taskRet = false;
-                            break;
-                        }
-
-                    case "WakeUp":
-                        {
-                            var tasks = ConfigFactory.CurrentConfig.TaskQueue.OfType<StartUpTask>().ToList();
-                            if (tasks.Count == 1)
-                            {
-                                taskRet &= StartUpSettingsUserControlModel.Instance.SerializeTask(tasks[0]).IsSuccess ?? false;
-                                break;
-                            }
-
-                            taskRet = false;
-                            break;
-                        }
-
-                    case "Combat":
-                        {
-                            var tasks = ConfigFactory.CurrentConfig.TaskQueue.OfType<FightTask>().ToList();
-                            if (tasks.Count == 1)
-                            {
-                                taskRet &= FightSettingsUserControlModel.Instance.SerializeTask(tasks[0]).IsSuccess ?? false;
-                                break;
-                            }
-
-                            taskRet = false;
-                            break;
-                        }
-
-                    case "Recruiting":
-                        {
-                            var tasks = ConfigFactory.CurrentConfig.TaskQueue.OfType<RecruitTask>().ToList();
-                            if (tasks.Count == 1)
-                            {
-                                taskRet &= RecruitSettingsUserControlModel.Instance.SerializeTask(tasks[0]).IsSuccess ?? false;
-                                break;
-                            }
-
-                            taskRet = false;
-                            break;
-                        }
-
-                    case "Mall":
-                        {
-                            var tasks = ConfigFactory.CurrentConfig.TaskQueue.OfType<MallTask>().ToList();
-                            if (tasks.Count == 1)
-                            {
-                                taskRet &= MallSettingsUserControlModel.Instance.SerializeTask(tasks[0]).IsSuccess ?? false;
-                                break;
-                            }
-
-                            taskRet = false;
-                            break;
-                        }
-
-                    case "Mission":
-                        {
-                            var tasks = ConfigFactory.CurrentConfig.TaskQueue.OfType<AwardTask>().ToList();
-                            if (tasks.Count == 1)
-                            {
-                                taskRet &= AwardSettingsUserControlModel.Instance.SerializeTask(tasks[0]).IsSuccess ?? false;
-                                break;
-                            }
-
-                            taskRet = false;
-                            break;
-                        }
-
-                    case "AutoRoguelike":
-                        {
-                            var tasks = ConfigFactory.CurrentConfig.TaskQueue.OfType<RoguelikeTask>().ToList();
-                            if (tasks.Count == 1)
-                            {
-                                taskRet &= RoguelikeSettingsUserControlModel.Instance.SerializeTask(tasks[0]).IsSuccess ?? false;
-                                break;
-                            }
-
-                            taskRet = false;
-                            break;
-                        }
-
-                    case "Reclamation":
-                        {
-                            var tasks = ConfigFactory.CurrentConfig.TaskQueue.OfType<ReclamationTask>().ToList();
-                            if (tasks.Count == 1)
-                            {
-                                taskRet &= ReclamationSettingsUserControlModel.Instance.SerializeTask(tasks[0]).IsSuccess ?? false;
-                                break;
-                            }
-
-                            taskRet = false;
-                            break;
-                        }
-
-                    default:
-                        --count;
-
-                        // Instances.TaskQueueViewModel._logger.Error("Unknown task: " + item);
-                        break;
-                }
-
-                if (taskRet)
-                {
+                    viewModel.AddLog(item + "Error", UiLogColor.Error);
                     continue;
                 }
 
-                Instances.TaskQueueViewModel.AddLog(item + "Error", UiLogColor.Error);
-                taskRet = true;
-                --count;
+                var enabled = queueTasks.Where(TaskQueueViewModel.IsTaskEnable).ToList();
+                var toSerialize = enabled.Count > 0 ? enabled : queueTasks;
+
+                int appended = 0;
+                foreach (var task in toSerialize)
+                {
+                    try
+                    {
+                        var (isSuccess, taskIds) = viewModel.SerializeQueueTask(task);
+                        var index = ConfigFactory.CurrentConfig.TaskQueue.IndexOf(task);
+                        switch (isSuccess)
+                        {
+                            case true:
+                                ++appended;
+                                viewModel.TaskItemViewModels.ElementAtOrDefault(index)?.SetTaskIds(taskIds);
+                                break;
+                            case false:
+                                taskRet = false;
+                                viewModel.AddLog(
+                                    LocalizationHelper.GetStringFormat(
+                                        "TaskAppend.Error",
+                                        LocalizationHelper.GetString(task.TaskType.ToString()),
+                                        task.NameDisplay),
+                                    UiLogColor.Error);
+                                break;
+                            case null:
+                                viewModel.AddLog(
+                                    LocalizationHelper.GetStringFormat(
+                                        "TaskAppend.Skip",
+                                        LocalizationHelper.GetString(task.TaskType.ToString()),
+                                        task.NameDisplay),
+                                    UiLogColor.Info);
+                                break;
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        taskRet = false;
+                        viewModel.AddLog(
+                            LocalizationHelper.GetStringFormat(
+                                "TaskAppend.Error",
+                                LocalizationHelper.GetString(task.TaskType.ToString()),
+                                task.NameDisplay) + "\n" + ex.Message,
+                            UiLogColor.Error);
+                    }
+
+                    if (!taskRet)
+                    {
+                        break;
+                    }
+                }
+
+                if (appended > 0)
+                {
+                    ++count;
+                    continue;
+                }
+
+                viewModel.AddLog(item + "Error", UiLogColor.Error);
             }
 
             if (count == 0)

--- a/src/MaaWpfGui/Services/RemoteControl/RemoteControlService.cs
+++ b/src/MaaWpfGui/Services/RemoteControl/RemoteControlService.cs
@@ -413,7 +413,7 @@ public class RemoteControlService
                     break;
                 case "Settings-Stage1":
                     await Execute.OnUIThreadAsync(() => {
-                        Instances.TaskQueueViewModel.TryApplyRemoteFightStage(data ?? string.Empty);
+                        TryApplyRemoteFightStage(data ?? string.Empty);
                     });
                     break;
                 default:
@@ -590,7 +590,7 @@ public class RemoteControlService
             var viewModel = Instances.TaskQueueViewModel;
             foreach (var item in originalNames)
             {
-                var queueTasks = TaskQueueViewModel.GetTasksForRemoteSubTask(item).ToList();
+                var queueTasks = GetTasksForRemoteSubTask(item).ToList();
                 if (queueTasks.Count == 0)
                 {
                     viewModel.AddLog(item + "Error", UiLogColor.Error);
@@ -682,6 +682,45 @@ public class RemoteControlService
         });
 
         await _runningState.UntilIdleAsync();
+    }
+
+    /// <summary>远控 LinkStart-XXX：按任务类型返回 TaskQueue 中的对应项（保留顺序）。</summary>
+    private static IEnumerable<BaseTask> GetTasksForRemoteSubTask(string remoteSubTaskName) =>
+        remoteSubTaskName switch {
+            "Base" => ConfigFactory.CurrentConfig.TaskQueue.OfType<InfrastTask>().Cast<BaseTask>(),
+            "WakeUp" => ConfigFactory.CurrentConfig.TaskQueue.OfType<StartUpTask>().Cast<BaseTask>(),
+            "Combat" => ConfigFactory.CurrentConfig.TaskQueue.OfType<FightTask>().Cast<BaseTask>(),
+            "Recruiting" => ConfigFactory.CurrentConfig.TaskQueue.OfType<RecruitTask>().Cast<BaseTask>(),
+            "Mall" => ConfigFactory.CurrentConfig.TaskQueue.OfType<MallTask>().Cast<BaseTask>(),
+            "Mission" => ConfigFactory.CurrentConfig.TaskQueue.OfType<AwardTask>().Cast<BaseTask>(),
+            "AutoRoguelike" => ConfigFactory.CurrentConfig.TaskQueue.OfType<RoguelikeTask>().Cast<BaseTask>(),
+            "Reclamation" => ConfigFactory.CurrentConfig.TaskQueue.OfType<ReclamationTask>().Cast<BaseTask>(),
+            _ => [],
+        };
+
+    /// <summary>远控 Settings-Stage1：写入首个已启用理智作战任务的关卡。</summary>
+    private static bool TryApplyRemoteFightStage(string stage)
+    {
+        var fight = ConfigFactory.CurrentConfig.TaskQueue.OfType<FightTask>().FirstOrDefault(TaskQueueViewModel.IsTaskEnable)
+            ?? ConfigFactory.CurrentConfig.TaskQueue.OfType<FightTask>().FirstOrDefault();
+        if (fight is null)
+        {
+            return false;
+        }
+
+        if (fight.StagePlan.Count == 0)
+        {
+            fight.StagePlan.Add(string.Empty);
+        }
+        else if (fight.StagePlan.Count > 1)
+        {
+            fight.StagePlan.Clear();
+            fight.StagePlan.Add(string.Empty);
+        }
+
+        fight.StagePlan[0] = stage ?? string.Empty;
+        Instances.TaskQueueViewModel.RefreshTaskModel(fight);
+        return true;
     }
 
     public static async Task ConnectionTest()

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -1037,45 +1037,6 @@ public class TaskQueueViewModel : Screen
     /// <returns>whether the task is enabled</returns>
     public static bool IsTaskEnable(BaseTask baseTask) => baseTask.IsEnable is true || (baseTask.IsEnable is null && !GuiSettingsUserControlModel.Instance.MainTasksInvertNullFunction);
 
-    /// <summary>远控 LinkStart-XXX：按任务类型返回 TaskQueue 中的对应项（保留顺序）。</summary>
-    public static IEnumerable<BaseTask> GetTasksForRemoteSubTask(string remoteSubTaskName) =>
-        remoteSubTaskName switch {
-            "Base" => ConfigFactory.CurrentConfig.TaskQueue.OfType<InfrastTask>().Cast<BaseTask>(),
-            "WakeUp" => ConfigFactory.CurrentConfig.TaskQueue.OfType<StartUpTask>().Cast<BaseTask>(),
-            "Combat" => ConfigFactory.CurrentConfig.TaskQueue.OfType<FightTask>().Cast<BaseTask>(),
-            "Recruiting" => ConfigFactory.CurrentConfig.TaskQueue.OfType<RecruitTask>().Cast<BaseTask>(),
-            "Mall" => ConfigFactory.CurrentConfig.TaskQueue.OfType<MallTask>().Cast<BaseTask>(),
-            "Mission" => ConfigFactory.CurrentConfig.TaskQueue.OfType<AwardTask>().Cast<BaseTask>(),
-            "AutoRoguelike" => ConfigFactory.CurrentConfig.TaskQueue.OfType<RoguelikeTask>().Cast<BaseTask>(),
-            "Reclamation" => ConfigFactory.CurrentConfig.TaskQueue.OfType<ReclamationTask>().Cast<BaseTask>(),
-            _ => [],
-        };
-
-    /// <summary>远控 Settings-Stage1：写入首个已启用理智作战任务的关卡。</summary>
-    public bool TryApplyRemoteFightStage(string stage)
-    {
-        var fight = ConfigFactory.CurrentConfig.TaskQueue.OfType<FightTask>().FirstOrDefault(IsTaskEnable)
-            ?? ConfigFactory.CurrentConfig.TaskQueue.OfType<FightTask>().FirstOrDefault();
-        if (fight is null)
-        {
-            return false;
-        }
-
-        if (fight.StagePlan.Count == 0)
-        {
-            fight.StagePlan.Add(string.Empty);
-        }
-        else if (fight.StagePlan.Count > 1)
-        {
-            fight.StagePlan.Clear();
-            fight.StagePlan.Add(string.Empty);
-        }
-
-        fight.StagePlan[0] = stage ?? string.Empty;
-        RefreshTaskModel(fight);
-        return true;
-    }
-
     /// <summary>序列化 TaskQueue 中的单条任务（供远控等调用）。</summary>
     public (bool? IsSuccess, IEnumerable<int> TaskIds) SerializeQueueTask(BaseTask task) => SerializeTask(task);
 

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -1037,6 +1037,48 @@ public class TaskQueueViewModel : Screen
     /// <returns>whether the task is enabled</returns>
     public static bool IsTaskEnable(BaseTask baseTask) => baseTask.IsEnable is true || (baseTask.IsEnable is null && !GuiSettingsUserControlModel.Instance.MainTasksInvertNullFunction);
 
+    /// <summary>远控 LinkStart-XXX：按任务类型返回 TaskQueue 中的对应项（保留顺序）。</summary>
+    public static IEnumerable<BaseTask> GetTasksForRemoteSubTask(string remoteSubTaskName) =>
+        remoteSubTaskName switch {
+            "Base" => ConfigFactory.CurrentConfig.TaskQueue.OfType<InfrastTask>().Cast<BaseTask>(),
+            "WakeUp" => ConfigFactory.CurrentConfig.TaskQueue.OfType<StartUpTask>().Cast<BaseTask>(),
+            "Combat" => ConfigFactory.CurrentConfig.TaskQueue.OfType<FightTask>().Cast<BaseTask>(),
+            "Recruiting" => ConfigFactory.CurrentConfig.TaskQueue.OfType<RecruitTask>().Cast<BaseTask>(),
+            "Mall" => ConfigFactory.CurrentConfig.TaskQueue.OfType<MallTask>().Cast<BaseTask>(),
+            "Mission" => ConfigFactory.CurrentConfig.TaskQueue.OfType<AwardTask>().Cast<BaseTask>(),
+            "AutoRoguelike" => ConfigFactory.CurrentConfig.TaskQueue.OfType<RoguelikeTask>().Cast<BaseTask>(),
+            "Reclamation" => ConfigFactory.CurrentConfig.TaskQueue.OfType<ReclamationTask>().Cast<BaseTask>(),
+            _ => [],
+        };
+
+    /// <summary>远控 Settings-Stage1：写入首个已启用理智作战任务的关卡。</summary>
+    public bool TryApplyRemoteFightStage(string stage)
+    {
+        var fight = ConfigFactory.CurrentConfig.TaskQueue.OfType<FightTask>().FirstOrDefault(IsTaskEnable)
+            ?? ConfigFactory.CurrentConfig.TaskQueue.OfType<FightTask>().FirstOrDefault();
+        if (fight is null)
+        {
+            return false;
+        }
+
+        if (fight.StagePlan.Count == 0)
+        {
+            fight.StagePlan.Add(string.Empty);
+        }
+        else if (fight.StagePlan.Count > 1)
+        {
+            fight.StagePlan.Clear();
+            fight.StagePlan.Add(string.Empty);
+        }
+
+        fight.StagePlan[0] = stage ?? string.Empty;
+        RefreshTaskModel(fight);
+        return true;
+    }
+
+    /// <summary>序列化 TaskQueue 中的单条任务（供远控等调用）。</summary>
+    public (bool? IsSuccess, IEnumerable<int> TaskIds) SerializeQueueTask(BaseTask task) => SerializeTask(task);
+
     /// <summary>
     /// 更新日期提示和关卡列表
     /// </summary>


### PR DESCRIPTION
### 问题

远控 `LinkStart-Combat` 在 `RemoteControlService.LinkStart` 中要求 `TaskQueue` 内 `FightTask` **数量恰好为 1**。  
从旧版配置迁移的用户队列通常包含：

- 主理智作战（`FightTask`，`Name` 为空或默认显示名）
- **剩余理智**（`Name == LocalizationHelper.GetString("RemainingSanityStage")`）
- 部分用户还有 **剿灭模式**（`Name == AnnihilationMode`）

此时 `tasks.Count == 2`（或更多），远控恒失败：日志 `CombatError` + `未选择任务`，与勾选、关卡是否填写无关。  
完整 `LinkStart`（一键长草）走 `TaskQueueViewModel.LinkStart()`，会跳过未勾选任务，故表现正常。

### 修改

1. 新增 `GetRemotePrimaryFightTasks()`：排除「剩余理智」「剿灭模式」等辅助 `FightTask`。
2. `case "Combat"`：对过滤后的列表仍要求 `Count == 1`，再 `SerializeTask`。
3. `Settings-Stage1`：优先写入上述主作战任务的 `StagePlan[0]`，并 `RefreshUI`；无法唯一确定时回退原 UI 路径。

### 测试建议

- 迁移配置（含「剩余理智」未勾选）+ 远控 `LinkStart-Combat`：应能连接并进入作战，不再 `CombatError`。
- `Settings-Stage1` + `LinkStart-Combat`：关卡写入主作战任务。
- 队列中人为添加 **2 个**主作战（非辅助名）：仍应失败（保持原语义）。
- 仅 1 个 `FightTask` 的新配置：行为与改前一致。

### 关联

- 远程控制协议：`docs/zh-cn/protocol/remote-control-schema.md`
- 配置迁移：`Helper/ConfigConverter.cs`（`fightTask2` / `RemainingSanityStage`）

---

## 代码变更位置

`src/MaaWpfGui/Services/RemoteControl/RemoteControlService.cs`

## 本地验证

1. 在已应用补丁的 MAA 工程编译运行 GUI。
2. 使用含「剩余理智」的任务队列配置，远控下发 `LinkStart-Combat` 。
3. 确认不再出现「未选择任务」。

## Summary by Sourcery

调整远程战斗控制，以忽略辅助战斗任务，并在存在多个战斗任务时正确应用关卡设置。

Bug 修复：
- 允许远程 LinkStart-Combat 在任务队列中包含 “Remaining Sanity” 或 “Annihilation” 辅助战斗任务时仍能正常工作，而不是因未选中任务而失败。

改进：
- 将远程 Settings-Stage1 更新路由到一个辅助函数，该函数优先更新主战斗任务的关卡设置，并在能够唯一识别时刷新 UI，否则回退到之前的行为。
- 扩展内部反射辅助函数，以同时搜索公共和非公共的实例方法，并在任务队列视图模型上直接使用 `ClearLog` 方法。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust remote combat control to ignore auxiliary fight tasks and correctly apply stage settings when multiple fight tasks exist.

Bug Fixes:
- Allow remote LinkStart-Combat to work with queues that include Remaining Sanity or Annihilation auxiliary fight tasks instead of failing with no task selected.

Enhancements:
- Route remote Settings-Stage1 updates to a helper that prefers updating the primary fight task’s stage and refreshes the UI when uniquely identifiable, falling back to the previous behavior otherwise.
- Broaden internal reflection helpers to search both public and non-public instance methods and use the ClearLog method directly on the task queue view model.

</details>