### PR TITLE
feat: 实现任务分组功能

### DIFF
--- a/src/MaaWpfGui/Configuration/Single/MaaTask/BaseTask.cs
+++ b/src/MaaWpfGui/Configuration/Single/MaaTask/BaseTask.cs
@@ -11,6 +11,7 @@
 // but WITHOUT ANY WARRANTY
 // </copyright>
 #nullable enable
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Text.Json.Serialization;
 using JetBrains.Annotations;
@@ -37,6 +38,7 @@ namespace MaaWpfGui.Configuration.Single.MaaTask;
 [JsonDerivedType(typeof(UserDataUpdateTask), typeDiscriminator: nameof(UserDataUpdateTask))]
 [JsonDerivedType(typeof(ReclamationTask), typeDiscriminator: nameof(ReclamationTask))]
 [JsonDerivedType(typeof(CustomTask), typeDiscriminator: nameof(CustomTask))]
+[JsonDerivedType(typeof(TaskGroup), typeDiscriminator: nameof(TaskGroup))]
 public class BaseTask : INotifyPropertyChanged
 {
     public event PropertyChangedEventHandler? PropertyChanged;
@@ -83,6 +85,27 @@ public class DepotTask : BaseTask
 
 public class OperBoxTask : BaseTask
 {
+}
+
+/// <summary>
+/// 任务分组，包含一组子任务，用于减少界面上的任务数量。
+/// </summary>
+public class TaskGroup : BaseTask
+{
+    public TaskGroup()
+    {
+        TaskType = TaskType.Group;
+    }
+
+    /// <summary>
+    /// Gets or sets the children tasks in this group.
+    /// </summary>
+    public List<BaseTask> Children { get; set; } = [];
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the group is expanded in the UI.
+    /// </summary>
+    public bool IsExpanded { get; set; } = true;
 }
 
 #pragma warning restore SA1402 // File may only contain a single type

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -2887,6 +2887,9 @@ public class AsstProxy
 
         /// <summary>自定义任务s</summary>
         Custom,
+
+        /// <summary>任务分组</summary>
+        Group,
     }
 
     private readonly HashSet<TaskType> _mainTaskTypes =

--- a/src/MaaWpfGui/Models/TaskQueueDropHandler.cs
+++ b/src/MaaWpfGui/Models/TaskQueueDropHandler.cs
@@ -1,0 +1,332 @@
+// <copyright file="TaskQueueDropHandler.cs" company="MaaAssistantArknights">
+// Part of the MaaWpfGui project, maintained by the MaaAssistantArknights team (Maa Team)
+// Copyright (C) 2021-2025 MaaAssistantArknights Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License v3.0 only as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY
+// </copyright>
+
+#nullable enable
+using System.Collections;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Windows;
+using GongSolutions.Wpf.DragDrop;
+using MaaWpfGui.Configuration.Factory;
+using MaaWpfGui.Configuration.Single.MaaTask;
+using MaaWpfGui.Helper;
+using MaaWpfGui.ViewModels;
+using Serilog;
+
+namespace MaaWpfGui.Models;
+
+/// <summary>
+/// Custom <see cref="IDropTarget"/> for the task queue ListBox and group ItemsControls.
+/// Supports:
+/// - Dragging a top-level task INTO a task group
+/// - Dragging a child task OUT OF a task group (back to top level)
+/// - Dragging a child task BETWEEN groups
+/// - Standard reorder within the same list
+/// </summary>
+public class TaskQueueDropHandler : DefaultDropHandler
+{
+    private static readonly ILogger _logger = Log.ForContext<TaskQueueDropHandler>();
+
+    /// <summary>
+    /// Called continuously while the user drags over a drop target.
+    /// Always shows "move" feedback for task queue items.
+    /// </summary>
+    public override void DragOver(IDropInfo dropInfo)
+    {
+        if (dropInfo.Data is ITaskQueueItemViewModel or TaskGroupViewModel or TaskItemViewModel)
+        {
+            dropInfo.Effects = DragDropEffects.Move;
+            dropInfo.DropTargetAdorner = DropTargetAdorners.Insert;
+        }
+    }
+
+    /// <summary>
+    /// Called when the user releases the drag. Handles cross-level moves (into/out of groups)
+    /// and falls back to the default handler for same-level reorder.
+    /// </summary>
+    public override void Drop(IDropInfo dropInfo)
+    {
+        var sourceItem = dropInfo.Data;
+        var targetItem = dropInfo.TargetItem;
+        var sourceCollection = dropInfo.DragInfo.SourceCollection;
+        var targetCollection = dropInfo.TargetCollection;
+
+        if (sourceItem == null)
+        {
+            return;
+        }
+
+        // ─────────────────────────────────────────────────
+        // Scenario A: Drag a top-level TaskItemViewModel ONTO a TaskGroupViewModel
+        //   → move the task INTO the group
+        // ─────────────────────────────────────────────────
+        if (sourceItem is TaskItemViewModel sourceTask
+            && targetItem is TaskGroupViewModel targetGroup
+            && sourceCollection is ObservableCollection<ITaskQueueItemViewModel>)
+        {
+            HandleMoveIntoGroup(sourceTask, targetGroup);
+            return;
+        }
+
+        // ─────────────────────────────────────────────────
+        // Scenario B: Drag a TaskItemViewModel from a group's ItemsControl
+        // to the top-level ListBox
+        //   → move the task OUT of the group
+        // ─────────────────────────────────────────────────
+        if (sourceItem is TaskItemViewModel childTask
+            && sourceCollection is ObservableCollection<TaskItemViewModel> sourceChildrenCollection
+            && targetCollection is ObservableCollection<ITaskQueueItemViewModel>)
+        {
+            HandleMoveOutOfGroup(childTask, sourceChildrenCollection, dropInfo.InsertIndex);
+            return;
+        }
+
+        // ─────────────────────────────────────────────────
+        // Scenario C: Drag a TaskItemViewModel between two different groups
+        //   → move from source group to target group
+        // ─────────────────────────────────────────────────
+        if (sourceItem is TaskItemViewModel crossTask
+            && sourceCollection is ObservableCollection<TaskItemViewModel> srcChildren
+            && targetCollection is ObservableCollection<TaskItemViewModel> dstChildren
+            && !ReferenceEquals(srcChildren, dstChildren))
+        {
+            HandleMoveBetweenGroups(crossTask, srcChildren, dstChildren, dropInfo.InsertIndex);
+            return;
+        }
+
+        // ─────────────────────────────────────────────────
+        // Scenario D (fallback): Same-level reorder
+        //   → let DefaultDropHandler handle it
+        // ─────────────────────────────────────────────────
+        base.Drop(dropInfo);
+
+        // After default reorder, refresh indices
+        if (targetCollection is ObservableCollection<ITaskQueueItemViewModel> topLevel)
+        {
+            RefreshTopLevelIndices();
+        }
+        else if (targetCollection is ObservableCollection<TaskItemViewModel> groupChildren)
+        {
+            RefreshGroupChildIndices(groupChildren);
+        }
+    }
+
+    /// <summary>
+    /// Moves a top-level task INTO a task group.
+    /// </summary>
+    private static void HandleMoveIntoGroup(TaskItemViewModel sourceTask, TaskGroupViewModel targetGroup)
+    {
+        int sourceIndex = sourceTask.Index;
+        if (sourceIndex < 0 || sourceIndex >= ConfigFactory.CurrentConfig.TaskQueue.Count)
+        {
+            return;
+        }
+
+        var task = ConfigFactory.CurrentConfig.TaskQueue[sourceIndex];
+        if (task is TaskGroup)
+        {
+            _logger.Warning("Cannot drag a TaskGroup into another group.");
+            return;
+        }
+
+        _logger.Information("Moving task {TaskType} into group {GroupName}",
+            task.TaskType, targetGroup.Name);
+
+        // Remove from top-level Config
+        ConfigFactory.CurrentConfig.TaskQueue.RemoveAt(sourceIndex);
+
+        // Remove from ViewModel list
+        Instances.TaskQueueViewModel.TaskItemViewModels.Remove(sourceTask);
+
+        // Dispose the old event subscription (the AddChild will create a new ViewModel)
+        sourceTask.Dispose();
+
+        // Add to the group (both data model and ViewModel)
+        targetGroup.AddChild(task);
+
+        // Refresh indices for remaining top-level items
+        RefreshTopLevelIndices();
+    }
+
+    /// <summary>
+    /// Moves a child task OUT OF a group, back to the top-level task queue.
+    /// </summary>
+    private static void HandleMoveOutOfGroup(
+        TaskItemViewModel childTask,
+        IList sourceChildrenCollection,
+        int insertIndex)
+    {
+        var parentGroup = FindParentGroup(sourceChildrenCollection);
+        if (parentGroup == null)
+        {
+            _logger.Warning("Could not find parent group for child task.");
+            return;
+        }
+
+        int childIndex = childTask.Index;
+        int groupQueueIndex = parentGroup.Index;
+
+        if (groupQueueIndex < 0 || groupQueueIndex >= ConfigFactory.CurrentConfig.TaskQueue.Count)
+        {
+            return;
+        }
+
+        var group = ConfigFactory.CurrentConfig.TaskQueue[groupQueueIndex] as TaskGroup;
+        if (group == null)
+        {
+            return;
+        }
+
+        if (childIndex < 0 || childIndex >= group.Children.Count || childIndex >= parentGroup.Children.Count)
+        {
+            return;
+        }
+
+        _logger.Information("Moving child task {TaskType} out of group {GroupName}",
+            group.Children[childIndex].TaskType, parentGroup.Name);
+
+        var task = parentGroup.RemoveChildAt(childIndex);
+        if (task == null)
+        {
+            return;
+        }
+
+        // Calculate the insert position in the top-level TaskQueue
+        // Insert after the group, but respect the insertIndex offset from the drag operation
+        int queueInsertIndex = groupQueueIndex + 1;
+
+        // Apply the drop position offset: insertIndex is within the group's ItemsControl,
+        // so we clamp the target position
+        if (insertIndex >= 0)
+        {
+            queueInsertIndex += insertIndex;
+        }
+
+        // Clamp
+        if (queueInsertIndex > ConfigFactory.CurrentConfig.TaskQueue.Count)
+        {
+            queueInsertIndex = ConfigFactory.CurrentConfig.TaskQueue.Count;
+        }
+
+        // Insert into Config
+        ConfigFactory.CurrentConfig.TaskQueue.Insert(queueInsertIndex, task);
+
+        // Create ViewModel with taskReference for the new top-level item
+        var newVm = new TaskItemViewModel(task.NameOrTaskType, task.IsEnable, taskReference: task)
+        {
+            Index = queueInsertIndex,
+        };
+
+        Instances.TaskQueueViewModel.TaskItemViewModels.Insert(queueInsertIndex, newVm);
+
+        // Refresh indices
+        RefreshTopLevelIndices();
+    }
+
+    /// <summary>
+    /// Moves a child task from one group to another.
+    /// </summary>
+    private static void HandleMoveBetweenGroups(
+        TaskItemViewModel childTask,
+        IList sourceChildrenCollection,
+        IList targetChildrenCollection,
+        int insertIndex)
+    {
+        var sourceGroup = FindParentGroup(sourceChildrenCollection);
+        var targetGroup = FindParentGroup(targetChildrenCollection);
+
+        if (sourceGroup == null || targetGroup == null)
+        {
+            _logger.Warning("Could not find source or target group for cross-group move.");
+            return;
+        }
+
+        int childIndex = childTask.Index;
+
+        var sourceTaskData = ConfigFactory.CurrentConfig.TaskQueue[sourceGroup.Index] as TaskGroup;
+        var targetTaskData = ConfigFactory.CurrentConfig.TaskQueue[targetGroup.Index] as TaskGroup;
+
+        if (sourceTaskData == null || targetTaskData == null)
+        {
+            return;
+        }
+
+        if (childIndex < 0 || childIndex >= sourceTaskData.Children.Count)
+        {
+            return;
+        }
+
+        _logger.Information("Moving child task from group {Source} to group {Target}",
+            sourceGroup.Name, targetGroup.Name);
+
+        // Remove from source group
+        var task = sourceGroup.RemoveChildAt(childIndex);
+        if (task == null)
+        {
+            return;
+        }
+
+        // Add to target group
+        if (insertIndex >= 0 && insertIndex < targetGroup.Children.Count)
+        {
+            // Insert at specific position in target
+            targetTaskData.Children.Insert(insertIndex, task);
+            var targetChildVm = new TaskItemViewModel(task.NameOrTaskType, task.IsEnable, taskReference: task)
+            {
+                Index = insertIndex,
+            };
+            targetChildVm.PropertyChanged += targetGroup.OnChildPropertyChanged;
+            targetGroup.Children.Insert(insertIndex, targetChildVm);
+        }
+        else
+        {
+            targetGroup.AddChild(task);
+        }
+
+        RefreshGroupChildIndices(targetGroup.Children);
+        RefreshGroupChildIndices(sourceGroup.Children);
+    }
+
+    /// <summary>
+    /// Finds the <see cref="TaskGroupViewModel"/> whose <see cref="TaskGroupViewModel.Children"/>
+    /// matches the given collection.
+    /// </summary>
+    private static TaskGroupViewModel? FindParentGroup(IList childrenCollection)
+    {
+        foreach (var item in Instances.TaskQueueViewModel.TaskItemViewModels)
+        {
+            if (item is TaskGroupViewModel gvm && ReferenceEquals(gvm.Children, childrenCollection))
+            {
+                return gvm;
+            }
+        }
+
+        return null;
+    }
+
+    private static void RefreshTopLevelIndices()
+    {
+        for (int i = 0; i < Instances.TaskQueueViewModel.TaskItemViewModels.Count; i++)
+        {
+            Instances.TaskQueueViewModel.TaskItemViewModels[i].Index = i;
+        }
+    }
+
+    private static void RefreshGroupChildIndices(ObservableCollection<TaskItemViewModel> children)
+    {
+        for (int i = 0; i < children.Count; i++)
+        {
+            children[i].Index = i;
+        }
+    }
+}

