### PR TITLE
rft: 统一使用重载的 GetValue 替换 Convert.To

### DIFF
--- a/src/MaaWpfGui/Helper/ConfigConverter.cs
+++ b/src/MaaWpfGui/Helper/ConfigConverter.cs
@@ -200,7 +200,7 @@ public class ConfigConverter
                 infrastTask.SendClue = ConfigurationHelper.GetValue(ConfigurationKeys.InfrastReceptionSendClue, true);
                 infrastTask.ContinueTraining = ConfigurationHelper.GetValue(ConfigurationKeys.ContinueTraining, false);
                 infrastTask.DormThreshold = ConfigurationHelper.GetValue(ConfigurationKeys.DormThreshold, 30);
-                infrastTask.DormFilterNotStationed = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.DormFilterNotStationedEnabled, true));
+                infrastTask.DormFilterNotStationed = ConfigurationHelper.GetValue(ConfigurationKeys.DormFilterNotStationedEnabled, true);
                 infrastTask.DormTrustEnabled = ConfigurationHelper.GetValue(ConfigurationKeys.DormTrustEnabled, false);
                 infrastTask.OriginiumShardAutoReplenishment = ConfigurationHelper.GetValue(ConfigurationKeys.OriginiumShardAutoReplenishment, true);
                 infrastTask.Filename = ConfigurationHelper.GetValue(ConfigurationKeys.CustomInfrastFile, string.Empty);

--- a/src/MaaWpfGui/Helper/WindowManager.cs
+++ b/src/MaaWpfGui/Helper/WindowManager.cs
@@ -33,10 +33,10 @@ public class WindowManager : Stylet.WindowManager
 
     private static readonly ILogger _logger = Log.ForContext<WindowManager>();
 
-    private readonly bool _loadWindowPlacement = Convert.ToBoolean(ConfigurationHelper.GetGlobalValue(ConfigurationKeys.LoadWindowPlacement, bool.TrueString));
-    private readonly bool _saveWindowPlacement = Convert.ToBoolean(ConfigurationHelper.GetGlobalValue(ConfigurationKeys.SaveWindowPlacement, bool.TrueString));
-    private readonly bool _minimizeDirectly = Convert.ToBoolean(ConfigurationHelper.GetGlobalValue(ConfigurationKeys.MinimizeDirectly, bool.FalseString));
-    private readonly bool _minimizeToTray = Convert.ToBoolean(ConfigurationHelper.GetGlobalValue(ConfigurationKeys.MinimizeToTray, bool.FalseString));
+    private readonly bool _loadWindowPlacement = ConfigurationHelper.GetGlobalValue(ConfigurationKeys.LoadWindowPlacement, true);
+    private readonly bool _saveWindowPlacement = ConfigurationHelper.GetGlobalValue(ConfigurationKeys.SaveWindowPlacement, true);
+    private readonly bool _minimizeDirectly = ConfigurationHelper.GetGlobalValue(ConfigurationKeys.MinimizeDirectly, false);
+    private readonly bool _minimizeToTray = ConfigurationHelper.GetGlobalValue(ConfigurationKeys.MinimizeToTray, false);
 
     /// <summary>
     /// Center other windows in MaaWpfGui.RootView

--- a/src/MaaWpfGui/Services/Managers/MainWindowManager.cs
+++ b/src/MaaWpfGui/Services/Managers/MainWindowManager.cs
@@ -44,10 +44,10 @@ public sealed class MainWindowManager : IMainWindowManager
     {
         MainWindow.StateChanged += MainWindowStateChanged;
 
-        bool minimizeToTray = Convert.ToBoolean(ConfigurationHelper.GetGlobalValue(ConfigurationKeys.MinimizeToTray, bool.FalseString));
+        bool minimizeToTray = ConfigurationHelper.GetGlobalValue(ConfigurationKeys.MinimizeToTray, false);
         SetMinimizeToTray(minimizeToTray);
 
-        bool useTrayIcon = Convert.ToBoolean(ConfigurationHelper.GetGlobalValue(ConfigurationKeys.UseTray, bool.TrueString));
+        bool useTrayIcon = ConfigurationHelper.GetGlobalValue(ConfigurationKeys.UseTray, true);
         SetUseTrayIcon(useTrayIcon);
 
         _previousState = GetWindowState();

--- a/src/MaaWpfGui/Utilities/SleepManagement.cs
+++ b/src/MaaWpfGui/Utilities/SleepManagement.cs
@@ -28,8 +28,8 @@ public static class SleepManagement
 
     private static readonly ILogger _logger = Log.ForContext("SourceContext", "SleepManagement");
 
-    private static bool _allowBlockSleep = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.BlockSleep, bool.FalseString));
-    private static bool _blockSleepWithScreenOn = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.BlockSleepWithScreenOn, bool.TrueString));
+    private static bool _allowBlockSleep = ConfigurationHelper.GetValue(ConfigurationKeys.BlockSleep, false);
+    private static bool _blockSleepWithScreenOn = ConfigurationHelper.GetValue(ConfigurationKeys.BlockSleepWithScreenOn, true);
     private static bool _isBlockingSleep = false;
 
     public static void SetBlockSleep(bool allowBlockSleep)

