### PR TITLE
将 Python 工具脚本的 shell 调用替换为 subprocess

### DIFF
--- a/tools/ChangelogGenerator/changelog_generator.py
+++ b/tools/ChangelogGenerator/changelog_generator.py
@@ -1,6 +1,7 @@
 import json
 import os
 import re
+import subprocess
 import urllib.error
 import urllib.request
 from argparse import ArgumentParser
@@ -229,12 +230,11 @@ def convert_contributors_name(name: str, commit_hash: str, name_type: str):
         return name
 
 
-def call_command(command: str):
-    with os.popen(command) as fp:
-        bf = fp._stream.buffer.read()
+def call_command(command: list[str]):
+    bf = subprocess.run(command, check=True, stdout=subprocess.PIPE).stdout
     try:
         return bf.decode().strip()
-    except:
+    except UnicodeDecodeError:
         return bf.decode("gbk").strip()
 
 
@@ -248,13 +248,13 @@ def main(tag_name=None, latest=None):
         contributors = {}
 
     if not latest:
-        latest = call_command('git describe --tags --match "v*" --abbrev=0')
+        latest = call_command(["git", "describe", "--tags", "--match", "v*", "--abbrev=0"])
     if not tag_name:
-        tag_name = call_command('git describe --tags --match "v*"')
+        tag_name = call_command(["git", "describe", "--tags", "--match", "v*"])
 
     print("From:", latest, ", To:", tag_name, "\n")
 
-    git_command = rf'git log {latest}..HEAD --pretty=format:"%H%n%aN%n%cN%n%s%n%P%n"'
+    git_command = ["git", "log", f"{latest}..HEAD", "--pretty=format:%H%n%aN%n%cN%n%s%n%P%n"]
     raw_gitlogs = call_command(git_command)
 
     raw_commits_info = {}

--- a/tools/ClangFormatter/clang-formatter.py
+++ b/tools/ClangFormatter/clang-formatter.py
@@ -1,5 +1,6 @@
 import json
 import os
+import subprocess
 from argparse import ArgumentParser
 
 
@@ -45,7 +46,7 @@ if __name__ == "__main__":
         else:
             print(f"Invalid ignore path: {ignore}")
 
-    os.system(f"{clang_format_exe} --version")
+    subprocess.run([clang_format_exe, "--version"], check=True)
 
     if not input_path:
         print("No input dir.")
@@ -67,11 +68,11 @@ if __name__ == "__main__":
                         continue
                     if os.path.splitext(file)[-1] in rule_array:
                         print(file)
-                        os.system(f'{clang_format_exe} -i -style={args.style} "{file}"')
+                        subprocess.run([clang_format_exe, "-i", f"-style={args.style}", file], check=True)
     elif os.path.isfile(input_path):
         file = input_path
         print(file)
-        os.system(f'{clang_format_exe} -i -style={args.style} "{file}"')
+        subprocess.run([clang_format_exe, "-i", f"-style={args.style}", file], check=True)
     else:
         print("Invalid input_path!")
 

--- a/tools/OptimizeTemplates/optimize_templates.py
+++ b/tools/OptimizeTemplates/optimize_templates.py
@@ -4,6 +4,7 @@ import os
 import pathlib
 import re
 import struct
+import subprocess
 from argparse import ArgumentParser
 
 import numpy as np
@@ -97,9 +98,9 @@ def update_png_with_optipng(file_path: str, perfect_pngs: dict, quiet: bool):
     input_file = output_file = file_path
     remove_auxiliary_data(input_file, output_file)
     if quiet:
-        os.system(f'optipng -quiet -o7 -zm1-9 -fix "{output_file}"')
+        subprocess.run(["optipng", "-quiet", "-o7", "-zm1-9", "-fix", output_file], check=True)
     else:
-        os.system(f'optipng -o7 -zm1-9 -fix "{output_file}"')
+        subprocess.run(["optipng", "-o7", "-zm1-9", "-fix", output_file], check=True)
 
     sz_after = os.stat(file_path).st_size
 
