### PR TITLE
perf: NotificationImplWpf当Toast不可用时提示原因

### DIFF
--- a/src/MaaWpfGui/Helper/Notification/INotificationPoster.cs
+++ b/src/MaaWpfGui/Helper/Notification/INotificationPoster.cs
@@ -20,4 +20,6 @@ internal interface INotificationPoster
     void ShowNotification(NotificationContent content);
 
     event EventHandler<string> ActionActivated;
+
+    (bool IsAvailable, string Detail) IsNotificationAvailable { get; }
 }

--- a/src/MaaWpfGui/Helper/Notification/NotificationImplLibNotify.cs
+++ b/src/MaaWpfGui/Helper/Notification/NotificationImplLibNotify.cs
@@ -82,4 +82,6 @@ internal class NotificationImplLibNotify : INotificationPoster
             gch.Free();
         };
     }
+
+    public (bool IsAvailable, string Detail) IsNotificationAvailable => throw new NotImplementedException();
 }

--- a/src/MaaWpfGui/Helper/Notification/NotificationImplWinRT.cs
+++ b/src/MaaWpfGui/Helper/Notification/NotificationImplWinRT.cs
@@ -14,6 +14,7 @@
 using System;
 using Microsoft.Toolkit.Uwp.Notifications;
 using Serilog;
+using Windows.UI.Notifications;
 
 namespace MaaWpfGui.Helper.Notification;
 
@@ -59,6 +60,29 @@ internal class NotificationImplWinRT : INotificationPoster, IDisposable
         catch (Exception e)
         {
             _logger.Error(e, "Failed to Toast Notification.");
+        }
+    }
+
+    public (bool IsAvailable, string Detail) IsNotificationAvailable
+    {
+        get {
+            try
+            {
+                var setting = ToastNotificationManagerCompat.CreateToastNotifier().Setting;
+                return setting switch {
+                    NotificationSetting.Enabled => (true, string.Empty),
+                    NotificationSetting.DisabledForApplication => (false, LocalizationHelper.GetString("ToastNotificationUnavailable.DisabledForApplication")),
+                    NotificationSetting.DisabledForUser => (false, LocalizationHelper.GetString("ToastNotificationUnavailable.DisabledForUser")),
+                    NotificationSetting.DisabledByGroupPolicy => (false, LocalizationHelper.GetString("ToastNotificationUnavailable.DisabledByGroupPolicy")),
+                    NotificationSetting.DisabledByManifest => (false, LocalizationHelper.GetString("ToastNotificationUnavailable.DisabledByManifest")),
+                    _ => (false, $"Unknown notification setting: {setting}"),
+                };
+            }
+            catch (Exception e)
+            {
+                _logger.Error(e, "Failed to create Toast Notifier.");
+                return (false, e.Message);
+            }
         }
     }
 }

--- a/src/MaaWpfGui/Helper/Notification/NotificationImplWpf.cs
+++ b/src/MaaWpfGui/Helper/Notification/NotificationImplWpf.cs
@@ -153,4 +153,6 @@ internal class NotificationImplWpf : INotificationPoster
             // ignored
         }
     }
+
+    public (bool IsAvailable, string Detail) IsNotificationAvailable => throw new NotImplementedException();
 }

--- a/src/MaaWpfGui/Helper/ToastNotification.cs
+++ b/src/MaaWpfGui/Helper/ToastNotification.cs
@@ -74,7 +74,7 @@ public class ToastNotification : IDisposable
 
     public static (bool IsAvailable, string Detail) ToastNotificationCheck()
     {
-        if (OperatingSystem.IsWindowsVersionAtLeast(10, 0, 10240))
+        if (_notificationPoster is NotificationImplWinRT)
         {
             return _notificationPoster.IsNotificationAvailable;
         }

--- a/src/MaaWpfGui/Helper/ToastNotification.cs
+++ b/src/MaaWpfGui/Helper/ToastNotification.cs
@@ -72,6 +72,15 @@ public class ToastNotification : IDisposable
         return new NotificationImplWpf();
     }
 
