### PR TITLE
fix: 调整 PC 端完成后退出逻辑显示与行为

### DIFF
--- a/src/MaaWpfGui/Models/PostActionSetting.cs
+++ b/src/MaaWpfGui/Models/PostActionSetting.cs
@@ -149,11 +149,22 @@ public class PostActionSetting : PropertyChangedBase
     private bool _exitEmulator;
 
     /// <summary>
-    /// Gets a value indicating whether PC 端（窗口绑定）无模拟器进程，完成后不可选择「退出模拟器」。
+    /// Gets a value indicating whether ExitEmulator should be treated as exiting the game client in PC attach-window mode.
     /// </summary>
-    public bool ExitEmulatorOptionEnabled => true;
+    public bool TreatExitEmulatorAsExitArknights
+    => ConnectSettingsUserControlModel.Instance.UseAttachWindow;
+
+    public bool ShouldExitEmulatorCloseArknights
+        => ExitEmulator && TreatExitEmulatorAsExitArknights;
+
+    public System.Windows.Visibility ExitPcClientVisibility
+        => TreatExitEmulatorAsExitArknights ? System.Windows.Visibility.Visible : System.Windows.Visibility.Collapsed;
+
+    public System.Windows.Visibility ExitEmulatorVisibility
+        => TreatExitEmulatorAsExitArknights ? System.Windows.Visibility.Collapsed : System.Windows.Visibility.Visible;
+
     public string ExitEmulatorText
-        => ConnectSettingsUserControlModel.Instance.UseAttachWindow
+        => TreatExitEmulatorAsExitArknights
             ? LocalizationHelper.GetString("ExitPCClient")
             : LocalizationHelper.GetString("ExitEmulator");
     public bool ExitEmulator
@@ -209,8 +220,6 @@ public class PostActionSetting : PropertyChangedBase
             {
                 return;
             }
-
-            NotifyOfPropertyChange(nameof(ExitEmulatorOptionEnabled));
 
             if (value)
             {
@@ -476,6 +485,7 @@ public class PostActionSetting : PropertyChangedBase
         }
 
         NotifyOfPropertyChange(nameof(AndroidControlPostActionsEnabled));
+        NotifyOfPropertyChange(nameof(ShouldExitEmulatorCloseArknights));
         RefreshDescription();
         SaveActions();
     }