--- a/src/MaaWpfGui/ViewModels/Dialogs/VersionUpdateDialogViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/Dialogs/VersionUpdateDialogViewModel.cs
@@ -133,7 +133,7 @@ public class VersionUpdateDialogViewModel : Screen
         set => SetAndNotify(ref _updateUrl, value);
     }
 
-    private bool _isFirstBootAfterUpdate = Convert.ToBoolean(ConfigurationHelper.GetGlobalValue(ConfigurationKeys.VersionUpdateIsFirstBoot, bool.FalseString));
+    private bool _isFirstBootAfterUpdate = ConfigurationHelper.GetGlobalValue(ConfigurationKeys.VersionUpdateIsFirstBoot, false);
 
     /// <summary>
     /// Gets or sets a value indicating whether it is the first boot after updating.
@@ -260,7 +260,7 @@ public class VersionUpdateDialogViewModel : Screen
         MirrorChyan,
     }
 
-    private bool _doNotShowUpdate = Convert.ToBoolean(ConfigurationHelper.GetGlobalValue(ConfigurationKeys.VersionUpdateDoNotShowUpdate, bool.FalseString));
+    private bool _doNotShowUpdate = ConfigurationHelper.GetGlobalValue(ConfigurationKeys.VersionUpdateDoNotShowUpdate, false);
 
     /// <summary>
     /// Gets or sets a value indicating whether to show the update.

--- a/src/MaaWpfGui/ViewModels/UI/RootViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/RootViewModel.cs
@@ -193,7 +193,7 @@ public class RootViewModel : Conductor<Screen>.Collection.OneActive
         }
     }
 
-    private bool _windowTitleScrollable = Convert.ToBoolean(ConfigurationHelper.GetGlobalValue(ConfigurationKeys.WindowTitleScrollable, bool.FalseString));
+    private bool _windowTitleScrollable = ConfigurationHelper.GetGlobalValue(ConfigurationKeys.WindowTitleScrollable, false);
 
     /// <summary>
     /// Gets or sets a value indicating whether to scroll the window title.
@@ -204,7 +204,7 @@ public class RootViewModel : Conductor<Screen>.Collection.OneActive
         set => SetAndNotify(ref _windowTitleScrollable, value);
     }
 
-    private bool _showCloseButton = !Convert.ToBoolean(ConfigurationHelper.GetGlobalValue(ConfigurationKeys.HideCloseButton, bool.FalseString));
+    private bool _showCloseButton = !ConfigurationHelper.GetGlobalValue(ConfigurationKeys.HideCloseButton, false);
 
     /// <summary>
     /// Gets or sets a value indicating whether to show close button.

--- a/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
@@ -352,7 +352,7 @@ public class SettingsViewModel : Screen
     /// </summary>
     public const string PallasLangKey = "pallas";
 
-    private bool _cheers = Convert.ToBoolean(ConfigurationHelper.GetGlobalValue(ConfigurationKeys.Cheers, bool.FalseString));
+    private bool _cheers = ConfigurationHelper.GetGlobalValue(ConfigurationKeys.Cheers, false);
 
     /// <summary>
     /// Gets or sets a value indicating whether to cheer.
@@ -375,7 +375,7 @@ public class SettingsViewModel : Screen
         }
     }
 
-    private bool _hangover = Convert.ToBoolean(ConfigurationHelper.GetGlobalValue(ConfigurationKeys.Hangover, bool.FalseString));
+    private bool _hangover = ConfigurationHelper.GetGlobalValue(ConfigurationKeys.Hangover, false);
 
     /// <summary>
     /// Gets or sets a value indicating whether to hangover.
@@ -632,7 +632,7 @@ public class SettingsViewModel : Screen
 
     public static int GuideMaxStep => 7;
 
-    private int _guideStepIndex = Convert.ToInt32(ConfigurationHelper.GetValue(ConfigurationKeys.GuideStepIndex, "0"));
+    private int _guideStepIndex = ConfigurationHelper.GetValue(ConfigurationKeys.GuideStepIndex, 0);
 
     public int GuideStepIndex
     {

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -1492,7 +1492,7 @@ public class TaskQueueViewModel : Screen
         set => SetAndNotify(ref _showInverse, value);
     }
 
-    private string _inverseShowText = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.MainFunctionInverseMode, bool.FalseString))
+    private string _inverseShowText = ConfigurationHelper.GetValue(ConfigurationKeys.MainFunctionInverseMode, false)
         ? LocalizationHelper.GetString("Inverse")
         : LocalizationHelper.GetString("Clear");
 
@@ -1505,7 +1505,7 @@ public class TaskQueueViewModel : Screen
         private set => SetAndNotify(ref _inverseShowText, value);
     }
 
