### PR TITLE
fix: 适配界园柳儿事件结果页

### DIFF
--- a/resource/tasks/Roguelike/JieGarden.json
+++ b/resource/tasks/Roguelike/JieGarden.json
@@ -1017,6 +1017,23 @@
             "JieGarden@Roguelike@StageEncounterSpecialClose",
             "JieGarden@Roguelike@StageCombatOpsEnter",
             "JieGarden@Roguelike@StageEmergencyOpsEnter",
+            "JieGarden@Roguelike@StageEncounterLiuerMoneyResult",
+            "JieGarden@Roguelike@ClickToDrops"
+        ]
+    },
+    "JieGarden@Roguelike@StageEncounterLiuerMoneyResult": {
+        "Doc": "柳儿事件交出木盒后的见钱问柳结果页",
+        "algorithm": "OcrDetect",
+        "action": "ClickSelf",
+        "withoutDet": true,
+        "roi": [830, 280, 450, 70],
+        "text": ["那可能是柳儿"],
+        "postDelay": 500,
+        "next": [
+            "JieGarden@Roguelike@StageEncounterOptions#next",
+            "JieGarden@Roguelike@StageEncounterSpecialClose",
+            "JieGarden@Roguelike@StageCombatOpsEnter",
+            "JieGarden@Roguelike@StageEmergencyOpsEnter",
             "JieGarden@Roguelike@ClickToDrops"
         ]
     },
@@ -1039,6 +1056,7 @@
             "JieGarden@Roguelike@StageSafeHouseReuse",
             "JieGarden@Roguelike@StageEncounterOptionLeave",
             "JieGarden@Roguelike@StageEncounterOptionWonderland",
+            "JieGarden@Roguelike@StageEncounterLiuerMoneyResult",
             "JieGarden@Roguelike@StageEncounterDrawCopperResult",
             "JieGarden@Roguelike@ChooseOperFlag",
             "JieGarden@Roguelike@CoppersTakeFlag",


### PR DESCRIPTION
## Summary

修复界园肉鸽「柳儿」事件在选择「交出木盒」后停留在「见钱问柳」结果页，最终超时触发放弃探索的问题。

Fixes #16878

## What

- 新增 JieGarden@Roguelike@StageEncounterLiuerMoneyResult 任务，通过 OCR 识别结果页右侧按钮「那可能是柳儿」。
- 将该任务加入不期而遇选项后的识别链路，并排在通用投钱结果模板之前。
- 在通用投钱结果模板命中后的 next 中补充该任务，降低误命中后继续空点的风险。

## Why

日志显示 MAA 已正确识别并点击「交出木盒」，左上角生命值消失也说明选项点击成功。问题发生在后续结果页：资源缺少「见钱问柳」结果页的专门处理，通用的投钱结果对号模板会在该页面误命中，随后进入 ClickToDrops 循环并最终走到 ExitThenAbandon。

## How

新增一个窄范围 OCR 处理任务，直接识别并点击「那可能是柳儿」按钮；同时调整 JieGarden 不期而遇结果页的识别顺序，让该专用处理优先于通用模板。

## Testing

- ConvertFrom-Json 校验 esource/tasks/Roguelike/JieGarden.json 通过。
- git diff --check -- resource/tasks/Roguelike/JieGarden.json 通过。
- 未进行模拟器实机复现测试。

## Summary by Sourcery

错误修复：
- 通过识别并点击特定的“那可能是柳儿”按钮来处理《节园》类Roguelike中柳儿事件的金钱结算页面，而不是回退到通用的金钱结算模板，从而避免误判并防止后续超时。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Handle the JieGarden roguelike Liuer event money result page by recognizing and clicking the specific "那可能是柳儿" button instead of falling back to the generic money result template, avoiding mis-detection and subsequent timeout.

</details>