### PR TITLE
feat: 理智药使用增加使用中的药品信息

### DIFF
--- a/src/MaaCore/Task/Fight/MedicineCounterTaskPlugin.cpp
+++ b/src/MaaCore/Task/Fight/MedicineCounterTaskPlugin.cpp
@@ -188,6 +188,16 @@ bool asst::MedicineCounterTaskPlugin::_run()
     auto info = basic_info_with_what("UseMedicine");
     info["details"]["is_expiring"] = m_used_count > m_max_count;
     info["details"]["count"] = using_medicine->using_count;
+    for (const auto& [use, inventory, expire_days, _] : using_medicine->medicines) {
+        if (use > 0) {
+            info["details"]["medicines"].emplace(
+                json::value {
+                    { "use", use },
+                    { "inventory", inventory },
+                    { "expire_days", expire_days },
+                });
+        }
+    }
     callback(AsstMsg::SubTaskExtraInfo, info);
     return true;
 }

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -2281,52 +2281,6 @@ public class AsstProxy
                     break;
                 }
 
-            case "UseMedicine":
-                var medicineReport = (JObject?)subTaskDetails;
-                if (medicineReport is null || !medicineReport.ContainsKey("is_expiring") || !medicineReport.ContainsKey("count"))
-                {
-                    break;
-                }
-
-                var isExpiringMedicine = medicineReport.TryGetValue("is_expiring", out var isExpiringMedicineToken) && (bool)isExpiringMedicineToken;
-                int medicineCount = medicineReport.TryGetValue("count", out var medicineCountToken) ? (int)medicineCountToken : -1;
-
-                if (medicineCount == -1)
-                {
-                    Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("MedicineUsed") + " Unknown times", UiLogColor.Error);
-                    break;
-                }
-
-                string medicineLog;
-                if (!isExpiringMedicine)
-                {
-                    MedicineUsedTimes += medicineCount;
-                    medicineLog = LocalizationHelper.GetString("MedicineUsed") + $" {MedicineUsedTimes}(+{medicineCount})";
-                    AchievementTrackerHelper.Instance.AddProgressToGroup(AchievementIds.SanitySaverGroup, medicineCount);
-                }
-                else
-                {
-                    ExpiringMedicineUsedTimes += medicineCount;
-                    var item = Instances.TaskQueueViewModel.TaskItemViewModels.FirstOrDefault(i => i.TaskIds.Contains(taskId));
-                    var expireOut = "--";
-                    if (item is not null && item.Index >= 0 && item.Index < ConfigFactory.CurrentConfig.TaskQueue.Count)
-                    {
-                        if (ConfigFactory.CurrentConfig.TaskQueue[item.Index] is FightTask fightTask)
-                        {
-                            var yjTime = DateTimeOffset.Now.ToYjDateTime().ToLocalTime();
-                            var daysUntilEndOfWeek = ((7 - (int)yjTime.DayOfWeek + 7) % 7) + 1; // 距离本周结束的天数, 用鹰历计算
-                            var expireDays = Math.Max(fightTask.UseExpiringMedicine ? fightTask.MedicineExpireDays : 0, FightSetting.Instance.ActivityExpireIn2Days && fightTask.UseExpireMedicineForActivity ? daysUntilEndOfWeek : 0);
-                            expireOut = $"{expireDays * 24}";
-                        }
-                    }
-                    medicineLog = LocalizationHelper.GetStringFormat("ExpiringMedicineUsed", expireOut) + $" {ExpiringMedicineUsedTimes}(+{medicineCount})";
-                    AchievementTrackerHelper.Instance.AddProgressToGroup(AchievementIds.SanitySaverGroup, medicineCount);
-                    AchievementTrackerHelper.Instance.SetProgress(AchievementIds.SanityExpire, ExpiringMedicineUsedTimes);
-                }
-
-                Instances.TaskQueueViewModel.AddLog(medicineLog, UiLogColor.Info);
-                break;
-
             case "StageQueueUnableToAgent":
                 Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("StageQueue") + $" {subTaskDetails!["stage_code"]} " + LocalizationHelper.GetString("UnableToAgent"), UiLogColor.Info);
                 break;

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -1221,7 +1221,7 @@ Right-click to clear inactive jobs</system:String>
     <system:String x:Key="StoneUsedTimes" xml:space="preserve">Stone: {0}  </system:String>
     <system:String x:Key="MedicineUsed">Medicine used</system:String>
     <system:String x:Key="ExpiringMedicineUsed">Expiring medicine (in {0} hours) used</system:String>
