### PR TITLE
feat: 自动公招新增使用停止招募选项

### DIFF
--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -1748,6 +1748,22 @@
         "postDelay": 1000,
         "next": ["RecruitFlag", "RecruitNowConfirm"]
     },
+    "RecruitStopToSkip": {
+        "algorithm": "OcrDetect",
+        "action": "ClickSelf",
+        "postDelay": 500,
+        "text": ["停止招"],
+        "roi": [0, 300, 1280, 420],
+        "next": ["RecruitStopToSkipConfirm"]
+    },
+    "RecruitStopToSkipConfirm": {
+        "algorithm": "OcrDetect",
+        "action": "ClickSelf",
+        "postDelay": 1000,
+        "text": ["确认停止"],
+        "roi": [640, 450, 640, 150],
+        "next": ["RecruitFlag", "RecruitStopToSkip"]
+    },
     "ReturnToActivities": {
         "template": "Return.png",
         "templThreshold": 0.7,

--- a/src/MaaCore/Task/Interface/RecruitTask.cpp
+++ b/src/MaaCore/Task/Interface/RecruitTask.cpp
@@ -50,6 +50,7 @@ bool asst::RecruitTask::set_params(const json::value& params)
     bool force_refresh = params.get("force_refresh", true);
     int times = params.get("times", 0);
     bool expedite = params.get("expedite", false);
+    bool stop_to_skip = params.get("stop_to_skip", false);
     [[maybe_unused]] int expedite_times = params.get("expedite_times", 0);
     bool skip_robot = params.get("skip_robot", true);
     std::vector<std::string> first_tags = params.get("first_tags", std::vector<std::string>(0));
@@ -71,6 +72,7 @@ bool asst::RecruitTask::set_params(const json::value& params)
     m_auto_recruit_task_ptr->set_max_times(times)
         .set_need_refresh(refresh)
         .set_use_expedited(expedite)
+        .set_stop_to_skip(stop_to_skip)
         .set_select_extra_tags(extra_tags_mode)
         .set_first_tags(first_tags)
         .set_select_level(std::move(select))

--- a/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.cpp
@@ -297,12 +297,12 @@ bool asst::AutoRecruitTask::_run()
             if (need_exit()) {
                 return false;
             }
-            Log.info("ready to use expedited plan");
+            Log.info("ready for stop to skip");
             if (recruit_stop_to_skip()) {
                 hire_all();
             }
             else {
-                Log.info("Failed stop to skip");
+                Log.info("Failed for stop to skip");
                 // There is a small chance that confirm button were clicked twice and got stuck into
                 // the bottom-right slot. ref: #1491
                 if (check_recruit_home_page()) {
@@ -312,7 +312,7 @@ bool asst::AutoRecruitTask::_run()
                     try_stop_to_skip = try_get_start_button(ctrler()->get_image()).has_value();
                 }
                 else {
-                    Log.info("Not in home page after failing to use expedited plan.");
+                    Log.info("Not in home page after failing for stop to skip.");
                     return false;
                 }
             }

--- a/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.cpp
@@ -144,6 +144,12 @@ asst::AutoRecruitTask& asst::AutoRecruitTask::set_use_expedited(bool use_or_not)
     return *this;
 }
 
