### PR TITLE
fix: open dorm operators list properly when there are 0-3 locked operators

### DIFF
--- a/resource/global/YoStarEN/resource/tasks/tasks.json
+++ b/resource/global/YoStarEN/resource/tasks/tasks.json
@@ -1266,6 +1266,10 @@
         "fullMatch": true,
         "text": ["Morale", "Resting", "In Use", "Working", "Assign"]
     },
+    "InfrastEnterDormOperList": {
+        "fullMatch": true,
+        "text": ["Morale", "Resting", "In Use", "Working", "Assign"]
+    },
     "InfrastFilterMenuAllButton": {
         "text": ["All"]
     },

--- a/resource/global/YoStarJP/resource/tasks/tasks.json
+++ b/resource/global/YoStarJP/resource/tasks/tasks.json
@@ -1226,6 +1226,9 @@
     "InfrastEnterOperList": {
         "text": ["体力", "休憩中", "仕事中", "配属"]
     },
+    "InfrastEnterDormOperList": {
+        "text": ["体力", "休憩中", "仕事中", "配属"]
+    },
     "InfrastFilterMenuAllButton": {
         "text": ["全て"]
     },

--- a/resource/global/YoStarKR/resource/tasks/tasks.json
+++ b/resource/global/YoStarKR/resource/tasks/tasks.json
@@ -1328,6 +1328,9 @@
     "InfrastEnterOperList": {
         "text": ["컨디션", "휴식중", "업무중", "배치"]
     },
+    "InfrastEnterDormOperList": {
+        "text": ["컨디션", "휴식중", "업무중", "배치"]
+    },
     "InfrastFilterMenuAllButton": {
         "text": ["전부"]
     },

--- a/resource/global/txwy/resource/tasks/tasks.json
+++ b/resource/global/txwy/resource/tasks/tasks.json
@@ -943,6 +943,9 @@
     "InfrastEnterOperList": {
         "text": ["心情", "休息中", "工作中", "進駐"]
     },
+    "InfrastEnterDormOperList": {
+        "text": ["心情", "休息中", "工作中", "進駐"]
+    },
     "InfrastConfirmButtonWait": {
         "text": ["正在提交", "反饋至神經"]
     },

--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -2806,13 +2806,20 @@
         "text": ["进驻信息"],
         "roi": [0, 0, 150, 720],
         "postDelay": 1000,
-        "next": ["InfrastEnterOperList"]
+        "next": ["InfrastEnterDormOperList", "InfrastEnterOperList"]
     },
     "InfrastEnterOperList": {
         "algorithm": "OcrDetect",
         "action": "ClickSelf",
         "text": ["心情", "休息中", "工作中", "进驻"],
         "roi": [800, 70, 480, 580],
+        "postDelay": 1000
+    },
+    "InfrastEnterDormOperList": {
+        "algorithm": "OcrDetect",
+        "action": "ClickSelf",
+        "text": ["心情", "休息中", "工作中", "进驻"],
+        "roi": [800, 500, 480, 180],
         "postDelay": 1000
     },
     "InfrastClearButton": {

--- a/src/MaaCore/Task/Infrast/InfrastAbstractTask.cpp
+++ b/src/MaaCore/Task/Infrast/InfrastAbstractTask.cpp
@@ -235,6 +235,14 @@ bool asst::InfrastAbstractTask::enter_oper_list_page()
     return task.run();
 }
 
+bool asst::InfrastAbstractTask::enter_dorm_oper_list_page()
+{
+    LogTraceFunction;
+
+    ProcessTask task(*this, { "InfrastEnterDormOperList", "InfrastStationedInfo" });
+    return task.run();
+}
+
 bool asst::InfrastAbstractTask::is_use_custom_opers()
 {
     return m_is_custom && (!current_room_config().names.empty() || !current_room_config().candidates.empty());

--- a/src/MaaCore/Task/Infrast/InfrastAbstractTask.h
+++ b/src/MaaCore/Task/Infrast/InfrastAbstractTask.h
@@ -34,6 +34,7 @@ protected:
     bool enter_facility(int index = 0);
     // 从刚点进设施的界面，到干员列表页
     bool enter_oper_list_page();
+    bool enter_dorm_oper_list_page();
 
     virtual int operlist_swipe_times() const noexcept { return 2; }
 

--- a/src/MaaCore/Task/Infrast/InfrastDormTask.cpp
+++ b/src/MaaCore/Task/Infrast/InfrastDormTask.cpp
@@ -58,7 +58,7 @@ bool asst::InfrastDormTask::_run()
                 break;
             }
         }
-        if (!enter_oper_list_page()) {
+        if (!enter_dorm_oper_list_page()) {
             return false;
         }
 


### PR DESCRIPTION
曾经会错误打开锁定干员选单，现在将OCR区域限制在最后一行，可以在有0-3个锁定干员的条件下正确地打开干员选单，适用于绝大多数情况（两个心情干员 + 菲亚梅塔）

在以下环境测试有效：
- macOS 官服
- PlayCover 16:9 分辨率
- ```preset = "PlayCover"```
- ```cpu_ocr = false```
- ```gpu_ocr = 1```
- ```touch_mode = "MacPlayTools"```


调整后的OCR区域：
<img width="480" height="180" alt="SCR-20260605-cafr" src="https://github.com/user-attachments/assets/602c565b-ffe9-4970-b69c-a46f6ba12da8" />

## Summary by Sourcery

错误修复：
- 通过将 OCR 区域缩小到最后一行干员，将宿舍中在仅有 0–3 名已锁定干员时错误打开的“已锁定干员”菜单问题修复。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix incorrect dorm locked-operator menu opening when there are 0–3 locked operators by narrowing the OCR region to the last operator row.

</details>