### PR TITLE
fix: TooltipBlock无法使用Binding进行绑定

### DIFF
--- a/src/MaaWpfGui/Styles/Controls/TooltipBlock.xaml.cs
+++ b/src/MaaWpfGui/Styles/Controls/TooltipBlock.xaml.cs
@@ -40,7 +40,7 @@ public partial class TooltipBlock : UserControl
 
     public static readonly DependencyProperty TooltipTextProperty = DependencyProperty.Register(nameof(TooltipText), typeof(string), typeof(TooltipBlock), new PropertyMetadata(string.Empty, OnTooltipTextChanged));
 
-    public static readonly DependencyProperty TooltipTextEmptyProperty = DependencyProperty.Register(nameof(TooltipTextEmpty), typeof(bool), typeof(TooltipBlock), new PropertyMetadata(false));
+    public static readonly DependencyProperty TooltipTextEmptyProperty = DependencyProperty.Register(nameof(TooltipTextEmpty), typeof(bool), typeof(TooltipBlock), new PropertyMetadata(true));
 
     public static readonly DependencyProperty TooltipMaxWidthProperty = DependencyProperty.Register(nameof(TooltipMaxWidth), typeof(double), typeof(TooltipBlock), new(double.MaxValue));
 

--- a/src/MaaWpfGui/Styles/Controls/TooltipBlock.xaml.cs
+++ b/src/MaaWpfGui/Styles/Controls/TooltipBlock.xaml.cs
@@ -38,7 +38,9 @@ public partial class TooltipBlock : UserControl
 
     public static readonly DependencyProperty TextBlockTextProperty = DependencyProperty.Register(nameof(TextBlockText), typeof(string), typeof(TooltipBlock), new("?"));
 
-    public static readonly DependencyProperty TooltipTextProperty = DependencyProperty.Register(nameof(TooltipText), typeof(string), typeof(TooltipBlock), new(string.Empty));
+    public static readonly DependencyProperty TooltipTextProperty = DependencyProperty.Register(nameof(TooltipText), typeof(string), typeof(TooltipBlock), new PropertyMetadata(string.Empty, OnTooltipTextChanged));
+
+    public static readonly DependencyProperty TooltipTextEmptyProperty = DependencyProperty.Register(nameof(TooltipTextEmpty), typeof(bool), typeof(TooltipBlock), new PropertyMetadata(false));
 
     public static readonly DependencyProperty TooltipMaxWidthProperty = DependencyProperty.Register(nameof(TooltipMaxWidth), typeof(double), typeof(TooltipBlock), new(double.MaxValue));
 
@@ -74,7 +76,19 @@ public partial class TooltipBlock : UserControl
         set => SetValue(TooltipTextProperty, value);
     }
 
-    public bool TooltipTextEmpty => string.IsNullOrEmpty(TooltipText);
+    public bool TooltipTextEmpty
+    {
+        get => (bool)GetValue(TooltipTextEmptyProperty);
+        private set => SetValue(TooltipTextEmptyProperty, value);
+    }
+
+    private static void OnTooltipTextChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is TooltipBlock block)
+        {
+            block.TooltipTextEmpty = string.IsNullOrEmpty((string?)e.NewValue);
+        }
+    }
 
     public double TooltipMaxWidth
     {


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

确保 TooltipBlock 的提示文本支持数据绑定，同时保持用于标记提示内容是否为空的标志为最新状态。

错误修复：
- 修复 TooltipBlock，使 TooltipText 在 WPF 数据绑定中能够正确参与，而无需依赖计算属性。

改进：
- 引入一个可绑定的依赖属性，用于跟踪提示文本是否为空，并在提示文本变化时更新该属性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure TooltipBlock tooltip text can be data-bound while keeping an up-to-date flag for empty tooltip content.

Bug Fixes:
- Fix TooltipBlock so TooltipText can participate correctly in WPF data binding without relying on a computed property.

Enhancements:
- Introduce a bindable dependency property to track whether the tooltip text is empty, updating it when the tooltip text changes.

</details>