### PR TITLE
fix: 处理界园事件内通宝交换后的事件结束页

### DIFF
--- a/resource/tasks/Roguelike/JieGarden.json
+++ b/resource/tasks/Roguelike/JieGarden.json
@@ -155,16 +155,7 @@
         "Doc": "放弃交换通宝的确认按钮",
         "baseTask": "JieGarden@Roguelike@CoppersListDialogConfirm",
         "template": "JieGarden@Roguelike@CoppersListDialogConfirm.png",
-        "next": [
-            "JieGarden@Roguelike@CoppersEventResultClose",
-            "JieGarden@Roguelike@CoppersTakeFlag#next",
-            "#self"
-        ]
-    },
-    "JieGarden@Roguelike@CoppersEventResultClose": {
-        "Doc": "事件内处理通宝交换后，关闭事件结果页的红勾",
-        "baseTask": "JieGarden@Roguelike@CloseEvent",
-        "template": "JieGarden@Roguelike@CloseEvent.png"
+        "next": ["JieGarden@Roguelike@DropsFlag", "JieGarden@Roguelike@CloseEvent", "#self"]
     },
     "JieGarden@Roguelike@CoppersAbandonExchange": {
         "Doc": "放弃交换通宝按钮",
@@ -174,7 +165,7 @@
         "postDelay": 1000,
         "templThreshold": 0.85,
         "cache": true,
-        "next": ["JieGarden@Roguelike@CoppersAbandonConfirm", "JieGarden@Roguelike@CoppersEventResultClose", "#self"]
+        "next": ["JieGarden@Roguelike@CoppersAbandonConfirm", "#self"]
     },
     "JieGarden@Roguelike@CoppersAnalyzer-CastOCR": {
         "Doc": "通宝已投出状态识别 - 通宝已投出识别用 roi 为 通宝类型 的 Rect.move(me.roi)",
@@ -254,7 +245,6 @@
             "JieGarden@Roguelike@CloseCollectionClose",
             "JieGarden@Roguelike@CoppersExchangeConfirm@(JieGarden@Roguelike@CloseCollectionContinue)",
             "JieGarden@Roguelike@CoppersExchangeFinish",
-            "JieGarden@Roguelike@CoppersEventResultClose",
             "#self"
         ]
     },
@@ -413,7 +403,6 @@
             "JieGarden@Roguelike@CoppersTakeConfirm@(JieGarden@Roguelike@CloseCollectionContinue)",
             "JieGarden@Roguelike@CoppersExchangeFinish",
             "JieGarden@Roguelike@CoppersExchangeConfirm",
-            "JieGarden@Roguelike@CoppersEventResultClose",
             "#self"
         ]
     },

--- a/resource/tasks/Roguelike/JieGarden.json
+++ b/resource/tasks/Roguelike/JieGarden.json
@@ -155,7 +155,16 @@
         "Doc": "放弃交换通宝的确认按钮",
         "baseTask": "JieGarden@Roguelike@CoppersListDialogConfirm",
         "template": "JieGarden@Roguelike@CoppersListDialogConfirm.png",
-        "next": ["JieGarden@Roguelike@CoppersTakeFlag#next", "#self"]
+        "next": [
+            "JieGarden@Roguelike@CoppersEventResultClose",
+            "JieGarden@Roguelike@CoppersTakeFlag#next",
+            "#self"
+        ]
+    },
+    "JieGarden@Roguelike@CoppersEventResultClose": {
+        "Doc": "事件内处理通宝交换后，关闭事件结果页的红勾",
+        "baseTask": "JieGarden@Roguelike@CloseEvent",
+        "template": "JieGarden@Roguelike@CloseEvent.png"
     },
     "JieGarden@Roguelike@CoppersAbandonExchange": {
         "Doc": "放弃交换通宝按钮",
@@ -165,7 +174,7 @@
         "postDelay": 1000,
         "templThreshold": 0.85,
         "cache": true,
-        "next": ["JieGarden@Roguelike@CoppersAbandonConfirm", "#self"]
+        "next": ["JieGarden@Roguelike@CoppersAbandonConfirm", "JieGarden@Roguelike@CoppersEventResultClose", "#self"]
     },
     "JieGarden@Roguelike@CoppersAnalyzer-CastOCR": {
         "Doc": "通宝已投出状态识别 - 通宝已投出识别用 roi 为 通宝类型 的 Rect.move(me.roi)",
@@ -245,6 +254,7 @@
             "JieGarden@Roguelike@CloseCollectionClose",
             "JieGarden@Roguelike@CoppersExchangeConfirm@(JieGarden@Roguelike@CloseCollectionContinue)",
             "JieGarden@Roguelike@CoppersExchangeFinish",
+            "JieGarden@Roguelike@CoppersEventResultClose",
             "#self"
         ]
     },
