### PR TITLE
feat(changelog): 记录 MaaMacGui 子仓库更新

### DIFF
--- a/tools/ChangelogGenerator/changelog_generator.py
+++ b/tools/ChangelogGenerator/changelog_generator.py
@@ -311,46 +311,57 @@ def build_maamacgui_changelog(latest: str) -> str:
 
     workdir = f"/tmp/MaaMacGui-{os.getpid()}"
     call_command(f"rm -rf {workdir}")
-    call_command(f"git clone --no-checkout https://github.com/{maamacgui_repo}.git {workdir}")
-    call_command(f"git -C {workdir} fetch origin {old_sha} {new_sha} --depth=200")
 
-    raw_gitlogs = call_command(
-        f'git -C {workdir} log {old_sha}..{new_sha} --pretty=format:"%H%n%aN%n%cN%n%s%n%P%n"'
-    )
+    try:
+        call_command(f"git clone --no-checkout https://github.com/{maamacgui_repo}.git {workdir}")
+        call_command(f"git -C {workdir} fetch origin {old_sha} {new_sha}")
 
-    if not raw_gitlogs.strip():
-        return ""
-
-    maamacgui_commits_info = {}
-    for raw_commit_info in raw_gitlogs.split("\n\n"):
-        try:
-            commit_hash, author, committer, message, parent = raw_commit_info.split(
-                "\n"
-            )
-        except ValueError:
-            continue
-
-        message, author = format_commit_info_with_pr(maamacgui_repo, commit_hash, message, author)
-
-        maamacgui_commits_info[commit_hash] = {
-            "hash": commit_hash[:8],
-            "author": author,
-            "committer": committer,
-            "message": message,
-            "parent": parent.split(),
-        }
-
-    sorted_commits = {cat: {} for cat in ["perf", "feat", "fix", "docs", "other"]}
-    for commit_hash, commit_info in maamacgui_commits_info.items():
-        update_commits(
-            commit_info["message"], sorted_commits, {commit_hash: commit_info}
+        commit_separator = "---MAA_COMMIT_END---"
+        raw_gitlogs = call_command(
+            f'git -C {workdir} log {old_sha}..{new_sha} '
+            f'--pretty=format:"%H%n%aN%n%cN%n%s%n%P%n{commit_separator}"'
         )
 
-    maamacgui_changelog = update_message(sorted_commits, [])[0]
-    if not maamacgui_changelog.strip():
-        return ""
+        if not raw_gitlogs.strip():
+            return ""
 
-    return "\n### MaaMacGui\n" + maamacgui_changelog
+        maamacgui_commits_info = {}
+        for raw_commit_info in raw_gitlogs.split(commit_separator):
+            raw_commit_info = raw_commit_info.strip()
+            if not raw_commit_info:
+                continue
+
+            lines = raw_commit_info.split("\n")
+            if len(lines) < 5:
+                continue
+
+            commit_hash, author, committer, message, parent = lines[:5]
+
+            message, author = format_commit_info_with_pr(
+                maamacgui_repo, commit_hash, message, author
+            )
+
+            maamacgui_commits_info[commit_hash] = {
+                "hash": commit_hash[:8],
+                "author": author,
+                "committer": committer,
+                "message": message,
+                "parent": parent.split(),
+            }
+
+        sorted_commits = {cat: {} for cat in ["perf", "feat", "fix", "docs", "other"]}
+        for commit_hash, commit_info in maamacgui_commits_info.items():
+            update_commits(
+                commit_info["message"], sorted_commits, {commit_hash: commit_info}
+            )
+
+        maamacgui_changelog = update_message(sorted_commits, [])[0]
+        if not maamacgui_changelog.strip():
+            return ""
+
+        return "\n### MaaMacGui\n" + maamacgui_changelog
+    finally:
+        call_command(f"rm -rf {workdir}")
 
 def main(tag_name=None, latest=None):
     global contributors, raw_commits_info

--- a/tools/ChangelogGenerator/changelog_generator.py
+++ b/tools/ChangelogGenerator/changelog_generator.py
@@ -8,7 +8,9 @@ from enum import Enum
 from pathlib import Path
 from typing import Tuple
 
-repo = "MaaAssistantArknights/MaaAssistantArknights"  # Owner/RepoName
+repo = "MaaAssistantArknights/MaaAssistantArknights"
+maamacgui_repo = "MaaAssistantArknights/MaaMacGui"
+maamacgui_submodule_path = "src/MaaMacGui"
 cur_dir = Path(__file__).parent
 contributors_path = cur_dir / "contributors.json"
 changelog_path = cur_dir.parent.parent / "CHANGELOG.md"
@@ -237,6 +239,118 @@ def call_command(command: str):
     except:
         return bf.decode("gbk").strip()
 
+def get_submodule_sha(ref: str, path: str) -> str:
+    output = call_command(f"git ls-tree {ref} {path}")
+    if not output:
+        return ""
+
+    parts = output.split()
+    if len(parts) < 3:
+        return ""
+
+    return parts[2]
+
+
+def github_api_get(url: str):
+    try:
+        req = urllib.request.Request(url)
+        req.add_header("Accept", "application/vnd.github+json")
+        req.add_header("X-GitHub-Api-Version", "2022-11-28")
+
+        token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+        if token:
+            req.add_header("Authorization", f"Bearer {token}")
+
+        resp = retry_urlopen(req).read()
+        return json.loads(resp)
+    except Exception as e:
+        print(f"Cannot request GitHub API: {url}. ({e})")
+        return None
+
+
+def get_associated_pr(repo_name: str, commit_hash: str):
+    pulls = github_api_get(
+        f"https://api.github.com/repos/{repo_name}/commits/{commit_hash}/pulls"
+    )
+    if not pulls:
+        return None
+
+    for pull in pulls:
+        if pull.get("merged_at"):
+            return pull
+
+    return pulls[0]
+
+
+def format_commit_info_with_pr(repo_name: str, commit_hash: str, message: str, author: str):
+    pr = get_associated_pr(repo_name, commit_hash)
+    if not pr:
+        return message, author
+
+    number = pr.get("number")
+    html_url = pr.get("html_url")
+    title = pr.get("title")
+    login = pr.get("user", {}).get("login")
+
+    if number and html_url and title:
+        title = re.sub(r"\s*\(#\d+\)\s*$", "", title)
+        message = f"{title} ([#{number}]({html_url}))"
+
+    if login:
+        author = login
+
+    return message, author
+
+
+def build_maamacgui_changelog(latest: str) -> str:
+    old_sha = get_submodule_sha(latest, maamacgui_submodule_path)
+    new_sha = get_submodule_sha("HEAD", maamacgui_submodule_path)
+
+    if not old_sha or not new_sha or old_sha == new_sha:
+        return ""
+
+    workdir = f"/tmp/MaaMacGui-{os.getpid()}"
+    call_command(f"rm -rf {workdir}")
+    call_command(f"git clone --no-checkout https://github.com/{maamacgui_repo}.git {workdir}")
+    call_command(f"git -C {workdir} fetch origin {old_sha} {new_sha} --depth=200")
+
+    raw_gitlogs = call_command(
+        f'git -C {workdir} log {old_sha}..{new_sha} --pretty=format:"%H%n%aN%n%cN%n%s%n%P%n"'
+    )
+
+    if not raw_gitlogs.strip():
+        return ""
+
+    maamacgui_commits_info = {}
+    for raw_commit_info in raw_gitlogs.split("\n\n"):
+        try:
+            commit_hash, author, committer, message, parent = raw_commit_info.split(
+                "\n"
+            )
+        except ValueError:
+            continue
+
+        message, author = format_commit_info_with_pr(maamacgui_repo, commit_hash, message, author)
+
+        maamacgui_commits_info[commit_hash] = {
+            "hash": commit_hash[:8],
+            "author": author,
+            "committer": committer,
+            "message": message,
+            "parent": parent.split(),
+        }
+
+    sorted_commits = {cat: {} for cat in ["perf", "feat", "fix", "docs", "other"]}
+    for commit_hash, commit_info in maamacgui_commits_info.items():
+        update_commits(
+            commit_info["message"], sorted_commits, {commit_hash: commit_info}
+        )
+
+    maamacgui_changelog = update_message(sorted_commits, [])[0]
+    if not maamacgui_changelog.strip():
+        return ""
+
+    return "\n### MaaMacGui\n" + maamacgui_changelog
 
 def main(tag_name=None, latest=None):
     global contributors, raw_commits_info
@@ -308,6 +422,7 @@ def main(tag_name=None, latest=None):
         first_hash = list(raw_commits_info.keys())[0]
         res = print_commits(build_commits_tree(first_hash))
         changelog_content = "## " + tag_name + "\n" + res[0]
+        changelog_content += build_maamacgui_changelog(latest)
         print(changelog_content)
         with open(changelog_path, "w", encoding="utf8") as f:
             f.write(changelog_content)


### PR DESCRIPTION
## 变更内容

- 在 changelog 生成流程中补充 MaaMacGui 子仓库更新记录
- 通过对比 `latest` 与 `HEAD` 中 `src/MaaMacGui` 的 submodule commit，获取 MaaMacGui 在对应版本区间内的变更
- 将 MaaMacGui 的变更追加到生成的 `CHANGELOG.md` 中，并在 Release 说明中显示
- MaaMacGui 变更项会优先使用关联 PR 的标题、PR 链接和 PR 作者用户名

## 实现说明

- 保留原有主仓库 changelog 生成逻辑
- 新增 MaaMacGui submodule commit 范围检测
- 当 `src/MaaMacGui` 指针发生变化时，拉取 MaaMacGui 仓库并读取 `old_sha..new_sha` 的提交记录
- 通过 GitHub API 查询 commit 关联的 PR
- 使用 MaaMacGui 子仓库 PR 链接，避免 `#数字` 在主仓库 Release 页面中跳转到错误仓库
- 使用 PR 作者用户名作为贡献者显示，避免直接显示 git author name

## 测试情况

已本地测试 `v6.10.4 -> v6.10.6` 区间的 changelog 生成。

生成结果中可以正常追加 MaaMacGui 小节

<img width="642" height="567" alt="changelogmacguiadd" src="https://github.com/user-attachments/assets/472dc9ac-a189-4e05-be63-a5700e81f4fe" />

## 说明

- 本次只修改 changelog 生成脚本
- 不修改 MaaMacGui submodule 指针
- 不修改 Release workflow
- 不提交本地生成的 `CHANGELOG.md`

## 由 Sourcery 生成的摘要

扩展变更日志生成逻辑，将上一个发布版本到当前 HEAD 之间的 MaaMacGui 子模块变更也包含进来。

新功能：
- 通过对比最新版本和 HEAD 之间的 MaaMacGui 子模块提交，生成一个 MaaMacGui 专属的变更日志部分。
- 通过 GitHub API 将 MaaMacGui 的提交映射到对应的拉取请求，并在可用时使用这些 PR 的标题、链接和作者信息。

增强：
- 复用现有的提交分类逻辑，对 MaaMacGui 的变更进行分类，并将其追加到主 CHANGELOG 输出中。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extend changelog generation to include MaaMacGui submodule changes between the previous release and HEAD.

New Features:
- Generate a MaaMacGui-specific changelog section by diffing the MaaMacGui submodule commits between latest and HEAD.
- Resolve MaaMacGui commits to their associated pull requests via the GitHub API and use PR titles, links, and authors when available.

Enhancements:
- Reuse existing commit classification logic to categorize MaaMacGui changes and append them to the main CHANGELOG output.

</details>