### PR TITLE
feat: 自动公招添加'每日仅一次'选项

### DIFF
--- a/src/MaaWpfGui/Configuration/Single/MaaTask/MallTask.cs
+++ b/src/MaaWpfGui/Configuration/Single/MaaTask/MallTask.cs
@@ -60,7 +60,7 @@ public class MallTask : BaseTask
     /// <summary>
     /// Gets or sets a value indicating whether 访问好友一天仅一次
     /// </summary>
-    public bool VisitFriendsOnceADay { get; set; }
+    public bool VisitFriendsOnceADay { get; set; } = true;
 
     /// <summary>
     /// Gets or sets 上次访问好友的时间

--- a/src/MaaWpfGui/Configuration/Single/MaaTask/RecruitTask.cs
+++ b/src/MaaWpfGui/Configuration/Single/MaaTask/RecruitTask.cs
@@ -14,8 +14,10 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text.Json.Serialization;
+using MaaWpfGui.Extensions;
 using MaaWpfGui.Helper;
 using MaaWpfGui.ViewModels.UserControl.TaskQueue;
 using static MaaWpfGui.Main.AsstProxy;
@@ -106,6 +108,36 @@ public class RecruitTask : BaseTask, IJsonOnDeserialized
     /// Gets or sets 5星时间
     /// </summary>
     public int Level5Time { get; set; } = 540;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether 公招一天仅一次
+    /// </summary>
+    public bool RecruitOnceADay { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets 上次公招的时间
+    /// </summary>
+    public string RecruitLastTime { get; set; } = DateTime.UtcNow.ToYjDate().AddDays(-1).ToFormattedString();
+
+    public bool IsRecruitAvailable
+    {
+        get
+        {
+            if (!RecruitOnceADay)
+            {
+                return true;
+            }
+
+            try
+            {
+                return DateTime.UtcNow.ToYjDate() > DateTime.ParseExact(RecruitLastTime.Replace('-', '/'), "yyyy/MM/dd HH:mm:ss", CultureInfo.InvariantCulture);
+            }
+            catch
+            {
+                return true;
+            }
+        }
+    }
 
     public void OnDeserialized()
     {

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/RecruitSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/RecruitSettingsUserControlModel.cs
@@ -16,6 +16,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using MaaWpfGui.Configuration.Single.MaaTask;
+using MaaWpfGui.Extensions;
 using MaaWpfGui.Helper;
 using MaaWpfGui.Models.AsstTasks;
 using MaaWpfGui.Utilities;
@@ -273,6 +274,15 @@ public class RecruitSettingsUserControlModel : TaskSettingsViewModel, RecruitSet
     }
     #endregion 公招时间
 
+    /// <summary>
+    /// Gets or sets a value indicating whether to only recruit once a day.
+    /// </summary>
+    public bool RecruitOnceADay
+    {
+        get => GetTaskConfig<RecruitTask>().RecruitOnceADay;
+        set => SetTaskConfig<RecruitTask>(t => t.RecruitOnceADay == value, t => t.RecruitOnceADay = value);
+    }
+
     public override void RefreshUI(BaseTask baseTask)
     {
         if (baseTask is RecruitTask)
@@ -291,6 +301,14 @@ public class RecruitSettingsUserControlModel : TaskSettingsViewModel, RecruitSet
             {
                 return (null, []);
             }
+
+            if (!recruit.IsRecruitAvailable)
+            {
+                return (null, []);
+            }
+
+            // Record execution time for daily limit
+            recruit.RecruitLastTime = DateTime.UtcNow.ToYjDate().ToFormattedString();
 
             var preserveTags = recruit.PreserveTagEnabled ? RecruitTagHelper.NormalizeTagList(recruit.PreserveTagList) : [];
             var firstTags = recruit.PreferTagEnabled ? RecruitTagHelper.NormalizeTagList(recruit.Level3PreferTags) : [];

--- a/src/MaaWpfGui/Views/UserControl/TaskQueue/RecruitSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/TaskQueue/RecruitSettingsUserControl.xaml
@@ -27,6 +27,12 @@
                 hc:InfoElement.Title="{DynamicResource RecruitMaxTimes}"
                 Minimum="0"
                 Value="{Binding RecruitMaxTimes}" />
+
+            <CheckBox
+                Margin="0,10,0,5"
+                Block.TextAlignment="Left"
+                Content="{DynamicResource OnlyOnceADay}"
+                IsChecked="{Binding RecruitOnceADay}" />
         </StackPanel>
 
         <StackPanel Visibility="{c:Binding EnableAdvancedSettings, Source={x:Static ui_vms:TaskQueueViewModel.TaskSettingVisibilities}}">


### PR DESCRIPTION
为自动公招任务添加「一日只执行一次」勾选框，引用信用收支中访问好友
每日限制的相同机制实现。

勾选后（默认开启），当天已执行过公招任务时再次启动 MAA 会被自动跳过，
不会进入公招界面。日期分界为凌晨 4:00（与游戏内日替刷新时间一致）。

修改文件：
- RecruitTask.cs: 添加 RecruitOnceADay、RecruitLastTime、IsRecruitAvailable
- RecruitSettingsUserControlModel.cs: ViewModel 绑定 + 跳过逻辑
- RecruitSettingsUserControl.xaml: 添加 OnlyOnceADay 勾选框
- MallTask.cs: VisitFriendsOnceADay 默认值同步为 true

本 PR 由 AI 辅助新手完成，如有不规范之处请多包涵。

## Summary by Sourcery

为自动公招添加每日执行上限，并统一“拜访好友”任务的每日默认设置。

New Features:
- 引入一个可配置选项，使自动公招任务每天最多运行一次；当当前游戏日内该任务已执行过时，将跳过本次执行。

Enhancements:
- 记录并持久化自动公招任务的最后执行时间，根据游戏的每日重置时间强制执行“每日一次”的限制。
- 在公招设置界面中以复选框形式提供新的每日招募限制选项，并将其与底层任务配置绑定。
- 将商城任务中“拜访好友每日一次”的选项默认设为启用，以与新的公招行为保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a daily-execution limit for auto recruitment and align visit-friends daily defaults.

New Features:
- Introduce a configurable option to run the auto recruitment task at most once per day, skipping execution when it has already run for the current game day.

Enhancements:
- Track and persist the last execution time of the auto recruitment task to enforce the once-per-day limit based on the game’s daily reset time.
- Expose the new daily recruitment limit as a checkbox in the recruitment settings UI and wire it to the underlying task configuration.
- Default the visit-friends daily-once option in mall tasks to enabled to match the new recruitment behavior.

</details>