### PR TITLE
fix: 增加贸易站订单切换重试和产物确认逻辑

### DIFF
--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -3011,6 +3011,18 @@
         "roi": [1030, 220, 190, 65],
         "preDelay": 500
     },
+    "VerifyTradeOrderChangedToMoney": {
+        "baseTask": "InfrastFlagMoney",
+        "template": "InfrastTradeMoneyFlag.png",
+        "action": "DoNothing",
+        "preDelay": 500
+    },
+    "VerifyTradeOrderChangedToSyntheticJade": {
+        "baseTask": "InfrastFlagSyntheticJade",
+        "template": "InfrastTradeSyntheticJadeFlag.png",
+        "action": "DoNothing",
+        "preDelay": 500
+    },
     "InfrastAddOperatorMfgGentle": {
         "template": "AddOperatorMfgGentle.png",
         "templThreshold": 0.8,
@@ -4869,38 +4881,56 @@
         "template": "InfrastTradeSyntheticJadeFlag.png",
         "cache": true,
         "roi": [950, 585, 207, 105],
-        "next": ["ChooseMoneyOrder"],
-        "preDelay": 500
+        "maxTimes": 3,
+        "next": ["ChooseMoneyOrder", "#self"],
+        "exceededNext": ["ChooseMoneyOrder"],
+        "preDelay": 500,
+        "postDelay": 500
     },
     "ChooseMoneyOrder": {
         "action": "ClickSelf",
         "cache": true,
         "roi": [395, 150, 248, 427],
-        "next": ["ChangeOrderConfirm"],
+        "next": ["ChangeMoneyOrderConfirm"],
         "preDelay": 500,
         "Doc": "加前延时等动画结束再执行点击"
     },
