### PR TITLE
fix(ocr): 等价类注入不再破坏 ocrReplace 的正则字符类

### DIFF
--- a/src/MaaCore/Config/Miscellaneous/OcrConfig.h
+++ b/src/MaaCore/Config/Miscellaneous/OcrConfig.h
@@ -20,7 +20,7 @@ public:
 
     std::string process_equivalence_class(const std::string& str) const;
 
-    auto get_eq_classes() const noexcept { return m_eq_classes; }
+    auto& get_eq_classes() const noexcept { return m_eq_classes; }
 
 protected:
     virtual bool parse(const json::value& json) override;

--- a/src/MaaCore/Utils/Algorithm.hpp
+++ b/src/MaaCore/Utils/Algorithm.hpp
@@ -11,6 +11,21 @@
 
 namespace asst::algorithm
 {
+// 追加等价类成员时对正则元字符做转义, 使成员始终按字面字符匹配;
+// in_char_class 为 true 时按字符类内部规则转义 (\ ] ^ -), 否则按普通正则元字符转义。
+inline static void append_regex_literal(std::string& out, std::string_view member, bool in_char_class)
+{
+    constexpr std::string_view class_specials = "\\]^-";
+    constexpr std::string_view regex_specials = "\\.^$|?*+()[]{}";
+    const std::string_view specials = in_char_class ? class_specials : regex_specials;
+    for (const char ch : member) {
+        if (specials.find(ch) != std::string_view::npos) {
+            out += '\\';
+        }
+        out += ch;
+    }
+}
+
 /**
  * @brief 将 OCR 等价类注入到一个正则表达式 `pattern` 中, 使等价类中的任一字符都能匹配同类中的其他字符,
  *        同时不破坏正则语法。
@@ -21,7 +36,7 @@ namespace asst::algorithm
  *   - 在字符类 "[...]" 之内, 等价字符作为普通类成员插入, 如 "[Oo]" -> "[Oo0]", 而不是
  *     "[O(?:o|0)]" —— 后者会让该字符类额外匹配 '(' '?' ':' '|' ')' (issue #15084)。
  * 反斜杠转义会被原样拷贝, 不会被当作字符类边界, 也不会被展开。
- * 等价类成员被视为普通字面字符, 而非正则语法。
+ * 追加等价类成员时会对正则元字符转义, 使其始终按字面字符匹配。
  *
  * @param pattern 待处理的正则替换式
  * @param equivalence_classes 等价类列表, 每个等价类是一组互相等价的字符
@@ -83,7 +98,7 @@ namespace asst::algorithm
         if (matched_class) {
             if (in_char_class) {
                 for (const auto& member : *matched_class) {
-                    result += member;
+                    append_regex_literal(result, member, true);
                 }
             }
             else {
@@ -92,7 +107,7 @@ namespace asst::algorithm
                     if (k != 0) {
                         result += '|';
                     }
-                    result += (*matched_class)[k];
+                    append_regex_literal(result, (*matched_class)[k], false);
                 }
                 result += ')';
             }

--- a/src/MaaCore/Utils/Algorithm.hpp
+++ b/src/MaaCore/Utils/Algorithm.hpp
@@ -3,6 +3,7 @@
 #include <limits>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -10,6 +11,104 @@
 
 namespace asst::algorithm
 {
+/**
+ * @brief 将 OCR 等价类注入到一个正则表达式 `pattern` 中, 使等价类中的任一字符都能匹配同类中的其他字符,
+ *        同时不破坏正则语法。
+ *
+ * 等价类是 OCR 容易混淆的一组字符 (例如 KR/JP 资源中的空格变体)。由于 `ocrReplace` 中的替换式本身是正则
+ * (如 "[Oo]"), 必须按语法感知的方式注入:
+ *   - 在字符类 "[...]" 之外, 字符被展开为非捕获分组, 如 "o" -> "(?:o|0)";
+ *   - 在字符类 "[...]" 之内, 等价字符作为普通类成员插入, 如 "[Oo]" -> "[Oo0]", 而不是
+ *     "[O(?:o|0)]" —— 后者会让该字符类额外匹配 '(' '?' ':' '|' ')' (issue #15084)。
+ * 反斜杠转义会被原样拷贝, 不会被当作字符类边界, 也不会被展开。
+ * 等价类成员被视为普通字面字符, 而非正则语法。
+ *
+ * @param pattern 待处理的正则替换式
+ * @param equivalence_classes 等价类列表, 每个等价类是一组互相等价的字符
+ * @return 注入等价类后的正则表达式
+ */
+[[nodiscard]] inline static std::string inject_equivalence_classes(
+    std::string_view pattern,
+    const std::vector<std::vector<std::string>>& equivalence_classes)
+{
+    std::string result;
+    result.reserve(pattern.size());
+
+    bool in_char_class = false;
+    for (size_t i = 0; i < pattern.size();) {
+        const char ch = pattern[i];
+
+        // 原样拷贝反斜杠转义 (如 "\[" "\]"), 避免被误认为字符类边界, 也不展开。
+        if (ch == '\\') {
+            result += ch;
+            if (i + 1 < pattern.size()) {
+                result += pattern[i + 1];
+                i += 2;
+            }
+            else {
+                ++i;
+            }
+            continue;
+        }
+
+        if (!in_char_class && ch == '[') {
+            in_char_class = true;
+            result += ch;
+            ++i;
+            continue;
+        }
+        if (in_char_class && ch == ']') {
+            in_char_class = false;
+            result += ch;
+            ++i;
+            continue;
+        }
+
+        // 在位置 i 处寻找能匹配的最长等价类成员; 同长度时按 equivalence_classes 的顺序取第一个。
+        const std::vector<std::string>* matched_class = nullptr;
+        size_t matched_len = 0;
+        for (const auto& eq_class : equivalence_classes) {
+            if (eq_class.size() <= 1) {
+                continue;
+            }
+            for (const auto& member : eq_class) {
+                if (i + member.size() <= pattern.size() && member.size() > matched_len &&
+                    pattern.compare(i, member.size(), member) == 0) {
+                    matched_class = &eq_class;
+                    matched_len = member.size();
+                }
+            }
+        }
+
+        if (matched_class) {
+            if (in_char_class) {
+                for (const auto& member : *matched_class) {
+                    result += member;
+                }
+            }
+            else {
+                result += "(?:";
+                for (size_t k = 0; k < matched_class->size(); ++k) {
+                    if (k != 0) {
+                        result += '|';
+                    }
+                    result += (*matched_class)[k];
+                }
+                result += ')';
+            }
+            i += matched_len;
+            continue;
+        }
+
+        // 没有匹配到等价类成员: 拷贝单个字节。多字节 UTF-8 序列按字节拷贝,
+        // 其后续字节 (>= 0x80) 不会与上面处理的 ASCII 边界字符冲突。
+        result += ch;
+        ++i;
+    }
+
+    return result;
+}
+
 enum class CharAllocationStatus
 {
     Success,

--- a/src/MaaCore/Vision/Config/OCRerConfig.cpp
+++ b/src/MaaCore/Vision/Config/OCRerConfig.cpp
@@ -2,6 +2,7 @@
 
 #include "Config/Miscellaneous/OcrConfig.h"
 #include "Config/TaskData.h"
+#include "Utils/Algorithm.hpp"
 
 using namespace asst;
 
@@ -29,27 +30,13 @@ void OCRerConfig::set_replace(
     m_params.replace.clear();
     m_params.replace.reserve(replace.size());
 
-    for (auto&& [key, val] : replace) {
-        auto& ocr_config = OcrConfig::get_instance();
-        std::string new_key = key;
-        for (const auto& eq_class : ocr_config.get_eq_classes()) {
-            if (eq_class.size() <= 1) {
-                continue;
-            }
-
-            // eq_class: [s, S] -> regex: "(?:s|S)"
-            std::string eq_classes_regex = "(?:";
-            for (const auto& elem : eq_class) {
-                (eq_classes_regex += elem) += '|';
-            }
-            eq_classes_regex.pop_back();
-            eq_classes_regex += ')';
-            std::ranges::for_each(eq_class, [&](std::string_view elem) {
-                utils::string_replace_all_in_place(new_key, elem, eq_classes_regex);
-            });
-        }
-        // do not create new_val as val is user-provided, and can avoid issues like 夕 and katakana タ
-        m_params.replace.emplace_back(std::move(new_key), val);
+    const auto eq_classes = OcrConfig::get_instance().get_eq_classes();
+    for (const auto& [key, val] : replace) {
+        // The replace key is a regex (e.g. "[Oo]"), so equivalence classes must be injected in a
+        // syntax-aware way; a naive string replace would corrupt character classes into ones that
+        // also match '(', '?', ':', '|' and ')' (issue #15084).
+        // do not modify val as it is user-provided, to avoid issues like 夕 and katakana タ
+        m_params.replace.emplace_back(algorithm::inject_equivalence_classes(key, eq_classes), val);
     }
     m_params.replace_full = replace_full;
 }

--- a/src/MaaCore/Vision/Config/OCRerConfig.cpp
+++ b/src/MaaCore/Vision/Config/OCRerConfig.cpp
@@ -30,7 +30,7 @@ void OCRerConfig::set_replace(
     m_params.replace.clear();
     m_params.replace.reserve(replace.size());
 
-    const auto eq_classes = OcrConfig::get_instance().get_eq_classes();
+    const auto& eq_classes = OcrConfig::get_instance().get_eq_classes();
     for (const auto& [key, val] : replace) {
         // The replace key is a regex (e.g. "[Oo]"), so equivalence classes must be injected in a
         // syntax-aware way; a naive string replace would corrupt character classes into ones that

--- a/unit_test/MaaCore/AlgorithmTest.cpp
+++ b/unit_test/MaaCore/AlgorithmTest.cpp
@@ -202,3 +202,54 @@ TEST_CASE("Group with empty candidate list returns no solution")
     REQUIRE(result.status == asst::algorithm::CharAllocationStatus::NoSolution);
     REQUIRE_FALSE(result.has_value());
 }
+
+namespace
+{
+using EquivalenceClasses = std::vector<std::vector<std::string>>;
+}
+
+TEST_CASE("inject_equivalence_classes leaves patterns unchanged when there are no classes")
+{
+    const EquivalenceClasses eq_classes;
+    REQUIRE(asst::algorithm::inject_equivalence_classes("[Oo]", eq_classes) == "[Oo]");
+    REQUIRE(asst::algorithm::inject_equivalence_classes("abc", eq_classes) == "abc");
+}
+
+TEST_CASE("inject_equivalence_classes ignores single-member classes")
+{
+    const EquivalenceClasses eq_classes { { "o" } };
+    REQUIRE(asst::algorithm::inject_equivalence_classes("o", eq_classes) == "o");
+}
+
+TEST_CASE("inject_equivalence_classes expands members outside a character class")
+{
+    const EquivalenceClasses eq_classes { { "o", "0" } };
+    REQUIRE(asst::algorithm::inject_equivalence_classes("o", eq_classes) == "(?:o|0)");
+    REQUIRE(asst::algorithm::inject_equivalence_classes("xoy", eq_classes) == "x(?:o|0)y");
+}
+
+TEST_CASE("inject_equivalence_classes keeps character classes valid")
+{
+    // Regression test for issue #15084: injecting into "[Oo]" must not produce
+    // "[O(?:o|0)]", which would also match '(', '?', ':', '|' and ')' and therefore
+    // turn a time string like "12:34:56" into "12034056".
+    const EquivalenceClasses eq_classes { { "o", "0" } };
+    REQUIRE(asst::algorithm::inject_equivalence_classes("[Oo]", eq_classes) == "[Oo0]");
+}
+
+TEST_CASE("inject_equivalence_classes preserves backslash escapes")
+{
+    const EquivalenceClasses eq_classes { { "o", "0" } };
+    // An escaped ']' must not close the character class, and the escaped character is
+    // copied verbatim instead of being expanded.
+    REQUIRE(asst::algorithm::inject_equivalence_classes("[\\]o]", eq_classes) == "[\\]o0]");
+}
+
+TEST_CASE("inject_equivalence_classes handles multi-codepoint space classes")
+{
+    // Mirrors the KR/JP resources, whose equivalence class holds two space variants
+    // (U+0020 and the ideographic space U+3000, encoded as \xe3\x80\x80 in UTF-8).
+    const EquivalenceClasses eq_classes { { " ", "\xe3\x80\x80" } };
+    REQUIRE(asst::algorithm::inject_equivalence_classes(" ", eq_classes) == "(?: |\xe3\x80\x80)");
+    REQUIRE(asst::algorithm::inject_equivalence_classes("[ a]", eq_classes) == "[ \xe3\x80\x80""a]");
+}

--- a/unit_test/MaaCore/AlgorithmTest.cpp
+++ b/unit_test/MaaCore/AlgorithmTest.cpp
@@ -253,3 +253,27 @@ TEST_CASE("inject_equivalence_classes handles multi-codepoint space classes")
     REQUIRE(asst::algorithm::inject_equivalence_classes(" ", eq_classes) == "(?: |\xe3\x80\x80)");
     REQUIRE(asst::algorithm::inject_equivalence_classes("[ a]", eq_classes) == "[ \xe3\x80\x80""a]");
 }
+
+TEST_CASE("inject_equivalence_classes handles negated character classes")
+{
+    // '^' right after '[' is the negation marker and must be preserved, while the
+    // members are still inserted as plain class atoms.
+    const EquivalenceClasses eq_classes { { "o", "0" } };
+    REQUIRE(asst::algorithm::inject_equivalence_classes("[^o]", eq_classes) == "[^o0]");
+}
+
+TEST_CASE("inject_equivalence_classes handles multiple equivalence classes")
+{
+    const EquivalenceClasses eq_classes { { "o", "0" }, { "l", "1" } };
+    REQUIRE(asst::algorithm::inject_equivalence_classes("lol", eq_classes) == "(?:l|1)(?:o|0)(?:l|1)");
+    REQUIRE(asst::algorithm::inject_equivalence_classes("[ol]", eq_classes) == "[o0l1]");
+}
+
+TEST_CASE("inject_equivalence_classes escapes regex-special members")
+{
+    // Members are treated as literal characters even when they are regex metacharacters,
+    // both outside and inside a character class.
+    const EquivalenceClasses eq_classes { { ".", "x" } };
+    REQUIRE(asst::algorithm::inject_equivalence_classes(".", eq_classes) == "(?:\\.|x)");
+    REQUIRE(asst::algorithm::inject_equivalence_classes("[.]", eq_classes) == "[.x]");
+}

--- a/unit_test/MaaCore/AlgorithmTest.cpp
+++ b/unit_test/MaaCore/AlgorithmTest.cpp
@@ -277,3 +277,16 @@ TEST_CASE("inject_equivalence_classes escapes regex-special members")
     REQUIRE(asst::algorithm::inject_equivalence_classes(".", eq_classes) == "(?:\\.|x)");
     REQUIRE(asst::algorithm::inject_equivalence_classes("[.]", eq_classes) == "[.x]");
 }
+
+TEST_CASE("inject_equivalence_classes handles escaped brackets in keys")
+{
+    // ocrReplace keys may contain escaped brackets; the escape must be consumed before the
+    // character-class handlers, so an escaped '[' never (re)opens a class.
+    // Inside a class: "[\[IO]" stays a valid class, with O expanded to also match o/0.
+    const EquivalenceClasses with_o { { "O", "o", "0" } };
+    REQUIRE(asst::algorithm::inject_equivalence_classes("[\\[IO]", with_o) == "[\\[IOo0]");
+
+    // Outside a class: the escaped '[' in "(\[|I)" does not open a class, and I expands.
+    const EquivalenceClasses with_i { { "I", "l", "1" } };
+    REQUIRE(asst::algorithm::inject_equivalence_classes("(\\[|I)", with_i) == "(\\[|(?:I|l|1))");
+}


### PR DESCRIPTION
OCRerConfig::set_replace 之前用朴素字符串替换把 OCR 等价类注入到替换式的 正则中，会把字符类 [Oo] 破坏成 [O(?:o|0)]，使其额外匹配 '(' '?' ':' '|' ')' 等字面字符。在 KR/JP 等定义了等价类的客户端上，这会让 NumberOcrReplace 把
时间串里的冒号替换成 0（如 12:34:56 -> 12034056），导致基建训练室等任务的
时间解析失败。

改为语法感知的注入（新增纯函数 asst::algorithm::inject_equivalence_classes）：
- 字符类外，等价字符展开为非捕获分组 (?:a|b)；
- 字符类内，等价字符作为普通类成员插入（[Oo] -> [Oo0]）；
- 反斜杠转义原样保留，不被误认为字符类边界。

函数放入 Utils/Algorithm.hpp，并在 AlgorithmTest.cpp 补充 Catch2 单元测试 覆盖上述回归。CN 基础资源等价类为空时行为不变。

Closes #15084

## Summary by Sourcery

以语法感知的方式将 OCR 等价类注入到正则替换模式中，避免破坏字符类并导致时间解析失败。

Bug Fixes:
- 防止 OCR 替换模式破坏正则字符类（例如将 `[Oo]` 变成能匹配多余标点的模式），从而避免在时间字符串中产生错误替换并引发后续解析失败。

Enhancements:
- 在 `Utils/Algorithm.hpp` 中引入可复用的 `inject_equivalence_classes` 工具，用于在正则模式中安全展开 OCR 等价类；当未定义等价类时，不改变原有行为。

Tests:
- 为 `inject_equivalence_classes` 添加单元测试，覆盖以下情况：空操作行为、忽略只有单一成员的等价类、在字符类内外进行展开、保留反斜杠转义，以及处理多码点空格等价类。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Inject OCR equivalence classes into regex replacement patterns in a syntax-aware way to avoid corrupting character classes and breaking time parsing.

Bug Fixes:
- Prevent OCR replace patterns from corrupting regex character classes (e.g. turning "[Oo]" into a pattern that matches extra punctuation), which caused incorrect replacements in time strings and subsequent parsing failures.

Enhancements:
- Introduce a reusable inject_equivalence_classes utility in Utils/Algorithm.hpp for safely expanding OCR equivalence classes in regex patterns without altering behavior when no classes are defined.

Tests:
- Add unit tests for inject_equivalence_classes covering no-op behavior, ignoring single-member classes, expansion inside and outside character classes, preserving backslash escapes, and handling multi-codepoint space equivalence classes.

</details>