### PR TITLE
fix: 修复MaaMacGui changelog贡献者mention

### DIFF
--- a/tools/ChangelogGenerator/changelog_generator.py
+++ b/tools/ChangelogGenerator/changelog_generator.py
@@ -23,6 +23,7 @@ with_merge = False
 
 contributors = {}
 raw_commits_info = {}
+commit_author_logins = {}
 
 IGNORE_PREFIXES = r"(?:build|ci|style|debug)"
 
@@ -284,35 +285,39 @@ def get_associated_pr(repo_name: str, commit_hash: str):
 
 
 def get_commit_author_login(repo_name: str, commit_hash: str) -> str:
+    cache_key = (repo_name, commit_hash)
+    if cache_key in commit_author_logins:
+        return commit_author_logins[cache_key]
+
     commit = github_api_get(
         f"https://api.github.com/repos/{repo_name}/commits/{commit_hash}"
     )
-    if not commit:
-        return ""
-
-    return (commit.get("author") or {}).get("login") or ""
-
-
-def format_commit_info_with_pr(
-    repo_name: str, commit_hash: str, message: str, author: str
-):
-    pr = get_associated_pr(repo_name, commit_hash)
     login = ""
+    if commit:
+        login = (commit.get("author") or {}).get("login") or ""
+    commit_author_logins[cache_key] = login
+
+    return login
+
+
+def format_commit_info_with_pr(repo_name: str, commit_hash: str, message: str):
+    pr = get_associated_pr(repo_name, commit_hash)
+    author_login = ""
 
     if pr:
         number = pr.get("number")
         html_url = pr.get("html_url")
         title = pr.get("title")
-        login = (pr.get("user") or {}).get("login") or ""
+        author_login = (pr.get("user") or {}).get("login") or ""
 
         if number and html_url and title:
             title = re.sub(r"\s*\(#\d+\)\s*$", "", title)
             message = f"{title} ([#{number}]({html_url}))"
 
-    if not login:
-        login = get_commit_author_login(repo_name, commit_hash)
+    if not author_login:
+        author_login = get_commit_author_login(repo_name, commit_hash)
 
-    return message, login
+    return message, author_login
 
 
 def build_maamacgui_changelog(latest: str) -> str:
@@ -350,10 +355,10 @@ def build_maamacgui_changelog(latest: str) -> str:
             if len(lines) < 5:
                 continue
 
-            commit_hash, author, committer, message, parent = lines[:5]
+            commit_hash, _, committer, message, parent = lines[:5]
 
             message, author = format_commit_info_with_pr(
-                maamacgui_repo, commit_hash, message, author
+                maamacgui_repo, commit_hash, message
             )
 
             maamacgui_commits_info[commit_hash] = {

--- a/tools/ChangelogGenerator/changelog_generator.py
+++ b/tools/ChangelogGenerator/changelog_generator.py
@@ -114,7 +114,7 @@ def individual_commits(commits: dict, indent: str = "") -> Tuple[str, list]:
 
         # 拼接 commit message
         ret_message += indent + "* " + commit_message
-        ret_message += "".join(f" @{ctr}" for ctr in ctrs if ctr != "web-flow")
+        ret_message += "".join(f" @{ctr}" for ctr in ctrs if ctr and ctr != "web-flow")
         ret_message += f" ({commit_hash})\n" if with_hash else "\n"
 
         if with_merge:
@@ -283,26 +283,36 @@ def get_associated_pr(repo_name: str, commit_hash: str):
     return pulls[0]
 
 
+def get_commit_author_login(repo_name: str, commit_hash: str) -> str:
+    commit = github_api_get(
+        f"https://api.github.com/repos/{repo_name}/commits/{commit_hash}"
+    )
+    if not commit:
+        return ""
+
+    return (commit.get("author") or {}).get("login") or ""
+
+
 def format_commit_info_with_pr(
     repo_name: str, commit_hash: str, message: str, author: str
 ):
     pr = get_associated_pr(repo_name, commit_hash)
-    if not pr:
-        return message, author
+    login = ""
 
-    number = pr.get("number")
-    html_url = pr.get("html_url")
-    title = pr.get("title")
-    login = pr.get("user", {}).get("login")
+    if pr:
+        number = pr.get("number")
+        html_url = pr.get("html_url")
+        title = pr.get("title")
+        login = (pr.get("user") or {}).get("login") or ""
 
-    if number and html_url and title:
-        title = re.sub(r"\s*\(#\d+\)\s*$", "", title)
-        message = f"{title} ([#{number}]({html_url}))"
+        if number and html_url and title:
+            title = re.sub(r"\s*\(#\d+\)\s*$", "", title)
+            message = f"{title} ([#{number}]({html_url}))"
 
-    if login:
-        author = login
+    if not login:
+        login = get_commit_author_login(repo_name, commit_hash)
 
-    return message, author
+    return message, login
 
 
 def build_maamacgui_changelog(latest: str) -> str:


### PR DESCRIPTION
## 变更内容

修复 MaaMacGui 子仓库 changelog 中贡献者 mention 可能错误的问题。

- associated PR 存在时，优先使用 PR 作者的 `user.login`，并保持 PR title / PR link 逻辑不变。
- 无 associated PR 时，使用 GitHub commit API 的 `author.login` 作为贡献者。
- 无法确认 GitHub login 时，不追加作者 mention。
- 不再使用 git author name / display name / commit author name 生成 `@mention`。
- 不写入主仓库 `contributors` 映射，避免污染主仓库贡献者缓存。
- 过滤空 contributors，避免生成无效 mention。

## 验证

- `python3 -m py_compile tools/ChangelogGenerator/changelog_generator.py`
- `git diff --cached --check`
- 使用 MaaMacGui 真实历史区间验证：
  - `Add localized strings for relaunch case` 输出 `@ABA2396`
  - `RelaunchAnchor` 输出 `@hguandl`
  - 不再输出 `@uye` / `@hao Guan`
  - PR 记录仍正常输出 `@FireflySentinel` / `@ColdSpellhere`

## Summary by Sourcery

基于 GitHub 元数据而非本地 git 作者信息，改进 MaaMacGui 更新日志中的贡献者提及方式。

Bug 修复：
- 防止空的贡献者账号在生成的更新日志中产生无效的 @提及。
- 确保 MaaMacGui 更新日志使用关联的 PR 作者登录名或提交作者登录名作为贡献者提及，避免错误或缺失的映射。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve MaaMacGui changelog contributor mentions based on GitHub metadata instead of local git author information.

Bug Fixes:
- Prevent empty contributor handles from producing invalid @mentions in generated changelogs.
- Ensure MaaMacGui changelog uses the associated PR author login or commit author login as the contributor mention, avoiding incorrect or missing mappings.

</details>