--- a/src/MaaWpfGui/Models/TaskSettingVisibilityInfo.cs
+++ b/src/MaaWpfGui/Models/TaskSettingVisibilityInfo.cs
@@ -149,6 +149,7 @@ public class TaskSettingVisibilityInfo : PropertyChangedBase
             ReclamationTask => Reclamation = enable,
             UserDataUpdateTask => UserDataUpdate = enable,
             CustomTask => Custom = enable,
+            TaskGroup => false, // groups have no dedicated settings panel
             _ => throw new NotImplementedException(),
         };
         EnableAdvancedSettings = false;
@@ -173,6 +174,7 @@ public class TaskSettingVisibilityInfo : PropertyChangedBase
         AdvancedSettingsVisibility = task switch {
             AwardTask or StartUpTask or UserDataUpdateTask => false,
             ReclamationTask rt => rt.Theme == ReclamationTheme.Tales,
+            TaskGroup => false,
             _ => true,
         };
     }

--- a/src/MaaWpfGui/ViewModels/ITaskQueueItemViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/ITaskQueueItemViewModel.cs
@@ -1,0 +1,47 @@
+// <copyright file="ITaskQueueItemViewModel.cs" company="MaaAssistantArknights">
+// Part of the MaaWpfGui project, maintained by the MaaAssistantArknights team (Maa Team)
+// Copyright (C) 2021-2025 MaaAssistantArknights Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License v3.0 only as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY
+// </copyright>
+
+#nullable enable
+using System.Collections.Generic;
+using MaaWpfGui.Constants.Enums;
+
+namespace MaaWpfGui.ViewModels;
+
+/// <summary>
+/// Interface for items that can appear in the task queue list.
+/// Both <see cref="TaskItemViewModel"/> and <see cref="TaskGroupViewModel"/> implement this.
+/// </summary>
+public interface ITaskQueueItemViewModel
+{
+    string Name { get; set; }
+
+    bool? IsEnable { get; set; }
+
+    int Index { get; set; }
+
+    bool EnableSetting { get; set; }
+
+    TaskItemStatus StatusDisplay { get; set; }
+
+    /// <summary>
+    /// Gets the task IDs associated with this item.
+    /// For <see cref="TaskItemViewModel"/>, returns the actual task IDs.
+    /// For <see cref="TaskGroupViewModel"/>, returns an empty list (children manage their own IDs).
+    /// </summary>
+    IReadOnlyList<int> TaskIds { get; }
+
+    /// <summary>
+    /// Sets the task IDs for this item.
+    /// </summary>
+    void SetTaskIds(IEnumerable<int> taskIds);
+}