+asst::AutoRecruitTask& asst::AutoRecruitTask::set_stop_to_skip(bool use_or_not) noexcept
+{
+    m_stop_to_skip = use_or_not;
+    return *this;
+}
+
 asst::AutoRecruitTask& asst::AutoRecruitTask::set_select_extra_tags(ExtraTagsMode select_extra_tags_mode) noexcept
 {
     m_select_extra_tags_mode = select_extra_tags_mode;
@@ -228,6 +234,7 @@ bool asst::AutoRecruitTask::_run()
     static constexpr int slot_retry_limit = 3;
 
     bool try_use_expedited = m_use_expedited;
+    bool try_stop_to_skip = m_stop_to_skip;
 
     while (m_cur_times < m_max_times) {
         auto start_rect = try_get_start_button(ctrler()->get_image());
@@ -257,7 +264,7 @@ bool asst::AutoRecruitTask::_run()
                 return false;
             }
             Log.info("There is no available start button.");
-            if (!try_use_expedited) {
+            if (!try_use_expedited && !try_stop_to_skip) {
                 return true;
             }
         }
@@ -279,6 +286,30 @@ bool asst::AutoRecruitTask::_run()
                     // however, there is another possibility (#7266: all the slots are empty now)
                     // if we can get another start btn, we still have a chance to continue
                     try_use_expedited = try_get_start_button(ctrler()->get_image()).has_value();
+                }
+                else {
+                    Log.info("Not in home page after failing to use expedited plan.");
+                    return false;
+                }
+            }
+        }
+        else if (try_stop_to_skip) {
+            if (need_exit()) {
+                return false;
+            }
+            Log.info("ready to use expedited plan");
+            if (recruit_stop_to_skip()) {
+                hire_all();
+            }
+            else {
+                Log.info("Failed stop to skip");
+                // There is a small chance that confirm button were clicked twice and got stuck into
+                // the bottom-right slot. ref: #1491
+                if (check_recruit_home_page()) {
+                    // same as ran out of expedited plan to stop trying
+                    // however, there is another possibility (#7266: all the slots are empty now)
+                    // if we can get another start btn, we still have a chance to continue
+                    try_stop_to_skip = try_get_start_button(ctrler()->get_image()).has_value();
                 }
                 else {
                     Log.info("Not in home page after failing to use expedited plan.");
@@ -812,6 +843,12 @@ bool asst::AutoRecruitTask::check_recruit_home_page()
 bool asst::AutoRecruitTask::recruit_now()
 {
     ProcessTask task(*this, { "RecruitNow" });
+    return task.run();
+}
+
+bool asst::AutoRecruitTask::recruit_stop_to_skip()
+{
+    ProcessTask task(*this, { "RecruitStopToSkip" });
     return task.run();
 }
 

--- a/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.h
+++ b/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.h
@@ -25,6 +25,7 @@ public:
     AutoRecruitTask& set_need_refresh(bool need_refresh) noexcept;
     AutoRecruitTask& set_max_times(int max_times) noexcept;
     AutoRecruitTask& set_use_expedited(bool use_or_not) noexcept;
+    AutoRecruitTask& set_stop_to_skip(bool use_or_not) noexcept;
     AutoRecruitTask& set_select_extra_tags(ExtraTagsMode select_extra_tags_mode) noexcept;
     AutoRecruitTask& set_first_tags(std::vector<std::string> first_tags) noexcept;
     AutoRecruitTask& set_skip_robot(bool skip_robot) noexcept;
@@ -58,6 +59,7 @@ protected:
     bool recruit_begin();
     bool check_timer(int);
     bool recruit_now();
+    bool recruit_stop_to_skip();
     bool confirm();
     bool refresh();
     // 检查是否有已完成且未领取的招募，有则领取，无则返回true
@@ -169,6 +171,7 @@ protected:
     std::vector<int> m_confirm_level;
     bool m_need_refresh = false;
     bool m_use_expedited = false; // 是否使用加急许可
+    bool m_stop_to_skip = false;  // 是否使用停止招募
     ExtraTagsMode m_select_extra_tags_mode = ExtraTagsMode::NoExtra;
     std::vector<std::string> m_first_tags;
     int m_max_times = 0;

--- a/src/MaaWpfGui/Configuration/Single/MaaTask/RecruitTask.cs
+++ b/src/MaaWpfGui/Configuration/Single/MaaTask/RecruitTask.cs
@@ -32,6 +32,12 @@ public class RecruitTask : BaseTask
     public bool? UseExpedited { get; set; } = false;
 
     /// <summary>
+    /// Gets or sets a value indicating whether 是否使用停止招募提前结束招募
+    /// </summary>
+    [JsonIgnore]
+    public bool? StopToSkip { get; set; } = false;
+
+    /// <summary>
     /// Gets or sets 单轮最大公招次数
     /// </summary>
     public int MaxTimes { get; set; } = 4;

--- a/src/MaaWpfGui/Models/AsstTasks/AsstRecruitTask.cs
+++ b/src/MaaWpfGui/Models/AsstTasks/AsstRecruitTask.cs
@@ -61,6 +61,11 @@ public class AsstRecruitTask : AsstBaseTask
     public bool UseExpedited { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether 是否使用停止招募，可选，默认 false
+    /// </summary>
+    public bool StopToSkip { get; set; }
+
+    /// <summary>
     /// Gets or sets 使用加急许可
     /// </summary>
     public int ExpeditedTimes { get; set; }
@@ -145,6 +150,7 @@ public class AsstRecruitTask : AsstBaseTask
             ["times"] = RecruitTimes,
             ["set_time"] = SetRecruitTime,
             ["expedite"] = UseExpedited,
+            ["stop_to_skip"] = StopToSkip,
             ["skip_robot"] = NotChooseLevel1,
             ["extra_tags_mode"] = SelectExtraTags,
             ["first_tags"] = JArray.FromObject(Level3FirstList),

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -1387,6 +1387,7 @@ Cache files (such as maps, operator avatars, etc.) need to be regenerated after 
     <system:String x:Key="AutoRefresh">Auto refresh 3★ Tags</system:String>
     <system:String x:Key="ForceRefresh">Continue trying to refresh Tags without recruitment permit</system:String>
     <system:String x:Key="AutoUseExpedited">Auto use Expedited Plan*</system:String>
+    <system:String x:Key="AutoStopToSkip">Auto stop to skip*</system:String>
     <system:String x:Key="Level3UseShortTime">Set 7:40 instead of 9:00 for 3★ Tags</system:String>
     <system:String x:Key="Level3UseShortTime2">Set 1:00 instead of 9:00 for 3★ Tags</system:String>
     <system:String x:Key="Level3UseShortTimeTip">Doesn't interfere with other ★ stars</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -1388,6 +1388,7 @@ DEBUGディレクトリに保存される画像には数量制限があり、超
     <system:String x:Key="AutoRefresh">星3タグを自動的に更新する</system:String>
     <system:String x:Key="ForceRefresh">採用不可でもタグの更新を行う</system:String>
     <system:String x:Key="AutoUseExpedited">緊急招集票を自動的に使用*</system:String>
+    <system:String x:Key="AutoStopToSkip">採用停止自動的に使用*</system:String>
     <system:String x:Key="Level3UseShortTime">星3タグを7:40に設定する</system:String>
     <system:String x:Key="Level3UseShortTime2">星3タグを1:00に設定する</system:String>
     <system:String x:Key="Level3UseShortTimeTip">他のレアリティには影響しない</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -1389,6 +1389,7 @@ DEBUG 디렉토리에 저장된 이미지는 수량 제한이 있으며 초과 �
     <system:String x:Key="AutoRefresh">★3 태그 자동 새로고침</system:String>
     <system:String x:Key="ForceRefresh">모집없이 태그 새로고침 반복 시도</system:String>
     <system:String x:Key="AutoUseExpedited">즉시 완료 허가증 자동 사용*</system:String>
+    <system:String x:Key="AutoStopToSkip">모집 중지 자동 사용*</system:String>
     <system:String x:Key="Level3UseShortTime">★3 태그 9:00 대신 7:40 설정</system:String>
     <system:String x:Key="Level3UseShortTime2">★3 태그 9:00 대신 1:00 설정</system:String>
     <system:String x:Key="Level3UseShortTimeTip">다른 등급에는 적용되지 않습니다</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -1388,6 +1388,7 @@ DEBUG 目录下保存的图片有数量限制，超出后会自动清理旧图�
     <system:String x:Key="AutoRefresh">自动刷新 3 星 Tags</system:String>
     <system:String x:Key="ForceRefresh">无招聘许可时继续尝试刷新 Tags</system:String>
     <system:String x:Key="AutoUseExpedited">自动使用加急许可*</system:String>
+    <system:String x:Key="AutoStopToSkip">自动使用停止招募*</system:String>
     <system:String x:Key="Level3UseShortTime">3 星设置 7:40 而非 9:00</system:String>
     <system:String x:Key="Level3UseShortTime2">3 星设置 1:00 而非 9:00</system:String>
     <system:String x:Key="Level3UseShortTimeTip">不影响其他星级 Tags</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -1388,6 +1388,7 @@ DEBUG 目錄下儲存的圖片有數量限制，超出後會自動清理舊圖�
     <system:String x:Key="AutoRefresh">自動刷新 3★ Tags</system:String>
     <system:String x:Key="ForceRefresh">無招聘許可時繼續嘗試刷新 Tags</system:String>
     <system:String x:Key="AutoUseExpedited">自動使用加急許可*</system:String>
+    <system:String x:Key="AutoStopToSkip">自動使用停止招募*</system:String>
     <system:String x:Key="Level3UseShortTime">3★ 設定 7:40 而非 9:00</system:String>
     <system:String x:Key="Level3UseShortTime2">3★ 設定 1:00 而非 9:00</system:String>
     <system:String x:Key="Level3UseShortTimeTip">不影響其他星級 Tags</system:String>

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/RecruitSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/RecruitSettingsUserControlModel.cs
@@ -104,9 +104,23 @@ public class RecruitSettingsUserControlModel : TaskSettingsViewModel, RecruitSet
         }
     }
 
+    public bool? StopToSkipWithNull
+    {
+        get => GetTaskConfig<RecruitTask>().StopToSkip;
+        set {
+            if (value == true)
+            {
+                value = null;
+            }
+
+            SetTaskConfig<RecruitTask>(t => t.StopToSkip == value, t => t.StopToSkip = value);
+        }
+    }
+
     public static void ResetRecruitVariables(RecruitTask? recruit)
     {
         recruit?.UseExpedited ??= false;
+        recruit?.StopToSkip ??= false;
     }
 
     /// <summary>
@@ -272,6 +286,7 @@ public class RecruitSettingsUserControlModel : TaskSettingsViewModel, RecruitSet
                 SetRecruitTime = true,
                 RecruitTimes = recruit.MaxTimes,
                 UseExpedited = recruit.UseExpedited is not false,
+                StopToSkip = recruit.StopToSkip is not false,
                 ExpeditedTimes = recruit.MaxTimes,
                 SelectExtraTags = recruit.ExtraTagMode,
                 Level3FirstList = recruit.Level3PreferTags,

--- a/src/MaaWpfGui/Views/UserControl/TaskQueue/RecruitSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/TaskQueue/RecruitSettingsUserControl.xaml
@@ -22,6 +22,11 @@
                 <controls:TooltipBlock TooltipText="{DynamicResource CheckBoxesNotSaved}" />
             </StackPanel>
 
+            <StackPanel Margin="0,10" Orientation="Horizontal">
+                <CheckBox Content="{DynamicResource AutoStopToSkip}" IsChecked="{Binding StopToSkipWithNull}" />
+                <controls:TooltipBlock TooltipText="{DynamicResource CheckBoxesNotSaved}" />
+            </StackPanel>
+
             <hc:NumericUpDown
                 Margin="0,5"
                 hc:InfoElement.Title="{DynamicResource RecruitMaxTimes}"


### PR DESCRIPTION
## feat: 自动公招新增使用停止招募选项
### 新增  
为自动公招新增一个“自动使用停止招募”的一次性选项，并实现了此选项勾选时，使用“停止招募”选项主动在不返还“招募许可”道具且不消耗“加急许可”道具的情况下放弃此次招募，并得以让招募继续进行。

### 说明
本人是一个开服且全图鉴的玩家，日常游玩过程中长期没有每日刷公招的习惯，同时经常会在黄票商店刷新时突击使用加急招募通过公开招募四星及以上干员获取黄票，这导致我的仓库中出现了“招募许可”远远多于“加急许可”的情况，因此于我而言，公招向黄票的转化瓶颈在于加急许可道具，如果可以仅仅通过停止招募来放弃低星的非目标公开招募轮次避免无法获得黄票的轮次并刷新标签是具有实际意义的，我认为这是一个确实存在的需求，故将此功能实现后提交此拉取请求。

这是本人首次为本项目提交代码，如有因不了解情况导致的问题，恳请开发组多多指出

此处附带本人账号内的相关仓库截图

<img width="159" height="258" alt="image" src="https://github.com/user-attachments/assets/11c1c044-409e-46c2-9220-fc037c76639c" />

### 截图
<img width="527" height="160" alt="image" src="https://github.com/user-attachments/assets/0dff70d1-6b68-4687-9fd1-a1dae4683a0c" />

## Summary by Sourcery

为自动公招添加一个可配置选项：当无法开始新的公招时，通过游戏内的停止招募操作来跳过本次招募，从而不消耗加急许可。

新功能：
- 为每个任务提供自动公招选项，使用游戏的“停止招募”操作来放弃当前招募并立即继续下一次招募，而无需使用加急许可。
- 通过任务配置、序列化以及公招设置界面在所有支持的语言中持久化新的“停止以跳过”设置。

增强：
- 扩展自动公招的控制流程，当无法开始新的公招且已启用该选项时，回退为“停止以跳过”的行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a configurable option for auto recruit to skip a recruitment by using the in-game stop action when new starts are unavailable, without consuming expedited permits.

New Features:
- Expose a per-task auto recruit option to use the game’s stop recruitment action to abandon and immediately continue to the next recruitment without using expedited permits.
- Persist the new stop-to-skip setting through task configuration, serialization, and the recruit settings UI across supported languages.

Enhancements:
- Extend the auto recruit control flow to fall back to the stop-to-skip behavior when no new recruitment can be started but the option is enabled.

</details>