### PR TITLE
fix: mask_src=true 时 mask 与 template 尺寸不符导致 OpenCV 4.11+ 崩溃

### DIFF
--- a/src/MaaCore/Vision/Matcher.cpp
+++ b/src/MaaCore/Vision/Matcher.cpp
@@ -279,7 +279,15 @@ std::vector<Matcher::RawResult> Matcher::preproc_and_match(const cv::Mat& image,
                 }
             }
             if (matched.empty()) {
-                cv::matchTemplate(image_match, templ_match, matched, match_algorithm, mask_opt.value());
+                // mask_src=true: mask is computed from the image (size == image size).
+                // cv::matchTemplate requires mask.size() == templ.size(), so passing an
+                // image-sized mask when the template is smaller crashes in OpenCV 4.11+.
+                if (!params.mask_src && mask_opt->size() == templ_match.size()) {
+                    cv::matchTemplate(image_match, templ_match, matched, match_algorithm, mask_opt.value());
+                }
+                else {
+                    cv::matchTemplate(image_match, templ_match, matched, match_algorithm);
+                }
                 match_path = MatchPath::OpenCV;
             }
         }


### PR DESCRIPTION
尝试修复一下，没有Dmp有点难以下手，6.9.3 没出现这个崩溃，这个问题有点神秘了

fix https://github.com/MaaAssistantArknights/MaaAssistantArknights/issues/16840

mask_src=true 时 calc_mask 以 image_gray 为源，生成与图像等大的 mask。 cv::matchTemplate 要求 mask.size() == templ.size()，尺寸不符在 OpenCV 4.11+ 中触发 -213 Unknown/unsupported array type 崩溃

冷却干员头像匹配（analyze_oper_with_cache）使用 mask_src=true 的 BattleAvatarCoolingData maskRange，是该路径的受害场景

修复：fallback matchTemplate 调用前检查 mask_src 与尺寸匹配，
mask_src=true 或尺寸不匹配时退化为无掩码匹配

## Summary by Sourcery

Bug Fixes:
- 当模板图像较小时，如果启用了 `mask_src` 或遮罩大小不匹配，避免将与图像同尺寸的遮罩传递给 `cv::matchTemplate`，而是回退到无遮罩匹配。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Avoid passing image-sized masks to cv::matchTemplate when the template is smaller by falling back to unmasked matching if mask_src is enabled or mask size mismatches.

</details>