### PR TITLE
fix: screencap of foldable device

### DIFF
--- a/resource/config.json
+++ b/resource/config.json
@@ -68,9 +68,9 @@
             "chmodMinitouch": "[Adb] -s [AdbSerial] shell chmod 700 \"/data/local/tmp/[minitouchWorkingFile]\"",
             "callMinitouch": "[Adb] -s [AdbSerial] shell \"/data/local/tmp/[minitouchWorkingFile]\" -i",
             "callMaatouch": "[Adb] -s [AdbSerial] shell \"export CLASSPATH=/data/local/tmp/[minitouchWorkingFile]; app_process /data/local/tmp com.shxyke.MaaTouch.App\"",
-            "screencapRawByNC": "[Adb] -s [AdbSerial] exec-out \"screencap | nc -w 3 [NcAddress] [NcPort]\"",
-            "screencapRawWithGzip": "[Adb] -s [AdbSerial] exec-out \"screencap | gzip -1\"",
-            "screencapEncode": "[Adb] -s [AdbSerial] exec-out screencap -p",
+            "screencapRawByNC": "[Adb] -s [AdbSerial] exec-out \"screencap [ScreencapDisplayIdArg] | nc -w 3 [NcAddress] [NcPort]\"",
+            "screencapRawWithGzip": "[Adb] -s [AdbSerial] exec-out \"screencap [ScreencapDisplayIdArg] | gzip -1\"",
+            "screencapEncode": "[Adb] -s [AdbSerial] exec-out screencap [ScreencapDisplayIdArg] -p",
             "click": "[Adb] -s [AdbSerial] shell input tap [x] [y]",
             "swipe": "[Adb] -s [AdbSerial] shell input swipe [x1] [y1] [x2] [y2] [duration]",
             "input": "[Adb] -s [AdbSerial] shell input text [text]",
