### PR TITLE
Revert "fix: 调整基建干员名 OCR 区域"

### DIFF
--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -2560,7 +2560,7 @@
         "algorithm": "OcrDetect",
         "text": [],
         "rectMove_Doc": "基于笑脸的位置移动",
-        "rectMove": [-8, 17, 130, 28]
+        "rectMove": [-8, 20, 125, 22]
     },
     "InfrastOperFacilityOcr": {
         "algorithm": "OcrDetect",


### PR DESCRIPTION
Reverts MaaAssistantArknights/MaaAssistantArknights#16905

Sorry, this is on me.

I re-tested the change with EN and JP screenshots . The result confirms that the shared `InfrastOperNameOcr` ROI change affects overseas clients badly. The enlarged ROI works for the CN case I was trying to fix, but it also includes extra UI edges and background noise on EN/JP operator cards, which causes OCR to produce wrong names.

So this should not have been changed as a common default task. Please revert this PR for now. If we still want to fix the CN issue later, I will prepare a narrower change that does not affect overseas resources.

Please accept my sincere apologies again for the trouble, and thanks for catching it.

## Summary by Sourcery

Bug Fixes:
- 恢复用于识别基础设施干员名称的原始 OCR ROI，以避免先前改动在英文/日文客户端上引入的识别错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Restore the original OCR ROI for infrastructure operator names to avoid misrecognition on EN/JP clients introduced by the prior change.

</details>