### PR TITLE
rft: InvokeProcSubTaskMsg 重构

### DIFF
--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -708,6 +708,10 @@ public class AsstProxy
 
     private AsstHandle _handle;
 
+    public delegate void AsstSubTaskMsgDelegate(AsstMsg msg, AsstSubTaskMsg? details);
+
+    public event AsstSubTaskMsgDelegate? AsstSubTaskMsgEvent;
+
     private void ProcMsg(AsstMsg msg, JObject details)
     {
         switch (msg)
@@ -744,7 +748,7 @@ public class AsstProxy
             case AsstMsg.SubTaskCompleted:
             case AsstMsg.SubTaskExtraInfo:
                 ProcSubTaskMsg(msg, details);
-                TaskQueueViewModel.InvokeProcSubTaskMsg(msg, details);
+                AsstSubTaskMsgEvent?.Invoke(msg, details.ToObject<AsstSubTaskMsg>() ?? null);
                 break;
 
             case AsstMsg.SubTaskStopped:

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -748,7 +748,15 @@ public class AsstProxy
             case AsstMsg.SubTaskCompleted:
             case AsstMsg.SubTaskExtraInfo:
                 ProcSubTaskMsg(msg, details);
-                AsstSubTaskMsgEvent?.Invoke(msg, details.ToObject<AsstSubTaskMsg>() ?? null);
+                try
+                {
+                    var payload = details.ToObject<AsstSubTaskMsg>() ?? null;
+                    AsstSubTaskMsgEvent?.Invoke(msg, payload);
+                }
+                catch (Exception ex)
+                {
+                    _logger.Error("Failed to parse SubTaskMsg: {ExMessage}\nSubTaskMsg:{SubTaskMsg}", ex.Message, details);
+                }
                 break;
 
             case AsstMsg.SubTaskStopped:

--- a/src/MaaWpfGui/Models/AsstSubTaskMsg.cs
+++ b/src/MaaWpfGui/Models/AsstSubTaskMsg.cs
@@ -25,7 +25,7 @@ public class AsstSubTaskMsg
     public int TaskId { get; set; } = 0;
 
     [JsonProperty("class")]
-    public string @class { get; set; } = string.Empty;
+    public string Class { get; set; } = string.Empty;
 
     [JsonProperty("subtask")]
     public string SubTask { get; set; } = string.Empty;

--- a/src/MaaWpfGui/Models/AsstSubTaskMsg.cs
+++ b/src/MaaWpfGui/Models/AsstSubTaskMsg.cs
@@ -1,0 +1,44 @@
+// <copyright file="AsstSubTaskMsg.cs" company="MaaAssistantArknights">
+// Part of the MaaWpfGui project, maintained by the MaaAssistantArknights team (Maa Team)
+// Copyright (C) 2021-2025 MaaAssistantArknights Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License v3.0 only as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY
+// </copyright>
+#nullable enable
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace MaaWpfGui.Models;
+
+public class AsstSubTaskMsg
+{
+    [JsonProperty("taskchain")]
+    public string TaskChain { get; set; } = string.Empty;
+
+    [JsonProperty("taskid")]
+    public int TaskId { get; set; } = 0;
+
+    [JsonProperty("class")]
+    public string @class { get; set; } = string.Empty;
+
+    [JsonProperty("subtask")]
+    public string SubTask { get; set; } = string.Empty;
+
+    [JsonProperty("what")]
+    public string? What { get; set; } // 大部分为what
+
+    [JsonProperty("why")]
+    public string? Why { get; set; } // 极少量 SubTaskError 会有why
+
+    [JsonProperty("uuid")]
+    public string UUID { get; set; } = string.Empty;
+
+    [JsonProperty("details")]
+    public JObject? Details { get; set; }
+}

--- a/src/MaaWpfGui/ViewModels/TaskSettingsViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/TaskSettingsViewModel.cs
@@ -63,11 +63,6 @@ public abstract class TaskSettingsViewModel : PropertyChangedBase
         return false;
     }
 
-    // 计划重构为event
-    public virtual void ProcSubTaskMsg(AsstMsg msg, JObject details)
-    {
-    }
-
     /// <summary>
     /// 刷新UI
     /// </summary>

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -2170,15 +2170,6 @@ public class TaskQueueViewModel : Screen
         }
     }
 
