### PR TITLE
fix: 调整基建干员名 OCR 区域

### DIFF
--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -2527,7 +2527,7 @@
         "algorithm": "OcrDetect",
         "text": [],
         "rectMove_Doc": "基于笑脸的位置移动",
-        "rectMove": [-8, 20, 125, 22]
+        "rectMove": [-8, 17, 130, 28]
     },
     "InfrastOperFacilityOcr": {
         "algorithm": "OcrDetect",


### PR DESCRIPTION
## 问题

#16856 中，基建办公室自定义选择乌啾时，已选中的乌啾在选人页中可能被 OCR 成“乌”，导致已有的选中识别和复核逻辑无法命中目标干员。

## 修改

- 调整 `InfrastOperNameOcr` 的笑脸锚点派生 ROI。
- 宽度增加 5，高度上下各增加 3，避免选中态干员名右侧被截断。

## 验证

- `wujiu.png` 原 ROI 复现，**确实**只读出“乌”。
- `wujiu.png` 新 ROI 可读出“乌啾”。

以下是复现用图：
<img width="1919" height="1079" alt="wujiu" src="https://github.com/user-attachments/assets/6c2d38dd-12e4-4471-b96e-e9fb5022e14d" />
- `formal_review_test.png` 真实复核截图可读出“乌啾”。

以下是新旧roi示例：
<img width="1919" height="1079" alt="new_offset_example_reads_wujiu" src="https://github.com/user-attachments/assets/c702e8aa-6538-4faa-a507-a2001e2bb766" />
<img width="1919" height="1079" alt="old_offset_example_reads_wu" src="https://github.com/user-attachments/assets/9e25ca7b-8f09-48b1-aa73-8e3baab78312" />

- `python -m json.tool resource/tasks/tasks.json` 通过。
- `git diff --check origin/dev-v2..HEAD` 通过。

fixes #16856

## Summary by Sourcery

Bug 修复：
- 通过扩展名称 OCR 区域，修复在基础设施办公室选择界面中将干员“乌啾”误识别为“乌”的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix misrecognition of the operator 乌啾 as 乌 in the infrastructure office selection screen by expanding the name OCR region.

</details>