--- a/src/MaaWpfGui/ViewModels/TaskGroupViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/TaskGroupViewModel.cs
@@ -1,0 +1,290 @@
+// <copyright file="TaskGroupViewModel.cs" company="MaaAssistantArknights">
+// Part of the MaaWpfGui project, maintained by the MaaAssistantArknights team (Maa Team)
+// Copyright (C) 2021-2025 MaaAssistantArknights Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License v3.0 only as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY
+// </copyright>
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using MaaWpfGui.Configuration.Factory;
+using MaaWpfGui.Configuration.Single.MaaTask;
+using MaaWpfGui.Constants.Enums;
+using MaaWpfGui.Helper;
+using MaaWpfGui.Models;
+using Stylet;
+
+namespace MaaWpfGui.ViewModels;
+
+/// <summary>
+/// ViewModel for a task group that contains multiple child tasks.
+/// Supports expand/collapse via Expander in the UI.
+/// </summary>
+public class TaskGroupViewModel : PropertyChangedBase, IDisposable, ITaskQueueItemViewModel
+{
+    private readonly TaskGroup _taskGroup;
+
+    public TaskGroupViewModel(TaskGroup taskGroup)
+    {
+        _taskGroup = taskGroup;
+        _name = taskGroup.NameOrTaskType;
+        _isExpanded = taskGroup.IsExpanded;
+        Children = new ObservableCollection<TaskItemViewModel>();
+        _isEnable = ComputeAggregatedIsEnable();
+        foreach (var child in taskGroup.Children)
+        {
+            var childVm = new TaskItemViewModel(child.NameOrTaskType, child.IsEnable, taskReference: child)
+            {
+                Index = Children.Count,
+            };
+            childVm.PropertyChanged += OnChildPropertyChanged;
+            Children.Add(childVm);
+        }
+
+        Instances.AsstProxy.OnTaskStatusChanged += OnTaskStatusChanged;
+    }
+
+    private string _name;
+
+    public string Name
+    {
+        get => _name;
+        set {
+            if (!SetAndNotify(ref _name, value))
+            {
+                return;
+            }
+
+            _taskGroup.Name = value;
+        }
+    }
+
+    private bool _isExpanded;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the group is expanded in the UI.
+    /// </summary>
+    public bool IsExpanded
+    {
+        get => _isExpanded;
+        set {
+            if (!SetAndNotify(ref _isExpanded, value))
+            {
+                return;
+            }
+
+            _taskGroup.IsExpanded = value;
+        }
+    }
+
+    private bool? _isEnable;
+
+    /// <summary>
+    /// Gets or sets the aggregated IsEnable state.
+    /// true = all children enabled, false = all disabled, null = mixed.
+    /// When set, propagates the value to all children.
+    /// </summary>
+    public bool? IsEnable
+    {
+        get => _isEnable;
+        set {
+            if (!SetAndNotify(ref _isEnable, value))
+            {
+                return;
+            }
+
+            if (value.HasValue)
+            {
+                foreach (var child in Children)
+                {
+                    child.IsEnable = value.Value;
+                }
+            }
+
+            _taskGroup.IsEnable = value;
+        }
+    }
+
+    /// <summary>
+    /// Gets the children ViewModels displayed inside the group.
+    /// </summary>
+    public ObservableCollection<TaskItemViewModel> Children { get; }
+
+    public int Index { get => field; set => SetAndNotify(ref field, value); }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the settings panel is enabled for this group.
+    /// </summary>
+    public bool EnableSetting
+    {
+        get => field;
+        set {
+            SetAndNotify(ref field, value);
+            if (value)
+            {
+                // Groups don't have their own settings panel; select the first child instead
+                var firstChild = Children.FirstOrDefault();
+                if (firstChild != null)
+                {
+                    firstChild.EnableSetting = true;
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the aggregated status display from children.
+    /// </summary>
+    public TaskItemStatus StatusDisplay
+    {
+        get => field;
+        set => SetAndNotify(ref field, value);
+    }
+
+    /// <summary>
+    /// Gets an empty list — groups do not own task IDs directly; children manage their own.
+    /// </summary>
+    public IReadOnlyList<int> TaskIds => [];
+
+    /// <summary>
+    /// No-op — groups do not own task IDs directly; children manage their own.
+    /// </summary>
+    public void SetTaskIds(IEnumerable<int> taskIds)
+    {
+    }
+
+    /// <summary>
+    /// Recalculates the aggregated IsEnable state based on children's states.
+    /// </summary>
+    public void UpdateAggregatedIsEnable()
+    {
+        IsEnable = ComputeAggregatedIsEnable();
+    }
+
+    private bool? ComputeAggregatedIsEnable()
+    {
+        if (Children.Count == 0)
+        {
+            return true;
+        }
+
+        bool allOn = Children.All(c => c.IsEnable == true);
+        bool allOff = Children.All(c => c.IsEnable == false);
+
+        if (allOn)
+        {
+            return true;
+        }
+
+        if (allOff)
+        {
+            return false;
+        }
+
+        return null; // mixed
+    }
+
+    internal void OnChildPropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName == nameof(TaskItemViewModel.IsEnable))
+        {
+            // Recalculate aggregated IsEnable when a child's IsEnable changes
+            var newAggregated = ComputeAggregatedIsEnable();
+            if (newAggregated != _isEnable)
+            {
+                // Directly set the field to avoid re-propagation loop
+                _isEnable = newAggregated;
+                NotifyOfPropertyChange(nameof(IsEnable));
+                _taskGroup.IsEnable = newAggregated;
+            }
+        }
+    }
+
+    private void OnTaskStatusChanged(int taskId, TaskItemStatus status)
+    {
+        // Aggregate status: Error > InProgress > Completed > Skipped > Idle
+        bool hasError = Children.Any(c => c.StatusDisplay == TaskItemStatus.Error);
+        bool hasInProgress = Children.Any(c => c.StatusDisplay == TaskItemStatus.InProgress);
+        bool allCompleted = Children.Count > 0 && Children.All(c => c.StatusDisplay == TaskItemStatus.Completed);
+
+        if (hasError)
+        {
+            StatusDisplay = TaskItemStatus.Error;
+        }
+        else if (hasInProgress)
+        {
+            StatusDisplay = TaskItemStatus.InProgress;
+        }
+        else if (allCompleted)
+        {
+            StatusDisplay = TaskItemStatus.Completed;
+        }
+        else
+        {
+            StatusDisplay = TaskItemStatus.Idle;
+        }
+    }
+
+    /// <summary>
+    /// Adds a child ViewModel to this group, linked to the given BaseTask.
+    /// </summary>
+    public void AddChild(BaseTask task)
+    {
+        _taskGroup.Children.Add(task);
+        var childVm = new TaskItemViewModel(task.NameOrTaskType, task.IsEnable, taskReference: task)
+        {
+            Index = Children.Count,
+        };
+        childVm.PropertyChanged += OnChildPropertyChanged;
+        Children.Add(childVm);
+        UpdateAggregatedIsEnable();
+    }
+
+    /// <summary>
+    /// Removes a child ViewModel at the given index and returns the associated BaseTask.
+    /// </summary>
+    public BaseTask? RemoveChildAt(int index)
+    {
+        if (index < 0 || index >= Children.Count || index >= _taskGroup.Children.Count)
+        {
+            return null;
+        }
+
+        var task = _taskGroup.Children[index];
+        var childVm = Children[index];
+        childVm.PropertyChanged -= OnChildPropertyChanged;
+        childVm.Dispose();
+        Children.RemoveAt(index);
+        _taskGroup.Children.RemoveAt(index);
+
+        // Update indices
+        for (int i = index; i < Children.Count; i++)
+        {
+            Children[i].Index = i;
+        }
+
+        UpdateAggregatedIsEnable();
+        return task;
+    }
+
+    public void Dispose()
+    {
+        Instances.AsstProxy.OnTaskStatusChanged -= OnTaskStatusChanged;
+        foreach (var child in Children)
+        {
+            child.PropertyChanged -= OnChildPropertyChanged;
+            child.Dispose();
+        }
+
+        Children.Clear();
+    }
+}

--- a/src/MaaWpfGui/ViewModels/TaskItemViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/TaskItemViewModel.cs
@@ -15,6 +15,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using MaaWpfGui.Configuration.Factory;
+using MaaWpfGui.Configuration.Single.MaaTask;
 using MaaWpfGui.Constants.Enums;
 using MaaWpfGui.Helper;
 using MaaWpfGui.Models;
@@ -22,12 +23,15 @@ using Stylet;
 
 namespace MaaWpfGui.ViewModels;
 
-public class TaskItemViewModel : PropertyChangedBase, IDisposable
+public class TaskItemViewModel : PropertyChangedBase, IDisposable, ITaskQueueItemViewModel
 {
-    public TaskItemViewModel(string name, bool? isCheckedWithNull = true)
+    private readonly BaseTask? _taskReference;
+
+    public TaskItemViewModel(string name, bool? isCheckedWithNull = true, BaseTask? taskReference = null)
     {
         _name = name;
         _isEnable = isCheckedWithNull;
+        _taskReference = taskReference;
         Instances.AsstProxy.OnTaskStatusChanged += OnTaskStatusChanged;
     }
 
@@ -42,7 +46,14 @@ public class TaskItemViewModel : PropertyChangedBase, IDisposable
                 return;
             }
 
-            ConfigFactory.CurrentConfig.TaskQueue[Index].Name = value;
+            if (_taskReference != null)
+            {
+                _taskReference.Name = value;
+            }
+            else
+            {
+                ConfigFactory.CurrentConfig.TaskQueue[Index].Name = value;
+            }
         }
     }
 
@@ -57,7 +68,15 @@ public class TaskItemViewModel : PropertyChangedBase, IDisposable
                 return;
             }
 
-            ConfigFactory.CurrentConfig.TaskQueue[Index].IsEnable = value;
+            if (_taskReference != null)
+            {
+                _taskReference.IsEnable = value;
+            }
+            else
+            {
+                ConfigFactory.CurrentConfig.TaskQueue[Index].IsEnable = value;
+            }
+
             StatusDisplay = TaskItemStatus.Idle;
         }
     }
@@ -72,7 +91,10 @@ public class TaskItemViewModel : PropertyChangedBase, IDisposable
         get => field;
         set {
             SetAndNotify(ref field, value);
-            TaskSettingVisibilityInfo.Instance.Set(Index, value);
+            if (_taskReference == null)
+            {
+                TaskSettingVisibilityInfo.Instance.Set(Index, value);
+            }
         }
     }
 
@@ -130,5 +152,5 @@ public class TaskItemViewModel : PropertyChangedBase, IDisposable
         }
     }
 
-    void IDisposable.Dispose() => Instances.AsstProxy.OnTaskStatusChanged -= OnTaskStatusChanged;
+    public void Dispose() => Instances.AsstProxy.OnTaskStatusChanged -= OnTaskStatusChanged;
 }

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -70,9 +70,9 @@ public class TaskQueueViewModel : Screen
     public static SemaphoreSlim TaskQueueSerializingLock { get; } = new(1, 1);
 
     /// <summary>
-    /// Gets or private sets the view models of task items.
+    /// Gets or private sets the view models of task items (both single tasks and task groups).
     /// </summary>
-    public ObservableCollection<TaskItemViewModel> TaskItemViewModels { get; private set; } = [];
+    public ObservableCollection<ITaskQueueItemViewModel> TaskItemViewModels { get; private set; } = [];
 
     /// <summary>
     /// Gets the visibility of task setting views.