+    public static (bool IsAvailable, string Detail) ToastNotificationCheck()
+    {
+        if (OperatingSystem.IsWindowsVersionAtLeast(10, 0, 10240))
+        {
+            return _notificationPoster.IsNotificationAvailable;
+        }
+        return (true, string.Empty);
+    }
+
     /// <summary>
     /// 按钮激活后的事件，参数为按钮标签
     /// </summary>
@@ -280,8 +289,7 @@ public class ToastNotification : IDisposable
     public void Show(double lifeTime = 10d, uint row = 1,
         NotificationSounds sound = NotificationSounds.Notification, params NotificationHint[] hints)
     {
-        Execute.OnUIThread(() =>
-        {
+        Execute.OnUIThread(() => {
             // TODO: 整理过时代码
             if (!ConfigFactory.Root.GUI.UseNotify)
             {

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -87,7 +87,7 @@
     <system:String x:Key="Copy">Copy</system:String>
     <!--  Toast 不可用  -->
     <system:String x:Key="ToastNotificationUnavailable">Toast 通知不可用, {0}</system:String>
-    <system:String x:Key="ToastNotificationUnavailable.DisabledForApplication">用户在设置中关闭了该应用的通知</system:String>
+    <system:String x:Key="ToastNotificationUnavailable.DisabledForApplication">用户在Windows设置中关闭了该应用的通知</system:String>
     <system:String x:Key="ToastNotificationUnavailable.DisabledForUser">用户关闭了所有应用通知</system:String>
     <system:String x:Key="ToastNotificationUnavailable.DisabledByGroupPolicy">组策略禁用</system:String>
     <system:String x:Key="ToastNotificationUnavailable.DisabledByManifest">清单禁用</system:String>

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -86,11 +86,11 @@
     <system:String x:Key="GpuAllowDeprecated">Allow deprecated GPU</system:String>
     <system:String x:Key="Copy">Copy</system:String>
     <!--  Toast 不可用  -->
-    <system:String x:Key="ToastNotificationUnavailable">Toast 通知不可用, {0}</system:String>
-    <system:String x:Key="ToastNotificationUnavailable.DisabledForApplication">用户在Windows设置中关闭了该应用的通知</system:String>
-    <system:String x:Key="ToastNotificationUnavailable.DisabledForUser">用户关闭了所有应用通知</system:String>
-    <system:String x:Key="ToastNotificationUnavailable.DisabledByGroupPolicy">组策略禁用</system:String>
-    <system:String x:Key="ToastNotificationUnavailable.DisabledByManifest">清单禁用</system:String>
+    <system:String x:Key="ToastNotificationUnavailable">Toast notifications are unavailable: {0}</system:String>
+    <system:String x:Key="ToastNotificationUnavailable.DisabledForApplication">The user has disabled notifications for this app in Windows Settings.</system:String>
+    <system:String x:Key="ToastNotificationUnavailable.DisabledForUser">The user has disabled all app notifications.</system:String>
+    <system:String x:Key="ToastNotificationUnavailable.DisabledByGroupPolicy">Group Policy Disabled</system:String>
+    <system:String x:Key="ToastNotificationUnavailable.DisabledByManifest">Manifest Disabled</system:String>
     <!--  !Toast 不可用  -->
     <!--  Settings Guide  -->
     <system:String x:Key="LeftClick">Left Click</system:String>

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -85,6 +85,13 @@
     <system:String x:Key="GpuDriverOutdatedMessage">The driver version ({1}, release date: {2}) of the selected GPU ({0}) for inference acceleration is over two years old, which may cause compatibility issues.\n\nIt is recommended to update the graphics driver or switch to a different GPU in ｢{key=Settings} - {key=PerformanceSettings}｣.</system:String>
     <system:String x:Key="GpuAllowDeprecated">Allow deprecated GPU</system:String>
     <system:String x:Key="Copy">Copy</system:String>
+    <!--  Toast 不可用  -->
+    <system:String x:Key="ToastNotificationUnavailable">Toast 通知不可用, {0}</system:String>
+    <system:String x:Key="ToastNotificationUnavailable.DisabledForApplication">用户在设置中关闭了该应用的通知</system:String>
+    <system:String x:Key="ToastNotificationUnavailable.DisabledForUser">用户关闭了所有应用通知</system:String>
+    <system:String x:Key="ToastNotificationUnavailable.DisabledByGroupPolicy">组策略禁用</system:String>
+    <system:String x:Key="ToastNotificationUnavailable.DisabledByManifest">清单禁用</system:String>
+    <!--  !Toast 不可用  -->
     <!--  Settings Guide  -->
     <system:String x:Key="LeftClick">Left Click</system:String>
     <system:String x:Key="RightClick">Right Click</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -87,7 +87,7 @@
     <system:String x:Key="Copy">コピー</system:String>
     <!--  Toast 不可用  -->
     <system:String x:Key="ToastNotificationUnavailable">Toast 通知不可用, {0}</system:String>
-    <system:String x:Key="ToastNotificationUnavailable.DisabledForApplication">用户在设置中关闭了该应用的通知</system:String>
+    <system:String x:Key="ToastNotificationUnavailable.DisabledForApplication">用户在Windows设置中关闭了该应用的通知</system:String>
     <system:String x:Key="ToastNotificationUnavailable.DisabledForUser">用户关闭了所有应用通知</system:String>
     <system:String x:Key="ToastNotificationUnavailable.DisabledByGroupPolicy">组策略禁用</system:String>
     <system:String x:Key="ToastNotificationUnavailable.DisabledByManifest">清单禁用</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -85,6 +85,13 @@
     <system:String x:Key="GpuDriverOutdatedMessage">現在選択されている推論加速 GPU（{0}）のドライバーバージョン（{1}、リリース日：{2}）は2年以上経過しており、互換性の問題が発生する可能性があります。\n\nグラフィックスドライバーを更新するか、「{key=Settings} - {key=PerformanceSettings}」で別の GPU に変更することをおすすめします。</system:String>
     <system:String x:Key="GpuAllowDeprecated">非推奨 GPU の使用を許可する</system:String>
     <system:String x:Key="Copy">コピー</system:String>
+    <!--  Toast 不可用  -->
+    <system:String x:Key="ToastNotificationUnavailable">Toast 通知不可用, {0}</system:String>
+    <system:String x:Key="ToastNotificationUnavailable.DisabledForApplication">用户在设置中关闭了该应用的通知</system:String>
+    <system:String x:Key="ToastNotificationUnavailable.DisabledForUser">用户关闭了所有应用通知</system:String>
+    <system:String x:Key="ToastNotificationUnavailable.DisabledByGroupPolicy">组策略禁用</system:String>
+    <system:String x:Key="ToastNotificationUnavailable.DisabledByManifest">清单禁用</system:String>
+    <!--  !Toast 不可用  -->
     <!--  設定ガイド  -->
     <system:String x:Key="LeftClick">左クリック</system:String>
     <system:String x:Key="RightClick">右クリック</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -86,11 +86,11 @@
     <system:String x:Key="GpuAllowDeprecated">非推奨 GPU の使用を許可する</system:String>
     <system:String x:Key="Copy">コピー</system:String>
     <!--  Toast 不可用  -->
-    <system:String x:Key="ToastNotificationUnavailable">Toast 通知不可用, {0}</system:String>
-    <system:String x:Key="ToastNotificationUnavailable.DisabledForApplication">用户在Windows设置中关闭了该应用的通知</system:String>
-    <system:String x:Key="ToastNotificationUnavailable.DisabledForUser">用户关闭了所有应用通知</system:String>
-    <system:String x:Key="ToastNotificationUnavailable.DisabledByGroupPolicy">组策略禁用</system:String>
-    <system:String x:Key="ToastNotificationUnavailable.DisabledByManifest">清单禁用</system:String>
+    <system:String x:Key="ToastNotificationUnavailable">Toast 通知は使用できません、 {0}</system:String>
+    <system:String x:Key="ToastNotificationUnavailable.DisabledForApplication">ユーザーはWindowsの設定でこのアプリの通知をオフにした</system:String>
+    <system:String x:Key="ToastNotificationUnavailable.DisabledForUser">ユーザーはすべてのアプリの通知をオフにしました</system:String>
+    <system:String x:Key="ToastNotificationUnavailable.DisabledByGroupPolicy">グループ ポリシーによって無効化されました</system:String>
+    <system:String x:Key="ToastNotificationUnavailable.DisabledByManifest">マニフェストによって無効化されました</system:String>
     <!--  !Toast 不可用  -->
     <!--  設定ガイド  -->
     <system:String x:Key="LeftClick">左クリック</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -85,6 +85,13 @@
     <system:String x:Key="GpuDriverOutdatedMessage">현재 선택된 추론 가속 GPU({0})의 드라이버 버전({1}, 릴리스 날짜: {2})이 2년 이상 경과되어 호환성 문제가 발생할 수 있습니다.\n\n그래픽 드라이버를 업데이트하거나 ｢{key=Settings} - {key=PerformanceSettings}｣ 에서 다른 GPU로 변경하는 것을 권장합니다.</system:String>
     <system:String x:Key="GpuAllowDeprecated">권장되지 않는 GPU 사용 허용</system:String>
     <system:String x:Key="Copy">복사</system:String>
+    <!--  Toast 不可用  -->
+    <system:String x:Key="ToastNotificationUnavailable">Toast 通知不可用, {0}</system:String>
+    <system:String x:Key="ToastNotificationUnavailable.DisabledForApplication">用户在设置中关闭了该应用的通知</system:String>
+    <system:String x:Key="ToastNotificationUnavailable.DisabledForUser">用户关闭了所有应用通知</system:String>
+    <system:String x:Key="ToastNotificationUnavailable.DisabledByGroupPolicy">组策略禁用</system:String>
+    <system:String x:Key="ToastNotificationUnavailable.DisabledByManifest">清单禁用</system:String>
+    <!--  !Toast 不可用  -->
     <!--  설정 가이드  -->
     <system:String x:Key="LeftClick">왼쪽 클릭</system:String>
     <system:String x:Key="RightClick">오른쪽 클릭</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -87,7 +87,7 @@
     <system:String x:Key="Copy">복사</system:String>
     <!--  Toast 不可用  -->
     <system:String x:Key="ToastNotificationUnavailable">Toast 通知不可用, {0}</system:String>
-    <system:String x:Key="ToastNotificationUnavailable.DisabledForApplication">用户在设置中关闭了该应用的通知</system:String>
+    <system:String x:Key="ToastNotificationUnavailable.DisabledForApplication">用户在Windows设置中关闭了该应用的通知</system:String>
     <system:String x:Key="ToastNotificationUnavailable.DisabledForUser">用户关闭了所有应用通知</system:String>
     <system:String x:Key="ToastNotificationUnavailable.DisabledByGroupPolicy">组策略禁用</system:String>
     <system:String x:Key="ToastNotificationUnavailable.DisabledByManifest">清单禁用</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -86,11 +86,11 @@
     <system:String x:Key="GpuAllowDeprecated">권장되지 않는 GPU 사용 허용</system:String>
     <system:String x:Key="Copy">복사</system:String>
     <!--  Toast 不可用  -->
-    <system:String x:Key="ToastNotificationUnavailable">Toast 通知不可用, {0}</system:String>
-    <system:String x:Key="ToastNotificationUnavailable.DisabledForApplication">用户在Windows设置中关闭了该应用的通知</system:String>
-    <system:String x:Key="ToastNotificationUnavailable.DisabledForUser">用户关闭了所有应用通知</system:String>
-    <system:String x:Key="ToastNotificationUnavailable.DisabledByGroupPolicy">组策略禁用</system:String>
-    <system:String x:Key="ToastNotificationUnavailable.DisabledByManifest">清单禁用</system:String>
+    <system:String x:Key="ToastNotificationUnavailable">Toast 알림을 사용할 수 없습니다, {0}</system:String>
+    <system:String x:Key="ToastNotificationUnavailable.DisabledForApplication">사용자가 Windows 설정에서 이 앱의 알림을 비활성화했습니다</system:String>
+    <system:String x:Key="ToastNotificationUnavailable.DisabledForUser">사용자가 모든 앱 알림을 비활성화했습니다</system:String>
+    <system:String x:Key="ToastNotificationUnavailable.DisabledByGroupPolicy">그룹 정책에 의해 비활성화됨</system:String>
+    <system:String x:Key="ToastNotificationUnavailable.DisabledByManifest">매니페스트에 의해 비활성화됨</system:String>
     <!--  !Toast 不可用  -->
     <!--  설정 가이드  -->
     <system:String x:Key="LeftClick">왼쪽 클릭</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -87,7 +87,7 @@
     <system:String x:Key="Copy">复制</system:String>
     <!--  Toast 不可用  -->
     <system:String x:Key="ToastNotificationUnavailable">Toast 通知不可用, {0}</system:String>
-    <system:String x:Key="ToastNotificationUnavailable.DisabledForApplication">用户在设置中关闭了该应用的通知</system:String>
+    <system:String x:Key="ToastNotificationUnavailable.DisabledForApplication">用户在Windows设置中关闭了该应用的通知</system:String>
     <system:String x:Key="ToastNotificationUnavailable.DisabledForUser">用户关闭了所有应用通知</system:String>
     <system:String x:Key="ToastNotificationUnavailable.DisabledByGroupPolicy">组策略禁用</system:String>
     <system:String x:Key="ToastNotificationUnavailable.DisabledByManifest">清单禁用</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -85,6 +85,13 @@
     <system:String x:Key="GpuDriverOutdatedMessage">当前选择的推理加速 GPU（{0}）的驱动版本（{1}，发布日期：{2}）距今已超过两年，可能存在兼容性问题。\n\n建议更新显卡驱动或前往 ｢{key=Settings} - {key=PerformanceSettings}｣ 更换其他 GPU。</system:String>
     <system:String x:Key="GpuAllowDeprecated">允许使用不推荐的 GPU</system:String>
     <system:String x:Key="Copy">复制</system:String>
+    <!--  Toast 不可用  -->
+    <system:String x:Key="ToastNotificationUnavailable">Toast 通知不可用, {0}</system:String>
+    <system:String x:Key="ToastNotificationUnavailable.DisabledForApplication">用户在设置中关闭了该应用的通知</system:String>
+    <system:String x:Key="ToastNotificationUnavailable.DisabledForUser">用户关闭了所有应用通知</system:String>
+    <system:String x:Key="ToastNotificationUnavailable.DisabledByGroupPolicy">组策略禁用</system:String>
+    <system:String x:Key="ToastNotificationUnavailable.DisabledByManifest">清单禁用</system:String>
+    <!--  !Toast 不可用  -->
     <!--  设置指引  -->
     <system:String x:Key="LeftClick">左键</system:String>
     <system:String x:Key="RightClick">右键</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -87,7 +87,7 @@
     <system:String x:Key="Copy">复制</system:String>
     <!--  Toast 不可用  -->
     <system:String x:Key="ToastNotificationUnavailable">Toast 通知不可用, {0}</system:String>
-    <system:String x:Key="ToastNotificationUnavailable.DisabledForApplication">用户在Windows设置中关闭了该应用的通知</system:String>
+    <system:String x:Key="ToastNotificationUnavailable.DisabledForApplication">用户在 Windows 设置中关闭了该应用的通知</system:String>
     <system:String x:Key="ToastNotificationUnavailable.DisabledForUser">用户关闭了所有应用通知</system:String>
     <system:String x:Key="ToastNotificationUnavailable.DisabledByGroupPolicy">组策略禁用</system:String>
     <system:String x:Key="ToastNotificationUnavailable.DisabledByManifest">清单禁用</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -87,7 +87,7 @@
     <system:String x:Key="Copy">複製</system:String>
     <!--  Toast 不可用  -->
     <system:String x:Key="ToastNotificationUnavailable">Toast 通知不可用, {0}</system:String>
-    <system:String x:Key="ToastNotificationUnavailable.DisabledForApplication">用户在设置中关闭了该应用的通知</system:String>
+    <system:String x:Key="ToastNotificationUnavailable.DisabledForApplication">用户在Windows设置中关闭了该应用的通知</system:String>
     <system:String x:Key="ToastNotificationUnavailable.DisabledForUser">用户关闭了所有应用通知</system:String>
     <system:String x:Key="ToastNotificationUnavailable.DisabledByGroupPolicy">组策略禁用</system:String>
     <system:String x:Key="ToastNotificationUnavailable.DisabledByManifest">清单禁用</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -85,6 +85,13 @@
     <system:String x:Key="GpuDriverOutdatedMessage">目前選擇的推理加速 GPU（{0}）的驅動版本（{1}，發布日期：{2}）距今已超過兩年，可能存在相容性問題。\n\n建議更新顯示卡驅動或前往 ｢{key=Settings} - {key=PerformanceSettings}｣ 更換其他 GPU。</system:String>
     <system:String x:Key="GpuAllowDeprecated">允許使用不推薦的 GPU</system:String>
     <system:String x:Key="Copy">複製</system:String>
+    <!--  Toast 不可用  -->
+    <system:String x:Key="ToastNotificationUnavailable">Toast 通知不可用, {0}</system:String>
+    <system:String x:Key="ToastNotificationUnavailable.DisabledForApplication">用户在设置中关闭了该应用的通知</system:String>
+    <system:String x:Key="ToastNotificationUnavailable.DisabledForUser">用户关闭了所有应用通知</system:String>
+    <system:String x:Key="ToastNotificationUnavailable.DisabledByGroupPolicy">组策略禁用</system:String>
+    <system:String x:Key="ToastNotificationUnavailable.DisabledByManifest">清单禁用</system:String>
+    <!--  !Toast 不可用  -->
     <!--  設定指引  -->
     <system:String x:Key="LeftClick">左鍵</system:String>
     <system:String x:Key="RightClick">右鍵</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -86,11 +86,11 @@
     <system:String x:Key="GpuAllowDeprecated">允許使用不推薦的 GPU</system:String>
     <system:String x:Key="Copy">複製</system:String>
     <!--  Toast 不可用  -->
-    <system:String x:Key="ToastNotificationUnavailable">Toast 通知不可用, {0}</system:String>
-    <system:String x:Key="ToastNotificationUnavailable.DisabledForApplication">用户在Windows设置中关闭了该应用的通知</system:String>
-    <system:String x:Key="ToastNotificationUnavailable.DisabledForUser">用户关闭了所有应用通知</system:String>
-    <system:String x:Key="ToastNotificationUnavailable.DisabledByGroupPolicy">组策略禁用</system:String>
-    <system:String x:Key="ToastNotificationUnavailable.DisabledByManifest">清单禁用</system:String>
+    <system:String x:Key="ToastNotificationUnavailable">無法使用 Toast 通知，{0}</system:String>
+    <system:String x:Key="ToastNotificationUnavailable.DisabledForApplication">使用者已在 Windows 設定中關閉此應用程式的通知</system:String>
+    <system:String x:Key="ToastNotificationUnavailable.DisabledForUser">使用者已關閉所有應用程式通知</system:String>
+    <system:String x:Key="ToastNotificationUnavailable.DisabledByGroupPolicy">遭群組原則停用</system:String>
+    <system:String x:Key="ToastNotificationUnavailable.DisabledByManifest">遭資訊清單停用</system:String>
     <!--  !Toast 不可用  -->
     <!--  設定指引  -->
     <system:String x:Key="LeftClick">左鍵</system:String>

--- a/src/MaaWpfGui/ViewModels/UI/RootViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/RootViewModel.cs
@@ -75,10 +75,25 @@ public class RootViewModel : Conductor<Screen>.Collection.OneActive
         _ = Instances.VersionUpdateDialogViewModel.ShowUpdateOrDownload();
 
         // 主窗口已显示，此时弹窗不会导致 WPF 因无窗口而退出
+        Task.Run(ConfigBrokenCheck);
+        Task.Run(ToastNotificationCheck);
+    }
+
+    private static void ConfigBrokenCheck()
+    {
         var recoveryMessage = ConfigFactory.ConsumePendingRecoveryMessage();
         if (recoveryMessage is not null)
         {
             MessageBoxHelper.Show(recoveryMessage, LocalizationHelper.GetString("ConfigurationBrokenCaption"), MessageBoxButton.OK, MessageBoxImage.Warning);
+        }
+    }
+
+    private static void ToastNotificationCheck()
+    {
+        var (isAvailable, detail) = ToastNotification.ToastNotificationCheck();
+        if (!isAvailable)
+        {
+            Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetStringFormat("ToastNotificationUnavailable", detail), UiLogColor.Error);
         }
     }
 

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -44,7 +44,6 @@ using MaaWpfGui.ViewModels.Items;
 using MaaWpfGui.ViewModels.UserControl.Settings;
 using MaaWpfGui.ViewModels.UserControl.TaskQueue;
 using MaaWpfGui.Views.Dialogs;
-using Microsoft.Toolkit.Uwp.Notifications;
 using Newtonsoft.Json.Linq;
 using Serilog;
 using Stylet;

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -44,6 +44,7 @@ using MaaWpfGui.ViewModels.Items;
 using MaaWpfGui.ViewModels.UserControl.Settings;
 using MaaWpfGui.ViewModels.UserControl.TaskQueue;
 using MaaWpfGui.Views.Dialogs;
+using Microsoft.Toolkit.Uwp.Notifications;
 using Newtonsoft.Json.Linq;
 using Serilog;
 using Stylet;

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/GuiSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/GuiSettingsUserControlModel.cs
@@ -16,6 +16,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows;
+using HandyControl.Controls;
 using MaaWpfGui.Configuration.Factory;
 using MaaWpfGui.Constants;
 using MaaWpfGui.Helper;
@@ -153,6 +154,11 @@ public class GuiSettingsUserControlModel : PropertyChangedBase
             if (value)
             {
                 ToastNotification.ShowDirect("Test test");
+                var (isAvailable, detail) = ToastNotification.ToastNotificationCheck();
+                if (!isAvailable)
+                {
+                    Growl.Error(LocalizationHelper.GetStringFormat("ToastNotificationUnavailable", detail));
+                }
             }
         }
     }


### PR DESCRIPTION
启动时:

<img width="381" height="68" alt="8_8W@4RO{`Z1}XOA855KL2T" src="https://github.com/user-attachments/assets/f14f4921-b810-498d-a2d7-7ad008346a82" />

激活通知设置时:

<img width="504" height="169" alt="{ILIVLK7CQ%JIRLWE4SAFZ2" src="https://github.com/user-attachments/assets/8e3b36a1-75e8-44db-980b-653bb1c1a296" />

- [x] zh-tw
- [ ] EN
- [x] JP
- [x] KR

@Manicsteiner @HX3N @momomochi987 @Constrat

## Summary by Sourcery

为 Windows 讯息通知（toast notifications）在不可用时新增可用性检查和面向用户的提示信息。

新功能：
- 提供一个通知可用性检查，用于报告 Windows 讯息通知是否已启用；如果未启用，则返回一条可读性良好的原因说明。
- 当讯息通知不可用时，在任务队列中记录一条启动时日志消息。
- 当用户在 GUI 设置中启用通知但系统的 toast 功能不可用时，在界面中显示错误提示 toast。

功能增强：
- 扩展通知发布接口，加入一个可报告可用性的属性，并在 WinRT 通知后端中实现。
- 为所有受支持语言添加有关 toast 通知不可用原因的本地化字符串。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add availability checks and user-facing messaging for Windows toast notifications when they are not usable.

New Features:
- Expose a notification availability check that reports whether Windows toast notifications are enabled and, if not, returns a human-readable reason.
- Log a startup message to the task queue when toast notifications are unavailable.
- Display an error toast in the GUI settings when the user enables notifications but the system toast feature is unavailable.

Enhancements:
- Extend the notification poster interface with an availability-reporting property implemented for the WinRT notification backend.
- Add localized strings for toast notification unavailability reasons across supported languages.

</details>