### PR TITLE
rft: 水月萨卡兹肉鸽 关闭next弹窗

### DIFF
--- a/resource/tasks/Roguelike/JieGarden.json
+++ b/resource/tasks/Roguelike/JieGarden.json
@@ -124,7 +124,6 @@
     },
     "JieGarden@Roguelike@CloseCollectionContinue": {
         "doc": "类似招募卷奖励后点next, 后续其他执行也重构为此类",
-        "template": "JieGarden@Roguelike@CloseCollectionContinue.png",
         "action": "ClickSelf",
         "roi": [563, 486, 174, 125],
         "templThreshold": 0.95,

--- a/resource/tasks/Roguelike/Mizuki.json
+++ b/resource/tasks/Roguelike/Mizuki.json
@@ -25,7 +25,7 @@
     },
     "Mizuki@Roguelike@ChooseOper": {
         "next": [
-            "Mizuki@Roguelike@CloseCollectionContinue",
+            "Mizuki@Roguelike@ChooseOper@(Mizuki@Roguelike@CloseCollectionContinue)",
             "Mizuki@Roguelike@CloseCollectionClose",
             "Mizuki@Roguelike@ChooseOperConfirm",
             "Mizuki@Roguelike@Abandon",
@@ -52,13 +52,8 @@
         "templThreshold": 0.9,
         "roi": [549, 440, 123, 130],
         "maskRange": [100, 255],
-        "next": [
-            "Mizuki@Roguelike@StageEncounterEnter",
-            "Mizuki@Roguelike@Stages#next",
-            "Mizuki@Roguelike@DropsFlag",
-            "Mizuki@Roguelike@CloseEvent",
-            "Mizuki@Roguelike@ChooseOperFlag"
-        ]
+        "onErrorNext": ["#back"],
+        "next": ["#next"]
     },
     "Mizuki@Roguelike@CloseEvent": {
         "action": "ClickRect",
@@ -444,7 +439,7 @@
             "Mizuki@Roguelike@StageRegionalCommissioning",
             "Mizuki@Roguelike@StageGambling",
             "Mizuki@Roguelike@DiceConfirm",
-            "Mizuki@Roguelike@CloseCollectionContinue",
+            "Mizuki@Roguelike@Stages@(Mizuki@Roguelike@CloseCollectionContinue)",
             "Mizuki@Roguelike@CloseCollectionClose",
             "Mizuki@Roguelike@StageDreadfulFoe",
             "Mizuki@Roguelike@StageDreadfulFoe-5"
@@ -470,7 +465,7 @@
             "Mizuki@Roguelike@StageDreadfulFoe-5",
             "Mizuki@Roguelike@StageRegionalCommissioning",
             "Mizuki@Roguelike@DiceConfirm",
-            "Mizuki@Roguelike@CloseCollectionContinue",
+            "Mizuki@Roguelike@Stages@(Mizuki@Roguelike@CloseCollectionContinue)",
             "Mizuki@Roguelike@CloseCollectionClose"
         ],
         "onErrorNext": ["Mizuki@Roguelike@ExitThenAbandon"]
@@ -494,7 +489,7 @@
             "Mizuki@Roguelike@StageRegionalCommissioning",
             "Mizuki@Roguelike@StageGambling",
             "Mizuki@Roguelike@DiceConfirm",
-            "Mizuki@Roguelike@CloseCollectionContinue",
+            "Mizuki@Roguelike@Stages@(Mizuki@Roguelike@CloseCollectionContinue)",
             "Mizuki@Roguelike@CloseCollectionClose"
         ],
         "onErrorNext": ["Mizuki@Roguelike@ExitThenAbandon"]

--- a/resource/tasks/Roguelike/Sarkaz.json
+++ b/resource/tasks/Roguelike/Sarkaz.json
@@ -81,7 +81,7 @@
     },
     "Sarkaz@Roguelike@ChooseOper": {
         "next": [
-            "Sarkaz@Roguelike@CloseCollectionContinue",
+            "Sarkaz@Roguelike@ChooseOper@(Sarkaz@Roguelike@CloseCollectionContinue)",
             "Sarkaz@Roguelike@CloseCollectionClose",
             "Sarkaz@Roguelike@ChooseOperConfirm",
             "Sarkaz@Roguelike@ChooseOperConfirmToGiveUp",
@@ -136,15 +136,8 @@
                 [130, 130, 130]
             ]
         ],
