### PR TITLE
fix: 移除dft路径下的缓存 & 补充缓存驱逐机制

### DIFF
--- a/src/MaaCore/Vision/MaskedCcoeffMatcher.cpp
+++ b/src/MaaCore/Vision/MaskedCcoeffMatcher.cpp
@@ -2,6 +2,8 @@
 
 #include "MaaUtils/NoWarningCV.hpp"
 
+#include "Utils/Logger.hpp"
+
 #include <array>
 #include <vector>
 
@@ -150,7 +152,10 @@ std::shared_ptr<const MaskedCcoeffMatcher::TemplatePlan> MaskedCcoeffMatcher::ge
     // 从尾部淘汰直到满足内存上限
     while (m_cache_total_bytes + new_bytes > k_max_cache_bytes && !m_lru_list.empty()) {
         const std::string& victim = m_lru_list.back();
-        m_cache_total_bytes -= m_template_plan_cache.at(victim).bytes;
+        const size_t victim_bytes = m_template_plan_cache.at(victim).bytes;
+        Log.debug("MaskedCcoeffMatcher | evict", victim, victim_bytes / 1024, "KB, total",
+                  m_cache_total_bytes / 1024, "KB");
+        m_cache_total_bytes -= victim_bytes;
         m_template_plan_cache.erase(victim);
         m_lru_list.pop_back();
     }

--- a/src/MaaCore/Vision/MaskedCcoeffMatcher.cpp
+++ b/src/MaaCore/Vision/MaskedCcoeffMatcher.cpp
@@ -45,6 +45,8 @@ void MaskedCcoeffMatcher::sync_cache_revision(const uint64_t revision)
     }
     // 清一下缓存
     m_template_plan_cache.clear();
+    m_lru_list.clear();
+    m_cache_total_bytes = 0;
     m_cache_revision.store(revision, std::memory_order_release);
 }
 
@@ -72,16 +74,30 @@ std::string MaskedCcoeffMatcher::make_mat_cache_key(const cv::Mat& mat)
            std::to_string(h);
 }
 
+size_t MaskedCcoeffMatcher::calc_plan_bytes(const std::string& key, const TemplatePlan& plan)
+{
+    size_t b = key.size();
+    b += plan.M.total() * plan.M.elemSize();
+    for (const auto& t : plan.T_prime) {
+        b += t.total() * t.elemSize();
+    }
+    b += plan.sparse_entries.size() * sizeof(SparseEntry);
+    return b;
+}
+
 std::shared_ptr<const MaskedCcoeffMatcher::TemplatePlan> MaskedCcoeffMatcher::get_or_build_template_plan(
     const std::string& cache_key,
     const cv::Mat& templ_f32,
     const cv::Mat& mask_f32,
     int mask_pixels)
 {
+    // 记录 miss 时的 revision，插入前校验是否已被清缓存
+    const uint64_t revision_at_miss = m_cache_revision.load(std::memory_order_acquire);
     {
         std::lock_guard lk(m_cache_mtx);
-        if (const auto it = m_template_plan_cache.find(cache_key); it != m_template_plan_cache.end()) {
-            return it->second;
+        if (auto it = m_template_plan_cache.find(cache_key); it != m_template_plan_cache.end()) {
+            m_lru_list.splice(m_lru_list.begin(), m_lru_list, it->second.lru_it);
+            return it->second.plan;
         }
     }
 
@@ -116,10 +132,33 @@ std::shared_ptr<const MaskedCcoeffMatcher::TemplatePlan> MaskedCcoeffMatcher::ge
     }
     plan->K = static_cast<int>(plan->sparse_entries.size());
 
+    const size_t new_bytes = calc_plan_bytes(cache_key, *plan);
+
     std::lock_guard lk(m_cache_mtx);
-    auto [it, inserted] = m_template_plan_cache.emplace(cache_key, plan);
-    static_cast<void>(inserted);
-    return it->second;
+
+    // 二次检查：另一线程可能已插入同一 key，虽然当前设计是单线程的Runner（
+    if (auto it = m_template_plan_cache.find(cache_key); it != m_template_plan_cache.end()) {
+        m_lru_list.splice(m_lru_list.begin(), m_lru_list, it->second.lru_it);
+        return it->second.plan;
+    }
+
+    // revision 已变说明缓存在 build 期间被清过，旧数据不缓存
+    if (m_cache_revision.load(std::memory_order_relaxed) != revision_at_miss) {
+        return plan;
+    }
+
+    // 从尾部淘汰直到满足内存上限
+    while (m_cache_total_bytes + new_bytes > k_max_cache_bytes && !m_lru_list.empty()) {
+        const std::string& victim = m_lru_list.back();
+        m_cache_total_bytes -= m_template_plan_cache.at(victim).bytes;
+        m_template_plan_cache.erase(victim);
+        m_lru_list.pop_back();
+    }
+
+    auto list_it = m_lru_list.insert(m_lru_list.begin(), cache_key);
+    m_template_plan_cache.emplace(cache_key, CacheEntry { plan, list_it, new_bytes });
+    m_cache_total_bytes += new_bytes;
+    return plan;
 }
 
 

