### PR TITLE
fix: 处理界园司岁台分队招募券 NEXT 关闭

### DIFF
--- a/resource/tasks/Roguelike/JieGarden.json
+++ b/resource/tasks/Roguelike/JieGarden.json
@@ -683,7 +683,7 @@
         "roi": [550, 545, 184, 64],
         "next": [
             "JieGarden@Roguelike@RandomPickAfterNextLevel",
-            "JieGarden@Roguelike@NextLevel@JieGarden@Roguelike@CloseCollectionContinue2",
+            "JieGarden@Roguelike@NextLevel@(JieGarden@Roguelike@CloseCollectionContinue2)",
             "JieGarden@Roguelike@CloseInterview",
             "JieGarden@Roguelike@StrategyChange",
             "JieGarden@Roguelike@NextLevel"
@@ -720,7 +720,7 @@
         "template": "JieGarden@Roguelike@RandomPick.png",
         "next": [
             "JieGarden@Roguelike@RandomPickAfterNextLevel@NextAfterLoadingText",
-            "JieGarden@Roguelike@RandomPickAfterNextLevel@JieGarden@Roguelike@CloseCollectionContinue2",
+            "JieGarden@Roguelike@RandomPickAfterNextLevel@(JieGarden@Roguelike@CloseCollectionContinue2)",
             "JieGarden@Roguelike@CloseInterview",
             "JieGarden@Roguelike@StrategyChange",
             "#self"
@@ -1201,7 +1201,7 @@
         "Doc": "优先紧急作战,1-2层",
         "algorithm": "JustReturn",
         "next": [
-            "JieGarden@Roguelike@Stages@JieGarden@Roguelike@CloseCollectionContinue2",
+            "JieGarden@Roguelike@Stages@(JieGarden@Roguelike@CloseCollectionContinue2)",
             "JieGarden@Roguelike@NextLevel",
             "JieGarden@Roguelike@RandomPickAfterNextLevel",
             "JieGarden@Roguelike@CloseCollectionContinue",
@@ -1226,7 +1226,7 @@
     "JieGarden@Roguelike@Stages_boskyPassageDefault": {
         "algorithm": "JustReturn",
         "next": [
-            "JieGarden@Roguelike@Stages@JieGarden@Roguelike@CloseCollectionContinue2",
+            "JieGarden@Roguelike@Stages@(JieGarden@Roguelike@CloseCollectionContinue2)",
             "JieGarden@Roguelike@NextLevel",
             "JieGarden@Roguelike@RandomPickAfterNextLevel",
             "JieGarden@Roguelike@CloseCollectionContinue",
@@ -1239,7 +1239,7 @@
         "Doc": "avoid battle,其他模式和5-6层策略",
         "algorithm": "JustReturn",
         "next": [
-            "JieGarden@Roguelike@Stages@JieGarden@Roguelike@CloseCollectionContinue2",
+            "JieGarden@Roguelike@Stages@(JieGarden@Roguelike@CloseCollectionContinue2)",
             "JieGarden@Roguelike@NextLevel",
             "JieGarden@Roguelike@RandomPickAfterNextLevel",
             "JieGarden@Roguelike@CloseCollectionContinue",
@@ -1265,7 +1265,7 @@
         "doc": "指挥分队专用投资策略，调用 RoguelikeRoutingTaskPlugin",
         "algorithm": "JustReturn",
         "next": [
-            "JieGarden@Roguelike@Stages@JieGarden@Roguelike@CloseCollectionContinue2",
+            "JieGarden@Roguelike@Stages@(JieGarden@Roguelike@CloseCollectionContinue2)",
             "JieGarden@Roguelike@NextLevel",
             "JieGarden@Roguelike@RandomPickAfterNextLevel",
             "JieGarden@Roguelike@CloseCollectionContinue",
@@ -1283,7 +1283,7 @@
         "Doc": "避紧急作战,3-4层策略",
         "algorithm": "JustReturn",
         "next": [
-            "JieGarden@Roguelike@Stages@JieGarden@Roguelike@CloseCollectionContinue2",
+            "JieGarden@Roguelike@Stages@(JieGarden@Roguelike@CloseCollectionContinue2)",
             "JieGarden@Roguelike@NextLevel",
             "JieGarden@Roguelike@RandomPickAfterNextLevel",
             "JieGarden@Roguelike@CloseCollectionContinue",

--- a/resource/tasks/Roguelike/JieGarden.json
+++ b/resource/tasks/Roguelike/JieGarden.json
@@ -135,6 +135,13 @@
             "JieGarden@Roguelike@CoppersRecastResult"
         ]
     },
+    "JieGarden@Roguelike@CloseCollectionContinue2": {
+        "doc": "获得招募卷奖励后点next, 后续其他执行也重构为此类",
+        "baseTask": "JieGarden@Roguelike@CloseCollectionContinue",
+        "template": "JieGarden@Roguelike@CloseCollectionContinue.png",
+        "templThreshold": 0.95,
+        "next": ["#next", "#back"]
+    },
     "JieGarden@Roguelike@CloseEvent": {
         "action": "ClickRect",
         "specificRect": [153, 79, 63, 29]
@@ -675,8 +682,8 @@
         "text": ["洪陆楼", "山水阁", "云瓦亭", "汝吾门", "见字祠", "始末陵", "是非境"],
         "roi": [550, 545, 184, 64],
         "next": [
-            "JieGarden@Roguelike@RecruitmentVoucherNext",
             "JieGarden@Roguelike@RandomPickAfterNextLevel",
+            "JieGarden@Roguelike@NextLevel@JieGarden@Roguelike@CloseCollectionContinue2",
             "JieGarden@Roguelike@CloseInterview",
             "JieGarden@Roguelike@StrategyChange",
             "JieGarden@Roguelike@NextLevel"
@@ -713,26 +720,10 @@
         "template": "JieGarden@Roguelike@RandomPick.png",
         "next": [
             "JieGarden@Roguelike@RandomPickAfterNextLevel@NextAfterLoadingText",
-            "JieGarden@Roguelike@RecruitmentVoucherNext",
+            "JieGarden@Roguelike@RandomPickAfterNextLevel@JieGarden@Roguelike@CloseCollectionContinue2",
             "JieGarden@Roguelike@CloseInterview",
             "JieGarden@Roguelike@StrategyChange",
             "#self"
-        ]
-    },
-    "JieGarden@Roguelike@RecruitmentVoucherNext": {
-        "template": "JieGarden@Roguelike@CloseCollectionContinue.png",
-        "templThreshold": 0.95,
-        "roi": [563, 486, 174, 125],
-        "action": "ClickSelf",
-        "postDelay": 1000,
-        "next": [
-            "#self",
-            "JieGarden@Roguelike@Stages#next",
-            "JieGarden@Roguelike@NextLevel",
-            "JieGarden@Roguelike@NextLevel#next",
-            "JieGarden@Roguelike@CloseInterview",
-            "JieGarden@Roguelike@StrategyChange",
-            "JieGarden@Roguelike@RandomPickAfterNextLevel"
         ]
     },
     "JieGarden@Roguelike@RecruitMain": {
@@ -1210,7 +1201,7 @@
         "Doc": "优先紧急作战,1-2层",
         "algorithm": "JustReturn",
         "next": [
-            "JieGarden@Roguelike@RecruitmentVoucherNext",
+            "JieGarden@Roguelike@Stages@JieGarden@Roguelike@CloseCollectionContinue2",
             "JieGarden@Roguelike@NextLevel",
             "JieGarden@Roguelike@RandomPickAfterNextLevel",
             "JieGarden@Roguelike@CloseCollectionContinue",
@@ -1235,7 +1226,7 @@
     "JieGarden@Roguelike@Stages_boskyPassageDefault": {
         "algorithm": "JustReturn",
         "next": [
-            "JieGarden@Roguelike@RecruitmentVoucherNext",
+            "JieGarden@Roguelike@Stages@JieGarden@Roguelike@CloseCollectionContinue2",
             "JieGarden@Roguelike@NextLevel",
             "JieGarden@Roguelike@RandomPickAfterNextLevel",
             "JieGarden@Roguelike@CloseCollectionContinue",
@@ -1248,7 +1239,7 @@
         "Doc": "avoid battle,其他模式和5-6层策略",
         "algorithm": "JustReturn",
         "next": [
-            "JieGarden@Roguelike@RecruitmentVoucherNext",
+            "JieGarden@Roguelike@Stages@JieGarden@Roguelike@CloseCollectionContinue2",
             "JieGarden@Roguelike@NextLevel",
             "JieGarden@Roguelike@RandomPickAfterNextLevel",
             "JieGarden@Roguelike@CloseCollectionContinue",
@@ -1274,7 +1265,7 @@
         "doc": "指挥分队专用投资策略，调用 RoguelikeRoutingTaskPlugin",
         "algorithm": "JustReturn",
         "next": [
-            "JieGarden@Roguelike@RecruitmentVoucherNext",
+            "JieGarden@Roguelike@Stages@JieGarden@Roguelike@CloseCollectionContinue2",
             "JieGarden@Roguelike@NextLevel",
             "JieGarden@Roguelike@RandomPickAfterNextLevel",
             "JieGarden@Roguelike@CloseCollectionContinue",
@@ -1292,7 +1283,7 @@
         "Doc": "避紧急作战,3-4层策略",
         "algorithm": "JustReturn",
         "next": [
-            "JieGarden@Roguelike@RecruitmentVoucherNext",
+            "JieGarden@Roguelike@Stages@JieGarden@Roguelike@CloseCollectionContinue2",
             "JieGarden@Roguelike@NextLevel",
             "JieGarden@Roguelike@RandomPickAfterNextLevel",
             "JieGarden@Roguelike@CloseCollectionContinue",

--- a/resource/tasks/Roguelike/JieGarden.json
+++ b/resource/tasks/Roguelike/JieGarden.json
@@ -675,6 +675,7 @@
         "text": ["洪陆楼", "山水阁", "云瓦亭", "汝吾门", "见字祠", "始末陵", "是非境"],
         "roi": [550, 545, 184, 64],
         "next": [
+            "JieGarden@Roguelike@RecruitmentVoucherNext",
             "JieGarden@Roguelike@RandomPickAfterNextLevel",
             "JieGarden@Roguelike@CloseInterview",
             "JieGarden@Roguelike@StrategyChange",
@@ -712,9 +713,26 @@
         "template": "JieGarden@Roguelike@RandomPick.png",
         "next": [
             "JieGarden@Roguelike@RandomPickAfterNextLevel@NextAfterLoadingText",
+            "JieGarden@Roguelike@RecruitmentVoucherNext",
             "JieGarden@Roguelike@CloseInterview",
             "JieGarden@Roguelike@StrategyChange",
             "#self"
+        ]
+    },
+    "JieGarden@Roguelike@RecruitmentVoucherNext": {
+        "template": "JieGarden@Roguelike@CloseCollectionContinue.png",
+        "templThreshold": 0.95,
+        "roi": [563, 486, 174, 125],
+        "action": "ClickSelf",
+        "postDelay": 1000,
+        "next": [
+            "#self",
+            "JieGarden@Roguelike@Stages#next",
+            "JieGarden@Roguelike@NextLevel",
+            "JieGarden@Roguelike@NextLevel#next",
+            "JieGarden@Roguelike@CloseInterview",
+            "JieGarden@Roguelike@StrategyChange",
+            "JieGarden@Roguelike@RandomPickAfterNextLevel"
         ]
     },
     "JieGarden@Roguelike@RecruitMain": {
@@ -1192,6 +1210,7 @@
         "Doc": "优先紧急作战,1-2层",
         "algorithm": "JustReturn",
         "next": [
+            "JieGarden@Roguelike@RecruitmentVoucherNext",
             "JieGarden@Roguelike@NextLevel",
             "JieGarden@Roguelike@RandomPickAfterNextLevel",
             "JieGarden@Roguelike@CloseCollectionContinue",
@@ -1216,6 +1235,7 @@
     "JieGarden@Roguelike@Stages_boskyPassageDefault": {
         "algorithm": "JustReturn",
         "next": [
+            "JieGarden@Roguelike@RecruitmentVoucherNext",
             "JieGarden@Roguelike@NextLevel",
             "JieGarden@Roguelike@RandomPickAfterNextLevel",
             "JieGarden@Roguelike@CloseCollectionContinue",
@@ -1228,6 +1248,7 @@
         "Doc": "avoid battle,其他模式和5-6层策略",
         "algorithm": "JustReturn",
         "next": [
+            "JieGarden@Roguelike@RecruitmentVoucherNext",
             "JieGarden@Roguelike@NextLevel",
             "JieGarden@Roguelike@RandomPickAfterNextLevel",
             "JieGarden@Roguelike@CloseCollectionContinue",
@@ -1253,6 +1274,7 @@
         "doc": "指挥分队专用投资策略，调用 RoguelikeRoutingTaskPlugin",
         "algorithm": "JustReturn",
         "next": [
+            "JieGarden@Roguelike@RecruitmentVoucherNext",
             "JieGarden@Roguelike@NextLevel",
             "JieGarden@Roguelike@RandomPickAfterNextLevel",
             "JieGarden@Roguelike@CloseCollectionContinue",
@@ -1270,6 +1292,7 @@
         "Doc": "避紧急作战,3-4层策略",
         "algorithm": "JustReturn",
         "next": [
+            "JieGarden@Roguelike@RecruitmentVoucherNext",
             "JieGarden@Roguelike@NextLevel",
             "JieGarden@Roguelike@RandomPickAfterNextLevel",
             "JieGarden@Roguelike@CloseCollectionContinue",


### PR DESCRIPTION
## 摘要

- 处理界园司岁台分队招募券 `NEXT` 弹层
- 支持连续点击多张招募券留存时出现的 `NEXT`
- 保留后续对底部 `×` 关闭弹层的处理

## 问题

司岁台分队在进入新的一层时，若留存招募券数量未达到上限，会获得随机招募券并留存。

正常只获得一张招募券时，现有流程可以处理后续关闭；但上次界园更新，古今学识有了新节点《燃火篇·后记》，使得司岁台分队可以每层存两张券，会出现底部带 `NEXT` 的招募券弹层。#15884 和 #16795 的现场日志均卡在 `JieGarden@Roguelike@RandomPickAfterNextLevel`，当时待识别节点中没有能够处理该 `NEXT` 弹层的任务，最终重试到上限后任务失败。

## 解决

新增 `JieGarden@Roguelike@RecruitmentVoucherNext`：

- 使用 #15884 附件截图裁剪出的 `NEXT` 模板
- 识别到底部 `NEXT` 后点击
- 点击后优先回到自身，若仍然是 `NEXT` 则继续点击
- `NEXT` 消失后继续识别地图节点、下一层、访谈关闭、策略切换等正常后继

同时将该节点接入 `NextLevel`、`RandomPickAfterNextLevel` 和各类 `Stages_*` 策略入口，覆盖进层后弹出、随机节点后弹出、以及恢复任务时已停在弹层上的情况。

如果连续 `NEXT` 结束后进入底部 `×` 关闭弹层，后续的 `CloseInterview` 分支会继续处理关闭。

ROI
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/ec25c6aa-f9ef-4c2f-9096-cb394c0bd667" />

## 验证

- `resource/tasks/Roguelike/JieGarden.json` 可以正常解析
- `git diff --check` 通过
- 使用 #15884 和 #16795 的现场截图验证模板匹配：
  - `NEXT` 弹层截图匹配分均为 `0.993+`
  - 当前底部 `×` 弹层截图匹配分约 `0.305`，低于 `0.95` 阈值，不会误触 `NEXT`

Fixes #15884
Fixes #16795

## Summary by Sourcery

处理「JieGarden roguelike 招募券」包含“下一步（NEXT）”按钮的弹窗，使自动化流程能够在连续领取招募券奖励以及进入后续楼层时不中断地继续进行。

Bug Fixes:
- 修复在连续获得多张招募券时，当出现底部带有“下一步（NEXT）”按钮的「JieGarden roguelike 招募券」弹窗时，自动化流程会卡住的问题。
- 确保在任务恢复时，如果正停留在招募券“下一步（NEXT）”弹窗上，也能正确继续执行任务。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle JieGarden roguelike recruitment voucher NEXT popups so automation can progress through consecutive voucher rewards and subsequent layers without getting stuck.

Bug Fixes:
- Fix automation getting stuck on JieGarden roguelike recruitment voucher popups with a bottom NEXT button when multiple vouchers are obtained consecutively.
- Ensure tasks can resume correctly when restored while already stopped on a recruitment voucher NEXT popup.

</details>