### PR TITLE
rft: 肉鸽弹窗类事件处理重构 CloseCollectionClose

### DIFF
--- a/resource/tasks/Roguelike/JieGarden.json
+++ b/resource/tasks/Roguelike/JieGarden.json
@@ -52,7 +52,7 @@
     "JieGarden@Roguelike@ChooseOper": {
         "next": [
             "JieGarden@Roguelike@ChooseOper@(JieGarden@Roguelike@CloseCollectionContinue)",
-            "JieGarden@Roguelike@CloseCollectionClose",
+            "JieGarden@Roguelike@ChooseOperFlag@(JieGarden@Roguelike@CloseCollectionClose)",
             "JieGarden@Roguelike@ChooseOperConfirm",
             "JieGarden@Roguelike@ChooseOperConfirmToGiveUp",
             "JieGarden@Roguelike@Abandon",
@@ -112,15 +112,8 @@
                 [170, 170, 170]
             ]
         ],
-        "next": [
-            "JieGarden@Roguelike@StageEncounterEnter",
-            "JieGarden@Roguelike@Stages#next",
-            "JieGarden@Roguelike@DropsFlag",
-            "JieGarden@Roguelike@CloseEvent",
-            "JieGarden@Roguelike@ChooseOperFlag",
-            "JieGarden@Roguelike@CoppersExchangeFinish",
-            "JieGarden@Roguelike@CoppersRecastResult"
-        ]
+        "onErrorNext": ["#back"],
+        "next": ["#next"]
     },
     "JieGarden@Roguelike@CloseCollectionContinue": {
         "doc": "类似招募卷奖励后点next, 后续其他执行也重构为此类",
@@ -242,7 +235,7 @@
         "baseTask": "JieGarden@Roguelike@CoppersListDialogConfirm",
         "template": "JieGarden@Roguelike@CoppersListDialogConfirm.png",
         "next": [
-            "JieGarden@Roguelike@CloseCollectionClose",
+            "JieGarden@Roguelike@CoppersExchangeConfirm@(JieGarden@Roguelike@CloseCollectionClose)",
             "JieGarden@Roguelike@CoppersExchangeConfirm@(JieGarden@Roguelike@CloseCollectionContinue)",
             "JieGarden@Roguelike@CoppersExchangeFinish",
             "#self"
@@ -370,7 +363,7 @@
         "roi": [794, 559, 381, 147],
         "postDelay": 3000,
         "next": [
-            "JieGarden@Roguelike@CloseCollectionClose",
+            "JieGarden@Roguelike@CoppersRecastConfirm-NoRetain@(JieGarden@Roguelike@CloseCollectionClose)",
             "JieGarden@Roguelike@CoppersRecastConfirm-NoRetain@(JieGarden@Roguelike@CloseCollectionContinue)",
             "JieGarden@Roguelike@CoppersRecastResult",
             "#self"
@@ -383,7 +376,7 @@
         "postDelay": 500,
         "roi": [1033, 462, 153, 155],
         "next": [
-            "JieGarden@Roguelike@CloseCollectionClose",
+            "JieGarden@Roguelike@CoppersRecastResult@(JieGarden@Roguelike@CloseCollectionClose)",
             "JieGarden@Roguelike@CoppersRecastResult@(JieGarden@Roguelike@CloseCollectionContinue)",
             "JieGarden@Roguelike@CoppersTakeFlag",
             "JieGarden@Roguelike@DropsFlag",
@@ -399,7 +392,7 @@
         "postDelay": 500,
         "cache": true,
         "next": [
-            "JieGarden@Roguelike@CloseCollectionClose",
+            "JieGarden@Roguelike@CoppersTakeConfirm@(JieGarden@Roguelike@CloseCollectionClose)",
             "JieGarden@Roguelike@CoppersTakeConfirm@(JieGarden@Roguelike@CloseCollectionContinue)",
             "JieGarden@Roguelike@CoppersExchangeFinish",
             "JieGarden@Roguelike@CoppersExchangeConfirm",
@@ -555,7 +548,7 @@
     "JieGarden@Roguelike@GetDropSelect": {
         "next": [
             "JieGarden@Roguelike@GetDropSelect@(JieGarden@Roguelike@CloseCollectionContinue)",
-            "JieGarden@Roguelike@CloseCollectionClose",
+            "JieGarden@Roguelike@GetDropSelect@(JieGarden@Roguelike@CloseCollectionClose)",
             "JieGarden@Roguelike@CloseEvent",
             "JieGarden@Roguelike@GetDropSelectRecruit",
             "JieGarden@Roguelike@GetDropSelectReward",
@@ -578,7 +571,7 @@
     "JieGarden@Roguelike@GetDrops": {
         "next": [
             "JieGarden@Roguelike@GetDrops@(JieGarden@Roguelike@CloseCollectionContinue)",
-            "JieGarden@Roguelike@CloseCollectionClose",
+            "JieGarden@Roguelike@GetDrops@(JieGarden@Roguelike@CloseCollectionClose)",
             "JieGarden@Roguelike@CloseEvent",
             "JieGarden@Roguelike@GetDrop1",
             "JieGarden@Roguelike@GetDrop2",
@@ -1134,7 +1127,7 @@
     },
     "JieGarden@Roguelike@StageTraderEnter": {
         "next": [
-            "JieGarden@Roguelike@StageTraderEnter-CloseCollectionClose",
+            "JieGarden@Roguelike@StageTraderEnter@(JieGarden@Roguelike@CloseCollectionClose)",
             "JieGarden@Roguelike@StageTraderEnter@(JieGarden@Roguelike@CloseCollectionContinue)",
             "JieGarden@Roguelike@StageVerticalConfirmTrader",
             "JieGarden@Roguelike@StageTraderEnter",
@@ -1143,11 +1136,6 @@
             "JieGarden@Roguelike@StageTraderLeave",
             "JieGarden@Roguelike@StageTraderLeaveConfirm"
         ]
-    },
-    "JieGarden@Roguelike@StageTraderEnter-CloseCollectionClose": {
-        "template": "JieGarden@Roguelike@CloseCollectionClose.png",
-        "baseTask": "JieGarden@Roguelike@CloseCollectionClose",
-        "next": ["JieGarden@Roguelike@StageTraderEnter#next"]
     },
     "JieGarden@Roguelike@StageTraderInvest-Wallet": {
         "doc": "商店投资界面的右上角的单局余额",
@@ -1189,7 +1177,7 @@
             "JieGarden@Roguelike@NextLevel",
             "JieGarden@Roguelike@RandomPickAfterNextLevel",
             "JieGarden@Roguelike@Stages@(JieGarden@Roguelike@CloseCollectionContinue)",
-            "JieGarden@Roguelike@CloseCollectionClose",
+            "JieGarden@Roguelike@Stages@(JieGarden@Roguelike@CloseCollectionClose)",
             "JieGarden@Roguelike@StageBoskyPassage",
             "JieGarden@Roguelike@StageGuidance",
             "JieGarden@Roguelike@StageEmergencyOps",
@@ -1213,7 +1201,7 @@
             "JieGarden@Roguelike@NextLevel",
             "JieGarden@Roguelike@RandomPickAfterNextLevel",
             "JieGarden@Roguelike@Stages@(JieGarden@Roguelike@CloseCollectionContinue)",
-            "JieGarden@Roguelike@CloseCollectionClose",
+            "JieGarden@Roguelike@Stages@(JieGarden@Roguelike@CloseCollectionClose)",
             "JieGarden@Roguelike@Routing_BoskyPassage",
             "JieGarden@Roguelike@Stages_leaveBoskyPassage#next"
         ]
@@ -1225,7 +1213,7 @@
             "JieGarden@Roguelike@NextLevel",
             "JieGarden@Roguelike@RandomPickAfterNextLevel",
             "JieGarden@Roguelike@Stages@(JieGarden@Roguelike@CloseCollectionContinue)",
-            "JieGarden@Roguelike@CloseCollectionClose",
+            "JieGarden@Roguelike@Stages@(JieGarden@Roguelike@CloseCollectionClose)",
             "JieGarden@Roguelike@StageBoskyPassage",
             "JieGarden@Roguelike@StageGuidance",
             "JieGarden@Roguelike@StageTrader",
@@ -1250,7 +1238,7 @@
             "JieGarden@Roguelike@NextLevel",
             "JieGarden@Roguelike@RandomPickAfterNextLevel",
             "JieGarden@Roguelike@Stages@(JieGarden@Roguelike@CloseCollectionContinue)",
-            "JieGarden@Roguelike@CloseCollectionClose",
+            "JieGarden@Roguelike@Stages@(JieGarden@Roguelike@CloseCollectionClose)",
             "JieGarden@Roguelike@Routing-FastPass"
         ],
         "onErrorNext": ["JieGarden@Roguelike@ExitThenAbandon"]
@@ -1267,7 +1255,7 @@
             "JieGarden@Roguelike@NextLevel",
             "JieGarden@Roguelike@RandomPickAfterNextLevel",
             "JieGarden@Roguelike@Stages@(JieGarden@Roguelike@CloseCollectionContinue)",
-            "JieGarden@Roguelike@CloseCollectionClose",
+            "JieGarden@Roguelike@Stages@(JieGarden@Roguelike@CloseCollectionClose)",
             "JieGarden@Roguelike@StageBoskyPassage",
             "JieGarden@Roguelike@StageGuidance",
             "JieGarden@Roguelike@StageCombatOps",

--- a/resource/tasks/Roguelike/JieGarden.json
+++ b/resource/tasks/Roguelike/JieGarden.json
@@ -51,7 +51,7 @@
     },
     "JieGarden@Roguelike@ChooseOper": {
         "next": [
-            "JieGarden@Roguelike@ChooseOper@(JieGarden@Roguelike@CloseCollectionContinue)",
+            "JieGarden@Roguelike@ChooseOperFlag@(JieGarden@Roguelike@CloseCollectionContinue)",
             "JieGarden@Roguelike@ChooseOperFlag@(JieGarden@Roguelike@CloseCollectionClose)",
             "JieGarden@Roguelike@ChooseOperConfirm",
             "JieGarden@Roguelike@ChooseOperConfirmToGiveUp",

--- a/resource/tasks/Roguelike/Mizuki.json
+++ b/resource/tasks/Roguelike/Mizuki.json
@@ -25,7 +25,7 @@
     },
     "Mizuki@Roguelike@ChooseOper": {
         "next": [
-            "Mizuki@Roguelike@ChooseOper@(Mizuki@Roguelike@CloseCollectionContinue)",
+            "Mizuki@Roguelike@ChooseOperFlag@(Mizuki@Roguelike@CloseCollectionContinue)",
             "Mizuki@Roguelike@ChooseOperFlag@(Mizuki@Roguelike@CloseCollectionClose)",
             "Mizuki@Roguelike@ChooseOperConfirm",
             "Mizuki@Roguelike@Abandon",

--- a/resource/tasks/Roguelike/Mizuki.json
+++ b/resource/tasks/Roguelike/Mizuki.json
@@ -26,7 +26,7 @@
     "Mizuki@Roguelike@ChooseOper": {
         "next": [
             "Mizuki@Roguelike@ChooseOper@(Mizuki@Roguelike@CloseCollectionContinue)",
-            "Mizuki@Roguelike@CloseCollectionClose",
+            "Mizuki@Roguelike@ChooseOperFlag@(Mizuki@Roguelike@CloseCollectionClose)",
             "Mizuki@Roguelike@ChooseOperConfirm",
             "Mizuki@Roguelike@Abandon",
             "Mizuki@Roguelike@ChooseOperConfirm#next"
@@ -39,13 +39,8 @@
         "action": "ClickSelf",
         "templThreshold": 0.9,
         "roi": [572, 434, 144, 141],
-        "next": [
-            "Mizuki@Roguelike@StageEncounterEnter",
-            "Mizuki@Roguelike@Stages#next",
-            "Mizuki@Roguelike@DropsFlag",
-            "Mizuki@Roguelike@CloseEvent",
-            "Mizuki@Roguelike@ChooseOperFlag"
-        ]
+        "onErrorNext": ["#back"],
+        "next": ["#next"]
     },
     "Mizuki@Roguelike@CloseCollectionContinue": {
         "action": "ClickSelf",
@@ -440,7 +435,7 @@
             "Mizuki@Roguelike@StageGambling",
             "Mizuki@Roguelike@DiceConfirm",
             "Mizuki@Roguelike@Stages@(Mizuki@Roguelike@CloseCollectionContinue)",
-            "Mizuki@Roguelike@CloseCollectionClose",
+            "Mizuki@Roguelike@Stages@(Mizuki@Roguelike@CloseCollectionClose)",
             "Mizuki@Roguelike@StageDreadfulFoe",
             "Mizuki@Roguelike@StageDreadfulFoe-5"
         ],
@@ -466,7 +461,7 @@
             "Mizuki@Roguelike@StageRegionalCommissioning",
             "Mizuki@Roguelike@DiceConfirm",
             "Mizuki@Roguelike@Stages@(Mizuki@Roguelike@CloseCollectionContinue)",
-            "Mizuki@Roguelike@CloseCollectionClose"
+            "Mizuki@Roguelike@Stages@(Mizuki@Roguelike@CloseCollectionClose)"
         ],
         "onErrorNext": ["Mizuki@Roguelike@ExitThenAbandon"]
     },
@@ -490,7 +485,7 @@
             "Mizuki@Roguelike@StageGambling",
             "Mizuki@Roguelike@DiceConfirm",
             "Mizuki@Roguelike@Stages@(Mizuki@Roguelike@CloseCollectionContinue)",
-            "Mizuki@Roguelike@CloseCollectionClose"
+            "Mizuki@Roguelike@Stages@(Mizuki@Roguelike@CloseCollectionClose)"
         ],
         "onErrorNext": ["Mizuki@Roguelike@ExitThenAbandon"]
     },

--- a/resource/tasks/Roguelike/Sami.json
+++ b/resource/tasks/Roguelike/Sami.json
@@ -96,7 +96,7 @@
     },
     "Sami@Roguelike@ChooseOper": {
         "next": [
-            "Sami@Roguelike@CloseCollectionClose",
+            "Sami@Roguelike@ChooseOperFlag@(Sami@Roguelike@CloseCollectionClose)",
             "Sami@Roguelike@ChooseOperConfirm",
             "Sami@Roguelike@Abandon",
             "Sami@Roguelike@ChooseOperConfirm#next"
@@ -137,13 +137,8 @@
         "action": "ClickSelf",
         "templThreshold": 0.9,
         "roi": [572, 434, 144, 141],
-        "next": [
-            "Sami@Roguelike@StageEncounterEnter",
-            "Sami@Roguelike@Stages#next",
-            "Sami@Roguelike@DropsFlag",
-            "Sami@Roguelike@CloseEvent",
-            "Sami@Roguelike@ChooseOperFlag"
-        ]
+        "onErrorNext": ["#back"],
+        "next": ["#next"]
     },
     "Sami@Roguelike@CloseEvent": {},
     "Sami@Roguelike@CloseInterview": {
@@ -1057,7 +1052,7 @@
             "Sami@Roguelike@StageDreadfulFoe-5",
             "Sami@Roguelike@StageEmergencyOps",
             "Sami@Roguelike@StageEmergencyOpsAI6",
-            "Sami@Roguelike@CloseCollectionClose",
+            "Sami@Roguelike@StagesChaosZero@(Sami@Roguelike@CloseCollectionClose)",
             "Sami@Roguelike@ChooseOperFlag",
             "Sami@Roguelike@StageEncounterSpecialClose",
             "Sami@Roguelike@TraderRandomShopping",
@@ -1116,7 +1111,7 @@
             "Sami@Roguelike@StageDreadfulFoe",
             "Sami@Roguelike@StageDreadfulFoe-5",
             "Sami@Roguelike@StageMysteriousPresage",
-            "Sami@Roguelike@CloseCollectionClose"
+            "Sami@Roguelike@Stages@(Sami@Roguelike@CloseCollectionClose)"
         ],
         "onErrorNext": ["Sami@Roguelike@ExitThenAbandon"]
     },
@@ -1162,7 +1157,7 @@
             "Sami@Roguelike@StageGamblingAI6",
             "Sami@Roguelike@StageDreadfulFoe",
             "Sami@Roguelike@StageDreadfulFoe-5",
-            "Sami@Roguelike@CloseCollectionClose",
+            "Sami@Roguelike@Stages@(Sami@Roguelike@CloseCollectionClose)",
             "Sami@Roguelike@Abandon"
         ],
         "onErrorNext": ["Sami@Roguelike@ExitThenAbandon"]
@@ -1218,7 +1213,7 @@
             "Sami@Roguelike@StageDreadfulFoe",
             "Sami@Roguelike@StageDreadfulFoe-5",
             "Sami@Roguelike@StageFerociousPresage",
-            "Sami@Roguelike@CloseCollectionClose"
+            "Sami@Roguelike@Stages@(Sami@Roguelike@CloseCollectionClose)"
         ],
         "onErrorNext": ["Sami@Roguelike@ExitThenAbandon"]
     },
@@ -1275,7 +1270,7 @@
             "Sami@Roguelike@StageVerticalWindAndRainAI6",
             "Sami@Roguelike@StageVerticalEmergencyTransportation",
             "Sami@Roguelike@StageVerticalEmergencyTransportationAI6",
-            "Sami@Roguelike@CloseCollectionClose"
+            "Sami@Roguelike@Stages@(Sami@Roguelike@CloseCollectionClose)"
         ],
         "onErrorNext": ["Sami@Roguelike@ExitThenAbandon"]
     },