@@ -186,9 +186,9 @@ public class TaskQueueViewModel : Screen
             }
             else if (e.Action == NotifyCollectionChangedAction.Remove)
             {
-                foreach (var item in e.OldItems?.OfType<TaskItemViewModel>() ?? [])
+                foreach (var item in e.OldItems?.OfType<IDisposable>() ?? [])
                 {
-                    (item as IDisposable)?.Dispose(); // 释放事件订阅; 暂未支持TaskItemViewModels.clear()
+                    item.Dispose(); // 释放事件订阅; 暂未支持TaskItemViewModels.clear()
                 }
 
                 if (e.OldStartingIndex >= 0 && e.OldStartingIndex < ConfigFactory.CurrentConfig.TaskQueue.Count)
@@ -994,11 +994,15 @@ public class TaskQueueViewModel : Screen
     /// </summary>
     private void InitializeItems()
     {
-        List<TaskItemViewModel> taskqueue = [];
+        List<ITaskQueueItemViewModel> taskqueue = [];
         for (int i = 0; i < ConfigFactory.CurrentConfig.TaskQueue.Count; i++)
         {
             var task = ConfigFactory.CurrentConfig.TaskQueue.ElementAt(i);
-            if (task is not null)
+            if (task is TaskGroup group)
+            {
+                taskqueue.Add(new TaskGroupViewModel(group) { Index = i });
+            }
+            else if (task is not null)
             {
                 taskqueue.Add(new TaskItemViewModel(task.NameOrTaskType, task.IsEnable) { Index = i });
             }
@@ -1007,7 +1011,7 @@ public class TaskQueueViewModel : Screen
         TaskItemViewModels = [.. taskqueue];
         TaskItemViewModels.CollectionChanged += TaskItemSelectionChanged;
         var taskItem = TaskItemViewModels.ElementAtOrDefault(ConfigFactory.CurrentConfig.TaskSelectedIndex);
-        taskItem ??= TaskItemViewModels.FirstOrDefault(i => ConfigFactory.CurrentConfig.TaskQueue[i.Index] is FightTask);
+        taskItem ??= TaskItemViewModels.FirstOrDefault(i => i is TaskItemViewModel tiv && ConfigFactory.CurrentConfig.TaskQueue[tiv.Index] is FightTask);
         taskItem ??= TaskItemViewModels.FirstOrDefault();
         if (taskItem is { })
         {
@@ -1309,15 +1313,43 @@ public class TaskQueueViewModel : Screen
     {
         foreach (var item in TaskItemViewModels)
         {
-            switch (ConfigFactory.CurrentConfig.TaskQueue[item.Index].TaskType)
+            if (item is TaskGroupViewModel groupVm)
             {
-                case TaskType.Roguelike:
-                case TaskType.Reclamation:
-                case TaskType.Custom:
-                    continue;
-            }
+                foreach (var child in groupVm.Children)
+                {
+                    var childIndex = child.Index;
+                    if (childIndex >= 0
+                        && ConfigFactory.CurrentConfig.TaskQueue[groupVm.Index] is TaskGroup group
+                        && childIndex < group.Children.Count)
+                    {
+                        switch (group.Children[childIndex].TaskType)
+                        {
+                            case TaskType.Roguelike:
+                            case TaskType.Reclamation:
+                            case TaskType.Custom:
+                                continue;
+                        }
+                    }
 
-            item.IsEnable = true;
+                    child.IsEnable = true;
+                }
+            }
+            else
+            {
+                var idx = item.Index;
+                if (idx >= 0 && idx < ConfigFactory.CurrentConfig.TaskQueue.Count)
+                {
+                    switch (ConfigFactory.CurrentConfig.TaskQueue[idx].TaskType)
+                    {
+                        case TaskType.Roguelike:
+                        case TaskType.Reclamation:
+                        case TaskType.Custom:
+                            continue;
+                    }
+                }
+
+                item.IsEnable = true;
+            }
         }
     }
 
@@ -1353,21 +1385,40 @@ public class TaskQueueViewModel : Screen
     }
 
     /// <summary>
+    /// Creates a new empty task group and adds it to the end of the task queue.
+    /// </summary>
+    [UsedImplicitly]
+    public void CreateGroup()
+    {
+        var group = new TaskGroup { Name = "任务组", IsExpanded = true };
+        ConfigFactory.CurrentConfig.TaskQueue.Add(group);
+        var groupVm = new TaskGroupViewModel(group) { Index = TaskItemViewModels.Count };
+        TaskItemViewModels.Add(groupVm);
+        AddLog(LocalizationHelper.GetStringFormat("TaskGroupCreated", group.NameOrTaskType), UiLogColor.Info);
+    }
+
+    /// <summary>
     /// 重命名任务
     /// </summary>
-    /// <param name="taskItem">任务项</param>
+    /// <param name="taskItem">任务项或任务组</param>
     [UsedImplicitly]
-    public void RenameTask(TaskItemViewModel taskItem)
+    public void RenameTask(ITaskQueueItemViewModel taskItem)
     {
         if (taskItem == null || !Idle)
         {
             return;
         }
 
-        var taskType = ConfigFactory.CurrentConfig.TaskQueue[taskItem.Index].TaskType;
+        int idx = taskItem.Index;
+        if (idx < 0 || idx >= ConfigFactory.CurrentConfig.TaskQueue.Count)
+        {
+            return;
+        }
+
+        var taskType = ConfigFactory.CurrentConfig.TaskQueue[idx].TaskType;
         var currentName = taskItem.Name.Replace("\r", string.Empty).Replace("\n", string.Empty);
         var dialog = new Views.Dialogs.TextDialogUserControl(
-            LocalizationHelper.GetString("RenameTask") + $" {taskItem.Index + 1}-{LocalizationHelper.GetString(taskType.ToString())}",
+            LocalizationHelper.GetString("RenameTask") + $" {idx + 1}-{LocalizationHelper.GetString(taskType.ToString())}",
             LocalizationHelper.GetString("RenameTaskPrompt"),
             currentName) {
             Owner = Application.Current.MainWindow,
@@ -1378,10 +1429,10 @@ public class TaskQueueViewModel : Screen
         if (result == true && !string.IsNullOrWhiteSpace(dialog.InputText))
         {
             var newName = dialog.InputText.Trim().Replace("\r", string.Empty).Replace("\n", string.Empty);
-            if (taskItem.Index < ConfigFactory.CurrentConfig.TaskQueue.Count)
+            if (idx < ConfigFactory.CurrentConfig.TaskQueue.Count)
             {
-                ConfigFactory.CurrentConfig.TaskQueue[taskItem.Index].Name = newName;
-                taskItem.Name = ConfigFactory.CurrentConfig.TaskQueue[taskItem.Index].NameOrTaskType;
+                ConfigFactory.CurrentConfig.TaskQueue[idx].Name = newName;
+                taskItem.Name = ConfigFactory.CurrentConfig.TaskQueue[idx].NameOrTaskType;
                 AddLog(LocalizationHelper.GetStringFormat("TaskRenamed", newName), UiLogColor.Info);
             }
             else
@@ -1392,24 +1443,24 @@ public class TaskQueueViewModel : Screen
     }
 
     /// <summary>
-    /// 单次运行任务。
+    /// 单次运行任务.
     /// </summary>
     /// <param name="taskItem">任务项</param>
     /// <returns>A <see cref="Task"/>representing the asynchronous operation.</returns>
     [UsedImplicitly]
-    public async Task RunTaskOnce(TaskItemViewModel taskItem)
+    public async Task RunTaskOnce(ITaskQueueItemViewModel taskItem)
     {
-        if (taskItem == null || !Idle)
+        if (taskItem is not TaskItemViewModel tiv || !Idle)
         {
             return;
         }
 
-        if (taskItem.Index < 0 || taskItem.Index >= ConfigFactory.CurrentConfig.TaskQueue.Count)
+        if (tiv.Index < 0 || tiv.Index >= ConfigFactory.CurrentConfig.TaskQueue.Count)
         {
             return;
         }
 
-        var task = ConfigFactory.CurrentConfig.TaskQueue[taskItem.Index];
+        var task = ConfigFactory.CurrentConfig.TaskQueue[tiv.Index];
         var originalIsEnable = task.IsEnable;
 
         try
@@ -1425,11 +1476,11 @@ public class TaskQueueViewModel : Screen
     }
 
     /// <summary>
-    /// 复制任务
+    /// 复制任务或任务组
     /// </summary>
-    /// <param name="taskItem">任务项</param>
+    /// <param name="taskItem">任务项或任务组</param>
     [UsedImplicitly]
-    public void CopyTask(TaskItemViewModel taskItem)
+    public void CopyTask(ITaskQueueItemViewModel taskItem)
     {
         if (taskItem == null || !Idle)
         {
@@ -1449,38 +1500,61 @@ public class TaskQueueViewModel : Screen
             AddLog(LocalizationHelper.GetString("TaskCopyFailed"), UiLogColor.Error);
             return;
         }
+
         newTask.Name = newTask.NameOrTaskType + " (2)";
         ConfigFactory.CurrentConfig.TaskQueue.Insert(index + 1, newTask);
-        TaskItemViewModels.Insert(index + 1, new TaskItemViewModel(newTask.NameOrTaskType));
+
+        if (taskItem is TaskGroupViewModel)
+        {
+            // Re-create group VM after insertion
+            var groupVm = new TaskGroupViewModel((TaskGroup)newTask) { Index = index + 1 };
+            TaskItemViewModels.Insert(index + 1, groupVm);
+        }
+        else
+        {
+            TaskItemViewModels.Insert(index + 1, new TaskItemViewModel(newTask.NameOrTaskType));
+        }
+
         AddLog(LocalizationHelper.GetStringFormat("TaskCopied", newTask.NameOrTaskType), UiLogColor.Info);
     }
 
     /// <summary>
-    /// 删除任务
+    /// 删除任务或任务组
     /// </summary>
-    /// <param name="taskItem">任务项</param>
+    /// <param name="taskItem">任务项或任务组</param>
     [UsedImplicitly]
-    public void RemoveTask(TaskItemViewModel taskItem)
+    public void RemoveTask(ITaskQueueItemViewModel taskItem)
     {
         if (taskItem == null || !Idle)
         {
             return;
         }
 
-        var taskType = ConfigFactory.CurrentConfig.TaskQueue[taskItem.Index].TaskType;
+        int idx = taskItem.Index;
+        if (idx < 0 || idx >= ConfigFactory.CurrentConfig.TaskQueue.Count)
+        {
+            return;
+        }
+
+        var taskType = ConfigFactory.CurrentConfig.TaskQueue[idx].TaskType;
         var result = MessageBoxHelper.Show(
-            LocalizationHelper.GetStringFormat("ConfirmDeleteTaskMessage", $"{taskItem.Index + 1}-{LocalizationHelper.GetString(taskType.ToString())}", taskItem.Name),
+            LocalizationHelper.GetStringFormat("ConfirmDeleteTaskMessage", $"{idx + 1}-{LocalizationHelper.GetString(taskType.ToString())}", taskItem.Name),
             LocalizationHelper.GetString("ConfirmDeleteTask"),
             MessageBoxButton.YesNo,
             MessageBoxImage.Question);
 
         if (result == MessageBoxResult.Yes)
         {
-            var index = taskItem.Index;
-            if (index < ConfigFactory.CurrentConfig.TaskQueue.Count)
+            if (idx < ConfigFactory.CurrentConfig.TaskQueue.Count)
             {
-                TaskItemViewModels.RemoveAt(index);
+                if (taskItem is TaskGroupViewModel groupVm)
+                {
+                    groupVm.Dispose();
+                }
+
+                TaskItemViewModels.RemoveAt(idx);
                 AddLog(LocalizationHelper.GetStringFormat("TaskDeleted", taskItem.Name), UiLogColor.Info);
+                AchievementTrackerHelper.Instance.Unlock(AchievementIds.QueueSimplifier);
                 AchievementTrackerHelper.Instance.Unlock(AchievementIds.QueueSimplifier);
             }
         }
@@ -1577,21 +1651,43 @@ public class TaskQueueViewModel : Screen
         {
             foreach (var item in TaskItemViewModels)
             {
-                switch (ConfigFactory.CurrentConfig.TaskQueue[item.Index].TaskType)
+                if (item is TaskGroupViewModel groupVm)
                 {
-                    case TaskType.Roguelike:
-                    case TaskType.Reclamation:
-                    case TaskType.Custom:
-                        continue;
+                    foreach (var child in groupVm.Children)
+                    {
+                        child.IsEnable = !(child.IsEnable ?? true);
+                    }
                 }
+                else
+                {
+                    var idx = item.Index;
+                    if (idx >= 0 && idx < ConfigFactory.CurrentConfig.TaskQueue.Count)
+                    {
+                        switch (ConfigFactory.CurrentConfig.TaskQueue[idx].TaskType)
+                        {
+                            case TaskType.Roguelike:
+                            case TaskType.Reclamation:
+                            case TaskType.Custom:
+                                continue;
+                        }
+                    }
 
-                item.IsEnable = !(item.IsEnable ?? true);
+                    item.IsEnable = !(item.IsEnable ?? true);
+                }
             }
         }
         else
         {
             foreach (var item in TaskItemViewModels)
             {
+                if (item is TaskGroupViewModel groupVm)
+                {
+                    foreach (var child in groupVm.Children)
+                    {
+                        child.IsEnable = false;
+                    }
+                }
+
                 item.IsEnable = false;
             }
         }
@@ -1854,21 +1950,61 @@ public class TaskQueueViewModel : Screen
 
         bool taskRet = true;
 
-        // 直接遍历TaskItemViewModels里面的内容，是排序后的
-        int count = 0;
-        foreach (var item in tasks)
+        // 展平任务列表：将 TaskGroup 展开为其子任务，排除禁用的任务和组
+        var executionList = new List<(BaseTask Task, ITaskQueueItemViewModel? ViewModel)>();
+        foreach (var task in ConfigFactory.CurrentConfig.TaskQueue)
         {
-            var index = ConfigFactory.CurrentConfig.TaskQueue.IndexOf(item);
-            _logger.Information("Index {Index}, Type {TaskType}, Name {TaskName}, IsEnable {IsEnable}",
-                index,
+            if (task is TaskGroup group)
+            {
+                // 组本身禁用则跳过整个组
+                if (!IsTaskEnable(group))
+                {
+                    var groupVm = TaskItemViewModels.ElementAtOrDefault(ConfigFactory.CurrentConfig.TaskQueue.IndexOf(group));
+                    if (groupVm is TaskGroupViewModel gvm)
+                    {
+                        foreach (var child in gvm.Children)
+                        {
+                            child.StatusDisplay = TaskItemStatus.Skipped;
+                        }
+                    }
+
+                    continue;
+                }
+
+                foreach (var child in group.Children)
+                {
+                    if (!IsTaskEnable(child))
+                    {
+                        continue;
+                    }
+
+                    executionList.Add((child, FindTaskItemViewModel(child)));
+                }
+            }
+            else
+            {
+                if (!IsTaskEnable(task))
+                {
+                    var index = ConfigFactory.CurrentConfig.TaskQueue.IndexOf(task);
+                    if (index >= 0 && index < TaskItemViewModels.Count)
+                    {
+                        TaskItemViewModels[index].StatusDisplay = TaskItemStatus.Skipped;
+                    }
+
+                    continue;
+                }
+
+                executionList.Add((task, TaskItemViewModels.ElementAtOrDefault(ConfigFactory.CurrentConfig.TaskQueue.IndexOf(task))));
+            }
+        }
+
+        int count = 0;
+        foreach (var (item, vm) in executionList)
+        {
+            _logger.Information("Type {TaskType}, Name {TaskName}, IsEnable {IsEnable}",
                 item.TaskType,
                 item.NameOrTaskType,
                 item.IsEnable);
-            if (!IsTaskEnable(item))
-            {
-                SetTaskStatus(index, TaskItemStatus.Skipped);
-                continue;
-            }
 
             try
             {
@@ -1877,16 +2013,28 @@ public class TaskQueueViewModel : Screen
                 {
                     case true:
                         ++count;
-                        Instances.TaskQueueViewModel.TaskItemViewModels.ElementAtOrDefault(index)?.SetTaskIds(taskIds);
+                        if (vm is TaskItemViewModel tiv)
+                        {
+                            tiv.SetTaskIds(taskIds);
+                        }
+
                         break;
                     case false:
                         taskRet = false;
                         AddLog(LocalizationHelper.GetStringFormat("TaskAppend.Error", LocalizationHelper.GetString(item.TaskType.ToString()), item.NameOrTaskType), UiLogColor.Error);
-                        SetTaskStatus(index, TaskItemStatus.Error);
+                        if (vm is TaskItemViewModel tivErr)
+                        {
+                            tivErr.StatusDisplay = TaskItemStatus.Error;
+                        }
+
                         break;
                     case null:
                         AddLog(LocalizationHelper.GetStringFormat("TaskAppend.Skip", LocalizationHelper.GetString(item.TaskType.ToString()), item.NameOrTaskType), UiLogColor.Info);
-                        SetTaskStatus(index, TaskItemStatus.Skipped);
+                        if (vm is TaskItemViewModel tivSkip)
+                        {
+                            tivSkip.StatusDisplay = TaskItemStatus.Skipped;
+                        }
+
                         break;
                 }
             }
@@ -1924,16 +2072,6 @@ public class TaskQueueViewModel : Screen
 
         AchievementTrackerHelper.Instance.MissionStartCountAdd();
         AchievementTrackerHelper.Instance.UseDailyAdd();
-
-        static void SetTaskStatus(int index, TaskItemStatus status)
-        {
-            if (index < 0 || index >= Instances.TaskQueueViewModel.TaskItemViewModels.Count)
-            {
-                return;
-            }
-
-            Instances.TaskQueueViewModel.TaskItemViewModels[index].StatusDisplay = status;
-        }
     }
 
     private void ResetTaskItemStatuses()
@@ -1941,6 +2079,13 @@ public class TaskQueueViewModel : Screen
         foreach (var item in TaskItemViewModels)
         {
             item.StatusDisplay = TaskItemStatus.Idle;
+            if (item is TaskGroupViewModel groupVm)
+            {
+                foreach (var child in groupVm.Children)
+                {
+                    child.StatusDisplay = TaskItemStatus.Idle;
+                }
+            }
         }
     }
 
@@ -2178,7 +2323,8 @@ public class TaskQueueViewModel : Screen
         }
     }
 
-    /// <summary>序列化任务</summary>
+    /// <summary>
+    /// 序列化任务</summary>
     /// <param name="task">存储的任务</param>
     /// <param name="taskId">任务id, null时追加任务, 非null为设置任务参数</param>
     /// <returns>null为未序列化, false失败, true成功</returns>
@@ -2196,5 +2342,72 @@ public class TaskQueueViewModel : Screen
             }
         }
         return (ret, id);
+    }
+
+    /// <summary>
+    /// Flattens the task list: expands TaskGroup into their children.
+    /// Only tasks that are actually serializable to MaaCore are included.
+    /// </summary>
+    private static IEnumerable<(BaseTask Task, int? GroupIndex)> FlattenTasksForExecution(IEnumerable<BaseTask> tasks)
+    {
+        foreach (var task in tasks)
+        {
+            if (task is TaskGroup group)
+            {
+                foreach (var child in group.Children)
+                {
+                    yield return (child, null);
+                }
+            }
+            else
+            {
+                yield return (task, null);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Finds the <see cref="TaskItemViewModel"/> corresponding to a <see cref="BaseTask"/>,
+    /// searching both top-level items and group children.
+    /// </summary>
+    private static TaskItemViewModel? FindTaskItemViewModel(BaseTask task)
+    {
+        // Search in top-level TaskItemViewModels
+        for (int i = 0; i < Instances.TaskQueueViewModel.TaskItemViewModels.Count; i++)
+        {
+            if (i >= ConfigFactory.CurrentConfig.TaskQueue.Count)
+            {
+                break;
+            }
+
+            if (Instances.TaskQueueViewModel.TaskItemViewModels[i] is TaskItemViewModel tiv
+                && ReferenceEquals(ConfigFactory.CurrentConfig.TaskQueue[i], task))
+            {
+                return tiv;
+            }
+        }
+
+        // Search inside TaskGroupViewModels
+        for (int i = 0; i < Instances.TaskQueueViewModel.TaskItemViewModels.Count; i++)
+        {
+            if (i >= ConfigFactory.CurrentConfig.TaskQueue.Count)
+            {
+                break;
+            }
+
+            if (Instances.TaskQueueViewModel.TaskItemViewModels[i] is TaskGroupViewModel groupVm
+                && ConfigFactory.CurrentConfig.TaskQueue[i] is TaskGroup group)
+            {
+                for (int j = 0; j < group.Children.Count && j < groupVm.Children.Count; j++)
+                {
+                    if (ReferenceEquals(group.Children[j], task))
+                    {
+                        return groupVm.Children[j];
+                    }
+                }
+            }
+        }
+
+        return null;
     }
 }

--- a/src/MaaWpfGui/Views/UI/TaskQueueView.xaml
+++ b/src/MaaWpfGui/Views/UI/TaskQueueView.xaml
@@ -9,12 +9,14 @@
     xmlns:enums="clr-namespace:MaaWpfGui.Constants.Enums"
     xmlns:hc="https://handyorg.github.io/handycontrol"
     xmlns:helper="clr-namespace:MaaWpfGui.Helper"
+    xmlns:local="clr-namespace:MaaWpfGui.Models"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:properties="clr-namespace:MaaWpfGui.Styles.Properties"
     xmlns:s="https://github.com/canton7/Stylet"
     xmlns:taskQueue="clr-namespace:MaaWpfGui.Views.UserControl.TaskQueue"
     xmlns:ui_vms="clr-namespace:MaaWpfGui.ViewModels.UI"
     xmlns:userControl="clr-namespace:MaaWpfGui.Views.UserControl"
+    xmlns:vms="clr-namespace:MaaWpfGui.ViewModels"
     MinWidth="720"
     d:Background="White"
     d:DataContext="{d:DesignInstance {x:Type ui_vms:TaskQueueViewModel}}"
@@ -42,6 +44,367 @@
                 </Trigger>
             </Style.Triggers>
         </Style>
+
+        <local:TaskQueueDropHandler x:Key="TaskQueueDropHandler" />
+
+        <!-- ============================================ -->
+        <!--  DataTemplate for single task items          -->
+        <!-- ============================================ -->
+        <DataTemplate DataType="{x:Type vms:TaskItemViewModel}">
+            <Border x:Name="TaskItemBorder" CornerRadius="4">
+                <Border.Style>
+                    <Style TargetType="Border">
+                        <Setter Property="Background" Value="Transparent" />
+                        <Setter Property="Opacity" Value="1" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding StatusDisplay}" Value="{x:Static enums:TaskItemStatus.InProgress}">
+                                <Setter Property="Background" Value="{DynamicResource TaskQueue.TaskItemStatus.InProgress}" />
+                            </DataTrigger>
+                            <DataTrigger Binding="{Binding StatusDisplay}" Value="{x:Static enums:TaskItemStatus.Completed}">
+                                <Setter Property="Background" Value="{DynamicResource TaskQueue.TaskItemStatus.Completed}" />
+                            </DataTrigger>
+                            <DataTrigger Binding="{Binding StatusDisplay}" Value="{x:Static enums:TaskItemStatus.Error}">
+                                <Setter Property="Background" Value="{DynamicResource TaskQueue.TaskItemStatus.Error}" />
+                            </DataTrigger>
+                            <DataTrigger Binding="{Binding StatusDisplay}" Value="{x:Static enums:TaskItemStatus.Skipped}">
+                                <Setter Property="Opacity" Value="0.5" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Border.Style>
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+
+                    <!--  Column 0  -->
+                    <CheckBox
+                        Grid.Column="0"
+                        MaxWidth="140"
+                        Margin="4.5,0,0,0"
+                        HorizontalAlignment="Left"
+                        IsChecked="{Binding IsEnable}"
+                        IsHitTestVisible="{Binding ElementName=TaskList, Path=DataContext.Idle}"
+                        MouseRightButtonUp="{s:Action ToggleCheckBoxNullOnRightClick, Target={x:Type helper:CheckBoxHelper}}">
+                        <controls:TextBlock Text="{Binding Name}" Visibility="Hidden" />
+                        <CheckBox.ToolTip>
+                            <ToolTip>
+                                <StackPanel>
+                                    <TextBlock HorizontalAlignment="Left">
+                                        <TextBlock.Style>
+                                            <Style BasedOn="{StaticResource TextBlockBaseStyle}" TargetType="TextBlock">
+                                                <Setter Property="Text" Value="{DynamicResource CheckBoxesNotSavedAsNull}" />
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding Source={x:Static ui_vms:SettingsViewModel.GuiSettings}, Path=MainTasksInvertNullFunction}" Value="True">
+                                                        <Setter Property="Text" Value="{DynamicResource CheckBoxesNotSavedAsNullInvert}" />
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </TextBlock.Style>
+                                    </TextBlock>
+                                    <TextBlock HorizontalAlignment="Left" Text="{DynamicResource MainTasksNullFunctionalitySwitch}" />
+                                </StackPanel>
+                            </ToolTip>
+                        </CheckBox.ToolTip>
+                    </CheckBox>
+                    <controls:TextBlock
+                        Grid.Column="0"
+                        Margin="26,0,4,0"
+                        HorizontalAlignment="Stretch"
+                        VerticalAlignment="Center"
+                        Background="Transparent"
+                        IsHitTestVisible="False"
+                        Text="{Binding Name}">
+                        <controls:TextBlock.Style>
+                            <Style BasedOn="{StaticResource MaaTextBlockDefaultStyle}" TargetType="{x:Type controls:TextBlock}">
+                                <Style.Triggers>
+                                    <MultiDataTrigger>
+                                        <MultiDataTrigger.Conditions>
+                                            <Condition Binding="{Binding Source={x:Static ui_vms:SettingsViewModel.GuiSettings}, Path=MainTasksInvertNullFunction}" Value="True" />
+                                            <Condition Binding="{Binding IsEnable}" Value="{x:Null}" />
+                                        </MultiDataTrigger.Conditions>
+                                        <Setter Property="Foreground" Value="{DynamicResource TraceLogBrush}" />
+                                    </MultiDataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </controls:TextBlock.Style>
+                    </controls:TextBlock>
+
+                    <!--  Column 1: gear icon + action buttons  -->
+                    <StackPanel Grid.Column="1" Orientation="Horizontal">
+                        <StackPanel Orientation="Horizontal">
+                            <StackPanel.Style>
+                                <Style TargetType="StackPanel">
+                                    <Setter Property="Visibility" Value="Collapsed" />
+                                    <Style.Triggers>
+                                        <MultiDataTrigger>
+                                            <MultiDataTrigger.Conditions>
+                                                <Condition Binding="{Binding IsMouseOver, RelativeSource={RelativeSource AncestorType={x:Type Border}, AncestorLevel=1}}" Value="True" />
+                                                <Condition Binding="{Binding Idle, Source={x:Static ui_vms:TaskQueueViewModel.TaskSettingDataContext}}" Value="True" />
+                                            </MultiDataTrigger.Conditions>
+                                            <Setter Property="Visibility" Value="Visible" />
+                                        </MultiDataTrigger>
+                                    </Style.Triggers>
+                                </Style>
+                            </StackPanel.Style>
+                            <Button
+                                hc:IconElement.Geometry="{StaticResource CopyTaskGeometry}"
+                                Command="{s:Action CopyTask, Target={x:Static helper:Instances.TaskQueueViewModel}}"
+                                CommandParameter="{Binding}"
+                                Style="{StaticResource TaskActionButtonStyle}"
+                                ToolTip="{DynamicResource Copy}" />
+                            <Button
+                                hc:IconElement.Geometry="{StaticResource RenameTaskGeometry}"
+                                Command="{s:Action RenameTask, Target={x:Static helper:Instances.TaskQueueViewModel}}"
+                                CommandParameter="{Binding}"
+                                Style="{StaticResource TaskActionButtonStyle}"
+                                ToolTip="{DynamicResource Rename}" />
+                            <Button
+                                hc:IconElement.Geometry="{StaticResource DeleteTaskGeometry}"
+                                Command="{s:Action RemoveTask, Target={x:Static helper:Instances.TaskQueueViewModel}}"
+                                CommandParameter="{Binding}"
+                                Style="{StaticResource TaskActionButtonStyle}"
+                                ToolTip="{DynamicResource Delete}" />
+                        </StackPanel>
+                        <hc:ButtonGroup>
+                            <RadioButton
+                                x:Name="TaskSettingRadioButton"
+                                Width="22"
+                                Margin="0,0,4,0"
+                                Padding="0"
+                                hc:VisualElement.HighlightBackground="Transparent"
+                                hc:VisualElement.HighlightForeground="{DynamicResource PrimaryBrush}"
+                                Background="Transparent"
+                                BorderThickness="0"
+                                ContextMenuService.IsEnabled="{Binding DataContext.Idle, RelativeSource={RelativeSource AncestorType=UserControl}}"
+                                GroupName="TaskSettings"
+                                IsChecked="{Binding EnableSetting}"
+                                Style="{DynamicResource RadioGroupItemSingle}">
+                                <Grid Width="16" Height="16">
+                                    <Path
+                                        Data="{StaticResource ConfigGeometry}"
+                                        Stretch="Uniform"
+                                        Visibility="{c:Binding !EnableSetting}">
+                                        <Path.Style>
+                                            <Style TargetType="Path">
+                                                <Setter Property="Fill" Value="{DynamicResource SecondaryTextBrush}" />
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding IsMouseOver, RelativeSource={RelativeSource AncestorType=RadioButton}}" Value="True">
+                                                        <Setter Property="Fill" Value="{DynamicResource PrimaryBrush}" />
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </Path.Style>
+                                    </Path>
+                                    <Path
+                                        Data="{StaticResource ConfigGeometry2}"
+                                        Fill="{DynamicResource PrimaryBrush}"
+                                        Stretch="Uniform"
+                                        Visibility="{c:Binding EnableSetting}" />
+                                </Grid>
+                                <RadioButton.ToolTip>
+                                    <ToolTip>
+                                        <StackPanel>
+                                            <TextBlock FontWeight="SemiBold" Text="{DynamicResource LeftClick}" />
+                                            <TextBlock Text="{DynamicResource TaskSettings}" />
+                                            <TextBlock FontWeight="SemiBold" Text="{DynamicResource RightClick}" />
+                                            <TextBlock Text="{DynamicResource RunTaskOnce}" />
+                                        </StackPanel>
+                                    </ToolTip>
+                                </RadioButton.ToolTip>
+                                <RadioButton.ContextMenu>
+                                    <ContextMenu Width="150">
+                                        <MenuItem
+                                            Command="{s:Action RunTaskOnce, Target={x:Static helper:Instances.TaskQueueViewModel}}"
+                                            CommandParameter="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
+                                            Header="{DynamicResource RunTaskOnce}" />
+                                    </ContextMenu>
+                                </RadioButton.ContextMenu>
+                            </RadioButton>
+                        </hc:ButtonGroup>
+                    </StackPanel>
+                </Grid>
+            </Border>
+        </DataTemplate>
+
+        <!-- ============================================ -->
+        <!--  DataTemplate for task groups (Expander)     -->
+        <!-- ============================================ -->
+        <DataTemplate DataType="{x:Type vms:TaskGroupViewModel}">
+            <Expander
+                Margin="-4,0,0,0"
+                IsExpanded="{Binding IsExpanded}">
+                <Expander.Header>
+                    <Border CornerRadius="4">
+                        <Border.Style>
+                            <Style TargetType="Border">
+                                <Setter Property="Background" Value="Transparent" />
+                                <Setter Property="Opacity" Value="1" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding StatusDisplay}" Value="{x:Static enums:TaskItemStatus.InProgress}">
+                                        <Setter Property="Background" Value="{DynamicResource TaskQueue.TaskItemStatus.InProgress}" />
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding StatusDisplay}" Value="{x:Static enums:TaskItemStatus.Completed}">
+                                        <Setter Property="Background" Value="{DynamicResource TaskQueue.TaskItemStatus.Completed}" />
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding StatusDisplay}" Value="{x:Static enums:TaskItemStatus.Error}">
+                                        <Setter Property="Background" Value="{DynamicResource TaskQueue.TaskItemStatus.Error}" />
+                                    </DataTrigger>
+                                    <DataTrigger Binding="{Binding StatusDisplay}" Value="{x:Static enums:TaskItemStatus.Skipped}">
+                                        <Setter Property="Opacity" Value="0.5" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Border.Style>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="Auto" />
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+
+                            <CheckBox
+                                Grid.Column="0"
+                                Margin="2,0,4,0"
+                                HorizontalAlignment="Left"
+                                IsChecked="{Binding IsEnable}"
+                                IsThreeState="True" />
+
+                            <controls:TextBlock
+                                Grid.Column="1"
+                                VerticalAlignment="Center"
+                                FontWeight="SemiBold"
+                                Text="{Binding Name}" />
+
+                            <StackPanel Grid.Column="2" Orientation="Horizontal" Visibility="Collapsed">
+                                <StackPanel.Style>
+                                    <Style TargetType="StackPanel">
+                                        <Setter Property="Visibility" Value="Collapsed" />
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding IsMouseOver, RelativeSource={RelativeSource AncestorType=Expander}}" Value="True">
+                                                <Setter Property="Visibility" Value="Visible" />
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </StackPanel.Style>
+                            <Button
+                                hc:IconElement.Geometry="{StaticResource CopyTaskGeometry}"
+                                Command="{s:Action CopyTask, Target={x:Static helper:Instances.TaskQueueViewModel}}"
+                                CommandParameter="{Binding}"
+                                Style="{StaticResource TaskActionButtonStyle}"
+                                ToolTip="{DynamicResource Copy}" />
+                            <Button
+                                hc:IconElement.Geometry="{StaticResource RenameTaskGeometry}"
+                                Command="{s:Action RenameTask, Target={x:Static helper:Instances.TaskQueueViewModel}}"
+                                CommandParameter="{Binding}"
+                                Style="{StaticResource TaskActionButtonStyle}"
+                                ToolTip="{DynamicResource Rename}" />
+                            <Button
+                                hc:IconElement.Geometry="{StaticResource DeleteTaskGeometry}"
+                                Command="{s:Action RemoveTask, Target={x:Static helper:Instances.TaskQueueViewModel}}"
+                                CommandParameter="{Binding}"
+                                Style="{StaticResource TaskActionButtonStyle}"
+                                ToolTip="{DynamicResource Delete}" />
+                        </StackPanel>
+                    </Grid>
+                    </Border>
+                </Expander.Header>
+                <Expander.Content>
+                    <ItemsControl
+                        Margin="12,0,0,0"
+                        dd:DragDrop.DropHandler="{StaticResource TaskQueueDropHandler}"
+                        dd:DragDrop.DragDropContext="TaskQueue"
+                        dd:DragDrop.IsDragSource="True"
+                        dd:DragDrop.IsDropTarget="True"
+                        ItemsSource="{Binding Children}">
+                        <ItemsControl.Resources>
+                            <DataTemplate DataType="{x:Type vms:TaskItemViewModel}">
+                                <Border CornerRadius="4">
+                                    <Border.Style>
+                                        <Style TargetType="Border">
+                                            <Setter Property="Background" Value="Transparent" />
+                                            <Setter Property="Opacity" Value="1" />
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding StatusDisplay}" Value="{x:Static enums:TaskItemStatus.InProgress}">
+                                                    <Setter Property="Background" Value="{DynamicResource TaskQueue.TaskItemStatus.InProgress}" />
+                                                </DataTrigger>
+                                                <DataTrigger Binding="{Binding StatusDisplay}" Value="{x:Static enums:TaskItemStatus.Completed}">
+                                                    <Setter Property="Background" Value="{DynamicResource TaskQueue.TaskItemStatus.Completed}" />
+                                                </DataTrigger>
+                                                <DataTrigger Binding="{Binding StatusDisplay}" Value="{x:Static enums:TaskItemStatus.Error}">
+                                                    <Setter Property="Background" Value="{DynamicResource TaskQueue.TaskItemStatus.Error}" />
+                                                </DataTrigger>
+                                                <DataTrigger Binding="{Binding StatusDisplay}" Value="{x:Static enums:TaskItemStatus.Skipped}">
+                                                    <Setter Property="Opacity" Value="0.5" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Border.Style>
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="Auto" />
+                                        </Grid.ColumnDefinitions>
+
+                                        <CheckBox
+                                            Grid.Column="0"
+                                            MaxWidth="120"
+                                            Margin="4.5,0,0,0"
+                                            HorizontalAlignment="Left"
+                                            IsChecked="{Binding IsEnable}" />
+
+                                        <controls:TextBlock
+                                            Grid.Column="0"
+                                            Margin="26,0,4,0"
+                                            HorizontalAlignment="Stretch"
+                                            VerticalAlignment="Center"
+                                            Background="Transparent"
+                                            IsHitTestVisible="False"
+                                            Text="{Binding Name}" />
+
+                                        <StackPanel Grid.Column="1" Orientation="Horizontal">
+                                            <StackPanel.Style>
+                                                <Style TargetType="StackPanel">
+                                                    <Setter Property="Visibility" Value="Collapsed" />
+                                                    <Style.Triggers>
+                                                        <MultiDataTrigger>
+                                                            <MultiDataTrigger.Conditions>
+                                                                <Condition Binding="{Binding IsMouseOver, RelativeSource={RelativeSource AncestorType={x:Type Border}, AncestorLevel=1}}" Value="True" />
+                                                                <Condition Binding="{Binding Idle, Source={x:Static ui_vms:TaskQueueViewModel.TaskSettingDataContext}}" Value="True" />
+                                                            </MultiDataTrigger.Conditions>
+                                                            <Setter Property="Visibility" Value="Visible" />
+                                                        </MultiDataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </StackPanel.Style>
+                                            <Button
+                                                hc:IconElement.Geometry="{StaticResource CopyTaskGeometry}"
+                                                Command="{s:Action CopyTask, Target={x:Static helper:Instances.TaskQueueViewModel}}"
+                                                CommandParameter="{Binding}"
+                                                Style="{StaticResource TaskActionButtonStyle}"
+                                                ToolTip="{DynamicResource Copy}" />
+                                            <Button
+                                                hc:IconElement.Geometry="{StaticResource RenameTaskGeometry}"
+                                                Command="{s:Action RenameTask, Target={x:Static helper:Instances.TaskQueueViewModel}}"
+                                                CommandParameter="{Binding}"
+                                                Style="{StaticResource TaskActionButtonStyle}"
+                                                ToolTip="{DynamicResource Rename}" />
+                                            <Button
+                                                hc:IconElement.Geometry="{StaticResource DeleteTaskGeometry}"
+                                                Command="{s:Action RemoveTask, Target={x:Static helper:Instances.TaskQueueViewModel}}"
+                                                CommandParameter="{Binding}"
+                                                Style="{StaticResource TaskActionButtonStyle}"
+                                                ToolTip="{DynamicResource Delete}" />
+                                        </StackPanel>
+                                    </Grid>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.Resources>
+                    </ItemsControl>
+                </Expander.Content>
+            </Expander>
+        </DataTemplate>
     </UserControl.Resources>
     <Grid>
         <userControl:GuideUserControl
