### PR TITLE
fix: 修复 SS 复刻理智药过期天数配置不生效

### DIFF
--- a/docs/en-us/protocol/integration.md
+++ b/docs/en-us/protocol/integration.md
@@ -134,8 +134,11 @@ Currently supported stages for navigation include:
   ::: field name="medicine" type="number" optional default="0"  
   Maximum number of Sanity Potions used.  
   :::  
+  ::: field name="medicine_expire_days" type="number" optional default="0"
+  Allows using Sanity Potions that expire within this many days; `0` disables expiring Sanity Potion usage.
+  :::
   ::: field name="expiring_medicine" type="number" optional default="0"  
-  Maximum number of Sanity Potions expiring within 48 hours.  
+  Deprecated and kept only for backward compatibility; non-`0` values are treated as `medicine_expire_days = 2`.
   :::  
   ::: field name="stone" type="number" optional default="0"  
   Maximum number of Originite Prime used.  
@@ -197,7 +200,7 @@ Currently supported stages for navigation include:
    "enable": true,
    "stage": "1-7",
    "medicine": 1,
-   "expiring_medicine": 0,
+   "medicine_expire_days": 0,
    "stone": 0,
    "times": 10,
    "series": 0,

--- a/docs/ja-jp/protocol/integration.md
+++ b/docs/ja-jp/protocol/integration.md
@@ -134,8 +134,11 @@ Bilibili：`张三`、入力可能：`张三`、`张`、`三`
   ::: field name="medicine" type="number" optional default="0"  
   理性回復剤の最大使用数。  
   :::  
+  ::: field name="medicine_expire_days" type="number" optional default="0"
+  指定した日数以内に期限切れになる理性回復剤の使用を許可します。`0` は期限切れ間近の理性回復剤を使用しないことを表します。
+  :::
   ::: field name="expiring_medicine" type="number" optional default="0"  
-  48 時間以内に期限切れになる理性回復剤の最大使用数。  
+  非推奨です。旧パラメータ互換のためにのみ残されています。非 `0` の値は `medicine_expire_days = 2` として扱われます。
   :::  
   ::: field name="stone" type="number" optional default="0"  
   純正源石の最大使用数。  
@@ -197,7 +200,7 @@ Bilibili：`张三`、入力可能：`张三`、`张`、`三`
    "enable": true,
    "stage": "1-7",
    "medicine": 1,
-   "expiring_medicine": 0,
+   "medicine_expire_days": 0,
    "stone": 0,
    "times": 10,
    "series": 0,

--- a/docs/ko-kr/protocol/integration.md
+++ b/docs/ko-kr/protocol/integration.md
@@ -128,8 +128,11 @@ Bilibili 서버: `张三`인 경우 `张三`, `张`, `三` 입력 가능
 ::: field name="medicine" type="number" optional default="0"  
 이성 회복제 최대 사용 개수  
 :::  
+::: field name="medicine_expire_days" type="number" optional default="0"
+지정한 일수 이내에 만료되는 이성 회복제 사용을 허용합니다. `0`은 만료 예정 이성 회복제를 사용하지 않음을 의미합니다.
+:::
 ::: field name="expiring_medicine" type="number" optional default="0"  
-48시간 내 만료되는 이성 회복제 최대 사용 개수  
+폐기 예정이며 구형 파라미터 호환용으로만 유지됩니다. `0`이 아닌 값은 `medicine_expire_days = 2`로 처리됩니다.
 :::  
 ::: field name="stone" type="number" optional default="0"  
 오리지늄 최대 사용 개수  
@@ -184,7 +187,7 @@ Bilibili 서버: `张三`인 경우 `张三`, `张`, `三` 입력 가능
    "enable": true,
    "stage": "1-7",
    "medicine": 1,
-   "expiring_medicine": 0,
+   "medicine_expire_days": 0,
    "stone": 0,
    "times": 10,
    "series": 0,

--- a/docs/zh-cn/protocol/integration.md
+++ b/docs/zh-cn/protocol/integration.md
@@ -134,8 +134,11 @@ B服：`张三`，可输入 `张三`、`张`、`三`
   ::: field name="medicine" type="number" optional default="0"  
   最大使用理智药数量。  
   :::  