--- a/resource/tasks/Roguelike/Sarkaz.json
+++ b/resource/tasks/Roguelike/Sarkaz.json
@@ -82,7 +82,7 @@
     "Sarkaz@Roguelike@ChooseOper": {
         "next": [
             "Sarkaz@Roguelike@ChooseOper@(Sarkaz@Roguelike@CloseCollectionContinue)",
-            "Sarkaz@Roguelike@CloseCollectionClose",
+            "Sarkaz@Roguelike@ChooseOperFlag@(Sarkaz@Roguelike@CloseCollectionClose)",
             "Sarkaz@Roguelike@ChooseOperConfirm",
             "Sarkaz@Roguelike@ChooseOperConfirmToGiveUp",
             "Sarkaz@Roguelike@Abandon",
@@ -116,15 +116,8 @@
                 [170, 170, 170]
             ]
         ],
-        "next": [
-            "Sarkaz@Roguelike@StageEncounterEnter",
-            "Sarkaz@Roguelike@Stages#next",
-            "Sarkaz@Roguelike@DropsFlag",
-            "Sarkaz@Roguelike@CloseEvent",
-            "Sarkaz@Roguelike@ChooseOperFlag",
-            "Sarkaz@Roguelike@DecreaseBurdenSwapUiToDefault1",
-            "Sarkaz@Roguelike@DecreaseBurdenSwapUiToDefault2"
-        ]
+        "onErrorNext": ["#back"],
+        "next": ["#next"]
     },
     "Sarkaz@Roguelike@CloseCollectionContinue": {
         "action": "ClickSelf",
@@ -174,7 +167,7 @@
             "Sarkaz@Roguelike@DecreaseBurdenSwapUiToDefault1",
             "Sarkaz@Roguelike@DecreaseBurdenSwapUiToDefault2",
             "Sarkaz@Roguelike@DecreaseBurdenChaos@(Sarkaz@Roguelike@CloseCollectionContinue)",
-            "Sarkaz@Roguelike@CloseCollectionClose",
+            "Sarkaz@Roguelike@DecreaseBurdenChaos@(Sarkaz@Roguelike@CloseCollectionClose)",
             "Sarkaz@Roguelike@DecreaseBurdenChaos"
         ]
     },