@@ -84,9 +84,9 @@
         {
             "configName": "CapWithShell",
             "baseConfig": "General",
-            "screencapRawByNC": "[Adb] -s [AdbSerial] shell \"screencap | nc -w 3 [NcAddress] [NcPort]\"",
-            "screencapRawWithGzip": "[Adb] -s [AdbSerial] shell \"screencap | gzip -1\"",
-            "screencapEncode": "[Adb] -s [AdbSerial] shell screencap -p"
+            "screencapRawByNC": "[Adb] -s [AdbSerial] shell \"screencap [ScreencapDisplayIdArg] | nc -w 3 [NcAddress] [NcPort]\"",
+            "screencapRawWithGzip": "[Adb] -s [AdbSerial] shell \"screencap [ScreencapDisplayIdArg] | gzip -1\"",
+            "screencapEncode": "[Adb] -s [AdbSerial] shell screencap [ScreencapDisplayIdArg] -p"
         },
         {
             "configName": "BlueStacks",
@@ -100,7 +100,7 @@
         {
             "configName": "LDPlayer",
             "baseConfig": "CapWithShell",
-            "screencapRawByNC": "[Adb] -s [AdbSerial] shell \"screencap | busybox nc -w 3 [NcAddress] [NcPort]\""
+            "screencapRawByNC": "[Adb] -s [AdbSerial] shell \"screencap [ScreencapDisplayIdArg] | busybox nc -w 3 [NcAddress] [NcPort]\""
         },
         {
             "configName": "Androws",
@@ -156,9 +156,9 @@
             "configName": "Waydroid",
             "baseConfig": "CompatPOSIXShell",
             "start": "[Adb] -s [AdbSerial] shell am start --windowingMode 4 -n [PackageName]/com.u8.sdk.U8UnityContext",
-            "screencapRawWithGzip": "[Adb] -s [AdbSerial] exec-out \"screencap 2>/dev/null | gzip -1\"",
-            "screencapEncode": "[Adb] -s [AdbSerial] exec-out \"screencap -p 2>/dev/null\"",
-            "screencapRawByNC": "[Adb] -s [AdbSerial] exec-out \"screencap 2>/dev/null | nc -w 3 [NcAddress] [NcPort]\""
+            "screencapRawWithGzip": "[Adb] -s [AdbSerial] exec-out \"screencap [ScreencapDisplayIdArg] 2>/dev/null | gzip -1\"",
+            "screencapEncode": "[Adb] -s [AdbSerial] exec-out \"screencap [ScreencapDisplayIdArg] -p 2>/dev/null\"",
+            "screencapRawByNC": "[Adb] -s [AdbSerial] exec-out \"screencap [ScreencapDisplayIdArg] 2>/dev/null | nc -w 3 [NcAddress] [NcPort]\""
         },
         {
             "configName": "AVD",

--- a/src/MaaCore/Controller/AdbController.cpp
+++ b/src/MaaCore/Controller/AdbController.cpp
@@ -1127,6 +1127,30 @@ bool asst::AdbController::connect(const std::string& adb_path, const std::string
         return false;
     }
 
+    // best-effort: read screencap default display id from help output for this run
+    {
+        const std::string screencap_help_cmd = m_conn_ctx.replace_cmd("[Adb] -s [AdbSerial] exec-out screencap --help");
+        auto screencap_help_ret = call_command(screencap_help_cmd, 10000, false /* probe only, no reconnect */);
+        if (screencap_help_ret) {
+            auto& screencap_help_str = screencap_help_ret.value();
+            convert_lf(screencap_help_str);
+
+            static const boost::regex default_display_id_regex(R"(default(?:s)?\s+to\s+([0-9]+))",
+                                                               boost::regex::icase);
+            boost::smatch match;
+            if (boost::regex_search(screencap_help_str, match, default_display_id_regex) && match.size() > 1) {
+                m_conn_ctx.screencap_display_id = match.str(1);
+                Log.info("screencap default display_id:", m_conn_ctx.screencap_display_id);
+            }
+            else {
+                Log.info("screencap default display_id not found in help output");
+            }
+        }
+        else {
+            Log.info("screencap help probe failed, continue without display_id override");
+        }
+    }
+
     // 按需获取display ID 信息
     if (!adb_cfg.display_id.empty()) {
         // [PackageName] 不参与 replace_cmd 的统一替换（保留为运行时参数）。

--- a/src/MaaCore/Controller/AdbController.h
+++ b/src/MaaCore/Controller/AdbController.h
@@ -33,6 +33,7 @@ struct AdbConnectionContext
 
     // 连接过程中获取/更新的动态状态
     std::string display_id;
+    std::string screencap_display_id;
     std::string event_id;
     std::string nc_address = "10.0.2.2";
     uint16_t nc_port = 0;
@@ -44,6 +45,7 @@ struct AdbConnectionContext
         package_name = client_type.empty() ? "" : Config.get_package_name(client_type).value_or("");
         adb_cfg = {};
         display_id.clear();
+        screencap_display_id.clear();
         event_id.clear();
         nc_address = "10.0.2.2";
         nc_port = 0;
@@ -51,12 +53,16 @@ struct AdbConnectionContext
 
     std::string replace_cmd(const std::string& cfg_cmd) const
     {
+        const std::string screencap_display_id_arg =
+            screencap_display_id.empty() ? std::string() : "-d " + screencap_display_id;
         return utils::string_replace_all(
             cfg_cmd,
             {
                 { "[Adb]", adb_path },
                 { "[AdbSerial]", address },
                 { "[DisplayId]", display_id },
+                { "[ScreencapDisplayId]", screencap_display_id },
+                { "[ScreencapDisplayIdArg]", screencap_display_id_arg },
                 { "[EventId]", event_id },
                 { "[NcPort]", std::to_string(nc_port) },
                 { "[NcAddress]", nc_address },


### PR DESCRIPTION
On Foldable devices like the Google Pixel Fold, the current MAA command will fail, because it returns the following content:

```log
adb exec-out screencap -p
[Warning] Multiple displays were found, but no display id was specified! Defaulting to the first display found, however this default is not guaranteed to be consistent across captures. A display id should be specified.
A display ID can be specified with the [-d display-id] option.
See "dumpsys SurfaceFlinger --display-id" for valid display IDs.
�PNG
...following are png binaries
```

And MAA treated the whole stdout as the PNG file. With this warning, the file no longer has a valid magic number header, and it fails.

The solution for this is to provide the `-d` display-id.

There is no way to specify "the current active display" in the `-d` flag, as I know, but it is possible to get the ID via this command:


```log
adb exec-out screencap --help

usage: screencap [-ahp] [-d display-id] [FILENAME]
   -h: this message
   -a: captures all the active displays. This appends an integer postfix to the FILENAME.
       e.g., FILENAME_0.png, FILENAME_1.png. If both -a and -d are given, it ignores -d.
   -d: specify the display ID to capture (If the id is not given, it defaults to 1000000000000000000)
       see "dumpsys SurfaceFlinger --display-id" for valid display IDs.
   -p: outputs in png format.
   --preserve-display-colors: Set to true to preserves the native display colorspace. Useful
       for mixed HDR + SDR content, using identical processing as the display's

If FILENAME ends with .png it will be saved as a png.
If FILENAME is not given, the results will be printed to stdout.
```

Where `1000000000000000000` is the current active display. (If you change the posture of the foldable screen, this ID will change when running `adb exec-out screencap --help`).

I compiled and tested on my device, and now it can connect my foldable device out of the box.

## Sourcery 总结

确保 Android screencap 命令在具有多个显示屏的设备上捕获有效图像。

错误修复：
- 通过检测并使用设备报告的默认显示屏 ID，修复可折叠设备上的 screencap 捕获问题。

功能增强：
- 为可选的 screencap 显示屏参数添加连接上下文支持，同时尽可能兼容不公开显示屏 ID 的设备。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure Android screencap commands capture a valid image on devices with multiple displays.

Bug Fixes:
- Fix screencap capture on foldable devices by detecting and using the device-reported default display ID.

Enhancements:
- Add connection-context support for optional screencap display arguments while preserving best-effort compatibility with devices that do not expose the display ID.

</details>