@@ -403,6 +413,7 @@
             "JieGarden@Roguelike@CoppersTakeConfirm@(JieGarden@Roguelike@CloseCollectionContinue)",
             "JieGarden@Roguelike@CoppersExchangeFinish",
             "JieGarden@Roguelike@CoppersExchangeConfirm",
+            "JieGarden@Roguelike@CoppersEventResultClose",
             "#self"
         ]
     },


### PR DESCRIPTION
## 说明

修复界园肉鸽事件内进入通宝交换后，通宝交换结束可能卡在事件结果页的问题。

## 问题分析

在 issue #16925 的日志中，MAA 识别到事件“饕餮廊”，并选择了“拾钱”：

```text
[2026-05-29 16:08:30.589][INF][Px212936][Tx6672] Event: 饕餮廊 special_val 0 choose option 1
[2026-05-29 16:08:32.718][INF][Px212936][Tx6672]     Y     | 拾钱
[2026-05-29 16:08:38.729][INF][Px212936][Tx6672] asst::RoguelikeStageEncounterTaskPlugin::select_analyzed_option | Clicking option 1: 拾钱
```

选择后进入通宝交换界面。该界面顶部仍有目标生命值，因此 `RoguelikeStageEncounterTaskPlugin::select_analyzed_option()` 用 HP 消失判断选项点击成功时，会把这次点击误判为未响应：

```text
[2026-05-29 16:08:41.452][TRC][Px212936][Tx6672] match_templ | Roguelike@HpFlag.png [opencv] score: 0.983582 rect: [ 150, 10, 25, 49 ] roi: [ 70, 0, 250, 70 ]
[2026-05-29 16:08:41.497][ERR][Px212936][Tx6672] asst::RoguelikeStageEncounterTaskPlugin::select_analyzed_option | The option doesn't respond to click
```

之后任务图仍然识别到通宝交换界面，`RoguelikeCoppersTaskPlugin` 进入 EXCHANGE 模式。插件判断新通宝不值得替换已有通宝，因此走放弃交换路径：

```text
[2026-05-29 16:08:45.240][INF][Px212936][Tx6672] asst::RoguelikeCoppersTaskPlugin::verify | plugin activated for EXCHANGE mode
[2026-05-29 16:08:55.659][INF][Px212936][Tx6672]  asst::RoguelikeCoppersTaskPlugin::handle_exchange_mode new copper ( 厉-凡物变 ) is worse than all existing coppers, abandoning exchange
```

MAA 随后点击放弃交换按钮，并确认弹窗：

```text
[2026-05-29 16:08:56.363][TRC][Px212936][Tx6672] match_templ | JieGarden@Roguelike@CoppersAbandonExchange.png [opencv] score: 0.988695 rect: [ 909, 655, 126, 42 ] roi: [ 859, 605, 226, 115 ]
[2026-05-29 16:08:58.133][TRC][Px212936][Tx6672] match_templ | JieGarden@Roguelike@CoppersListDialogConfirm.png [opencv] score: 0.979145 rect: [ 881, 456, 211, 60 ] roi: [ 832, 406, 311, 160 ]
```

确认后会进入事件结果页，底部出现事件结果页红勾。原有流程里，`CoppersAbandonConfirm` 的后继虽然包含 `CloseEvent`，但**当时先匹配到了仍可见的 `CoppersAbandonExchange`，于是流程又跳回放弃交换节点**：

```text
[2026-05-29 16:08:59.735][INF][Px212936][Tx6672] {"class":"asst::ProcessTask","cur_task":"JieGarden@Roguelike@CoppersAbandonConfirm","details":{"cur_retry":0,"retry_times":20,"to_be_recognized":["JieGarden@Roguelike@CoppersAbandonExchange","JieGarden@Roguelike@DropsFlag","JieGarden@Roguelike@CloseEvent","JieGarden@Roguelike@CoppersAbandonConfirm"]},"first":["JieGarden@Roguelike@Begin"],"pre_task":"JieGarden@Roguelike@CoppersAbandonExchange","subtask":"ProcessTask","taskchain":"Roguelike","taskid":9}
[2026-05-29 16:08:59.948][TRC][Px212936][Tx6672] match_templ | JieGarden@Roguelike@CoppersAbandonExchange.png [opencv] score: 0.906022 rect: [ 909, 655, 126, 42 ] roi: [ 909, 655, 126, 42 ]
```

但 `CoppersAbandonExchange` 原有后继只包含 `CoppersAbandonConfirm` 和自身，缺少事件结果页出口。之后流程只能继续识别放弃交换相关节点，无法点击事件结果页红勾，最终重试失败：