-    private string _inverseMenuText = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.MainFunctionInverseMode, bool.FalseString))
+    private string _inverseMenuText = ConfigurationHelper.GetValue(ConfigurationKeys.MainFunctionInverseMode, false)
         ? LocalizationHelper.GetString("Clear")
         : LocalizationHelper.GetString("Inverse");
 

--- a/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
@@ -256,7 +256,7 @@ public class ToolboxViewModel : Screen
         }
     } = ConfigurationHelper.GetValue(ConfigurationKeys.ChooseLevel5, true);
 
-    private bool _chooseLevel6 = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.ChooseLevel6, bool.TrueString));
+    private bool _chooseLevel6 = ConfigurationHelper.GetValue(ConfigurationKeys.ChooseLevel6, true);
 
     /// <summary>
     /// Gets or sets a value indicating whether to choose level 6.
@@ -354,7 +354,7 @@ public class ToolboxViewModel : Screen
         }
     } = ConfigurationHelper.GetValue(ConfigurationKeys.ToolBoxChooseLevel5Time, 540);
 
-    private bool _autoSetTime = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.AutoSetTime, bool.TrueString));
+    private bool _autoSetTime = ConfigurationHelper.GetValue(ConfigurationKeys.AutoSetTime, true);
 
     /// <summary>
     /// Gets or sets a value indicating whether to set time automatically.
@@ -425,7 +425,7 @@ public class ToolboxViewModel : Screen
         ret &= Instances.AsstProxy.AsstStart();
     }
 
-    private bool _recruitmentShowPotential = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.RecruitmentShowPotential, bool.TrueString));
+    private bool _recruitmentShowPotential = ConfigurationHelper.GetValue(ConfigurationKeys.RecruitmentShowPotential, true);
 
     public bool RecruitmentShowPotential
     {
@@ -1982,7 +1982,7 @@ public class ToolboxViewModel : Screen
     // 請勿更改
     // このコードを変更しないでください
     // 변경하지 마십시오
-    private bool _gachaShowDisclaimer = true; // !Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.ShowDisclaimerNoMore, bool.FalseString));
+    private bool _gachaShowDisclaimer = true; // !ConfigurationHelper.GetValue(ConfigurationKeys.ShowDisclaimerNoMore, false);
 
     public bool GachaShowDisclaimer
     {
@@ -1992,7 +1992,7 @@ public class ToolboxViewModel : Screen
         }
     }
 
-    private bool _gachaShowDisclaimerNoMore = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.GachaShowDisclaimerNoMore, bool.FalseString));
+    private bool _gachaShowDisclaimerNoMore = ConfigurationHelper.GetValue(ConfigurationKeys.GachaShowDisclaimerNoMore, false);
 
     public bool GachaShowDisclaimerNoMore
     {
@@ -2084,7 +2084,7 @@ public class ToolboxViewModel : Screen
         set => SetAndNotify(ref _peepScreenFpf, value);
     }
 
-    private int _peepTargetFps = int.Parse(ConfigurationHelper.GetValue(ConfigurationKeys.PeepTargetFps, "20"));
+    private int _peepTargetFps = ConfigurationHelper.GetValue(ConfigurationKeys.PeepTargetFps, 20);
 
     public int PeepTargetFps
     {

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/AchievementSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/AchievementSettingsUserControlModel.cs
@@ -208,7 +208,7 @@ public class AchievementSettingsUserControlModel : PropertyChangedBase
         AchievementTrackerHelper.Instance.LockAll();
     }
 
-    private bool _achievementPopupDisabled = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.AchievementPopupDisabled, bool.FalseString));
+    private bool _achievementPopupDisabled = ConfigurationHelper.GetValue(ConfigurationKeys.AchievementPopupDisabled, false);
 
     /// <summary>
     /// Gets or sets a value indicating whether to disable achievement notifications.

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/BackgroundSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/BackgroundSettingsUserControlModel.cs
@@ -117,7 +117,7 @@ public class BackgroundSettingsUserControlModel : PropertyChangedBase
         }
     }
 
-    private int _backgroundOpacity = int.Parse(ConfigurationHelper.GetGlobalValue(ConfigurationKeys.BackgroundOpacity, "50"));
+    private int _backgroundOpacity = ConfigurationHelper.GetGlobalValue(ConfigurationKeys.BackgroundOpacity, 50);
 
     public int BackgroundOpacity
     {
@@ -127,7 +127,7 @@ public class BackgroundSettingsUserControlModel : PropertyChangedBase
         }
     }
 
