### PR TITLE
fix: 修复生息演算 RA-15 提前下初雪导致任务失败的问题

### DIFF
--- a/resource/tasks/RA/Reclamation3.json
+++ b/resource/tasks/RA/Reclamation3.json
@@ -756,7 +756,7 @@
         "algorithm": "OcrDetect",
         "action": "DoNothing",
         "text": ["24+"],
-        "ocrReplace": [["(2[2-9]|[3-9]\\d+)", "24+"]],
+        "ocrReplace": [["(2[4-9]|[5-9]\\d+)", "24+"]],
         "roi": [1198, 495, 75, 43],
         "next": ["RelaunchAnchor@RA@RA15-DeployCX"]
     },


### PR DESCRIPTION
当前代码会在OCR识别到22/23费时进行下干员的操作，导致没有减费干员会出现下不去初雪的问题。修正为：识别到24/25费时进行下干员的操作，经过多次实测，修复后可以正常运行。

## Summary by Sourcery

Bug Fixes:
- 在 Reclamation3 RA 任务中延迟算子部署触发时间，使得 OCR 成本识别不再导致「陈：假日威龙」过早部署，从而防止任务失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Delay operator deployment trigger in Reclamation3 RA task so that OCR cost recognition no longer causes early deployment of Ch'en the Holungday, preventing task failures.

</details>