### PR TITLE
feat: 支持 ImageCropper 截取 PC 窗口

### DIFF
--- a/tools/ImageCropper/README.md
+++ b/tools/ImageCropper/README.md
@@ -1,6 +1,6 @@
 # 截图工具
 
-本工具可以对 **预先准备好的截图** 或 **通过 ADB 连接设备**，进行 ROI 区域的截取、保存、取色操作。
+本工具可以对 **预先准备好的截图**、**通过 ADB 连接设备** 或 **通过 WGC 截取 PC 窗口**，进行 ROI 区域的截取、保存、取色操作。
 
 ## 环境
 
@@ -19,11 +19,12 @@ python -m pip install -r requirements.txt
 
 ## 使用
 
-0. (非必要) 根据 `set_screenshot_target_long/short_side` 的使用情况，调整脚本中的 `截图参数` 和 `初始窗口大小`
+0. (非必要) 根据 `set_screenshot_target_long/short_side` 的使用情况，调整脚本中的 `截图参数` 和 `初始窗口大小`；截取 PC 窗口时可调整 `window_name`（目标窗口标题关键字）与 `win32_screencap_method`（默认 `Background` = FramePool/WGC，失败自动回退 PrintWindow）
 1. 如果有预先准备好的截图，需保存到 `./src/` 路径下
 2. 运行 `start.bat` 或 `python main.py [device serial]` ，设备地址为可选
     - 根据提示 `Please select the device (ENTER to pass):` ，选择 adb 已连接设备（按 ENTER 跳过选择）
     - 如果没有该提示，请使用 `python main.py [device serial]` 连接设备
+    - **截取 PC 窗口（WGC）**：运行 `python main.py --pc [窗口标题关键字]` ，关键字默认为 `明日方舟`（官方 PC 客户端）。按标题子串匹配可见顶层窗口，自动绑定第一个命中的窗口；无需 ADB，需 Windows 10 1903+
 3. 在弹窗中左键选择目标区域，滚轮缩放图片，右键移动图片
 4. 使用快捷键操作：
     - 按 <kbd>S</kbd> <kbd>ENTER</kbd> 保存目标区域

--- a/tools/ImageCropper/main.py
+++ b/tools/ImageCropper/main.py
@@ -1,3 +1,4 @@
+import sys
 from datetime import datetime
 from pathlib import Path
 from typing import Optional
@@ -5,8 +6,8 @@ from typing import Optional
 import colormatcher
 import cv2
 import numpy as np
-from maa.controller import AdbController, Controller
-from maa.define import MaaAdbScreencapMethodEnum
+from maa.controller import AdbController, Controller, Win32Controller
+from maa.define import MaaAdbScreencapMethodEnum, MaaWin32ScreencapMethodEnum
 from maa.toolkit import Toolkit
 from roimage import Roi, Roimage
 
@@ -14,6 +15,12 @@ from roimage import Roi, Roimage
 # device_serial = "127.0.0.1:16384"
 device_serial = None
 adb_screencap_method = MaaAdbScreencapMethodEnum.Default
+
+# PC 端窗口截图参数 (Win32 / WGC)
+# window_name 为目标窗口标题关键字(子串匹配)
+window_name = "明日方舟"
+# Background = FramePool(WGC) | PrintWindow:优先 WGC,失败自动退回 PrintWindow
+win32_screencap_method = MaaWin32ScreencapMethodEnum.Background
 
 # 初始窗口大小 (width, height)
 # window_size = (720, 1280) # 竖屏
@@ -89,6 +96,27 @@ def get_adb_devices_list() -> Optional[Controller]:
                     address=device_serial,
                     screencap_methods=adb_screencap_method,
                 )
