### PR TITLE
fix: 修复 POSIX RawByNc 截图等待回连可能卡住的问题

### DIFF
--- a/src/MaaCore/Controller/Platform/PosixIO.cpp
+++ b/src/MaaCore/Controller/Platform/PosixIO.cpp
@@ -101,10 +101,57 @@ std::optional<int> asst::PosixIO::call_command(
     }
 
     // parent process
+    auto kill_child = [&]() {
+        ::kill(m_child, SIGTERM);
+        Log.error("Killing child `", cmd, "`, pid:", m_child);
+        ::kill(m_child, SIGKILL);
+        ::waitpid(m_child, &exit_ret, 0);
+    };
+
     if (recv_by_socket) {
         sockaddr addr {};
         socklen_t len = sizeof(addr);
         sock_buffer = asst::platform::single_page_buffer<char>();
+
+        if (timeout) {
+            bool socket_ready = false;
+            while (!need_exit()) {
+                auto elapsed = duration_cast<milliseconds>(steady_clock::now() - start_time).count();
+                auto remaining = timeout - elapsed;
+                if (remaining <= 0) {
+                    Log.warn("timeout when waiting socket connection, killing child:", m_child);
+                    kill_child();
+                    return std::nullopt;
+                }
+
+                ::pollfd event { .fd = m_server_sock, .events = POLLIN, .revents = 0 };
+                int poll_timeout = remaining > 5000 ? 5000 : static_cast<int>(remaining);
+                int poll_ret = ::poll(&event, 1, poll_timeout);
+                if (poll_ret > 0) {
+                    if (event.revents & POLLIN) {
+                        socket_ready = true;
+                        break;
+                    }
+
+                    Log.warn("socket connection failed before timeout, killing child:", m_child);
+                    kill_child();
+                    return std::nullopt;
+                }
+                if (poll_ret == 0 || errno == EINTR) {
+                    continue;
+                }
+
+                Log.error("poll() failed:", std::strerror(errno));
+                kill_child();
+                return std::nullopt;
+            }
+
+            if (!socket_ready) {
+                Log.warn("socket connection is interrupted, killing child:", m_child);
+                kill_child();
+                return std::nullopt;
+            }
+        }
 
         int client_socket = ::accept(m_server_sock, &addr, &len);
         if (client_socket < 0) {


### PR DESCRIPTION
POSIX 下 `RawByNc` 截图会在本机开一个 socket，然后执行设备侧 `screencap | nc [NcAddress] [NcPort]`，由设备侧 `nc` 回连本机 socket，把截图数据写回来。

现在的问题是 `PosixIO::call_command()` 在 `recv_by_socket=true` 时会先直接 `accept()`。如果设备侧 `nc` 没有成功回连，就会阻塞在这里；后面的 pipe 读取循环里虽然有 `check_timeout()`，但 `accept()` 不返回的话根本走不到那里。

Windows 侧没有这个问题，因为 `Win32IO` 用的是 `AcceptEx` + `WaitForMultipleObjectsEx`，socket 等待和进程/pipe 等待都在同一个 timeout loop 里。

修复：
- 在 POSIX 的 `accept()` 前先用 `poll()` 等待 socket 可读。
- 等待时间使用当前 `call_command()` 剩余的 timeout。
- 超时或 socket 状态异常时，结束本次 adb 子进程并返回失败，让外层继续尝试其他截图方式。
- 不改 `ncAddress`，不改截图方式选择逻辑。

## 由 Sourcery 提供的总结

通过在接受客户端连接之前，对 POSIX RawByNc 截图的套接字连接进行带超时的轮询处理，当设备无法重新连接时，避免出现无限期阻塞。

Bug 修复：
- 在等待 nc 套接字连接时强制使用超时，防止 POSIX RawByNc 截图调用无限期挂起。

增强内容：
- 添加辅助逻辑，当在剩余的 `call_command` 超时时间内仍未建立套接字连接时，终止 adb 子进程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle POSIX RawByNc screenshot socket connections with timeout-aware polling before accepting clients to avoid indefinite blocking when the device fails to reconnect.

Bug Fixes:
- Prevent POSIX RawByNc screenshot calls from hanging indefinitely by enforcing a timeout when waiting for the nc socket connection.

Enhancements:
- Add helper logic to terminate the adb child process when the socket connection is not established within the remaining call_command timeout.

</details>