### PR TITLE
feat: 增加 Wayland 控制方法

### DIFF
--- a/docs/en-us/develop/development.md
+++ b/docs/en-us/develop/development.md
@@ -78,7 +78,7 @@ We've preset several different development environments for you to choose from:
    - Press F5 to run
 
    ::: tip
-   To run Win32Controller (Windows window control) / MaaFwAdbController (MaaFramework touch mode) features, you need to manually download the package for your platform from [MaaFramework Releases](https://github.com/MaaXYZ/MaaFramework/releases), and place `MaaWin32ControlUnit.dll` / `MaaAdbControlUnit.dll` from the `bin` directory into MAA's DLL directory (e.g. `build/bin/Debug`). PRs for an auto-download script are welcome!
+   To run Win32Controller (Windows window control) / MaaFwAdbController / MaaFwWlrController (MaaFramework touch mode) features, you need to manually download the package for your platform from [MaaFramework Releases](https://github.com/MaaXYZ/MaaFramework/releases), and place `MaaWin32ControlUnit.dll` / `MaaAdbControlUnit.dll` from the `bin` directory into MAA's DLL directory (e.g. `build/bin/Debug`). PRs for an auto-download script are welcome!
 
    To debug these features, [compile the Debug version of MaaFramework yourself](https://maafw.com/docs/4.1-BuildGuide) and use the corresponding DLLs, or it will randomly crash at breakpoints.
    :::

--- a/docs/en-us/develop/linux-tutorial.md
+++ b/docs/en-us/develop/linux-tutorial.md
@@ -74,7 +74,7 @@ Mac can use the `tools/build_macos_universal.zsh` script for compilation. It's r
    cmake --install build --prefix <target_directory>
    ```
 
-4. To debug MaaFwAdbController (MaaFramework touch mode) features, you need to [compile the Debug version of MaaFramework yourself](https://maafw.com/docs/4.1-BuildGuide) and put `libMaaAdbControlUnit.so` in the installation directory.
+4. To debug MaaFwAdbController/MaaFwWlrController (MaaFramework touch mode) features, you need to [compile the Debug version of MaaFramework yourself](https://maafw.com/docs/4.1-BuildGuide) and put `libMaaAdbControlUnit.so`/`libMaaWlRootsControlUnit.so` in the installation directory.
 
 ## Integration Documentation
 

--- a/docs/en-us/protocol/integration.md
+++ b/docs/en-us/protocol/integration.md
@@ -1173,7 +1173,7 @@ Invalid placeholder. Enum value: 0.
 Deprecated. Originally for enabling Minitouch; "1" - on, "0" - off. Note that the device may not support it. Enum value: 1 (deprecated).  
 :::  
 ::: field name="TouchMode" type="string" optional default="minitouch"  
-Touch mode setting. Options: minitouch | maatouch | adb | MaaFwAdb. Default minitouch. Enum value: 2.  
+Touch mode setting. Options: minitouch | maatouch | adb | MaaFwAdb | MaaFwWlr. Default minitouch. Enum value: 2.  
 :::  
 ::: field name="DeploymentWithPause" type="boolean" optional  
 Whether to pause when deploying operators (affects IS, Copilot and Stationary Security Service). Options: "1" | "0". Enum value: 3.  

--- a/docs/ja-jp/develop/development.md
+++ b/docs/ja-jp/develop/development.md
@@ -84,7 +84,7 @@ icon: iconoir:developer
    - F5 キーを押して実行
 
    ::: tip
-   Win32Controller（Windows ウィンドウ制御）/ MaaFwAdbController（MaaFramework のタッチモード）関連機能を実行する場合は、[MaaFramework Releases](https://github.com/MaaXYZ/MaaFramework/releases) から対応プラットフォームのアーカイブをダウンロードし、`bin` ディレクトリ内の `MaaWin32ControlUnit.dll` / `MaaAdbControlUnit.dll` を MAA の DLL と同じディレクトリ（例：`build/bin/Debug`）に配置してください。自動ダウンロードスクリプトの PR 歓迎！
+   Win32Controller（Windows ウィンドウ制御）/ MaaFwAdbController / MaaFwWlrController（MaaFramework のタッチモード）関連機能を実行する場合は、[MaaFramework Releases](https://github.com/MaaXYZ/MaaFramework/releases) から対応プラットフォームのアーカイブをダウンロードし、`bin` ディレクトリ内の `MaaWin32ControlUnit.dll` / `MaaAdbControlUnit.dll` を MAA の DLL と同じディレクトリ（例：`build/bin/Debug`）に配置してください。自動ダウンロードスクリプトの PR 歓迎！
 
    関連機能をデバッグする場合は、[MaaFramework の Debug バージョンを自分でコンパイル](https://maafw.com/docs/4.1-BuildGuide)し、対応する DLL ファイルを使用する必要があります。そうしないと、ブレークポイントデバッグ中に謎のクラッシュが発生します。
    :::

--- a/docs/ja-jp/develop/linux-tutorial.md
+++ b/docs/ja-jp/develop/linux-tutorial.md
@@ -57,7 +57,7 @@ MAAの構築方法はまだ議論されていますが、このチュートリ�
    cmake --install build --prefix <target_directory>
    ```
 
-4. MaaFwAdbController（MaaFramework のタッチモード）関連機能をデバッグする場合は、[MaaFramework の Debug バージョンを自分でコンパイル](https://maafw.com/docs/4.1-BuildGuide)し、`libMaaAdbControlUnit.so` をインストールディレクトリにコピーする必要があります。
+4. MaaFwAdbController/MaaFwWlrController（MaaFramework のタッチモード）関連機能をデバッグする場合は、[MaaFramework の Debug バージョンを自分でコンパイル](https://maafw.com/docs/4.1-BuildGuide)し、`libMaaAdbControlUnit.so`/`libMaaWlRootsControlUnit.so` をインストールディレクトリにコピーする必要があります。
 
 ## その他のインストール方法
 

--- a/docs/ja-jp/protocol/integration.md
+++ b/docs/ja-jp/protocol/integration.md
@@ -1172,7 +1172,7 @@ bool ASSTAPI AsstSetInstanceOption(AsstHandle handle, AsstInstanceOptionKey key,
 廃止済み。元は Minitouch を有効にするかどうか。"1" オン、"0" オフ。デバイスがサポートされていない可能性がります。列挙値：1（廃止済み）。  
 :::  
 ::: field name="TouchMode" type="string" optional default="minitouch"  
-タッチ モード設定。可能な値：minitouch | maatouch | adb | MaaFwAdb。デフォルト minitouch。列挙値：2。  
+タッチ モード設定。可能な値：minitouch | maatouch | adb | MaaFwAdb | MaaFwWlr。デフォルト minitouch。列挙値：2。  
 :::  
 ::: field name="DeploymentWithPause" type="boolean" optional  
 暫停状態でオペレーターを配置するかどうか。自動戦闘、統合戦略、保全駐在に同時に影響。可能な値："1" または "0"。列挙値：3。  

--- a/docs/ko-kr/develop/development.md
+++ b/docs/ko-kr/develop/development.md
@@ -83,7 +83,7 @@ icon: iconoir:developer
    - F5 키를 눌러 실행
 
    ::: tip
-   Win32Controller(Windows 창 제어) / MaaFwAdbController(MaaFramework 터치 수행 방식) 관련 기능을 실행하려면 [MaaFramework Releases](https://github.com/MaaXYZ/MaaFramework/releases)에서 해당 플랫폼 압축 파일을 다운로드하고, `bin` 디렉토리의 `MaaWin32ControlUnit.dll` / `MaaAdbControlUnit.dll`을 MAA DLL과 같은 디렉토리(예: `build/bin/Debug`)에 배치해야 합니다. 자동 다운로드 스크립트 PR 환영!
+   Win32Controller(Windows 창 제어) / MaaFwAdbController / MaaFwWlrController(MaaFramework 터치 수행 방식) 관련 기능을 실행하려면 [MaaFramework Releases](https://github.com/MaaXYZ/MaaFramework/releases)에서 해당 플랫폼 압축 파일을 다운로드하고, `bin` 디렉토리의 `MaaWin32ControlUnit.dll` / `MaaAdbControlUnit.dll`을 MAA DLL과 같은 디렉토리(예: `build/bin/Debug`)에 배치해야 합니다. 자동 다운로드 스크립트 PR 환영!
 
    若需调试相关功能，则需要自行编译 MaaFramework 的 Debug 版本，使用对应的 DLL 文件，否则在断点调试时会神秘闪退。
    :::

--- a/docs/ko-kr/develop/linux-tutorial.md
+++ b/docs/ko-kr/develop/linux-tutorial.md
@@ -80,7 +80,7 @@ MaaAssistantArknights/MaaMacGui 프로젝트의 [README.md](https://github.com/M
    cmake --install build --prefix <target_directory>
    ```
 
-4. 若需调试 MaaFwAdbController（MaaFramework 触控模式）相关功能，需要[自行编译 MaaFramework](https://maafw.com/docs/4.1-BuildGuide) 的 Debug 版本，将 `libMaaAdbControlUnit.so` 放到安装目录下。
+4. 若需调试 MaaFwAdbController/MaaFwWlrController（MaaFramework 触控模式）相关功能，需要[自行编译 MaaFramework](https://maafw.com/docs/4.1-BuildGuide) 的 Debug 版本，将 `libMaaAdbControlUnit.so`/`libMaaWlRootsControlUnit.so` 放到安装目录下。
 
 ::::
 

--- a/docs/ko-kr/protocol/integration.md
+++ b/docs/ko-kr/protocol/integration.md
@@ -1161,7 +1161,7 @@ Value
 폐기됨. 원 Minitouch 활성화 여부; "1" 켜기, "0" 끄기. 장치가 지원하지 않을 수 있음. 열거값: 1 (폐기됨)  
 :::  
 ::: field name="TouchMode" type="string" optional default="minitouch"  
-터치 모드 설정. 옵션: minitouch | maatouch | adb | MaaFwAdb. 기본값 minitouch. 열거값: 2  
+터치 모드 설정. 옵션: minitouch | maatouch | adb | MaaFwAdb | MaaFwWlr. 기본값 minitouch. 열거값: 2  
 :::  
 ::: field name="DeploymentWithPause" type="boolean" optional  
 오퍼레이터 배치 시 일시정지 여부, 자동지휘/통합 전략/보안파견에 모두 영향. 옵션: "1" 켜기, "0" 끄기. 열거값: 3  

--- a/docs/zh-cn/develop/development.md
+++ b/docs/zh-cn/develop/development.md
@@ -78,7 +78,7 @@ icon: iconoir:developer
    - 按 F5 运行
 
    ::: tip
-   若需运行 Win32Controller（Windows 窗口控制）/ MaaFwAdbController（MaaFramework 触控模式）相关功能，需要自行从 [MaaFramework Releases](https://github.com/MaaXYZ/MaaFramework/releases) 下载对应平台的压缩包，将 `bin` 目录中的 `MaaWin32ControlUnit.dll` / `MaaAdbControlUnit.dll` 放到 MAA 的 DLL 同目录下（如 `build/bin/Debug`）。欢迎 PR 一个自动下载脚本！
+   若需运行 Win32Controller（Windows 窗口控制）/ MaaFwAdbController / MaaFwWlrController（MaaFramework 触控模式）相关功能，需要自行从 [MaaFramework Releases](https://github.com/MaaXYZ/MaaFramework/releases) 下载对应平台的压缩包，将 `bin` 目录中的 `MaaWin32ControlUnit.dll` / `MaaAdbControlUnit.dll` 放到 MAA 的 DLL 同目录下（如 `build/bin/Debug`）。欢迎 PR 一个自动下载脚本！
 
    若需调试相关功能，则需要[自行编译 MaaFramework](https://maafw.com/docs/4.1-BuildGuide) 的 Debug 版本，使用对应的 DLL 文件，否则在断点调试时会神秘闪退。
    :::

--- a/docs/zh-cn/develop/linux-tutorial.md
+++ b/docs/zh-cn/develop/linux-tutorial.md
@@ -80,7 +80,7 @@ Mac 可以使用 `tools/build_macos_universal.zsh` 脚本进行编译
    cmake --install build --prefix <target_directory>
    ```
 
-4. 若需调试 MaaFwAdbController（MaaFramework 触控模式）相关功能，需要[自行编译 MaaFramework](https://maafw.com/docs/4.1-BuildGuide) 的 Debug 版本，将 `libMaaAdbControlUnit.so` 放到安装目录下。
+4. 若需调试 MaaFwAdbController/MaaFwWlrController（MaaFramework 触控模式）相关功能，需要[自行编译 MaaFramework](https://maafw.com/docs/4.1-BuildGuide) 的 Debug 版本，将 `libMaaAdbControlUnit.so`/`libMaaWlRootsControlUnit.so` 放到安装目录下。
    ::::
 
 ## 集成文档

--- a/docs/zh-cn/protocol/integration.md
+++ b/docs/zh-cn/protocol/integration.md
@@ -1172,7 +1172,7 @@ bool ASSTAPI AsstSetInstanceOption(AsstHandle handle, AsstInstanceOptionKey key,
 已弃用。原为是否启用 Minitouch；"1" 开，"0" 关。注意设备可能不支持。枚举值：1（已弃用）。  
 :::  
 ::: field name="TouchMode" type="string" optional default="minitouch"  
-触控模式设置。可选值：minitouch | maatouch | adb | MaaFwAdb。默认 minitouch。枚举值：2。  
+触控模式设置。可选值：minitouch | maatouch | adb | MaaFwAdb | MaaFwWlr。默认 minitouch。枚举值：2。  
 :::  
 ::: field name="DeploymentWithPause" type="boolean" optional  
 是否暂停下干员，同时影响抄作业、肉鸽、保全。可用值："1" 或 "0"。枚举值：3。  

--- a/docs/zh-tw/develop/development.md
+++ b/docs/zh-tw/develop/development.md
@@ -78,7 +78,7 @@ icon: iconoir:developer
    - 按 F5 執行。
 
    ::: tip
-   若需執行 Win32Controller（Windows 視窗控制）/ MaaFwAdbController（MaaFramework 觸控模式）相關功能，需要自行從 [MaaFramework Releases](https://github.com/MaaModular/MaaFramework/releases) 下載對應平台的壓縮檔案，將 `bin` 目錄中的 `MaaWin32ControlUnit.dll` / `MaaAdbControlUnit.dll` 放到 MAA 的 DLL 同目錄下（例如 `build/bin/Debug`）。歡迎 PR 一個自動下載腳本！
+   若需執行 Win32Controller（Windows 視窗控制）/ MaaFwAdbController / MaaFwWlrController（MaaFramework 觸控模式）相關功能，需要自行從 [MaaFramework Releases](https://github.com/MaaModular/MaaFramework/releases) 下載對應平台的壓縮檔案，將 `bin` 目錄中的 `MaaWin32ControlUnit.dll` / `MaaAdbControlUnit.dll` 放到 MAA 的 DLL 同目錄下（例如 `build/bin/Debug`）。歡迎 PR 一個自動下載腳本！
 
    若需針對相關功能進行除錯，則需要自行編譯 MaaFramework 的 Debug 版本，使用對應的 DLL 檔案，否則在斷點除錯時會神秘閃退。
    :::

--- a/docs/zh-tw/develop/linux-tutorial.md
+++ b/docs/zh-tw/develop/linux-tutorial.md
@@ -80,7 +80,7 @@ Mac 使用者可以使用 `tools/build_macos_universal.zsh` 腳本進行編譯�
    cmake --install build --prefix <target_directory>
    ```
 
-4. 若需針對 MaaFwAdbController（MaaFramework 觸控模式）相關功能進行除錯，需要[自行編譯 MaaFramework](https://maafw.com/docs/4.1-BuildGuide) 的 Debug 版本，將 `libMaaAdbControlUnit.so` 放到安裝目錄下。
+4. 若需針對 MaaFwAdbController/MaaFwWlrController（MaaFramework 觸控模式）相關功能進行除錯，需要[自行編譯 MaaFramework](https://maafw.com/docs/4.1-BuildGuide) 的 Debug 版本，將 `libMaaAdbControlUnit.so`/`libMaaWlRootsControlUnit.so` 放到安裝目錄下。
 
 ::::
 

--- a/docs/zh-tw/protocol/integration.md
+++ b/docs/zh-tw/protocol/integration.md
@@ -1172,7 +1172,7 @@ bool ASSTAPI AsstSetInstanceOption(AsstHandle handle, AsstInstanceOptionKey key,
 已棄用。原為是否啟用 Minitouch；"1" 開，"0" 關。請注意設備可能不支援。列舉值：1（已棄用）。  
 :::  
 ::: field name="TouchMode" type="string" optional default="minitouch"  
-觸控模式設定。可選值：minitouch | maatouch | adb | MaaFwAdb。預設為 minitouch。列舉值：2。  
+觸控模式設定。可選值：minitouch | maatouch | adb | MaaFwAdb | MaaFwWlr。預設為 minitouch。列舉值：2。  
 :::  
 ::: field name="DeploymentWithPause" type="boolean" optional  
 是否暫停下幹員，同時影響抄作業、肉鴿、保全派駐。可用值："1" 或 "0"。列舉值：3。  

--- a/src/MaaCore/Assistant.cpp
+++ b/src/MaaCore/Assistant.cpp
@@ -143,6 +143,12 @@ bool asst::Assistant::set_instance_option(InstanceOptionKey key, const std::stri
             return true;
         }
 #endif
+#ifdef __linux__
+        else if (constexpr std::string_view MaaFwWlr = "MaaFwWlr"; value == MaaFwWlr) {
+            m_ctrler->set_touch_mode(TouchMode::MaaFwWlr);
+            return true;
+        }
+#endif
         break;
     case InstanceOptionKey::DeploymentWithPause:
         if (constexpr std::string_view Enable = "1"; value == Enable) {

--- a/src/MaaCore/Common/AsstTypes.h
+++ b/src/MaaCore/Common/AsstTypes.h
@@ -58,6 +58,7 @@ enum class TouchMode
     MacPlayTools = 3,
     MaaFwAdb = 4,
     Android = 5,
+    MaaFwWlr = 6,
 };
 
 #ifdef _WIN32

--- a/src/MaaCore/Controller/Controller.cpp
+++ b/src/MaaCore/Controller/Controller.cpp
@@ -32,6 +32,10 @@
 #include "MaaFwAndroidNativeController.h"
 #endif
 
+#ifdef __linux__
+#include "MaaFwWlrController.h"
+#endif
+
 #include "Common/AsstTypes.h"
 #include "Utils/Logger.hpp"
 
@@ -66,6 +70,10 @@ std::shared_ptr<asst::ControllerAPI>
         case ControllerType::MaaFwAndroidNative:
             Log.debug("Use Android");
             return std::make_shared<MaaFwAndroidNativeController>(m_callback, m_inst);
+#endif
+#ifdef __linux__
+        case ControllerType::MaaFwWlr:
+            return std::make_shared<MaaFwWlrController>(m_callback, m_inst, platform_type);
 #endif
         default:
             return nullptr;
@@ -383,6 +391,11 @@ void asst::Controller::set_touch_mode(const TouchMode& mode) noexcept
 #ifdef __ANDROID__
     case TouchMode::Android:
         m_controller_type = ControllerType::MaaFwAndroidNative;
+        break;
+#endif
+#ifdef __linux__
+    case TouchMode::MaaFwWlr:
+        m_controller_type = ControllerType::MaaFwWlr;
         break;
 #endif
     default:

--- a/src/MaaCore/Controller/ControllerAPI.h
+++ b/src/MaaCore/Controller/ControllerAPI.h
@@ -22,6 +22,9 @@ enum class ControllerType
 #ifdef __ANDROID__
     MaaFwAndroidNative,
 #endif
+#ifdef __linux__
+    MaaFwWlr,
+#endif
 };
 
 class ControllerAPI

--- a/src/MaaCore/Controller/MaaFwWlrController.cpp
+++ b/src/MaaCore/Controller/MaaFwWlrController.cpp
@@ -15,22 +15,23 @@ bool asst::MaaFwWlrController::connect(
     const std::string& address,
     const std::string& config [[maybe_unused]])
 {
-    if (m_loader.loaded()) {
-        if (m_unit) {
-            m_loader.destroy(m_unit);
-            m_unit = nullptr;
-        }
-        m_loader = MaaFwWlrControlUnitLoader();
+    (void)adb_path;
+    (void)config;
+
+    if (m_unit) {
+        m_loader.destroy(m_unit);
+        m_unit = nullptr;
     }
 
-    const auto dll_path = "libMaaWlRootsControlUnit";
-    if (!m_loader.load(dll_path)) {
-        return false;
+    if (!m_loader.loaded()) {
+        const auto dll_path = "libMaaWlRootsControlUnit";
+        if (!m_loader.load(dll_path)) {
+            return false;
+        }
     }
 
     m_socket_path = address;
     m_unit = m_loader.create(m_socket_path.c_str(), false);
-
     if (!m_unit) {
         Log.error("Failed to create control unit");
         return false;

--- a/src/MaaCore/Controller/MaaFwWlrController.cpp
+++ b/src/MaaCore/Controller/MaaFwWlrController.cpp
@@ -1,0 +1,182 @@
+#include "MaaFwWlrController.h"
+
+#ifdef __linux__
+
+#define CHECK_EXIST(x)                                         \
+    do {                                                       \
+        if (!(x)) {                                            \
+            Log.error(__FUNCTION__, "|", #x, "is not inited"); \
+            return { };                                        \
+        }                                                      \
+    } while (0)
+
+bool asst::MaaFwWlrController::connect(
+    const std::string& adb_path [[maybe_unused]],
+    const std::string& address,
+    const std::string& config [[maybe_unused]])
+{
+    if (m_loader.loaded()) {
+        if (m_unit) {
+            m_loader.destroy(m_unit);
+            m_unit = nullptr;
+        }
+        m_loader = MaaFwWlrControlUnitLoader();
+    }
+
+    const auto dll_path = "libMaaWlRootsControlUnit";
+    if (!m_loader.load(dll_path)) {
+        return false;
+    }
+
+    m_socket_path = address;
+    m_unit = m_loader.create(m_socket_path.c_str(), false);
+
+    if (!m_unit) {
+        Log.error("Failed to create control unit");
+        return false;
+    }
+
+    if (!m_unit->connect()) {
+        Log.error("Failed to connect control unit");
+        m_loader.destroy(m_unit);
+        m_unit = nullptr;
+        return false;
+    }
+
+    cv::Mat dummy { };
+    return screencap(dummy);
+}
+
+bool asst::MaaFwWlrController::screencap(cv::Mat& image_payload, bool allow_reconnect [[maybe_unused]])
+{
+    CHECK_EXIST(m_unit);
+
+    if (!m_unit->screencap(image_payload) || image_payload.empty()) {
+        return false;
+    }
+
+    m_screen_size.first = image_payload.cols;
+    m_screen_size.second = image_payload.rows;
+
+    return true;
+}
+
+bool asst::MaaFwWlrController::click(const Point& p)
+{
+    using enum InputEvent::Type;
+    return inject_input_event(InputEvent { .type = TOUCH_DOWN, .point = { p.x, p.y } }) &&
+           inject_input_event(InputEvent { .type = WAIT_MS, .milisec = 20 }) &&
+           inject_input_event(InputEvent { .type = TOUCH_UP, .point = { p.x, p.y } }) && park_cursor();
+}
+
+bool asst::MaaFwWlrController::swipe(
+    const Point& p1,
+    const Point& p2,
+    int duration,
+    bool extra_swipe,
+    double slope_in,
+    double slope_out,
+    bool with_pause [[maybe_unused]])
+{
+    int x1 = p1.x, y1 = p1.y;
+    int x2 = p2.x, y2 = p2.y;
+
+    const auto width = m_screen_size.first;
+    const auto height = m_screen_size.second;
+
+    if (width > 0 && height > 0) {
+        if (x1 < 0 || x1 >= width || y1 < 0 || y1 >= height) {
+            Log.warn("swipe point1 is out of range", x1, y1);
+            x1 = std::clamp(x1, 0, width - 1);
+            y1 = std::clamp(y1, 0, height - 1);
+        }
+    }
+
+    using enum InputEvent::Type;
+
+    if (!inject_input_event(InputEvent { .type = TOUCH_DOWN, .point = { x1, y1 } })) {
+        return false;
+    }
+
+    const auto& opt = Config.get_options();
+    int actual_duration = duration > 0 ? duration : opt.minitouch_swipe_default_duration;
+
+    auto bounds_check = [width, height](int x, int y) {
+        if (width <= 0 || height <= 0) {
+            return true;
+        }
+        return x >= 0 && x < width && y >= 0 && y < height;
+    };
+
+    auto move_func = [this](int x, int y) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(DefaultSwipeDelay));
+        return inject_input_event(InputEvent { .type = TOUCH_MOVE, .point = { x, y } });
+    };
+
+    auto do_swipe = [&](int _x1, int _y1, int _x2, int _y2, int _duration) {
+        return interpolate_swipe(
+            _x1,
+            _y1,
+            _x2,
+            _y2,
+            _duration,
+            DefaultSwipeDelay,
+            slope_in,
+            slope_out,
+            move_func,
+            bounds_check);
+    };
+
+    if (!do_swipe(x1, y1, x2, y2, actual_duration)) {
+        inject_input_event(InputEvent { .type = TOUCH_UP, .point = { x2, y2 } });
+        return false;
+    }
+
+    if (extra_swipe && opt.minitouch_extra_swipe_duration > 0) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(opt.minitouch_swipe_extra_end_delay));
+        do_swipe(x2, y2, x2, y2 - opt.minitouch_extra_swipe_dist, opt.minitouch_extra_swipe_duration);
+    }
+
+    return inject_input_event(InputEvent { .type = TOUCH_UP, .point = { x2, y2 } }) && park_cursor();
+}
+
+bool asst::MaaFwWlrController::inject_input_event(const InputEvent& event)
+{
+    CHECK_EXIST(m_unit);
+
+    using enum InputEvent::Type;
+    switch (event.type) {
+    case TOUCH_DOWN:
+        return m_unit->touch_down(event.pointerId, event.point.x, event.point.y, 0);
+    case TOUCH_UP:
+        return m_unit->touch_up(event.pointerId);
+    case TOUCH_MOVE:
+        return m_unit->touch_move(event.pointerId, event.point.x, event.point.y, 0);
+    case KEY_DOWN:
+        return m_unit->key_down(event.keycode);
+    case KEY_UP:
+        return m_unit->key_up(event.keycode);
+    case WAIT_MS:
+        std::this_thread::sleep_for(std::chrono::milliseconds(event.milisec));
+        return true;
+    case TOUCH_RESET:
+        [[fallthrough]];
+    case COMMIT:
+        return true;
+    case UNKNOWN:
+    default:
+        Log.error("unknown input event type");
+        return false;
+    }
+}
+
+bool asst::MaaFwWlrController::press_esc()
+{
+    static constexpr int KEY_ESC = 1;
+
+    return inject_input_event(InputEvent { .type = InputEvent::Type::KEY_DOWN, .keycode = KEY_ESC }) &&
+           inject_input_event(InputEvent { .type = InputEvent::Type::WAIT_MS, .milisec = 20 }) &&
+           inject_input_event(InputEvent { .type = InputEvent::Type::KEY_UP, .keycode = KEY_ESC });
+}
+
+#endif

--- a/src/MaaCore/Controller/MaaFwWlrController.h
+++ b/src/MaaCore/Controller/MaaFwWlrController.h
@@ -1,0 +1,174 @@
+#pragma once
+
+#ifdef __linux__ // Linux or Android
+
+#include "Common/AsstMsg.h"
+#include "Config/GeneralConfig.h"
+#include "Controller/SwipeHelper.hpp"
+#include "ControllerAPI.h"
+#include "InstHelper.h"
+#include "MaaFwControlUnitInterface.h"
+#include "Platform/PlatformIO.h"
+#include "Utils/LibraryHolder.hpp"
+
+namespace asst
+{
+
+struct MaaFwWlrControlUnitLoader : LibraryHolder<MaaFwWlrControlUnitLoader>
+{
+    bool loaded() const noexcept { return m_loaded; }
+
+    bool load(const std::filesystem::path& dll_path)
+    {
+        if (m_loaded) {
+            return false;
+        }
+
+        m_loaded = load_library(dll_path);
+
+        if (!m_loaded) {
+            Log.error("Failed to load library:", dll_path);
+            return false;
+        }
+
+        m_get_version = get_function<const char*()>("MaaWlRootsControlUnitGetVersion");
+        m_create = get_function<MaaFwControlUnitAPI*(const char*, bool)>("MaaWlRootsControlUnitCreate");
+        m_destroy = get_function<void(MaaFwControlUnitAPI*)>("MaaWlRootsControlUnitDestroy");
+
+        return m_get_version && m_create && m_destroy;
+    }
+
+    MaaFwControlUnitAPI* create(const char* wlr_socket_path, bool use_win32_vk_code) const
+    {
+        if (!m_loaded || !m_create) {
+            Log.error("Library not loaded or create function not available");
+            return nullptr;
+        }
+
+        return m_create(wlr_socket_path, use_win32_vk_code);
+    }
+
+    void destroy(MaaFwControlUnitAPI* handle) const
+    {
+        if (!m_loaded || !m_destroy) {
+            Log.error("Library not loaded or destroy function not available");
+            return;
+        }
+
+        if (handle) {
+            m_destroy(handle);
+        }
+    }
+
+    const char* get_version() const
+    {
+        if (!m_loaded || !m_get_version) {
+            Log.error("Library not loaded or get_version function not available");
+            return nullptr;
+        }
+
+        return m_get_version();
+    }
+
+private:
+    bool m_loaded = false;
+
+    std::function<MaaFwControlUnitAPI*(const char*, bool)> m_create;
+    std::function<void(MaaFwControlUnitAPI*)> m_destroy;
+    std::function<const char*()> m_get_version;
+};
+
+class MaaFwWlrController : public ControllerAPI, private InstHelper
+{
+public:
+    MaaFwWlrController(const MaaFwWlrController&) = delete;
+    MaaFwWlrController(MaaFwWlrController&&) = delete;
+    MaaFwWlrController& operator=(const MaaFwWlrController&) = delete;
+    MaaFwWlrController& operator=(MaaFwWlrController&&) = delete;
+
+    MaaFwWlrController(const AsstCallback& callback, Assistant* inst, PlatformType platform_type [[maybe_unused]]) :
+        InstHelper(inst),
+        m_callback(callback),
+        m_loader()
+    {
+    }
+
+    virtual ~MaaFwWlrController() override
+    {
+        if (m_unit) {
+            m_loader.destroy(m_unit);
+            m_unit = nullptr;
+        };
+    }
+
+    bool connect(const std::string& adb_path, const std::string& address, const std::string& config) override;
+
+    bool inited() const noexcept override { return m_loader.loaded() && m_unit; }
+
+    const std::string& get_uuid() const override { return m_socket_path; }
+
+    size_t get_pipe_data_size() const noexcept override { return { }; }
+
+    size_t get_version() const noexcept override { return { }; }
+
+    bool screencap(cv::Mat& image_payload, bool allow_reconnect = false) override;
+
+    bool start_game(const std::string& client_type [[maybe_unused]]) override
+    {
+        Log.warn("start_game is not supported on MaaFwWlrController");
+        return false;
+    }
+
+    bool stop_game(const std::string& client_type [[maybe_unused]]) override
+    {
+        Log.warn("stop_game is not supported on MaaFwWlrController");
+        return false;
+    }
+
+    bool click(const Point& p) override;
+
+    bool input(const std::string& text [[maybe_unused]]) override
+    {
+        Log.warn("input is not supported on MaaFwWlrController");
+        return false;
+    }
+
+    bool swipe(
+        const Point& p1,
+        const Point& p2,
+        int duration = 0,
+        bool extra_swipe = false,
+        double slope_in = 1,
+        double slope_out = 1,
+        bool with_pause = false) override;
+
+    bool inject_input_event(const InputEvent& event) override;
+
+    bool press_esc() override;
+
+    ControlFeat::Feat support_features() const noexcept override { return ControlFeat::PRECISE_SWIPE; }
+
+    std::pair<int, int> get_screen_res() const noexcept override { return m_screen_size; }
+
+private:
+    bool park_cursor()
+    {
+        return inject_input_event(InputEvent { .type = InputEvent::Type::WAIT_MS, .milisec = 20 }) &&
+               inject_input_event(
+                   InputEvent { .type = InputEvent::Type::TOUCH_MOVE,
+                                .point = { m_screen_size.first - 10, m_screen_size.second - 10 } });
+    }
+
+    static constexpr int DefaultSwipeDelay = 5; // ms
+
+    AsstCallback m_callback;
+    MaaFwWlrControlUnitLoader m_loader;
+    MaaFwControlUnitAPI* m_unit = nullptr;
+
+    std::string m_socket_path;
+    std::pair<int, int> m_screen_size = { 0, 0 };
+};
+
+}
+
+#endif


### PR DESCRIPTION
已使用 [cage](https://github.com/cage-kiosk/cage) 进行简单测试, 可以正常点击划动和按 esc
- 可以完全后台运行, 但需要设置嵌套混成器的分辨率为 16:9 (详见 https://github.com/MaaXYZ/MaaFramework/pull/1131)
- 现在使用 adb address 代为传递 Wayland socket 地址
- 操作完成后 park_cursor 把鼠标放到右下角避免干扰识别
---
使用方法:
嵌套混成器 (如 cage) 运行方舟, 如
```bash
export PROTONPATH=/usr/share/steam/compatibilitytools.d/dwproton/
cage -d umu-run C:/Program\ Files/Hypergryph\ Launcher/Launcher.exe
```
```toml
[connection]
type = "MaaFwWlr" # 需要 cli 支持
device = "/run/user/1000/wayland-?" # cage 的 WAYLAND_DISPLAY
```

## Summary by Sourcery

在 Linux 上新增基于 Wayland 的 MaaFwWlr 触控控制器，并将其暴露为可选触控模式。

新增功能：
- 引入适用于 Linux 上 Wayland/wlroots 的 `MaaFwWlrController` 实现，包括屏幕捕获、点击、滑动以及 ESC 键处理。
- 将 `MaaFwWlr` 添加为新的 `ControllerType` 和 `TouchMode`，并将其接入控制器工厂和实例选项，以便通过名称进行选择。

文档：
- 更新多语言开发文档和 Linux 调试指南，记录 `MaaFwWlrController` 的使用方法及其所需的 `libMaaWlRootsControlUnit.so` 库。
- 扩展所有受支持语言的集成协议文档，将 `MaaFwWlr` 列为有效的 `TouchMode` 选项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a new Wayland-based MaaFwWlr touch controller on Linux and expose it as a selectable touch mode.

New Features:
- Introduce MaaFwWlrController implementation for Wayland/wlroots on Linux, including screen capture, click, swipe, and ESC key handling.
- Add MaaFwWlr as a new ControllerType and TouchMode, and wire it into the controller factory and instance options to allow selection by name.

Documentation:
- Update multilingual development and Linux debugging guides to document MaaFwWlrController usage and its required libMaaWlRootsControlUnit.so library.
- Extend integration protocol documentation in all supported languages to list MaaFwWlr as a valid TouchMode option.

</details>