+
+
+# 获取 PC 端窗口控制器 (Win32 / WGC)
+# 与 MAA 本体一致:在可见顶层窗口中按标题匹配后绑定;此处用子串匹配,比本体的完全匹配更通用
+def get_win32_controller(name_keyword: str) -> Optional[Controller]:
+    print("MaaToolkit searching desktop windows...\n")
+    windows = Toolkit.find_desktop_windows()
+    matched = [w for w in windows if w.window_name and name_keyword in w.window_name]
+    if not matched:
+        print(f'No visible window matching "{name_keyword}".')
+        return None
+    for i, w in enumerate(matched):
+        print(f"{i:>3} | {str(w.hwnd):>18} | [{w.class_name}] {w.window_name}")
+    target = matched[0]
+    if len(matched) > 1:
+        print(f'Multiple windows matched "{name_keyword}", using the first one.')
+    print(f'Attaching to "{target.window_name}" (hwnd={target.hwnd}).')
+    return Win32Controller(
+        hWnd=target.hwnd,
+        screencap_method=win32_screencap_method,
+    )
 
 
 # OpenCV 鼠标回调
@@ -298,6 +326,7 @@ if __name__ == "__main__":
     # Print Help Infos
     print(
         "Usage: python3 main.py [device serial]\n"
+        "       python3 main.py --pc [window title keyword]   (capture a PC window via WGC)\n"
         "Put the images under ./src, and run this script, it will be auto converted to target size.\n"
         "Hold down the left mouse button, drag mouse to select a ROI.\n"
         "Hold down the right mouse button, drag mouse to move the image.\n"
@@ -318,14 +347,25 @@ if __name__ == "__main__":
     if not dst_path.is_dir():
         dst_path.mkdir()
 
-    # 搜索并连接设备
-    controller = get_adb_devices_list()
-    if not controller:
-        print("ADB Devices Not Found. Reading from ./src folder...")
+    # 解析参数:--pc / -p / --window / -w 进入 PC 窗口(Win32/WGC)模式,否则走 ADB
+    cli_args = sys.argv[1:]
+    use_pc = bool(cli_args) and cli_args[0] in ("--pc", "-p", "--window", "-w")
+    if use_pc and len(cli_args) > 1 and cli_args[1]:
+        window_name = cli_args[1]
+
+    # 搜索并连接设备 / 窗口
+    if use_pc:
+        controller = get_win32_controller(window_name)
+        if not controller:
+            print(f'PC window "{window_name}" not found. Reading from ./src folder...')
+    else:
+        controller = get_adb_devices_list()
+        if not controller:
+            print("ADB Devices Not Found. Reading from ./src folder...")
     if controller:
         set_screenshot_target_side(controller)
         if controller.post_connection().failed:
-            print(f"Failed to connect device({device_serial}).")
+            print("Failed to connect controller.")
             exit(1)
 
     # 初始化 cv2 窗口

--- a/tools/ImageCropper/requirements.txt
+++ b/tools/ImageCropper/requirements.txt
@@ -1,2 +1,2 @@
-MaaFw~=4.0
-opencv_python~=4.10
+MaaFw~=5.10
+opencv_python~=4.13


### PR DESCRIPTION
## Summary by Sourcery

在现有的 ADB 和静态图像来源基础上，为 ImageCropper 工具新增对 PC 窗口的捕获与裁剪支持。

新功能：
- 允许 ImageCropper 通过 Win32/WGC，从 PC 窗口截取屏幕图像，并可通过可配置的窗口标题关键字和截屏方式进行控制。
- 新增 CLI 参数，用于选择 PC 窗口捕获模式并指定目标窗口标题关键字。

增强：
- 统一控制器连接处理逻辑，使其既适用于 ADB 设备也适用于 PC 窗口，并改进连接失败时的提示信息。

构建：
- 更新 ImageCropper 工具使用的 MaaFw 和 OpenCV Python 依赖版本。

文档：
- 更新 ImageCropper 的 README，记录 PC 窗口捕获的使用方式、配置选项和 CLI 参数。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for capturing and cropping PC windows in the ImageCropper tool in addition to existing ADB and static image sources.

New Features:
- Allow ImageCropper to capture screenshots from PC windows via Win32/WGC using a configurable window title keyword and screencap method.
- Introduce CLI flags to select PC window capture mode and specify the target window title keyword.

Enhancements:
- Unify controller connection handling to work with either ADB devices or PC windows and improve connection failure messaging.

Build:
- Bump MaaFw and OpenCV Python dependency versions used by the ImageCropper tool.

Documentation:
- Update ImageCropper README to document PC window capture usage, configuration options, and CLI parameters.

</details>