-    <system:String x:Key="UseMedicine.MedicineInfo">药: {0}, 库存: {1}</system:String>
+    <system:String x:Key="UseMedicine.MedicineInfo">Medicine: {0}, Inventory: {1}</system:String>
     <system:String x:Key="StoneUsed">Originite Prime used</system:String>
     <system:String x:Key="ActingCommandError">PRTS error</system:String>
     <system:String x:Key="FightMissionFailedAndStop">Proxy failed too many times, task stopped</system:String>

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -1221,6 +1221,7 @@ Right-click to clear inactive jobs</system:String>
     <system:String x:Key="StoneUsedTimes" xml:space="preserve">Stone: {0}  </system:String>
     <system:String x:Key="MedicineUsed">Medicine used</system:String>
     <system:String x:Key="ExpiringMedicineUsed">Expiring medicine (in {0} hours) used</system:String>
+    <system:String x:Key="UseMedicine.MedicineInfo">药: {0}, 库存: {1}</system:String>
     <system:String x:Key="StoneUsed">Originite Prime used</system:String>
     <system:String x:Key="ActingCommandError">PRTS error</system:String>
     <system:String x:Key="FightMissionFailedAndStop">Proxy failed too many times, task stopped</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -1222,7 +1222,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="StoneUsedTimes" xml:space="preserve">石: {0}  </system:String>
     <system:String x:Key="MedicineUsed">回復剤を使った</system:String>
     <system:String x:Key="ExpiringMedicineUsed">{0}時間以内に期限が切れる回復剤を使った</system:String>
-    <system:String x:Key="UseMedicine.MedicineInfo">药: {0}, 库存: {1}</system:String>
+    <system:String x:Key="UseMedicine.MedicineInfo">回復剤：{0}、在庫：{1}</system:String>
     <system:String x:Key="StoneUsed">源石を使った</system:String>
     <system:String x:Key="ActingCommandError">自動指揮のミスが生じました</system:String>
     <system:String x:Key="FightMissionFailedAndStop">自動指揮の失敗回数が上限に達したため、任務が停止されました</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -1222,6 +1222,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="StoneUsedTimes" xml:space="preserve">石: {0}  </system:String>
     <system:String x:Key="MedicineUsed">回復剤を使った</system:String>
     <system:String x:Key="ExpiringMedicineUsed">{0}時間以内に期限が切れる回復剤を使った</system:String>
+    <system:String x:Key="UseMedicine.MedicineInfo">药: {0}, 库存: {1}</system:String>
     <system:String x:Key="StoneUsed">源石を使った</system:String>
     <system:String x:Key="ActingCommandError">自動指揮のミスが生じました</system:String>
     <system:String x:Key="FightMissionFailedAndStop">自動指揮の失敗回数が上限に達したため、任務が停止されました</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -1223,6 +1223,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="StoneUsedTimes" xml:space="preserve">\n순오리지늄: {0}  </system:String>
     <system:String x:Key="MedicineUsed">이성 회복제를 사용했습니다</system:String>
     <system:String x:Key="ExpiringMedicineUsed">{0}시간 이내 만료되는 이성 회복제를 사용했습니다</system:String>
+    <system:String x:Key="UseMedicine.MedicineInfo">药: {0}, 库存: {1}</system:String>
     <system:String x:Key="StoneUsed">순오리지늄을 사용했습니다</system:String>
     <system:String x:Key="ActingCommandError">대리 지휘 오류 발생</system:String>
     <system:String x:Key="FightMissionFailedAndStop">대리 지휘 실패 횟수 초과로 작업을 중단합니다</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -1223,7 +1223,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="StoneUsedTimes" xml:space="preserve">\n순오리지늄: {0}  </system:String>
     <system:String x:Key="MedicineUsed">이성 회복제를 사용했습니다</system:String>
     <system:String x:Key="ExpiringMedicineUsed">{0}시간 이내 만료되는 이성 회복제를 사용했습니다</system:String>
-    <system:String x:Key="UseMedicine.MedicineInfo">药: {0}, 库存: {1}</system:String>
+    <system:String x:Key="UseMedicine.MedicineInfo">의약품: {0}, 재고: {1}</system:String>
     <system:String x:Key="StoneUsed">순오리지늄을 사용했습니다</system:String>
     <system:String x:Key="ActingCommandError">대리 지휘 오류 발생</system:String>
     <system:String x:Key="FightMissionFailedAndStop">대리 지휘 실패 횟수 초과로 작업을 중단합니다</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -1222,6 +1222,7 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="StoneUsedTimes" xml:space="preserve">石: {0}  </system:String>
     <system:String x:Key="MedicineUsed">已使用理智药</system:String>
     <system:String x:Key="ExpiringMedicineUsed">已使用 {0} H内过期理智药</system:String>