--- a/src/MaaCore/Vision/MaskedCcoeffMatcher.cpp
+++ b/src/MaaCore/Vision/MaskedCcoeffMatcher.cpp
@@ -27,11 +27,6 @@ struct MaskedCcoeffMatcher::TemplatePlan
     int K = 0;                               // sparse_entries.size()
 };
 
-struct MaskedCcoeffMatcher::DftPlan
-{
-    std::array<cv::Mat, 3> T_prime_dft; // FFT(M*(T_c - μT_c))，每通道一个
-    cv::Mat M_dft;                      // FFT(M)
-};
 
 MaskedCcoeffMatcher& MaskedCcoeffMatcher::get_instance()
 {
@@ -50,7 +45,6 @@ void MaskedCcoeffMatcher::sync_cache_revision(const uint64_t revision)
     }
     // 清一下缓存
     m_template_plan_cache.clear();
-    m_dft_plan_cache.clear();
     m_cache_revision.store(revision, std::memory_order_release);
 }
 
@@ -128,40 +122,6 @@ std::shared_ptr<const MaskedCcoeffMatcher::TemplatePlan> MaskedCcoeffMatcher::ge
     return it->second;
 }
 
-std::shared_ptr<const MaskedCcoeffMatcher::DftPlan> MaskedCcoeffMatcher::get_or_build_dft_plan(
-    const std::string& cache_key,
-    const TemplatePlan& template_plan,
-    int dft_rows,
-    int dft_cols)
-{
-    const std::string dft_key = cache_key + ":dft:" + std::to_string(dft_rows) + "x" + std::to_string(dft_cols);
-    {
-        std::lock_guard lk(m_cache_mtx);
-        if (const auto it = m_dft_plan_cache.find(dft_key); it != m_dft_plan_cache.end()) {
-            return it->second;
-        }
-    }
-
-    auto dft_plan = std::make_shared<DftPlan>();
-    cv::Mat padded = cv::Mat::zeros(dft_rows, dft_cols, CV_64F);
-    cv::Mat src_d;
-    auto compute_into = [&](const cv::Mat& src, cv::Mat& out) {
-        padded.setTo(0.0);
-        src.convertTo(src_d, CV_64F);
-        src_d.copyTo(padded(cv::Rect(0, 0, src_d.cols, src_d.rows)));
-        cv::dft(padded, out, cv::DFT_COMPLEX_OUTPUT);
-    };
-
-    compute_into(template_plan.M, dft_plan->M_dft);
-    for (int c = 0; c < 3; ++c) {
-        compute_into(template_plan.T_prime[c], dft_plan->T_prime_dft[c]);
-    }
-
-    std::lock_guard lk(m_cache_mtx);
-    auto [it, inserted] = m_dft_plan_cache.emplace(dft_key, dft_plan);
-    static_cast<void>(inserted);
-    return it->second;
-}
 
 bool MaskedCcoeffMatcher::should_fallback_to_opencv(int mask_pixels, int result_positions)
 {
@@ -201,7 +161,7 @@ bool MaskedCcoeffMatcher::should_fallback_to_opencv(int mask_pixels, int result_
 //
 // 优化后：
 //   FFT(I_c) 和 FFT(I_c²) 每通道各算一次并复用
-//   FFT(T'_c) 和 FFT(M) 通过缓存跨调用复用
+//   TemplatePlan（T'_c、稀疏列表）通过缓存跨调用复用
 //
 // 等价于 cv::matchTemplate(image, templ, result, TM_CCOEFF_NORMED, mask)
 cv::Mat MaskedCcoeffMatcher::match(
@@ -300,7 +260,6 @@ cv::Mat MaskedCcoeffMatcher::match(
     // DFT 的填充尺寸：仅在确认走 FFT 路径后才需要
     const int dft_rows = cv::getOptimalDFTSize(I.rows + T.rows - 1);
     const int dft_cols = cv::getOptimalDFTSize(I.cols + T.cols - 1);
-    const auto dft_plan = get_or_build_dft_plan(cache_key, *template_plan, dft_rows, dft_cols);
 
     cv::Mat padded(dft_rows, dft_cols, CV_64F, cv::Scalar(0));
     cv::Mat I_dft(dft_rows, dft_cols, CV_64FC2);
@@ -316,6 +275,13 @@ cv::Mat MaskedCcoeffMatcher::match(
         src_d.copyTo(padded(cv::Rect(0, 0, src_d.cols, src_d.rows)));
         cv::dft(padded, out, cv::DFT_COMPLEX_OUTPUT);
     };
+
+    std::array<cv::Mat, 3> T_prime_dft;
+    cv::Mat M_dft;
+    make_dft_into(template_plan->M, M_dft);
+    for (int c = 0; c < 3; ++c) {
+        make_dft_into(template_plan->T_prime[c], T_prime_dft[c]);
+    }
     auto xcorr_into = [&](const cv::Mat& dft_A, const cv::Mat& dft_B, cv::Mat& out) {
         cv::mulSpectrums(dft_A, dft_B, spectrum, 0, true);
         cv::dft(spectrum, result_buf, cv::DFT_INVERSE | cv::DFT_REAL_OUTPUT | cv::DFT_SCALE);
@@ -340,17 +306,17 @@ cv::Mat MaskedCcoeffMatcher::match(
     cv::Mat I_sq_sum = I_ch[0].mul(I_ch[0]) + I_ch[1].mul(I_ch[1]) + I_ch[2].mul(I_ch[2]);
     cv::Mat I_sq_sum_dft(dft_rows, dft_cols, CV_64FC2);
     make_dft_into(I_sq_sum, I_sq_sum_dft);
-    xcorr_into(I_sq_sum_dft, dft_plan->M_dft, sum_MI2_buf);
+    xcorr_into(I_sq_sum_dft, M_dft, sum_MI2_buf);
     cv::add(sigma_I_sq, sum_MI2_buf, sigma_I_sq);
 
     for (int c = 0; c < 3; ++c) {
         make_dft_into(I_ch[c], I_dft);
 
         // numerator += xcorr(T'_c, I_c)
-        xcorr_add(I_dft, dft_plan->T_prime_dft[c], numerator);
+        xcorr_add(I_dft, T_prime_dft[c], numerator);
 
         // sigma_I² 第二项：-Σ_c (sum_MI_c)² / mask_area，逐通道累加
-        xcorr_into(I_dft, dft_plan->M_dft, sum_MI_buf);
+        xcorr_into(I_dft, M_dft, sum_MI_buf);
         cv::Mat var_d;
         cv::multiply(sum_MI_buf, sum_MI_buf, var_d, -1.0 / mask_area);
         cv::add(sigma_I_sq, var_d, sigma_I_sq);

--- a/src/MaaCore/Vision/MaskedCcoeffMatcher.cpp
+++ b/src/MaaCore/Vision/MaskedCcoeffMatcher.cpp
@@ -136,7 +136,7 @@ std::shared_ptr<const MaskedCcoeffMatcher::TemplatePlan> MaskedCcoeffMatcher::ge
 
     std::lock_guard lk(m_cache_mtx);
 
-    // 二次检查：另一线程可能已插入同一 key，虽然当前设计是单线程的Runner（
+    // 二次检查：另一线程可能已插入同一 key，虽然当前设计使用的是单线程 Runner
     if (auto it = m_template_plan_cache.find(cache_key); it != m_template_plan_cache.end()) {
         m_lru_list.splice(m_lru_list.begin(), m_lru_list, it->second.lru_it);
         return it->second.plan;

--- a/src/MaaCore/Vision/MaskedCcoeffMatcher.h
+++ b/src/MaaCore/Vision/MaskedCcoeffMatcher.h
@@ -29,7 +29,6 @@ public:
 
 private:
     struct TemplatePlan;
-    struct DftPlan;
 
     static void fnv1a_update(uint64_t& h, const void* data, size_t size);
 
@@ -39,15 +38,8 @@ private:
         const cv::Mat& mask_f32,
         int mask_pixels);
 
-    std::shared_ptr<const DftPlan> get_or_build_dft_plan(
-        const std::string& cache_key,
-        const TemplatePlan& template_plan,
-        int dft_rows,
-        int dft_cols);
-
     std::mutex m_cache_mtx;
     std::unordered_map<std::string, std::shared_ptr<const TemplatePlan>> m_template_plan_cache;
-    std::unordered_map<std::string, std::shared_ptr<const DftPlan>> m_dft_plan_cache;
     std::atomic<uint64_t> m_cache_revision { 0 };
 };
 }

--- a/src/MaaCore/Vision/MaskedCcoeffMatcher.h
+++ b/src/MaaCore/Vision/MaskedCcoeffMatcher.h
@@ -3,6 +3,7 @@
 #include "MaaUtils/NoWarningCVMat.hpp"
 
 #include <atomic>
+#include <list>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -29,8 +30,15 @@ public:
 
 private:
     struct TemplatePlan;
+    struct CacheEntry
+    {
+        std::shared_ptr<const TemplatePlan> plan;
+        std::list<std::string>::iterator    lru_it;
+        size_t                              bytes;
+    };
 
     static void fnv1a_update(uint64_t& h, const void* data, size_t size);
+    static size_t calc_plan_bytes(const std::string& key, const TemplatePlan& plan);
 
     std::shared_ptr<const TemplatePlan> get_or_build_template_plan(
         const std::string& cache_key,
@@ -38,8 +46,12 @@ private:
         const cv::Mat& mask_f32,
         int mask_pixels);
 
+    static constexpr size_t k_max_cache_bytes = 64ULL * 1024 * 1024; // 64 MB
+
     std::mutex m_cache_mtx;
-    std::unordered_map<std::string, std::shared_ptr<const TemplatePlan>> m_template_plan_cache;
-    std::atomic<uint64_t> m_cache_revision { 0 };
+    std::list<std::string>                      m_lru_list;
+    std::unordered_map<std::string, CacheEntry> m_template_plan_cache;
+    size_t                                      m_cache_total_bytes { 0 };
+    std::atomic<uint64_t>                       m_cache_revision { 0 };
 };
 }


### PR DESCRIPTION
几乎没法复用DFT路径，内存占用还高，去掉去掉

```
[2026-05-22 17:42:38] MaskedCcoeffMatcher cache stats (revision_cleared)
  template_plan: requests=63769, hits=63425, hit_rate=99.46%, entries=344
  dft_plan: requests=30, hits=12, hit_rate=40.00%, entries=18
```

## Summary by Sourcery

限制带掩膜模板匹配的缓存大小，并将缓存数据简化为仅缓存模板规划（TemplatePlan），使用 LRU 淘汰策略。

增强内容：
- 移除单独的 DFT 计划结构和缓存，在每次匹配调用中重新计算 mask/template 的 DFT。
- 引入基于 LRU 的 `TemplatePlan` 缓存，设置 64 MB 的内存上限，并在溢出或缓存版本变更时进行淘汰。
- 当缓存版本同步时，重置缓存的记账信息，包括 LRU 状态和已缓存字节总数。
- 明确注释，说明在带掩膜模板匹配中，只有 `TemplatePlan` 数据会在多次调用之间共享。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Limit masked template matching cache size and simplify cached data to only template plans with an LRU eviction policy.

Enhancements:
- Remove the separate DFT plan structure and cache, recomputing mask/template DFTs within each match call.
- Introduce an LRU-based TemplatePlan cache with a 64 MB memory cap and eviction on overflow or cache revision changes.
- Reset cache bookkeeping, including LRU state and total cached bytes, when the cache revision is synced.
- Clarify comments to reflect that only TemplatePlan data is shared across calls in masked template matching.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

限制带掩膜模板匹配的缓存大小，并将缓存数据简化为仅缓存模板规划（TemplatePlan），使用 LRU 淘汰策略。

增强内容：
- 移除单独的 DFT 计划结构和缓存，在每次匹配调用中重新计算 mask/template 的 DFT。
- 引入基于 LRU 的 `TemplatePlan` 缓存，设置 64 MB 的内存上限，并在溢出或缓存版本变更时进行淘汰。
- 当缓存版本同步时，重置缓存的记账信息，包括 LRU 状态和已缓存字节总数。
- 明确注释，说明在带掩膜模板匹配中，只有 `TemplatePlan` 数据会在多次调用之间共享。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Limit masked template matching cache size and simplify cached data to only template plans with an LRU eviction policy.

Enhancements:
- Remove the separate DFT plan structure and cache, recomputing mask/template DFTs within each match call.
- Introduce an LRU-based TemplatePlan cache with a 64 MB memory cap and eviction on overflow or cache revision changes.
- Reset cache bookkeeping, including LRU state and total cached bytes, when the cache revision is synced.
- Clarify comments to reflect that only TemplatePlan data is shared across calls in masked template matching.

</details>

</details>

增强内容：
- 移除 `DftPlan` 结构体及其相关的缓存映射，仅依赖 `TemplatePlan` 缓存，并在 `match()` 内重新计算 DFT。
- 调整带掩码模板匹配的注释，以体现跨调用仅缓存 `TemplatePlan` 数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

限制带掩膜模板匹配的缓存大小，并将缓存数据简化为仅缓存模板规划（TemplatePlan），使用 LRU 淘汰策略。

增强内容：
- 移除单独的 DFT 计划结构和缓存，在每次匹配调用中重新计算 mask/template 的 DFT。
- 引入基于 LRU 的 `TemplatePlan` 缓存，设置 64 MB 的内存上限，并在溢出或缓存版本变更时进行淘汰。
- 当缓存版本同步时，重置缓存的记账信息，包括 LRU 状态和已缓存字节总数。
- 明确注释，说明在带掩膜模板匹配中，只有 `TemplatePlan` 数据会在多次调用之间共享。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Limit masked template matching cache size and simplify cached data to only template plans with an LRU eviction policy.

Enhancements:
- Remove the separate DFT plan structure and cache, recomputing mask/template DFTs within each match call.
- Introduce an LRU-based TemplatePlan cache with a 64 MB memory cap and eviction on overflow or cache revision changes.
- Reset cache bookkeeping, including LRU state and total cached bytes, when the cache revision is synced.
- Clarify comments to reflect that only TemplatePlan data is shared across calls in masked template matching.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

限制带掩膜模板匹配的缓存大小，并将缓存数据简化为仅缓存模板规划（TemplatePlan），使用 LRU 淘汰策略。

增强内容：
- 移除单独的 DFT 计划结构和缓存，在每次匹配调用中重新计算 mask/template 的 DFT。
- 引入基于 LRU 的 `TemplatePlan` 缓存，设置 64 MB 的内存上限，并在溢出或缓存版本变更时进行淘汰。
- 当缓存版本同步时，重置缓存的记账信息，包括 LRU 状态和已缓存字节总数。
- 明确注释，说明在带掩膜模板匹配中，只有 `TemplatePlan` 数据会在多次调用之间共享。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Limit masked template matching cache size and simplify cached data to only template plans with an LRU eviction policy.

Enhancements:
- Remove the separate DFT plan structure and cache, recomputing mask/template DFTs within each match call.
- Introduce an LRU-based TemplatePlan cache with a 64 MB memory cap and eviction on overflow or cache revision changes.
- Reset cache bookkeeping, including LRU state and total cached bytes, when the cache revision is synced.
- Clarify comments to reflect that only TemplatePlan data is shared across calls in masked template matching.

</details>

</details>

</details>