@@ -200,7 +193,7 @@
             "Sarkaz@Roguelike@DecreaseBurdenSwapUiToDefault1",
             "Sarkaz@Roguelike@DecreaseBurdenSwapUiToDefault2",
             "Sarkaz@Roguelike@DecreaseBurdenRetardation@(Sarkaz@Roguelike@CloseCollectionContinue)",
-            "Sarkaz@Roguelike@CloseCollectionClose",
+            "Sarkaz@Roguelike@DecreaseBurdenRetardation@(Sarkaz@Roguelike@CloseCollectionClose)",
             "Sarkaz@Roguelike@DecreaseBurdenRetardation"
         ]
     },
@@ -212,7 +205,7 @@
         "next": [
             "Sarkaz@Roguelike@DecreaseBurdenSwapUiToDefault2",
             "Sarkaz@Roguelike@DecreaseBurdenSwapUiToDefault1@(Sarkaz@Roguelike@CloseCollectionContinue)",
-            "Sarkaz@Roguelike@CloseCollectionClose",
+            "Sarkaz@Roguelike@DecreaseBurdenSwapUiToDefault1@(Sarkaz@Roguelike@CloseCollectionClose)",
             "Sarkaz@Roguelike@DecreaseBurdenSwapUiToDefault1"
         ]
     },