-    private static int _backgroundBlurEffectRadius = int.Parse(ConfigurationHelper.GetGlobalValue(ConfigurationKeys.BackgroundBlurEffectRadius, "5"));
+    private static int _backgroundBlurEffectRadius = ConfigurationHelper.GetGlobalValue(ConfigurationKeys.BackgroundBlurEffectRadius, 5);
 
     public int BackgroundBlurEffectRadius
     {

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/ConnectSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/ConnectSettingsUserControlModel.cs
@@ -95,7 +95,7 @@ public class ConnectSettingsUserControlModel : PropertyChangedBase
             new() { Display = LocalizationHelper.GetString("MaaFwAdbTouchMode"), Value = "MaaFwAdb" },
         ];
 
-    private bool _autoDetectConnection = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.AutoDetect, bool.TrueString));
+    private bool _autoDetectConnection = ConfigurationHelper.GetValue(ConfigurationKeys.AutoDetect, true);
 
     public bool AutoDetectConnection
     {
@@ -115,7 +115,7 @@ public class ConnectSettingsUserControlModel : PropertyChangedBase
         }
     }
 
-    private bool _alwaysAutoDetectConnection = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.AlwaysAutoDetect, bool.FalseString));
+    private bool _alwaysAutoDetectConnection = ConfigurationHelper.GetValue(ConfigurationKeys.AlwaysAutoDetect, false);
 
     public bool AlwaysAutoDetectConnection
     {
@@ -272,7 +272,7 @@ public class ConnectSettingsUserControlModel : PropertyChangedBase
 
     public class MuMuEmulator12ConnectionExtras : PropertyChangedBase
     {
-        private bool _enable = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.MuMu12ExtrasEnabled, bool.FalseString));
+        private bool _enable = ConfigurationHelper.GetValue(ConfigurationKeys.MuMu12ExtrasEnabled, false);
 
         public bool Enable
         {
@@ -411,7 +411,7 @@ public class ConnectSettingsUserControlModel : PropertyChangedBase
             }
         }
 
-        private bool _mumuBridgeConnection = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.MumuBridgeConnection, bool.FalseString));
+        private bool _mumuBridgeConnection = ConfigurationHelper.GetValue(ConfigurationKeys.MumuBridgeConnection, false);
 
         public bool MuMuBridgeConnection
         {
@@ -484,7 +484,7 @@ public class ConnectSettingsUserControlModel : PropertyChangedBase
 
     public class LdPlayerConnectionExtras : PropertyChangedBase
     {
-        private bool _enable = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.LdPlayerExtrasEnabled, bool.FalseString));
+        private bool _enable = ConfigurationHelper.GetValue(ConfigurationKeys.LdPlayerExtrasEnabled, false);
 
         public bool Enable
         {
@@ -609,7 +609,7 @@ public class ConnectSettingsUserControlModel : PropertyChangedBase
             }
         }
 
-        private bool _manualSetIndex = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.LdPlayerManualSetIndex, bool.FalseString));
+        private bool _manualSetIndex = ConfigurationHelper.GetValue(ConfigurationKeys.LdPlayerManualSetIndex, false);
 
         public bool ManualSetIndex
         {
@@ -751,7 +751,7 @@ public class ConnectSettingsUserControlModel : PropertyChangedBase
 
     public LdPlayerConnectionExtras LdPlayerExtras { get; set; } = new();
 
-    private bool _retryOnDisconnected = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.RetryOnAdbDisconnected, bool.FalseString));
+    private bool _retryOnDisconnected = ConfigurationHelper.GetValue(ConfigurationKeys.RetryOnAdbDisconnected, false);
 
     /// <summary>
     /// Gets or sets a value indicating whether to retry task after ADB disconnected.
@@ -775,7 +775,7 @@ public class ConnectSettingsUserControlModel : PropertyChangedBase
         }
     }
 
-    private bool _allowAdbRestart = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.AllowAdbRestart, bool.TrueString));
+    private bool _allowAdbRestart = ConfigurationHelper.GetValue(ConfigurationKeys.AllowAdbRestart, true);
 
     /// <summary>
     /// Gets or sets a value indicating whether to retry task after ADB disconnected.
@@ -789,7 +789,7 @@ public class ConnectSettingsUserControlModel : PropertyChangedBase
         }
     }
 
-    private bool _allowAdbHardRestart = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.AllowAdbHardRestart, bool.TrueString));
+    private bool _allowAdbHardRestart = ConfigurationHelper.GetValue(ConfigurationKeys.AllowAdbHardRestart, true);
 
     /// <summary>
     /// Gets or sets a value indicating whether to allow for killing ADB process.
@@ -803,7 +803,7 @@ public class ConnectSettingsUserControlModel : PropertyChangedBase
         }
     }
 
-    private bool _adbLiteEnabled = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.AdbLiteEnabled, bool.FalseString));
+    private bool _adbLiteEnabled = ConfigurationHelper.GetValue(ConfigurationKeys.AdbLiteEnabled, false);
 
     public bool AdbLiteEnabled
     {
@@ -815,7 +815,7 @@ public class ConnectSettingsUserControlModel : PropertyChangedBase
         }
     }
 
