### PR TITLE
fix: 添加 is_amiya 方法以处理升变

### DIFF
--- a/src/MaaCore/Config/Miscellaneous/BattleDataConfig.h
+++ b/src/MaaCore/Config/Miscellaneous/BattleDataConfig.h
@@ -169,9 +169,15 @@ public:
         return get_tokens(get_role(name), name);
     }
 
+    bool is_amiya(battle::Role role, const std::string& name) const
+    {
+        return name == "阿米娅" &&
+               (role == battle::Role::Caster || role == battle::Role::Warrior || role == battle::Role::Medic);
+    }
+
     bool is_name_invalid(battle::Role role, const std::string& name) const
     {
-        return name.empty() || find_oper(role, name) == nullptr;
+        return name.empty() || (!is_amiya(role, name) && find_oper(role, name) == nullptr);
     }
 
     // Legacy wrapper (name-only). If name is ambiguous across roles, returns true.


### PR DESCRIPTION
#16084 没处理阿米娅升变，现在只要不是法术阿米娅都有问题，这个改法和原本的接口 `bool is_name_invalid(const std::string& name) const` 行为是一致的。
要不先暂时这么改着？要改 battle_data.json 的话感觉牵扯挺多的

## Summary by Sourcery

在战斗数据配置中，为提升职能后的阿米娅干员名称提供特殊校验逻辑。

Bug Fixes:
- 将提升后、非术师职能的阿米娅视为有效的干员名称，而不再标记为无效。
- 在处理阿米娅时，使名称校验行为与旧版接口保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle special-case validation for Amiya operator names across promoted roles in battle data configuration.

Bug Fixes:
- Treat promoted non-caster versions of Amiya as valid operator names instead of invalid.
- Align name validation behavior with legacy interfaces when handling Amiya.

</details>