+  ::: field name="medicine_expire_days" type="number" optional default="0"
+  允许使用多少天内过期的理智药，`0` 表示不使用过期理智药。
+  :::
   ::: field name="expiring_medicine" type="number" optional default="0"  
-  最大使用 48 小时内过期理智药数量。  
+  已废弃，仅用于兼容旧参数；非 `0` 时等同于 `medicine_expire_days = 2`。
   :::  
   ::: field name="stone" type="number" optional default="0"  
   最大吃石头数量。  
@@ -197,7 +200,7 @@ B服：`张三`，可输入 `张三`、`张`、`三`
    "enable": true,
    "stage": "1-7",
    "medicine": 1,
-   "expiring_medicine": 0,
+   "medicine_expire_days": 0,
    "stone": 0,
    "times": 10,
    "series": 0,

--- a/docs/zh-tw/protocol/integration.md
+++ b/docs/zh-tw/protocol/integration.md
@@ -135,8 +135,11 @@ B 服：`張三`，可輸入 `張三`、`張`、`三`
   ::: field name="medicine" type="number" optional default="0"  
   理智藥最大使用量。  
   :::  
+  ::: field name="medicine_expire_days" type="number" optional default="0"
+  允許使用多少天內過期的理智藥，`0` 表示不使用過期理智藥。
+  :::
   ::: field name="expiring_medicine" type="number" optional default="0"  
-  48 小時內過期理智藥最大使用量。  
+  已棄用，僅用於相容舊參數；非 `0` 時等同於 `medicine_expire_days = 2`。
   :::  
   ::: field name="stone" type="number" optional default="0"  
   碎石最大數量。  
@@ -197,7 +200,7 @@ B 服：`張三`，可輸入 `張三`、`張`、`三`
    "enable": true,
    "stage": "1-7",
    "medicine": 1,
-   "expiring_medicine": 0,
+   "medicine_expire_days": 0,
    "stone": 0,
    "times": 10,
    "series": 0,

--- a/src/MaaCore/Task/Fight/SideStoryReopenTask.cpp
+++ b/src/MaaCore/Task/Fight/SideStoryReopenTask.cpp
@@ -22,9 +22,9 @@ void asst::SideStoryReopenTask::set_medicine(int medicine)
     m_medicine = medicine;
 }
 
-void asst::SideStoryReopenTask::set_expiring_medicine(int expiring_medicine)
+void asst::SideStoryReopenTask::set_medicine_expire_days(int medicine_expire_days)
 {
-    m_expiring_medicine = expiring_medicine;
+    m_medicine_expire_days = medicine_expire_days;
 }
 
 void asst::SideStoryReopenTask::set_stone(int stone)
@@ -210,7 +210,7 @@ bool asst::SideStoryReopenTask::fight(bool use_medicine, bool use_stone)
 
     auto medicine_plugin = fight_task.register_plugin<MedicineCounterTaskPlugin>();
     medicine_plugin->set_count(use_medicine ? 1 : 0);
-    medicine_plugin->set_expire_days(m_expiring_medicine);
+    medicine_plugin->set_expire_days(m_medicine_expire_days);
 
     auto plugin = fight_task.register_plugin<StageQueueMissionCompletedTaskPlugin>();
     plugin->set_drop_stats(std::move(m_drop_stats));

--- a/src/MaaCore/Task/Fight/SideStoryReopenTask.cpp
+++ b/src/MaaCore/Task/Fight/SideStoryReopenTask.cpp
@@ -210,7 +210,7 @@ bool asst::SideStoryReopenTask::fight(bool use_medicine, bool use_stone)
 
     auto medicine_plugin = fight_task.register_plugin<MedicineCounterTaskPlugin>();
     medicine_plugin->set_count(use_medicine ? 1 : 0);
-    medicine_plugin->set_expire_days(m_expiring_medicine != 0 ? 2 : 0);
+    medicine_plugin->set_expire_days(m_expiring_medicine);
 
     auto plugin = fight_task.register_plugin<StageQueueMissionCompletedTaskPlugin>();
     plugin->set_drop_stats(std::move(m_drop_stats));

