### PR TITLE
feat: 支持 mumu 6.0 截图增强路径

### DIFF
--- a/src/MaaCore/Controller/MumuExtras.cpp
+++ b/src/MaaCore/Controller/MumuExtras.cpp
@@ -112,6 +112,8 @@ bool MumuExtras::load_mumu_library()
     for (const auto& rel_path : kCandidateRelativePaths) {
         auto lib_path = mumu_path_ / rel_path;
         if (load_library(lib_path)) {
+            LogInfo << "Successfully loaded MuMu external renderer library from: "
+                    << lib_path.string();
             loaded = true;
             break;
         }

--- a/src/MaaCore/Controller/MumuExtras.cpp
+++ b/src/MaaCore/Controller/MumuExtras.cpp
@@ -101,11 +101,27 @@ std::optional<cv::Mat> MumuExtras::screencap()
 
 bool MumuExtras::load_mumu_library()
 {
-    auto new_lib_path = mumu_path_ / "nx_device/12.0/shell/sdk/external_renderer_ipc"; // MuMu 5.0 内测路径, 可能变更
-    auto lib_path = mumu_path_ / "shell/sdk/external_renderer_ipc";
+    // 候选路径列表，按版本从新到旧排列，新增版本只需追加一项
+    static const std::vector<std::filesystem::path> kCandidateRelativePaths = {
+        "nx_device/15.0/shell/sdk/external_renderer_ipc", // MuMu 6.0
+        "nx_device/12.0/shell/sdk/external_renderer_ipc", // MuMu 5.0 / MuMu 12
+        "shell/sdk/external_renderer_ipc",                // MuMu 旧版本
+    };
 
-    if (!load_library(new_lib_path) && !load_library(lib_path)) {
-        LogError << "Failed to load library" << VAR(new_lib_path) << "or" << VAR(lib_path);
+    bool loaded = false;
+    for (const auto& rel_path : kCandidateRelativePaths) {
+        auto lib_path = mumu_path_ / rel_path;
+        if (load_library(lib_path)) {
+            loaded = true;
+            break;
+        }
+    }
+
+    if (!loaded) {
+        LogError << "Failed to load library from all candidate paths";
+        for (const auto& rel_path : kCandidateRelativePaths) {
+            LogError << "  tried: " << (mumu_path_ / rel_path).string();
+        }
         return false;
     }
 

--- a/src/MaaWpfGui/Helper/EmulatorHelper.cs
+++ b/src/MaaWpfGui/Helper/EmulatorHelper.cs
@@ -49,7 +49,7 @@ public class EmulatorHelper
                 "LDPlayer" => KillEmulatorLdPlayer(),
                 "XYAZ" => KillEmulatorXyaz(),
                 "BlueStacks" => KillEmulatorBlueStacks(),
-                "MuMuEmulator12" => KillEmulatorMuMuEmulator12(),
+                "MuMuEmulator12" => KillEmulatorMuMuEmulator(),
                 _ => KillEmulatorByWindow(),
             };
         }
@@ -61,10 +61,10 @@ public class EmulatorHelper
     }
 
     /// <summary>
-    /// 一个用于调用 MuMu12 模拟器控制台关闭 MuMu12 的方法
+    /// 一个用于调用 MuMu 模拟器控制台关闭 MuMu 的方法
     /// </summary>
     /// <returns>是否关闭成功</returns>
-    private static bool KillEmulatorMuMuEmulator12()
+    private static bool KillEmulatorMuMuEmulator()
     {
         string address = SettingsViewModel.ConnectSettings.ConnectAddress;
         int emuIndex;
@@ -72,9 +72,9 @@ public class EmulatorHelper
         {
             emuIndex = 0;
         }
-        else if (SettingsViewModel.ConnectSettings.MuMuEmulator12Extras.MuMuBridgeConnection)
+        else if (SettingsViewModel.ConnectSettings.MuMuEmulatorExtras.MuMuBridgeConnection)
         {
-            emuIndex = int.TryParse(SettingsViewModel.ConnectSettings.MuMuEmulator12Extras.Index, out var indexParse) ? indexParse : 0;
+            emuIndex = int.TryParse(SettingsViewModel.ConnectSettings.MuMuEmulatorExtras.Index, out var indexParse) ? indexParse : 0;
         }
         else if (address.Contains(':'))
         {
@@ -94,7 +94,7 @@ public class EmulatorHelper
                         emuIndex = (port - 5555) / 2;
                         break;
                     default:
-                        _logger.Error("Port {Port} is not valid for MuMuEmulator12", port);
+                        _logger.Error("Port {Port} is not valid for MuMu emulator", port);
                         return false;
                 }
             }

--- a/src/MaaWpfGui/Helper/WinAdapter.cs
+++ b/src/MaaWpfGui/Helper/WinAdapter.cs
@@ -46,8 +46,8 @@ public class WinAdapter
         { "HD-Player", "BlueStacks" },
         { "dnplayer", "LDPlayer" },
         { "Nox", "Nox" },
-        { "MuMuPlayer", "MuMuEmulator12" }, // MuMu 12
-        { "MuMuNxDevice", "MuMuEmulator12" }, // MuMu 12 5.0
+        { "MuMuPlayer", "MuMuEmulator12" },
+        { "MuMuNxDevice", "MuMuEmulator12" },
         { "MEmu", "XYAZ" },
     };
 

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -155,7 +155,7 @@ public class AsstProxy
         return ret;
     }
 
-    private static void AsstSetConnectionExtrasMuMu12(string extras)
+    private static void AsstSetConnectionExtrasMuMu(string extras)
     {
         AsstSetConnectionExtras("MuMuEmulator12", extras);
     }
