### PR TITLE
feat: 新增 X11 触控方法, 支持 Wine 运行的 PC 端

### DIFF
--- a/docs/en-us/protocol/integration.md
+++ b/docs/en-us/protocol/integration.md
@@ -1173,7 +1173,7 @@ Invalid placeholder. Enum value: 0.
 Deprecated. Originally for enabling Minitouch; "1" - on, "0" - off. Note that the device may not support it. Enum value: 1 (deprecated).  
 :::  
 ::: field name="TouchMode" type="string" optional default="minitouch"  
-Touch mode setting. Options: minitouch | maatouch | adb | MaaFwAdb. Default minitouch. Enum value: 2.  
+Touch mode setting. Options: minitouch | maatouch | adb | MaaFwAdb | X11. Default minitouch. Enum value: 2.  
 :::  
 ::: field name="DeploymentWithPause" type="boolean" optional  
 Whether to pause when deploying operators (affects IS, Copilot and Stationary Security Service). Options: "1" | "0". Enum value: 3.  

--- a/docs/ja-jp/protocol/integration.md
+++ b/docs/ja-jp/protocol/integration.md
@@ -1172,7 +1172,7 @@ bool ASSTAPI AsstSetInstanceOption(AsstHandle handle, AsstInstanceOptionKey key,
 廃止済み。元は Minitouch を有効にするかどうか。"1" オン、"0" オフ。デバイスがサポートされていない可能性がります。列挙値：1（廃止済み）。  
 :::  
 ::: field name="TouchMode" type="string" optional default="minitouch"  
-タッチ モード設定。可能な値：minitouch | maatouch | adb | MaaFwAdb。デフォルト minitouch。列挙値：2。  
+タッチ モード設定。可能な値：minitouch | maatouch | adb | MaaFwAdb | X11。デフォルト minitouch。列挙値：2。  
 :::  
 ::: field name="DeploymentWithPause" type="boolean" optional  
 暫停状態でオペレーターを配置するかどうか。自動戦闘、統合戦略、保全駐在に同時に影響。可能な値："1" または "0"。列挙値：3。  

--- a/docs/ko-kr/protocol/integration.md
+++ b/docs/ko-kr/protocol/integration.md
@@ -1161,7 +1161,7 @@ Value
 폐기됨. 원 Minitouch 활성화 여부; "1" 켜기, "0" 끄기. 장치가 지원하지 않을 수 있음. 열거값: 1 (폐기됨)  
 :::  
 ::: field name="TouchMode" type="string" optional default="minitouch"  
-터치 모드 설정. 옵션: minitouch | maatouch | adb | MaaFwAdb. 기본값 minitouch. 열거값: 2  
+터치 모드 설정. 옵션: minitouch | maatouch | adb | MaaFwAdb | X11. 기본값 minitouch. 열거값: 2  
 :::  
 ::: field name="DeploymentWithPause" type="boolean" optional  
 오퍼레이터 배치 시 일시정지 여부, 자동지휘/통합 전략/보안파견에 모두 영향. 옵션: "1" 켜기, "0" 끄기. 열거값: 3  

--- a/docs/zh-cn/protocol/integration.md
+++ b/docs/zh-cn/protocol/integration.md
@@ -1172,7 +1172,7 @@ bool ASSTAPI AsstSetInstanceOption(AsstHandle handle, AsstInstanceOptionKey key,
 已弃用。原为是否启用 Minitouch；"1" 开，"0" 关。注意设备可能不支持。枚举值：1（已弃用）。  
 :::  
 ::: field name="TouchMode" type="string" optional default="minitouch"  
-触控模式设置。可选值：minitouch | maatouch | adb | MaaFwAdb。默认 minitouch。枚举值：2。  
+触控模式设置。可选值：minitouch | maatouch | adb | MaaFwAdb | X11。默认 minitouch。枚举值：2。  
 :::  
 ::: field name="DeploymentWithPause" type="boolean" optional  
 是否暂停下干员，同时影响抄作业、肉鸽、保全。可用值："1" 或 "0"。枚举值：3。  

--- a/docs/zh-tw/protocol/integration.md
+++ b/docs/zh-tw/protocol/integration.md
@@ -1172,7 +1172,7 @@ bool ASSTAPI AsstSetInstanceOption(AsstHandle handle, AsstInstanceOptionKey key,
 已棄用。原為是否啟用 Minitouch；"1" 開，"0" 關。請注意設備可能不支援。列舉值：1（已棄用）。  
 :::  
 ::: field name="TouchMode" type="string" optional default="minitouch"  
-觸控模式設定。可選值：minitouch | maatouch | adb | MaaFwAdb。預設為 minitouch。列舉值：2。  
+觸控模式設定。可選值：minitouch | maatouch | adb | MaaFwAdb | X11。預設為 minitouch。列舉值：2。  
 :::  
 ::: field name="DeploymentWithPause" type="boolean" optional  
 是否暫停下幹員，同時影響抄作業、肉鴿、保全派駐。可用值："1" 或 "0"。列舉值：3。  

--- a/src/MaaCore/Assistant.cpp
+++ b/src/MaaCore/Assistant.cpp
@@ -142,6 +142,11 @@ bool asst::Assistant::set_instance_option(InstanceOptionKey key, const std::stri
             m_ctrler->set_touch_mode(TouchMode::Android);
             return true;
         }
+#elif defined(__linux__)
+        else if (constexpr std::string_view X11 = "X11"; value == X11) {
+            m_ctrler->set_touch_mode(TouchMode::X11);
+            return true;
+        }
 #endif
         break;
     case InstanceOptionKey::DeploymentWithPause:

--- a/src/MaaCore/CMakeLists.txt
+++ b/src/MaaCore/CMakeLists.txt
@@ -33,6 +33,9 @@ endif()
 
 if(LINUX)
     target_link_libraries(MaaCore pthread dl)
+
+    find_package(X11)
+    target_link_libraries(MaaCore X11::X11)
 endif()
 
 if(APPLE AND WITH_MAC_SCK)

--- a/src/MaaCore/CMakeLists.txt
+++ b/src/MaaCore/CMakeLists.txt
@@ -34,7 +34,7 @@ endif()
 if(LINUX)
     target_link_libraries(MaaCore pthread dl)
 
-    find_package(X11)
+    find_package(X11 REQUIRED)
     target_link_libraries(MaaCore X11::X11)
 endif()
 

--- a/src/MaaCore/Common/AsstTypes.h
+++ b/src/MaaCore/Common/AsstTypes.h
@@ -58,6 +58,7 @@ enum class TouchMode
     MacPlayTools = 3,
     MaaFwAdb = 4,
     Android = 5,
+    X11 = 6,
 };
 
 #ifdef _WIN32

--- a/src/MaaCore/Controller/Controller.cpp
+++ b/src/MaaCore/Controller/Controller.cpp
@@ -30,6 +30,8 @@
 
 #ifdef __ANDROID__
 #include "MaaFwAndroidNativeController.h"
+#elif defined(__linux__)
+#include "X11Controller.h"
 #endif
 
 #include "Common/AsstTypes.h"
@@ -66,6 +68,9 @@ std::shared_ptr<asst::ControllerAPI>
         case ControllerType::MaaFwAndroidNative:
             Log.debug("Use Android");
             return std::make_shared<MaaFwAndroidNativeController>(m_callback, m_inst);
+#elif defined(__linux__)
+        case ControllerType::X11:
+            return std::make_shared<X11Controller>(m_callback, m_inst, platform_type);
 #endif
         default:
             return nullptr;
@@ -384,6 +389,9 @@ void asst::Controller::set_touch_mode(const TouchMode& mode) noexcept
     case TouchMode::Android:
         m_controller_type = ControllerType::MaaFwAndroidNative;
         break;
+#elif defined(__linux__)
+    case TouchMode::X11:
+        m_controller_type = ControllerType::X11;
 #endif
     default:
         m_controller_type = ControllerType::Minitouch;

--- a/src/MaaCore/Controller/ControllerAPI.h
+++ b/src/MaaCore/Controller/ControllerAPI.h
@@ -21,6 +21,8 @@ enum class ControllerType
     MaaFwAdb,
 #ifdef __ANDROID__
     MaaFwAndroidNative,
+#elif defined(__linux__)
+    X11,
 #endif
 };
 

--- a/src/MaaCore/Controller/X11Controller.cpp
+++ b/src/MaaCore/Controller/X11Controller.cpp
@@ -1,0 +1,251 @@
+#if defined(__linux__) && !defined(__ANDROID__)
+
+#include "X11Controller.h"
+
+#include <chrono>
+#include <cstdlib>
+#include <string>
+#include <thread>
+
+bool asst::X11Controller::connect(
+    const std::string& adb_path [[maybe_unused]],
+    const std::string& address,
+    const std::string& config [[maybe_unused]])
+{
+    if (m_display != nullptr) {
+        XCloseDisplay(m_display);
+    }
+
+    XSetErrorHandler([](Display* display, XErrorEvent* e) -> int {
+        char buf[1024];
+        XGetErrorText(display, e->error_code, buf, sizeof(buf));
+        Log.error("X11:", std::string(buf));
+        return True;
+    });
+
+    m_display = XOpenDisplay(nullptr);
+    if (m_display == nullptr) {
+        Log.error("Failed to open X display");
+        set_window(None);
+        return false;
+    }
+
+    // e.g. address = "0x3e00003"
+    Window w { };
+    try {
+        w = std::stoi(address, nullptr, 16);
+    }
+    catch (...) {
+        Log.error("Invalid window XID", address);
+        return false;
+    }
+
+    if (w == 0) {
+        Log.error("Invalid window XID", address, "(", w, ")");
+        return false;
+    }
+
+    set_window(w);
+    Log.info("Fetching info from window", m_uuid);
+    if (auto attr = get_xwin_attrib(); attr) {
+        Log.info("Connected to X display, window, ", "size:", attr->width, "x", attr->height, "rescaling");
+        // likely has no effect, you still have to set the resolution in game manually
+        if (XMoveResizeWindow(m_display, m_window, attr->x, attr->y, 1280, 720) == False) {
+            Log.info("Failed to rescale the window");
+            set_window(None);
+            return false;
+        }
+        XFlush(m_display);
+        return true;
+    }
+    set_window(None);
+    return false;
+}
+
+bool asst::X11Controller::screencap(cv::Mat& image_payload, bool allow_reconnect [[maybe_unused]])
+{
+    using enum InputEvent::Type;
+
+    if (auto attrib = get_xwin_attrib(); attrib) {
+        XImage* ximg = XGetImage(m_display, m_window, 0, 0, attrib->width, attrib->height, AllPlanes, ZPixmap);
+        if (ximg != nullptr) {
+            ximg_to_cv(image_payload, ximg);
+            XDestroyImage(ximg);
+            return true;
+        }
+        Log.error("Failed to call XGetImage");
+    }
+    return false;
+}
+
+bool asst::X11Controller::swipe(
+    const Point& p1,
+    const Point& p2,
+    int duration,
+    bool extra_swipe,
+    double slope_in,
+    double slope_out,
+    bool with_pause [[maybe_unused]])
+{
+    const auto [x1, y1] = p1;
+    const auto [x2, y2] = p2;
+
+    using enum InputEvent::Type;
+
+    static constexpr int interval = 2;
+
+    auto move_func = [this](int x, int y) {
+        inject_input_event(InputEvent { .type = WAIT_MS, .milisec = interval });
+        return inject_input_event(InputEvent { .type = TOUCH_MOVE, .point = { x, y } });
+    };
+
+    bool res = true;
+
+    res &= inject_input_event(InputEvent { .type = TOUCH_DOWN, .point = p1 });
+    res &= interpolate_swipe(x1, y1, x2, y2, duration, interval, slope_in, slope_out, move_func);
+
+    Point end = p2;
+
+    if (extra_swipe) {
+        const auto& opt = Config.get_options();
+        inject_input_event(InputEvent { .type = WAIT_MS, .milisec = opt.minitouch_swipe_extra_end_delay });
+        end.y -= opt.minitouch_extra_swipe_dist;
+        res &= interpolate_swipe(x2, y2, end.x, end.y, opt.minitouch_extra_swipe_duration, interval, 0, 0, move_func);
+    }
+
+    res &= inject_input_event(InputEvent { .type = TOUCH_UP, .point = end });
+
+    park_cursor();
+
+    return res;
+}
+
+bool asst::X11Controller::inject_input_event(const InputEvent& event)
+{
+    if (m_display == nullptr || m_window == None) {
+        return false;
+    }
+
+    XButtonEvent bev {
+        .display = m_display,
+        .window = m_window,
+        .root = DefaultRootWindow(m_display),
+        .subwindow = None,
+        .time = CurrentTime,
+        .x = event.point.x,
+        .y = event.point.y,
+        .x_root = event.point.x,
+        .y_root = event.point.y,
+        .state = 0,
+        .button = Button1,
+        .same_screen = True,
+    };
+
+    XMotionEvent mev {
+        .type = MotionNotify,
+        .display = m_display,
+        .window = m_window,
+        .root = DefaultRootWindow(m_display),
+        .subwindow = None,
+        .time = CurrentTime,
+        .x = event.point.x,
+        .y = event.point.y,
+        .x_root = event.point.x,
+        .y_root = event.point.y,
+        .state = 0,
+        .same_screen = True,
+    };
+
+    using enum InputEvent::Type;
+
+    switch (event.type) {
+    case TOUCH_DOWN:
+        bev.type = ButtonPress;
+        return XSendEvent(bev.display, bev.window, True, ButtonPressMask, reinterpret_cast<XEvent*>(&bev)) == True &&
+               XFlush(bev.display) == True;
+    case TOUCH_UP:
+        bev.type = ButtonRelease;
+        return XSendEvent(bev.display, bev.window, True, ButtonReleaseMask, reinterpret_cast<XEvent*>(&bev)) == True &&
+               XFlush(bev.display) == True;
+    case TOUCH_MOVE:
+        return XSendEvent(bev.display, bev.window, True, PointerMotionMask, reinterpret_cast<XEvent*>(&mev)) == True &&
+               XFlush(bev.display) == True;
+    case TOUCH_RESET:
+        return true;
+    case KEY_DOWN:
+        // return send_keysym(static_cast<KeySym>(event.keycode), KeyPress);
+        return false;
+    case KEY_UP:
+        // return send_keysym(static_cast<KeySym>(event.keycode), KeyRelease);
+        return false;
+    case WAIT_MS:
+        std::this_thread::sleep_for(std::chrono::milliseconds(event.milisec));
+        return true;
+    case COMMIT:
+        return XFlush(bev.display) == True;
+    case UNKNOWN:
+        Log.error("Unknown input event type");
+        return false;
+    }
+
+    return false;
+}
+
+bool asst::X11Controller::focus_window() const
+{
+    Atom atom = XInternAtom(m_display, "_NET_ACTIVE_WINDOW", False);
+
+    XEvent ev { };
+    ev.xclient.type = ClientMessage;
+    ev.xclient.serial = 0;
+    ev.xclient.send_event = True;
+    ev.xclient.window = m_window;
+    ev.xclient.message_type = atom;
+    ev.xclient.format = 32;
+    ev.xclient.data.l[0] = 1;
+    ev.xclient.data.l[1] = CurrentTime;
+    ev.xclient.data.l[2] = 0;
+    ev.xclient.data.l[3] = 0;
+    ev.xclient.data.l[4] = 0;
+
+    Status s = XSendEvent(
+        m_display,
+        DefaultRootWindow(m_display),
+        False,
+        SubstructureRedirectMask | SubstructureNotifyMask,
+        &ev);
+    return s == True;
+}
+
+bool asst::X11Controller::send_keysym(KeySym keysym, int type) const
+{
+    if (m_display == nullptr) {
+        return false;
+    }
+
+    focus_window() && XFlush(m_display) == True;
+
+    KeyCode keycode = XKeysymToKeycode(m_display, keysym);
+
+    XKeyEvent kev {
+        .type = type,
+        .display = m_display,
+        .window = m_window,
+        .root = DefaultRootWindow(m_display),
+        .subwindow = None,
+        .time = CurrentTime,
+        .x = 0,
+        .y = 0,
+        .x_root = 0,
+        .y_root = 0,
+        .state = 0,
+        .keycode = keycode,
+        .same_screen = True,
+    };
+
+    const auto event_mask = type == KeyPress ? KeyPressMask : KeyReleaseMask;
+    return XSendEvent(m_display, m_window, True, event_mask, reinterpret_cast<XEvent*>(&kev)) == True &&
+           XFlush(m_display) == True;
+}
+
+#endif

--- a/src/MaaCore/Controller/X11Controller.cpp
+++ b/src/MaaCore/Controller/X11Controller.cpp
@@ -14,7 +14,9 @@ bool asst::X11Controller::connect(
 {
     if (m_display != nullptr) {
         XCloseDisplay(m_display);
+        m_display = nullptr;
     }
+    set_window(None);
 
     XSetErrorHandler([](Display* display, XErrorEvent* e) -> int {
         char buf[1024];
@@ -38,7 +40,6 @@ bool asst::X11Controller::connect(
     catch (...) {
         Log.error("Invalid window XID", address);
         return false;
-    }
     }
 
     if (w == 0) {

--- a/src/MaaCore/Controller/X11Controller.cpp
+++ b/src/MaaCore/Controller/X11Controller.cpp
@@ -33,11 +33,12 @@ bool asst::X11Controller::connect(
     // e.g. address = "0x3e00003"
     Window w { };
     try {
-        w = std::stoi(address, nullptr, 16);
+        w = static_cast<Window>(std::stoull(address, nullptr, 16));
     }
     catch (...) {
         Log.error("Invalid window XID", address);
         return false;
+    }
     }
 
     if (w == 0) {

--- a/src/MaaCore/Controller/X11Controller.h
+++ b/src/MaaCore/Controller/X11Controller.h
@@ -33,7 +33,12 @@ public:
     {
     }
 
-    virtual ~X11Controller() override { XCloseDisplay(m_display); };
+    virtual ~X11Controller() override
+    {
+        if (m_display) {
+            XCloseDisplay(m_display);
+        }
+    }
 
     X11Controller(const X11Controller&) = delete;
     X11Controller(X11Controller&&) = delete;

--- a/src/MaaCore/Controller/X11Controller.h
+++ b/src/MaaCore/Controller/X11Controller.h
@@ -1,0 +1,193 @@
+#pragma once
+
+#if defined(__linux__) && !defined(__ANDROID__)
+
+#include <optional>
+
+#include "Common/AsstMsg.h"
+#include "ControllerAPI.h"
+#include "InstHelper.h"
+#include "MaaUtils/NoWarningCV.hpp"
+#include "Platform/PlatformIO.h"
+#include "SwipeHelper.hpp"
+#include "Utils/DebugImageHelper.hpp"
+#include "Utils/Logger.hpp"
+
+extern "C"
+{
+#include <X11/X.h>
+#include <X11/Xlib.h>
+#include <X11/Xutil.h>
+#include <X11/keysym.h>
+}
+
+namespace asst
+{
+
+struct X11Controller : public ControllerAPI, protected InstHelper
+{
+public:
+    X11Controller(AsstCallback callback, Assistant* inst, PlatformType) :
+        InstHelper(inst),
+        m_callback(std::move(callback))
+    {
+    }
+
+    virtual ~X11Controller() override { XCloseDisplay(m_display); };
+
+    X11Controller(const X11Controller&) = delete;
+    X11Controller(X11Controller&&) = delete;
+    X11Controller& operator=(const X11Controller&) = delete;
+    X11Controller& operator=(X11Controller&&) = delete;
+
+    virtual bool connect(
+        const std::string& adb_path [[maybe_unused]],
+        const std::string& address,
+        const std::string& config [[maybe_unused]]) override;
+
+    virtual bool inited() const noexcept override { return m_display != nullptr && m_window != None; }
+
+    virtual const std::string& get_uuid() const override { return m_uuid; }
+
+    virtual size_t get_pipe_data_size() const noexcept override { return 0; }
+
+    virtual size_t get_version() const noexcept override { return 0; }
+
+    virtual bool screencap(cv::Mat& image_payload, bool allow_reconnect [[maybe_unused]] = false) override;
+
+    virtual bool start_game(const std::string&) override
+    {
+        Log.warn("start_game is not supported on X11Controller");
+        return false;
+    }
+
+    virtual bool stop_game(const std::string& client_type [[maybe_unused]]) override
+    {
+        // TODO: Implement this pure virtual method.
+        return false;
+    }
+
+    virtual bool click(const Point& p) override
+    {
+        if (m_display == nullptr || m_window == None) {
+            return false;
+        }
+
+        using enum InputEvent::Type;
+
+        bool result = true;
+
+        result &= inject_input_event(InputEvent { .type = TOUCH_DOWN, .point = p });
+
+        // result &= inject_input_event(InputEvent { .type = WAIT_MS, .milisec = 10 });
+
+        result &= inject_input_event(InputEvent { .type = TOUCH_UP, .point = p });
+
+        park_cursor();
+
+        return result;
+    }
+
+    virtual bool input(const std::string&) override
+    {
+        // TODO
+        return false;
+    }
+
+    virtual bool swipe(
+        const Point& p1,
+        const Point& p2,
+        int duration = 0,
+        bool extra_swipe = false,
+        double slope_in = 1,
+        double slope_out = 1,
+        bool with_pause = false) override;
+
+    virtual bool inject_input_event(const InputEvent& event) override;
+
+    virtual bool press_esc() override
+    {
+        if (m_display == nullptr || m_window == None) {
+            return false;
+        }
+
+        const bool result = send_keysym(XK_Escape, KeyPress) && send_keysym(XK_Escape, KeyRelease);
+        return result;
+    }
+
+    virtual ControlFeat::Feat support_features() const noexcept override { return ControlFeat::PRECISE_SWIPE; }
+
+    virtual std::pair<int, int> get_screen_res() const noexcept override
+    {
+        if (auto attrib = get_xwin_attrib(); attrib) {
+            return { attrib->width, attrib->height };
+        }
+        return { 0, 0 };
+    }
+
+protected:
+    std::optional<XWindowAttributes> get_xwin_attrib() const
+    {
+        if (m_display == nullptr || m_window == None) {
+            return std::nullopt;
+        }
+
+        XWindowAttributes attr;
+        if (XGetWindowAttributes(m_display, m_window, &attr) == False) {
+            Log.error("Failed to get window attributes for window", m_window);
+            // set_window(None);
+            return std::nullopt;
+        }
+        m_max_x = attr.width;
+        m_max_y = attr.height;
+        return attr;
+    }
+
+    static void ximg_to_cv(cv::Mat& image_payload, const XImage* ximg)
+    {
+        if (ximg == nullptr) {
+            return;
+        }
+        if (ximg->bits_per_pixel != 32 || ximg->format != ZPixmap) {
+            Log.error("Unsupported image format");
+            image_payload.release();
+            return;
+        }
+
+        cv::Mat view(ximg->height, ximg->width, CV_8UC4, ximg->data, ximg->bytes_per_line);
+        cv::cvtColor(view, image_payload, cv::COLOR_RGBA2RGB);
+    }
+
+    bool focus_window() const;
+
+private:
+    AsstCallback m_callback = nullptr;
+
+    void set_window(Window w)
+    {
+        m_window = w;
+        m_uuid = std::format("{:#x}", w);
+    }
+
+    bool park_cursor()
+    {
+        Point point = { m_max_x - 10, m_max_y - 10 };
+        return inject_input_event(
+            InputEvent {
+                .type = InputEvent::Type::TOUCH_MOVE,
+                .point = point,
+            });
+    }
+
+    bool send_keysym(KeySym keysym, int type) const;
+
+    Display* m_display = nullptr;
+    Window m_window = None;
+    std::string m_uuid;
+    mutable int m_max_x { };
+    mutable int m_max_y { };
+};
+
+} // namespace asst
+
+#endif

--- a/src/MaaCore/Controller/X11Controller.h
+++ b/src/MaaCore/Controller/X11Controller.h
@@ -68,7 +68,7 @@ public:
 
     virtual bool stop_game(const std::string& client_type [[maybe_unused]]) override
     {
-        // TODO: Implement this pure virtual method.
+        Log.warn("stop_game is not implemented on X11Controller");
         return false;
     }
 


### PR DESCRIPTION
在 X11 或支持 XWayland 的混成器中用 Wine/Proton 运行明日方舟 PC 端时, 默认会是 X11 窗口, 而且可以直接吃 XSendEvent 来控制, 窗口在后台也能截图, 所以实现起来很简单.

- 理论上 X11 和 Wayland 桌面环境 (XWayland) 都可以使用
- 不需要窗口始终置顶 (但操作时可能抢焦点)
- 支持精确滑动
- Wine 也可以作为 Wayland 窗口运行, 此时无法工作 (但一般人不会故意这么搞)
- 操作完成后 `park_cursor` 把鼠标放到右下角避免干扰识别
- `input()` 字符串可能比较麻烦暂时没实现

---

使用方法:
用 `xwininfo` 等工具找出方舟的 X 窗口 ID, (如 `0x3e00003`)
cli 配置:
```toml
[connection]
type = "X11" # 需要 cli 支持
device = "0x3e00003"
```
---
可能的问题:
- 现在使用 adb address 代为传递窗口 ID, 比较难看
- 是否需要增加根据窗口标题自动找方舟窗口的功能?
- 是否需要支持使用 `$DISPLAY` 以外的 X 环境?

以及, 需要给 Core 增加个 x11 依赖 (虽然应该比较小), 可能的解决方案
- `dlopen(libX11.so)` 现在用的函数比较少, 应该有可能
- 把实现放到 MaaFw 上去, 也像 Win32 那样加载?
- 最好是能直接 all in wayland, 比如把 Fw 的 wlroots 控制给搬过来? 虽然可能没法单独截和操作窗口, 但是可以嵌套混成器所以影响不大.

---
- https://github.com/MaaXYZ/MaaFramework/pull/1131
- https://github.com/MaaAssistantArknights/MaaAssistantArknights/pull/15407
- https://github.com/MaaAssistantArknights/MaaAssistantArknights/issues/15745

## Summary by Sourcery

为 Linux 添加一个新的基于 X11 的控制器实现，并将其接入核心控制器选择和配置系统。

新功能：
- 引入一个 `X11Controller`，可以在 Linux 上控制并捕获指定的 X11 窗口。
- 允许在 Linux 上通过实例选项使用 `"X11"` TouchMode 字符串来选择 X11 触控模式。

增强内容：
- 在 Linux 构建中将 MaaCore 链接到 X11 库以支持新的控制器。
- 扩展控制器和触控模式的枚举类型以包含 X11 选项。
- 在所有支持的语言的协议文档中添加更新，以记录新的 X11 TouchMode 选项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a new X11-based controller implementation for Linux and wire it into the core controller selection and configuration system.

New Features:
- Introduce an X11Controller that can control and capture from a specified X11 window on Linux.
- Allow selecting the X11 touch mode via instance options using the "X11" TouchMode string on Linux.

Enhancements:
- Link MaaCore against the X11 library on Linux builds to support the new controller.
- Extend controller and touch mode enums to include an X11 option.
- Add protocol documentation updates in all supported languages to document the new X11 TouchMode option.

</details>