@@ -134,11 +135,11 @@ def update_png_with_oxipng(file_path: str, perfect_pngs: dict, quiet: bool):
     img_before = np.array(Image.open(file_path).convert("L"))
 
     if quiet:
-        os.system(f'oxipng -o max --fast -Z -s -q "{file_path}"')
-        os.system(f'oxipng -o 2 -s -q "{file_path}"')
+        subprocess.run(["oxipng", "-o", "max", "--fast", "-Z", "-s", "-q", file_path], check=True)
+        subprocess.run(["oxipng", "-o", "2", "-s", "-q", file_path], check=True)
     else:
-        os.system(f'oxipng -o max --fast -Z -s "{file_path}"')
-        os.system(f'oxipng -o 2 -s "{file_path}"')
+        subprocess.run(["oxipng", "-o", "max", "--fast", "-Z", "-s", file_path], check=True)
+        subprocess.run(["oxipng", "-o", "2", "-s", file_path], check=True)
 
     sz_after = os.stat(file_path).st_size
 

--- a/tools/RoguelikeRecruitmentTool/roguelike_recruitment_tool/main_window.py
+++ b/tools/RoguelikeRecruitmentTool/roguelike_recruitment_tool/main_window.py
@@ -1,5 +1,5 @@
-from os import system
 from pathlib import Path
+import subprocess
 
 from pydantic import ValidationError
 from PyQt5.QtCore import Qt
@@ -395,7 +395,7 @@ class MainWindow(QMainWindow):
                 with open(config_path, "w", encoding="utf-8") as fp:
                     fp.write(json_str)
                 if self.prettier_checkbox_widget.isChecked():
-                    system("prettier -w " + str(config_path))
+                    subprocess.run(["prettier", "-w", str(config_path)], check=True)
             except Exception as e:
                 self.log_widget.insertPlainText(f"Failed!")
                 self.process_exception(e, f"Error when saving {theme}")


### PR DESCRIPTION
## 概要

将 Python 工具脚本里的 shell 字符串执行替换为 `subprocess.run([...], check=True)`。

避免手动拼接命令字符串，让路径参数由 Python 直接传给子进程，`check=True` 使得外部工具执行失败会直接抛出异常，便于及时发现问题。

涉及文件：

- `tools/OptimizeTemplates/optimize_templates.py`
  - 替换 `oxipng` / `optipng` 的 `os.system(...)`
- `tools/ClangFormatter/clang-formatter.py`
  - 替换 `clang-format` 的 `os.system(...)`
- `tools/ChangelogGenerator/changelog_generator.py`
  - 将 git 命令的 `os.popen(...)` 替换为 `subprocess.run(..., stdout=subprocess.PIPE, check=True)`
- `tools/RoguelikeRecruitmentTool/roguelike_recruitment_tool/main_window.py`
  - 将内部配置维护工具中的 `system("prettier ...")` 替换为参数列表形式的 `subprocess.run(...)`

## 验证

已实际运行受影响路径：

- 对所有修改过的 Python 文件执行 `python3 -m py_compile`
- 使用 `tools/ClangFormatter/clang-formatter.py` 格式化真实 C++ 文件的临时副本
- 使用 `tools/OptimizeTemplates/optimize_templates.py` 分别执行 `oxipng` 和 `optipng` 路径，测试文件路径包含空格
- 执行 `tools/ChangelogGenerator/changelog_generator.py --base HEAD --tag HEAD`
- 调用 `ChangelogGenerator.call_command(...)` 实际执行 `git describe`
- 使用真实 `resource/roguelike/*/recruitment.json` 的临时副本调用 `RoguelikeRecruitmentTool.MainWindow.on_save(...)`，确认内部配置维护工具的 `prettier` 子进程路径执行成功

备注：`RoguelikeRecruitmentTool` 是位于 `tools/` 下的内部配置维护工具。本次验证重点是保存逻辑里的 `prettier` 调用路径，因此使用真实配置数据的临时副本直接调用 `on_save` 进行验证。
