### PR TITLE
feat: 增加但书组与可露希尔组

### DIFF
--- a/resource/infrast.json
+++ b/resource/infrast.json
@@ -3462,7 +3462,7 @@
             "bskill_tra_against": {
                 "desc": ["进驻贸易站时，如果下笔赤金订单是违约订单，则赤金交付数额外+1"],
                 "efficient": {
-                    "Money": 47
+                    "Money": 0
                 },
                 "name": ["违约索赔·α"],
                 "template": "Bskill_tra_against.png"
@@ -3470,7 +3470,7 @@
             "bskill_tra_against2": {
                 "desc": ["进驻贸易站时，如果下笔赤金订单是违约订单，则赤金交付数额外+2"],
                 "efficient": {
-                    "Money": 93.8
+                    "Money": 0
                 },
                 "name": ["违约索赔·β"],
                 "template": "Bskill_tra_against2.png"
@@ -3510,7 +3510,7 @@
             "bskill_tra_closure": {
                 "desc": ["进驻贸易站时，订单获取效率+10%，固定获取可露希尔特别订单（不视作违约订单）"],
                 "efficient": {
-                    "all": 10.1
+                    "Money": 0
                 },
                 "name": ["特别订单"],
                 "template": "Bskill_tra_closure.png"
@@ -4062,6 +4062,48 @@
         "skillsGroup": [
             {
                 "allowExternal": true,
+                "desc": "但书-0组",
+                "necessary": [
+                    {
+                        "desc": "但书-0",
+                        "efficient": {
+                            "Money": 47
+                        },
+                        "skills": ["bskill_tra_law", "bskill_tra_against"]
+                    }
+                ],
+                "optional": []
+            },
+            {
+                "allowExternal": true,
+                "desc": "但书-2组",
+                "necessary": [
+                    {
+                        "desc": "但书-2",
+                        "efficient": {
+                            "Money": 93.8
+                        },
+                        "skills": ["bskill_tra_law", "bskill_tra_against2"]
+                    }
+                ],
+                "optional": []
+            },
+            {
+                "allowExternal": true,
+                "desc": "可露希尔组",
+                "necessary": [
+                    {
+                        "desc": "可露希尔",
+                        "efficient": {
+                            "Money": 45.1
+                        },
+                        "skills": ["bskill_tra_closure"]
+                    }
+                ],
+                "optional": []
+            },
+            {
+                "allowExternal": true,
                 "desc": "德2拉2组",
                 "necessary": [
                     {
@@ -4101,6 +4143,13 @@
                             "all": 35.2
                         },
                         "skills": ["bskill_tra_spd3"]
+                    },
+                    {
+                        "desc": "可露希尔",
+                        "efficient": {
+                            "Money": 45
+                        },
+                        "skills": ["bskill_tra_closure"]
                     }
                 ]
             },
@@ -4167,6 +4216,13 @@
                             "all": 32
                         },
                         "skills": ["bskill_tra_limit_diff", "bskill_tra_limit_count"]
+                    },
+                    {
+                        "desc": "可露希尔",
+                        "efficient": {
+                            "Money": 45
+                        },
+                        "skills": ["bskill_tra_closure"]
                     }
                 ]
             },


### PR DESCRIPTION
将但书与可露希尔的单技能 Money 效率置为 0，使其不再按普通单干员效率参与贸易站排序，而是通过 skillsGroup 估算实际收益，以在绝大部分情况下避免但书与可露希尔被选入同贸易站。

但书组补充合同法技能匹配：但书实际识别到的是合同法 + 违约索赔技能集合，SkillsGroup 必须完整匹配技能集合，否则但书组不会触发。

为可露希尔新增独立组。
根据攻略测算（公孙长乐@bilibili），可露希尔在队友提供约 60%-100% 贸易效率时，订单侧等效效率约为 40%-47%；同时其特别订单每 2 赤金获得 1200 龙门币，还会带来额外的赤金/制造站侧收益。
因此将其定制为 45.1，并在德拉相关组合中的可选项同时加入，保证排序上稳定优于孑-0 的 43。

## Summary by Sourcery

通过基于技能组的评估（而非单干效率）来调整贸易站干员效率建模，以适配达什和凯尔希。

New Features:
- 为达什新增专用技能组配置，要求其“合同法”技能组完全匹配后才会启用技能组处理。
- 为凯尔希新增独立技能组，并为其设定自定义的有效贸易效率值，用于贸易站组合计算。

Enhancements:
- 将达什和凯尔希的单一“Money”技能效率设为 0，使其在标准贸易站排序中被排除，转而通过 `skillsGroup` 基于预估收益进行评估。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust trading post operator efficiency modeling to handle Dashi and Kelsey via grouped skill evaluation instead of single-operator efficiency.

New Features:
- Introduce a dedicated skills group configuration for Dashi that requires full matching of her contract-law skill set to activate group handling.
- Add an independent skills group for Kelsey with a customized effective trading efficiency value for use in trading post combinations.

Enhancements:
- Set single-skill Money efficiencies of Dashi and Kelsey to zero so they are excluded from standard trading post sorting and instead evaluated via skillsGroup-based estimated收益.

</details>