-    public static void InvokeProcSubTaskMsg(AsstMsg msg, JObject details)
-    {
-        foreach (var instance in _taskViewModelTypes)
-        {
-            // 调用 ProcSubTaskMsg 方法
-            instance.ProcSubTaskMsg(msg, details);
-        }
-    }
-
     public void RefreshTaskModel(BaseTask task)
     {
         foreach (var instance in _taskViewModelTypes)

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/RoguelikeSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/RoguelikeSettingsUserControlModel.cs
@@ -22,6 +22,7 @@ using MaaWpfGui.Constants;
 using MaaWpfGui.Constants.Enums;
 using MaaWpfGui.Helper;
 using MaaWpfGui.Main;
+using MaaWpfGui.Models;
 using MaaWpfGui.Models.AsstTasks;
 using MaaWpfGui.Utilities;
 using MaaWpfGui.Utilities.ValueType;
@@ -40,6 +41,7 @@ public class RoguelikeSettingsUserControlModel : TaskSettingsViewModel, Roguelik
     static RoguelikeSettingsUserControlModel()
     {
         Instance = new();
+        Instances.AsstProxy.AsstSubTaskMsgEvent += Instance.ProcSubTaskMsg;
     }
 
     public static RoguelikeSettingsUserControlModel Instance { get; }
@@ -838,15 +840,15 @@ public class RoguelikeSettingsUserControlModel : TaskSettingsViewModel, Roguelik
         }
     }
 
-    public override void ProcSubTaskMsg(AsstMsg msg, JObject details)
+    public void ProcSubTaskMsg(AsstMsg msg, AsstSubTaskMsg? details)
     {
         if (msg != AsstMsg.SubTaskExtraInfo)
         {
             return;
         }
 
-        var subTaskDetails = details["details"];
-        switch (details["what"]?.ToString() ?? string.Empty)
+        var subTaskDetails = details?.Details;
+        switch (details?.What ?? string.Empty)
         {
             case "RoguelikeInvestmentReachFull":
                 Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("RoguelikeInvestmentReachFull"), UiLogColor.Info);

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/StartUpSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/StartUpSettingsUserControlModel.cs
@@ -32,6 +32,7 @@ public class StartUpSettingsUserControlModel : TaskSettingsViewModel, StartUpSet
     static StartUpSettingsUserControlModel()
     {
         Instance = new();
+        Instances.AsstProxy.AsstSubTaskMsgEvent += Instance.ProcSubTaskMsg;
     }
 
     public static StartUpSettingsUserControlModel Instance { get; }
@@ -58,11 +59,11 @@ public class StartUpSettingsUserControlModel : TaskSettingsViewModel, StartUpSet
         await Instances.TaskQueueViewModel.LinkStartWithTasks([task]);
     }
 
-    public override void ProcSubTaskMsg(AsstMsg msg, JObject details)
+    public void ProcSubTaskMsg(AsstMsg msg, AsstSubTaskMsg? details)
     {
-        if (msg == AsstMsg.SubTaskExtraInfo && details["what"]?.ToString() == "AccountSwitch")
+        if (msg == AsstMsg.SubTaskExtraInfo && details?.What == "AccountSwitch")
         {
-            Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("AccountSwitch") + $" -->> {details["details"]!["account_name"]}", UiLogColor.Info); // subTaskDetails!["current_account"]
+            Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("AccountSwitch") + $" -->> {details?.Details?["account_name"]}", UiLogColor.Info); // subTaskDetails!["current_account"]
         }
     }
 


### PR DESCRIPTION
## Summary by Sourcery

将子任务消息处理重构为使用强类型、基于事件的模型，而非虚函数回调和静态分发。

增强点：
- 引入 `AsstSubTaskMsg` 模型，用于表示结构化的子任务消息。
- 使用 `AsstProxy` 的子任务消息事件，替换 `TaskSettingsViewModel.ProcSubTaskMsg` 和 `TaskQueueViewModel` 的静态分发。
- 更新 roguelike 和 startup 设置视图模型，使其直接订阅子任务消息事件并消费强类型的消息数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor sub-task message handling to use a strongly-typed event-based model instead of virtual callbacks and static dispatch.

Enhancements:
- Introduce an AsstSubTaskMsg model to represent structured sub-task messages.
- Replace TaskSettingsViewModel.ProcSubTaskMsg and TaskQueueViewModel static dispatch with an AsstProxy sub-task message event.
- Update roguelike and startup settings view models to subscribe directly to sub-task message events and consume typed message data.

</details>