+    <system:String x:Key="UseMedicine.MedicineInfo">药: {0}, 库存: {1}</system:String>
     <system:String x:Key="StoneUsed">已使用源石</system:String>
     <system:String x:Key="ActingCommandError">代理指挥失误</system:String>
     <system:String x:Key="FightMissionFailedAndStop">代理失败次数已达上限，任务已停止</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -1222,7 +1222,7 @@ C:\\leidian\\LDPlayer9\n
     <system:String x:Key="StoneUsedTimes" xml:space="preserve">石: {0}  </system:String>
     <system:String x:Key="MedicineUsed">已使用理智藥</system:String>
     <system:String x:Key="ExpiringMedicineUsed">已使用 {0} 小時內過期的理智藥</system:String>
-    <system:String x:Key="UseMedicine.MedicineInfo">药: {0}, 库存: {1}</system:String>
+    <system:String x:Key="UseMedicine.MedicineInfo">藥: {0}, 庫存: {1}</system:String>
     <system:String x:Key="StoneUsed">已使用源石</system:String>
     <system:String x:Key="ActingCommandError">代理指揮失誤</system:String>
     <system:String x:Key="FightMissionFailedAndStop">代理失敗次數已達上限，任務已停止</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -1222,6 +1222,7 @@ C:\\leidian\\LDPlayer9\n
     <system:String x:Key="StoneUsedTimes" xml:space="preserve">石: {0}  </system:String>
     <system:String x:Key="MedicineUsed">已使用理智藥</system:String>
     <system:String x:Key="ExpiringMedicineUsed">已使用 {0} 小時內過期的理智藥</system:String>
+    <system:String x:Key="UseMedicine.MedicineInfo">药: {0}, 库存: {1}</system:String>
     <system:String x:Key="StoneUsed">已使用源石</system:String>
     <system:String x:Key="ActingCommandError">代理指揮失誤</system:String>
     <system:String x:Key="FightMissionFailedAndStop">代理失敗次數已達上限，任務已停止</system:String>

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/FightSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/FightSettingsUserControlModel.cs
@@ -27,6 +27,7 @@ using MaaWpfGui.Constants;
 using MaaWpfGui.Constants.Enums;
 using MaaWpfGui.Extensions;
 using MaaWpfGui.Helper;
+using MaaWpfGui.Main;
 using MaaWpfGui.Models;
 using MaaWpfGui.Models.AsstTasks;
 using MaaWpfGui.States;
@@ -36,6 +37,7 @@ using MaaWpfGui.ViewModels.UI;
 using Newtonsoft.Json;
 using Serilog;
 using Stylet;
+using static MaaWpfGui.Helper.Instances.Data;
 using static MaaWpfGui.Main.AsstProxy;
 
 namespace MaaWpfGui.ViewModels.UserControl.TaskQueue;
@@ -65,6 +67,7 @@ public class FightSettingsUserControlModel : TaskSettingsViewModel, FightSetting
         _runningState = RunningState.Instance;
         _runningState.StateChanged += OnRunningStateChanged;
         Instances.AsstProxy.OnTaskStatusChanged += OnTaskStatusChanged;
+        Instances.AsstProxy.AsstSubTaskMsgEvent += ProcSubTaskMsg;
 
         if (Instances.ToolboxViewModel is { } toolboxViewModel)
         {
@@ -1338,26 +1341,6 @@ public class FightSettingsUserControlModel : TaskSettingsViewModel, FightSetting
 
     #endregion UI Item
 
-    private struct UiRefreshingScope : IDisposable
-    {
-        private static int _depth = 0;
-
-        public UiRefreshingScope()
-        {
-            ++_depth;
-            Instance.IsRefreshingUI = true;
-        }
-
-        readonly void IDisposable.Dispose()
-        {
-            --_depth;
-            if (_depth == 0)
-            {
-                Instance.IsRefreshingUI = false;
-            }
-        }
-    }
-
     private interface ISerialize : ITaskQueueModelSerialize
     {
         (bool? IsSuccess, IEnumerable<int> TaskId) ITaskQueueModelSerialize.Serialize(BaseTask? baseTask, int? taskId)
@@ -1483,5 +1466,89 @@ public class FightSettingsUserControlModel : TaskSettingsViewModel, FightSetting
         }
     }
 
