### PR TITLE
perf: 刷理智关卡选择提示当前任务将执行的关卡

### DIFF
--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -624,6 +624,7 @@ Then delete the entries corresponding to the paths.
     <system:String x:Key="FightStageResetMode">Closed stage is reset to</system:String>
     <system:String x:Key="HideSeries">Hide series</system:String>
     <system:String x:Key="MainViewButtonFeature">Variable function button</system:String>
+    <system:String x:Key="StagePlanTip">The first opened stage would be entered. If all levels are unopened, the current task will be skipped.\nCurrently executing: {0}</system:String>
     <system:String x:Key="CustomStageCode">Manual entry of stage names</system:String>
     <system:String x:Key="CustomStageCodeTip" xml:space="preserve">Support most main stage names + stage names from the original list (e.g. 4-10, AP-5, H10-1-Hard, etc.)
 At the end of the stage, enter ｢Normal/Hard｣ to switch difficulty: Chapters 10-14 use Standard/Adverse, Chapters 15+ use Normal/Raid

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -624,7 +624,7 @@ Then delete the entries corresponding to the paths.
     <system:String x:Key="FightStageResetMode">Closed stage is reset to</system:String>
     <system:String x:Key="HideSeries">Hide series</system:String>
     <system:String x:Key="MainViewButtonFeature">Variable function button</system:String>
-    <system:String x:Key="StagePlanTip">The first opened stage would be entered. If all levels are unopened, the current task will be skipped.\nCurrently executing: {0}</system:String>
+    <system:String x:Key="StagePlanTip">Executes the first open stage. If all stages are closed, skips the current task.\nCurrent execution: {0}</system:String>
     <system:String x:Key="CustomStageCode">Manual entry of stage names</system:String>
     <system:String x:Key="CustomStageCodeTip" xml:space="preserve">Support most main stage names + stage names from the original list (e.g. 4-10, AP-5, H10-1-Hard, etc.)
 At the end of the stage, enter ｢Normal/Hard｣ to switch difficulty: Chapters 10-14 use Standard/Adverse, Chapters 15+ use Normal/Raid

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -624,6 +624,7 @@ HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Notifications\Settin
     <system:String x:Key="FightStageResetMode">期限切れのレベルをこれにリセットする</system:String>
     <system:String x:Key="HideSeries">連戦回数を隠します</system:String>
     <system:String x:Key="MainViewButtonFeature">スタート画面に表示する便利ボタン</system:String>
+    <system:String x:Key="StagePlanTip">最初に開かれたステージに入ります。すべてのレベルが未開放の場合は、現在のタスクはスキップされます。\n現在実行中: {0}</system:String>
     <system:String x:Key="CustomStageCode">ステージ名を入力する</system:String>
     <system:String x:Key="CustomStageCodeTip" xml:space="preserve">(テスト機能)ステージ名と番号（例: 4-10、AP-5、H10-1-Hardなど）
 の両方がサポートされています。ステージの最後に「Normal/Hard」を入力すると難易度を切り替えできます（10〜14章は標準/厄難、15章以降は通常/険地）</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -621,10 +621,10 @@ HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Notifications\Settin
     <system:String x:Key="UseExpireMedicineForActivity">今週中に期限切れとなる正気回復ポーションは、アクティビティ終了の48時間以内に使用してください。</system:String>
     <system:String x:Key="NoActivity">活動なし</system:String>
     <system:String x:Key="HideUnavailableStage">リストに当日開放されないステージを隠す</system:String>
-    <system:String x:Key="FightStageResetMode">期限切れのレベルをこれにリセットする</system:String>
+    <system:String x:Key="FightStageResetMode">期限切れのステージをこれにリセットする</system:String>
     <system:String x:Key="HideSeries">連戦回数を隠します</system:String>
     <system:String x:Key="MainViewButtonFeature">スタート画面に表示する便利ボタン</system:String>