-    private bool _killAdbOnExit = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.KillAdbOnExit, bool.FalseString));
+    private bool _killAdbOnExit = ConfigurationHelper.GetValue(ConfigurationKeys.KillAdbOnExit, false);
 
     public bool KillAdbOnExit
     {
@@ -1287,7 +1287,7 @@ public class ConnectSettingsUserControlModel : PropertyChangedBase
         }
     }
 
-    public bool AdbReplaced { get; set; } = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.AdbReplaced, bool.FalseString));
+    public bool AdbReplaced { get; set; } = ConfigurationHelper.GetValue(ConfigurationKeys.AdbReplaced, false);
 
     #region AttachWindow (Win32窗口绑定) 配置
 

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/ExternalNotificationSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/ExternalNotificationSettingsUserControlModel.cs
@@ -45,7 +45,7 @@ public class ExternalNotificationSettingsUserControlModel : PropertyChangedBase
             true);
     }
 
-    private bool _externalNotificationSendWhenComplete = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.ExternalNotificationSendWhenComplete, bool.TrueString));
+    private bool _externalNotificationSendWhenComplete = ConfigurationHelper.GetValue(ConfigurationKeys.ExternalNotificationSendWhenComplete, true);
 
     public bool ExternalNotificationSendWhenComplete
     {
@@ -56,7 +56,7 @@ public class ExternalNotificationSettingsUserControlModel : PropertyChangedBase
         }
     }
 
-    private bool _externalNotificationEnableDetails = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.ExternalNotificationEnableDetails, bool.FalseString));
+    private bool _externalNotificationEnableDetails = ConfigurationHelper.GetValue(ConfigurationKeys.ExternalNotificationEnableDetails, false);
 
     public bool ExternalNotificationEnableDetails
     {
@@ -67,7 +67,7 @@ public class ExternalNotificationSettingsUserControlModel : PropertyChangedBase
         }
     }
 
-    private bool _externalNotificationSendWhenError = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.ExternalNotificationSendWhenError, bool.TrueString));
+    private bool _externalNotificationSendWhenError = ConfigurationHelper.GetValue(ConfigurationKeys.ExternalNotificationSendWhenError, true);
 
     public bool ExternalNotificationSendWhenError
     {
@@ -79,7 +79,7 @@ public class ExternalNotificationSettingsUserControlModel : PropertyChangedBase
     }
 
 
-    private bool _externalNotificationSendWhenStalled = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.ExternalNotificationSendWhenStalled, bool.FalseString));
+    private bool _externalNotificationSendWhenStalled = ConfigurationHelper.GetValue(ConfigurationKeys.ExternalNotificationSendWhenStalled, false);
 
     public bool ExternalNotificationSendWhenStalled
     {
@@ -347,7 +347,7 @@ public class ExternalNotificationSettingsUserControlModel : PropertyChangedBase
         }
     }
 
-    private bool _smtpUseSsl = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.ExternalNotificationSmtpUseSsl, bool.FalseString));
+    private bool _smtpUseSsl = ConfigurationHelper.GetValue(ConfigurationKeys.ExternalNotificationSmtpUseSsl, false);
 
     public bool SmtpUseSsl
     {
@@ -358,7 +358,7 @@ public class ExternalNotificationSettingsUserControlModel : PropertyChangedBase
         }
     }
 
-    private bool _smtpRequireAuthentication = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.ExternalNotificationSmtpRequiresAuthentication, bool.FalseString));
+    private bool _smtpRequireAuthentication = ConfigurationHelper.GetValue(ConfigurationKeys.ExternalNotificationSmtpRequiresAuthentication, false);
 
     public bool SmtpRequireAuthentication
     {

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/GameSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/GameSettingsUserControlModel.cs
@@ -119,7 +119,7 @@ public class GameSettingsUserControlModel : PropertyChangedBase
                (oldType != "Bilibili" || newType != "Official");
     }
 
-    private bool _deploymentWithPause = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.RoguelikeDeploymentWithPause, bool.FalseString));
+    private bool _deploymentWithPause = ConfigurationHelper.GetValue(ConfigurationKeys.RoguelikeDeploymentWithPause, false);
 
     public bool DeploymentWithPause
     {
@@ -153,7 +153,7 @@ public class GameSettingsUserControlModel : PropertyChangedBase
         }
     }
 
-    private bool _copilotWithScript = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.CopilotWithScript, bool.FalseString));
+    private bool _copilotWithScript = ConfigurationHelper.GetValue(ConfigurationKeys.CopilotWithScript, false);
 
     public bool CopilotWithScript
     {
@@ -164,7 +164,7 @@ public class GameSettingsUserControlModel : PropertyChangedBase
         }
     }
 
-    private bool _manualStopWithScript = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.ManualStopWithScript, bool.FalseString));
+    private bool _manualStopWithScript = ConfigurationHelper.GetValue(ConfigurationKeys.ManualStopWithScript, false);
 
     public bool ManualStopWithScript
     {
@@ -275,7 +275,7 @@ public class GameSettingsUserControlModel : PropertyChangedBase
         }
     }
 