@@ -84,7 +447,8 @@
                             Margin="0,10,0,0"
                             HorizontalAlignment="Center"
                             d:ItemsSource="{d:SampleData ItemCount=16}"
-                            dd:DragDrop.DragDropContext="{Binding RelativeSource={RelativeSource Self}}"
+                            dd:DragDrop.DropHandler="{StaticResource TaskQueueDropHandler}"
+                            dd:DragDrop.DragDropContext="TaskQueue"
                             dd:DragDrop.IsDragSource="{Binding Idle}"
                             dd:DragDrop.IsDropTarget="{Binding Idle}"
                             Background="Transparent"
@@ -92,195 +456,6 @@
                             ItemsSource="{Binding TaskItemViewModels}"
                             Style="{DynamicResource NoSelectedHighlightListBoxStyle}"
                             ToolTip="{DynamicResource LabelSequenceTip}">
-                            <ListBox.ItemTemplate>
-                                <DataTemplate>
-                                    <Border x:Name="TaskItemBorder" CornerRadius="4">
-                                        <Border.Style>
-                                            <Style TargetType="Border">
-                                                <Setter Property="Background" Value="Transparent" />
-                                                <Setter Property="Opacity" Value="1" />
-                                                <Style.Triggers>
-                                                    <!--  运行中 - 蓝色  -->
-                                                    <DataTrigger Binding="{Binding StatusDisplay}" Value="{x:Static enums:TaskItemStatus.InProgress}">
-                                                        <Setter Property="Background" Value="{DynamicResource TaskQueue.TaskItemStatus.InProgress}" />
-                                                    </DataTrigger>
-                                                    <!--  成功完成 - 绿色  -->
-                                                    <DataTrigger Binding="{Binding StatusDisplay}" Value="{x:Static enums:TaskItemStatus.Completed}">
-                                                        <Setter Property="Background" Value="{DynamicResource TaskQueue.TaskItemStatus.Completed}" />
-                                                    </DataTrigger>
-                                                    <!--  出现错误 - 红色  -->
-                                                    <DataTrigger Binding="{Binding StatusDisplay}" Value="{x:Static enums:TaskItemStatus.Error}">
-                                                        <Setter Property="Background" Value="{DynamicResource TaskQueue.TaskItemStatus.Error}" />
-                                                    </DataTrigger>
-                                                    <!--  已跳过 - 灰色  -->
-                                                    <DataTrigger Binding="{Binding StatusDisplay}" Value="{x:Static enums:TaskItemStatus.Skipped}">
-                                                        <Setter Property="Opacity" Value="0.5" />
-                                                    </DataTrigger>
-                                                </Style.Triggers>
-                                            </Style>
-                                        </Border.Style>
-                                        <Grid>
-                                            <Grid.ColumnDefinitions>
-                                                <ColumnDefinition Width="*" />
-                                                <ColumnDefinition Width="Auto" />
-                                            </Grid.ColumnDefinitions>
-
-                                            <!--  Column 0: stretch-fill settings button (gear hidden, catches clicks on blank space)  -->
-                                            <CheckBox
-                                                Grid.Column="0"
-                                                MaxWidth="140"
-                                                Margin="4.5,0,0,0"
-                                                HorizontalAlignment="Left"
-                                                IsChecked="{Binding IsEnable}"
-                                                IsHitTestVisible="{Binding ElementName=TaskList, Path=DataContext.Idle}"
-                                                MouseRightButtonUp="{s:Action ToggleCheckBoxNullOnRightClick,
-                                                                              Target={x:Type helper:CheckBoxHelper}}">
-                                                <controls:TextBlock Text="{Binding Name}" Visibility="Hidden" />
-                                                <CheckBox.ToolTip>
-                                                    <ToolTip>
-                                                        <StackPanel>
-                                                            <TextBlock HorizontalAlignment="Left">
-                                                                <TextBlock.Style>
-                                                                    <Style BasedOn="{StaticResource TextBlockBaseStyle}" TargetType="TextBlock">
-                                                                        <Setter Property="Text" Value="{DynamicResource CheckBoxesNotSavedAsNull}" />
-                                                                        <Style.Triggers>
-                                                                            <DataTrigger Binding="{Binding Source={x:Static ui_vms:SettingsViewModel.GuiSettings}, Path=MainTasksInvertNullFunction}" Value="True">
-                                                                                <Setter Property="Text" Value="{DynamicResource CheckBoxesNotSavedAsNullInvert}" />
-                                                                            </DataTrigger>
-                                                                        </Style.Triggers>
-                                                                    </Style>
-                                                                </TextBlock.Style>
-                                                            </TextBlock>
-                                                            <TextBlock HorizontalAlignment="Left" Text="{DynamicResource MainTasksNullFunctionalitySwitch}" />
-                                                        </StackPanel>
-                                                    </ToolTip>
-                                                </CheckBox.ToolTip>
-                                            </CheckBox>
-                                            <controls:TextBlock
-                                                Grid.Column="0"
-                                                Margin="26,0,4,0"
-                                                HorizontalAlignment="Stretch"
-                                                VerticalAlignment="Center"
-                                                Background="Transparent"
-                                                IsHitTestVisible="False"
-                                                Text="{Binding Name}">
-                                                <controls:TextBlock.Style>
-                                                    <Style BasedOn="{StaticResource MaaTextBlockDefaultStyle}" TargetType="{x:Type controls:TextBlock}">
-                                                        <Style.Triggers>
-                                                            <MultiDataTrigger>
-                                                                <MultiDataTrigger.Conditions>
-                                                                    <Condition Binding="{Binding Source={x:Static ui_vms:SettingsViewModel.GuiSettings}, Path=MainTasksInvertNullFunction}" Value="True" />
-                                                                    <Condition Binding="{Binding IsEnable}" Value="{x:Null}" />
-                                                                </MultiDataTrigger.Conditions>
-                                                                <Setter Property="Foreground" Value="{DynamicResource TraceLogBrush}" />
-                                                            </MultiDataTrigger>
-                                                        </Style.Triggers>
-                                                    </Style>
-                                                </controls:TextBlock.Style>
-                                            </controls:TextBlock>
-
-                                            <!--  Column 1: gear icon + action buttons (all independent from Column 0)  -->
-                                            <StackPanel Grid.Column="1" Orientation="Horizontal">
-                                                <StackPanel Orientation="Horizontal">
-                                                    <StackPanel.Style>
-                                                        <Style TargetType="StackPanel">
-                                                            <Setter Property="Visibility" Value="Collapsed" />
-                                                            <Style.Triggers>
-                                                                <MultiDataTrigger>
-                                                                    <MultiDataTrigger.Conditions>
-                                                                        <Condition Binding="{Binding IsMouseOver, RelativeSource={RelativeSource AncestorType={x:Type Border}, AncestorLevel=1}}" Value="True" />
-                                                                        <Condition Binding="{Binding Idle, Source={x:Static ui_vms:TaskQueueViewModel.TaskSettingDataContext}}" Value="True" />
-                                                                    </MultiDataTrigger.Conditions>
-                                                                    <Setter Property="Visibility" Value="Visible" />
-                                                                </MultiDataTrigger>
-                                                            </Style.Triggers>
-                                                        </Style>
-                                                    </StackPanel.Style>
-                                                    <Button
-                                                        hc:IconElement.Geometry="{StaticResource CopyTaskGeometry}"
-                                                        Command="{s:Action CopyTask,
-                                                                           Target={x:Static helper:Instances.TaskQueueViewModel}}"
-                                                        CommandParameter="{Binding}"
-                                                        Style="{StaticResource TaskActionButtonStyle}"
-                                                        ToolTip="{DynamicResource Copy}" />
-                                                    <Button
-                                                        hc:IconElement.Geometry="{StaticResource RenameTaskGeometry}"
-                                                        Command="{s:Action RenameTask,
-                                                                           Target={x:Static helper:Instances.TaskQueueViewModel}}"
-                                                        CommandParameter="{Binding}"
-                                                        Style="{StaticResource TaskActionButtonStyle}"
-                                                        ToolTip="{DynamicResource Rename}" />
-                                                    <Button
-                                                        hc:IconElement.Geometry="{StaticResource DeleteTaskGeometry}"
-                                                        Command="{s:Action RemoveTask,
-                                                                           Target={x:Static helper:Instances.TaskQueueViewModel}}"
-                                                        CommandParameter="{Binding}"
-                                                        Style="{StaticResource TaskActionButtonStyle}"
-                                                        ToolTip="{DynamicResource Delete}" />
-                                                </StackPanel>
-                                                <hc:ButtonGroup>
-                                                    <RadioButton
-                                                        x:Name="TaskSettingRadioButton"
-                                                        Width="22"
-                                                        Margin="0,0,4,0"
-                                                        Padding="0"
-                                                        hc:VisualElement.HighlightBackground="Transparent"
-                                                        hc:VisualElement.HighlightForeground="{DynamicResource PrimaryBrush}"
-                                                        Background="Transparent"
-                                                        BorderThickness="0"
-                                                        ContextMenuService.IsEnabled="{Binding DataContext.Idle, RelativeSource={RelativeSource AncestorType=UserControl}}"
-                                                        GroupName="TaskSettings"
-                                                        IsChecked="{Binding EnableSetting}"
-                                                        Style="{DynamicResource RadioGroupItemSingle}">
-                                                        <Grid Width="16" Height="16">
-                                                            <Path
-                                                                Data="{StaticResource ConfigGeometry}"
-                                                                Stretch="Uniform"
-                                                                Visibility="{c:Binding !EnableSetting}">
-                                                                <Path.Style>
-                                                                    <Style TargetType="Path">
-                                                                        <Setter Property="Fill" Value="{DynamicResource SecondaryTextBrush}" />
-                                                                        <Style.Triggers>
-                                                                            <DataTrigger Binding="{Binding IsMouseOver, RelativeSource={RelativeSource AncestorType=RadioButton}}" Value="True">
-                                                                                <Setter Property="Fill" Value="{DynamicResource PrimaryBrush}" />
-                                                                            </DataTrigger>
-                                                                        </Style.Triggers>
-                                                                    </Style>
-                                                                </Path.Style>
-                                                            </Path>
-                                                            <Path
-                                                                Data="{StaticResource ConfigGeometry2}"
-                                                                Fill="{DynamicResource PrimaryBrush}"
-                                                                Stretch="Uniform"
-                                                                Visibility="{c:Binding EnableSetting}" />
-                                                        </Grid>
-                                                        <RadioButton.ToolTip>
-                                                            <ToolTip>
-                                                                <StackPanel>
-                                                                    <TextBlock FontWeight="SemiBold" Text="{DynamicResource LeftClick}" />
-                                                                    <TextBlock Text="{DynamicResource TaskSettings}" />
-
-                                                                    <TextBlock FontWeight="SemiBold" Text="{DynamicResource RightClick}" />
-                                                                    <TextBlock Text="{DynamicResource RunTaskOnce}" />
-                                                                </StackPanel>
-                                                            </ToolTip>
-                                                        </RadioButton.ToolTip>
-                                                        <RadioButton.ContextMenu>
-                                                            <ContextMenu Width="150">
-                                                                <MenuItem
-                                                                    Command="{s:Action RunTaskOnce,
-                                                                                       Target={x:Static helper:Instances.TaskQueueViewModel}}"
-                                                                    CommandParameter="{Binding PlacementTarget.DataContext, RelativeSource={RelativeSource AncestorType=ContextMenu}}"
-                                                                    Header="{DynamicResource RunTaskOnce}" />
-                                                            </ContextMenu>
-                                                        </RadioButton.ContextMenu>
-                                                    </RadioButton>
-                                                </hc:ButtonGroup>
-                                            </StackPanel>
-                                        </Grid>
-                                    </Border>
-                                </DataTemplate>
-                            </ListBox.ItemTemplate>
                             <ListBox.ItemContainerStyle>
                                 <Style BasedOn="{StaticResource NoSelectedHighlightListBoxItemStyle}" TargetType="{x:Type ListBoxItem}">
                                     <Setter Property="HorizontalContentAlignment" Value="Stretch" />