-    <system:String x:Key="StagePlanTip">最初に開かれたステージに入ります。すべてのレベルが未開放の場合は、現在のタスクはスキップされます。\n現在実行中: {0}</system:String>
+    <system:String x:Key="StagePlanTip">最初の開放したステージを実行します。すべてのステージが未開放の場合は、現在のタスクはスキップされます。\n現在実行中: {0}</system:String>
     <system:String x:Key="CustomStageCode">ステージ名を入力する</system:String>
     <system:String x:Key="CustomStageCodeTip" xml:space="preserve">(テスト機能)ステージ名と番号（例: 4-10、AP-5、H10-1-Hardなど）
 の両方がサポートされています。ステージの最後に「Normal/Hard」を入力すると難易度を切り替えできます（10〜14章は標準/厄難、15章以降は通常/険地）</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -624,6 +624,7 @@ HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Notifications\Settin
     <system:String x:Key="FightStageResetMode">만료된 단계가 다음으로 재설정됩니다</system:String>
     <system:String x:Key="HideSeries">{key=Series} 숨기기</system:String>
     <system:String x:Key="MainViewButtonFeature">메인 화면 버튼의 기능</system:String>
+    <system:String x:Key="StagePlanTip">열려 있는 첫 번째 단계로 진입합니다. 모든 단계가 열려 있지 않으면 현재 작업은 건너뜁니다.\n현재 실행 중: {0}</system:String>
     <system:String x:Key="CustomStageCode">스테이지 코드 수동 입력</system:String>
     <system:String x:Key="CustomStageCodeTip" xml:space="preserve">대부분의 기본 스테이지 이름과 원래 스테이지 이름 목록 지원 (예: 4-10, AP-5, H10-1-Hard)
 스테이지 이름 끝에 ｢Normal/Hard｣ 를 입력해 난이도를 전환할 수 있습니다 (10-14장은 표준/재앙, 15장 이후는 일반/험지)

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -621,10 +621,10 @@ HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Notifications\Settin
     <system:String x:Key="UseExpireMedicineForActivity">이벤트 종료 48시간 전, 이번 주 만료되는 이성 회복제 사용</system:String>
     <system:String x:Key="NoActivity">활동 없음</system:String>
     <system:String x:Key="HideUnavailableStage">미개방 스테이지 숨기기</system:String>
-    <system:String x:Key="FightStageResetMode">만료된 단계가 다음으로 재설정됩니다</system:String>
+    <system:String x:Key="FightStageResetMode">만료된 스테이지 재설정</system:String>
     <system:String x:Key="HideSeries">{key=Series} 숨기기</system:String>
     <system:String x:Key="MainViewButtonFeature">메인 화면 버튼의 기능</system:String>
-    <system:String x:Key="StagePlanTip">열려 있는 첫 번째 단계로 진입합니다. 모든 단계가 열려 있지 않으면 현재 작업은 건너뜁니다.\n현재 실행 중: {0}</system:String>
+    <system:String x:Key="StagePlanTip">열려 있는 첫 번째 스테이지로 진입합니다. 모든 스테이지가 열려 있지 않으면 현재 작업은 건너뜁니다.\n현재 실행 중: {0}</system:String>
     <system:String x:Key="CustomStageCode">스테이지 코드 수동 입력</system:String>
     <system:String x:Key="CustomStageCodeTip" xml:space="preserve">대부분의 기본 스테이지 이름과 원래 스테이지 이름 목록 지원 (예: 4-10, AP-5, H10-1-Hard)
 스테이지 이름 끝에 ｢Normal/Hard｣ 를 입력해 난이도를 전환할 수 있습니다 (10-14장은 표준/재앙, 15장 이후는 일반/험지)

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -624,6 +624,7 @@ HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Notifications\Settin
     <system:String x:Key="FightStageResetMode">过期关卡重置为</system:String>
     <system:String x:Key="HideSeries">隐藏代理倍率</system:String>
     <system:String x:Key="MainViewButtonFeature">主界面可选择按钮功能</system:String>