-    private bool _blockSleep = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.BlockSleep, bool.FalseString));
+    private bool _blockSleep = ConfigurationHelper.GetValue(ConfigurationKeys.BlockSleep, false);
 
     public bool BlockSleep
     {
@@ -287,7 +287,7 @@ public class GameSettingsUserControlModel : PropertyChangedBase
         }
     }
 
-    private bool _blockSleepWithScreenOn = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.BlockSleepWithScreenOn, bool.TrueString));
+    private bool _blockSleepWithScreenOn = ConfigurationHelper.GetValue(ConfigurationKeys.BlockSleepWithScreenOn, true);
 
     public bool BlockSleepWithScreenOn
     {
@@ -315,7 +315,7 @@ public class GameSettingsUserControlModel : PropertyChangedBase
         }
     }
 
-    private bool _enablePenguin = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.EnablePenguin, bool.TrueString));
+    private bool _enablePenguin = ConfigurationHelper.GetValue(ConfigurationKeys.EnablePenguin, true);
 
     /// <summary>
     /// Gets or sets a value indicating whether to enable penguin upload.
@@ -329,7 +329,7 @@ public class GameSettingsUserControlModel : PropertyChangedBase
         }
     }
 
-    private bool _enableYituliu = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.EnableYituliu, bool.TrueString));
+    private bool _enableYituliu = ConfigurationHelper.GetValue(ConfigurationKeys.EnableYituliu, true);
 
     /// <summary>
     /// Gets or sets a value indicating whether to enable yituliu upload.

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/GuiSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/GuiSettingsUserControlModel.cs
@@ -70,7 +70,7 @@ public class GuiSettingsUserControlModel : PropertyChangedBase
             new() { Display = LocalizationHelper.GetString("Switchable"), Value = "ClearInverse" },
          ];
 
-    private bool _useTray = Convert.ToBoolean(ConfigurationHelper.GetGlobalValue(ConfigurationKeys.UseTray, bool.TrueString));
+    private bool _useTray = ConfigurationHelper.GetGlobalValue(ConfigurationKeys.UseTray, true);
 
     /// <summary>
     /// Gets or sets a value indicating whether to use tray icon.
@@ -90,7 +90,7 @@ public class GuiSettingsUserControlModel : PropertyChangedBase
         }
     }
 
-    private bool _minimizeToTray = Convert.ToBoolean(ConfigurationHelper.GetGlobalValue(ConfigurationKeys.MinimizeToTray, bool.FalseString));
+    private bool _minimizeToTray = ConfigurationHelper.GetGlobalValue(ConfigurationKeys.MinimizeToTray, false);
 
     /// <summary>
     /// Gets or sets a value indicating whether to minimize to tray.
@@ -109,7 +109,7 @@ public class GuiSettingsUserControlModel : PropertyChangedBase
         }
     }
 
-    private bool _windowTitleScrollable = Convert.ToBoolean(ConfigurationHelper.GetGlobalValue(ConfigurationKeys.WindowTitleScrollable, bool.FalseString));
+    private bool _windowTitleScrollable = ConfigurationHelper.GetGlobalValue(ConfigurationKeys.WindowTitleScrollable, false);
 
     /// <summary>
     /// Gets or sets a value indicating whether to make window title scrollable.
@@ -125,7 +125,7 @@ public class GuiSettingsUserControlModel : PropertyChangedBase
         }
     }
 
-    private bool _hideCloseButton = Convert.ToBoolean(ConfigurationHelper.GetGlobalValue(ConfigurationKeys.HideCloseButton, bool.FalseString));
+    private bool _hideCloseButton = ConfigurationHelper.GetGlobalValue(ConfigurationKeys.HideCloseButton, false);
 
     /// <summary>
     /// Gets or sets a value indicating whether to hide close button.

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/RemoteControlUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/RemoteControlUserControlModel.cs
@@ -12,7 +12,6 @@
 // </copyright>
 
 #nullable enable
-using System;
 using MaaWpfGui.Constants;
 using MaaWpfGui.Helper;
 using Stylet;
@@ -84,7 +83,7 @@ public class RemoteControlUserControlModel : PropertyChangedBase
         }
     }
 
-    private int _remoteControlPollIntervalMs = Convert.ToInt32(ConfigurationHelper.GetValue(ConfigurationKeys.RemoteControlPollIntervalMs, "1000"));
+    private int _remoteControlPollIntervalMs = ConfigurationHelper.GetValue(ConfigurationKeys.RemoteControlPollIntervalMs, 1000);
 
     public int RemoteControlPollIntervalMs
     {

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/StartSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/StartSettingsUserControlModel.cs
@@ -75,7 +75,7 @@ public class StartSettingsUserControlModel : PropertyChangedBase
         }
     }
 
