### PR TITLE
fix: 修复 MaaWpfGui 编译警告

### DIFF
--- a/src/MaaWpfGui/Configuration/Converter/TolerantEnumConverter.cs
+++ b/src/MaaWpfGui/Configuration/Converter/TolerantEnumConverter.cs
@@ -21,23 +21,6 @@ using System.Text.Json.Serialization;
 namespace MaaWpfGui.Configuration.Converter;
 
 /// <summary>
-/// 容错枚举转换器工厂，为所有枚举类型自动创建 <see cref="TolerantEnumConverter{TEnum}"/>。
-/// 替代 <see cref="JsonStringEnumConverter"/>，提供字符串枚举、字典键以及 <c>[Flags]</c> 组合值支持。
-/// </summary>
-internal sealed class TolerantEnumConverterFactory : JsonConverterFactory
-{
-    /// <inheritdoc/>
-    public override bool CanConvert(Type typeToConvert) => typeToConvert.IsEnum;
-
-    /// <inheritdoc/>
-    public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
-    {
-        var converterType = typeof(TolerantEnumConverter<>).MakeGenericType(typeToConvert);
-        return (JsonConverter)Activator.CreateInstance(converterType)!;
-    }
-}
-
-/// <summary>
 /// 容错的枚举 JSON 转换器。
 /// 遇到无法识别的字符串或数值时，抛出带路径信息的 <see cref="JsonException"/>，
 /// 由上层根级容错逻辑决定如何恢复到属性默认值。

--- a/src/MaaWpfGui/Configuration/Converter/TolerantEnumConverterFactory.cs
+++ b/src/MaaWpfGui/Configuration/Converter/TolerantEnumConverterFactory.cs
@@ -1,0 +1,37 @@
+// <copyright file="TolerantEnumConverterFactory.cs" company="MaaAssistantArknights">
+// Part of the MaaWpfGui project, maintained by the MaaAssistantArknights team (Maa Team)
+// Copyright (C) 2021-2025 MaaAssistantArknights Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License v3.0 only as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY
+// </copyright>
+
+#nullable enable
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace MaaWpfGui.Configuration.Converter;
+
+/// <summary>
+/// 容错枚举转换器工厂，为所有枚举类型自动创建 <see cref="TolerantEnumConverter{TEnum}"/>。
+/// 替代 <see cref="JsonStringEnumConverter"/>，提供字符串枚举、字典键以及 <c>[Flags]</c> 组合值支持。
+/// </summary>
+internal sealed class TolerantEnumConverterFactory : JsonConverterFactory
+{
+    /// <inheritdoc/>
+    public override bool CanConvert(Type typeToConvert) => typeToConvert.IsEnum;
+
+    /// <inheritdoc/>
+    public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+    {
+        var converterType = typeof(TolerantEnumConverter<>).MakeGenericType(typeToConvert);
+        return (JsonConverter)Activator.CreateInstance(converterType)!;
+    }
+}

--- a/src/MaaWpfGui/Helper/AchievementTrackerHelper.cs
+++ b/src/MaaWpfGui/Helper/AchievementTrackerHelper.cs
@@ -16,13 +16,13 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Media;
-using System.Windows.Threading;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Threading;
 using HandyControl.Controls;
 using HandyControl.Data;
 using HandyControl.Tools.Command;

--- a/src/MaaWpfGui/Styles/Properties/RainbowAnimationBehavior.cs
+++ b/src/MaaWpfGui/Styles/Properties/RainbowAnimationBehavior.cs
@@ -68,7 +68,7 @@ public static class RainbowAnimationBehavior
         {
             TextBlock tb => tb.Foreground,
             Control ctrl => ctrl.Foreground,
-            _ => null,
+            _ => (Brush)null!,
         };
 
         if (brush is LinearGradientBrush linearBrush

--- a/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
@@ -603,8 +603,15 @@ public class SettingsViewModel : Screen
         if (!helperAdded || !factoryAdded)
         {
             // 任一侧添加失败，回滚另一侧
-            if (helperAdded) { ConfigurationHelper.DeleteConfiguration(NewConfigurationName); }
-            if (factoryAdded) { ConfigFactory.DeleteConfiguration(NewConfigurationName); }
+            if (helperAdded)
+            {
+                ConfigurationHelper.DeleteConfiguration(NewConfigurationName);
+            }
+
+            if (factoryAdded)
+            {
+                ConfigFactory.DeleteConfiguration(NewConfigurationName);
+            }
 
             Growl.Info(new GrowlInfo {
                 IsCustom = true,

--- a/src/MaaWpfGui/Views/Dialogs/AchievementListDialogView.xaml.cs
+++ b/src/MaaWpfGui/Views/Dialogs/AchievementListDialogView.xaml.cs
@@ -33,5 +33,4 @@ public partial class AchievementListDialogView
         // 关闭窗口时执行一次空搜索，重置可见性
         AchievementTrackerHelper.Instance.Search();
     }
-
 }


### PR DESCRIPTION
- CS8600: RainbowAnimationBehavior.cs 中 null 字面量转 Brush 类型显式标注
- SA1210: AchievementTrackerHelper.cs 中 using 指令按命名空间字母序重排
- SA1649/SA1402: TolerantEnumConverterFactory 拆分至独立文件
- SA1508: AchievementListDialogView.xaml.cs 删除闭合括号前多余空行
- SA1501: SettingsViewModel.cs 中单行 if 语句展开为多行

## Summary by Sourcery

在 MaaWpfGui 中解决可空性和样式警告，并将容错枚举转换器工厂拆分到单独文件以提升清晰度。

Bug 修复：
- 在 `RainbowAnimationBehavior` 中显式处理可空的 `Brush` 返回值，以满足可空引用类型分析的要求。

增强改进：
- 将 `TolerantEnumConverterFactory` 移动到单独的源文件中，以符合每个类型单独成文件的约定并提升可维护性。
- 将 `SettingsViewModel` 中的单行条件回滚逻辑重构为多行代码块，以提高可读性。
- 调整 `AchievementTrackerHelper` 中的 `using` 指令顺序，以遵循按字母顺序和样式规范。
- 移除 `AchievementListDialogView` 代码隐藏文件中在右大括号前多余的空行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Resolve nullable and style warnings in MaaWpfGui and split the tolerant enum converter factory into its own file for clarity.

Bug Fixes:
- Explicitly handle nullable Brush returns in RainbowAnimationBehavior to satisfy nullable reference type analysis.

Enhancements:
- Move TolerantEnumConverterFactory into a dedicated source file to comply with file-per-type conventions and improve maintainability.
- Reformat single-line conditional rollback logic in SettingsViewModel into multi-line blocks for readability.
- Reorder using directives in AchievementTrackerHelper to follow alphabetical and style guidelines.
- Remove an extraneous blank line before the closing brace in AchievementListDialogView code-behind.

</details>