### PR TITLE
feat: 切换主题时保存当前画面截图

### DIFF
--- a/resource/tasks/UiTheme/SwitchTheme.json
+++ b/resource/tasks/UiTheme/SwitchTheme.json
@@ -1,0 +1,46 @@
+{    
+    "SwitchTheme@ToggleSettingsMenu": {
+        "action": "ClickSelf",
+        "roi": [227, 327, 159, 152],
+        "postDelay": 1000,
+        "next": ["SwitchTheme@ChangeTheme", "SwitchTheme@ToggleSettingsMenu"]
+    },
+    "SwitchTheme@ChangeTheme": {
+        "action": "ClickSelf",
+        "roi": [563, 566, 132, 132],
+        "next": ["SwitchTheme@SelectLightTheme", "SwitchTheme@SwipeToLightTheme"]
+    },
+    "SwitchTheme@SelectLightTheme": {
+        "action": "ClickSelf",
+        "roi": [0, 99, 430, 180],
+        "maxTimes": 10,
+        "exceededNext": ["SwitchTheme@CancelThemeChange"],
+        "next": ["SwitchTheme@ConfirmThemeChange", "SwitchTheme@SelectLightTheme"]
+    },
+    "SwitchTheme@SwipeToLightTheme": {
+        "algorithm": "JustReturn",
+        "action": "Swipe",
+        "specificRect": [200, 170, 10, 10],
+        "rectMove": [200, 600, 10, 10],
+        "specialParams": [150, 0, 1, 1],
+        "postDelay": 500,
+        "maxTimes": 10,
+        "next": ["SwitchTheme@SelectLightTheme", "SwitchTheme@SwipeToLightTheme"]
+    },
+    "SwitchTheme@ConfirmThemeChange": {
+        "action": "ClickSelf",
+        "roi": [1070, 620, 200, 90],
+        "postDelay": 500,
+        "next": ["SwitchTheme@ReturnTheme"]
+    },
+    "SwitchTheme@CancelThemeChange": {
+        "action": "ClickSelf",
+        "roi": [918, 645, 66, 38],
+        "next": ["SwitchTheme@ReturnTheme"]
+    },
+    "SwitchTheme@ReturnTheme": {
+        "baseTask": "ReturnButton",
+        "template": ["Return.png", "Return-White.png"],
+        "next": ["#next"]
+    }
+}

--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -93,50 +93,6 @@
         "next": ["#next"],
         "maxTimes": 20
     },
