### PR TITLE
feat: 悖论模拟支持跳过战斗失败的作业, 自动战斗作业增加对应结构

### DIFF
--- a/src/MaaCore/Task/Interface/CopilotTask.cpp
+++ b/src/MaaCore/Task/Interface/CopilotTask.cpp
@@ -96,7 +96,7 @@ bool asst::CopilotTask::set_params(const json::value& params)
         m_battle_task_ptr->set_wait_until_end(true);
         auto configs = static_cast<std::vector<MultiCopilotConfig>>(*multi_tasks_opt);
         std::vector<MultiCopilotTaskPlugin::MultiCopilotConfig> configs_cvt;
-        for (const auto& [filename, stage_name, is_raid] : configs) {
+        for (const auto& [id, filename, stage_name, is_raid] : configs) {
             MultiCopilotTaskPlugin::MultiCopilotConfig config_cvt;
             auto copilot_opt = parse_copilot_filename(filename);
             if (!copilot_opt) {
@@ -109,6 +109,7 @@ bool asst::CopilotTask::set_params(const json::value& params)
             config_cvt.copilot_file = *copilot_opt;
             config_cvt.nav_name = stage_name;
             config_cvt.is_raid = is_raid;
+            config_cvt.id = id; // ID 从0开始
             configs_cvt.emplace_back(std::move(config_cvt));
         }
 

--- a/src/MaaCore/Task/Interface/CopilotTask.h
+++ b/src/MaaCore/Task/Interface/CopilotTask.h
@@ -18,11 +18,12 @@ class CopilotTask final : public InterfaceTask
 public:
     struct MultiCopilotConfig
     {
+        int id = -1;
         std::string filename;   // 文件名
         std::string stage_name; // 关卡名
         bool is_raid = false;   // 是否是突袭
 
-        MEO_JSONIZATION(filename, stage_name, MEO_OPT is_raid);
+        MEO_JSONIZATION(MEO_OPT id, filename, stage_name, MEO_OPT is_raid);
     };
 
 public:

--- a/src/MaaCore/Task/Interface/ParadoxCopilotTask.cpp
+++ b/src/MaaCore/Task/Interface/ParadoxCopilotTask.cpp
@@ -15,7 +15,7 @@ asst::ParadoxCopilotTask::ParadoxCopilotTask(const AsstCallback& callback, Assis
 {
     m_paradox_task_ptr->set_battle_task_ptr(m_battle_task_ptr);
     m_battle_task_ptr->set_retry_times(0);
-    m_stop_task_ptr->set_tasks({ "Copilot@WaitUntilEndOfAction" });
+    m_stop_task_ptr->set_tasks({ "Copilot@WaitUntilEndOfAction-Bypass" });
     m_start_task_ptr->set_tasks({ "BattleStartAll" }).set_retry_times(3).set_ignore_error(false);
 
     /*
@@ -50,12 +50,23 @@ bool asst::ParadoxCopilotTask::set_params(const json::value& params)
         return true;
     }
 
-    auto batch_opt = params.find<std::vector<std::string>>("list");
-    if (batch_opt) {
+    if (auto batch_opt = params.find<std::vector<CopilotConfig>>("list")) {
         m_battle_task_ptr->set_wait_until_end(true);
         m_subtasks.reserve(batch_opt->size() * 4);
         for (const auto& item : *batch_opt) {
-            m_paradox_task_ptr->add_file(item);
+            m_paradox_task_ptr->add_file(item.id, item.filename);
+            m_subtasks.emplace_back(m_paradox_task_ptr);
+            m_subtasks.emplace_back(m_start_task_ptr);
+            m_subtasks.emplace_back(m_battle_task_ptr);
+            m_subtasks.emplace_back(m_stop_task_ptr);
+        }
+        return true;
+    }
+    else if (auto old_batch_opt = params.find<std::vector<std::string>>("list"); old_batch_opt) {
+        m_battle_task_ptr->set_wait_until_end(true);
+        m_subtasks.reserve(old_batch_opt->size() * 4);
+        for (const auto& filename : *old_batch_opt) {
+            m_paradox_task_ptr->add_file(-1, filename);
             m_subtasks.emplace_back(m_paradox_task_ptr);
             m_subtasks.emplace_back(m_start_task_ptr);
             m_subtasks.emplace_back(m_battle_task_ptr);

--- a/src/MaaCore/Task/Interface/ParadoxCopilotTask.h
+++ b/src/MaaCore/Task/Interface/ParadoxCopilotTask.h
@@ -13,6 +13,15 @@ class BattleProcessTask;
 class ParadoxCopilotTask final : public InterfaceTask
 {
 public:
+    struct CopilotConfig
+    {
+        int id;
+        std::string filename;
+
+        MEO_JSONIZATION(id, filename);
+    };
+
+public:
     inline static constexpr std::string_view TaskType = "ParadoxCopilot";
 
     ParadoxCopilotTask(const AsstCallback& callback, Assistant* inst);

--- a/src/MaaCore/Task/Miscellaneous/MultiCopilotTaskPlugin.cpp
+++ b/src/MaaCore/Task/Miscellaneous/MultiCopilotTaskPlugin.cpp
@@ -33,6 +33,7 @@ bool asst::MultiCopilotTaskPlugin::_run()
     json::value info = basic_info_with_what("CopilotListLoadTaskFileSuccess");
     info["details"]["stage_name"] = Copilot.get_stage_name();
     info["details"]["file_name"] = std::move(file_name);
+    info["details"]["id"] = config.id;
     callback(AsstMsg::SubTaskExtraInfo, info);
 
     bool ret = true;

--- a/src/MaaCore/Task/Miscellaneous/MultiCopilotTaskPlugin.h
+++ b/src/MaaCore/Task/Miscellaneous/MultiCopilotTaskPlugin.h
@@ -15,6 +15,7 @@ public:
         std::filesystem::path copilot_file; // 文件名
         std::string nav_name;               // 关卡名
         bool is_raid = false;               // 是否是突袭
+        int id;
     };
 
 public:

--- a/src/MaaCore/Task/Miscellaneous/ParadoxRecognitionTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/ParadoxRecognitionTask.cpp
@@ -15,7 +15,8 @@ bool asst::ParadoxRecognitionTask::_run()
         return false;
     }
 
-    const auto& path = utils::path(m_paradox_files.front());
+    const auto& [id, raw_path] = m_paradox_files.front();
+    const auto& path = utils::path(raw_path);
     std::string file_name;
     if (!Copilot.load(path)) {
         Log.error("CopilotConfig parse failed");
@@ -31,6 +32,7 @@ bool asst::ParadoxRecognitionTask::_run()
     json::value info = basic_info_with_what("CopilotListLoadTaskFileSuccess");
     info["details"]["stage_name"] = Copilot.get_stage_name();
     info["details"]["file_name"] = file_name;
+    info["details"]["id"] = id;
     callback(AsstMsg::SubTaskExtraInfo, info);
 
     m_navigate_name = standardize_name(stage_name);
@@ -91,9 +93,9 @@ void asst::ParadoxRecognitionTask::enter_paradox(const int skill_num, const int 
     }
 }
 
-void asst::ParadoxRecognitionTask::add_file(const std::string& navigate_name)
+void asst::ParadoxRecognitionTask::add_file(int id, const std::string& navigate_name)
 {
-    m_paradox_files.emplace_back(navigate_name);
+    m_paradox_files.emplace_back(id, navigate_name);
 }
 
 void asst::ParadoxRecognitionTask::swipe_page() const

--- a/src/MaaCore/Task/Miscellaneous/ParadoxRecognitionTask.h
+++ b/src/MaaCore/Task/Miscellaneous/ParadoxRecognitionTask.h
@@ -25,7 +25,7 @@ private:
 public:
     using AbstractTask::AbstractTask;
     virtual ~ParadoxRecognitionTask() override = default;
-    void add_file(const std::string& navigate_name);
+    void add_file(int id, const std::string& navigate_name);
 
     void set_battle_task_ptr(const std::shared_ptr<BattleProcessTask>& ptr) { m_battle_task_ptr = ptr; }
 
@@ -40,7 +40,7 @@ private:
     static std::string standardize_name(const std::string& navigate_name);
     void enter_paradox(int skill_num, int rarity) const; // 进悖论模拟
 
-    std::vector<std::string> m_paradox_files;
+    std::vector<std::pair<int, std::string>> m_paradox_files;
     OperName m_oper_name {};
     std::string m_navigate_name;
     asst::Rect m_navigate_rect;

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -2153,6 +2153,14 @@ public class AsstProxy
             case "CopilotListLoadTaskFileSuccess":
                 Instances.CopilotViewModel.AddLog($"Parse {subTaskDetails!["file_name"]}[{subTaskDetails["stage_name"]}] Success");
                 Instances.CopilotViewModel.HasRequirementIgnored = false;
+                if (subTaskDetails["id"] is JToken { Type: JTokenType.Integer } id)
+                {
+                    Instances.CopilotViewModel.CurrentCopilotId = (int)id;
+                }
+                else
+                {
+                    Instances.CopilotViewModel.CurrentCopilotId = -1;
+                }
                 break;
 
             case "SSSStage":

--- a/src/MaaWpfGui/Models/AsstTasks/AsstCopilotTask.cs
+++ b/src/MaaWpfGui/Models/AsstTasks/AsstCopilotTask.cs
@@ -144,6 +144,9 @@ public class AsstCopilotTask : AsstBaseTask
 
     public class MultiTask
     {
+        [JsonProperty("id")]
+        public int Index { get; set; }
+
         [JsonProperty("filename")]
         public string FileName { get; set; } = string.Empty;
 

--- a/src/MaaWpfGui/Models/AsstTasks/AsstParadoxCopilotTask.cs
+++ b/src/MaaWpfGui/Models/AsstTasks/AsstParadoxCopilotTask.cs
@@ -26,7 +26,7 @@ public class AsstParadoxCopilotTask : AsstBaseTask
     /// Gets or sets 多作业列表, 导航至关卡 (启用自动战斗序列、取消代理)
     /// </summary>
     [JsonProperty("list")]
-    public List<string> MultiTasks { get; set; } = [];
+    public List<MultiTask> MultiTasks { get; set; } = [];
 
     [JsonProperty("filename")]
     public string? FileName { get; set; }
@@ -45,4 +45,6 @@ public class AsstParadoxCopilotTask : AsstBaseTask
 
         return (TaskType, json);
     }
+
+    public record MultiTask([property: JsonProperty("id")] int Id, [property: JsonProperty("filename")] string FileName);
 }

--- a/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
@@ -383,6 +383,8 @@ public partial class CopilotViewModel : Screen
     /// </summary>
     public bool HasRequirementIgnored { get; set; } = false;
 
+    public int CurrentCopilotId { get; set; } = -1;
+
     public bool UseSanityPotion { get => field; set => SetAndNotify(ref field, value); }
 
     /// <summary>
@@ -1799,7 +1801,7 @@ public partial class CopilotViewModel : Screen
         Execute.OnUIThread(() => {
             foreach (var model in CopilotItemViewModels)
             {
-                if (!model.IsChecked)
+                if (!model.IsChecked || (CurrentCopilotId != -1 && model.Index != CurrentCopilotId))
                 {
                     continue;
                 }
@@ -2067,7 +2069,7 @@ public partial class CopilotViewModel : Screen
 
             var t = CopilotItemViewModels.Where(i => i.IsChecked).Select(i => {
                 _copilotIdList.Add(i.CopilotId);
-                return new MultiTask { FileName = i.FilePath, IsRaid = i.IsRaid, StageName = i.Name, };
+                return new MultiTask { Index = i.Index, FileName = i.FilePath, IsRaid = i.IsRaid, StageName = i.Name, };
             });
 
             var task = new AsstCopilotTask() {
@@ -2091,7 +2093,7 @@ public partial class CopilotViewModel : Screen
 
             var t = CopilotItemViewModels.Where(i => i.IsChecked).Select(i => {
                 _copilotIdList.Add(i.CopilotId);
-                return i.FilePath;
+                return new AsstParadoxCopilotTask.MultiTask(i.Index, i.FilePath);
             });
 
             var task = new AsstParadoxCopilotTask() { MultiTasks = [.. t], };


### PR DESCRIPTION
## Summary by Sourcery

为悖论（paradox）模拟和普通 copilot 流程新增“识别符感知”的多 copilot 支持，通过在后端任务与 WPF UI 中传递 ID，从而实现对单个任务的选择性处理，以及在战斗失败时进行跳过。

New Features:
- 允许悖论 copilot 批处理参数接收带有 ID 和文件名的结构化项目，同时保持对之前仅使用文件名格式的兼容。
- 在识别与多 copilot 任务插件中传播 copilot 任务 ID，使 extra-info 回调中包含来源任务的 ID。
- 在 WPF UI 中跟踪当前正在运行的 copilot ID，并在标记批处理项目成功时使用该 ID，从而只更新对应的任务。

Enhancements:
- 更新悖论 copilot 停止任务以使用“绕过（bypass）”变体，使失败的战斗可以被跳过，而不会终止整个批处理。
- 扩展 C# 中 copilot 和悖论 copilot 的任务模型，以便在多任务列表中将 ID 与文件名一起序列化。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add identifier-aware multi-copilot support to paradox simulation and normal copilot flows, wiring IDs through backend tasks and the WPF UI to enable selective handling of individual jobs and bypassing failed battles.

New Features:
- Allow paradox copilot batch parameters to accept structured items with IDs and filenames while retaining compatibility with the previous filename-only format.
- Propagate copilot job IDs through recognition and multi-copilot task plugins so extra-info callbacks include the originating job ID.
- Track the currently running copilot ID in the WPF UI and use it when marking batch items on success so only the corresponding job is updated.

Enhancements:
- Update paradox copilot stop task to use a bypass variant so failed battles can be skipped without halting the whole batch.
- Extend C# task models for copilot and paradox copilot to serialize IDs alongside filenames in multi-task lists.

</details>