@@ -223,7 +216,7 @@
         "specificRect": [1210, 120, 0, 0],
         "next": [
             "Sarkaz@Roguelike@DecreaseBurdenSwapUiToDefault2@(Sarkaz@Roguelike@CloseCollectionContinue)",
-            "Sarkaz@Roguelike@CloseCollectionClose",
+            "Sarkaz@Roguelike@DecreaseBurdenSwapUiToDefault2@(Sarkaz@Roguelike@CloseCollectionClose)",
             "Sarkaz@Roguelike@DecreaseBurdenSwapUiToDefault2",
             "Sarkaz@Roguelike@DecreaseBurdenUseTheFirst"
         ]
@@ -347,7 +340,7 @@
     "Sarkaz@Roguelike@GetDropSelect": {
         "next": [
             "Sarkaz@Roguelike@GetDropSelect@(Sarkaz@Roguelike@CloseCollectionContinue)",
-            "Sarkaz@Roguelike@CloseCollectionClose",
+            "Sarkaz@Roguelike@GetDropSelect@(Sarkaz@Roguelike@CloseCollectionClose)",
             "Sarkaz@Roguelike@GetDropSelectRecruit",
             "Sarkaz@Roguelike@GetDropSelectReward",
             "Sarkaz@Roguelike@ChooseOperFlag",
@@ -360,7 +353,7 @@
     "Sarkaz@Roguelike@GetDrops": {
         "next": [
             "Sarkaz@Roguelike@GetDrops@(Sarkaz@Roguelike@CloseCollectionContinue)",
-            "Sarkaz@Roguelike@CloseCollectionClose",
+            "Sarkaz@Roguelike@GetDrops@(Sarkaz@Roguelike@CloseCollectionClose)",
             "Sarkaz@Roguelike@GetDrop1",
             "Sarkaz@Roguelike@GetDrop2",
             "Sarkaz@Roguelike@GetDrop3",
@@ -631,17 +624,11 @@
     "Sarkaz@Roguelike@StageEncounter": {
         "templThreshold": 0.96
     },
-    "Sarkaz@Roguelike@StageEncounterClose": {
-        "Doc": "关掉进入事件可能弹出的窗口",
-        "baseTask": "Sarkaz@Roguelike@CloseCollectionClose",
-        "template": "Sarkaz@Roguelike@CloseCollectionClose.png",
-        "next": ["Sarkaz@Roguelike@StageEncounterJudgeOption"]
-    },
     "Sarkaz@Roguelike@StageEncounterEnter": {},
     "Sarkaz@Roguelike@StageEncounterJudgeClick2": {
         "next": [
             "Sarkaz@Roguelike@StageEncounterJudgeClick2@(Sarkaz@Roguelike@CloseCollectionContinue)",
-            "Sarkaz@Roguelike@StageEncounterClose",
+            "Sarkaz@Roguelike@StageEncounterJudgeClick2@(Sarkaz@Roguelike@CloseCollectionClose)",
             "Sarkaz@Roguelike@StageEncounterJudgeOption"
         ]
     },
@@ -894,7 +881,7 @@
             ]
         ],
         "next": [
-            "Sarkaz@Roguelike@StageTraderEnter-CloseCollectionClose",
+            "Sarkaz@Roguelike@StageTraderEnter@(Sarkaz@Roguelike@CloseCollectionClose)",
             "Sarkaz@Roguelike@StageTraderEnter@(Sarkaz@Roguelike@CloseCollectionContinue)",
             "Sarkaz@Roguelike@StageVerticalConfirmTrader",
             "Sarkaz@Roguelike@StageTraderEnter",
@@ -904,11 +891,6 @@
             "Sarkaz@Roguelike@StageTraderLeave",
             "Sarkaz@Roguelike@StageTraderLeaveConfirm"
         ]
-    },
-    "Sarkaz@Roguelike@StageTraderEnter-CloseCollectionClose": {
-        "template": "Sarkaz@Roguelike@CloseCollectionClose.png",
-        "baseTask": "Sarkaz@Roguelike@CloseCollectionClose",
-        "next": ["Sarkaz@Roguelike@StageTraderEnter#next"]
     },
     "Sarkaz@Roguelike@StageTraderHD": {
         "Doc": "已深化",
@@ -955,7 +937,7 @@
         "next": [
             "Sarkaz@Roguelike@NextLevel",
             "Sarkaz@Roguelike@Stages@(Sarkaz@Roguelike@CloseCollectionContinue)",
-            "Sarkaz@Roguelike@CloseCollectionClose",
+            "Sarkaz@Roguelike@Stages@(Sarkaz@Roguelike@CloseCollectionClose)",
             "Sarkaz@Roguelike@StageBurdenOperation#next",
             "Sarkaz@Roguelike@StageBoskyPassage",
             "Sarkaz@Roguelike@StageEmergencyOps",
@@ -987,7 +969,7 @@
         "next": [
             "Sarkaz@Roguelike@NextLevel",
             "Sarkaz@Roguelike@Stages@(Sarkaz@Roguelike@CloseCollectionContinue)",
-            "Sarkaz@Roguelike@CloseCollectionClose",
+            "Sarkaz@Roguelike@Stages@(Sarkaz@Roguelike@CloseCollectionClose)",
             "Sarkaz@Roguelike@StageBurdenOperation#next",
             "Sarkaz@Roguelike@StageBoskyPassage",
             "Sarkaz@Roguelike@StageTraderHD",
@@ -1019,7 +1001,7 @@
         "next": [
             "Sarkaz@Roguelike@NextLevel",
             "Sarkaz@Roguelike@Stages@(Sarkaz@Roguelike@CloseCollectionContinue)",
-            "Sarkaz@Roguelike@CloseCollectionClose",
+            "Sarkaz@Roguelike@Stages@(Sarkaz@Roguelike@CloseCollectionClose)",
             "Sarkaz@Roguelike@DecreaseBurdenRetardation",
             "Sarkaz@Roguelike@Routing-FastInvestment"
         ],
@@ -1031,7 +1013,7 @@
         "next": [
             "Sarkaz@Roguelike@NextLevel",
             "Sarkaz@Roguelike@Stages@(Sarkaz@Roguelike@CloseCollectionContinue)",
-            "Sarkaz@Roguelike@CloseCollectionClose",
+            "Sarkaz@Roguelike@Stages@(Sarkaz@Roguelike@CloseCollectionClose)",
             "Sarkaz@Roguelike@DecreaseBurdenChaos",
             "Sarkaz@Roguelike@DecreaseBurdenRetardation",
             "Sarkaz@Roguelike@StageBoskyPassage",
@@ -1063,7 +1045,7 @@
         "next": [
             "Sarkaz@Roguelike@NextLevel",
             "Sarkaz@Roguelike@Stages@(Sarkaz@Roguelike@CloseCollectionContinue)",
-            "Sarkaz@Roguelike@CloseCollectionClose",
+            "Sarkaz@Roguelike@Stages@(Sarkaz@Roguelike@CloseCollectionClose)",
             "Sarkaz@Roguelike@ChooseBurdenOperatorAtStart",
             "Sarkaz@Roguelike@DecreaseBurdenChaos",
             "Sarkaz@Roguelike@DecreaseBurdenRetardation",

--- a/resource/tasks/Roguelike/Sarkaz.json
+++ b/resource/tasks/Roguelike/Sarkaz.json
@@ -81,7 +81,7 @@
     },
     "Sarkaz@Roguelike@ChooseOper": {
         "next": [
-            "Sarkaz@Roguelike@ChooseOper@(Sarkaz@Roguelike@CloseCollectionContinue)",
+            "Sarkaz@Roguelike@ChooseOperFlag@(Sarkaz@Roguelike@CloseCollectionContinue)",
             "Sarkaz@Roguelike@ChooseOperFlag@(Sarkaz@Roguelike@CloseCollectionClose)",
             "Sarkaz@Roguelike@ChooseOperConfirm",
             "Sarkaz@Roguelike@ChooseOperConfirmToGiveUp",


### PR DESCRIPTION
## Summary by Sourcery

使类 Rogue-like 任务配置在多种场景下与基于 CloseCollectionClose 的弹窗事件处理方式保持一致。

增强内容：
- 更新 JieGarden 的类 Rogue-like 任务配置，使其使用基于 CloseCollectionClose 的弹窗事件处理模式。
- 更新 Mizuki 的类 Rogue-like 任务配置，使其使用基于 CloseCollectionClose 的弹窗事件处理模式。
- 使 Sami 和 Sarkaz 的类 Rogue-like 任务配置与统一的 CloseCollectionClose 弹窗处理模型保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align roguelike task configurations with the new CloseCollectionClose-based popup event handling across multiple scenarios.

Enhancements:
- Update JieGarden roguelike task configuration to use the CloseCollectionClose-based popup event handling pattern.
- Update Mizuki roguelike task configuration to use the CloseCollectionClose-based popup event handling pattern.
- Bring Sami and Sarkaz roguelike task configurations in line with the unified CloseCollectionClose popup handling model.

</details>

改进内容：
- 使 JieGarden 的 roguelike 任务配置与基于 CloseCollectionClose 的新弹窗事件处理模式保持一致。
- 使 Mizuki 的 roguelike 任务配置与基于 CloseCollectionClose 的新弹窗事件处理模式保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

使类 Rogue-like 任务配置在多种场景下与基于 CloseCollectionClose 的弹窗事件处理方式保持一致。

增强内容：
- 更新 JieGarden 的类 Rogue-like 任务配置，使其使用基于 CloseCollectionClose 的弹窗事件处理模式。
- 更新 Mizuki 的类 Rogue-like 任务配置，使其使用基于 CloseCollectionClose 的弹窗事件处理模式。
- 使 Sami 和 Sarkaz 的类 Rogue-like 任务配置与统一的 CloseCollectionClose 弹窗处理模型保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align roguelike task configurations with the new CloseCollectionClose-based popup event handling across multiple scenarios.

Enhancements:
- Update JieGarden roguelike task configuration to use the CloseCollectionClose-based popup event handling pattern.
- Update Mizuki roguelike task configuration to use the CloseCollectionClose-based popup event handling pattern.
- Bring Sami and Sarkaz roguelike task configurations in line with the unified CloseCollectionClose popup handling model.

</details>

</details>