-    private bool _runDirectly = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.RunDirectly, bool.FalseString));
+    private bool _runDirectly = ConfigurationHelper.GetValue(ConfigurationKeys.RunDirectly, false);
 
     /// <summary>
     /// Gets or sets a value indicating whether to run directly.
@@ -89,7 +89,7 @@ public class StartSettingsUserControlModel : PropertyChangedBase
         }
     }
 
-    private bool _minimizeDirectly = Convert.ToBoolean(ConfigurationHelper.GetGlobalValue(ConfigurationKeys.MinimizeDirectly, bool.FalseString));
+    private bool _minimizeDirectly = ConfigurationHelper.GetGlobalValue(ConfigurationKeys.MinimizeDirectly, false);
 
     /// <summary>
     /// Gets or sets a value indicating whether to minimize directly.
@@ -103,7 +103,7 @@ public class StartSettingsUserControlModel : PropertyChangedBase
         }
     }
 
-    private bool _openEmulatorAfterLaunch = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.StartEmulator, bool.FalseString));
+    private bool _openEmulatorAfterLaunch = ConfigurationHelper.GetValue(ConfigurationKeys.StartEmulator, false);
 
     /// <summary>
     /// Gets or sets a value indicating whether to start emulator.
@@ -214,7 +214,7 @@ public class StartSettingsUserControlModel : PropertyChangedBase
         }
     }
 
-    private bool _blockSleep = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.BlockSleep, bool.FalseString));
+    private bool _blockSleep = ConfigurationHelper.GetValue(ConfigurationKeys.BlockSleep, false);
 
     public bool BlockSleep
     {
@@ -226,7 +226,7 @@ public class StartSettingsUserControlModel : PropertyChangedBase
         }
     }
 
-    private bool _blockSleepWithScreenOn = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.BlockSleepWithScreenOn, bool.TrueString));
+    private bool _blockSleepWithScreenOn = ConfigurationHelper.GetValue(ConfigurationKeys.BlockSleepWithScreenOn, true);
 
     public bool BlockSleepWithScreenOn
     {

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/TimerSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/TimerSettingsUserControlModel.cs
@@ -31,7 +31,7 @@ public class TimerSettingsUserControlModel : PropertyChangedBase
 
     public static TimerSettingsUserControlModel Instance { get; }
 
-    private bool _forceScheduledStart = Convert.ToBoolean(ConfigurationHelper.GetGlobalValue(ConfigurationKeys.ForceScheduledStart, bool.FalseString));
+    private bool _forceScheduledStart = ConfigurationHelper.GetGlobalValue(ConfigurationKeys.ForceScheduledStart, false);
 
     /// <summary>
     /// Gets or sets a value indicating whether to force scheduled start.
@@ -45,7 +45,7 @@ public class TimerSettingsUserControlModel : PropertyChangedBase
         }
     }
 
-    private bool _showWindowBeforeForceScheduledStart = Convert.ToBoolean(ConfigurationHelper.GetGlobalValue(ConfigurationKeys.ShowWindowBeforeForceScheduledStart, bool.FalseString));
+    private bool _showWindowBeforeForceScheduledStart = ConfigurationHelper.GetGlobalValue(ConfigurationKeys.ShowWindowBeforeForceScheduledStart, false);
 
     /// <summary>
     /// Gets or sets a value indicating whether show window before force scheduled start.
@@ -59,7 +59,7 @@ public class TimerSettingsUserControlModel : PropertyChangedBase
         }
     }
 
-    private bool _customConfig = Convert.ToBoolean(ConfigurationHelper.GetGlobalValue(ConfigurationKeys.CustomConfig, bool.FalseString));
+    private bool _customConfig = ConfigurationHelper.GetGlobalValue(ConfigurationKeys.CustomConfig, false);
 
     /// <summary>
     /// Gets or sets a value indicating whether to use custom config.

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/VersionUpdateSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/VersionUpdateSettingsUserControlModel.cs
@@ -393,7 +393,7 @@ public class VersionUpdateSettingsUserControlModel : PropertyChangedBase
         OnPropertyChanged(nameof(MirrorChyanCdkExpiredLocalTime));
     }
 
-    private bool _startupUpdateCheck = Convert.ToBoolean(ConfigurationHelper.GetGlobalValue(ConfigurationKeys.StartupUpdateCheck, bool.TrueString));
+    private bool _startupUpdateCheck = ConfigurationHelper.GetGlobalValue(ConfigurationKeys.StartupUpdateCheck, true);
 
     // UI 绑定的方法
     [UsedImplicitly]
@@ -415,7 +415,7 @@ public class VersionUpdateSettingsUserControlModel : PropertyChangedBase
         }
     }
 
-    private bool _updateAutoCheck = Convert.ToBoolean(ConfigurationHelper.GetGlobalValue(ConfigurationKeys.UpdateAutoCheck, bool.FalseString));
+    private bool _updateAutoCheck = ConfigurationHelper.GetGlobalValue(ConfigurationKeys.UpdateAutoCheck, false);
 
     /// <summary>
     /// Gets or sets a value indicating whether to check update.