```text
[2026-05-29 16:09:01.550][INF][Px212936][Tx6672] {"class":"asst::ProcessTask","cur_task":"JieGarden@Roguelike@CoppersAbandonExchange","details":{"cur_retry":0,"retry_times":20,"to_be_recognized":["JieGarden@Roguelike@CoppersAbandonConfirm","JieGarden@Roguelike@CoppersAbandonExchange"]},"first":["JieGarden@Roguelike@Begin"],"pre_task":"JieGarden@Roguelike@CoppersAbandonConfirm","subtask":"ProcessTask","taskchain":"Roguelike","taskid":9}
[2026-05-29 16:09:16.413][INF][Px212936][Tx6672] Assistant::append_callback | SubTaskError {"class":"asst::ProcessTask","details":{},"first":["JieGarden@Roguelike@Begin"],"pre_task":"JieGarden@Roguelike@CoppersAbandonConfirm","subtask":"ProcessTask","taskchain":"Roguelike","taskid":9,"uuid":"ae57d92209866db0"}
```

## 修改内容

调整 `CoppersAbandonConfirm` 的后继，不再复用 `CoppersTakeFlag#next`。

原流程中，`CoppersAbandonConfirm` 通过 `CoppersTakeFlag#next` 间接展开为：

```text
CoppersAbandonExchange
DropsFlag
CloseEvent
#self
```
确认放弃交换后，流程不应再次回到 `CoppersAbandonExchange`。本次改为只保留放弃确认后的合法出口：

- DropsFlag：普通通宝交换放弃后，回到掉落流程；
- CloseEvent：事件内通宝交换放弃后，关闭事件结果页；
- #self：确认弹窗尚未消失时继续等待/重试。

这样可以避免确认放弃后再次误匹配 `CoppersAbandonExchange`，从而进入只包含放弃交换相关节点的分支。

本次不新增额外事件结果页节点，也不修改交换确认路径。`CoppersTakeConfirm` / `CoppersExchangeConfirm` 的原有流程保持不变。



## 验证

- `python -m json.tool resource\tasks\Roguelike\JieGarden.json`
- `git diff --check`

## 实测验证

使用包含本修复的本地构建进行界园肉鸽实机测试。

事件内通宝交换确认路径中，MAA 在“所见”事件内进入通宝交换，确认交换后可以识别并点击事件结果页红勾，随后回到主线地图继续路线识别：

```text
740: ... "details":{"choose_option":1,"default_choose":1,"name":"所见"} ... "what":"RoguelikeEvent"
792: ... "details":{"to_discard":"衡-水生木护 (2,2)","to_pickup":"衡-霹雳"} ... "what":"RoguelikeCoppersExchangeInfo"
805: ... "task":"CoppersExchangeConfirm" ... "score":1.0,"template":"JieGarden@Roguelike@CoppersListDialogConfirm.png"
807: ... "task":"CoppersExchangeFinish" ... "score":0.902324,"text":"交换"
812: ... "task":"CloseEvent" ... "score":0.980058,"template":"JieGarden@Roguelike@CloseEvent.png"
821: ... "task":"Routing_BoskyPassage" ... "score":0.986808,"template":"JieGarden@RoguelikeMapNode-YiTrader.png"
```

同次实测中，普通通宝交换仍回到掉落流程，未受影响：

```text
317: ... "details":{"to_discard":"大炎通宝 (2,3)","to_pickup":"衡-雾凇"} ... "what":"RoguelikeCoppersExchangeInfo"
330: ... "task":"CoppersExchangeConfirm" ... "score":1.0,"template":"JieGarden@Roguelike@CoppersListDialogConfirm.png"
332: ... "task":"CoppersExchangeFinish" ... "score":0.992927,"text":"交换"
338: ... "task":"DropsFlag" ... "score":0.982643,"template":"Roguelike@DropsFlag.png"
```
完整log：
[jiegarden-coppers-event-test-20260531-032524-logs.zip](https://github.com/user-attachments/files/28428593/jiegarden-coppers-event-test-20260531-032524-logs.zip)

希望大家可以帮忙一起测测，确保稳定性。
Fixes #16925

## Summary by Sourcery

在劫园类Roguelike关卡中，处理事件中铜币交换后的事件结果界面关闭逻辑，防止在交换流程结束后卡在结果界面。

Bug Fixes:
- 修复劫园Roguelike事件在完成事件内铜币交换后卡在事件结果界面的情况；无论玩家选择进行铜币交换还是放弃铜币，都能正常退出事件结果界面。

Enhancements:
- 新增一个专用的任务节点，用于在事件中处理铜币逻辑后关闭事件结果界面，并将其接入所有相关的铜币交换与放弃流程，同时保持原有“从交换流程进入掉落流程”的正常行为不变。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle closing the event result screen after in-event copper exchanges in JieGarden roguelike runs to prevent getting stuck after exchange flows.

Bug Fixes:
- Prevent JieGarden roguelike events from getting stuck on the event result screen after completing an in-event copper exchange, regardless of whether the player exchanges or abandons the copper.

Enhancements:
- Introduce a dedicated task node for closing the event result screen after copper handling within events and wire it into all relevant copper exchange and abandon flows while preserving normal exchange-to-drops behavior.

</details>