### PR TITLE
chore: update MaaDeps version to v2.11.0

### DIFF
--- a/tools/maadeps-download.py
+++ b/tools/maadeps-download.py
@@ -10,7 +10,7 @@ from maadeps_download import detect_host_triplet
 from maadeps_download import main as download_main
 
 REPO = "MaaAssistantArknights/MaaDeps"
-VERSION = "v2.10.1-maa.1"
+VERSION = "v2.11.0"
 
 parser = argparse.ArgumentParser()
 parser.add_argument("triplet", nargs="?")


### PR DESCRIPTION
see https://github.com/MaaAssistantArknights/MaaDeps/pull/36

## Summary by Sourcery

构建：
- 在 `maadeps-download` 工具中，将 MaaDeps 依赖引用从 `v2.10.1-maa.1` 升级到 `v2.11.0`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Bump MaaDeps dependency reference from v2.10.1-maa.1 to v2.11.0 in the maadeps-download utility.

</details>