@@ -375,6 +550,11 @@
                                             CommandParameter="{Binding TaskTypeList[9].Value}"
                                             Header="{Binding TaskTypeList[9].Display}"
                                             Visibility="{c:Binding ShowDebugTask}" />
+                                        <Separator />
+                                        <MenuItem
+                                            Padding="0,3"
+                                            Command="{s:Action CreateGroup}"
+                                            Header="创建分组" />
                                     </ContextMenu>
                                 </hc:ContextMenuButton.Menu>
                             </hc:ContextMenuButton>


### PR DESCRIPTION
- 新增 TaskGroup 数据模型（BaseTask 子类），包含 Children 子任务列表和 IsExpanded 展开状态
- TaskType 枚举新增 Group 类型
- 新增 ITaskQueueItemViewModel 接口，统一单任务和分组的 ViewModel 抽象
- 新增 TaskGroupViewModel，支持展开/折叠和聚合启用状态
- 新增 TaskQueueDropHandler，支持任务和分组的拖拽排序
- 重构 TaskQueueView.xaml，使用 DataTemplate 分别渲染单任务和分组（Expander）
- 重构 TaskQueueViewModel，支持分组初始化、启用/禁用传播


第一次给大项目提交PR，中间也用了一些AI来辅助撰写，如有问题还请多多包涵，群里可以@我让我改（
间距什么的好像还有点问题，任务组还不能重命名，之后可以再改改，主要是想要请大佬们先看一眼合不合适，合适的话我再继续完善这个功能

