### PR TITLE
fix: 在最后一列干员名字不全时不选

### DIFF
--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -549,8 +549,10 @@ std::vector<asst::BattleFormationTask::QuickFormationOper>
         size_t i = opers_result.size() - 1;
         int last_right = opers_result[i].rect.x + opers_result[i].rect.width;
         int prev_right = opers_result[i - 2].rect.x + opers_result[i - 2].rect.width;
-        const int least_distance = 130; // 正常情况下一般是 140 左右，最后一列不完全的时候一般是 100 左右
-        if (last_right - prev_right < least_distance) {
+        int word_dist = last_right - prev_right;
+        int flag_dist = opers_result[i].flag_rect.x - opers_result[i - 2].flag_rect.x;
+        constexpr int ErrThresh = 5;
+        if (flag_dist - word_dist > ErrThresh) {
             opers_result.pop_back();
         }
         else {

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -545,6 +545,19 @@ std::vector<asst::BattleFormationTask::QuickFormationOper>
     }
     sort_by_vertical_(opers_result);
 
+    while (opers_result.size() > 2) {
+        size_t i = opers_result.size() - 1;
+        int last_right = opers_result[i].rect.x + opers_result[i].rect.width;
+        int prev_right = opers_result[i - 2].rect.x + opers_result[i - 2].rect.width;
+        const int least_distance = 130; // 正常情况下一般是 140 左右，最后一列不完全的时候一般是 100 左右
+        if (last_right - prev_right < least_distance) {
+            opers_result.pop_back();
+        }
+        else {
+            break;
+        }
+    }
+
     Log.info(opers_result);
     return opers_result;
 }


### PR DESCRIPTION
如果最后一列干员名字不全，而且恰好前缀是另一个干员名字，会错选

<img width="920" height="427" alt="图片" src="https://github.com/user-attachments/assets/bed2e129-35e3-4582-8a87-d3b0ecad67b7" />

## Summary by Sourcery

错误修复：
- 避免在最后一列包含被截断名称且其边界框与前一个运算符列过于接近时，错误选择运算符。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Avoid misselecting an operator when the last column contains a truncated name whose bounding box is too close to the previous operator column.

</details>