+    private static void ProcSubTaskMsg(AsstMsg type, AsstSubTaskMsg? msg)
+    {
+        if (type != AsstMsg.SubTaskExtraInfo || msg is null)
+        {
+            return;
+        }
+
+        switch (msg.What)
+        {
+            case "UseMedicine":
+                var report = msg.Details?.ToObject<MedicineUsingInfo>();
+                if (report is null)
+                {
+                    break;
+                }
+
+                if (report.Count == -1)
+                {
+                    Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("MedicineUsed") + " Unknown times", UiLogColor.Error);
+                    break;
+                }
+
+                string medicineLog;
+                if (!report.IsExpiring)
+                {
+                    MedicineUsedTimes += report.Count;
+                    medicineLog = LocalizationHelper.GetString("MedicineUsed") + $" {MedicineUsedTimes}(+{report.Count})";
+                    AchievementTrackerHelper.Instance.AddProgressToGroup(AchievementIds.SanitySaverGroup, report.Count);
+                }
+                else
+                {
+                    ExpiringMedicineUsedTimes += report.Count;
+                    var item = Instances.TaskQueueViewModel.TaskItemViewModels.FirstOrDefault(i => i.TaskIds.Contains(msg.TaskId));
+                    var expireOut = "--";
+                    if (item is not null && item.Index >= 0 && item.Index < ConfigFactory.CurrentConfig.TaskQueue.Count)
+                    {
+                        if (ConfigFactory.CurrentConfig.TaskQueue[item.Index] is FightTask fightTask)
+                        {
+                            var yjTime = DateTimeOffset.Now.ToYjDateTime().ToLocalTime();
+                            var daysUntilEndOfWeek = ((7 - (int)yjTime.DayOfWeek + 7) % 7) + 1; // 距离本周结束的天数, 用鹰历计算
+                            var expireDays = Math.Max(fightTask.UseExpiringMedicine ? fightTask.MedicineExpireDays : 0, Instance.ActivityExpireIn2Days && fightTask.UseExpireMedicineForActivity ? daysUntilEndOfWeek : 0);
+                            expireOut = $"{expireDays * 24}";
+                        }
+                    }
+                    medicineLog = LocalizationHelper.GetStringFormat("ExpiringMedicineUsed", expireOut) + $" {ExpiringMedicineUsedTimes}(+{report.Count})";
+                    AchievementTrackerHelper.Instance.AddProgressToGroup(AchievementIds.SanitySaverGroup, report.Count);
+                    AchievementTrackerHelper.Instance.SetProgress(AchievementIds.SanityExpire, ExpiringMedicineUsedTimes);
+                }
+
+                var list = report.Medicines.Select(i => LocalizationHelper.GetStringFormat("UseMedicine.MedicineInfo", i.Use, i.Inventory)).ToList();
+                list.ForEach(i => medicineLog += "\n" + i);
+                Instances.TaskQueueViewModel.AddLog(medicineLog, UiLogColor.Info);
+                break;
+        }
+    }
+
+    private struct UiRefreshingScope : IDisposable
+    {
+        private static int _depth = 0;
+
+        public UiRefreshingScope()
+        {
+            ++_depth;
+            Instance.IsRefreshingUI = true;
+        }
+
+        readonly void IDisposable.Dispose()
+        {
+            --_depth;
+            if (_depth == 0)
+            {
+                Instance.IsRefreshingUI = false;
+            }
+        }
+    }
+
+    #region Model
+
+    private record MedicineUsingInfo([property: JsonProperty("is_expiring")] bool IsExpiring, [property: JsonProperty("count")] int Count, [property: JsonProperty("medicines")] List<MedicineInfo> Medicines);
+
+    private record MedicineInfo([property: JsonProperty("use")] int Use, [property: JsonProperty("inventory")] int Inventory, [property: JsonProperty("expire_days")] int ExpireDays);
+
     private sealed record InventoryTargetRuntimeState(string DropId, int StartInventory, int EffectiveQuantity);
+
+    #endregion Model
 }

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/FightSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/FightSettingsUserControlModel.cs
@@ -1487,7 +1487,6 @@ public class FightSettingsUserControlModel : TaskSettingsViewModel, FightSetting
                 {
                     MedicineUsedTimes += report.Count;
                     medicineLog = LocalizationHelper.GetString("MedicineUsed") + $" {MedicineUsedTimes}(+{report.Count})";
-                    AchievementTrackerHelper.Instance.AddProgressToGroup(AchievementIds.SanitySaverGroup, report.Count);
                 }
                 else
                 {
@@ -1505,12 +1504,15 @@ public class FightSettingsUserControlModel : TaskSettingsViewModel, FightSetting
                         }
                     }
                     medicineLog = LocalizationHelper.GetStringFormat("ExpiringMedicineUsed", expireOut) + $" {ExpiringMedicineUsedTimes}(+{report.Count})";