-        "next": [
-            "Sarkaz@Roguelike@StageEncounterEnter",
-            "Sarkaz@Roguelike@Stages#next",
-            "Sarkaz@Roguelike@DropsFlag",
-            "Sarkaz@Roguelike@CloseEvent",
-            "Sarkaz@Roguelike@ChooseOperFlag",
-            "Sarkaz@Roguelike@DecreaseBurdenSwapUiToDefault1",
-            "Sarkaz@Roguelike@DecreaseBurdenSwapUiToDefault2"
-        ]
+        "onErrorNext": ["#back"],
+        "next": ["#next"]
     },
     "Sarkaz@Roguelike@CloseEvent": {
         "action": "ClickRect",
@@ -180,7 +173,7 @@
         "next": [
             "Sarkaz@Roguelike@DecreaseBurdenSwapUiToDefault1",
             "Sarkaz@Roguelike@DecreaseBurdenSwapUiToDefault2",
-            "Sarkaz@Roguelike@CloseCollectionContinue",
+            "Sarkaz@Roguelike@DecreaseBurdenChaos@(Sarkaz@Roguelike@CloseCollectionContinue)",
             "Sarkaz@Roguelike@CloseCollectionClose",
             "Sarkaz@Roguelike@DecreaseBurdenChaos"
         ]
@@ -206,7 +199,7 @@
         "next": [
             "Sarkaz@Roguelike@DecreaseBurdenSwapUiToDefault1",
             "Sarkaz@Roguelike@DecreaseBurdenSwapUiToDefault2",
-            "Sarkaz@Roguelike@CloseCollectionContinue",
+            "Sarkaz@Roguelike@DecreaseBurdenRetardation@(Sarkaz@Roguelike@CloseCollectionContinue)",
             "Sarkaz@Roguelike@CloseCollectionClose",
             "Sarkaz@Roguelike@DecreaseBurdenRetardation"
         ]
@@ -218,7 +211,7 @@
         "specificRect": [1210, 120, 0, 0],
         "next": [
             "Sarkaz@Roguelike@DecreaseBurdenSwapUiToDefault2",
-            "Sarkaz@Roguelike@CloseCollectionContinue",
+            "Sarkaz@Roguelike@DecreaseBurdenSwapUiToDefault1@(Sarkaz@Roguelike@CloseCollectionContinue)",
             "Sarkaz@Roguelike@CloseCollectionClose",
             "Sarkaz@Roguelike@DecreaseBurdenSwapUiToDefault1"
         ]
@@ -229,7 +222,7 @@
         "action": "ClickRect",
         "specificRect": [1210, 120, 0, 0],
         "next": [
-            "Sarkaz@Roguelike@CloseCollectionContinue",
+            "Sarkaz@Roguelike@DecreaseBurdenSwapUiToDefault2@(Sarkaz@Roguelike@CloseCollectionContinue)",
             "Sarkaz@Roguelike@CloseCollectionClose",
             "Sarkaz@Roguelike@DecreaseBurdenSwapUiToDefault2",
             "Sarkaz@Roguelike@DecreaseBurdenUseTheFirst"
@@ -353,7 +346,7 @@
     "Sarkaz@Roguelike@GetDropRecruit": {},
     "Sarkaz@Roguelike@GetDropSelect": {
         "next": [
-            "Sarkaz@Roguelike@CloseCollectionContinue",
+            "Sarkaz@Roguelike@GetDropSelect@(Sarkaz@Roguelike@CloseCollectionContinue)",
             "Sarkaz@Roguelike@CloseCollectionClose",
             "Sarkaz@Roguelike@GetDropSelectRecruit",
             "Sarkaz@Roguelike@GetDropSelectReward",
@@ -366,7 +359,7 @@
     "Sarkaz@Roguelike@GetDropSelectReward": {},
     "Sarkaz@Roguelike@GetDrops": {
         "next": [
-            "Sarkaz@Roguelike@CloseCollectionContinue",
+            "Sarkaz@Roguelike@GetDrops@(Sarkaz@Roguelike@CloseCollectionContinue)",
             "Sarkaz@Roguelike@CloseCollectionClose",
             "Sarkaz@Roguelike@GetDrop1",
             "Sarkaz@Roguelike@GetDrop2",
@@ -644,16 +637,10 @@
         "template": "Sarkaz@Roguelike@CloseCollectionClose.png",
         "next": ["Sarkaz@Roguelike@StageEncounterJudgeOption"]
     },
-    "Sarkaz@Roguelike@StageEncounterContinue": {
-        "Doc": "关掉进入事件可能弹出的窗口",
-        "baseTask": "Sarkaz@Roguelike@CloseCollectionContinue",
-        "template": "Sarkaz@Roguelike@CloseCollectionContinue.png",
-        "next": ["Sarkaz@Roguelike@StageEncounterJudgeOption"]
-    },
     "Sarkaz@Roguelike@StageEncounterEnter": {},
     "Sarkaz@Roguelike@StageEncounterJudgeClick2": {
         "next": [
-            "Sarkaz@Roguelike@StageEncounterContinue",
+            "Sarkaz@Roguelike@StageEncounterJudgeClick2@(Sarkaz@Roguelike@CloseCollectionContinue)",
             "Sarkaz@Roguelike@StageEncounterClose",
             "Sarkaz@Roguelike@StageEncounterJudgeOption"
         ]
@@ -908,7 +895,7 @@
         ],
         "next": [
             "Sarkaz@Roguelike@StageTraderEnter-CloseCollectionClose",
-            "Sarkaz@Roguelike@StageTraderEnter-CloseCollectionContinue",
+            "Sarkaz@Roguelike@StageTraderEnter@(Sarkaz@Roguelike@CloseCollectionContinue)",
             "Sarkaz@Roguelike@StageVerticalConfirmTrader",
             "Sarkaz@Roguelike@StageTraderEnter",
             "Sarkaz@Roguelike@StageTraderRefreshWithDice",
@@ -921,11 +908,6 @@
     "Sarkaz@Roguelike@StageTraderEnter-CloseCollectionClose": {
         "template": "Sarkaz@Roguelike@CloseCollectionClose.png",
         "baseTask": "Sarkaz@Roguelike@CloseCollectionClose",
-        "next": ["Sarkaz@Roguelike@StageTraderEnter#next"]
-    },
-    "Sarkaz@Roguelike@StageTraderEnter-CloseCollectionContinue": {
-        "template": "Sarkaz@Roguelike@CloseCollectionContinue.png",
-        "baseTask": "Sarkaz@Roguelike@CloseCollectionContinue",
         "next": ["Sarkaz@Roguelike@StageTraderEnter#next"]
     },
     "Sarkaz@Roguelike@StageTraderHD": {
@@ -972,7 +954,7 @@
         "algorithm": "JustReturn",
         "next": [
             "Sarkaz@Roguelike@NextLevel",
-            "Sarkaz@Roguelike@CloseCollectionContinue",
+            "Sarkaz@Roguelike@Stages@(Sarkaz@Roguelike@CloseCollectionContinue)",
             "Sarkaz@Roguelike@CloseCollectionClose",
             "Sarkaz@Roguelike@StageBurdenOperation#next",
             "Sarkaz@Roguelike@StageBoskyPassage",
@@ -1004,7 +986,7 @@
         "algorithm": "JustReturn",
         "next": [
             "Sarkaz@Roguelike@NextLevel",
-            "Sarkaz@Roguelike@CloseCollectionContinue",
+            "Sarkaz@Roguelike@Stages@(Sarkaz@Roguelike@CloseCollectionContinue)",
             "Sarkaz@Roguelike@CloseCollectionClose",
             "Sarkaz@Roguelike@StageBurdenOperation#next",
             "Sarkaz@Roguelike@StageBoskyPassage",
@@ -1036,7 +1018,7 @@
         "algorithm": "JustReturn",
         "next": [
             "Sarkaz@Roguelike@NextLevel",
-            "Sarkaz@Roguelike@CloseCollectionContinue",
+            "Sarkaz@Roguelike@Stages@(Sarkaz@Roguelike@CloseCollectionContinue)",
             "Sarkaz@Roguelike@CloseCollectionClose",
             "Sarkaz@Roguelike@DecreaseBurdenRetardation",
             "Sarkaz@Roguelike@Routing-FastInvestment"
@@ -1048,7 +1030,7 @@
         "algorithm": "JustReturn",
         "next": [
             "Sarkaz@Roguelike@NextLevel",
-            "Sarkaz@Roguelike@CloseCollectionContinue",
+            "Sarkaz@Roguelike@Stages@(Sarkaz@Roguelike@CloseCollectionContinue)",
             "Sarkaz@Roguelike@CloseCollectionClose",
             "Sarkaz@Roguelike@DecreaseBurdenChaos",
             "Sarkaz@Roguelike@DecreaseBurdenRetardation",
@@ -1080,7 +1062,7 @@
         "algorithm": "JustReturn",
         "next": [
             "Sarkaz@Roguelike@NextLevel",
-            "Sarkaz@Roguelike@CloseCollectionContinue",
+            "Sarkaz@Roguelike@Stages@(Sarkaz@Roguelike@CloseCollectionContinue)",
             "Sarkaz@Roguelike@CloseCollectionClose",
             "Sarkaz@Roguelike@ChooseBurdenOperatorAtStart",
             "Sarkaz@Roguelike@DecreaseBurdenChaos",


### PR DESCRIPTION
## Summary by Sourcery

调整 Mizuki 和 Sarkaz 肉鸽运行的任务配置，以在游戏过程中关闭或跳过“下一步”弹窗。

增强：
- 优化 Mizuki 肉鸽任务行为，以自动处理下一步弹窗。
- 优化 Sarkaz 肉鸽任务行为，以自动处理下一步弹窗。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust roguelike task configurations for Mizuki and Sarkaz runs to close or skip the "next" popup during gameplay.

Enhancements:
- Refine Mizuki roguelike task behavior to automatically handle the next-step popup.
- Refine Sarkaz roguelike task behavior to automatically handle the next-step popup.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

调整 Mizuki 和 Sarkaz 肉鸽运行的任务配置，以在游戏过程中关闭或跳过“下一步”弹窗。

增强：
- 优化 Mizuki 肉鸽任务行为，以自动处理下一步弹窗。
- 优化 Sarkaz 肉鸽任务行为，以自动处理下一步弹窗。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust roguelike task configurations for Mizuki and Sarkaz runs to close or skip the "next" popup during gameplay.

Enhancements:
- Refine Mizuki roguelike task behavior to automatically handle the next-step popup.
- Refine Sarkaz roguelike task behavior to automatically handle the next-step popup.

</details>

</details>