@@ -487,7 +497,10 @@ public class PostActionSetting : PropertyChangedBase
             if (e.PropertyName is nameof(ConnectSettingsUserControlModel.ConnectConfig) or nameof(ConnectSettingsUserControlModel.UseAttachWindow))
             {
                 NotifyOfPropertyChange(nameof(AndroidControlPostActionsEnabled));
-                NotifyOfPropertyChange(nameof(ExitEmulatorOptionEnabled));
+                NotifyOfPropertyChange(nameof(TreatExitEmulatorAsExitArknights));
+                NotifyOfPropertyChange(nameof(ShouldExitEmulatorCloseArknights));
+                NotifyOfPropertyChange(nameof(ExitPcClientVisibility));
+                NotifyOfPropertyChange(nameof(ExitEmulatorVisibility));
                 NotifyOfPropertyChange(nameof(ExitEmulatorText));
                 RefreshDescription();
                 ClearUnsupportedPostActionsForAttachWindow();

--- a/src/MaaWpfGui/Models/PostActionSetting.cs
+++ b/src/MaaWpfGui/Models/PostActionSetting.cs
@@ -151,18 +151,15 @@ public class PostActionSetting : PropertyChangedBase
     /// <summary>
     /// Gets a value indicating whether PC 端（窗口绑定）无模拟器进程，完成后不可选择「退出模拟器」。
     /// </summary>
-    public bool ExitEmulatorOptionEnabled => !ConnectSettingsUserControlModel.Instance.UseAttachWindow;
-
+    public bool ExitEmulatorOptionEnabled => true;
+    public string ExitEmulatorText
+        => ConnectSettingsUserControlModel.Instance.UseAttachWindow
+            ? LocalizationHelper.GetString("ExitPCClient")
+            : LocalizationHelper.GetString("ExitEmulator");
     public bool ExitEmulator
     {
         get => _exitEmulator;
-        set
-        {
-            if (value && ConnectSettingsUserControlModel.Instance.UseAttachWindow)
-            {
-                return;
-            }
-
+        set {
             if (!SetAndNotify(ref _exitEmulator, value))
             {
                 return;
@@ -378,7 +375,7 @@ public class PostActionSetting : PropertyChangedBase
 
         if (ExitEmulator)
         {
-            actions.Add(LocalizationHelper.GetString("ExitEmulator"));
+            actions.Add(ExitEmulatorText);
         }
 
         if (ExitSelf)
@@ -473,14 +470,6 @@ public class PostActionSetting : PropertyChangedBase
         }
         */
 
-        if (_exitEmulator)
-        {
-            _exitEmulator = false;
-            _postActions &= ~PostActions.ExitEmulator;
-            NotifyOfPropertyChange(nameof(ExitEmulator));
-            changed = true;
-        }
-
         if (!changed)
         {
             return;
@@ -497,14 +486,10 @@ public class PostActionSetting : PropertyChangedBase
         {
             if (e.PropertyName is nameof(ConnectSettingsUserControlModel.ConnectConfig) or nameof(ConnectSettingsUserControlModel.UseAttachWindow))
             {
-                if (ConnectSettingsUserControlModel.Instance.UseAttachWindow && ExitEmulator)
-                {
-                    ExitEmulator = false;
-                    ExitArknights = true;
-                }
-
                 NotifyOfPropertyChange(nameof(AndroidControlPostActionsEnabled));
                 NotifyOfPropertyChange(nameof(ExitEmulatorOptionEnabled));
+                NotifyOfPropertyChange(nameof(ExitEmulatorText));
+                RefreshDescription();
                 ClearUnsupportedPostActionsForAttachWindow();
             }
         };

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -775,6 +775,7 @@ If the game is launched in portrait mode and then switched to landscape, it may 
     <system:String x:Key="ExitArknights">Exit Arknights</system:String>
     <system:String x:Key="ExitSelf">Exit MAA</system:String>
     <system:String x:Key="ExitEmulator">Exit Emulator</system:String>
+    <system:String x:Key="ExitPCClient">Exit PC Client</system:String>
     <system:String x:Key="Hibernate">Hibernate</system:String>
     <system:String x:Key="HibernateTip">You need to enable the hibernate feature in Windows power options, otherwise this feature will be invalid.</system:String>
     <system:String x:Key="Sleep">Sleep</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -776,6 +776,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="ExitArknights">アークナイツを終了する</system:String>
     <system:String x:Key="ExitSelf">MAAを終了する</system:String>
     <system:String x:Key="ExitEmulator">エミュレータを終了する</system:String>
+    <system:String x:Key="ExitPCClient">PC クライアントを終了する</system:String>
     <system:String x:Key="Hibernate">休止状態にする</system:String>
     <system:String x:Key="HibernateTip">Windows の電源オプションで休止状態を有効にする必要があります。そうしないと、この機能は無効になります。</system:String>
     <system:String x:Key="Sleep">スリープ</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -777,6 +777,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="ExitArknights">명일방주를 종료</system:String>
     <system:String x:Key="ExitSelf">MAA를 종료</system:String>
     <system:String x:Key="ExitEmulator">에뮬레이터를 종료</system:String>
+    <system:String x:Key="ExitPCClient">PC 클라이언트 종료</system:String>
     <system:String x:Key="Hibernate">최대 절전 모드</system:String>
     <system:String x:Key="HibernateTip">Windows의 전원 옵션에서 최대 절전 모드를 활성화해야 합니다. 그렇지 않으면 이 기능이 비활성화됩니다.</system:String>
     <system:String x:Key="Sleep">절전 모드</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -776,6 +776,7 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="ExitArknights">退出 明日方舟</system:String>
     <system:String x:Key="ExitSelf">退出 MAA</system:String>
     <system:String x:Key="ExitEmulator">退出 模拟器</system:String>
+    <system:String x:Key="ExitPCClient">退出 PC客户端</system:String>
     <system:String x:Key="Hibernate">休眠</system:String>
     <system:String x:Key="HibernateTip">需在 Windows 电源选项中启用休眠功能，否则该功能无效。</system:String>
     <system:String x:Key="Sleep">睡眠</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -776,6 +776,7 @@ C:\\leidian\\LDPlayer9\n
     <system:String x:Key="ExitArknights">關閉 明日方舟</system:String>
     <system:String x:Key="ExitSelf">關閉 MAA</system:String>
     <system:String x:Key="ExitEmulator">關閉 模擬器</system:String>
+    <system:String x:Key="ExitPCClient">關閉 PC 用戶端</system:String>
     <system:String x:Key="Hibernate">休眠</system:String>
     <system:String x:Key="HibernateTip">需要在 Windows 電源選項中啟用休眠功能，否則該功能無效。</system:String>
     <system:String x:Key="Sleep">睡眠</system:String>

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -465,7 +465,9 @@ public class TaskQueueViewModel : Screen
             await Task.Delay(1000);
         }
 
-        if (actions.ExitArknights)
+        var exitEmulatorAsExitArknights = actions.ExitEmulator && SettingsViewModel.ConnectSettings.UseAttachWindow;
+
+        if (actions.ExitArknights || exitEmulatorAsExitArknights)
         {
             var clientType = SettingsViewModel.GameSettings.ClientType;
             if (!Instances.AsstProxy.AsstStartCloseDown(clientType))

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -465,9 +465,7 @@ public class TaskQueueViewModel : Screen
             await Task.Delay(1000);
         }
 
-        var exitEmulatorAsExitArknights = actions.ExitEmulator && SettingsViewModel.ConnectSettings.UseAttachWindow;
-
-        if (actions.ExitArknights || exitEmulatorAsExitArknights)
+        if (actions.ExitArknights || actions.ShouldExitEmulatorCloseArknights)
         {
             var clientType = SettingsViewModel.GameSettings.ClientType;
             if (!Instances.AsstProxy.AsstStartCloseDown(clientType))
@@ -478,7 +476,7 @@ public class TaskQueueViewModel : Screen
             await Task.Delay(1000);
         }
 
-        if (actions.ExitEmulator && !SettingsViewModel.ConnectSettings.UseAttachWindow)
+        if (actions.ExitEmulator && !actions.TreatExitEmulatorAsExitArknights)
         {
             DoKillEmulator();
             await Task.Delay(1000);

--- a/src/MaaWpfGui/Views/UserControl/TaskQueue/PostActionUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/TaskQueue/PostActionUserControl.xaml
@@ -29,6 +29,7 @@
                 <controls:TooltipBlock TooltipText="{DynamicResource PostActionOnceTip}" />
             </StackPanel>
             <hc:Divider />
+            
             <CheckBox
                 Margin="0,10"
                 IsChecked="{Binding BackToAndroidHome}"
@@ -36,6 +37,7 @@
                 MouseRightButtonUp="{s:Action PostActionsAndOnce}">
                 <controls:TextBlock Text="{DynamicResource BackToAndroidHome}" TextWrapping="Wrap" />
             </CheckBox>
+            
             <CheckBox
                 Margin="0,10"
                 IsChecked="{Binding ExitArknights}"
@@ -43,13 +45,24 @@
                 MouseRightButtonUp="{s:Action PostActionsAndOnce}">
                 <controls:TextBlock Text="{DynamicResource ExitArknights}" TextWrapping="Wrap" />
             </CheckBox>
+            
             <CheckBox
                 Margin="0,10"
                 IsChecked="{Binding ExitEmulator}"
-                IsEnabled="{c:Binding ExitEmulatorOptionEnabled}"
+                IsEnabled="{c:Binding !ExitArknights}"
+                Visibility="{Binding ExitPcClientVisibility}"
                 MouseRightButtonUp="{s:Action PostActionsAndOnce}">
                 <controls:TextBlock Text="{Binding ExitEmulatorText}" TextWrapping="Wrap" />
             </CheckBox>
+            
+            <CheckBox
+                Margin="0,10"
+                IsChecked="{Binding ExitEmulator}"
+                Visibility="{Binding ExitEmulatorVisibility}"
+                MouseRightButtonUp="{s:Action PostActionsAndOnce}">
+                <controls:TextBlock Text="{DynamicResource ExitEmulator}" TextWrapping="Wrap" />
+            </CheckBox>
+            
             <CheckBox
                 Margin="0,10"
                 IsChecked="{Binding ExitSelf}"
@@ -57,7 +70,9 @@
                 MouseRightButtonUp="{s:Action PostActionsAndOnce}">
                 <controls:TextBlock Text="{DynamicResource ExitSelf}" TextWrapping="Wrap" />
             </CheckBox>
+            
             <hc:Divider />
+            
             <CheckBox
                 Margin="0,10"
                 IsChecked="{Binding IfNoOtherMaa}"
@@ -81,6 +96,7 @@
                 </CheckBox>
                 <controls:TooltipBlock x:Name="DormFilterNotStationedTipsTooltipBlock" TooltipText="{DynamicResource HibernateTip}" />
             </StackPanel>
+            
             <CheckBox
                 Margin="0,10"
                 IsChecked="{Binding Shutdown}"

--- a/src/MaaWpfGui/Views/UserControl/TaskQueue/PostActionUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/TaskQueue/PostActionUserControl.xaml
@@ -48,7 +48,7 @@
                 IsChecked="{Binding ExitEmulator}"
                 IsEnabled="{c:Binding ExitEmulatorOptionEnabled}"
                 MouseRightButtonUp="{s:Action PostActionsAndOnce}">
-                <controls:TextBlock Text="{DynamicResource ExitEmulator}" TextWrapping="Wrap" />
+                <controls:TextBlock Text="{Binding ExitEmulatorText}" TextWrapping="Wrap" />
             </CheckBox>
             <CheckBox
                 Margin="0,10"


### PR DESCRIPTION
## 概述

- 从模拟器切换到 PC 端时，保留“退出模拟器”完成后选项的勾选状态。
- 在 PC 端模式下，将该选项显示为“退出 PC客户端”。
- 在 PC 端模式下，执行该完成后选项时按关闭 PC 客户端处理。

## 修改原因

此前从模拟器模式切换到 PC 端模式时，如果“退出模拟器”处于勾选状态，会自动跳转为“退出明日方舟”。

这个行为会导致 UI 状态发生非预期变化。现在改为保留原选项，只在 PC 端模式下改变其显示名称和执行含义。

## 行为变化

- 模拟器模式：显示“退出模拟器”，执行关闭模拟器。
- PC 端模式：显示“退出 PC客户端”，执行关闭 PC 客户端。
- 模式切换时不再自动将“退出模拟器”切换为“退出明日方舟”。

## 验证

已通过以下命令编译：

```powershell
dotnet build src\MaaWpfGui\MaaWpfGui.csproj --configuration Debug --no-restore
dotnet build src\MaaWpfGui\MaaWpfGui.csproj --configuration Release --no-restore

## Summary by Sourcery

调整“完成后退出”的行为，使其在模拟器和 PC 客户端模式之间切换时，能够保留已选择的选项，并使其标签和动作与当前模式保持一致。

Bug Fixes:
- 在模拟器和 PC 客户端模式之间切换时，保留“完成后退出”选项的选中状态，而不是自动重新映射该选项。

Enhancements:
- 始终显示“完成后退出”选项，同时根据当前连接模式在“退出模拟器”和“退出 PC 客户端”之间动态更改其标签。
- 当附加到 PC 客户端窗口时，将“退出模拟器”选项视为关闭 PC 客户端，并相应更新执行后的动作描述文本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust post-completion exit behavior to preserve the selected option when switching between emulator and PC client modes and align its label and action with the current mode.

Bug Fixes:
- Preserve the checked state of the 'exit after completion' option when switching between emulator and PC client modes instead of automatically remapping it.

Enhancements:
- Always expose the exit-after-completion option while dynamically changing its label between exiting the emulator and exiting the PC client based on the current connection mode.
- Treat the emulator-exit option as closing the PC client when attached to a PC client window, and update the post-action description text accordingly.

</details>