-                    AchievementTrackerHelper.Instance.AddProgressToGroup(AchievementIds.SanitySaverGroup, report.Count);
                     AchievementTrackerHelper.Instance.SetProgress(AchievementIds.SanityExpire, ExpiringMedicineUsedTimes);
                 }
 
-                var list = report.Medicines?.Select(i => LocalizationHelper.GetStringFormat("UseMedicine.MedicineInfo", i.Use, i.Inventory)).ToList();
-                list?.ForEach(i => medicineLog += "\n" + i);
+                AchievementTrackerHelper.Instance.AddProgressToGroup(AchievementIds.SanitySaverGroup, report.Count);
+                if (report.Medicines?.Count > 0)
+                {
+                    var list = report.Medicines?.Select(i => LocalizationHelper.GetStringFormat("UseMedicine.MedicineInfo", i.Use, i.Inventory)).ToList();
+                    medicineLog += "\n" + string.Join("\n", list ?? []);
+                }
                 Instances.TaskQueueViewModel.AddLog(medicineLog, UiLogColor.Info);
                 break;
         }

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/FightSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/FightSettingsUserControlModel.cs
@@ -1482,12 +1482,6 @@ public class FightSettingsUserControlModel : TaskSettingsViewModel, FightSetting
                     break;
                 }
 
-                if (report.Count == -1)
-                {
-                    Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("MedicineUsed") + " Unknown times", UiLogColor.Error);
-                    break;
-                }
-
                 string medicineLog;
                 if (!report.IsExpiring)
                 {
@@ -1544,7 +1538,7 @@ public class FightSettingsUserControlModel : TaskSettingsViewModel, FightSetting
 
     #region Model
 
-    private record MedicineUsingInfo([property: JsonProperty("is_expiring")] bool IsExpiring, [property: JsonProperty("count")] int Count, [property: JsonProperty("medicines")] List<MedicineInfo> Medicines);
+    private record MedicineUsingInfo([property: JsonProperty("is_expiring")] bool IsExpiring, [property: JsonProperty("count")] int Count, [property: JsonProperty("medicines")] List<MedicineInfo>? Medicines);
 
     private record MedicineInfo([property: JsonProperty("use")] int Use, [property: JsonProperty("inventory")] int Inventory, [property: JsonProperty("expire_days")] int ExpireDays);
 

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/FightSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/FightSettingsUserControlModel.cs
@@ -1515,8 +1515,8 @@ public class FightSettingsUserControlModel : TaskSettingsViewModel, FightSetting
                     AchievementTrackerHelper.Instance.SetProgress(AchievementIds.SanityExpire, ExpiringMedicineUsedTimes);
                 }
 
-                var list = report.Medicines.Select(i => LocalizationHelper.GetStringFormat("UseMedicine.MedicineInfo", i.Use, i.Inventory)).ToList();
-                list.ForEach(i => medicineLog += "\n" + i);
+                var list = report.Medicines?.Select(i => LocalizationHelper.GetStringFormat("UseMedicine.MedicineInfo", i.Use, i.Inventory)).ToList();
+                list?.ForEach(i => medicineLog += "\n" + i);
                 Instances.TaskQueueViewModel.AddLog(medicineLog, UiLogColor.Info);
                 break;
         }


### PR DESCRIPTION
- close #17032


## Summary by Sourcery

为理智药剂使用添加详细的报告和 UI 处理，包括按药剂的使用信息，并重构处理该子任务消息的位置。

新特性：
- 在理智药剂使用的 `SubTaskExtraInfo` 消息中加入按药剂的使用详情，并在任务队列日志中展示这些信息。

增强：
- 将药剂使用子任务的处理从 `AsstProxy` 移动到 `FightSettingsUserControlModel`，并扩展以展示当前使用的药剂信息，同时保留成就追踪功能。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add detailed reporting and UI handling for sanity medicine usage, including per-medicine information, and refactor where this subtask message is processed.

New Features:
- Include per-medicine usage details in SubTaskExtraInfo messages for sanity medicine usage and surface them in the task queue logs.

Enhancements:
- Move medicine usage subtask handling from AsstProxy into FightSettingsUserControlModel and extend it to show currently used medicine information while preserving achievement tracking.

</details>