### PR TITLE
fix: 优化追加自定干员弹窗删除时的布局

### DIFF
--- a/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
@@ -120,6 +120,10 @@ public partial class CopilotViewModel : Screen
             Inited = e.NewState.Inited;
             Stopping = e.NewState.Stopping;
         };
+        UserAdditionalItems.CollectionChanged += (_, _) => {
+            NotifyOfPropertyChange(nameof(UserAdditionalGridHeight));
+            NotifyOfPropertyChange(nameof(UserAdditionalPopupVerticalOffset));
+        };
 
         var copilotTaskList = ConfigurationHelper.GetValue(ConfigurationKeys.CopilotTaskList, string.Empty);
         if (string.IsNullOrEmpty(copilotTaskList))
@@ -437,6 +441,21 @@ public partial class CopilotViewModel : Screen
     /// Gets the view models of UserAdditional items.
     /// </summary>
     public ObservableCollection<UserAdditionalItemViewModel> UserAdditionalItems { get; } = [];
+
+    private const int MaxVisibleUserAdditionalRows = 7;
+    private const double UserAdditionalRowHeight = 40;
+    private const double UserAdditionalGridExtraHeight = 70;
+    private const double UserAdditionalGridMaxHeight = UserAdditionalGridExtraHeight + (MaxVisibleUserAdditionalRows * UserAdditionalRowHeight);
+
+    public double UserAdditionalGridHeight
+    {
+        get {
+            var rows = Math.Clamp(UserAdditionalItems.Count, 1, MaxVisibleUserAdditionalRows);
+            return UserAdditionalGridExtraHeight + (rows * UserAdditionalRowHeight);
+        }
+    }
+
+    public double UserAdditionalPopupVerticalOffset => (UserAdditionalGridHeight - UserAdditionalGridMaxHeight) / 2;
 
     /// <summary>
     /// Opens the UserAdditional popup for editing.

--- a/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
@@ -443,15 +443,16 @@ public partial class CopilotViewModel : Screen
     public ObservableCollection<UserAdditionalItemViewModel> UserAdditionalItems { get; } = [];
 
     private const int MaxVisibleUserAdditionalRows = 7;
-    private const double UserAdditionalRowHeight = 40;
-    private const double UserAdditionalGridExtraHeight = 70;
-    private const double UserAdditionalGridMaxHeight = UserAdditionalGridExtraHeight + (MaxVisibleUserAdditionalRows * UserAdditionalRowHeight);
+
+    public double UserAdditionalRowHeight => 40;
+
+    public double UserAdditionalGridMaxHeight => 350;
 
     public double UserAdditionalGridHeight
     {
         get {
             var rows = Math.Clamp(UserAdditionalItems.Count, 1, MaxVisibleUserAdditionalRows);
-            return UserAdditionalGridExtraHeight + (rows * UserAdditionalRowHeight);
+            return UserAdditionalGridMaxHeight - ((MaxVisibleUserAdditionalRows - rows) * UserAdditionalRowHeight);
         }
     }
 

--- a/src/MaaWpfGui/Views/UI/CopilotView.xaml
+++ b/src/MaaWpfGui/Views/UI/CopilotView.xaml
@@ -384,7 +384,8 @@
                                     Placement="Center"
                                     PlacementTarget="{Binding ElementName=UserAdditionalButton}"
                                     PopupAnimation="Slide"
-                                    StaysOpen="False">
+                                    StaysOpen="False"
+                                    VerticalOffset="{Binding UserAdditionalPopupVerticalOffset}">
                                     <Border
                                         MaxWidth="600"
                                         MaxHeight="500"
@@ -397,7 +398,7 @@
                                             <TextBlock Margin="0,0,0,5" Text="{DynamicResource AddUserAdditional}" />
                                             <DataGrid
                                                 x:Name="UserAdditionalDataGrid"
-                                                MaxHeight="350"
+                                                Height="{Binding UserAdditionalGridHeight}"
                                                 AutoGenerateColumns="False"
                                                 Background="{DynamicResource RegionBrush}"
                                                 CanUserAddRows="False"

--- a/src/MaaWpfGui/Views/UI/CopilotView.xaml
+++ b/src/MaaWpfGui/Views/UI/CopilotView.xaml
@@ -399,6 +399,7 @@
                                             <DataGrid
                                                 x:Name="UserAdditionalDataGrid"
                                                 Height="{Binding UserAdditionalGridHeight}"
+                                                MaxHeight="{Binding UserAdditionalGridMaxHeight}"
                                                 AutoGenerateColumns="False"
                                                 Background="{DynamicResource RegionBrush}"
                                                 CanUserAddRows="False"
@@ -407,7 +408,7 @@
                                                 CanUserResizeRows="False"
                                                 HeadersVisibility="Column"
                                                 ItemsSource="{Binding UserAdditionalItems}"
-                                                RowHeight="40"
+                                                RowHeight="{Binding UserAdditionalRowHeight}"
                                                 SelectionMode="Single">
                                                 <DataGrid.RowStyle>
                                                     <Style TargetType="DataGridRow">


### PR DESCRIPTION
## 说明

优化自动战斗中“追加自定干员”弹窗的列表布局。

原逻辑中，干员列表使用 `MaxHeight` 限制高度。列表内容减少时，弹窗会按内容重新收缩并保持居中，
导致删除干员后列表项和删除按钮的位置发生跳动。

现在改为根据干员数量计算列表高度：
- 7 名以内按实际行数收缩；
- 超过 7 名后保持最大可见高度，并通过滚动查看剩余内容；
- 弹窗仍保持原有的居中定位，但根据列表高度变化调整垂直偏移，使上边缘位置保持稳定。

这样删除条目时，下方内容按行向上补位，操作列位置不会随弹窗整体居中收缩而跳动。

## 取舍

没有改为固定弹窗宽度，也没有切换到手动计算水平偏移的定位方式。
当前实现保留原有弹窗的自适应宽度和水平居中行为，只针对高度变化做补偿，改动范围更小，
也避免长干员名导致宽度变化时需要额外测量弹窗实际宽度。

## 验证

- `dotnet build src/MaaWpfGui/MaaWpfGui.csproj -c RelWithDebInfo -p:Platform=x64`

测试录像如下：

https://github.com/user-attachments/assets/192e246e-e265-4668-a8b4-a9adf073579b




Fixes #16799

## Summary by Sourcery

Bug Fixes:
- 根据条目数量动态调整 additional-operator 弹出列表的高度和垂直偏移量，以在添加或删除条目时保持弹出窗口的视觉稳定性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Adjust the additional-operator popup list height and vertical offset dynamically based on the number of items to keep the popup visually stable when adding or removing entries.

</details>