### PR TITLE
ci: Use wingetcreate instead of winget-releaser

### DIFF
--- a/.github/workflows/release-package-distribution.yml
+++ b/.github/workflows/release-package-distribution.yml
@@ -114,6 +114,8 @@ jobs:
     env:
       RELEASE_TAG: ${{ needs.meta.outputs.RELEASE_TAG }}
       WINGET_CREATE_GITHUB_TOKEN: ${{ secrets.MAABOT_WINGET_TOKEN }}
+      WINGET_CREATE_VERSION: 'v1.12.8.0'
+      WINGET_CREATE_SHA256: '8BD738851B524885410112678E3771B341C5C716DE60FBBECB88AB0A363ED85D'
 
     steps:
       - name: Upload MAA to WinGet
@@ -124,12 +126,20 @@ jobs:
           $URL_x64 = "https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases/download/$RELEASE_TAG/MAA-$RELEASE_TAG-win-x64.zip"
           $URL_arm64 = "https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases/download/$RELEASE_TAG/MAA-$RELEASE_TAG-win-arm64.zip"
 
-          # Update package using wingetcreate
-          curl.exe -JLO https://aka.ms/wingetcreate/latest
+          # Download winget-reate
+          curl.exe -JLO "https://github.com/microsoft/winget-create/releases/download/$env:WINGET_CREATE_VERSION/wingetcreate.exe"
+
+          # Verify the hash of wingetcreate.exe
+          if ((Get-FileHash wingetcreate.exe).Hash -ne $env:WINGET_CREATE_SHA256) {
+            Write-Error "wingetcreate.exe hash does not match expected value. Aborting."
+            exit 1
+          }
+
+          # Update the package using wingetcreate
           .\wingetcreate.exe update MaaAssistantArknights.MaaAssistantArknights `
             --version $RELEASE_TAG `
             --urls "$URL_x64|x64" "$URL_arm64|arm64" `
-            --submit          
+            --submit
 
   maa_cos:
     name: Upload to MAA COS

--- a/.github/workflows/release-package-distribution.yml
+++ b/.github/workflows/release-package-distribution.yml
@@ -113,6 +113,7 @@ jobs:
 
     env:
       RELEASE_TAG: ${{ needs.meta.outputs.RELEASE_TAG }}
+      GITHUB_TOKEN: ${{ secrets.MAABOT_WINGET_TOKEN }}
       WINGET_CREATE_GITHUB_TOKEN: ${{ secrets.MAABOT_WINGET_TOKEN }}
       WINGET_CREATE_VERSION: 'v1.12.8.0'
       WINGET_CREATE_SHA256: '8BD738851B524885410112678E3771B341C5C716DE60FBBECB88AB0A363ED85D'
@@ -121,13 +122,31 @@ jobs:
       - name: Upload MAA to WinGet
         shell: pwsh
         run: |
-          # Build the URLs based on the release
-          # It would be safer to get the actual download URL from GitHub API, but for simplicity we just construct it here
           $RELEASE_TAG = "${{ env.RELEASE_TAG }}"
-          $URL_x64 = "https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases/download/$RELEASE_TAG/MAA-$RELEASE_TAG-win-x64.zip"
-          $URL_arm64 = "https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases/download/$RELEASE_TAG/MAA-$RELEASE_TAG-win-arm64.zip"
 
-          # Download winget-reate
+          # Fetch the release assets from GitHub Releases API and resolve actual download URLs
+          $headers = @{
+            Accept                 = "application/vnd.github+json"
+            "X-GitHub-Api-Version" = "2022-11-28"
+          }
+
+          if ($env:GITHUB_TOKEN) {
+            $headers.Authorization = "Bearer $env:GITHUB_TOKEN"
+          }
+
+          $release = Invoke-RestMethod `
+            -Uri "https://api.github.com/repos/MaaAssistantArknights/MaaAssistantArknights/releases/tags/$RELEASE_TAG" `
+            -Headers $headers
+
+          $URL_x64 = $release.assets | Where-Object { $_.name -match "-win-x64.zip" } | Select-Object -First 1 -ExpandProperty browser_download_url
+          $URL_arm64 = $release.assets | Where-Object { $_.name -match "-win-arm64.zip" } | Select-Object -First 1 -ExpandProperty browser_download_url
+
+          if (-not $URL_x64 -or -not $URL_arm64) {
+            Write-Error "Failed to resolve release assets from GitHub API for tag '$RELEASE_TAG'."
+            exit 1
+          }
+
+          # Download winget-create
           curl.exe -JLO "https://github.com/microsoft/winget-create/releases/download/$env:WINGET_CREATE_VERSION/wingetcreate.exe"
 
           # Verify the hash of wingetcreate.exe

--- a/.github/workflows/release-package-distribution.yml
+++ b/.github/workflows/release-package-distribution.yml
@@ -113,7 +113,6 @@ jobs:
 
     env:
       RELEASE_TAG: ${{ needs.meta.outputs.RELEASE_TAG }}
-      GITHUB_TOKEN: ${{ secrets.MAABOT_WINGET_TOKEN }}
       WINGET_CREATE_GITHUB_TOKEN: ${{ secrets.MAABOT_WINGET_TOKEN }}
       WINGET_CREATE_VERSION: 'v1.12.8.0'
       WINGET_CREATE_SHA256: '8BD738851B524885410112678E3771B341C5C716DE60FBBECB88AB0A363ED85D'
@@ -130,8 +129,8 @@ jobs:
             "X-GitHub-Api-Version" = "2022-11-28"
           }
 
-          if ($env:GITHUB_TOKEN) {
-            $headers.Authorization = "Bearer $env:GITHUB_TOKEN"
+          if ($env:WINGET_CREATE_GITHUB_TOKEN) {
+            $headers.Authorization = "Bearer $env:WINGET_CREATE_GITHUB_TOKEN"
           }
 
           $release = Invoke-RestMethod `

