### PR TITLE
feat: 理智药过期天数支持手动输入，小时改为天

### DIFF
--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -635,7 +635,8 @@ Then delete the entries corresponding to the paths.
     <system:String x:Key="AllowUseStoneSave">Save ｢Use Originium｣</system:String>
     <system:String x:Key="AllowUseStoneSaveWarning">This function is considered dangerous. Pressing the ｢{key=Confirm}｣ button indicates that you understand and are willing to accept the potential risks.</system:String>
     <system:String x:Key="UseAlternateStage">Use alternative stage</system:String>
-    <system:String x:Key="UseExpiringMedicine">Unlimited use of expiring (&lt;N hours) sanity potion</system:String>
+    <system:String x:Key="UseExpiringMedicine">Unlimited use of sanity potion expiring in &lt;N days</system:String>
+    <system:String x:Key="MedicineExpireDaysTip">You can enter days manually. Items displayed as "N days" in-game actually have more than N days remaining and will not be used.</system:String>
     <system:String x:Key="UseExpireMedicineForActivity">Use sanity potions that expire this week within 48 hours before the activity ends</system:String>
     <system:String x:Key="NoActivity">No activity</system:String>
     <system:String x:Key="HideUnavailableStage">Hide today's not open stages</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -635,7 +635,8 @@ HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Notifications\Settin
     <system:String x:Key="AllowUseStoneSave">源石の数を割る保存状態を許可</system:String>
     <system:String x:Key="AllowUseStoneSaveWarning">この機能は危険な機能と見なされます。「{key=Confirm}」ボタンを押すと、リスクを理解し、受け入れることに同意したと見なされます。</system:String>
     <system:String x:Key="UseAlternateStage">代替ステージを選択可能にする</system:String>
-    <system:String x:Key="UseExpiringMedicine">N時間以内に期限が切れる回復剤を無制限に使用</system:String>
+    <system:String x:Key="UseExpiringMedicine">N日未満で期限が切れる回復剤を無制限に使用</system:String>
+    <system:String x:Key="MedicineExpireDaysTip">日数を手動入力できます。ゲーム内で「N日」と表示される場合、実際の残り時間はN日を超えているため、使用対象外です。</system:String>
     <system:String x:Key="UseExpireMedicineForActivity">今週中に期限切れとなる正気回復ポーションは、アクティビティ終了の48時間以内に使用してください。</system:String>
     <system:String x:Key="NoActivity">活動なし</system:String>
     <system:String x:Key="HideUnavailableStage">リストに当日開放されないステージを隠す</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -635,7 +635,8 @@ HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Notifications\Settin
     <system:String x:Key="AllowUseStoneSave">순오리지늄 사용 상태 저장 허용</system:String>
     <system:String x:Key="AllowUseStoneSaveWarning">이 기능은 위험할 수 있습니다. ｢{key=Confirm}｣ 버튼을 누르면 잠재적인 위험을 이해하고 감수하는 것으로 간주됩니다.</system:String>
     <system:String x:Key="UseAlternateStage">대체 스테이지 사용</system:String>
-    <system:String x:Key="UseExpiringMedicine">N 시간 미만 이성 회복제 사용</system:String>
+    <system:String x:Key="UseExpiringMedicine">N 일 미만 이성 회복제 사용</system:String>
+    <system:String x:Key="MedicineExpireDaysTip">수동으로 일수를 입력할 수 있습니다. 게임 내에서 "N일"로 표시되는 아이템은 실제 남은 시간이 N일을 초과하므로 사용되지 않습니다.</system:String>
     <system:String x:Key="UseExpireMedicineForActivity">이벤트 종료 48시간 전, 이번 주 만료되는 이성 회복제 사용</system:String>
     <system:String x:Key="NoActivity">활동 없음</system:String>
     <system:String x:Key="HideUnavailableStage">미개방 스테이지 숨기기</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -635,7 +635,8 @@ HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Notifications\Settin
     <system:String x:Key="AllowUseStoneSave">允许使用源石保存状态</system:String>
     <system:String x:Key="AllowUseStoneSaveWarning">该功能属于危险功能。按下 ｢{key=Confirm}｣ 键即视为你了解并愿意承担可能出现的风险。</system:String>
     <system:String x:Key="UseAlternateStage">使用备选关卡</system:String>
-    <system:String x:Key="UseExpiringMedicine">无限吃 N 小时内过期的理智药</system:String>
+    <system:String x:Key="UseExpiringMedicine">无限吃小于 N 天过期的理智药</system:String>
+    <system:String x:Key="MedicineExpireDaysTip">可手动输入天数。游戏内显示"N 天"实际剩余超过 N 天，不在使用范围内。</system:String>
     <system:String x:Key="UseExpireMedicineForActivity">活动结束前 48H 吃当周过期理智药</system:String>
     <system:String x:Key="NoActivity">暂无活动</system:String>
     <system:String x:Key="HideUnavailableStage">下拉框中隐藏当日不开放关卡</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -635,7 +635,8 @@ HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Notifications\Settin
     <system:String x:Key="AllowUseStoneSave">允許吃源石保存狀態</system:String>
     <system:String x:Key="AllowUseStoneSaveWarning">該功能屬於危險功能。按下 ｢{key=Confirm}｣ 鍵即視為您了解並願意承擔可能出現的風險。</system:String>
     <system:String x:Key="UseAlternateStage">使用備選關卡</system:String>