-    "SwitchTheme@ToggleSettingsMenu": {
-        "action": "ClickSelf",
-        "roi": [227, 327, 159, 152],
-        "postDelay": 1000,
-        "next": ["SwitchTheme@ChangeTheme", "SwitchTheme@ToggleSettingsMenu"]
-    },
-    "SwitchTheme@ChangeTheme": {
-        "action": "ClickSelf",
-        "roi": [563, 566, 132, 132],
-        "next": ["SwitchTheme@SelectLightTheme", "SwitchTheme@SwipeToLightTheme"]
-    },
-    "SwitchTheme@SelectLightTheme": {
-        "action": "ClickSelf",
-        "roi": [0, 99, 430, 180],
-        "maxTimes": 10,
-        "exceededNext": ["SwitchTheme@CancelThemeChange"],
-        "next": ["SwitchTheme@ConfirmThemeChange", "SwitchTheme@SelectLightTheme"]
-    },
-    "SwitchTheme@SwipeToLightTheme": {
-        "algorithm": "JustReturn",
-        "action": "Swipe",
-        "specificRect": [200, 170, 10, 10],
-        "rectMove": [200, 600, 10, 10],
-        "specialParams": [150, 0, 1, 1],
-        "postDelay": 500,
-        "maxTimes": 10,
-        "next": ["SwitchTheme@SelectLightTheme", "SwitchTheme@SwipeToLightTheme"]
-    },
-    "SwitchTheme@ConfirmThemeChange": {
-        "action": "ClickSelf",
-        "roi": [1070, 620, 200, 90],
-        "postDelay": 500,
-        "next": ["SwitchTheme@ReturnTheme"]
-    },
-    "SwitchTheme@CancelThemeChange": {
-        "action": "ClickSelf",
-        "roi": [918, 645, 66, 38],
-        "next": ["SwitchTheme@ReturnTheme"]
-    },
-    "SwitchTheme@ReturnTheme": {
-        "baseTask": "ReturnButton",
-        "template": ["Return.png", "Return-White.png"],
-        "next": ["#next"]
-    },
     "StageTheme": {
         "templThreshold": 0.7,
         "action": "ClickSelf",

--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -4370,7 +4370,7 @@
         "Doc": "本任务是插件 ScreenshotTaskPlugin 的配置",
         "Doc_2": "需要在任务 Task 开始时截图时，将 Task 加入到此任务的 next 列表。",
         "algorithm": "JustReturn",
-        "next": ["Roguelike@StageEncounterOptionUnknown"]
+        "next": ["Roguelike@StageEncounterOptionUnknown", "SwitchTheme@ToggleSettingsMenu"]
     },
     "ScreenshotTaskPlugin-Config-Debug": {
         "Doc": "本任务是插件 ScreenshotTaskPlugin 的配置",

--- a/src/MaaCore/Task/Interface/AwardTask.cpp
+++ b/src/MaaCore/Task/Interface/AwardTask.cpp
@@ -2,6 +2,7 @@
 
 #include <utility>
 
+#include "Task/Miscellaneous/ScreenshotTaskPlugin.h"
 #include "Task/ProcessTask.h"
 
 #include "Utils/Logger.hpp"
@@ -24,6 +25,8 @@ asst::AwardTask::AwardTask(const AsstCallback& callback, Assistant* inst) :
     orundum_task_ptr->set_tasks({ "OrundumActivitiesBegin" });
     mining_task_ptr->set_tasks({ "MiningActivitiesBegin" });
     specialaccess_task_ptr->set_tasks({ "SpecialAccessActivitiesBegin" });
+
+    award_task_ptr->register_plugin<ScreenshotTaskPlugin>();
 
     m_subtasks.emplace_back(award_task_ptr);
     m_subtasks.emplace_back(mail_task_ptr);

--- a/src/MaaCore/Task/Interface/DepotTask.cpp
+++ b/src/MaaCore/Task/Interface/DepotTask.cpp
@@ -1,6 +1,7 @@
 #include "DepotTask.h"
 
 #include "Task/Miscellaneous/DepotRecognitionTask.h"
+#include "Task/Miscellaneous/ScreenshotTaskPlugin.h"
 #include "Task/ProcessTask.h"
 
 asst::DepotTask::DepotTask(const AsstCallback& callback, Assistant* inst) :
@@ -8,6 +9,7 @@ asst::DepotTask::DepotTask(const AsstCallback& callback, Assistant* inst) :
 {
     auto enter_task = std::make_shared<ProcessTask>(m_callback, m_inst, TaskType);
     enter_task->set_tasks({ "DepotBegin" }).set_ignore_error(true);
+    enter_task->register_plugin<ScreenshotTaskPlugin>();
     m_subtasks.emplace_back(enter_task);
 
     auto recognition_task = std::make_shared<DepotRecognitionTask>(m_callback, m_inst, TaskType);

--- a/src/MaaCore/Task/Interface/FightTask.cpp
+++ b/src/MaaCore/Task/Interface/FightTask.cpp
@@ -9,6 +9,7 @@
 #include "Task/Fight/SideStoryReopenTask.h"
 #include "Task/Fight/StageDropsTaskPlugin.h"
 #include "Task/Fight/StageNavigationTask.h"
+#include "Task/Miscellaneous/ScreenshotTaskPlugin.h"
 #include "Task/ProcessTask.h"
 #include "Utils/Logger.hpp"
 #include <ranges>
@@ -34,6 +35,7 @@ asst::FightTask::FightTask(const AsstCallback& callback, Assistant* inst) :
         .set_times_limit("PRTS3", 0)
         .set_times_limit("EndOfAction", 0)
         .set_retry_times(5);
+    m_start_up_task_ptr->register_plugin<ScreenshotTaskPlugin>();
 
     m_stage_navigation_task_ptr->set_fight_task_ptr(m_fight_task_ptr);
     m_stage_navigation_task_ptr->set_enable(false).set_retry_times(0);

--- a/src/MaaCore/Task/Interface/InfrastTask.cpp
+++ b/src/MaaCore/Task/Interface/InfrastTask.cpp
@@ -14,6 +14,7 @@
 #include "Task/Infrast/InfrastTradeTask.h"
 #include "Task/Infrast/InfrastTrainingTask.h"
 #include "Task/Infrast/ReplenishOriginiumShardTaskPlugin.h"
+#include "Task/Miscellaneous/ScreenshotTaskPlugin.h"
 #include "Task/ProcessTask.h"
 
 asst::InfrastTask::InfrastTask(const AsstCallback& callback, Assistant* inst) :
@@ -34,6 +35,7 @@ asst::InfrastTask::InfrastTask(const AsstCallback& callback, Assistant* inst) :
     LogTraceFunction;
 
     m_infrast_begin_task_ptr->set_tasks({ "InfrastBegin" }).set_ignore_error(false);
+    m_infrast_begin_task_ptr->register_plugin<ScreenshotTaskPlugin>();
     m_queue_rotation_task->set_tasks({ "InfrastEnterRotation" }).set_ignore_error(true);
     m_replenish_task_ptr = m_mfg_task_ptr->register_plugin<ReplenishOriginiumShardTaskPlugin>();
     m_info_task_ptr->set_ignore_error(true);

--- a/src/MaaCore/Task/Interface/MallTask.cpp
+++ b/src/MaaCore/Task/Interface/MallTask.cpp
@@ -2,6 +2,7 @@
 
 #include "Task/Miscellaneous/CreditFightTask.h"
 #include "Task/Miscellaneous/CreditShoppingTask.h"
+#include "Task/Miscellaneous/ScreenshotTaskPlugin.h"
 #include "Task/ProcessTask.h"
 
 #include "Utils/Logger.hpp"
@@ -19,6 +20,8 @@ asst::MallTask::MallTask(const AsstCallback& callback, Assistant* inst) :
 
     m_visit_task_ptr->set_tasks({ "VisitBegin" });
     m_mall_task_ptr->set_tasks({ "MallBegin" });
+    m_visit_task_ptr->register_plugin<ScreenshotTaskPlugin>();
+    m_mall_task_ptr->register_plugin<ScreenshotTaskPlugin>();
     m_shopping_first_task_ptr->set_enable(false).set_retry_times(1);
     m_shopping_task_ptr->set_enable(false).set_retry_times(1);
     m_shopping_force_task_ptr->set_enable(false).set_retry_times(1);

--- a/src/MaaCore/Task/Interface/OperBoxTask.cpp
+++ b/src/MaaCore/Task/Interface/OperBoxTask.cpp
@@ -1,6 +1,7 @@
 #include "OperBoxTask.h"
 
 #include "Task/Miscellaneous/OperBoxRecognitionTask.h"
+#include "Task/Miscellaneous/ScreenshotTaskPlugin.h"
 #include "Task/ProcessTask.h"
 
 asst::OperBoxTask::OperBoxTask(const AsstCallback& callback, Assistant* inst) :
@@ -8,6 +9,7 @@ asst::OperBoxTask::OperBoxTask(const AsstCallback& callback, Assistant* inst) :
 {
     auto enter_task = std::make_shared<ProcessTask>(m_callback, m_inst, TaskType);
     enter_task->set_tasks({ "OperBoxBegin" }).set_ignore_error(true);
+    enter_task->register_plugin<ScreenshotTaskPlugin>();
     m_subtasks.emplace_back(enter_task);
 
     auto recognition_task = std::make_shared<OperBoxRecognitionTask>(m_callback, m_inst, TaskType);


### PR DESCRIPTION
## Summary by Sourcery

将截图捕获集成到关键的 UI 流程任务中，并配置新的主题切换任务。

新功能：
- 当进入干员凭证（awards）、访问好友（visiting friends）、打开商店（mall）、仓库（depot）、干员列表（operator box）、基建（infrastructure）以及开始战斗流程（starting combat flows）时，通过 `ScreenshotTaskPlugin` 捕获截图。
- 新增用于切换 UI 主题的 `SwitchTheme` 任务配置。

改进：
- 将 `ScreenshotTaskPlugin` 接入现有流程任务，在重要的导航节点自动进行截图。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add screenshot capture integration to key UI flow tasks and configure a new theme switch task.

New Features:
- Capture screenshots via ScreenshotTaskPlugin when entering awards, visiting friends, opening the mall, depot, operator box, infrastructure, and starting combat flows.
- Introduce a new SwitchTheme task configuration for UI theme switching.

Enhancements:
- Wire ScreenshotTaskPlugin into existing process tasks so screenshots are automatically taken at important navigation points.

</details>