--- a/src/MaaCore/Task/Fight/SideStoryReopenTask.h
+++ b/src/MaaCore/Task/Fight/SideStoryReopenTask.h
@@ -12,7 +12,7 @@ public:
 
     void set_sidestory_name(std::string sidestory_name);
     void set_medicine(int medicine);
-    void set_expiring_medicine(int expiring_medicine);
+    void set_medicine_expire_days(int medicine_expire_days);
     void set_stone(int stone);
 
     bool set_enable_penguin(bool enable);
@@ -33,7 +33,7 @@ private:
 
     std::string m_sidestory_name; // 活动名简称：IC、CW等
     int m_medicine = 0;
-    int m_expiring_medicine = 0;
+    int m_medicine_expire_days = 0;
     int m_stone = 0;
     int m_cur_medicine;               // 已使用的理智药数量，不计算临期药品。在每次任务开始前，通过clear()清空
     int m_cur_stone;                  // 已碎石数量。在每次任务开始前，通过clear()清空

--- a/src/MaaCore/Task/Interface/FightTask.cpp
+++ b/src/MaaCore/Task/Interface/FightTask.cpp
@@ -165,7 +165,7 @@ bool asst::FightTask::set_params(const json::value& params)
     m_stage_drops_plugin_ptr->set_yituliu_id(penguin_id);
 
     m_sidestory_reopen_task_ptr->set_medicine(medicine);
-    m_sidestory_reopen_task_ptr->set_expiring_medicine(medicine_expire_days);
+    m_sidestory_reopen_task_ptr->set_medicine_expire_days(medicine_expire_days);
     m_sidestory_reopen_task_ptr->set_stone(stone);
     m_sidestory_reopen_task_ptr->set_enable_penguin(enable_penguin);
     m_sidestory_reopen_task_ptr->set_penguin_id(std::move(penguin_id));

--- a/src/MaaCore/Task/Interface/FightTask.cpp
+++ b/src/MaaCore/Task/Interface/FightTask.cpp
@@ -165,7 +165,7 @@ bool asst::FightTask::set_params(const json::value& params)
     m_stage_drops_plugin_ptr->set_yituliu_id(penguin_id);
 
     m_sidestory_reopen_task_ptr->set_medicine(medicine);
-    m_sidestory_reopen_task_ptr->set_expiring_medicine(medicine_expire_days == 0 ? 0 : 9999);
+    m_sidestory_reopen_task_ptr->set_expiring_medicine(medicine_expire_days);
     m_sidestory_reopen_task_ptr->set_stone(stone);
     m_sidestory_reopen_task_ptr->set_enable_penguin(enable_penguin);
     m_sidestory_reopen_task_ptr->set_penguin_id(std::move(penguin_id));


### PR DESCRIPTION
## Summary

修复 SS 复刻关卡中，过期理智药天数配置未生效的问题。

## What

让 SS reopen 流程传递并使用 `medicine_expire_days` 的实际配置值，而不是将任意非 0 值固定折叠为 2 天。

## Why

这是把旧的 `expiring_medicine` 布尔/48h 逻辑迁移到新的 `medicine_expire_days` 可配置天数时，漏改了 SS reopen 旁路，导致它仍把任意非零配置按旧语义折叠成 2 天。

相关背景：在 [PR #13849 “feat: 新增吃指定天数过期的理智药”](https://github.com/MaaAssistantArknights/MaaAssistantArknights/pull/13849#discussion_r3092541767) 的 Copilot review 中，也提到了 `SideStoryReopenTask.cpp` 里这处 `m_expiring_medicine != 0 ? 2 : 0` 的逻辑。

## How

- `FightTask` 将解析到的 `medicine_expire_days` 原样传给 `SideStoryReopenTask`
- `SideStoryReopenTask` 将该值原样传给 `MedicineCounterTaskPlugin`
- 旧的 `expiring_medicine` 兼容逻辑保持不变，非 0 仍对应 2 天

## Testing

- `git diff --check`
- `cmake --preset windows-x64 -B build-verify-ssreopen`
- `cmake --build build-verify-ssreopen --config Release --target MaaCore --parallel 8`