## Summary by Sourcery

在任务队列中引入任务分组功能，允许用户将多个任务组织到可折叠的分组中，并在执行时进行正确的状态追踪。

新功能：
- 新增 `TaskGroup` 任务模型，包含子任务列表、展开/折叠状态，以及在 `TaskType` 枚举中加入新的 `Group` 条目。
- 新增 `TaskGroupViewModel` 和共享的 `ITaskQueueItemViewModel` 抽象，使任务队列可以同时显示和管理单个任务和任务组。
- 在任务队列中支持创建、复制、重命名、删除以及切换整个任务组，同时也支持对单个任务执行这些操作。
- 在执行时将任务组扁平化为其子任务，同时在 UI 中汇总并显示组级别的状态。
- 新增 `TaskQueueDropHandler`，以支持通过拖放来重新排序任务，以及将任务移动到组内、组外及不同组之间。

改进：
- 重构 `TaskQueueViewModel` 和 `TaskQueueView`，以渲染混合的任务和任务组条目，更新选中逻辑和启用/禁用逻辑，并确保正确的资源释放和索引维护。
- 更新任务设置的可见性规则，使任务组本身不再拥有独立的设置面板，而是将配置委托给其子任务。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce task grouping support in the task queue, allowing users to organize multiple tasks under expandable groups and execute them with proper status tracking.

New Features:
- Add TaskGroup task model with child task list, expansion state, and a new Group entry in the TaskType enum.
- Add TaskGroupViewModel and a shared ITaskQueueItemViewModel abstraction so the task queue can display and manage both single tasks and groups.
- Enable creating, copying, renaming, deleting, and toggling entire task groups alongside individual tasks in the task queue.
- Flatten task groups into their child tasks for execution while aggregating and displaying group-level statuses in the UI.
- Add TaskQueueDropHandler to support drag-and-drop reordering and moving tasks into, out of, and between groups.

Enhancements:
- Refactor TaskQueueViewModel and TaskQueueView to render mixed task and group items, update selection and enable/disable logic, and ensure proper disposal and index maintenance.
- Update task settings visibility rules so task groups themselves have no dedicated settings panel and delegate configuration to child tasks.

</details>