### PR TITLE
fix(macOS): 降低 RA4 和 RA15 二倍速识别阈值

### DIFF
--- a/resource/platform_diff/iOS/resource/tasks.json
+++ b/resource/platform_diff/iOS/resource/tasks.json
@@ -46,5 +46,11 @@
     },
     "RelaunchAnchor@RA@RA1-DoubleSpeed": {
         "templThreshold": 0.7
+    },
+    "RelaunchAnchor@RA@RA4-DoubleSpeed": {
+        "templThreshold": 0.7
+    },
+    "RelaunchAnchor@RA@RA15-DoubleSpeed": {
+        "templThreshold": 0.7
     }
 }


### PR DESCRIPTION
## 变更内容

- 在 macOS平台差异配置中，为 RA4 和 RA15 的二倍速识别节点补充 `templThreshold: 0.7`
- 与此前 macOS的 iOS 差异配置保持一致

## 修改位置

- `resource/platform_diff/iOS/resource/tasks.json`

## 原因

RA4 和 RA15 在 iOS/macOS 触控环境下识别二倍速按钮时也有用户反馈出现模板匹配分数偏低的问题，和此前 RA1 的情况类似。  
因此仅在 iOS 平台差异文件中降低对应节点阈值，避免影响通用任务配置和其他平台。

## 说明

本次未修改通用任务文件 `resource/tasks/RA/Reclamation3.json`。

## Summary by Sourcery

错误修复：
- 在 macOS/iOS 的 platform-diff 任务配置中，降低 RA4 和 RA15 的双倍速度模板匹配阈值，以减少漏检情况。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Lower the double-speed template matching threshold for RA4 and RA15 in the macOS/iOS platform-diff task configuration to reduce missed detections.

</details>