@@ -894,7 +894,7 @@ public class AsstProxy
                     switch (SettingsViewModel.ConnectSettings.ConnectConfig)
                     {
                         case "MuMuEmulator12":
-                            if (!SettingsViewModel.ConnectSettings.MuMuEmulator12Extras.Enable)
+                            if (!SettingsViewModel.ConnectSettings.MuMuEmulatorExtras.Enable)
                             {
                                 break;
                             }
@@ -2646,7 +2646,7 @@ public class AsstProxy
         switch (SettingsViewModel.ConnectSettings.ConnectConfig)
         {
             case "MuMuEmulator12":
-                AsstSetConnectionExtrasMuMu12(SettingsViewModel.ConnectSettings.MuMuEmulator12Extras.Config);
+                AsstSetConnectionExtrasMuMu(SettingsViewModel.ConnectSettings.MuMuEmulatorExtras.Config);
                 break;
 
             case "LDPlayer":

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -674,9 +674,9 @@ Only supports Official(CN), Bilibili and Traditional Chinese servers. Third-part
     <system:String x:Key="MuMu12ExtrasEnabled">Enable MuMu's screenshot enhancement mode</system:String>
     <system:String x:Key="MuMuEmulatorPathNotFound">MuMu Emulator path not found.</system:String>
     <system:String x:Key="MuMuExternalRendererMissing" xml:space="preserve">external_renderer_ipc.dll was not found under the selected MuMu installation.\n
-Expected relative path: nx_device/15.0/shell/sdk/external_renderer_ipc/external_renderer_ipc.dll or
-nx_device/12.0/shell/sdk/external_renderer_ipc/external_renderer_ipc.dll or
-shell/sdk/external_renderer_ipc/external_renderer_ipc.dll\n
+Expected relative path: nx_device/15.0/shell/sdk/external_renderer_ipc.dll or
+nx_device/12.0/shell/sdk/external_renderer_ipc.dll or
+shell/sdk/external_renderer_ipc.dll\n
 Please verify the installation directory.</system:String>
     <system:String x:Key="MuMu12ExtrasEnabledTip" xml:space="preserve">
 MuMu / MuMu Arknights V4.0.0 or later is required. MuMu Global requires V5.21.3 or later.

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -185,7 +185,7 @@ To customize rotation schedules, please use ｢{key=InfrastModeCustom}｣.</syst
     <system:String x:Key="CustomizeInfrastSelectionEmpty">Custom Base infrastructure selection is empty. Please check your configuration or turn off the Custom Base function.</system:String>
     <system:String x:Key="General">General Mode</system:String>
     <system:String x:Key="BlueStacks">BlueStacks</system:String>
-    <system:String x:Key="MuMuEmulator12">MuMu Emulator 12</system:String>
+    <system:String x:Key="MuMuEmulator12">MuMu Emulator</system:String>
     <system:String x:Key="LDPlayer">LD Player</system:String>
     <system:String x:Key="AVD">Android Virtual Device (AVD)</system:String>
     <system:String x:Key="Androws">Androws</system:String>
@@ -672,9 +672,10 @@ Only supports Official(CN), Bilibili and Traditional Chinese servers. Third-part
     <system:String x:Key="ConnectionPreset">Connection Preset</system:String>
     <system:String x:Key="ScreenshotTest">Screenshot test</system:String>
     <system:String x:Key="MuMu12ExtrasEnabled">Enable MuMu's screenshot enhancement mode</system:String>
-    <system:String x:Key="MuMuEmulatorPathNotFound">MuMu Emulator 12 path not found.</system:String>
+    <system:String x:Key="MuMuEmulatorPathNotFound">MuMu Emulator path not found.</system:String>
     <system:String x:Key="MuMuExternalRendererMissing" xml:space="preserve">external_renderer_ipc.dll was not found under the selected MuMu installation.\n
-Expected relative path: nx_device/12.0/shell/sdk/external_renderer_ipc/external_renderer_ipc.dll or
+Expected relative path: nx_device/15.0/shell/sdk/external_renderer_ipc/external_renderer_ipc.dll or
+nx_device/12.0/shell/sdk/external_renderer_ipc/external_renderer_ipc.dll or
 shell/sdk/external_renderer_ipc/external_renderer_ipc.dll\n
 Please verify the installation directory.</system:String>
     <system:String x:Key="MuMu12ExtrasEnabledTip" xml:space="preserve">
@@ -682,15 +683,14 @@ MuMu / MuMu Arknights V4.0.0 or later is required. MuMu Global requires V5.21.3 
 It's strongly recommended to run a screenshot test immediately after enabling this feature.
 MAA will attempt to automatically fill in the exec path through the registry. If failed, please fill it in manually.\n
 The installation path should be the root directory of the emulator installation, for example, if the emulator process file path is
-C:\\Program Files\\Netease\\MuMuPlayer-12.0\\shell\\MuMuPlayer.exe or
-C:\\Program Files\\Netease\\MuMuPlayer-12.0\\nx_device\\12.0\\shell\\MuMuNxDevice.exe
+C:\\Program Files\\Netease\\MuMuPlayer\\nx_device\\12.0\\shell\\MuMuNxDevice.exe
 then it should be filled in as
-C:\\Program Files\\Netease\\MuMuPlayer-12.0\n
+C:\\Program Files\\Netease\\MuMuPlayer\n
 Note:
 1. If the port number of the connection address is 7555, you need to change the port number to 16384.
 2. If using network bridging, check the MuMu network bridging mode and manually enter the serial number.
     </system:String>
-    <system:String x:Key="MuMu12EmulatorPath">MuMu12 Emulator exec path</system:String>
+    <system:String x:Key="MuMu12EmulatorPath">MuMu Installation Path</system:String>
     <system:String x:Key="MuMuBridgeConnection">MuMu Network Bridge Connection</system:String>
     <system:String x:Key="MuMuBridgeConnectionTip">Unless you know what you are doing, do not enable this option</system:String>
     <system:String x:Key="MuMu12Index">Instance Number</system:String>
@@ -1187,8 +1187,8 @@ Right-click to clear inactive jobs</system:String>
     <system:String x:Key="TouchModeNotAvailable">Touch mode is not available, please go to ｢{key=Settings} - {key=ConnectionSettings}｣ to switch to a different touch mode.</system:String>
     <system:String x:Key="ScreencapFailed">Screencap failed. If it happens repeatedly, try to restart or change the emulator!</system:String>
     <system:String x:Key="FastestWayToScreencap">Screenshot test tasks: {0}ms ({1})</system:String>
-    <system:String x:Key="FastestWayToScreencapWarningTip">Screencap takes a long time (avg: {0}ms) which may cause some abnormal behaviors using automatic combat functions (e.g. Auto I. S.). If using MuMu12 or LDPlayer, please try enabling screenshot enhancement</system:String>
-    <system:String x:Key="FastestWayToScreencapErrorTip">Screencap takes too long (avg: {0}ms), so automatic combat functions (e.g. Auto I. S.) may not run properly. It is recommended to try restarting or changing the emulator! If using MuMu12 or LDPlayer, please try enabling screenshot enhancement</system:String>
+    <system:String x:Key="FastestWayToScreencapWarningTip">Screencap takes a long time (avg: {0}ms) which may cause some abnormal behaviors using automatic combat functions (e.g. Auto I. S.). If using MuMu or LDPlayer, please try enabling screenshot enhancement</system:String>
+    <system:String x:Key="FastestWayToScreencapErrorTip">Screencap takes too long (avg: {0}ms), so automatic combat functions (e.g. Auto I. S.) may not run properly. It is recommended to try restarting or changing the emulator! If using MuMu or LDPlayer, please try enabling screenshot enhancement</system:String>
     <system:String x:Key="IdentifyTheMistakes">Recognition error</system:String>
     <system:String x:Key="TaskError" xml:space="preserve">Task error:&#160;</system:String>
     <system:String x:Key="CombatError">Combat error</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -672,9 +672,10 @@ HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Notifications\Settin
     <system:String x:Key="ConnectionPreset">接続構成</system:String>
     <system:String x:Key="ScreenshotTest">スクリーンショットテスト</system:String>
     <system:String x:Key="MuMu12ExtrasEnabled">MuMu のスクリーンショット拡張モードを有効にする</system:String>
-    <system:String x:Key="MuMuEmulatorPathNotFound">MuMu Emulator 12 のパスが見つかりません。</system:String>
+    <system:String x:Key="MuMuEmulatorPathNotFound">MuMu エミュレータのパスが見つかりません。</system:String>
     <system:String x:Key="MuMuExternalRendererMissing" xml:space="preserve">external_renderer_ipc.dll が選択した MuMu インストール内に見つかりませんでした。\n
 想定される相対パス：
+nx_device/15.0/shell/sdk/external_renderer_ipc/external_renderer_ipc.dll または
 nx_device/12.0/shell/sdk/external_renderer_ipc/external_renderer_ipc.dll または
 shell/sdk/external_renderer_ipc/external_renderer_ipc.dll\n
 インストールディレクトリを確認してください。</system:String>
@@ -683,15 +684,14 @@ MuMu / MuMu Arknights V4.0.0 以降を利用する必要があり、MuMu Global 
 この機能を有効にした後、すぐにスクリーンショットテストを実行することを強くお勧めします。
 MAA はレジストリからインストールパスを自動的に取得しますが、失敗した場合は手動で入力してください。\n
 インストールパスには、エミュレーターのインストールディレクトリのルートディレクトリを入力する必要があります。例えば、エミュレーターのプロセスファイルパスが
-C:\\Program Files\\Netease\\MuMuPlayer-12.0\\shell\\MuMuPlayer.exe または
-C:\\Program Files\\Netease\\MuMuPlayer-12.0\\nx_device\\12.0\\shell\\MuMuNxDevice.exe
+C:\\Program Files\\Netease\\MuMuPlayer\\nx_device\\12.0\\shell\\MuMuNxDevice.exe
 の場合、
-C:\\Program Files\\Netease\\MuMuPlayer-12.0 を入力してください。\n
+C:\\Program Files\\Netease\\MuMuPlayer を入力してください。\n
 注意：
 1. 接続アドレスのポート番号が 7555 の場合、ポート番号を 16384 に変更してください。
 2. ネットワークブリッジを使用している場合は、MuMu ネットワークブリッジモードを選択し、シリアル番号を手動で入力する必要があります。
     </system:String>
-    <system:String x:Key="MuMu12EmulatorPath">MuMu12 エミュレータパス</system:String>
+    <system:String x:Key="MuMu12EmulatorPath">MuMu エミュレータパス</system:String>
     <system:String x:Key="MuMuBridgeConnection">MuMu ネットワークブリッジモード</system:String>
     <system:String x:Key="MuMuBridgeConnectionTip">自分が何をしているのか分かっていない限り、このオプションを有効にしないでください</system:String>
     <system:String x:Key="MuMu12Index">インスタンス番号</system:String>
@@ -1188,8 +1188,8 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="TouchModeNotAvailable">タッチモードは利用できません。「{key=Settings} - {key=ConnectionSettings}」に入って、他のタッチモードに変更してください。</system:String>
     <system:String x:Key="ScreencapFailed">スクリーンキャプチャに失敗しました。繰り返し発生する場合は、エミュレータの再起動または変更をお試しください！</system:String>
     <system:String x:Key="FastestWayToScreencap">スクリーンショット テストには: {0}ms ({1})</system:String>
-    <system:String x:Key="FastestWayToScreencapWarningTip">スクリーンキャップには時間がかかるため(平均: {0}ms)、自動戦闘機能 (Auto I.S. など) を使用すると異常な動作が発生する可能性があります。Mumu12やLDPlayerを使用している場合は、スクリーンショット拡張を試してください。</system:String>
-    <system:String x:Key="FastestWayToScreencapErrorTip">スクリーンキャップに時間がかかりすぎるため(平均: {0}ms)、自動戦闘機能 (Auto I.S. など) が適切に動作しない可能性があります、シミュレータの再起動や交換をお勧めします！Mumu12やLDPlayerを使用している場合は、スクリーンショット拡張を試してください。</system:String>
+    <system:String x:Key="FastestWayToScreencapWarningTip">スクリーンキャップには時間がかかるため(平均: {0}ms)、自動戦闘機能 (Auto I.S. など) を使用すると異常な動作が発生する可能性があります。MuMuやLDPlayerを使用している場合は、スクリーンショット拡張を試してください。</system:String>
+    <system:String x:Key="FastestWayToScreencapErrorTip">スクリーンキャップに時間がかかりすぎるため(平均: {0}ms)、自動戦闘機能 (Auto I.S. など) が適切に動作しない可能性があります、シミュレータの再起動や交換をお勧めします！MuMuやLDPlayerを使用している場合は、スクリーンショット拡張を試してください。</system:String>
     <system:String x:Key="IdentifyTheMistakes">認識エラー</system:String>
     <system:String x:Key="TaskError" xml:space="preserve">タスクエラー: </system:String>
     <system:String x:Key="CombatError">戦闘エラー</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -675,9 +675,9 @@ HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Notifications\Settin
     <system:String x:Key="MuMuEmulatorPathNotFound">MuMu エミュレータのパスが見つかりません。</system:String>
     <system:String x:Key="MuMuExternalRendererMissing" xml:space="preserve">external_renderer_ipc.dll が選択した MuMu インストール内に見つかりませんでした。\n
 想定される相対パス：
-nx_device/15.0/shell/sdk/external_renderer_ipc/external_renderer_ipc.dll または
-nx_device/12.0/shell/sdk/external_renderer_ipc/external_renderer_ipc.dll または
-shell/sdk/external_renderer_ipc/external_renderer_ipc.dll\n
+nx_device/15.0/shell/sdk/external_renderer_ipc.dll または
+nx_device/12.0/shell/sdk/external_renderer_ipc.dll または
+shell/sdk/external_renderer_ipc.dll\n
 インストールディレクトリを確認してください。</system:String>
     <system:String x:Key="MuMu12ExtrasEnabledTip" xml:space="preserve">
 MuMu / MuMu Arknights V4.0.0 以降を利用する必要があり、MuMu Global は V5.21.3 以降に対応しています。

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -675,9 +675,9 @@ HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Notifications\Settin
     <system:String x:Key="MuMuEmulatorPathNotFound">MuMu 에뮬레이터 경로를 찾을 수 없습니다.</system:String>
     <system:String x:Key="MuMuExternalRendererMissing" xml:space="preserve">선택한 MuMu 설치 폴더에서 external_renderer_ipc.dll을 찾을 수 없습니다.\n
 예상 상대 경로:
-nx_device/15.0/shell/sdk/external_renderer_ipc/external_renderer_ipc.dll 또는
-nx_device/12.0/shell/sdk/external_renderer_ipc/external_renderer_ipc.dll 또는
-shell/sdk/external_renderer_ipc/external_renderer_ipc.dll\n
+nx_device/15.0/shell/sdk/external_renderer_ipc.dll 또는
+nx_device/12.0/shell/sdk/external_renderer_ipc.dll 또는
+shell/sdk/external_renderer_ipc.dll\n
 설치 폴더를 확인하세요.</system:String>
     <system:String x:Key="MuMu12ExtrasEnabledTip" xml:space="preserve">
 MuMu / MuMu Arknights V4.0.0 이상 버전이 필요합니다. MuMu Global은 V5.21.3 이상 버전이 필요합니다.

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -672,9 +672,10 @@ HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Notifications\Settin
     <system:String x:Key="ConnectionPreset">연결 프리셋</system:String>
     <system:String x:Key="ScreenshotTest">스크린샷 테스트</system:String>
     <system:String x:Key="MuMu12ExtrasEnabled">MuMu 스크린샷 강화 기능 활성화</system:String>
-    <system:String x:Key="MuMuEmulatorPathNotFound">MuMu Emulator 12 경로를 찾을 수 없습니다.</system:String>
+    <system:String x:Key="MuMuEmulatorPathNotFound">MuMu 에뮬레이터 경로를 찾을 수 없습니다.</system:String>
     <system:String x:Key="MuMuExternalRendererMissing" xml:space="preserve">선택한 MuMu 설치 폴더에서 external_renderer_ipc.dll을 찾을 수 없습니다.\n
 예상 상대 경로:
+nx_device/15.0/shell/sdk/external_renderer_ipc/external_renderer_ipc.dll 또는
 nx_device/12.0/shell/sdk/external_renderer_ipc/external_renderer_ipc.dll 또는
 shell/sdk/external_renderer_ipc/external_renderer_ipc.dll\n
 설치 폴더를 확인하세요.</system:String>
@@ -683,15 +684,14 @@ MuMu / MuMu Arknights V4.0.0 이상 버전이 필요합니다. MuMu Global은 V5
 이 기능을 활성화한 후 즉시 스크린샷 테스트를 실행하는 것을 강력히 권장합니다.
 MAA는 레지스트리를 통해 설치 경로를 자동으로 가져옵니다. 가져오지 못한 경우 수동으로 입력해 주세요.\n
 설치 경로는 에뮬레이터 경로의 최상위 폴더를 입력해야 합니다. 예를 들어, 에뮬레이터 프로세스 파일 경로가
-C:\\Program Files\\Netease\\MuMuPlayer-12.0\\shell\\MuMuPlayer.exe 또는
-C:\\Program Files\\Netease\\MuMuPlayer-12.0\\nx_device\\12.0\\shell\\MuMuNxDevice.exe
+C:\\Program Files\\Netease\\MuMuPlayer\\nx_device\\12.0\\shell\\MuMuNxDevice.exe
 인 경우
-C:\\Program Files\\Netease\\MuMuPlayer-12.0으로 입력해야 합니다.\n
+C:\\Program Files\\Netease\\MuMuPlayer으로 입력해야 합니다.\n
 주의:
 1. 연결 주소의 포트 번호가 7555일 경우, 포트 번호를 16384로 변경해야 합니다.
 2. 네트워크 브리징을 사용 중인 경우 MuMu 네트워크 브리징 모드를 선택하고 일련 번호를 수동으로 입력해야 합니다.
     </system:String>
-    <system:String x:Key="MuMu12EmulatorPath">MuMu12 에뮬레이터 경로</system:String>
+    <system:String x:Key="MuMu12EmulatorPath">MuMu 에뮬레이터 경로</system:String>
     <system:String x:Key="MuMuBridgeConnection">MuMu 네트워크 브리지 모드</system:String>
     <system:String x:Key="MuMuBridgeConnectionTip">무슨 역할을 하는지 잘 모른다면 이 옵션을 활성화하지 마세요</system:String>
     <system:String x:Key="MuMu12Index">인스턴스 번호</system:String>
@@ -1189,8 +1189,8 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="TouchModeNotAvailable">터치 수행 방식이 사용 불가능합니다. ｢{key=Settings} - {key=ConnectionSettings}｣에서 다른 방식으로 변경해 주세요.</system:String>
     <system:String x:Key="ScreencapFailed">스크린샷 캡처에 실패했습니다. 반복적으로 발생 시 에뮬레이터를 다시 시작하거나 변경해 보세요!</system:String>
     <system:String x:Key="FastestWayToScreencap">스크린샷 캡처 속도: {0}ms ({1})</system:String>
-    <system:String x:Key="FastestWayToScreencapWarningTip">스크린샷 캡처 속도가 느려서 (평균: {0}ms) Copilot 기능에서 일부 비정상적인 동작이 발생할 수 있습니다. MuMu12 또는 LDPlayer를 사용하는 경우 스크린샷 향상 기능을 활성화해 보세요.</system:String>
-    <system:String x:Key="FastestWayToScreencapErrorTip">스크린샷 캡처 속도가 너무 느려서 (평균: {0}ms) Copliot 기능이 제대로 실행되지 않을 수 있습니다. 에뮬레이터를 재시작하거나 변경하는 것을 권장합니다! MuMu12 또는 LDPlayer를 사용하는 경우 스크린샷 향상 기능을 활성화해 보세요.</system:String>
+    <system:String x:Key="FastestWayToScreencapWarningTip">스크린샷 캡처 속도가 느려서 (평균: {0}ms) Copilot 기능에서 일부 비정상적인 동작이 발생할 수 있습니다. MuMu 또는 LDPlayer를 사용하는 경우 스크린샷 향상 기능을 활성화해 보세요.</system:String>
+    <system:String x:Key="FastestWayToScreencapErrorTip">스크린샷 캡처 속도가 너무 느려서 (평균: {0}ms) Copliot 기능이 제대로 실행되지 않을 수 있습니다. 에뮬레이터를 재시작하거나 변경하는 것을 권장합니다! MuMu 또는 LDPlayer를 사용하는 경우 스크린샷 향상 기능을 활성화해 보세요.</system:String>
     <system:String x:Key="IdentifyTheMistakes">인식 오류</system:String>
     <system:String x:Key="TaskError" xml:space="preserve">작업 오류: </system:String>
     <system:String x:Key="CombatError">작전 오류</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -675,9 +675,9 @@ HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Notifications\Settin
     <system:String x:Key="MuMuEmulatorPathNotFound">未找到 MuMu 模拟器路径。</system:String>
     <system:String x:Key="MuMuExternalRendererMissing" xml:space="preserve">external_renderer_ipc.dll 未在所选 MuMu 安装目录中找到。\n
 期望的相对路径：
-nx_device/15.0/shell/sdk/external_renderer_ipc/external_renderer_ipc.dll 或
-nx_device/12.0/shell/sdk/external_renderer_ipc/external_renderer_ipc.dll 或
-shell/sdk/external_renderer_ipc/external_renderer_ipc.dll\n
+nx_device/15.0/shell/sdk/external_renderer_ipc.dll 或
+nx_device/12.0/shell/sdk/external_renderer_ipc.dll 或
+shell/sdk/external_renderer_ipc.dll\n
 请确认安装目录。</system:String>
     <system:String x:Key="MuMu12ExtrasEnabledTip" xml:space="preserve">
 需使用官版或方舟专版 MuMu V4.0.0 或更新版本，国际版需 V5.21.3 或更新版本。

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -672,9 +672,10 @@ HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Notifications\Settin
     <system:String x:Key="ConnectionPreset">连接配置</system:String>
     <system:String x:Key="ScreenshotTest">截图测试</system:String>
     <system:String x:Key="MuMu12ExtrasEnabled">启用 MuMu 截图增强模式</system:String>
-    <system:String x:Key="MuMuEmulatorPathNotFound">未找到 MuMu Emulator 12 路径。</system:String>
+    <system:String x:Key="MuMuEmulatorPathNotFound">未找到 MuMu 模拟器路径。</system:String>
     <system:String x:Key="MuMuExternalRendererMissing" xml:space="preserve">external_renderer_ipc.dll 未在所选 MuMu 安装目录中找到。\n
 期望的相对路径：
+nx_device/15.0/shell/sdk/external_renderer_ipc/external_renderer_ipc.dll 或
 nx_device/12.0/shell/sdk/external_renderer_ipc/external_renderer_ipc.dll 或
 shell/sdk/external_renderer_ipc/external_renderer_ipc.dll\n
 请确认安装目录。</system:String>
@@ -683,10 +684,9 @@ shell/sdk/external_renderer_ipc/external_renderer_ipc.dll\n
 强烈建议在开启本功能后立刻运行一次截图测试。
 MAA 会自动通过注册表获取安装路径，若获取失败则请手动填写。\n
 安装路径应填写模拟器安装目录的根目录，例如模拟器进程文件路径为
-C:\\Program Files\\Netease\\MuMuPlayer-12.0\\shell\\MuMuPlayer.exe 或
-C:\\Program Files\\Netease\\MuMuPlayer-12.0\\nx_device\\12.0\\shell\\MuMuNxDevice.exe
+C:\\Program Files\\Netease\\MuMuPlayer\\nx_device\\12.0\\shell\\MuMuNxDevice.exe
 则应填写
-C:\\Program Files\\Netease\\MuMuPlayer-12.0。\n
+C:\\Program Files\\Netease\\MuMuPlayer。\n
 注意：
 1. 若当前连接地址端口号为 7555，则需将端口号改为 16384。
 2. 若正在使用网络桥接，则需勾选 MuMu 网络桥接模式并手动填写序号。
@@ -1188,8 +1188,8 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="TouchModeNotAvailable">触控模式不可用。请进入 ｢{key=Settings} - {key=ConnectionSettings}｣ 切换其他触控模式。</system:String>
     <system:String x:Key="ScreencapFailed">截图失败，如反复出现请尝试重启或更换模拟器！</system:String>
     <system:String x:Key="FastestWayToScreencap">最快截图耗时: {0}ms ({1})</system:String>
-    <system:String x:Key="FastestWayToScreencapWarningTip">截图用时较长(平均: {0}ms)，自动战斗类功能（如自动肉鸽）可能表现异常。如使用 Mumu12、雷电模拟器请尝试开启截图增强</system:String>
-    <system:String x:Key="FastestWayToScreencapErrorTip">截图用时过长(平均: {0}ms)，自动战斗类功能（如自动肉鸽）很可能无法正常运行，建议尝试重启或更换模拟器！如使用 Mumu12、雷电模拟器请尝试开启截图增强</system:String>
+    <system:String x:Key="FastestWayToScreencapWarningTip">截图用时较长(平均: {0}ms)，自动战斗类功能（如自动肉鸽）可能表现异常。如使用 MuMu、雷电模拟器请尝试开启截图增强</system:String>
+    <system:String x:Key="FastestWayToScreencapErrorTip">截图用时过长(平均: {0}ms)，自动战斗类功能（如自动肉鸽）很可能无法正常运行，建议尝试重启或更换模拟器！如使用 MuMu、雷电模拟器请尝试开启截图增强</system:String>
     <system:String x:Key="IdentifyTheMistakes">识别错误</system:String>
     <system:String x:Key="TaskError" xml:space="preserve">任务出错: </system:String>
     <system:String x:Key="CombatError">战斗出错</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -185,7 +185,7 @@
     <system:String x:Key="CustomizeInfrastSelectionEmpty">自定義設施配置選擇為空，請檢查配置或關閉自定義功能。</system:String>
     <system:String x:Key="General">通用模式</system:String>
     <system:String x:Key="BlueStacks">藍疊模擬器</system:String>
-    <system:String x:Key="MuMuEmulator12">MuMu 模擬器 12</system:String>
+    <system:String x:Key="MuMuEmulator12">MuMu 模擬器</system:String>
     <system:String x:Key="LDPlayer">雷電模擬器</system:String>
     <system:String x:Key="AVD">Android 虛擬裝置（AVD）</system:String>
     <system:String x:Key="Androws">應用寶模擬器</system:String>
@@ -672,9 +672,10 @@ HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Notifications\Settin
     <system:String x:Key="ConnectionPreset">連線配置</system:String>
     <system:String x:Key="ScreenshotTest">截圖測試</system:String>
     <system:String x:Key="MuMu12ExtrasEnabled">啟用 MuMu 截圖增強模式</system:String>
-    <system:String x:Key="MuMuEmulatorPathNotFound">找不到 MuMu Emulator 12 路徑。</system:String>
+    <system:String x:Key="MuMuEmulatorPathNotFound">找不到 MuMu 模擬器路徑。</system:String>
     <system:String x:Key="MuMuExternalRendererMissing" xml:space="preserve">external_renderer_ipc.dll 未在所選 MuMu 安裝目錄中找到。\n
 預期的相對路徑：
+nx_device/15.0/shell/sdk/external_renderer_ipc/external_renderer_ipc.dll 或
 nx_device/12.0/shell/sdk/external_renderer_ipc/external_renderer_ipc.dll 或
 shell/sdk/external_renderer_ipc/external_renderer_ipc.dll\n
 請確認安裝目錄。</system:String>
@@ -683,15 +684,14 @@ shell/sdk/external_renderer_ipc/external_renderer_ipc.dll\n
 強烈建議在開啟本功能後立刻執行一次截圖測試。
 MAA 會自動透過登錄檔取得安裝路徑，若取得失敗則請手動填寫。\n
 安裝路徑應填寫模擬器安裝目錄的根目錄，例如模擬器執行檔路徑為：
-C:\\Program Files\\Netease\\MuMuPlayer-12.0\\shell\\MuMuPlayer.exe 或
-C:\\Program Files\\Netease\\MuMuPlayer-12.0\\nx_device\\12.0\\shell\\MuMuNxDevice.exe
+C:\\Program Files\\Netease\\MuMuPlayer\\nx_device\\12.0\\shell\\MuMuNxDevice.exe
 則應填寫：
-C:\\Program Files\\Netease\\MuMuPlayer-12.0\n
+C:\\Program Files\\Netease\\MuMuPlayer\n
 注意：
 1. 若目前連線位址通訊埠編號為 7555，則需將通訊埠編號改為 16384。
 2. 若正在使用網路橋接，則需勾選 MuMu 網路橋接模式並手動填寫序號。
     </system:String>
-    <system:String x:Key="MuMu12EmulatorPath">MuMu12 模擬器路徑</system:String>
+    <system:String x:Key="MuMu12EmulatorPath">MuMu 模擬器路徑</system:String>
     <system:String x:Key="MuMuBridgeConnection">MuMu 網路橋接模式</system:String>
     <system:String x:Key="MuMuBridgeConnectionTip">除非您知道自己在做什麼，否則不要啟用此選項</system:String>
     <system:String x:Key="MuMu12Index">實例編號</system:String>
@@ -1188,8 +1188,8 @@ C:\\leidian\\LDPlayer9\n
     <system:String x:Key="TouchModeNotAvailable">觸控模式不可用。請進入 ｢{key=Settings} - {key=ConnectionSettings}｣ 切換其他觸控模式。</system:String>
     <system:String x:Key="ScreencapFailed">截圖失敗，如反覆出現請嘗試重啟或更換模擬器！</system:String>
     <system:String x:Key="FastestWayToScreencap">最快截圖用時: {0}ms ({1})</system:String>
-    <system:String x:Key="FastestWayToScreencapWarningTip">截圖用時較長 (平均: {0}ms)，執行自動戰鬥類功能（如自動肉鴿）時可能表現異常。若使用 MuMu 12、雷電模擬器請嘗試開啟截圖增強</system:String>
-    <system:String x:Key="FastestWayToScreencapErrorTip">截圖用時過長 (平均: {0}ms)，自動戰鬥類功能（如自動肉鴿）很可能無法正常執行，建議嘗試重啟或更換模擬器！若使用 MuMu 12、雷電模擬器請嘗試開啟截圖增強</system:String>
+    <system:String x:Key="FastestWayToScreencapWarningTip">截圖用時較長 (平均: {0}ms)，執行自動戰鬥類功能（如自動肉鴿）時可能表現異常。若使用 MuMu、雷電模擬器請嘗試開啟截圖增強</system:String>
+    <system:String x:Key="FastestWayToScreencapErrorTip">截圖用時過長 (平均: {0}ms)，自動戰鬥類功能（如自動肉鴿）很可能無法正常執行，建議嘗試重啟或更換模擬器！若使用 MuMu、雷電模擬器請嘗試開啟截圖增強</system:String>
     <system:String x:Key="IdentifyTheMistakes">辨識錯誤</system:String>
     <system:String x:Key="TaskError" xml:space="preserve">任務出錯: </system:String>
     <system:String x:Key="CombatError">戰鬥出錯</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -675,9 +675,9 @@ HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Notifications\Settin
     <system:String x:Key="MuMuEmulatorPathNotFound">找不到 MuMu 模擬器路徑。</system:String>
     <system:String x:Key="MuMuExternalRendererMissing" xml:space="preserve">external_renderer_ipc.dll 未在所選 MuMu 安裝目錄中找到。\n
 預期的相對路徑：
-nx_device/15.0/shell/sdk/external_renderer_ipc/external_renderer_ipc.dll 或
-nx_device/12.0/shell/sdk/external_renderer_ipc/external_renderer_ipc.dll 或
-shell/sdk/external_renderer_ipc/external_renderer_ipc.dll\n
+nx_device/15.0/shell/sdk/external_renderer_ipc.dll 或
+nx_device/12.0/shell/sdk/external_renderer_ipc.dll 或
+shell/sdk/external_renderer_ipc.dll\n
 請確認安裝目錄。</system:String>
     <system:String x:Key="MuMu12ExtrasEnabledTip" xml:space="preserve">
 需使用官版或方舟專版 MuMu V4.0.0 或更新版本，國際版需 V5.21.3 或更新版本。

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/ConnectSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/ConnectSettingsUserControlModel.cs
@@ -272,7 +272,7 @@ public class ConnectSettingsUserControlModel : PropertyChangedBase
         set => SetAndNotify(ref _screencapCost, value);
     }
 
-    public class MuMuEmulator12ConnectionExtras : PropertyChangedBase
+    public class MuMuEmulatorConnectionExtras : PropertyChangedBase
     {
         private bool _enable = ConfigurationHelper.GetValue(ConfigurationKeys.MuMu12ExtrasEnabled, false);
 
@@ -307,10 +307,13 @@ public class ConnectSettingsUserControlModel : PropertyChangedBase
 
             try
             {
+                // 按版本从新到旧排列，新增版本只需追加一项
                 string[] possibleUninstallKeys =
                 [
+                    @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\MuMuPlayer-15.0",
                     @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\MuMuPlayer-12.0",
                     @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\MuMuPlayer",
+                    @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\MuMuPlayerGlobal-15.0",
                     @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\MuMuPlayerGlobal-12.0",
                     @"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\YXArkNights-12.0",
                 ];
@@ -393,13 +396,18 @@ public class ConnectSettingsUserControlModel : PropertyChangedBase
                     return;
                 }
 
-                // 当路径存在时，检查 external_renderer_ipc.dll 是否可用（兼容 MuMu 5/12 路径）
+                // 当路径存在时，检查 external_renderer_ipc.dll 是否可用（兼容多个 MuMu 版本路径）
+                // 新增版本只需在此列表追加一项
                 if (!string.IsNullOrEmpty(value) && Directory.Exists(value))
                 {
-                    var dllPath1 = Path.Combine(value, "nx_device", "12.0", "shell", "sdk", "external_renderer_ipc.dll");
-                    var dllPath2 = Path.Combine(value, "shell", "sdk", "external_renderer_ipc.dll");
+                    string[] candidateRelativePaths =
+                    [
+                        Path.Combine("nx_device", "15.0", "shell", "sdk", "external_renderer_ipc.dll"),  // MuMu 6.0
+                        Path.Combine("nx_device", "12.0", "shell", "sdk", "external_renderer_ipc.dll"),  // MuMu 5.0 / MuMu 12
+                        Path.Combine("shell", "sdk", "external_renderer_ipc.dll"),                          // MuMu 旧版本
+                    ];
 
-                    if (!File.Exists(dllPath1) && !File.Exists(dllPath2))
+                    if (!candidateRelativePaths.Any(relPath => File.Exists(Path.Combine(value, relPath))))
                     {
                         MessageBoxHelper.Show(LocalizationHelper.GetString("MuMuExternalRendererMissing"));
                         MessageBoxHelper.Show(LocalizationHelper.GetString("MuMu12ExtrasEnabledTip"));
@@ -482,7 +490,7 @@ public class ConnectSettingsUserControlModel : PropertyChangedBase
         }
     }
 
-    public MuMuEmulator12ConnectionExtras MuMuEmulator12Extras { get; set; } = new();
+    public MuMuEmulatorConnectionExtras MuMuEmulatorExtras { get; set; } = new();
 
     public class LdPlayerConnectionExtras : PropertyChangedBase
     {
@@ -1068,7 +1076,7 @@ public class ConnectSettingsUserControlModel : PropertyChangedBase
         switch (ConnectConfig)
         {
             case "MuMuEmulator12":
-                if (MuMuEmulator12Extras.Enable && ScreencapMethod != "MumuExtras")
+                if (MuMuEmulatorExtras.Enable && ScreencapMethod != "MumuExtras")
                 {
                     TestLinkInfo = $"{LocalizationHelper.GetString("MuMuExtrasNotEnabledMessage")}\n{ScreencapTestCost}";
                     return;

--- a/src/MaaWpfGui/Views/UserControl/Settings/ConnectSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/Settings/ConnectSettingsUserControl.xaml
@@ -212,34 +212,34 @@
                         Margin="10"
                         HorizontalAlignment="Center"
                         Content="{DynamicResource MuMu12ExtrasEnabled}"
-                        IsChecked="{Binding MuMuEmulator12Extras.Enable}" />
+                        IsChecked="{Binding MuMuEmulatorExtras.Enable}" />
                     <StackPanel
                         HorizontalAlignment="Center"
                         Orientation="Vertical"
-                        Visibility="{c:Binding MuMuEmulator12Extras.Enable}">
+                        Visibility="{c:Binding MuMuEmulatorExtras.Enable}">
                         <hc:TextBox
                             Width="420"
                             Height="30"
                             Margin="10"
-                            hc:InfoElement.Placeholder="Example: C:\Program Files\Netease\MuMuPlayer-12.0"
+                            hc:InfoElement.Placeholder="Example: C:\Program Files\Netease\MuMuPlayer"
                             hc:TitleElement.Title="{DynamicResource MuMu12EmulatorPath}"
                             hc:TitleElement.TitlePlacement="Left"
-                            Text="{Binding MuMuEmulator12Extras.EmulatorPath}" />
+                            Text="{Binding MuMuEmulatorExtras.EmulatorPath}" />
                         <StackPanel HorizontalAlignment="Center" Orientation="Vertical">
                             <CheckBox
                                 Margin="10"
                                 HorizontalAlignment="Center"
                                 VerticalAlignment="Center"
                                 Content="{DynamicResource MuMuBridgeConnection}"
-                                IsChecked="{Binding MuMuEmulator12Extras.MuMuBridgeConnection}" />
+                                IsChecked="{Binding MuMuEmulatorExtras.MuMuBridgeConnection}" />
                             <hc:TextBox
                                 Height="30"
                                 Margin="10"
                                 HorizontalContentAlignment="Center"
                                 hc:TitleElement.Title="{DynamicResource MuMu12Index}"
                                 hc:TitleElement.TitlePlacement="Left"
-                                Text="{Binding MuMuEmulator12Extras.Index}"
-                                Visibility="{c:Binding MuMuEmulator12Extras.MuMuBridgeConnection}" />
+                                Text="{Binding MuMuEmulatorExtras.Index}"
+                                Visibility="{c:Binding MuMuEmulatorExtras.MuMuBridgeConnection}" />
                         </StackPanel>
                     </StackPanel>
                 </StackPanel>


### PR DESCRIPTION
## 由 Sourcery 生成的摘要

扩展 MuMu 模拟器集成以支持更新版本，并泛化连接附加参数（extras）的处理逻辑。

新功能：
- 在核心控制器中添加对 MuMu 6.0 截图库路径的支持。
- 通过额外的 Windows 卸载注册表键检测 MuMu 6.0 的安装。
- 针对多个不同版本的 `external_renderer_ipc.dll` 位置验证 MuMu 模拟器路径，从而在各版本间启用附加功能（extras）。

增强项：
- 将原本特定于 MuMu 12 的连接附加参数和关闭处理逻辑抽象为与版本无关的 MuMu 模拟器通用辅助方法。
- 当加载 MuMu 外部渲染库失败时，通过列出所有尝试过的候选路径来改进错误日志记录。

文档：
- 更新本地化和设置界面文案，以反映泛化后的 MuMu 模拟器附加功能以及对新版本的支持。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Extend MuMu emulator integration to support newer versions and generalize connection extras handling.

New Features:
- Add support for MuMu 6.0 screenshot library paths in the core controller.
- Detect MuMu 6.0 installations via additional Windows uninstall registry keys.
- Validate MuMu emulator paths against multiple version-specific external_renderer_ipc.dll locations to enable extras across versions.

Enhancements:
- Generalize MuMu 12-specific connection extras and shutdown handling into version-agnostic MuMu emulator helpers.
- Improve error logging when failing to load the MuMu external renderer library by listing all attempted candidate paths.

Documentation:
- Update localization and settings UI strings to reflect generalized MuMu emulator extras and new version support.

</details>