--- a/.github/workflows/release-package-distribution.yml
+++ b/.github/workflows/release-package-distribution.yml
@@ -137,8 +137,8 @@ jobs:
             -Uri "https://api.github.com/repos/MaaAssistantArknights/MaaAssistantArknights/releases/tags/$RELEASE_TAG" `
             -Headers $headers
 
-          $URL_x64 = $release.assets | Where-Object { $_.name -match "-win-x64.zip" } | Select-Object -First 1 -ExpandProperty browser_download_url
-          $URL_arm64 = $release.assets | Where-Object { $_.name -match "-win-arm64.zip" } | Select-Object -First 1 -ExpandProperty browser_download_url
+          $URL_x64 = $release.assets | Where-Object { $_.name -match "-win-x64.zip$" } | Select-Object -First 1 -ExpandProperty browser_download_url
+          $URL_arm64 = $release.assets | Where-Object { $_.name -match "-win-arm64.zip$" } | Select-Object -First 1 -ExpandProperty browser_download_url
 
           if (-not $URL_x64 -or -not $URL_arm64) {
             Write-Error "Failed to resolve release assets from GitHub API for tag '$RELEASE_TAG'."

--- a/.github/workflows/release-package-distribution.yml
+++ b/.github/workflows/release-package-distribution.yml
@@ -113,18 +113,23 @@ jobs:
 
     env:
       RELEASE_TAG: ${{ needs.meta.outputs.RELEASE_TAG }}
+      WINGET_CREATE_GITHUB_TOKEN: ${{ secrets.MAABOT_WINGET_TOKEN }}
 
     steps:
       - name: Upload MAA to WinGet
-        uses: vedantmgoyal9/winget-releaser@main
-        with:
-          identifier: MaaAssistantArknights.MaaAssistantArknights
-          version: ""
-          installers-regex: "-win-"
-          max-versions-to-keep: 0
-          release-tag: ${{ env.RELEASE_TAG }}
-          fork-user: MaaAssistantArknights
-          token: ${{ secrets.MAABOT_WINGET_TOKEN }}
+        run: |
+          # Build the URLs based on the release
+          # It would be safer to get the actual download URL from GitHub API, but for simplicity we just construct it here
+          $RELEASE_TAG = "${{ env.RELEASE_TAG }}"
+          $URL_x64 = "https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases/download/$RELEASE_TAG/MAA-$RELEASE_TAG-win-x64.zip"
+          $URL_arm64 = "https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases/download/$RELEASE_TAG/MAA-$RELEASE_TAG-win-arm64.zip"
+
+          # Update package using wingetcreate
+          curl.exe -JLO https://aka.ms/wingetcreate/latest
+          .\wingetcreate.exe update MaaAssistantArknights.MaaAssistantArknights `
+            --version $RELEASE_TAG `
+            --urls "$URL_x64|x64" "$URL_arm64|arm64" `
+            --submit          
 
   maa_cos:
     name: Upload to MAA COS

