### PR TITLE
fix: 修复 adb-lite 跳过 adb connect 后未初始化 client

### DIFF
--- a/src/MaaCore/Controller/Platform/AdbLiteIO.cpp
+++ b/src/MaaCore/Controller/Platform/AdbLiteIO.cpp
@@ -28,9 +28,9 @@ std::optional<int> asst::AdbLiteIO::call_command(
     static const boost::regex devices_regex(R"(^.+ devices$)");
     static const boost::regex release_regex(R"(^.+ kill-server$)");
     static const boost::regex connect_regex(R"(^.+ connect (\S+)$)");
-    static const boost::regex shell_regex(R"(^.+ -s \S+ shell (.+)$)");
-    static const boost::regex exec_regex(R"(^.+ -s \S+ exec-out (.+)$)");
-    static const boost::regex push_regex(R"#(^.+ -s \S+ push "(.+)" "(.+)"$)#");
+    static const boost::regex shell_regex(R"(^.+ -s (\S+) shell (.+)$)");
+    static const boost::regex exec_regex(R"(^.+ -s (\S+) exec-out (.+)$)");
+    static const boost::regex push_regex(R"#(^.+ -s (\S+) push "(.+)" "(.+)"$)#");
 
     // adb devices
     if (boost::regex_match(cmd, devices_regex)) {
@@ -63,10 +63,8 @@ std::optional<int> asst::AdbLiteIO::call_command(
     // adb connect
     // TODO: adb server 尚未实现，第一次连接需要执行一次 adb.exe 启动 daemon
     if (boost::regex_match(cmd, match, connect_regex)) {
-        m_adb_client = adb::client::create(match[1].str()); // TODO: compare address with existing (if any)
-
         try {
-            pipe_data = m_adb_client->connect();
+            pipe_data = get_adb_client(match[1].str())->connect();
             ret = 0;
             goto ret_exit;
         }
@@ -80,17 +78,11 @@ std::optional<int> asst::AdbLiteIO::call_command(
 
     // adb shell
     if (boost::regex_match(cmd, match, shell_regex)) {
-        if (!m_adb_client) {
-            Log.error("adb client not initialized");
-            ret = std::nullopt;
-            goto ret_exit;
-        }
-
-        std::string command = match[1].str();
+        std::string command = match[2].str();
         remove_quotes(command);
 
         try {
-            pipe_data = m_adb_client->shell(command);
+            pipe_data = get_adb_client(match[1].str())->shell(command);
             ret = 0;
             goto ret_exit;
         }
@@ -103,17 +95,11 @@ std::optional<int> asst::AdbLiteIO::call_command(
 
     // adb exec-out
     if (boost::regex_match(cmd, match, exec_regex)) {
-        if (!m_adb_client) {
-            Log.error("adb client not initialized");
-            ret = std::nullopt;
-            goto ret_exit;
-        }
-
-        std::string command = match[1].str();
+        std::string command = match[2].str();
         remove_quotes(command);
 
         try {
-            pipe_data = m_adb_client->exec(command);
+            pipe_data = get_adb_client(match[1].str())->exec(command);
             ret = 0;
             goto ret_exit;
         }
@@ -126,14 +112,8 @@ std::optional<int> asst::AdbLiteIO::call_command(
 
     // adb push
     if (boost::regex_match(cmd, match, push_regex)) {
-        if (!m_adb_client) {
-            Log.error("adb client not initialized");
-            ret = std::nullopt;
-            goto ret_exit;
-        }
-
         try {
-            m_adb_client->push(match[1].str(), match[2].str(), 0644);
+            get_adb_client(match[1].str())->push(match[2].str(), match[3].str(), 0644);
             ret = 0;
             goto ret_exit;
         }
@@ -156,22 +136,29 @@ ret_exit:
     return ret;
 }
 
+std::shared_ptr<adb::client> asst::AdbLiteIO::get_adb_client(std::string_view serial)
+{
+    const std::string serial_str(serial);
+    if (!m_adb_client || m_adb_serial != serial_str) {
+        m_adb_serial = serial_str;
+        m_adb_client = adb::client::create(m_adb_serial);
+    }
+
+    return m_adb_client;
+}
+
 std::shared_ptr<asst::IOHandler> asst::AdbLiteIO::interactive_shell(const std::string& cmd)
 {
-    static const boost::regex shell_regex(R"(^.+ -s \S+ shell (.+)$)");
+    static const boost::regex shell_regex(R"(^.+ -s (\S+) shell (.+)$)");
     boost::smatch match;
 
     if (boost::regex_match(cmd, match, shell_regex)) {
-        if (!m_adb_client) {
-            Log.error("adb client not initialized");
-            return nullptr;
-        }
-
-        std::string command = match[1].str();
+        std::string command = match[2].str();
         remove_quotes(command);
 
         try {
-            return std::make_shared<IOHandlerAdbLite>(m_adb_client->interactive_shell(command));
+            return std::make_shared<IOHandlerAdbLite>(
+                get_adb_client(match[1].str())->interactive_shell(command));
         }
         catch (const std::exception& e) {
             Log.error("adb shell failed:", e.what());

--- a/src/MaaCore/Controller/Platform/AdbLiteIO.cpp
+++ b/src/MaaCore/Controller/Platform/AdbLiteIO.cpp
@@ -61,7 +61,6 @@ std::optional<int> asst::AdbLiteIO::call_command(
     }
 
     // adb connect
-    // TODO: adb server 尚未实现，第一次连接需要执行一次 adb.exe 启动 daemon
     if (boost::regex_match(cmd, match, connect_regex)) {
         try {
             pipe_data = get_adb_client(match[1].str())->connect();

--- a/src/MaaCore/Controller/Platform/AdbLiteIO.cpp
+++ b/src/MaaCore/Controller/Platform/AdbLiteIO.cpp
@@ -138,6 +138,7 @@ ret_exit:
 
 std::shared_ptr<adb::client> asst::AdbLiteIO::get_adb_client(std::string_view serial)
 {
+    std::lock_guard lock(m_adb_client_mutex);
     const std::string serial_str(serial);
     if (!m_adb_client || m_adb_serial != serial_str) {
         m_adb_serial = serial_str;
@@ -173,13 +174,18 @@ std::shared_ptr<asst::IOHandler> asst::AdbLiteIO::interactive_shell(const std::s
 
 void asst::AdbLiteIO::release_adb(const std::string& adb_release, int64_t timeout)
 {
-    if (m_adb_client) {
-        std::string pipe_data;
-        std::string sock_data;
-        auto start_time = std::chrono::steady_clock::now();
-
-        call_command(adb_release, false, pipe_data, sock_data, timeout, start_time);
+    // 只在读取 m_adb_client 时持锁，避免 call_command 内部调用 get_adb_client 时死锁
+    {
+        std::lock_guard lock(m_adb_client_mutex);
+        if (!m_adb_client) {
+            return;
+        }
     }
+
+    std::string pipe_data;
+    std::string sock_data;
+    auto start_time = std::chrono::steady_clock::now();
+    call_command(adb_release, false, pipe_data, sock_data, timeout, start_time);
 }
 
 bool asst::AdbLiteIO::remove_quotes(std::string& data)

--- a/src/MaaCore/Controller/Platform/AdbLiteIO.h
+++ b/src/MaaCore/Controller/Platform/AdbLiteIO.h
@@ -12,6 +12,9 @@
 
 #include "Utils/Logger.hpp"
 
+#include <string>
+#include <string_view>
+
 namespace asst
 {
 #ifdef _WIN32
@@ -41,9 +44,12 @@ public:
     virtual void release_adb(const std::string& adb_release, int64_t timeout = 20000) override;
 
 private:
+    std::shared_ptr<adb::client> get_adb_client(std::string_view serial);
+
     static bool remove_quotes(std::string& data);
 
     std::shared_ptr<adb::client> m_adb_client = nullptr;
+    std::string m_adb_serial;
 };
 
 class IOHandlerAdbLite : public IOHandler

--- a/src/MaaCore/Controller/Platform/AdbLiteIO.h
+++ b/src/MaaCore/Controller/Platform/AdbLiteIO.h
@@ -12,6 +12,7 @@
 
 #include "Utils/Logger.hpp"
 
+#include <mutex>
 #include <string>
 #include <string_view>
 
@@ -48,6 +49,8 @@ private:
 
     static bool remove_quotes(std::string& data);
 
+    // 保护 m_adb_client / m_adb_serial，防止 call_command 与 interactive_shell 并发访问
+    mutable std::mutex m_adb_client_mutex;
     std::shared_ptr<adb::client> m_adb_client = nullptr;
     std::string m_adb_serial;
 };


### PR DESCRIPTION
## 概述

- 在 `AdbController::connect` 确定目标 address/serial 后，通过 `PlatformIO::set_adb_serial` 显式声明当前 adb 设备。
- NativeIO 默认忽略该调用；AdbLiteIO 使用该 serial 初始化或切换内部 adb-lite client。
- adb-lite 的 `shell`、`exec-out`、`push` 和交互式 shell 只使用已声明的 client，不再从命令路径里隐式初始化 client。
- 为 AdbLiteIO 的 client/serial 状态增加内部锁，避免 `call_command` 与 `interactive_shell` 并发访问时产生数据竞争。

## 问题原因

#15300 之后，`AdbController::connect` 会先检查 `adb devices`。如果目标设备已经在列表中，例如 `emulator-5554 device`，就会跳过 `adb connect <serial>`。

这个行为对普通 adb/native 路径是合理的，因为每条命令都会把完整的 `-s <serial>` 交给外部 adb 进程。但 adb-lite 之前只在 `adb connect` 分支里初始化 `m_adb_client`。因此当设备已经在线、`adb connect` 被跳过时，后续的 `adb -s emulator-5554 shell ...` 会进入 adb-lite 路径，但此时 client 尚未初始化，日志中会出现：

```text
adb client not initialized
fallback to NativeIO
```

在 macOS 上这个问题会被 NativeIO fallback 掩盖，表现为 CLI 最终仍然显示 `Connected`；但实际上 adb-lite 路径没有成功工作。

## 修复方式

连接阶段已经知道当前 address/serial，所以在这里显式调用 `m_platform_io->set_adb_serial(address)`。对 NativeIO 来说这是 no-op；对 AdbLiteIO 来说，这是初始化或切换 `adb::client` 的唯一入口。

这样后续命令路径只需要校验命令中的 `-s <serial>` 与当前 client 对应的 serial 一致，然后使用已有 client 执行命令。这个设计避免了在 `shell` / `interactive_shell` 中偷偷初始化 client，也让 adb-lite 的连接状态由连接生命周期明确维护。

同时，AdbLiteIO 内部用 mutex 保护 `m_adb_client` / `m_adb_serial` 以及对 adb-lite client 的调用，避免 `call_command` 和 `interactive_shell` 并发访问同一状态。

## 验证

- 使用本机已安装的 MaaCore v6.10.6 和 Android 35 arm64 AVD 复现：
  - 已启用 adb-lite
  - `adb devices` 返回 `emulator-5554 device`
  - 日志出现 `adb client not initialized`
  - 随后出现 `fallback to NativeIO`
- 编译并安装修复后的 Core：
  - `cmake --build /private/tmp/maa-build-8599-core --parallel 8`
  - `cmake --install /private/tmp/maa-build-8599-core --config RelWithDebInfo`
- 通过本机 `maa` CLI 指向修复后的 Core，使用临时 adb-lite profile 测试：
  - `maa run connect-only -p adb-lite-test --no-summary -vvv`
  - 日志显示 `Setting adb lite enabled to true`
  - 日志到达 `Connected`
  - 日志到达 `FastestWayToScreencap Encode`
  - 未再出现 `adb client not initialized`
  - 未再出现 `fallback to NativeIO`