-    <system:String x:Key="UseExpiringMedicine">無限吃 N 小時內過期的理智藥</system:String>
+    <system:String x:Key="UseExpiringMedicine">無限吃小於 N 天過期的理智藥</system:String>
+    <system:String x:Key="MedicineExpireDaysTip">可手動輸入天數。遊戲內顯示「N 天」實際剩餘超過 N 天，不在使用範圍內。</system:String>
     <system:String x:Key="UseExpireMedicineForActivity">活動結束前 48H 吃當週過期理智藥</system:String>
     <system:String x:Key="NoActivity">暫無活動</system:String>
     <system:String x:Key="HideUnavailableStage">下拉選單中隱藏當日不開放關卡</system:String>

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/FightSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/FightSettingsUserControlModel.cs
@@ -923,13 +923,11 @@ public class FightSettingsUserControlModel : TaskSettingsViewModel, FightSetting
     }
 
     public List<GenericCombinedData<int>> MedicineExpireDayList { get; } = [
-        new() { Display = "24h x 1", Value = 1 },
-        new() { Display = "24h x 2", Value = 2 },
-        new() { Display = "24h x 3", Value = 3 },
-        new() { Display = "24h x 4", Value = 4 },
-        new() { Display = "24h x 5", Value = 5 },
-        new() { Display = "24h x 6", Value = 6 },
-        new() { Display = "24h x 7", Value = 7 },
+        new() { Display = "1", Value = 1 },
+        new() { Display = "2", Value = 2 },
+        new() { Display = "7", Value = 7 },
+        new() { Display = "14", Value = 14 },
+        new() { Display = "21", Value = 21 },
     ];
 
     public int MedicineExpireDays
@@ -939,6 +937,36 @@ public class FightSettingsUserControlModel : TaskSettingsViewModel, FightSetting
             SetTaskConfig<FightTask>(t => t.MedicineExpireDays == value, t => t.MedicineExpireDays = value);
             SetFightParams();
         }
+    }
+
+    /// <summary>
+    /// Gets or sets 到期药物天数文本，用于可编辑下拉框的手动输入。
+    /// </summary>
+    public string MedicineExpireDaysText { get => field; set => SetAndNotify(ref field, value); } = string.Empty;
+
+    // UI 绑定的方法
+    [UsedImplicitly]
+    public void MedicineExpireDaysDropDownClosed()
+    {
+        if (MedicineExpireDayList.FirstOrDefault(i => i.Display == MedicineExpireDaysText) is { } item)
+        {
+            MedicineExpireDays = item.Value;
+        }
+        else if (int.TryParse(MedicineExpireDaysText, out var days) && days > 0)
+        {
+            MedicineExpireDays = days;
+            MedicineExpireDaysText = days.ToString();
+        }
+        else
+        {
+            RefreshMedicineExpireDaysText();
+        }
+    }
+
+    private void RefreshMedicineExpireDaysText()
+    {
+        var days = GetTaskConfig<FightTask>().MedicineExpireDays;
+        MedicineExpireDaysText = MedicineExpireDayList.FirstOrDefault(i => i.Value == days)?.Display ?? days.ToString();
     }
 
     public bool UseExpireMedicineForActivity
@@ -1073,6 +1101,7 @@ public class FightSettingsUserControlModel : TaskSettingsViewModel, FightSetting
         RefreshCurrentStagePlan();
         RefreshWeeklySchedule();
         RefreshDropName();
+        RefreshMedicineExpireDaysText();
         NotifySpecifiedDropsStateChanged();
         Refresh();
     }

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/FightSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/FightSettingsUserControlModel.cs
@@ -939,36 +939,6 @@ public class FightSettingsUserControlModel : TaskSettingsViewModel, FightSetting
         }
     }
 
-    /// <summary>
-    /// Gets or sets 到期药物天数文本，用于可编辑下拉框的手动输入。
-    /// </summary>
-    public string MedicineExpireDaysText { get => field; set => SetAndNotify(ref field, value); } = string.Empty;
-
-    // UI 绑定的方法
-    [UsedImplicitly]
-    public void MedicineExpireDaysDropDownClosed()
-    {
-        if (MedicineExpireDayList.FirstOrDefault(i => i.Display == MedicineExpireDaysText) is { } item)
-        {
-            MedicineExpireDays = item.Value;
-        }
-        else if (int.TryParse(MedicineExpireDaysText, out var days) && days > 0)
-        {
-            MedicineExpireDays = days;
-            MedicineExpireDaysText = days.ToString();
-        }
-        else
-        {
-            RefreshMedicineExpireDaysText();
-        }
-    }
-
-    private void RefreshMedicineExpireDaysText()
-    {
-        var days = GetTaskConfig<FightTask>().MedicineExpireDays;
-        MedicineExpireDaysText = MedicineExpireDayList.FirstOrDefault(i => i.Value == days)?.Display ?? days.ToString();
-    }
-
     public bool UseExpireMedicineForActivity
     {
         get => GetTaskConfig<FightTask>().UseExpireMedicineForActivity;
@@ -1101,7 +1071,6 @@ public class FightSettingsUserControlModel : TaskSettingsViewModel, FightSetting
         RefreshCurrentStagePlan();
         RefreshWeeklySchedule();
         RefreshDropName();
-        RefreshMedicineExpireDaysText();
         NotifySpecifiedDropsStateChanged();
         Refresh();
     }