-    "ChangeOrderConfirm": {
+    "ChangeMoneyOrderConfirm": {
         "algorithm": "JustReturn",
         "action": "ClickRect",
         "specificRect": [0, 0, 380, 140],
-        "next": ["ChangeOrderConfirm@LoadingText", "Stop"]
+        "maxTimes": 10,
+        "postDelay": 500,
+        "next": ["ChangeMoneyOrderConfirm@LoadingText", "VerifyTradeOrderChangedToMoney", "#self"],
+        "exceededNext": ["VerifyTradeOrderChangedToMoney"]
     },
     "ChangeToSyntheticJadeFlagOrder": {
         "action": "ClickSelf",
         "template": "InfrastTradeMoneyFlag.png",
         "cache": true,
         "roi": [950, 585, 207, 105],
-        "next": ["ChooseSyntheticJadeOrder"],
-        "preDelay": 500
+        "maxTimes": 3,
+        "next": ["ChooseSyntheticJadeOrder", "#self"],
+        "exceededNext": ["ChooseSyntheticJadeOrder"],
+        "preDelay": 500,
+        "postDelay": 500
     },
     "ChooseSyntheticJadeOrder": {
         "action": "ClickSelf",
         "cache": true,
         "roi": [635, 150, 250, 427],
-        "next": ["ChangeOrderConfirm"],
+        "next": ["ChangeSyntheticJadeOrderConfirm"],
         "preDelay": 500,
         "Doc": "加前延时等动画结束再执行点击"
+    },
+    "ChangeSyntheticJadeOrderConfirm": {
+        "algorithm": "JustReturn",
+        "action": "ClickRect",
+        "specificRect": [0, 0, 380, 140],
+        "maxTimes": 10,
+        "postDelay": 500,
+        "next": ["ChangeSyntheticJadeOrderConfirm@LoadingText", "VerifyTradeOrderChangedToSyntheticJade", "#self"],
+        "exceededNext": ["VerifyTradeOrderChangedToSyntheticJade"]
     },
     "ChooseProductList": {
         "action": "ClickRect",

--- a/src/MaaCore/Task/Infrast/InfrastProductionTask.cpp
+++ b/src/MaaCore/Task/Infrast/InfrastProductionTask.cpp
@@ -126,6 +126,32 @@ bool asst::InfrastProductionTask::change_product()
             return false;
         };
 
+    auto run_trade_order_task =
+        [&](const std::string& task_name, const std::string& verify_task_name, const std::string& target_product_key) {
+            constexpr int TradeOrderChangeMaxTimes = 3;
+            for (int retry = 0; retry < TradeOrderChangeMaxTimes; ++retry) {
+                if (retry != 0) {
+                    Matcher verify_analyzer(ctrler()->get_image());
+                    verify_analyzer.set_task_info(verify_task_name);
+                    if (verify_analyzer.analyze()) {
+                        return true;
+                    }
+                }
+
+                if (!ProcessTask(*this, { task_name }).run()) {
+                    Log.warn("change trade order failed", task_name, retry);
+                    continue;
+                }
+
+                return true;
+            }
+
+            Log.warn("failed to change trade order to target order", target_product_key);
+            json::value fail_info = basic_info_with_what("ProductChangeFail");
+            callback(AsstMsg::SubTaskExtraInfo, fail_info);
+            return false;
+        };
+
     auto customProduct = current_room_config().product;
     switch (customProduct) {
     /*制造站的产品类型*/
@@ -173,14 +199,25 @@ bool asst::InfrastProductionTask::change_product()
     }
     /*贸易站的订单类型*/
     case infrast::CustomRoomConfig::Product::LMD: {
-        ProcessTask(*this, { "ChangeToMoneyOrder" }).run();
+        if (!run_trade_order_task("ChangeToMoneyOrder", "VerifyTradeOrderChangedToMoney", "Money")) {
+            return false;
+        }
+        m_product = "Money";
+        m_is_product_incorrect = false;
         json::value callback_info = basic_info_with_what("ProductChanged");
         callback_info["details"]["product"] = "Money";
         callback(AsstMsg::SubTaskExtraInfo, callback_info);
         break;
     }
     case infrast::CustomRoomConfig::Product::Orundum: {
-        ProcessTask(*this, { "ChangeToSyntheticJadeFlagOrder" }).run();
+        if (!run_trade_order_task(
+                "ChangeToSyntheticJadeFlagOrder",
+                "VerifyTradeOrderChangedToSyntheticJade",
+                "SyntheticJade")) {
+            return false;
+        }
+        m_product = "SyntheticJade";
+        m_is_product_incorrect = false;
         json::value callback_info = basic_info_with_what("ProductChanged");
         callback_info["details"]["product"] = "SyntheticJade";
         callback(AsstMsg::SubTaskExtraInfo, callback_info);


### PR DESCRIPTION
## 问题

贸易站切换订单时，原逻辑在点完订单切换流程后就继续执行，没有复核目标订单是否真的切换成功。遇到点击未生效、确认后还在提交、或 UI 状态没有及时更新时，可能误报 `ProductChanged`，后续换人会在错误订单类型下继续执行。

## Fix

- 订单切换增加外层重试，最多 3 轮。
- 每轮开头如果不是第一轮，会先截图复核目标订单 flag；已经切换成功就直接返回。
- 点击当前订单 flag 后，不再反复点击入口，而是等待订单选择状态出现；如果订单选项没出现，再由任务链重试入口。
- 确认订单切换时增加最多 10 次重试，等待 loading 或目标订单 flag 出现。
- 确认后如果出现 `正在提交` loading，会等待 loading 结束，再继续复核目标订单。
- 只有复核到目标订单 flag 后才发送 `ProductChanged`。
- 如果 3 轮后仍无法复核成功，发送 `ProductChangeFail`，不发送 `ProductChanged`，之后继续换人和后续任务。
- 逻辑本身复用了已有模板名，所以目前不需要新增 global 模板。

确认点击重试次数设为 10 次，是为了尽量避免卡在订单选择界面。若确认始终没有生效并停留在该界面，后续无论是换人、返回键还是小房子菜单都不可见，继续流程也会失败，这没办法。

## 代码处理

`InfrastProductionTask::change_product()` 中新增贸易站订单切换封装逻辑：

- `ChangeToMoneyOrder` 对应目标复核 `VerifyTradeOrderChangedToMoney`
- `ChangeToSyntheticJadeFlagOrder` 对应目标复核 `VerifyTradeOrderChangedToSyntheticJade`

贸易站切换成功后会更新内部状态：

- `m_product = "Money"` 或 `m_product = "SyntheticJade"`
- `m_is_product_incorrect = false`
- 回调 `ProductChanged`

如果切换失败，`change_product()` 返回 `false` 并回调 `ProductChangeFail`。外层 `shift_facility_list()` 会记录 warning，但不阻断换人，继续按当前识别到的产物执行干员选择。

`tasks.json` 中拆分了确认节点：

- `ChangeMoneyOrderConfirm`
- `ChangeSyntheticJadeOrderConfirm`

这样两种订单分别可以接到各自的复核节点，避免共用确认节点后无法判断最终应该复核哪个目标订单。

## 本地测试

使用 Core runner 测试，任务为：

- 贸易站目标产物：源石碎片
- 干员：夜刀、空、慕斯

默认确认 ROI 版本：

- 当前龙门币订单被识别为不匹配
- 点击 `InfrastTradeMoneyFlag.png` 后识别到源石碎片订单选项
- 点击确认后复核到 `InfrastTradeSyntheticJadeFlag.png`
- 回调 `ProductChanged SyntheticJade`
- 任务完成

窄确认 ROI 版本：

- 第一轮确认点击 10 次后仍未复核到目标订单，进入外层重试
- 第二轮开始时重新复核当前仍为龙门币订单
- 再次选择源石碎片订单并点击确认
- 检测到 `正在提交` loading 后等待
- loading 结束后复核到 `InfrastTradeSyntheticJadeFlag.png`
- 回调 `ProductChanged SyntheticJade`
- 任务完成

对应测试日志已单独打包。
[logs-issue16928-trade-order.zip](https://github.com/user-attachments/files/28445892/logs-issue16928-trade-order.zip)


时间关系没测完全fail后继续选人，晚一点补。

Fixes #16928

## Summary by Sourcery

在基础设施生产任务中添加具有验证机制和显式成功/失败回调的稳健交易订单切换功能。

新功能：
- 引入可重用的辅助工具，用于在不同目标产品之间进行带验证的交易订单切换，并对重试次数进行上限控制。

错误修复：
- 确保在确认目标订单标识后才将变更报告为 `ProductChanged`，并在失败时标记为 `ProductChangeFail`，而不是在失败情况下继续静默执行。

改进：
- 更新交易站产品切换逻辑，使内部产品状态和正确性标志与实际订单保持同步。
- 优化交易订单确认的任务图定义，用于区分资金订单流与合成玉订单流。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add robust trade order switching with verification and explicit success/failure callbacks in infrastructure production tasks.

New Features:
- Introduce reusable helper to switch trade orders with verification and capped retries for different target products.

Bug Fixes:
- Ensure trade order change only reports ProductChanged after confirming the target order flag and mark failures as ProductChangeFail instead of proceeding silently.

Enhancements:
- Update trade station product switching to maintain internal product state and correctness flags in sync with the actual order.
- Refine task graph definitions for trade order confirmations to distinguish between money and synthetic jade order flows.

</details>