@@ -473,7 +473,7 @@ public class VersionUpdateSettingsUserControlModel : PropertyChangedBase
         }
     }
 
-    private bool _autoDownloadUpdatePackage = Convert.ToBoolean(ConfigurationHelper.GetGlobalValue(ConfigurationKeys.AutoDownloadUpdatePackage, bool.TrueString));
+    private bool _autoDownloadUpdatePackage = ConfigurationHelper.GetGlobalValue(ConfigurationKeys.AutoDownloadUpdatePackage, true);
 
     /// <summary>
     /// Gets or sets a value indicating whether to auto download update package.
@@ -487,7 +487,7 @@ public class VersionUpdateSettingsUserControlModel : PropertyChangedBase
         }
     }
 
-    private bool _autoInstallUpdatePackage = Convert.ToBoolean(ConfigurationHelper.GetGlobalValue(ConfigurationKeys.AutoInstallUpdatePackage, bool.FalseString));
+    private bool _autoInstallUpdatePackage = ConfigurationHelper.GetGlobalValue(ConfigurationKeys.AutoInstallUpdatePackage, false);
 
     /// <summary>
     /// Gets or sets a value indicating whether to auto install update package.
@@ -501,7 +501,7 @@ public class VersionUpdateSettingsUserControlModel : PropertyChangedBase
         }
     }
 
-    private bool _showUpdaterConsole = Convert.ToBoolean(ConfigurationHelper.GetGlobalValue(ConfigurationKeys.ShowUpdaterConsole, bool.FalseString));
+    private bool _showUpdaterConsole = ConfigurationHelper.GetGlobalValue(ConfigurationKeys.ShowUpdaterConsole, false);
 
     /// <summary>
     /// Gets or sets a value indicating whether to show the updater console window.

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/RoguelikeSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/RoguelikeSettingsUserControlModel.cs
@@ -797,7 +797,7 @@ public class RoguelikeSettingsUserControlModel : TaskSettingsViewModel, Roguelik
         set => SetTaskConfig<RoguelikeTask>(t => t.StopWhenLevelMax == value, t => t.StopWhenLevelMax = value);
     }
 
-    private bool _roguelikeDelayAbortUntilCombatComplete = Convert.ToBoolean(ConfigurationHelper.GetValue(ConfigurationKeys.RoguelikeDelayAbortUntilCombatComplete, bool.FalseString));
+    private bool _roguelikeDelayAbortUntilCombatComplete = ConfigurationHelper.GetValue(ConfigurationKeys.RoguelikeDelayAbortUntilCombatComplete, false);
 
     /// <summary>
     /// Gets or sets a value indicating whether delay abort until battle complete

--- a/src/MaaWpfGui/Views/UI/NotifyIcon.xaml.cs
+++ b/src/MaaWpfGui/Views/UI/NotifyIcon.xaml.cs
@@ -60,7 +60,7 @@ public partial class NotifyIcon
     private void InitIcon()
     {
         notifyIcon.Icon = AppIcon.GetIcon();
-        notifyIcon.Visibility = Convert.ToBoolean(ConfigurationHelper.GetGlobalValue(ConfigurationKeys.UseTray, bool.TrueString)) ? Visibility.Visible : Visibility.Collapsed;
+        notifyIcon.Visibility = ConfigurationHelper.GetGlobalValue(ConfigurationKeys.UseTray, true) ? Visibility.Visible : Visibility.Collapsed;
 
         notifyIcon.Click += NotifyIcon_MouseClick;
         notifyIcon.MouseDoubleClick += NotifyIcon_MouseClick;


### PR DESCRIPTION
rft: 统一使用重载的 GetValue 替换 Convert.To

## Summary by Sourcery

通过在各类设置、视图模型和工具中，将手动调用的 `Convert.To*` / `Parse` 替换为强类型的 `ConfigurationHelper.GetValue` / `GetGlobalValue` 重载，实现配置值获取方式的标准化。

Enhancements:
- 通过使用类型化的 `ConfigurationHelper.GetValue` / `GetGlobalValue` 重载，而不是 `Convert.ToBoolean` / `Convert.ToInt32` / `int.Parse` / 字符串默认值，来简化布尔值和数值类型配置的初始化。
- 使托盘、窗口、睡眠管理、远程控制和更新器等行为统一采用相同的配置访问模式，从而提升一致性和可维护性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Standardize configuration value retrieval by replacing manual Convert.To*/Parse calls with strongly-typed ConfigurationHelper.GetValue/GetGlobalValue overloads across settings, view models, and utilities.

Enhancements:
- Simplify boolean and numeric configuration initialization by using typed ConfigurationHelper.GetValue/GetGlobalValue overloads instead of Convert.ToBoolean/Convert.ToInt32/int.Parse/string defaults.
- Align tray, window, sleep management, remote control, and updater behaviors to the same configuration access pattern for consistency and maintainability.

</details>