--- a/src/MaaWpfGui/Views/UserControl/TaskQueue/FightSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/TaskQueue/FightSettingsUserControl.xaml
@@ -447,19 +447,15 @@
                 Orientation="Horizontal"
                 Visibility="{c:Binding UseExpiringMedicine}">
                 <controls:TextBlock Margin="4,0,7.5,0" Text="└" />
-                <hc:ComboBox
+                <hc:NumericUpDown
+                    Width="60"
                     Height="30"
-                    d:IsHitTestVisible="True"
-                    DisplayMemberPath="Display"
-                    DropDownClosed="{s:Action MedicineExpireDaysDropDownClosed}"
-                    IsEditable="True"
-                    IsTextSearchEnabled="False"
-                    ItemsSource="{Binding MedicineExpireDayList}"
-                    Loaded="{s:Action MakeComboBoxSearchable,
-                                      Target={x:Type ui_vms:SettingsViewModel}}"
-                    SelectedValue="{Binding MedicineExpireDays}"
-                    SelectedValuePath="Value"
-                    Text="{Binding MedicineExpireDaysText, UpdateSourceTrigger=PropertyChanged}" />
+                    HorizontalAlignment="Left"
+                    HorizontalContentAlignment="Center"
+                    VerticalContentAlignment="Center"
+                    Maximum="30"
+                    Minimum="1"
+                    Value="{Binding MedicineExpireDays, UpdateSourceTrigger=PropertyChanged}" />
                 <controls:TooltipBlock TooltipText="{DynamicResource MedicineExpireDaysTip}" />
             </StackPanel>
             <CheckBox Margin="0,10" IsChecked="{Binding UseExpireMedicineForActivity}">

--- a/src/MaaWpfGui/Views/UserControl/TaskQueue/FightSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/TaskQueue/FightSettingsUserControl.xaml
@@ -451,9 +451,16 @@
                     Height="30"
                     d:IsHitTestVisible="True"
                     DisplayMemberPath="Display"
+                    DropDownClosed="{s:Action MedicineExpireDaysDropDownClosed}"
+                    IsEditable="True"
+                    IsTextSearchEnabled="False"
                     ItemsSource="{Binding MedicineExpireDayList}"
+                    Loaded="{s:Action MakeComboBoxSearchable,
+                                      Target={x:Type ui_vms:SettingsViewModel}}"
                     SelectedValue="{Binding MedicineExpireDays}"
-                    SelectedValuePath="Value" />
+                    SelectedValuePath="Value"
+                    Text="{Binding MedicineExpireDaysText, UpdateSourceTrigger=PropertyChanged}" />
+                <controls:TooltipBlock TooltipText="{DynamicResource MedicineExpireDaysTip}" />
             </StackPanel>
             <CheckBox Margin="0,10" IsChecked="{Binding UseExpireMedicineForActivity}">
                 <TextBlock


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

允许在战斗设置界面中，以“天”为单位配置即将过期药品的阈值，支持预设选项和手动输入。

新功能：
- 添加一个可编辑的“即将过期药品天数”字段，用户可以手动输入药品到期前的天数。

改进：
- 将之前基于小时的即将过期药品预设，替换为一组基于天数的预设（1、2、7、14、21 天）。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

支持以天为单位配置即将过期药品的阈值，并提供预设选项和手动输入功能。

新功能：
- 允许用户在战斗设置界面中手动输入即将过期药品的天数阈值。

增强功能：
- 将之前按小时设置的即将过期药品预设选项替换为按天设置的预设选项：1、2、7、14 和 21 天。
- 更新所有受支持语言中即将过期药品天数设置的本地化标签。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

将即将过期药品的配置改为支持按天数预设和手动输入。

### 新功能：
- 在战斗设置中支持手动输入即将过期药品的天数阈值，并提供按天计算的预设选项。

### 改进：
- 将即将过期药品阈值及相关提示从小时制统一调整为天数制。

### 维护工作：
- 更新英语、日语、韩语、简体中文和繁体中文的相关本地化文本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将即将过期药品的配置改为支持按天数预设和手动输入。

New Features:
- 在战斗设置中支持手动输入即将过期药品的天数阈值，并提供按天计算的预设选项。

Enhancements:
- 将即将过期药品阈值及相关提示从小时制统一调整为天数制。

Chores:
- 更新英语、日语、韩语、简体中文和繁体中文的相关本地化文本。

</details>

</details>

</details>