### PR TITLE
fix: 更新检查失败时优先尝试 api2 再使用缓存

### DIFF
--- a/src/MaaWpfGui/Services/Web/MaaApiService.cs
+++ b/src/MaaWpfGui/Services/Web/MaaApiService.cs
@@ -33,7 +33,8 @@ public class MaaApiService : IMaaApiService
 
     private async Task<(bool Cached, JObject? Response)> RequestWithFallback(string api, string primaryBaseUrl, string? fallbackBaseUrl = null, bool allowFallbackToCache = true)
     {
-        var result = await TryRequest(api, primaryBaseUrl, allowFallbackToCache);
+        // 没有备用地址才会直接使用缓存
+        var result = await TryRequest(api, primaryBaseUrl, string.IsNullOrEmpty(fallbackBaseUrl) && allowFallbackToCache);
         if (result.Response != null || string.IsNullOrEmpty(fallbackBaseUrl))
         {
             return result;


### PR DESCRIPTION
本地maa版本一直没更新，发现删掉了cache就能正常查询并更新了。检查后发现是api.maa走了代理导致不通而api2直连通了。发现原先的逻辑是如果第一次检查失败就去看cache，所以导致了无法更新

## Summary by Sourcery

Bug Fixes:
- 修复当主 API 端点无法访问但备用端点可用时，由于使用过期缓存导致更新检查卡住的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix update checks getting stuck on stale cache when the primary API endpoint is unreachable but the secondary endpoint is available.

</details>