### PR TITLE
Revert "fix: 调整基建干员名 OCR 区域"

### DIFF
--- a/resource/global/YoStarEN/resource/tasks/tasks.json
+++ b/resource/global/YoStarEN/resource/tasks/tasks.json
@@ -1259,9 +1259,6 @@
     "ShamareThumbnail3": {
         "maskRange": [1, 255]
     },
-    "InfrastOperNameOcr": {
-        "rectMove": [-8, 20, 125, 22]
-    },
     "InfrastStationedInfo": {
         "text": ["Operator", "Operato"]
     },

--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -2560,7 +2560,7 @@
         "algorithm": "OcrDetect",
         "text": [],
         "rectMove_Doc": "基于笑脸的位置移动",
-        "rectMove": [-8, 17, 130, 28]
+        "rectMove": [-8, 20, 125, 22]
     },
     "InfrastOperFacilityOcr": {
         "algorithm": "OcrDetect",


### PR DESCRIPTION
Reverts MaaAssistantArknights/MaaAssistantArknights#16905

## Summary by Sourcery

改进：
- 在 `tasks.json` 中恢复此前用于基础设施运营商名称检测的 OCR 配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Restore the prior OCR configuration for infrastructure operator name detection in tasks.json.

</details>