### PR TITLE
fix: 降低 PlayCover 下肉鸽部分任务的模版匹配分数阈值

### DIFF
--- a/resource/platform_diff/iOS/resource/tasks.json
+++ b/resource/platform_diff/iOS/resource/tasks.json
@@ -32,6 +32,12 @@
     "BattleQuickFormationRole": {
         "templThreshold": 0.65
     },
+    "Roguelike@TraderRandomShoppingCancel": {
+        "templThreshold": 0.75
+    },
+    "Roguelike@StageTraderInvestSystemLeave": {
+        "templThreshold": 0.75
+    },
     "Mizuki@Roguelike@MissionFailedFlag": {
         "templThreshold": 0.75
     },

--- a/resource/platform_diff/iOS/resource/tasks.json
+++ b/resource/platform_diff/iOS/resource/tasks.json
@@ -32,7 +32,7 @@
     "BattleQuickFormationRole": {
         "templThreshold": 0.65
     },
-    "Roguelike@TraderRandomShoppingCancel": {
+    "Roguelike@StageTraderInvestCancel": {
         "templThreshold": 0.75
     },
     "Roguelike@StageTraderInvestSystemLeave": {

--- a/resource/platform_diff/iOS/resource/tasks.json
+++ b/resource/platform_diff/iOS/resource/tasks.json
@@ -50,6 +50,9 @@
     "Sarkaz@Roguelike@StageRefresh": {
         "templThreshold": 0.7
     },
+    "Sarkaz@RoguelikeRouting-RefreshNode": {
+        "templThreshold": 0.7
+    },
     "RelaunchAnchor@RA@RA1-DoubleSpeed": {
         "templThreshold": 0.7
     },


### PR DESCRIPTION
群友在 PlayCover + EN 服的双重 Debuff 下，卡住了。
~~我总感觉日志和截图有些匹配不上~~，但是问题大概就是这么个问题。
已获得正确的日志文件 [asst.log](https://github.com/user-attachments/files/28484412/asst.log) 与截图。
<img width="1280" height="720" alt="2026 06 01-10 34 43 869_raw" src="https://github.com/user-attachments/assets/34505f24-d327-4af0-b509-29ceba0e1308" />

```
[2026-06-01 10:34:43.205][TRC][Px27484][Tx52497] asst::PlayToolsController::screencap | enter
[2026-06-01 10:34:43.255][TRC][Px27484][Tx52497] asst::PlayToolsController::screencap | leave, 50 ms
[2026-06-01 10:34:43.280][TRC][Px27484][Tx52497] match_templ | Roguelike@StageTraderInvestCancel.png [opencv] score: 0.789736 rect: [ 580, 484, 89, 20 ] roi: [ 507, 418, 242, 149 ]
[2026-06-01 10:34:43.280][INF][Px27484][Tx52497] {"class":"asst::ProcessTask","cur_task":"JieGarden@Roguelike@StageTraderInvestSystemError","details":{"cur_retry":20,"retry_times":20,"to_be_recognized":["JieGarden@Roguelike@StageTraderInvestCancel"]},"first":["JieGarden@Roguelike@Begin"],"pre_task":"JieGarden@Roguelike@StageTraderInvestConfirm","subtask":"ProcessTask","taskchain":"Roguelike","taskid":40}
[2026-06-01 10:34:43.280][TRC][Px27484][Tx52497] ready to sleep 500
[2026-06-01 10:34:43.783][TRC][Px27484][Tx52497] end of sleep 500
[2026-06-01 10:34:43.783][TRC][Px27484][Tx52497] asst::PlayToolsController::screencap | enter
[2026-06-01 10:34:43.828][TRC][Px27484][Tx52497] asst::PlayToolsController::screencap | leave, 44 ms
[2026-06-01 10:34:43.855][TRC][Px27484][Tx52497] match_templ | Roguelike@StageTraderInvestCancel.png [opencv] score: 0.789736 rect: [ 580, 484, 89, 20 ] roi: [ 507, 418, 242, 149 ]
[2026-06-01 10:34:43.855][INF][Px27484][Tx52497] Assistant::append_callback | SubTaskError {"class":"asst::ProcessTask","details":{},"first":["JieGarden@Roguelike@Begin"],"pre_task":"JieGarden@Roguelike@StageTraderInvestConfirm","subtask":"ProcessTask","taskchain":"Roguelike","taskid":40,"uuid":"com.hypergryph.arknights"}
```

<img width="761" height="378" alt="image" src="https://github.com/user-attachments/assets/85f7159b-783e-4bbf-b578-4d3133d2ce6a" />

---

顺带，对萨卡兹肉鸽快速刷钱所使用的刷新节点任务的模版匹配阈值也进行了调整。（句子好长，好绕口）
[asst.log](https://github.com/user-attachments/files/28531048/asst.log)

···
[2026-06-02 19:50:45.972][TRC][Px65548][Tx4604] asst::PlayToolsController::screencap | enter
[2026-06-02 19:50:46.015][TRC][Px65548][Tx4604] asst::PlayToolsController::screencap | leave, 42 ms
[2026-06-02 19:50:46.030][TRC][Px65548][Tx4604] match_templ | Sarkaz@RoguelikeRouting-RefreshNode.png [opencv] score: 0.741615 rect: [ 798, 203, 47, 15 ] roi: [ 796, 130, 50, 170 ]
[2026-06-02 19:50:46.030][INF][Px65548][Tx4604] {"class":"asst::ProcessTask","cur_task":"","details":{"cur_retry":20,"retry_times":20,"to_be_recognized":["Sarkaz@RoguelikeRouting-RefreshNode"]},"first":["Sarkaz@RoguelikeRouting-RefreshNode"],"pre_task":"","subtask":"ProcessTask","taskchain":"Roguelike","taskid":2}
[2026-06-02 19:50:46.030][TRC][Px65548][Tx4604] ready to sleep 500
[2026-06-02 19:50:46.535][TRC][Px65548][Tx4604] end of sleep 500
[2026-06-02 19:50:46.535][TRC][Px65548][Tx4604] asst::PlayToolsController::screencap | enter
[2026-06-02 19:50:46.585][TRC][Px65548][Tx4604] asst::PlayToolsController::screencap | leave, 50 ms
[2026-06-02 19:50:46.599][TRC][Px65548][Tx4604] match_templ | Sarkaz@RoguelikeRouting-RefreshNode.png [opencv] score: 0.741614 rect: [ 798, 203, 47, 15 ] roi: [ 796, 130, 50, 170 ]
[2026-06-02 19:50:46.599][INF][Px65548][Tx4604] Assistant::append_callback | SubTaskError {"class":"asst::ProcessTask","details":{},"first":["Sarkaz@RoguelikeRouting-RefreshNode"],"pre_task":"","subtask":"ProcessTask","taskchain":"Roguelike","taskid":2,"uuid":"com.hypergryph.arknights"}
···


## Summary by Sourcery

错误修复：
- 降低 iOS 上特定类 Rogue-like 退出投资任务的模板匹配分数阈值，以防止在 PlayCover 环境和英文客户端条件下任务卡住。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Lower template matching score thresholds for specific roguelike exit-investment tasks on iOS to prevent task stalling under PlayCover and English client conditions.

</details>