--- a/.github/workflows/release-package-distribution.yml
+++ b/.github/workflows/release-package-distribution.yml
@@ -126,7 +126,7 @@ jobs:
           # Fetch the release assets from GitHub Releases API and resolve actual download URLs
           $headers = @{
             Accept                 = "application/vnd.github+json"
-            "X-GitHub-Api-Version" = "2022-11-28"
+            "X-GitHub-Api-Version" = "2026-03-10"
           }
 
           if ($env:WINGET_CREATE_GITHUB_TOKEN) {

--- a/.github/workflows/release-package-distribution.yml
+++ b/.github/workflows/release-package-distribution.yml
@@ -119,6 +119,7 @@ jobs:
 
     steps:
       - name: Upload MAA to WinGet
+        shell: pwsh
         run: |
           # Build the URLs based on the release
           # It would be safer to get the actual download URL from GitHub API, but for simplicity we just construct it here

--- a/.github/workflows/release-package-distribution.yml
+++ b/.github/workflows/release-package-distribution.yml
@@ -121,6 +121,7 @@ jobs:
       - name: Upload MAA to WinGet
         shell: pwsh
         run: |
+          $ErrorActionPreference = 'Stop'
           $RELEASE_TAG = "${{ env.RELEASE_TAG }}"
 
           # Fetch the release assets from GitHub Releases API and resolve actual download URLs

--- a/.github/workflows/release-package-distribution.yml
+++ b/.github/workflows/release-package-distribution.yml
@@ -156,7 +156,7 @@ jobs:
 
           # Update the package using wingetcreate
           .\wingetcreate.exe update MaaAssistantArknights.MaaAssistantArknights `
-            --version $RELEASE_TAG `
+            --version $RELEASE_TAG.TrimStart('v') `
             --urls "$URL_x64|x64" "$URL_arm64|arm64" `
             --submit
 


### PR DESCRIPTION
The workflow for releasing to WinGet has been failing in two ways:
1. The workflow has been failing
  * https://github.com/MaaAssistantArknights/MaaAssistantArknights/actions/runs/26305192737/job/77440078431
  * https://github.com/MaaAssistantArknights/MaaAssistantArknights/actions/runs/26118171108/job/76812849282
2. The manifests have been incorrect, they are all failing due to missing `NestedInstallerFiles`
  * https://github.com/microsoft/winget-pkgs/pull/375870
  * https://github.com/microsoft/winget-pkgs/pull/375847
  * https://github.com/microsoft/winget-pkgs/pull/375838
  * https://github.com/microsoft/winget-pkgs/pull/373268
  * https://github.com/microsoft/winget-pkgs/pull/370784  	

---

This PR updates the workflow to use [winget-create](https://github.com/microsoft/winget-create) instead of the `winget-releaser` which has been creating incorrect manifests.

---

See reference implementations:
* https://github.com/github/copilot-cli/blob/fbe38b08187013d2c6280ddfe04a915b2079ba62/.github/workflows/winget.yml
* https://github.com/JanDeDobbeleer/oh-my-posh/blob/44f1535c9377ee5434affcf0ee24d8bc4c387f5e/.github/workflows/release.yml#L144-L179

cc @mdanish-kh for sanity check

## 由 Sourcery 提供的摘要

CI：
- 在 `release-package-distribution` 工作流中，用脚本方式调用 `winget-create` 替换 `winget-releaser` action，以使用按架构区分的下载 URL 发布更新后的 WinGet 清单。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Replace the winget-releaser action with a scripted winget-create invocation in the release-package-distribution workflow to publish updated WinGet manifests using architecture-specific download URLs.

</details>