+    <system:String x:Key="StagePlanTip">将执行第一个开放的关卡, 如所有关卡均未开放则跳过当前任务\n当前执行: {0}</system:String>
     <system:String x:Key="CustomStageCode">手动输入关卡名</system:String>
     <system:String x:Key="CustomStageCodeTip" xml:space="preserve">支持大部分主线关卡名与原列表的关卡名（如 4-10、AP-5、H10-1-Hard）
 可在关卡结尾输入 ｢Normal/Hard｣ 切换难度：10-14 章对应标准/磨难，15 章及以后对应常规/险地

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -624,6 +624,7 @@ HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Notifications\Settin
     <system:String x:Key="FightStageResetMode">過期關卡重設為</system:String>
     <system:String x:Key="HideSeries">隱藏代理倍率</system:String>
     <system:String x:Key="MainViewButtonFeature">主介面可選擇按鈕功能</system:String>
+    <system:String x:Key="StagePlanTip">將執行第一個開放的關卡, 如所有關卡均未開放則跳過當前任務\n當前執行: {0}</system:String>
     <system:String x:Key="CustomStageCode">手動輸入關卡名稱</system:String>
     <system:String x:Key="CustomStageCodeTip" xml:space="preserve">支援大部分主線關卡名稱與原清單的關卡名稱（如 4-10、AP-5、H10-1-Hard）
 可在關卡結尾輸入 ｢Normal/Hard｣ 切換難度：10-14 章對應標準/磨難，15 章及以後對應常規/險地

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/FightSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/FightSettingsUserControlModel.cs
@@ -440,6 +440,23 @@ public class FightSettingsUserControlModel : TaskSettingsViewModel, FightSetting
 
     #endregion Drops
 
+    public string StagePlanTip { get => field; set => SetAndNotify(ref field, value); } = string.Empty;
+
+    public void StagePlanTipRefresh()
+    {
+        var stage = GetFightStage(StagePlan.Select(i => i.Stage)) ?? "--";
+        if (stage == string.Empty)
+        {
+            stage = LocalizationHelper.GetString("DefaultStage");
+        }
+
+        StagePlanTip = LocalizationHelper.GetStringFormat("StagePlanTip", stage);
+        if (CustomStageCode)
+        {
+            StagePlanTip += $"\n\n{LocalizationHelper.GetString("CustomStageCodeTip")}";
+        }
+    }
+
     public static Dictionary<string, string> AnnihilationModeList { get; } = new()
     {
         { LocalizationHelper.GetString("Annihilation.Current"), AnnihilationName },
@@ -694,6 +711,7 @@ public class FightSettingsUserControlModel : TaskSettingsViewModel, FightSetting
         RefreshCurrentStagePlan();
         RefreshWeeklySchedule();
         RefreshDropName();
+        StagePlanTipRefresh();
         Refresh();
     }
 

--- a/src/MaaWpfGui/Views/UserControl/TaskQueue/FightSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/TaskQueue/FightSettingsUserControl.xaml
@@ -219,9 +219,9 @@
                         Margin="0,5,6,0"
                         HorizontalAlignment="Right"
                         VerticalAlignment="Top"
+                        MouseEnter="{s:Action StagePlanTipRefresh}"
                         NormalOpacity="0.25"
-                        TooltipText="{DynamicResource CustomStageCodeTip}"
-                        Visibility="{c:Binding CustomStageCode}" />
+                        TooltipText="{Binding StagePlanTip}" />
                     <Button
                         Grid.Row="1"
                         Margin="6"


### PR DESCRIPTION
- 依赖#16796



@Constrat @HX3N @momomochi987 @Manicsteiner 

- [x] EN
- [x] JP
- [x] KR

<img width="652" height="230" alt=")`EWNNB7@WF_ NAKBK$SXAF" src="https://github.com/user-attachments/assets/b87ea061-875a-4b42-883f-ad772ebe3b66" />

## Summary by Sourcery

添加一个本地化提示，指明当前理智刷图任务将要运行的关卡，并在刷新 UI 时更新该提示。

New Features:
- 显示关卡计划提示，总结当前战斗任务所选关卡的信息，在适用时包括自定义关卡代码信息。

Enhancements:
- 添加本地化资源和 UI 绑定，以在所有支持的语言中为新的关卡计划提示文本提供支持。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a localized tip indicating which stage will be run for the current sanity-farming task and refresh it with the UI.

New Features:
- Display a stage plan tip summarizing the selected stage for the current fight task, including custom stage code information when applicable.

Enhancements:
- Add localized resources and UI bindings to support the new stage plan tip text across all supported languages.

</details>