### PR TITLE
feat: 库存数量保持

### DIFF
--- a/src/MaaWpfGui/Configuration/Single/MaaTask/BaseTask.cs
+++ b/src/MaaWpfGui/Configuration/Single/MaaTask/BaseTask.cs
@@ -36,6 +36,7 @@ namespace MaaWpfGui.Configuration.Single.MaaTask;
 [JsonDerivedType(typeof(OperBoxTask), typeDiscriminator: nameof(OperBoxTask))]
 [JsonDerivedType(typeof(UserDataUpdateTask), typeDiscriminator: nameof(UserDataUpdateTask))]
 [JsonDerivedType(typeof(ReclamationTask), typeDiscriminator: nameof(ReclamationTask))]
+[JsonDerivedType(typeof(DepotMaintainTask), typeDiscriminator: nameof(DepotMaintainTask))]
 [JsonDerivedType(typeof(CustomTask), typeDiscriminator: nameof(CustomTask))]
 public class BaseTask : INotifyPropertyChanged
 {

--- a/src/MaaWpfGui/Configuration/Single/MaaTask/DepotMaintainTask.cs
+++ b/src/MaaWpfGui/Configuration/Single/MaaTask/DepotMaintainTask.cs
@@ -1,0 +1,31 @@
+// <copyright file="DepotMaintainTask.cs" company="MaaAssistantArknights">
+// Part of the MaaWpfGui project, maintained by the MaaAssistantArknights team (Maa Team)
+// Copyright (C) 2021-2025 MaaAssistantArknights Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License v3.0 only as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY
+// </copyright>
+
+#nullable enable
+using System.Collections.Generic;
+using static MaaWpfGui.Main.AsstProxy;
+
+namespace MaaWpfGui.Configuration.Single.MaaTask;
+
+public class DepotMaintainTask : BaseTask
+{
+    public DepotMaintainTask() => TaskType = TaskType.DepotMaintain;
+
+    public bool UpdateDepot { get; set; } = true;
+
+    public bool IsStageManually { get; set; }
+
+    public List<Plan> PlanList { get; set; } = [];
+
+    public record Plan(string Stage, string DropId, int DropCount, bool UseMedicine, int MedicineCount, bool UseStone, int StoneCount);
+}

--- a/src/MaaWpfGui/Configuration/Single/MaaTask/DepotMaintainTask.cs
+++ b/src/MaaWpfGui/Configuration/Single/MaaTask/DepotMaintainTask.cs
@@ -27,5 +27,5 @@ public class DepotMaintainTask : BaseTask
 
     public List<Plan> PlanList { get; set; } = [];
 
-    public record Plan(string Stage, string DropId, int DropCount, bool UseMedicine, int MedicineCount, bool UseStone, int StoneCount);
+    public record Plan(string Stage = "", string DropId = "", int DropCount = 0, bool UseMedicine = false, int MedicineCount = 0, bool UseStone = false, int StoneCount = 0);
 }

--- a/src/MaaWpfGui/Configuration/Single/MaaTask/DepotMaintainTask.cs
+++ b/src/MaaWpfGui/Configuration/Single/MaaTask/DepotMaintainTask.cs
@@ -37,5 +37,5 @@ public class DepotMaintainTask : BaseTask
 
     public List<Plan> PlanList { get; set; } = [];
 
-    public record Plan(string Stage = "", string DropId = "", int DropCount = 0, bool UseMedicine = false, int MedicineCount = 0, bool UseStone = false, int StoneCount = 0);
+    public record class Plan(string Stage = "", string DropId = "", int DropCount = 0, bool UseMedicine = false, int MedicineCount = 0, bool UseStone = false, int StoneCount = 0, int TaskId = 0);
 }

--- a/src/MaaWpfGui/Configuration/Single/MaaTask/DepotMaintainTask.cs
+++ b/src/MaaWpfGui/Configuration/Single/MaaTask/DepotMaintainTask.cs
@@ -25,6 +25,16 @@ public class DepotMaintainTask : BaseTask
 
     public bool IsStageManually { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether 活动期间跳过整个库存保持任务。
+    /// </summary>
+    public bool SkipDuringActivity { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether 资源全开放期间跳过整个库存保持任务。
+    /// </summary>
+    public bool SkipDuringResourceCollection { get; set; }
+
     public List<Plan> PlanList { get; set; } = [];
 
     public record Plan(string Stage = "", string DropId = "", int DropCount = 0, bool UseMedicine = false, int MedicineCount = 0, bool UseStone = false, int StoneCount = 0);

--- a/src/MaaWpfGui/Extensions/ComboBoxExtensions.cs
+++ b/src/MaaWpfGui/Extensions/ComboBoxExtensions.cs
@@ -15,6 +15,7 @@ using System;
 using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Data;
 using System.Windows.Input;
 using Serilog;
 
@@ -38,6 +39,14 @@ public static class ComboBoxExtensions
         if (targetComboBox?.Template.FindName("PART_EditableTextBox", targetComboBox) is not TextBox targetTextBox)
         {
             return;
+        }
+
+        // 为每个 ComboBox 创建独立的 CollectionView，避免多个控件共享默认视图导致搜索过滤互相干扰
+        if (targetComboBox.ItemsSource != null)
+        {
+            var sourceList = targetComboBox.ItemsSource.OfType<object>().ToList();
+            var independentView = new CollectionViewSource { Source = sourceList };
+            targetComboBox.ItemsSource = independentView.View;
         }
 
         targetComboBox.Items.IsLiveFiltering = true;

--- a/src/MaaWpfGui/Extensions/ComboBoxExtensions.cs
+++ b/src/MaaWpfGui/Extensions/ComboBoxExtensions.cs
@@ -42,10 +42,10 @@ public static class ComboBoxExtensions
         }
 
         // 为每个 ComboBox 创建独立的 CollectionView，避免多个控件共享默认视图导致搜索过滤互相干扰
+        // 直接引用原始集合而非快照，保留源集合变更（如语言切换重建）的传播能力
         if (targetComboBox.ItemsSource != null)
         {
-            var sourceList = targetComboBox.ItemsSource.OfType<object>().ToList();
-            var independentView = new CollectionViewSource { Source = sourceList };
+            var independentView = new CollectionViewSource { Source = targetComboBox.ItemsSource };
             targetComboBox.ItemsSource = independentView.View;
         }
 
@@ -114,6 +114,9 @@ public static class ComboBoxExtensions
             if (targetComboBox.SelectedItem != null)
             {
                 targetComboBox.Tag = SelectionTag;
+
+                // 选中后清除搜索过滤，避免残留 filter 导致后续列表内容丢失
+                targetComboBox.Items.Filter = null;
             }
 
             targetComboBox.Dispatcher.BeginInvoke(new Action(() =>

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -2881,6 +2881,9 @@ public class AsstProxy
         /// <summary>更新用户数据</summary>
         UserDataUpdate,
 
+        /// <summary>仓库维护</summary>
+        DepotMaintain,
+
         /// <summary>小游戏</summary>
         MiniGame,
 

--- a/src/MaaWpfGui/Models/TaskSettingVisibilityInfo.cs
+++ b/src/MaaWpfGui/Models/TaskSettingVisibilityInfo.cs
@@ -54,6 +54,8 @@ public class TaskSettingVisibilityInfo : PropertyChangedBase
 
     public bool UserDataUpdate { get => field; set => SetAndNotify(ref field, value); }
 
+    public bool DepotMaintain { get => field; set => SetAndNotify(ref field, value); }
+
     public bool Custom { get => field; set => SetAndNotify(ref field, value); }
 
     public bool PostAction { get => field; set => SetAndNotify(ref field, value); }
@@ -148,6 +150,7 @@ public class TaskSettingVisibilityInfo : PropertyChangedBase
             RoguelikeTask => Roguelike = enable,
             ReclamationTask => Reclamation = enable,
             UserDataUpdateTask => UserDataUpdate = enable,
+            DepotMaintainTask => DepotMaintain = enable,
             CustomTask => Custom = enable,
             _ => throw new NotImplementedException(),
         };
@@ -188,6 +191,7 @@ public class TaskSettingVisibilityInfo : PropertyChangedBase
         Roguelike = false;
         Reclamation = false;
         UserDataUpdate = false;
+        DepotMaintain = false;
         Custom = false;
     }
 

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -853,12 +853,18 @@ Do not adjust the proxy multiplier setting in the game</system:String>
     <system:String x:Key="InventoryUpdateTip">Inventory data can be updated via  ｢{key=Toolbox}-{key=DepotRecognition}｣</system:String>
     <system:String x:Key="SpecifiedDropsInventoryUnavailable">Task "{0}" uses {key=TargetInventory}, but no inventory data is currently available, so it was skipped. Update it via ｢{key=Toolbox}-{key=DepotRecognition}｣.</system:String>
     <!--  DepotMaintain  -->
+    <system:String x:Key="DepotUpdateBeforeStart">Update inventory before starting</system:String>
     <system:String x:Key="AddPlan">Add</system:String>
     <system:String x:Key="CollapseAll">Collapse</system:String>
     <system:String x:Key="DepotPlanInvalidDropItem">Plan {0}: invalid drop item.</system:String>
     <system:String x:Key="DepotPlanInventoryEnough">Plan {0}: Inventory enough.</system:String>
     <system:String x:Key="DepotPlanStageNotOpen">Plan {0}: stage '{1}' is not open.</system:String>
     <system:String x:Key="DepotPlanAddTaskFailed">Plan {0}: add task failed.</system:String>
+    <system:String x:Key="DepotSkipDuringActivity">Skip during event</system:String>
+    <system:String x:Key="DepotSkipDuringResourceCollection">Skip during resource collection limited-time all-day open</system:String>
+    <system:String x:Key="DepotPlanSkippedActivity">An event is in progress, depot maintain skipped.</system:String>
+    <system:String x:Key="DepotPlanSkippedResourceCollection">Resource collection limited-time all-day open is in progress, depot maintain skipped.</system:String>
+    <system:String x:Key="DepotPlanUpdateDepotFailed">Failed to update inventory data.</system:String>
     <system:String x:Key="LessThanOneDay">Less than 1 day</system:String>
     <system:String x:Key="1-7">1-7</system:String>
     <system:String x:Key="CE-6">CE-6</system:String>

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -349,7 +349,7 @@ To customize rotation schedules, please use ｢{key=InfrastModeCustom}｣.</syst
 • {key=Quantity}: uses the selected material's drop count in this combat task as the target, and stops when the set amount is reached.
 • {key=TargetInventory}: uses the saved inventory data from ｢{key=Toolbox}-{key=DepotRecognition}｣ and only farms until the target stock is reached.
   • Inventory data is cached and may differ from your real stock after manual farming, crafting, or material use. Sync it with ｢{key=UserDataUpdate}｣ or ｢{key=Toolbox}-{key=DepotRecognition}｣.
-  • When {key=TargetInventory} is enabled, the material and amount cannot be changed during a run.</system:String>
+  • Inventory is updated in real time based on drops during a run; materials farmed by earlier tasks will reduce the deficit of subsequent tasks.</system:String>
     <system:String x:Key="StartupUpdateCheck">Startup Update Check</system:String>
     <system:String x:Key="UpdateAutoCheck">Scheduled Update Check</system:String>
     <system:String x:Key="UpdateAutoCheckTip">In-game 00:00 / 18:00 (Server local time 04:00 / 22:00)</system:String>

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -856,8 +856,11 @@ Do not adjust the proxy multiplier setting in the game</system:String>
     <system:String x:Key="DepotUpdateBeforeStart">Update inventory before starting</system:String>
     <system:String x:Key="AddPlan">Add</system:String>
     <system:String x:Key="CollapseAll">Collapse</system:String>
-    <system:String x:Key="DepotPlanInvalidDropItem">Plan {0}: invalid drop item.</system:String>
-    <system:String x:Key="DepotPlanInventoryEnough">Plan {0}: Inventory enough.</system:String>
+    <system:String x:Key="DepotPlanInvalidDropItem">Plan {0}: no drop item specified.</system:String>
+    <system:String x:Key="DepotPlanDuplicateDrop">Plan {0}: item '{1}' duplicates plan {2}.</system:String>
+    <system:String x:Key="DepotPlanZeroDropCount">Plan {0}: target inventory is 0.</system:String>
+    <system:String x:Key="DepotPlanNoStage">Plan {0}: stage not specified or is "Current/Last".</system:String>
+    <system:String x:Key="DepotPlanInventoryEnough">Plan {0}: {1} inventory sufficient (current {2} / target {3}).</system:String>
     <system:String x:Key="DepotPlanStageNotOpen">Plan {0}: stage '{1}' is not open.</system:String>
     <system:String x:Key="DepotPlanAddTaskFailed">Plan {0}: add task failed.</system:String>
     <system:String x:Key="DepotSkipDuringActivity">Skip during event</system:String>

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -765,6 +765,7 @@ If the game is launched in portrait mode and then switched to landscape, it may 
     <system:String x:Key="Roguelike">{key=AutoRoguelike}</system:String>
     <system:String x:Key="Reclamation">Reclamation Algorithm</system:String>
     <system:String x:Key="UserDataUpdate">Update Doctor Data</system:String>
+    <system:String x:Key="DepotMaintain">Depot Maintain</system:String>
     <system:String x:Key="MiniGame">Useful Tasks</system:String>
     <system:String x:Key="MiniGameCategoryPermanent">Permanent</system:String>
     <system:String x:Key="MiniGameCategoryCurrentEvent">Current Events</system:String>
@@ -851,6 +852,13 @@ Do not adjust the proxy multiplier setting in the game</system:String>
     <system:String x:Key="Inventory">Inv: </system:String>
     <system:String x:Key="InventoryUpdateTip">Inventory data can be updated via  ｢{key=Toolbox}-{key=DepotRecognition}｣</system:String>
     <system:String x:Key="SpecifiedDropsInventoryUnavailable">Task "{0}" uses {key=TargetInventory}, but no inventory data is currently available, so it was skipped. Update it via ｢{key=Toolbox}-{key=DepotRecognition}｣.</system:String>
+    <!--  DepotMaintain  -->
+    <system:String x:Key="AddPlan">Add</system:String>
+    <system:String x:Key="CollapseAll">Collapse</system:String>
+    <system:String x:Key="DepotPlanInvalidDropItem">Plan {0}: invalid drop item.</system:String>
+    <system:String x:Key="DepotPlanInventoryEnough">Plan {0}: Inventory enough.</system:String>
+    <system:String x:Key="DepotPlanStageNotOpen">Plan {0}: stage '{1}' is not open.</system:String>
+    <system:String x:Key="DepotPlanAddTaskFailed">Plan {0}: add task failed.</system:String>
     <system:String x:Key="LessThanOneDay">Less than 1 day</system:String>
     <system:String x:Key="1-7">1-7</system:String>
     <system:String x:Key="CE-6">CE-6</system:String>

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -857,7 +857,6 @@ Do not adjust the proxy multiplier setting in the game</system:String>
     <system:String x:Key="AddPlan">Add</system:String>
     <system:String x:Key="CollapseAll">Collapse</system:String>
     <system:String x:Key="DepotPlanInvalidDropItem">Plan {0}: no drop item specified.</system:String>
-    <system:String x:Key="DepotPlanDuplicateDrop">Plan {0}: item '{1}' duplicates plan {2}.</system:String>
     <system:String x:Key="DepotPlanZeroDropCount">Plan {0}: target inventory is 0.</system:String>
     <system:String x:Key="DepotPlanNoStage">Plan {0}: stage not specified or is "Current/Last".</system:String>
     <system:String x:Key="DepotPlanInventoryEnough">Plan {0}: {1} inventory sufficient (current {2} / target {3}).</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -854,12 +854,18 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="InventoryUpdateTip">在庫データは ｢{key=Toolbox}-{key=DepotRecognition}｣ で更新できます</system:String>
     <system:String x:Key="SpecifiedDropsInventoryUnavailable">タスク ｢{0}｣ では {key=TargetInventory} が有効ですが、利用可能な在庫データがないためスキップされました。｢{key=Toolbox}-{key=DepotRecognition}｣ で在庫を更新してください。</system:String>
     <!--  在庫維持  -->
+    <system:String x:Key="DepotUpdateBeforeStart">タスク開始前に在庫データを更新</system:String>
     <system:String x:Key="AddPlan">追加</system:String>
     <system:String x:Key="CollapseAll">折りたたむ</system:String>
     <system:String x:Key="DepotPlanInvalidDropItem">プラン {0}：ドロップアイテムが無効です。</system:String>
     <system:String x:Key="DepotPlanInventoryEnough">プラン {0}：在庫が十分です。</system:String>
     <system:String x:Key="DepotPlanStageNotOpen">プラン {0}：ステージ「{1}」は公開されていません。</system:String>
     <system:String x:Key="DepotPlanAddTaskFailed">プラン {0}：タスクの追加に失敗しました。</system:String>
+    <system:String x:Key="DepotSkipDuringActivity">イベント期間中はスキップ</system:String>
+    <system:String x:Key="DepotSkipDuringResourceCollection">資源收集限時全日開放期間中はスキップ</system:String>
+    <system:String x:Key="DepotPlanSkippedActivity">イベント開催中のため、在庫維持をスキップしました。</system:String>
+    <system:String x:Key="DepotPlanSkippedResourceCollection">資源收集限時全日開放期間中のため、在庫維持をスキップしました。</system:String>
+    <system:String x:Key="DepotPlanUpdateDepotFailed">在庫データの更新に失敗しました。</system:String>
     <system:String x:Key="LessThanOneDay">1日以内</system:String>
     <system:String x:Key="1-7">1-7</system:String>
     <system:String x:Key="CE-6">龍門幣-6(CE-6)</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -858,7 +858,6 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="AddPlan">追加</system:String>
     <system:String x:Key="CollapseAll">折りたたむ</system:String>
     <system:String x:Key="DepotPlanInvalidDropItem">プラン {0}：ドロップアイテム未指定。</system:String>
-    <system:String x:Key="DepotPlanDuplicateDrop">プラン {0}：アイテム ｢{1}｣ はプラン {2} と重複。</system:String>
     <system:String x:Key="DepotPlanZeroDropCount">プラン {0}：目標在庫が 0。</system:String>
     <system:String x:Key="DepotPlanNoStage">プラン {0}：ステージ未指定または ｢現在/前回｣。</system:String>
     <system:String x:Key="DepotPlanInventoryEnough">プラン {0}：{1} 在庫十分（現在 {2} / 目標 {3}）。</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -766,6 +766,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="Roguelike">{key=AutoRoguelike}</system:String>
     <system:String x:Key="Reclamation">生息演算</system:String>
     <system:String x:Key="UserDataUpdate">ユーザーデータ更新</system:String>
+    <system:String x:Key="DepotMaintain">在庫維持</system:String>
     <system:String x:Key="MiniGame">便利機能</system:String>
     <system:String x:Key="MiniGameCategoryPermanent">常設</system:String>
     <system:String x:Key="MiniGameCategoryCurrentEvent">現在のイベント</system:String>
@@ -852,6 +853,13 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="Inventory">在庫</system:String>
     <system:String x:Key="InventoryUpdateTip">在庫データは ｢{key=Toolbox}-{key=DepotRecognition}｣ で更新できます</system:String>
     <system:String x:Key="SpecifiedDropsInventoryUnavailable">タスク ｢{0}｣ では {key=TargetInventory} が有効ですが、利用可能な在庫データがないためスキップされました。｢{key=Toolbox}-{key=DepotRecognition}｣ で在庫を更新してください。</system:String>
+    <!--  在庫維持  -->
+    <system:String x:Key="AddPlan">追加</system:String>
+    <system:String x:Key="CollapseAll">折りたたむ</system:String>
+    <system:String x:Key="DepotPlanInvalidDropItem">プラン {0}：ドロップアイテムが無効です。</system:String>
+    <system:String x:Key="DepotPlanInventoryEnough">プラン {0}：在庫が十分です。</system:String>
+    <system:String x:Key="DepotPlanStageNotOpen">プラン {0}：ステージ「{1}」は公開されていません。</system:String>
+    <system:String x:Key="DepotPlanAddTaskFailed">プラン {0}：タスクの追加に失敗しました。</system:String>
     <system:String x:Key="LessThanOneDay">1日以内</system:String>
     <system:String x:Key="1-7">1-7</system:String>
     <system:String x:Key="CE-6">龍門幣-6(CE-6)</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -349,7 +349,7 @@
 • {key=Quantity}: この理性作戦タスク中で、その素材のドロップ数が設定値に達するまで周回します。
 • {key=TargetInventory}: ｢{key=Toolbox}-{key=DepotRecognition}｣ に保存された在庫データを参照し、設定した在庫数になるまで補充します。
   • 在庫データはキャッシュのため、手動周回や素材の使用後は実際とずれる場合があります。｢{key=UserDataUpdate}｣ または ｢{key=Toolbox}-{key=DepotRecognition}｣ で同期してください。
-  • {key=TargetInventory} を有効にすると、実行中は素材や数量を変更できません。</system:String>
+  • 実行中はドロップに応じて在庫がリアルタイム更新され、前のタスクでドロップした素材が後続タスクの不足数に反映されます。</system:String>
     <system:String x:Key="StartupUpdateCheck">起動時の更新チェック</system:String>
     <system:String x:Key="UpdateAutoCheck">定期的な更新チェック</system:String>
     <system:String x:Key="UpdateAutoCheckTip">ゲーム内 00:00 / 18:00（サーバー現地時間 04:00 / 22:00）</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -857,9 +857,12 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="DepotUpdateBeforeStart">タスク開始前に在庫データを更新</system:String>
     <system:String x:Key="AddPlan">追加</system:String>
     <system:String x:Key="CollapseAll">折りたたむ</system:String>
-    <system:String x:Key="DepotPlanInvalidDropItem">プラン {0}：ドロップアイテムが無効です。</system:String>
-    <system:String x:Key="DepotPlanInventoryEnough">プラン {0}：在庫が十分です。</system:String>
-    <system:String x:Key="DepotPlanStageNotOpen">プラン {0}：ステージ「{1}」は公開されていません。</system:String>
+    <system:String x:Key="DepotPlanInvalidDropItem">プラン {0}：ドロップアイテム未指定。</system:String>
+    <system:String x:Key="DepotPlanDuplicateDrop">プラン {0}：アイテム ｢{1}｣ はプラン {2} と重複。</system:String>
+    <system:String x:Key="DepotPlanZeroDropCount">プラン {0}：目標在庫が 0。</system:String>
+    <system:String x:Key="DepotPlanNoStage">プラン {0}：ステージ未指定または ｢現在/前回｣。</system:String>
+    <system:String x:Key="DepotPlanInventoryEnough">プラン {0}：{1} 在庫十分（現在 {2} / 目標 {3}）。</system:String>
+    <system:String x:Key="DepotPlanStageNotOpen">プラン {0}：ステージ ｢{1}｣ は公開されていません。</system:String>
     <system:String x:Key="DepotPlanAddTaskFailed">プラン {0}：タスクの追加に失敗しました。</system:String>
     <system:String x:Key="DepotSkipDuringActivity">イベント期間中はスキップ</system:String>
     <system:String x:Key="DepotSkipDuringResourceCollection">資源收集限時全日開放期間中はスキップ</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -855,12 +855,18 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="InventoryUpdateTip">재고 데이터는  ｢{key=Toolbox}-{key=DepotRecognition}｣ 을 통해 업데이트 가능</system:String>
     <system:String x:Key="SpecifiedDropsInventoryUnavailable">작업 "{0}" 에서 {key=TargetInventory} 가 켜져 있지만 현재 사용할 수 있는 재고 데이터가 없어 건너뜁니다. ｢{key=Toolbox}-{key=DepotRecognition}｣ 에서 재고를 업데이트해 주세요.</system:String>
     <!--  재고 유지  -->
+    <system:String x:Key="DepotUpdateBeforeStart">작업 시작 전 재고 데이터 업데이트</system:String>
     <system:String x:Key="AddPlan">추가</system:String>
     <system:String x:Key="CollapseAll">접기</system:String>
     <system:String x:Key="DepotPlanInvalidDropItem">계획 {0}: 드롭 아이템이 유효하지 않습니다.</system:String>
     <system:String x:Key="DepotPlanInventoryEnough">계획 {0}: 재고가 충분합니다.</system:String>
     <system:String x:Key="DepotPlanStageNotOpen">계획 {0}: 스테이지 '{1}' 가 열려 있지 않습니다.</system:String>
     <system:String x:Key="DepotPlanAddTaskFailed">계획 {0}: 작업 추가 실패.</system:String>
+    <system:String x:Key="DepotSkipDuringActivity">이벤트 기간 중 건너뛰기</system:String>
+    <system:String x:Key="DepotSkipDuringResourceCollection">자원 수집 한정 전일 개방 기간 중 건너뛰기</system:String>
+    <system:String x:Key="DepotPlanSkippedActivity">이벤트 진행 중이므로 재고 유지를 건너뛰었습니다.</system:String>
+    <system:String x:Key="DepotPlanSkippedResourceCollection">자원 수집 한정 전일 개방 기간 중이므로 재고 유지를 건너뛰었습니다.</system:String>
+    <system:String x:Key="DepotPlanUpdateDepotFailed">재고 데이터 업데이트에 실패했습니다.</system:String>
     <system:String x:Key="LessThanOneDay">1일 미만</system:String>
     <system:String x:Key="1-7">1-7</system:String>
     <system:String x:Key="CE-6">CE-6 (용문폐)</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -767,6 +767,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="Roguelike">{key=AutoRoguelike}</system:String>
     <system:String x:Key="Reclamation">생존 연산</system:String>
     <system:String x:Key="UserDataUpdate">사용자 데이터 업데이트</system:String>
+    <system:String x:Key="DepotMaintain">재고 유지</system:String>
     <system:String x:Key="MiniGame">편의 기능</system:String>
     <system:String x:Key="MiniGameCategoryPermanent">상시</system:String>
     <system:String x:Key="MiniGameCategoryCurrentEvent">현재 이벤트</system:String>
@@ -853,6 +854,13 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="Inventory">재고</system:String>
     <system:String x:Key="InventoryUpdateTip">재고 데이터는  ｢{key=Toolbox}-{key=DepotRecognition}｣ 을 통해 업데이트 가능</system:String>
     <system:String x:Key="SpecifiedDropsInventoryUnavailable">작업 "{0}" 에서 {key=TargetInventory} 가 켜져 있지만 현재 사용할 수 있는 재고 데이터가 없어 건너뜁니다. ｢{key=Toolbox}-{key=DepotRecognition}｣ 에서 재고를 업데이트해 주세요.</system:String>
+    <!--  재고 유지  -->
+    <system:String x:Key="AddPlan">추가</system:String>
+    <system:String x:Key="CollapseAll">접기</system:String>
+    <system:String x:Key="DepotPlanInvalidDropItem">계획 {0}: 드롭 아이템이 유효하지 않습니다.</system:String>
+    <system:String x:Key="DepotPlanInventoryEnough">계획 {0}: 재고가 충분합니다.</system:String>
+    <system:String x:Key="DepotPlanStageNotOpen">계획 {0}: 스테이지 '{1}' 가 열려 있지 않습니다.</system:String>
+    <system:String x:Key="DepotPlanAddTaskFailed">계획 {0}: 작업 추가 실패.</system:String>
     <system:String x:Key="LessThanOneDay">1일 미만</system:String>
     <system:String x:Key="1-7">1-7</system:String>
     <system:String x:Key="CE-6">CE-6 (용문폐)</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -858,8 +858,11 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="DepotUpdateBeforeStart">작업 시작 전 재고 데이터 업데이트</system:String>
     <system:String x:Key="AddPlan">추가</system:String>
     <system:String x:Key="CollapseAll">접기</system:String>
-    <system:String x:Key="DepotPlanInvalidDropItem">계획 {0}: 드롭 아이템이 유효하지 않습니다.</system:String>
-    <system:String x:Key="DepotPlanInventoryEnough">계획 {0}: 재고가 충분합니다.</system:String>
+    <system:String x:Key="DepotPlanInvalidDropItem">계획 {0}: 드롭 아이템 미지정.</system:String>
+    <system:String x:Key="DepotPlanDuplicateDrop">계획 {0}: 아이템 '{1}' 이(가) 계획 {2} 와 중복.</system:String>
+    <system:String x:Key="DepotPlanZeroDropCount">계획 {0}: 목표 재고가 0.</system:String>
+    <system:String x:Key="DepotPlanNoStage">계획 {0}: 스테이지 미지정 또는 \"현재/이전\".</system:String>
+    <system:String x:Key="DepotPlanInventoryEnough">계획 {0}: {1} 재고 충분 (현재 {2} / 목표 {3}).</system:String>
     <system:String x:Key="DepotPlanStageNotOpen">계획 {0}: 스테이지 '{1}' 가 열려 있지 않습니다.</system:String>
     <system:String x:Key="DepotPlanAddTaskFailed">계획 {0}: 작업 추가 실패.</system:String>
     <system:String x:Key="DepotSkipDuringActivity">이벤트 기간 중 건너뛰기</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -349,7 +349,7 @@
 • {key=Quantity}: 현재 전투 작업에서 해당 재료의 드롭 수를 목표로 삼아, 설정한 수량에 도달하면 멈춥니다.
 • {key=TargetInventory}: ｢{key=Toolbox}-{key=DepotRecognition}｣ 에 저장된 재고 데이터를 참고하여 설정한 재고 수량까지만 보충합니다.
   • 재고 데이터는 캐시이므로 수동 파밍, 제작, 재료 사용 후 실제 수량과 달라질 수 있습니다. ｢{key=UserDataUpdate}｣ 또는 ｢{key=Toolbox}-{key=DepotRecognition}｣ 에서 동기화해 주세요.
-  • {key=TargetInventory} 사용 중에는 실행 도중 재료와 수량을 바꿀 수 없습니다.</system:String>
+  • 실행 중에는 드롭에 따라 재고가 실시간 업데이트되며, 이전 작업에서 드롭된 재료가 후속 작업의 부족 수량에 반영됩니다.</system:String>
     <system:String x:Key="StartupUpdateCheck">시작 시 업데이트 확인</system:String>
     <system:String x:Key="UpdateAutoCheck">일정 시간마다 업데이트 확인</system:String>
     <system:String x:Key="UpdateAutoCheckTip">게임 내 00:00 / 18:00 (서버 현지 시간 04:00 / 22:00)</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -859,7 +859,6 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="AddPlan">추가</system:String>
     <system:String x:Key="CollapseAll">접기</system:String>
     <system:String x:Key="DepotPlanInvalidDropItem">계획 {0}: 드롭 아이템 미지정.</system:String>
-    <system:String x:Key="DepotPlanDuplicateDrop">계획 {0}: 아이템 '{1}' 이(가) 계획 {2} 와 중복.</system:String>
     <system:String x:Key="DepotPlanZeroDropCount">계획 {0}: 목표 재고가 0.</system:String>
     <system:String x:Key="DepotPlanNoStage">계획 {0}: 스테이지 미지정 또는 \"현재/이전\".</system:String>
     <system:String x:Key="DepotPlanInventoryEnough">계획 {0}: {1} 재고 충분 (현재 {2} / 목표 {3}).</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -766,6 +766,7 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="Roguelike">{key=AutoRoguelike}</system:String>
     <system:String x:Key="Reclamation">生息演算</system:String>
     <system:String x:Key="UserDataUpdate">更新数据</system:String>
+    <system:String x:Key="DepotMaintain">库存保持</system:String>
     <system:String x:Key="MiniGame">牛杂</system:String>
     <system:String x:Key="MiniGameCategoryPermanent">常驻活动</system:String>
     <system:String x:Key="MiniGameCategoryCurrentEvent">当期活动</system:String>
@@ -852,6 +853,13 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="Inventory">库存</system:String>
     <system:String x:Key="InventoryUpdateTip">可通过 ｢{key=Toolbox}-{key=DepotRecognition}｣ 更新库存数据</system:String>
     <system:String x:Key="SpecifiedDropsInventoryUnavailable">任务 ｢{0}｣ 启用了 {key=TargetInventory}，但当前没有可用的库存数据，已跳过。可通过 ｢{key=Toolbox}-{key=DepotRecognition}｣ 更新库存。</system:String>
+    <!--  库存保持  -->
+    <system:String x:Key="AddPlan">添加</system:String>
+    <system:String x:Key="CollapseAll">折叠</system:String>
+    <system:String x:Key="DepotPlanInvalidDropItem">计划 {0}：掉落物无效。</system:String>
+    <system:String x:Key="DepotPlanInventoryEnough">计划 {0}：库存已充足。</system:String>
+    <system:String x:Key="DepotPlanStageNotOpen">计划 {0}：关卡「{1}」未开放。</system:String>
+    <system:String x:Key="DepotPlanAddTaskFailed">计划 {0}：添加任务失败。</system:String>
     <system:String x:Key="LessThanOneDay">不到 1 天</system:String>
     <system:String x:Key="1-7">1-7</system:String>
     <system:String x:Key="CE-6">龙门币-6/5</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -858,7 +858,6 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="AddPlan">添加</system:String>
     <system:String x:Key="CollapseAll">折叠</system:String>
     <system:String x:Key="DepotPlanInvalidDropItem">计划 {0}：未指定掉落物。</system:String>
-    <system:String x:Key="DepotPlanDuplicateDrop">计划 {0}：材料 ｢{1}｣ 与计划 {2} 重复。</system:String>
     <system:String x:Key="DepotPlanZeroDropCount">计划 {0}：目标库存为 0。</system:String>
     <system:String x:Key="DepotPlanNoStage">计划 {0}：关卡未指定或为 ｢当前/上次｣。</system:String>
     <system:String x:Key="DepotPlanInventoryEnough">计划 {0}：{1} 库存已充足（当前 {2} / 目标 {3}）。</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -857,9 +857,12 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="DepotUpdateBeforeStart">任务开始前更新库存数据</system:String>
     <system:String x:Key="AddPlan">添加</system:String>
     <system:String x:Key="CollapseAll">折叠</system:String>
-    <system:String x:Key="DepotPlanInvalidDropItem">计划 {0}：掉落物无效。</system:String>
-    <system:String x:Key="DepotPlanInventoryEnough">计划 {0}：库存已充足。</system:String>
-    <system:String x:Key="DepotPlanStageNotOpen">计划 {0}：关卡「{1}」未开放。</system:String>
+    <system:String x:Key="DepotPlanInvalidDropItem">计划 {0}：未指定掉落物。</system:String>
+    <system:String x:Key="DepotPlanDuplicateDrop">计划 {0}：材料 ｢{1}｣ 与计划 {2} 重复。</system:String>
+    <system:String x:Key="DepotPlanZeroDropCount">计划 {0}：目标库存为 0。</system:String>
+    <system:String x:Key="DepotPlanNoStage">计划 {0}：关卡未指定或为 ｢当前/上次｣。</system:String>
+    <system:String x:Key="DepotPlanInventoryEnough">计划 {0}：{1} 库存已充足（当前 {2} / 目标 {3}）。</system:String>
+    <system:String x:Key="DepotPlanStageNotOpen">计划 {0}：关卡 ｢{1}｣ 未开放。</system:String>
     <system:String x:Key="DepotPlanAddTaskFailed">计划 {0}：添加任务失败。</system:String>
     <system:String x:Key="DepotSkipDuringActivity">活动期间跳过</system:String>
     <system:String x:Key="DepotSkipDuringResourceCollection">资源收集限时全天开放期间跳过</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -349,7 +349,7 @@
 • {key=Quantity}：以当前理智作战任务中该材料的掉落数量为目标，达到设定数量后停止。
 • {key=TargetInventory}：会参考 ｢{key=Toolbox}-{key=DepotRecognition}｣ 中保存的库存数据，只补到设定库存为止。
   • 库存数据是缓存值，手动刷关、合成或消耗材料后可能与实际不一致；可通过 ｢{key=UserDataUpdate}｣ 或 ｢{key=Toolbox}-{key=DepotRecognition}｣ 同步。
-  • 使用 {key=TargetInventory} 时，开始后不能临时修改材料和数量。</system:String>
+  • 运行时会根据掉落实时更新库存，前序任务刷出的材料会影响后续任务的缺口计算。</system:String>
     <system:String x:Key="StartupUpdateCheck">启动时检查更新</system:String>
     <system:String x:Key="UpdateAutoCheck">定时检查更新</system:String>
     <system:String x:Key="UpdateAutoCheckTip">游戏内 00:00 / 18:00（对应服务器当地时间 04:00 / 22:00）</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -854,12 +854,18 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="InventoryUpdateTip">可通过 ｢{key=Toolbox}-{key=DepotRecognition}｣ 更新库存数据</system:String>
     <system:String x:Key="SpecifiedDropsInventoryUnavailable">任务 ｢{0}｣ 启用了 {key=TargetInventory}，但当前没有可用的库存数据，已跳过。可通过 ｢{key=Toolbox}-{key=DepotRecognition}｣ 更新库存。</system:String>
     <!--  库存保持  -->
+    <system:String x:Key="DepotUpdateBeforeStart">任务开始前更新库存数据</system:String>
     <system:String x:Key="AddPlan">添加</system:String>
     <system:String x:Key="CollapseAll">折叠</system:String>
     <system:String x:Key="DepotPlanInvalidDropItem">计划 {0}：掉落物无效。</system:String>
     <system:String x:Key="DepotPlanInventoryEnough">计划 {0}：库存已充足。</system:String>
     <system:String x:Key="DepotPlanStageNotOpen">计划 {0}：关卡「{1}」未开放。</system:String>
     <system:String x:Key="DepotPlanAddTaskFailed">计划 {0}：添加任务失败。</system:String>
+    <system:String x:Key="DepotSkipDuringActivity">活动期间跳过</system:String>
+    <system:String x:Key="DepotSkipDuringResourceCollection">资源收集限时全天开放期间跳过</system:String>
+    <system:String x:Key="DepotPlanSkippedActivity">当前有活动进行中，已跳过库存保持。</system:String>
+    <system:String x:Key="DepotPlanSkippedResourceCollection">当前处于资源收集限时全天开放期间，已跳过库存保持。</system:String>
+    <system:String x:Key="DepotPlanUpdateDepotFailed">更新库存数据失败。</system:String>
     <system:String x:Key="LessThanOneDay">不到 1 天</system:String>
     <system:String x:Key="1-7">1-7</system:String>
     <system:String x:Key="CE-6">龙门币-6/5</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -349,7 +349,7 @@
 • {key=Quantity}：以目前理智作戰任務中該材料的掉落數量為目標，達到設定數量後停止。
 • {key=TargetInventory}：會參考 ｢{key=Toolbox}-{key=DepotRecognition}｣ 中保存的庫存資料，只補到設定庫存為止。
   • 庫存資料是快取值，手動刷關、合成或消耗材料後可能與實際不一致；可透過 ｢{key=UserDataUpdate}｣ 或 ｢{key=Toolbox}-{key=DepotRecognition}｣ 同步。
-  • 使用 {key=TargetInventory} 時，開始後不能臨時修改材料與數量。</system:String>
+  • 執行時會根據掉落即時更新庫存，前序任務刷出的材料會影響後續任務的缺口計算。</system:String>
     <system:String x:Key="StartupUpdateCheck">啟動時檢查更新</system:String>
     <system:String x:Key="UpdateAutoCheck">定時檢查更新</system:String>
     <system:String x:Key="UpdateAutoCheckTip">遊戲內 00:00 / 18:00（對應伺服器當地時間 04:00 / 22:00）</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -857,9 +857,12 @@ C:\\leidian\\LDPlayer9\n
     <system:String x:Key="DepotUpdateBeforeStart">任務開始前更新庫存資料</system:String>
     <system:String x:Key="AddPlan">新增</system:String>
     <system:String x:Key="CollapseAll">折疊</system:String>
-    <system:String x:Key="DepotPlanInvalidDropItem">計劃 {0}：掉落物無效。</system:String>
-    <system:String x:Key="DepotPlanInventoryEnough">計劃 {0}：庫存已充足。</system:String>
-    <system:String x:Key="DepotPlanStageNotOpen">計劃 {0}：關卡「{1}」未開放。</system:String>
+    <system:String x:Key="DepotPlanInvalidDropItem">計劃 {0}：未指定掉落物。</system:String>
+    <system:String x:Key="DepotPlanDuplicateDrop">計劃 {0}：材料 ｢{1}｣ 與計劃 {2} 重複。</system:String>
+    <system:String x:Key="DepotPlanZeroDropCount">計劃 {0}：目標庫存為 0。</system:String>
+    <system:String x:Key="DepotPlanNoStage">計劃 {0}：關卡未指定或為 ｢當前/上次｣。</system:String>
+    <system:String x:Key="DepotPlanInventoryEnough">計劃 {0}：{1} 庫存已充足（當前 {2} / 目標 {3}）。</system:String>
+    <system:String x:Key="DepotPlanStageNotOpen">計劃 {0}：關卡 ｢{1}｣ 未開放。</system:String>
     <system:String x:Key="DepotPlanAddTaskFailed">計劃 {0}：新增任務失敗。</system:String>
     <system:String x:Key="DepotSkipDuringActivity">活動期間跳過</system:String>
     <system:String x:Key="DepotSkipDuringResourceCollection">資源收集限時全天開放期間跳過</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -858,7 +858,6 @@ C:\\leidian\\LDPlayer9\n
     <system:String x:Key="AddPlan">新增</system:String>
     <system:String x:Key="CollapseAll">折疊</system:String>
     <system:String x:Key="DepotPlanInvalidDropItem">計劃 {0}：未指定掉落物。</system:String>
-    <system:String x:Key="DepotPlanDuplicateDrop">計劃 {0}：材料 ｢{1}｣ 與計劃 {2} 重複。</system:String>
     <system:String x:Key="DepotPlanZeroDropCount">計劃 {0}：目標庫存為 0。</system:String>
     <system:String x:Key="DepotPlanNoStage">計劃 {0}：關卡未指定或為 ｢當前/上次｣。</system:String>
     <system:String x:Key="DepotPlanInventoryEnough">計劃 {0}：{1} 庫存已充足（當前 {2} / 目標 {3}）。</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -854,12 +854,18 @@ C:\\leidian\\LDPlayer9\n
     <system:String x:Key="InventoryUpdateTip">可透過 ｢{key=Toolbox}-{key=DepotRecognition}｣ 更新庫存數據</system:String>
     <system:String x:Key="SpecifiedDropsInventoryUnavailable">任務 ｢{0}｣ 啟用了 {key=TargetInventory}，但目前沒有可用的庫存資料，已跳過。可透過 ｢{key=Toolbox}-{key=DepotRecognition}｣ 更新庫存。</system:String>
     <!--  庫存保持  -->
+    <system:String x:Key="DepotUpdateBeforeStart">任務開始前更新庫存資料</system:String>
     <system:String x:Key="AddPlan">新增</system:String>
     <system:String x:Key="CollapseAll">折疊</system:String>
     <system:String x:Key="DepotPlanInvalidDropItem">計劃 {0}：掉落物無效。</system:String>
     <system:String x:Key="DepotPlanInventoryEnough">計劃 {0}：庫存已充足。</system:String>
     <system:String x:Key="DepotPlanStageNotOpen">計劃 {0}：關卡「{1}」未開放。</system:String>
     <system:String x:Key="DepotPlanAddTaskFailed">計劃 {0}：新增任務失敗。</system:String>
+    <system:String x:Key="DepotSkipDuringActivity">活動期間跳過</system:String>
+    <system:String x:Key="DepotSkipDuringResourceCollection">資源收集限時全天開放期間跳過</system:String>
+    <system:String x:Key="DepotPlanSkippedActivity">目前有活動進行中，已跳過庫存保持。</system:String>
+    <system:String x:Key="DepotPlanSkippedResourceCollection">目前處於資源收集限時全天開放期間，已跳過庫存保持。</system:String>
+    <system:String x:Key="DepotPlanUpdateDepotFailed">更新庫存資料失敗。</system:String>
     <system:String x:Key="LessThanOneDay">不到 1 天</system:String>
     <system:String x:Key="1-7">1-7</system:String>
     <system:String x:Key="CE-6">龍門幣-6/5</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -766,6 +766,7 @@ C:\\leidian\\LDPlayer9\n
     <system:String x:Key="Roguelike">{key=AutoRoguelike}</system:String>
     <system:String x:Key="Reclamation">生息演算</system:String>
     <system:String x:Key="UserDataUpdate">更新使用者資料</system:String>
+    <system:String x:Key="DepotMaintain">庫存保持</system:String>
     <system:String x:Key="MiniGame">快捷功能</system:String>
     <system:String x:Key="MiniGameCategoryPermanent">常駐</system:String>
     <system:String x:Key="MiniGameCategoryCurrentEvent">目前活動</system:String>
@@ -852,6 +853,13 @@ C:\\leidian\\LDPlayer9\n
     <system:String x:Key="Inventory">庫存</system:String>
     <system:String x:Key="InventoryUpdateTip">可透過 ｢{key=Toolbox}-{key=DepotRecognition}｣ 更新庫存數據</system:String>
     <system:String x:Key="SpecifiedDropsInventoryUnavailable">任務 ｢{0}｣ 啟用了 {key=TargetInventory}，但目前沒有可用的庫存資料，已跳過。可透過 ｢{key=Toolbox}-{key=DepotRecognition}｣ 更新庫存。</system:String>
+    <!--  庫存保持  -->
+    <system:String x:Key="AddPlan">新增</system:String>
+    <system:String x:Key="CollapseAll">折疊</system:String>
+    <system:String x:Key="DepotPlanInvalidDropItem">計劃 {0}：掉落物無效。</system:String>
+    <system:String x:Key="DepotPlanInventoryEnough">計劃 {0}：庫存已充足。</system:String>
+    <system:String x:Key="DepotPlanStageNotOpen">計劃 {0}：關卡「{1}」未開放。</system:String>
+    <system:String x:Key="DepotPlanAddTaskFailed">計劃 {0}：新增任務失敗。</system:String>
     <system:String x:Key="LessThanOneDay">不到 1 天</system:String>
     <system:String x:Key="1-7">1-7</system:String>
     <system:String x:Key="CE-6">龍門幣-6/5</system:String>

--- a/src/MaaWpfGui/Services/StageManager.cs
+++ b/src/MaaWpfGui/Services/StageManager.cs
@@ -76,6 +76,28 @@ public class StageManager
 
     public IReadOnlyDictionary<string, SideStoryActivity> ActivityList => _activityList.AsReadOnly();
 
+    // 资源全开放活动（resourceCollection），用于判断当前是否处于资源全开放期间
+    private StageActivityInfo _resourceCollection = new() { IsResourceCollection = true };
+
+    /// <summary>
+    /// 判断当前是否有 SideStory（SideStory/故事集/别的限时）活动进行中。
+    /// </summary>
+    /// <returns>存在进行中的活动则返回 <c>true</c>。</returns>
+    public bool IsActivityOpen()
+    {
+        var time = DateTimeOffset.Now;
+        return _activityList.Any(ss => ss.Value.Info.StartTimeUtc <= time && time <= ss.Value.Info.ExpireTimeUtc);
+    }
+
+    /// <summary>
+    /// 判断当前是否处于资源全开放活动（resourceCollection）期间。
+    /// </summary>
+    /// <returns>处于资源全开放期间则返回 <c>true</c>。</returns>
+    public bool IsResourceCollectionOpen()
+    {
+        return _resourceCollection.BeingOpen;
+    }
+
     // mini game entries exposed from StageActivityV2 (richer model including Tip/TipKey)
     private List<MiniGameEntry> _miniGameEntries = InitializeDefaultMiniGameEntries();
 
@@ -268,6 +290,7 @@ public class StageManager
         AddPermanentStages(tempStage, resourceCollection);
 
         _stages = tempStage;
+        _resourceCollection = resourceCollection;
 
         // parse mini-game tasks from activity json if provided (use helper to populate temp list)
         var tempMiniGames = InitializeDefaultMiniGameEntries();

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -133,6 +133,11 @@ public class TaskQueueViewModel : Screen
     public static UserDataUpdateSettingsUserControlModel UserDataUpdateTask => UserDataUpdateSettingsUserControlModel.Instance;
 
     /// <summary>
+    /// Gets 库存维持任务Model
+    /// </summary>
+    public static DepotMaintainTaskUserControlModel DepotMaintainTask => DepotMaintainTaskUserControlModel.Instance;
+
+    /// <summary>
     /// Gets 生稀盐酸任务Model
     /// </summary>
     public static CustomSettingsUserControlModel CustomTask => CustomSettingsUserControlModel.Instance;
@@ -1345,6 +1350,7 @@ public class TaskQueueViewModel : Screen
             new GenericCombinedData<Type> { Display = LocalizationHelper.GetString("Roguelike"), Value = typeof(RoguelikeTask) },
             new GenericCombinedData<Type> { Display = LocalizationHelper.GetString("Reclamation"), Value = typeof(ReclamationTask) },
             new GenericCombinedData<Type> { Display = LocalizationHelper.GetString("UserDataUpdate"), Value = typeof(UserDataUpdateTask) },
+            new GenericCombinedData<Type> { Display = LocalizationHelper.GetString("DepotMaintain"), Value = typeof(DepotMaintainTask) },
             new GenericCombinedData<Type> { Display = LocalizationHelper.GetString("Custom"), Value = typeof(CustomTask) },
         ]);
 

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -1074,9 +1074,10 @@ public class TaskQueueViewModel : Screen
     {
         UpdateDatePrompt();
         var task = FightTask.UpdateStageList();
+        var task2 = DepotMaintainTask.UpdateStageList();
         if (waitStageListUpdated)
         {
-            task.Wait();
+            Task.WaitAll(task, task2);
         }
         ToolboxViewModel.UpdateMiniGameTaskList();
     }

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -1370,6 +1370,7 @@ public class TaskQueueViewModel : Screen
                 nameof(RoguelikeTask) => LocalizationHelper.GetString("Roguelike"),
                 nameof(ReclamationTask) => LocalizationHelper.GetString("Reclamation"),
                 nameof(UserDataUpdateTask) => LocalizationHelper.GetString("UserDataUpdate"),
+                nameof(DepotMaintainTask) => LocalizationHelper.GetString("DepotMaintain"),
                 nameof(CustomTask) => LocalizationHelper.GetString("Custom"),
                 _ => item.Display,
             };

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/GameSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/GameSettingsUserControlModel.cs
@@ -93,6 +93,7 @@ public class GameSettingsUserControlModel : PropertyChangedBase
             ConfigurationHelper.SetValue(ConfigurationKeys.ClientType, value);
             VersionUpdateSettings.ResourceInfoUpdate();
             FightSettingsUserControlModel.Instance.UpdateStageList();
+            DepotMaintainTaskUserControlModel.Instance.UpdateStageList();
             Instances.TaskQueueViewModel.UpdateDatePrompt();
 
             if (!NeedRestartAfterClientTypeChange(oldValue, value))

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
@@ -226,7 +226,6 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
     {
         return Execute.OnUIThreadAsync(async () => {
             using var log = new LogScope(_logger);
-            var stageList = Instances.StageManager.GetStageList();
             await TaskQueueViewModel.TaskQueueSerializingLock.WaitAsync();
 
             RefreshStageList();

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
@@ -42,7 +42,11 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
 
     public DepotMaintainTaskUserControlModel()
     {
-        PlanList.CollectionChanged += (_, __) => SavePlan();
+        PlanList.CollectionChanged += (_, __) =>
+        {
+            SavePlan();
+            NotifyOfPropertyChange(nameof(PlanInfo));
+        };
     }
 
     public static DepotMaintainTaskUserControlModel Instance { get; }
@@ -109,8 +113,31 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
 
     public string PlanInfo => string.Join("\n", PlanList.Select((t, i) => $"{i + 1}: {StageListSource.FirstOrDefault(i => i.Value == t.Stage)?.Display ?? t.Stage} - {t.DropName} x{t.DropCount}"));
 
+    /// <summary>
+    /// 单个 Plan 属性变化时，保存配置并通知 UI 刷新。
+    /// </summary>
+    /// <param name="notifyProperties">需要通知刷新的属性名。</param>
+    public void OnPlanChanged(params string[] notifyProperties)
+    {
+        if (IsRefreshingUI)
+        {
+            return;
+        }
+
+        SavePlan();
+        foreach (var prop in notifyProperties)
+        {
+            NotifyOfPropertyChange(prop);
+        }
+    }
+
     private void SavePlan()
     {
+        if (IsRefreshingUI)
+        {
+            return;
+        }
+
         var list = PlanList.Select(i => new DepotMaintainTask.Plan(i.Stage, i.DropId, i.DropCount, i.UseMedicine, i.MedicineCount, i.UseStone, i.StoneCount));
         SetTaskConfig<DepotMaintainTask>(t => t.PlanList.SequenceEqual(list), t => t.PlanList = [.. list]);
     }
@@ -144,6 +171,8 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
         {
             return;
         }
+
+        using var refresh = new UiRefreshingScope();
         var stageList = Instances.StageManager.GetStageList().Where(i => i.Value != AnnihilationName).ToList();
         var listCurrent = current.PlanList.ToList();
 
@@ -181,8 +210,7 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
         {
             get; set {
                 SetAndNotify(ref field, value);
-                Instance.NotifyOfPropertyChange(nameof(PlanInfo));
-                NotifyOfPropertyChange(nameof(Title));
+                Instance.OnPlanChanged(nameof(PlanInfo), nameof(Title));
             }
         } = string.Empty;
 
@@ -193,8 +221,7 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
         {
             get; set {
                 SetAndNotify(ref field, value);
-                Instance.NotifyOfPropertyChange(nameof(PlanInfo));
-                NotifyOfPropertyChange(nameof(Title));
+                Instance.OnPlanChanged(nameof(PlanInfo), nameof(Title));
             }
         } = string.Empty;
 
@@ -207,8 +234,7 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
         {
             get; set {
                 SetAndNotify(ref field, value);
-                Instance.NotifyOfPropertyChange(nameof(PlanInfo));
-                NotifyOfPropertyChange(nameof(Title));
+                Instance.OnPlanChanged(nameof(PlanInfo), nameof(Title));
             }
         }
 
@@ -243,6 +269,8 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
         {
             return;
         }
+
+        using var refresh = new UiRefreshingScope();
         var list = new List<Plan>();
         foreach (var plan in task.PlanList)
         {
@@ -256,10 +284,14 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
                 StoneCount = plan.StoneCount,
             };
             list.Add(uiPlan);
-            uiPlan.PropertyChanged += (_, __) => SavePlan();
         }
         PlanList = [.. list];
-        PlanList.CollectionChanged += (_, __) => SavePlan();
+        PlanList.CollectionChanged += (_, __) =>
+        {
+            SavePlan();
+            NotifyOfPropertyChange(nameof(PlanInfo));
+        };
+        NotifyOfPropertyChange(nameof(PlanInfo));
         Refresh();
     }
 
@@ -358,6 +390,29 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
                 return (true, taskIds);
             }
             return (null, []);
+        }
+    }
+
+    /// <summary>
+    /// UI 刷新作用域，防止刷新期间 ComboBox 等控件的绑定回写覆盖配置。
+    /// </summary>
+    private struct UiRefreshingScope : IDisposable
+    {
+        private static int _depth = 0;
+
+        public UiRefreshingScope()
+        {
+            ++_depth;
+            Instance.IsRefreshingUI = true;
+        }
+
+        readonly void IDisposable.Dispose()
+        {
+            --_depth;
+            if (_depth == 0)
+            {
+                Instance.IsRefreshingUI = false;
+            }
         }
     }
 }

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
@@ -53,7 +53,7 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
         set => SetTaskConfig<DepotMaintainTask>(t => t.UpdateDepot == value, t => t.UpdateDepot = value);
     }
 
-    public ObservableCollection<Plan> PlanList { get; private set => SetAndNotify(ref field, value); } = [new Plan()];
+    public ObservableCollection<Plan> PlanList { get; private set => SetAndNotify(ref field, value); } = [];
 
     public void AddPlan()
     {
@@ -113,7 +113,6 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
             //using (var refresh = new UiRefreshingScope())
             {
                 RefreshStageList();
-                RefreshCurrentStagePlan();
             }
             TaskQueueViewModel.TaskQueueSerializingLock.Release();
         });
@@ -125,8 +124,8 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
         {
             return;
         }
-        var stageList = Instances.StageManager.GetStageList().ToList();
-        var listCurrent = current.PlanList;
+        var stageList = Instances.StageManager.GetStageList().Where(i => i.Value != AnnihilationName).ToList();
+        var listCurrent = current.PlanList.ToList();
 
         var listSource = stageList.Select(i => new StageSourceItem() { Display = i.Display, Value = i.Value, IsVisible = true, IsOpen = Instances.StageManager.GetStageList().FirstOrDefault(p => p.Value == i.Value)?.IsStageOpen(Instances.TaskQueueViewModel.CurDayOfWeek) ?? true }).ToList();
 
@@ -135,25 +134,11 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
         {
             listSource.Add(new StageSourceItem() { Display = item.Stage, Value = item.Stage, IsOpen = false, IsVisible = true });
         }
-        listSource.Remove(listSource.FirstOrDefault(i => i.Value == AnnihilationName) ?? new());
         StageListSource = [.. listSource];
-        current.PlanList = listCurrent; // StageListSource更新后, 恢复StagePlan
-    }
-
-    private void RefreshCurrentStagePlan()
-    {
-        if (TaskSettingVisibilityInfo.CurrentTask is not DepotMaintainTask current)
+        foreach (var (plan, currentPlan) in PlanList.Zip(listCurrent))
         {
-            return;
+            plan.Stage = currentPlan.Stage; // StageListSource更新后, 恢复StagePlan
         }
-        var plan = current.PlanList;
-        var list = plan.Select((i, index) => new Plan() { Stage = i.Stage, DropId = i.DropId, DropCount = i.DropCount, UseMedicine = i.UseMedicine, MedicineCount = i.MedicineCount, UseStone = i.UseStone, StoneCount = i.StoneCount }).ToList();
-        foreach (var item in list)
-        {
-            item.PropertyChanged += (_, __) => SavePlan();
-        }
-        PlanList = [.. list];
-        PlanList.CollectionChanged += (_, __) => SavePlan();
     }
 
     // UI 绑定的方法

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
@@ -24,6 +24,7 @@ using MaaWpfGui.Models;
 using MaaWpfGui.Models.AsstTasks;
 using MaaWpfGui.Utilities;
 using MaaWpfGui.ViewModels.UI;
+using ObservableCollections;
 using Serilog;
 using Stylet;
 using static MaaWpfGui.Main.AsstProxy;
@@ -47,6 +48,15 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
             SavePlan();
             NotifyOfPropertyChange(nameof(PlanInfo));
         };
+
+        // 仓库数据变化时刷新计划显示（当前库存数量）
+        if (Instances.ToolboxViewModel is { } toolbox)
+        {
+            toolbox.DepotResult.CollectionChanged += (in NotifyCollectionChangedEventArgs<ToolboxViewModel.DepotResultDate> _) =>
+            {
+                NotifyOfPropertyChange(nameof(PlanInfo));
+            };
+        }
     }
 
     public static DepotMaintainTaskUserControlModel Instance { get; }
@@ -111,7 +121,27 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
     /// </summary>
     public ObservableCollection<StageSourceItem> StageListSource { get; private set => SetAndNotify(ref field, value); } = [];
 
-    public string PlanInfo => string.Join("\n", PlanList.Select((t, i) => $"{i + 1}: {StageListSource.FirstOrDefault(i => i.Value == t.Stage)?.Display ?? t.Stage} - {t.DropName} x{t.DropCount}"));
+    public string PlanInfo => string.Join("\n", PlanList.Select((t, i) => $"{i + 1}: {StageListSource.FirstOrDefault(i => i.Value == t.Stage)?.Display ?? t.Stage} - {t.DropName} {GetCurrentInventoryCount(t.DropId)}/{t.DropCount}"));
+
+    /// <summary>
+    /// 获取指定掉落物当前库存数量，无数据时返回 "--"。
+    /// </summary>
+    private static string GetCurrentInventoryCount(string dropId)
+    {
+        if (string.IsNullOrEmpty(dropId))
+        {
+            return "--";
+        }
+
+        var depot = Instances.ToolboxViewModel?.DepotResult;
+        if (depot == null || depot.Count == 0)
+        {
+            return "--";
+        }
+
+        var item = depot.FirstOrDefault(i => i.Id == dropId);
+        return item?.Count >= 0 ? item.Count.ToString() : "--";
+    }
 
     /// <summary>
     /// 单个 Plan 属性变化时，保存配置并通知 UI 刷新。
@@ -210,7 +240,8 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
         {
             get; set {
                 SetAndNotify(ref field, value);
-                Instance.OnPlanChanged(nameof(PlanInfo), nameof(Title));
+                NotifyOfPropertyChange(nameof(Title));
+                Instance.OnPlanChanged(nameof(PlanInfo));
             }
         } = string.Empty;
 
@@ -221,20 +252,31 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
         {
             get; set {
                 SetAndNotify(ref field, value);
-                Instance.OnPlanChanged(nameof(PlanInfo), nameof(Title));
+                NotifyOfPropertyChange(nameof(Title));
+                Instance.OnPlanChanged(nameof(PlanInfo));
             }
         } = string.Empty;
 
         /// <summary>
         /// Gets or sets 指定掉落材料名称。
         /// </summary>
-        public string DropName { get; set => SetAndNotify(ref field, value); } = LocalizationHelper.GetString("NotSelected");
+        public string DropName
+        {
+            get => field;
+            set
+            {
+                SetAndNotify(ref field, value);
+                NotifyOfPropertyChange(nameof(Title));
+                Instance.OnPlanChanged(nameof(PlanInfo));
+            }
+        } = LocalizationHelper.GetString("NotSelected");
 
         public int DropCount
         {
             get; set {
                 SetAndNotify(ref field, value);
-                Instance.OnPlanChanged(nameof(PlanInfo), nameof(Title));
+                NotifyOfPropertyChange(nameof(Title));
+                Instance.OnPlanChanged(nameof(PlanInfo));
             }
         }
 
@@ -274,7 +316,7 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
         var list = new List<Plan>();
         foreach (var plan in task.PlanList)
         {
-            var uiPlan = new Plan() {
+            var uiPlan = new Plan {
                 Stage = plan.Stage,
                 DropId = plan.DropId,
                 DropCount = plan.DropCount,
@@ -282,6 +324,10 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
                 MedicineCount = plan.MedicineCount,
                 UseStone = plan.UseStone,
                 StoneCount = plan.StoneCount,
+
+                // 根据 DropId 从掉落列表恢复 DropName，避免初始化显示为"不选择"
+                DropName = FightSettingsUserControlModel.Instance.DropsList.FirstOrDefault(i => i.Value == plan.DropId)?.Display
+                    ?? LocalizationHelper.GetString("NotSelected"),
             };
             list.Add(uiPlan);
         }
@@ -342,34 +388,65 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
 
             var depotList = Instances.ToolboxViewModel?.DepotResult.Where(item => item.Count >= 0).ToDictionary(item => item.Id, item => item.Count) ?? [];
             var taskIds = new List<int>();
+            var seenDropIds = new Dictionary<string, int>();
             for (int i = 0; i < depot.PlanList.Count; i++)
             {
                 var plan = depot.PlanList[i];
-                if (string.IsNullOrEmpty(plan.DropId) || plan.DropCount <= 0)
+                if (string.IsNullOrEmpty(plan.DropId))
                 {
                     Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetStringFormat("DepotPlanInvalidDropItem", i + 1), UiLogColor.Error);
                     taskIds.Add(0);
                     continue;
                 }
-                var count = depotList.TryGetValue(plan.DropId, out var value) ? value : 0;
-                count = plan.DropCount - count;
-                if (count <= 0)
+                if (plan.DropCount <= 0)
                 {
-                    Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetStringFormat("DepotPlanInventoryEnough", i + 1), UiLogColor.Info);
+                    Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetStringFormat("DepotPlanZeroDropCount", i + 1), UiLogColor.Error);
                     taskIds.Add(0);
                     continue;
                 }
-                var stage = FightSettingsUserControlModel.GetFightStage([plan.Stage]);
+
+                // 检查是否有重复材料
+                if (seenDropIds.TryGetValue(plan.DropId, out var firstIndex))
+                {
+                    var dropName = ItemListHelper.GetItemName(plan.DropId) ?? plan.DropId;
+                    Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetStringFormat("DepotPlanDuplicateDrop", i + 1, dropName, firstIndex + 1), UiLogColor.Error);
+                    continue;
+                }
+                else
+                {
+                    seenDropIds[plan.DropId] = i;
+                }
+
+                var stage = GetFightStage([plan.Stage]);
                 if (string.IsNullOrEmpty(stage))
                 {
-                    Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetStringFormat("DepotPlanStageNotOpen", i + 1, plan.Stage), UiLogColor.Error);
+                    if (string.IsNullOrEmpty(plan.Stage))
+                    {
+                        Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetStringFormat("DepotPlanNoStage", i + 1), UiLogColor.Error);
+                    }
+                    else
+                    {
+                        Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetStringFormat("DepotPlanStageNotOpen", i + 1, plan.Stage), UiLogColor.Error);
+                    }
+
                     taskIds.Add(0);
                     continue;
                 }
+
+                var currentCount = depotList.TryGetValue(plan.DropId, out var value) ? value : 0;
+                var need = plan.DropCount - currentCount;
+                if (need <= 0)
+                {
+                    var dropName = ItemListHelper.GetItemName(plan.DropId) ?? plan.DropId;
+                    Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetStringFormat("DepotPlanInventoryEnough", i + 1, dropName, currentCount, plan.DropCount), UiLogColor.Info);
+                    taskIds.Add(0);
+                    continue;
+                }
+
                 var fight = new AsstFightTask() {
                     Stage = stage,
-                    Drops = new() { { plan.DropId, count } },
-                    MaxTimes = count > 0 ? int.MaxValue : 0,
+                    Drops = new() { { plan.DropId, need } },
+                    MaxTimes = need > 0 ? int.MaxValue : 0,
                     Medicine = plan.UseMedicine ? plan.MedicineCount : 0,
                     Stone = plan.UseStone ? plan.StoneCount : 0,
                 };

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
@@ -60,6 +60,11 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
         PlanList.Add(new Plan());
     }
 
+    public void RemovePlan(Plan plan)
+    {
+        PlanList.Remove(plan);
+    }
+
     public bool IsStageManually
     {
         get => GetTaskConfig<DepotMaintainTask>().IsStageManually;
@@ -110,10 +115,7 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
             var stageList = Instances.StageManager.GetStageList();
             await TaskQueueViewModel.TaskQueueSerializingLock.WaitAsync();
 
-            //using (var refresh = new UiRefreshingScope())
-            {
-                RefreshStageList();
-            }
+            RefreshStageList();
             TaskQueueViewModel.TaskQueueSerializingLock.Release();
         });
     }
@@ -163,7 +165,6 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
                 SetAndNotify(ref field, value);
                 Instance.NotifyOfPropertyChange(nameof(PlanInfo));
                 NotifyOfPropertyChange(nameof(Title));
-                Instance.SavePlan();
             }
         } = string.Empty;
 
@@ -176,7 +177,6 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
                 SetAndNotify(ref field, value);
                 Instance.NotifyOfPropertyChange(nameof(PlanInfo));
                 NotifyOfPropertyChange(nameof(Title));
-                Instance.SavePlan();
             }
         } = string.Empty;
 
@@ -191,41 +191,16 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
                 SetAndNotify(ref field, value);
                 Instance.NotifyOfPropertyChange(nameof(PlanInfo));
                 NotifyOfPropertyChange(nameof(Title));
-                Instance.SavePlan();
             }
         }
 
-        public bool UseMedicine
-        {
-            get; set {
-                SetAndNotify(ref field, value);
-                Instance.SavePlan();
-            }
-        }
+        public bool UseMedicine { get; set => SetAndNotify(ref field, value); }
 
-        public int MedicineCount
-        {
-            get; set {
-                SetAndNotify(ref field, value);
-                Instance.SavePlan();
-            }
-        }
+        public int MedicineCount { get; set => SetAndNotify(ref field, value); }
 
-        public bool UseStone
-        {
-            get; set {
-                SetAndNotify(ref field, value);
-                Instance.SavePlan();
-            }
-        }
+        public bool UseStone { get; set => SetAndNotify(ref field, value); }
 
-        public int StoneCount
-        {
-            get; set {
-                SetAndNotify(ref field, value);
-                Instance.SavePlan();
-            }
-        }
+        public int StoneCount { get; set => SetAndNotify(ref field, value); }
 
         // UI 绑定的方法
         [UsedImplicitly]
@@ -246,10 +221,28 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
 
     public override void RefreshUI(BaseTask baseTask)
     {
-        if (baseTask is DepotMaintainTask)
+        if (baseTask is not DepotMaintainTask task)
         {
-            Refresh();
+            return;
         }
+        var list = new List<Plan>();
+        foreach (var plan in task.PlanList)
+        {
+            var uiPlan = new Plan() {
+                Stage = plan.Stage,
+                DropId = plan.DropId,
+                DropCount = plan.DropCount,
+                UseMedicine = plan.UseMedicine,
+                MedicineCount = plan.MedicineCount,
+                UseStone = plan.UseStone,
+                StoneCount = plan.StoneCount,
+            };
+            list.Add(uiPlan);
+            uiPlan.PropertyChanged += (_, __) => SavePlan();
+        }
+        PlanList = [.. list];
+        PlanList.CollectionChanged += (_, __) => SavePlan();
+        Refresh();
     }
 
     public override (bool? IsSuccess, IEnumerable<int> TaskId) SerializeTask(BaseTask? baseTask, int? taskId = null) => (this as ISerialize).Serialize(baseTask, taskId);

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
@@ -1,0 +1,237 @@
+// <copyright file="DepotMaintainTaskUserControlModel.cs" company="MaaAssistantArknights">
+// Part of the MaaWpfGui project, maintained by the MaaAssistantArknights team (Maa Team)
+// Copyright (C) 2021-2025 MaaAssistantArknights Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License v3.0 only as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY
+// </copyright>
+#nullable enable
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using JetBrains.Annotations;
+using MaaWpfGui.Configuration.Single.MaaTask;
+using MaaWpfGui.Constants;
+using MaaWpfGui.Helper;
+using MaaWpfGui.Models.AsstTasks;
+using Stylet;
+using static MaaWpfGui.Main.AsstProxy;
+
+namespace MaaWpfGui.ViewModels.UserControl.TaskQueue;
+
+public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMaintainTaskUserControlModel.ISerialize
+{
+    static DepotMaintainTaskUserControlModel()
+    {
+        Instance = new();
+    }
+
+    public DepotMaintainTaskUserControlModel()
+    {
+        PlanList.CollectionChanged += (_, __) => SavePlan();
+    }
+
+    public static DepotMaintainTaskUserControlModel Instance { get; }
+
+    public bool UpdateDepot
+    {
+        get => GetTaskConfig<DepotMaintainTask>().UpdateDepot;
+        set => SetTaskConfig<DepotMaintainTask>(t => t.UpdateDepot == value, t => t.UpdateDepot = value);
+    }
+
+    public ObservableCollection<Plan> PlanList { get; set; } = [new Plan()];
+
+    public void AddPlan()
+    {
+        PlanList.Add(new Plan());
+    }
+
+    public bool IsStageManually
+    {
+        get => GetTaskConfig<DepotMaintainTask>().IsStageManually;
+        set => SetTaskConfig<DepotMaintainTask>(t => t.IsStageManually == value, t => t.IsStageManually = value);
+    }
+
+    public string PlanInfo => string.Join("\n", PlanList.Select((t, i) => $"{i + 1}: {t.Stage} - {t.DropName} x{t.DropCount}"));
+
+    private void SavePlan()
+    {
+        var list = PlanList.Select(i => new DepotMaintainTask.Plan(i.Stage, i.DropId, i.DropCount, i.UseMedicine, i.MedicineCount, i.UseStone, i.StoneCount));
+        SetTaskConfig<DepotMaintainTask>(t => t.PlanList.SequenceEqual(list), t => t.PlanList = [.. list]);
+    }
+
+    // UI 绑定的方法
+    [UsedImplicitly]
+    public void CollapseAll()
+    {
+        foreach (var plan in PlanList)
+        {
+            plan.IsExpanded = false;
+        }
+    }
+
+    public class Plan : PropertyChangedBase
+    {
+        public bool IsExpanded { get; set => SetAndNotify(ref field, value); }
+
+        public string Title => $"{Stage} - {DropName} x{DropCount}";
+
+        public string Stage
+        {
+            get; set {
+                SetAndNotify(ref field, value);
+                Instance.NotifyOfPropertyChange(nameof(PlanInfo));
+                NotifyOfPropertyChange(nameof(Title));
+                Instance.SavePlan();
+            }
+        } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets 指定掉落材料 ID。
+        /// </summary>
+        public string DropId
+        {
+            get; set {
+                SetAndNotify(ref field, value);
+                Instance.NotifyOfPropertyChange(nameof(PlanInfo));
+                NotifyOfPropertyChange(nameof(Title));
+                Instance.SavePlan();
+            }
+        } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets 指定掉落材料名称。
+        /// </summary>
+        public string DropName { get; set => SetAndNotify(ref field, value); } = string.Empty;
+
+        public int DropCount
+        {
+            get; set {
+                SetAndNotify(ref field, value);
+                Instance.NotifyOfPropertyChange(nameof(PlanInfo));
+                NotifyOfPropertyChange(nameof(Title));
+                Instance.SavePlan();
+            }
+        }
+
+        public bool UseMedicine
+        {
+            get; set {
+                SetAndNotify(ref field, value);
+                Instance.SavePlan();
+            }
+        }
+
+        public int MedicineCount
+        {
+            get; set {
+                SetAndNotify(ref field, value);
+                Instance.SavePlan();
+            }
+        }
+
+        public bool UseStone
+        {
+            get; set {
+                SetAndNotify(ref field, value);
+                Instance.SavePlan();
+            }
+        }
+
+        public int StoneCount
+        {
+            get; set {
+                SetAndNotify(ref field, value);
+                Instance.SavePlan();
+            }
+        }
+
+        // UI 绑定的方法
+        [UsedImplicitly]
+        public void DropsListDropDownClosed()
+        {
+            if (FightSettingsUserControlModel.Instance.DropsList.FirstOrDefault(i => i.Display == DropName) is { } item)
+            {
+                DropId = item.Value;
+            }
+            else
+            {
+                DropId = string.Empty;
+                DropName = LocalizationHelper.GetString("NotSelected");
+                NotifyOfPropertyChange(nameof(DropName));
+            }
+        }
+    }
+
+    public override void RefreshUI(BaseTask baseTask)
+    {
+        if (baseTask is DepotMaintainTask)
+        {
+            Refresh();
+        }
+    }
+
+    public override (bool? IsSuccess, IEnumerable<int> TaskId) SerializeTask(BaseTask? baseTask, int? taskId = null) => (this as ISerialize).Serialize(baseTask, taskId);
+
+    private interface ISerialize : ITaskQueueModelSerialize
+    {
+        (bool? IsSuccess, IEnumerable<int> TaskId) ITaskQueueModelSerialize.Serialize(BaseTask? baseTask, int? taskId)
+        {
+            if (baseTask is not DepotMaintainTask depot || taskId > 0)
+            {
+                return (null, []);
+            }
+
+            var depotList = Instances.ToolboxViewModel?.DepotResult.Where(item => item.Count >= 0).ToDictionary(item => item.Id, item => item.Count) ?? [];
+            var taskIds = new List<int>();
+            for (int i = 0; i < depot.PlanList.Count; i++)
+            {
+                var plan = depot.PlanList[i];
+                if (string.IsNullOrEmpty(plan.DropId) || plan.DropCount <= 0)
+                {
+                    Instances.TaskQueueViewModel.AddLog($"Plan {i + 1}: invalid drop item.", UiLogColor.Error);
+                    continue;
+                }
+                var count = depotList.TryGetValue(plan.DropId, out var value) ? value : 0;
+                count = plan.DropCount - count;
+                if (count <= 0)
+                {
+                    Instances.TaskQueueViewModel.AddLog($"Plan {i + 1}: Inventory enough.", UiLogColor.Info);
+                    continue;
+                }
+                var stage = FightSettingsUserControlModel.GetFightStage([plan.Stage]);
+                if (string.IsNullOrEmpty(stage))
+                {
+                    Instances.TaskQueueViewModel.AddLog($"Plan {i + 1}: stage '{plan.Stage}' is not open.", UiLogColor.Error);
+                    continue;
+                }
+                var fight = new AsstFightTask() {
+                    Stage = stage,
+                    Drops = new() { { plan.DropId, plan.DropCount } },
+                    Medicine = plan.UseMedicine ? plan.MedicineCount : 0,
+                    Stone = plan.UseStone ? plan.StoneCount : 0,
+                };
+                var (ret, id) = Instances.AsstProxy.AsstAppendTaskWithEncoding(TaskType.Fight, fight);
+                if (!ret)
+                {
+                    Instances.TaskQueueViewModel.AddLog($"Plan {i + 1}: add task failed.", UiLogColor.Error);
+                }
+                else
+                {
+                    taskIds.Add(id);
+                }
+            }
+
+            if (taskIds.Count > 0)
+            {
+                return (true, taskIds);
+            }
+            return (null, []);
+        }
+    }
+}

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
@@ -74,8 +74,14 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
         }
 
         // 查找该 taskId 对应的 plan index
-        var planIndex = _planTaskIdMap.FirstOrDefault(kvp => kvp.Value == taskId).Key;
-        if (TaskSettingVisibilityInfo.CurrentTask is not DepotMaintainTask depot || planIndex < 0 || planIndex >= depot.PlanList.Count)
+        var planKvp = _planTaskIdMap.FirstOrDefault(kvp => kvp.Value == taskId);
+        if (planKvp.Value != taskId)
+        {
+            return;
+        }
+
+        int planIndex = planKvp.Key;
+        if (TaskSettingVisibilityInfo.CurrentTask is not DepotMaintainTask depot || planIndex >= depot.PlanList.Count)
         {
             return;
         }

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
@@ -51,6 +51,7 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
         PlanList.CollectionChanged += (_, __) => {
             SavePlan();
             NotifyOfPropertyChange(nameof(PlanInfo));
+
             // 增删后序号变化，通知所有 plan 刷新 Title
             foreach (var plan in PlanList)
             {

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
@@ -51,6 +51,11 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
         PlanList.CollectionChanged += (_, __) => {
             SavePlan();
             NotifyOfPropertyChange(nameof(PlanInfo));
+            // 增删后序号变化，通知所有 plan 刷新 Title
+            foreach (var plan in PlanList)
+            {
+                plan.RefreshTitle();
+            }
         };
 
         // 仓库数据变化时刷新计划显示（当前库存数量）
@@ -296,7 +301,12 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
     {
         public bool IsExpanded { get; set => SetAndNotify(ref field, value); }
 
-        public string Title => $"{Instance.StageListSource.FirstOrDefault(i => i.Value == Stage)?.Display ?? Stage} - {DropName} x{DropCount}";
+        public string Title => $"{Instance.PlanList.IndexOf(this) + 1}: {Instance.StageListSource.FirstOrDefault(i => i.Value == Stage)?.Display ?? Stage} - {DropName} x{DropCount}";
+
+        /// <summary>
+        /// 增删 plan 或语言切换后刷新 Title 显示（序号/关卡名/材料名）。
+        /// </summary>
+        public void RefreshTitle() => NotifyOfPropertyChange(nameof(Title));
 
         public string Stage
         {
@@ -395,6 +405,10 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
         PlanList.CollectionChanged += (_, __) => {
             SavePlan();
             NotifyOfPropertyChange(nameof(PlanInfo));
+            foreach (var plan in PlanList)
+            {
+                plan.RefreshTitle();
+            }
         };
         NotifyOfPropertyChange(nameof(PlanInfo));
         RefreshStageList();

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
@@ -53,6 +53,24 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
         set => SetTaskConfig<DepotMaintainTask>(t => t.UpdateDepot == value, t => t.UpdateDepot = value);
     }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether 活动期间跳过整个库存保持任务。
+    /// </summary>
+    public bool SkipDuringActivity
+    {
+        get => GetTaskConfig<DepotMaintainTask>().SkipDuringActivity;
+        set => SetTaskConfig<DepotMaintainTask>(t => t.SkipDuringActivity == value, t => t.SkipDuringActivity = value);
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether 资源全开放期间跳过整个库存保持任务。
+    /// </summary>
+    public bool SkipDuringResourceCollection
+    {
+        get => GetTaskConfig<DepotMaintainTask>().SkipDuringResourceCollection;
+        set => SetTaskConfig<DepotMaintainTask>(t => t.SkipDuringResourceCollection == value, t => t.SkipDuringResourceCollection = value);
+    }
+
     public ObservableCollection<Plan> PlanList { get; private set => SetAndNotify(ref field, value); } = [];
 
     public void AddPlan()
@@ -255,6 +273,40 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
             {
                 return (null, []);
             }
+
+            // 活动期间跳过：当有 SideStory 活动进行中时跳过整个库存保持任务
+            if (depot.SkipDuringActivity && Instances.StageManager.IsActivityOpen())
+            {
+                Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("DepotPlanSkippedActivity"), UiLogColor.Info);
+                return (null, []);
+            }
+
+            // 资源全开放期间跳过：当资源全开放活动进行中时跳过整个库存保持任务
+            if (depot.SkipDuringResourceCollection && Instances.StageManager.IsResourceCollectionOpen())
+            {
+                Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("DepotPlanSkippedResourceCollection"), UiLogColor.Info);
+                return (null, []);
+            }
+
+            // 任务开始前更新库存数据：先追加仓库识别任务，刷新库存后再执行计划
+            // FIXME：战斗任务支持运行时修改参数（AsstSetTaskParamsEncoded），理论上可在此先追加仓库识别任务，
+            //        待识别完成后通过回调用最新库存重新计算各 plan 的缺口并动态更新战斗任务的 drops/times。
+            //        但当前未实现该运行时联动；且 core 侧 drops 指定数量为 0 时 check_specify_quantity 不会拦截
+            //        （m_drop_stats 中无记录即视为未达标），仍会进入关卡，需依赖 times=0 阻止进入。
+            /*
+            if (depot.UpdateDepot)
+            {
+                if (!Instances.ToolboxViewModel.StartDepotRecognitionTask(startImmediately: false))
+                {
+                    Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("DepotPlanUpdateDepotFailed"), UiLogColor.Error);
+                    return (false, []);
+                }
+
+                int depotTaskId = Instances.AsstProxy.TasksStatus.Last().Key;
+                Instances.ToolboxViewModel.MarkDepotRecognitionSyncTimeForReset(depotTaskId);
+                taskIds.Add(depotTaskId);
+            }
+            */
 
             var depotList = Instances.ToolboxViewModel?.DepotResult.Where(item => item.Count >= 0).ToDictionary(item => item.Id, item => item.Count) ?? [];
             var taskIds = new List<int>();

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
@@ -263,7 +263,7 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
                 var plan = depot.PlanList[i];
                 if (string.IsNullOrEmpty(plan.DropId) || plan.DropCount <= 0)
                 {
-                    Instances.TaskQueueViewModel.AddLog($"Plan {i + 1}: invalid drop item.", UiLogColor.Error);
+                    Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetStringFormat("DepotPlanInvalidDropItem", i + 1), UiLogColor.Error);
                     taskIds.Add(0);
                     continue;
                 }
@@ -271,14 +271,14 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
                 count = plan.DropCount - count;
                 if (count <= 0)
                 {
-                    Instances.TaskQueueViewModel.AddLog($"Plan {i + 1}: Inventory enough.", UiLogColor.Info);
+                    Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetStringFormat("DepotPlanInventoryEnough", i + 1), UiLogColor.Info);
                     taskIds.Add(0);
                     continue;
                 }
                 var stage = FightSettingsUserControlModel.GetFightStage([plan.Stage]);
                 if (string.IsNullOrEmpty(stage))
                 {
-                    Instances.TaskQueueViewModel.AddLog($"Plan {i + 1}: stage '{plan.Stage}' is not open.", UiLogColor.Error);
+                    Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetStringFormat("DepotPlanStageNotOpen", i + 1, plan.Stage), UiLogColor.Error);
                     taskIds.Add(0);
                     continue;
                 }
@@ -292,7 +292,7 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
                 var (ret, id) = Instances.AsstProxy.AsstAppendTaskWithEncoding(TaskType.Fight, fight);
                 if (!ret)
                 {
-                    Instances.TaskQueueViewModel.AddLog($"Plan {i + 1}: add task failed.", UiLogColor.Error);
+                    Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetStringFormat("DepotPlanAddTaskFailed", i + 1), UiLogColor.Error);
                     taskIds.Add(0);
                 }
                 else

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
@@ -264,6 +264,7 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
                 if (string.IsNullOrEmpty(plan.DropId) || plan.DropCount <= 0)
                 {
                     Instances.TaskQueueViewModel.AddLog($"Plan {i + 1}: invalid drop item.", UiLogColor.Error);
+                    taskIds.Add(0);
                     continue;
                 }
                 var count = depotList.TryGetValue(plan.DropId, out var value) ? value : 0;
@@ -271,17 +272,20 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
                 if (count <= 0)
                 {
                     Instances.TaskQueueViewModel.AddLog($"Plan {i + 1}: Inventory enough.", UiLogColor.Info);
+                    taskIds.Add(0);
                     continue;
                 }
                 var stage = FightSettingsUserControlModel.GetFightStage([plan.Stage]);
                 if (string.IsNullOrEmpty(stage))
                 {
                     Instances.TaskQueueViewModel.AddLog($"Plan {i + 1}: stage '{plan.Stage}' is not open.", UiLogColor.Error);
+                    taskIds.Add(0);
                     continue;
                 }
                 var fight = new AsstFightTask() {
                     Stage = stage,
-                    Drops = new() { { plan.DropId, plan.DropCount } },
+                    Drops = new() { { plan.DropId, count } },
+                    MaxTimes = count > 0 ? int.MaxValue : 0,
                     Medicine = plan.UseMedicine ? plan.MedicineCount : 0,
                     Stone = plan.UseStone ? plan.StoneCount : 0,
                 };
@@ -289,6 +293,7 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
                 if (!ret)
                 {
                     Instances.TaskQueueViewModel.AddLog($"Plan {i + 1}: add task failed.", UiLogColor.Error);
+                    taskIds.Add(0);
                 }
                 else
                 {
@@ -296,7 +301,7 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
                 }
             }
 
-            if (taskIds.Count > 0)
+            if (taskIds.Any(id => id > 0))
             {
                 return (true, taskIds);
             }

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
@@ -17,6 +17,7 @@ using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
 using JetBrains.Annotations;
+using MaaWpfGui.Configuration.Factory;
 using MaaWpfGui.Configuration.Single.MaaTask;
 using MaaWpfGui.Constants;
 using MaaWpfGui.Constants.Enums;
@@ -38,9 +39,6 @@ namespace MaaWpfGui.ViewModels.UserControl.TaskQueue;
 public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMaintainTaskUserControlModel.ISerialize
 {
     private readonly ILogger _logger = Log.ForContext<DepotMaintainTaskUserControlModel>();
-
-    // plan index → core taskId 的映射，用于运行时重算缺口
-    private Dictionary<int, int> _planTaskIdMap = [];
 
     static DepotMaintainTaskUserControlModel()
     {
@@ -97,20 +95,12 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
             return;
         }
 
-        // 查找该 taskId 对应的 plan index
-        var planKvp = _planTaskIdMap.FirstOrDefault(kvp => kvp.Value == taskId);
-        if (planKvp.Value != taskId)
+        var task = ConfigFactory.CurrentConfig.TaskQueue.OfType<DepotMaintainTask>().FirstOrDefault(t => t.PlanList.Any(p => p.TaskId == taskId));
+        if (task == null || task.PlanList.FirstOrDefault(plan => plan.TaskId == taskId) is not { } plan)
         {
             return;
         }
 
-        int planIndex = planKvp.Key;
-        if (TaskSettingVisibilityInfo.CurrentTask is not DepotMaintainTask depot || planIndex >= depot.PlanList.Count)
-        {
-            return;
-        }
-
-        var plan = depot.PlanList[planIndex];
         if (string.IsNullOrEmpty(plan.DropId) || plan.DropCount <= 0)
         {
             return;
@@ -123,8 +113,7 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
             FightSettingsUserControlModel.RefreshFightTaskDrops(taskId, plan.DropId, plan.DropCount,
                 stage,
                 plan.UseMedicine ? plan.MedicineCount : 0,
-                plan.UseStone ? plan.StoneCount : 0,
-                (planIndex + 1).ToString());
+                plan.UseStone ? plan.StoneCount : 0);
         }
     }
 
@@ -238,7 +227,7 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
             return;
         }
 
-        var list = PlanList.Select(i => new DepotMaintainTask.Plan(i.Stage, i.DropId, i.DropCount, i.UseMedicine, i.MedicineCount, i.UseStone, i.StoneCount));
+        var list = PlanList.Select(i => new DepotMaintainTask.Plan(i.Stage, i.DropId, i.DropCount, i.UseMedicine, i.MedicineCount, i.UseStone, i.StoneCount, i.TaskId));
         SetTaskConfig<DepotMaintainTask>(t => t.PlanList.SequenceEqual(list), t => t.PlanList = [.. list]);
     }
 
@@ -360,6 +349,8 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
 
         public int StoneCount { get; set => SetAndNotify(ref field, value); }
 
+        public int TaskId { get; set; }
+
         // UI 绑定的方法
         [UsedImplicitly]
         public void DropsListDropDownClosed()
@@ -396,6 +387,7 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
                 MedicineCount = plan.MedicineCount,
                 UseStone = plan.UseStone,
                 StoneCount = plan.StoneCount,
+                TaskId = plan.TaskId,
 
                 // 根据 DropId 从掉落列表恢复 DropName，避免初始化显示为"不选择"
                 DropName = FightSettingsUserControlModel.Instance.DropsList.FirstOrDefault(i => i.Value == plan.DropId)?.Display
@@ -459,7 +451,6 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
             }
 
             var depotList = Instances.ToolboxViewModel?.DepotResult.Where(item => item.Count >= 0).ToDictionary(item => item.Id, item => item.Count) ?? [];
-            Instance._planTaskIdMap = [];
             for (int i = 0; i < depot.PlanList.Count; i++)
             {
                 var plan = depot.PlanList[i];
@@ -518,7 +509,7 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
                 else
                 {
                     taskIds.Add(id);
-                    Instance._planTaskIdMap[i] = id;
+                    depot.PlanList[i] = plan with { TaskId = id };
                 }
             }
 

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
@@ -113,7 +113,8 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
             FightSettingsUserControlModel.RefreshFightTaskDrops(taskId, plan.DropId, plan.DropCount,
                 stage,
                 plan.UseMedicine ? plan.MedicineCount : 0,
-                plan.UseStone ? plan.StoneCount : 0);
+                plan.UseStone ? plan.StoneCount : 0,
+                $"{task.PlanList.IndexOf(plan) + 1}");
         }
     }
 

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
@@ -19,6 +19,7 @@ using System.Threading.Tasks;
 using JetBrains.Annotations;
 using MaaWpfGui.Configuration.Single.MaaTask;
 using MaaWpfGui.Constants;
+using MaaWpfGui.Constants.Enums;
 using MaaWpfGui.Helper;
 using MaaWpfGui.Models;
 using MaaWpfGui.Models.AsstTasks;
@@ -35,6 +36,9 @@ namespace MaaWpfGui.ViewModels.UserControl.TaskQueue;
 public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMaintainTaskUserControlModel.ISerialize
 {
     private readonly ILogger _logger = Log.ForContext<DepotMaintainTaskUserControlModel>();
+
+    // plan index → core taskId 的映射，用于运行时重算缺口
+    private Dictionary<int, int> _planTaskIdMap = [];
 
     static DepotMaintainTaskUserControlModel()
     {
@@ -56,6 +60,41 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
             {
                 NotifyOfPropertyChange(nameof(PlanInfo));
             };
+        }
+
+        // 任务状态变化时，用最新库存重算该 plan 的缺口
+        Instances.AsstProxy.OnTaskStatusChanged += OnTaskStatusChanged;
+    }
+
+    private void OnTaskStatusChanged(int taskId, TaskItemStatus status)
+    {
+        if (status != TaskItemStatus.InProgress || taskId <= 0)
+        {
+            return;
+        }
+
+        // 查找该 taskId 对应的 plan index
+        var planIndex = _planTaskIdMap.FirstOrDefault(kvp => kvp.Value == taskId).Key;
+        if (TaskSettingVisibilityInfo.CurrentTask is not DepotMaintainTask depot || planIndex < 0 || planIndex >= depot.PlanList.Count)
+        {
+            return;
+        }
+
+        var plan = depot.PlanList[planIndex];
+        if (string.IsNullOrEmpty(plan.DropId) || plan.DropCount <= 0)
+        {
+            return;
+        }
+
+        // 复用 FightSettings 的公共方法，用最新库存重算缺口
+        var stage = GetFightStage([plan.Stage]);
+        if (!string.IsNullOrEmpty(stage))
+        {
+            FightSettingsUserControlModel.RefreshFightTaskDrops(taskId, plan.DropId, plan.DropCount,
+                stage,
+                plan.UseMedicine ? plan.MedicineCount : 0,
+                plan.UseStone ? plan.StoneCount : 0,
+                (planIndex + 1).ToString());
         }
     }
 
@@ -338,6 +377,7 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
             NotifyOfPropertyChange(nameof(PlanInfo));
         };
         NotifyOfPropertyChange(nameof(PlanInfo));
+        RefreshStageList();
         Refresh();
     }
 
@@ -366,12 +406,10 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
                 return (null, []);
             }
 
+            var taskIds = new List<int>();
+
             // 任务开始前更新库存数据：先追加仓库识别任务，刷新库存后再执行计划
-            // FIXME：战斗任务支持运行时修改参数（AsstSetTaskParamsEncoded），理论上可在此先追加仓库识别任务，
-            //        待识别完成后通过回调用最新库存重新计算各 plan 的缺口并动态更新战斗任务的 drops/times。
-            //        但当前未实现该运行时联动；且 core 侧 drops 指定数量为 0 时 check_specify_quantity 不会拦截
-            //        （m_drop_stats 中无记录即视为未达标），仍会进入关卡，需依赖 times=0 阻止进入。
-            /*
+            // 每个 plan 开始时会通过 OnTaskStatusChanged 用最新库存重算缺口
             if (depot.UpdateDepot)
             {
                 if (!Instances.ToolboxViewModel.StartDepotRecognitionTask(startImmediately: false))
@@ -384,10 +422,9 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
                 Instances.ToolboxViewModel.MarkDepotRecognitionSyncTimeForReset(depotTaskId);
                 taskIds.Add(depotTaskId);
             }
-            */
 
             var depotList = Instances.ToolboxViewModel?.DepotResult.Where(item => item.Count >= 0).ToDictionary(item => item.Id, item => item.Count) ?? [];
-            var taskIds = new List<int>();
+            Instance._planTaskIdMap = [];
             var seenDropIds = new Dictionary<string, int>();
             for (int i = 0; i < depot.PlanList.Count; i++)
             {
@@ -426,7 +463,7 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
                     }
                     else
                     {
-                        Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetStringFormat("DepotPlanStageNotOpen", i + 1, plan.Stage), UiLogColor.Error);
+                        Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetStringFormat("DepotPlanStageNotOpen", i + 1, plan.Stage));
                     }
 
                     taskIds.Add(0);
@@ -438,7 +475,7 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
                 if (need <= 0)
                 {
                     var dropName = ItemListHelper.GetItemName(plan.DropId) ?? plan.DropId;
-                    Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetStringFormat("DepotPlanInventoryEnough", i + 1, dropName, currentCount, plan.DropCount), UiLogColor.Info);
+                    Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetStringFormat("DepotPlanInventoryEnough", i + 1, dropName, currentCount, plan.DropCount));
                     taskIds.Add(0);
                     continue;
                 }
@@ -459,6 +496,7 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
                 else
                 {
                     taskIds.Add(id);
+                    Instance._planTaskIdMap[i] = id;
                 }
             }
 

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
@@ -11,21 +11,30 @@
 // but WITHOUT ANY WARRANTY
 // </copyright>
 #nullable enable
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
 using MaaWpfGui.Configuration.Single.MaaTask;
 using MaaWpfGui.Constants;
 using MaaWpfGui.Helper;
+using MaaWpfGui.Models;
 using MaaWpfGui.Models.AsstTasks;
+using MaaWpfGui.Utilities;
+using MaaWpfGui.ViewModels.UI;
+using Serilog;
 using Stylet;
 using static MaaWpfGui.Main.AsstProxy;
+using static MaaWpfGui.ViewModels.UserControl.TaskQueue.FightSettingsUserControlModel;
 
 namespace MaaWpfGui.ViewModels.UserControl.TaskQueue;
 
 public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMaintainTaskUserControlModel.ISerialize
 {
+    private readonly ILogger _logger = Log.ForContext<DepotMaintainTaskUserControlModel>();
+
     static DepotMaintainTaskUserControlModel()
     {
         Instance = new();
@@ -44,7 +53,7 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
         set => SetTaskConfig<DepotMaintainTask>(t => t.UpdateDepot == value, t => t.UpdateDepot = value);
     }
 
-    public ObservableCollection<Plan> PlanList { get; set; } = [new Plan()];
+    public ObservableCollection<Plan> PlanList { get; private set => SetAndNotify(ref field, value); } = [new Plan()];
 
     public void AddPlan()
     {
@@ -54,15 +63,97 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
     public bool IsStageManually
     {
         get => GetTaskConfig<DepotMaintainTask>().IsStageManually;
-        set => SetTaskConfig<DepotMaintainTask>(t => t.IsStageManually == value, t => t.IsStageManually = value);
+        set {
+            bool ret = SetTaskConfig<DepotMaintainTask>(t => t.IsStageManually == value, t => t.IsStageManually = value);
+            if (ret && !value)
+            {
+                for (int i = 0; i < PlanList.Count; i++)
+                {
+                    var stage = PlanList[i];
+                    if (!Instances.StageManager.GetStageList().Any(p => p.Value == stage.Stage))
+                    {
+                        PlanList[i].Stage = string.Empty;
+                    }
+                }
+            }
+        }
     }
 
-    public string PlanInfo => string.Join("\n", PlanList.Select((t, i) => $"{i + 1}: {t.Stage} - {t.DropName} x{t.DropCount}"));
+    /// <summary>
+    /// Gets or private sets a value indicating whether 关卡列表。
+    /// </summary>
+    public ObservableCollection<StageSourceItem> StageListSource { get; private set => SetAndNotify(ref field, value); } = [];
+
+    public string PlanInfo => string.Join("\n", PlanList.Select((t, i) => $"{i + 1}: {StageListSource.FirstOrDefault(i => i.Value == t.Stage)?.Display ?? t.Stage} - {t.DropName} x{t.DropCount}"));
 
     private void SavePlan()
     {
         var list = PlanList.Select(i => new DepotMaintainTask.Plan(i.Stage, i.DropId, i.DropCount, i.UseMedicine, i.MedicineCount, i.UseStone, i.StoneCount));
         SetTaskConfig<DepotMaintainTask>(t => t.PlanList.SequenceEqual(list), t => t.PlanList = [.. list]);
+    }
+
+    /// <summary>
+    /// 更新关卡列表。
+    /// 使用手动输入时，只更新关卡列表，不更新关卡选择
+    /// 使用隐藏当日不开放时，更新关卡列表，关卡选择为未开放的关卡时清空
+    /// 使用备选关卡时，更新关卡列表，关卡选择为未开放的关卡时在关卡列表中添加对应未开放关卡，避免清空导致进入上次关卡
+    /// 啥都不选时，更新关卡列表，关卡选择为未开放的关卡时在关卡列表中添加对应未开放关卡，避免清空导致进入上次关卡
+    /// 除手动输入外所有情况下，如果剩余理智为未开放的关卡，会被清空
+    /// </summary>
+    /// <returns>更新任务列表的Task</returns>
+    // FIXME：被注入对象只能在 private 函数内使用，只有 Model 显示之后才会被注入。如果 Model 还没有触发 OnInitialActivate 时调用此函数，会导致空引用异常。
+    // 这个函数被声明为 public，意味着它可能会在注入对象前被调用。
+    public Task UpdateStageList()
+    {
+        return Execute.OnUIThreadAsync(async () => {
+            using var log = new LogScope(_logger);
+            var stageList = Instances.StageManager.GetStageList();
+            await TaskQueueViewModel.TaskQueueSerializingLock.WaitAsync();
+
+            //using (var refresh = new UiRefreshingScope())
+            {
+                RefreshStageList();
+                RefreshCurrentStagePlan();
+            }
+            TaskQueueViewModel.TaskQueueSerializingLock.Release();
+        });
+    }
+
+    private void RefreshStageList()
+    {
+        if (TaskSettingVisibilityInfo.CurrentTask is not DepotMaintainTask current)
+        {
+            return;
+        }
+        var stageList = Instances.StageManager.GetStageList().ToList();
+        var listCurrent = current.PlanList;
+
+        var listSource = stageList.Select(i => new StageSourceItem() { Display = i.Display, Value = i.Value, IsVisible = true, IsOpen = Instances.StageManager.GetStageList().FirstOrDefault(p => p.Value == i.Value)?.IsStageOpen(Instances.TaskQueueViewModel.CurDayOfWeek) ?? true }).ToList();
+
+        // 补过期关卡进来
+        foreach (var item in listCurrent.Where(i => !listSource.Any(p => p.Value == i.Stage)))
+        {
+            listSource.Add(new StageSourceItem() { Display = item.Stage, Value = item.Stage, IsOpen = false, IsVisible = true });
+        }
+        listSource.Remove(listSource.FirstOrDefault(i => i.Value == AnnihilationName) ?? new());
+        StageListSource = [.. listSource];
+        current.PlanList = listCurrent; // StageListSource更新后, 恢复StagePlan
+    }
+
+    private void RefreshCurrentStagePlan()
+    {
+        if (TaskSettingVisibilityInfo.CurrentTask is not DepotMaintainTask current)
+        {
+            return;
+        }
+        var plan = current.PlanList;
+        var list = plan.Select((i, index) => new Plan() { Stage = i.Stage, DropId = i.DropId, DropCount = i.DropCount, UseMedicine = i.UseMedicine, MedicineCount = i.MedicineCount, UseStone = i.UseStone, StoneCount = i.StoneCount }).ToList();
+        foreach (var item in list)
+        {
+            item.PropertyChanged += (_, __) => SavePlan();
+        }
+        PlanList = [.. list];
+        PlanList.CollectionChanged += (_, __) => SavePlan();
     }
 
     // UI 绑定的方法
@@ -79,7 +170,7 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
     {
         public bool IsExpanded { get; set => SetAndNotify(ref field, value); }
 
-        public string Title => $"{Stage} - {DropName} x{DropCount}";
+        public string Title => $"{Instance.StageListSource.FirstOrDefault(i => i.Value == Stage)?.Display ?? Stage} - {DropName} x{DropCount}";
 
         public string Stage
         {
@@ -107,7 +198,7 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
         /// <summary>
         /// Gets or sets 指定掉落材料名称。
         /// </summary>
-        public string DropName { get; set => SetAndNotify(ref field, value); } = string.Empty;
+        public string DropName { get; set => SetAndNotify(ref field, value); } = LocalizationHelper.GetString("NotSelected");
 
         public int DropCount
         {

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
@@ -425,7 +425,6 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
 
             var depotList = Instances.ToolboxViewModel?.DepotResult.Where(item => item.Count >= 0).ToDictionary(item => item.Id, item => item.Count) ?? [];
             Instance._planTaskIdMap = [];
-            var seenDropIds = new Dictionary<string, int>();
             for (int i = 0; i < depot.PlanList.Count; i++)
             {
                 var plan = depot.PlanList[i];
@@ -440,18 +439,6 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
                     Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetStringFormat("DepotPlanZeroDropCount", i + 1), UiLogColor.Error);
                     taskIds.Add(0);
                     continue;
-                }
-
-                // 检查是否有重复材料
-                if (seenDropIds.TryGetValue(plan.DropId, out var firstIndex))
-                {
-                    var dropName = ItemListHelper.GetItemName(plan.DropId) ?? plan.DropId;
-                    Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetStringFormat("DepotPlanDuplicateDrop", i + 1, dropName, firstIndex + 1), UiLogColor.Error);
-                    continue;
-                }
-                else
-                {
-                    seenDropIds[plan.DropId] = i;
                 }
 
                 var stage = GetFightStage([plan.Stage]);

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
@@ -23,6 +23,7 @@ using MaaWpfGui.Constants.Enums;
 using MaaWpfGui.Helper;
 using MaaWpfGui.Models;
 using MaaWpfGui.Models.AsstTasks;
+using MaaWpfGui.Services;
 using MaaWpfGui.Utilities;
 using MaaWpfGui.ViewModels.UI;
 using MaaWpfGui.ViewModels.UserControl.Settings;
@@ -447,13 +448,12 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
             // 每个 plan 开始时会通过 OnTaskStatusChanged 用最新库存重算缺口
             if (depot.UpdateDepot)
             {
-                if (!Instances.ToolboxViewModel.StartDepotRecognitionTask(startImmediately: false))
+                var (result, depotTaskId) = Instances.AsstProxy.AsstAppendTaskWithEncoding(TaskType.Depot, (AsstTaskType.Depot, null));
+                if (!result)
                 {
                     Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("DepotPlanUpdateDepotFailed"), UiLogColor.Error);
                     return (false, []);
                 }
-
-                int depotTaskId = Instances.AsstProxy.TasksStatus.Last().Key;
                 Instances.ToolboxViewModel.MarkDepotRecognitionSyncTimeForReset(depotTaskId);
                 taskIds.Add(depotTaskId);
             }

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
@@ -25,6 +25,7 @@ using MaaWpfGui.Models;
 using MaaWpfGui.Models.AsstTasks;
 using MaaWpfGui.Utilities;
 using MaaWpfGui.ViewModels.UI;
+using MaaWpfGui.ViewModels.UserControl.Settings;
 using ObservableCollections;
 using Serilog;
 using Stylet;
@@ -47,8 +48,7 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
 
     public DepotMaintainTaskUserControlModel()
     {
-        PlanList.CollectionChanged += (_, __) =>
-        {
+        PlanList.CollectionChanged += (_, __) => {
             SavePlan();
             NotifyOfPropertyChange(nameof(PlanInfo));
         };
@@ -56,14 +56,31 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
         // 仓库数据变化时刷新计划显示（当前库存数量）
         if (Instances.ToolboxViewModel is { } toolbox)
         {
-            toolbox.DepotResult.CollectionChanged += (in NotifyCollectionChangedEventArgs<ToolboxViewModel.DepotResultDate> _) =>
-            {
+            toolbox.DepotResult.CollectionChanged += (in NotifyCollectionChangedEventArgs<ToolboxViewModel.DepotResultDate> _) => {
                 NotifyOfPropertyChange(nameof(PlanInfo));
             };
         }
 
         // 任务状态变化时，用最新库存重算该 plan 的缺口
         Instances.AsstProxy.OnTaskStatusChanged += OnTaskStatusChanged;
+
+        // 语言切换时由 FightSettings.RebuildDropsList 显式调用 OnLanguageChanged
+    }
+
+    public void OnLanguageChanged()
+    {
+        // DropsList 已由 RebuildDropsList 原地更新 Display（不增删项），ComboBox SelectedValue 不会丢失
+        // 只需刷新各 plan 的 DropName
+        foreach (var plan in PlanList)
+        {
+            if (!string.IsNullOrEmpty(plan.DropId))
+            {
+                plan.DropName = ItemListHelper.GetItemName(plan.DropId) ?? LocalizationHelper.GetString("NotSelected");
+            }
+        }
+
+        // 刷新关卡列表（关卡名随语言变化）
+        RefreshStageList();
     }
 
     private void OnTaskStatusChanged(int taskId, TaskItemStatus status)
@@ -166,6 +183,7 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
     /// </summary>
     public ObservableCollection<StageSourceItem> StageListSource { get; private set => SetAndNotify(ref field, value); } = [];
 
+    [PropertyDependsOn(typeof(GuiSettingsUserControlModel), nameof(GuiSettingsUserControlModel.Language))]
     public string PlanInfo => string.Join("\n", PlanList.Select((t, i) => $"{i + 1}: {StageListSource.FirstOrDefault(i => i.Value == t.Stage)?.Display ?? t.Stage} - {t.DropName} {GetCurrentInventoryCount(t.DropId)}/{t.DropCount}"));
 
     /// <summary>
@@ -306,9 +324,7 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
         /// </summary>
         public string DropName
         {
-            get => field;
-            set
-            {
+            get; set {
                 SetAndNotify(ref field, value);
                 NotifyOfPropertyChange(nameof(Title));
                 Instance.OnPlanChanged(nameof(PlanInfo));
@@ -376,8 +392,7 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
             list.Add(uiPlan);
         }
         PlanList = [.. list];
-        PlanList.CollectionChanged += (_, __) =>
-        {
+        PlanList.CollectionChanged += (_, __) => {
             SavePlan();
             NotifyOfPropertyChange(nameof(PlanInfo));
         };

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/FightSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/FightSettingsUserControlModel.cs
@@ -732,8 +732,44 @@ public class FightSettingsUserControlModel : TaskSettingsViewModel, FightSetting
         }
 
         AllDrops.Sort((a, b) => string.Compare(a.Value, b.Value, StringComparison.Ordinal));
-        DropsList = [.. AllDrops];
-        NotifyOfPropertyChange(nameof(DropsList));
+
+        // 原地更新 DropsList：只更新 Display 不增删项，避免 ComboBox SelectedValue 丢失
+        // 首次构建时 DropsList 为空，需要完整 Add；后续语言切换时只更新 Display
+        var allDropsDict = AllDrops.ToDictionary(i => i.Value, i => i.Display);
+        if (DropsList.Count == 0)
+        {
+            foreach (var item in AllDrops)
+            {
+                DropsList.Add(item);
+            }
+        }
+        else
+        {
+            // 更新已有项的 Display
+            foreach (var item in DropsList)
+            {
+                if (allDropsDict.TryGetValue(item.Value, out var newDisplay))
+                {
+                    item.Display = newDisplay;
+                }
+            }
+
+            // 补充新出现的项（如特有材料）
+            var existingValues = DropsList.Select(i => i.Value).ToHashSet();
+            foreach (var item in AllDrops.Where(i => !existingValues.Contains(i.Value)))
+            {
+                DropsList.Add(item);
+            }
+
+            // 删除不再存在的项（保留空值项即"不选择"）
+            for (int i = DropsList.Count - 1; i >= 0; i--)
+            {
+                if (!string.IsNullOrEmpty(DropsList[i].Value) && !allDropsDict.ContainsKey(DropsList[i].Value))
+                {
+                    DropsList.RemoveAt(i);
+                }
+            }
+        }
 
         foreach (var task in ConfigFactory.CurrentConfig.TaskQueue.OfType<FightTask>())
         {
@@ -767,6 +803,9 @@ public class FightSettingsUserControlModel : TaskSettingsViewModel, FightSetting
         }
 
         RefreshDropName();
+
+        // 通知 DepotMaintain 刷新各 plan 的 DropName
+        DepotMaintainTaskUserControlModel.Instance.OnLanguageChanged();
     }
 
     /// <summary>

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/FightSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/FightSettingsUserControlModel.cs
@@ -122,7 +122,7 @@ public class FightSettingsUserControlModel : TaskSettingsViewModel, FightSetting
     }
 
     /// <summary>
-    /// 当作战任务进入进行中状态时，仅捕获一次目标库存值，并在需要时刷新当前选中的面板。
+    /// 当作战任务进入进行中状态时，用最新库存重算指定掉落缺口并更新参数。
     /// </summary>
     private void OnTaskStatusChanged(int taskId, TaskItemStatus status)
     {
@@ -133,9 +133,18 @@ public class FightSettingsUserControlModel : TaskSettingsViewModel, FightSetting
 
         if (GetFightTaskByTaskId(taskId) is { } startedFight &&
             IsInventoryTargetDropEnabled(startedFight) &&
-            GetInventoryTargetRuntimeState(taskId) == null)
+            !string.IsNullOrEmpty(startedFight.DropId))
         {
-            SerializeTask(startedFight, taskId);
+            // 每次任务开始时用最新库存重算缺口（前序任务可能已经刷出了该材料）
+            var stage = GetFightStage(startedFight.StagePlan);
+            if (!string.IsNullOrEmpty(stage))
+            {
+                RefreshFightTaskDrops(taskId, startedFight.DropId, startedFight.DropCount,
+                    stage,
+                    startedFight.UseMedicine != false ? startedFight.MedicineCount : 0,
+                    startedFight.UseStone != false ? startedFight.StoneCount : 0,
+                    startedFight.NameOrTaskType);
+            }
         }
 
         Execute.OnUIThread(() => {
@@ -1092,6 +1101,56 @@ public class FightSettingsUserControlModel : TaskSettingsViewModel, FightSetting
         var stage = list?.FirstOrDefault(s => Instances.StageManager.IsStageOpen(s, Instances.TaskQueueViewModel.CurDayOfWeek));
         _logger.Information("GetFightStage: from {list}, selected {stage}", list, stage);
         return stage;
+    }
+
+    /// <summary>
+    /// 任务开始时用最新库存重算指定掉落材料的缺口，达标则 times=0，否则更新 drops 和 times。
+    /// 供理智作战和库存保持任务统一调用。
+    /// </summary>
+    /// <param name="taskId">core 任务 id</param>
+    /// <param name="dropId">指定掉落材料 ID</param>
+    /// <param name="dropCount">目标库存</param>
+    /// <param name="stage">关卡</param>
+    /// <param name="medicine">最大药剂数</param>
+    /// <param name="stone">最大源石数</param>
+    /// <param name="logLabel">日志标签（如计划序号）</param>
+    /// <returns>是否成功更新参数。</returns>
+    public static bool RefreshFightTaskDrops(int taskId, string dropId, int dropCount, string stage, int medicine, int stone, string? logLabel = null)
+    {
+        if (taskId <= 0 || string.IsNullOrEmpty(dropId) || dropCount <= 0)
+        {
+            return false;
+        }
+
+        var depotList = Instances.ToolboxViewModel?.DepotResult.Where(item => item.Count >= 0).ToDictionary(item => item.Id, item => item.Count) ?? [];
+        var currentCount = depotList.TryGetValue(dropId, out var value) ? value : 0;
+        var need = dropCount - currentCount;
+
+        var dropName = ItemListHelper.GetItemName(dropId) ?? dropId;
+        var task = new AsstFightTask() {
+            Stage = stage,
+            Medicine = medicine,
+            Stone = stone,
+            MaxTimes = int.MaxValue,
+        };
+
+        if (need <= 0)
+        {
+            // 库存已充足，times=0 阻止进入关卡
+            task.MaxTimes = 0;
+            task.Drops = new() { { dropId, 1 } };
+            Instances.TaskQueueViewModel.AddLog(
+                LocalizationHelper.GetStringFormat("DepotPlanInventoryEnough", logLabel ?? string.Empty, dropName, currentCount, dropCount),
+                UiLogColor.Info);
+        }
+        else
+        {
+            task.Drops = new() { { dropId, need } };
+            _logger.Information("FightTask {taskId} ({label}) re-calculated: {dropName} need {need} (current {current} / target {target})",
+                taskId, logLabel, dropName, need, currentCount, dropCount);
+        }
+
+        return Instances.AsstProxy.AsstSetTaskParamsEncoded(taskId, task);
     }
 
     /// <summary>

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/UserDataUpdateSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/UserDataUpdateSettingsUserControlModel.cs
@@ -22,8 +22,10 @@ using MaaWpfGui.Constants;
 using MaaWpfGui.Constants.Enums;
 using MaaWpfGui.Extensions;
 using MaaWpfGui.Helper;
+using MaaWpfGui.Services;
 using MaaWpfGui.Utilities.ValueType;
 using Stylet;
+using static MaaWpfGui.Main.AsstProxy;
 
 namespace MaaWpfGui.ViewModels.UserControl.TaskQueue;
 
@@ -115,13 +117,12 @@ public class UserDataUpdateSettingsUserControlModel : TaskSettingsViewModel, Use
 
             if (depotTriggerDue)
             {
-                ret = Instances.ToolboxViewModel.StartDepotRecognitionTask(false);
-                if (!ret)
+                var (result, depotTaskId) = Instances.AsstProxy.AsstAppendTaskWithEncoding(TaskType.Depot, (AsstTaskType.Depot, null));
+                if (!result)
                 {
+                    Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("DepotPlanUpdateDepotFailed"), UiLogColor.Error);
                     return (false, []);
                 }
-
-                int depotTaskId = Instances.AsstProxy.TasksStatus.Last().Key;
                 Instances.ToolboxViewModel.MarkDepotRecognitionSyncTimeForReset(depotTaskId);
                 ids.Add(depotTaskId);
             }

--- a/src/MaaWpfGui/Views/UI/TaskQueueView.xaml
+++ b/src/MaaWpfGui/Views/UI/TaskQueueView.xaml
@@ -431,6 +431,7 @@
                                 Height="30"
                                 HorizontalAlignment="Stretch"
                                 VerticalAlignment="Top"
+                                hc:BorderElement.CornerRadius="0,4,4,0"
                                 Command="{s:Action InverseSelected}"
                                 Content="{Binding InverseShowText}"
                                 IsEnabled="{c:Binding 'Idle or !Inited'}"

--- a/src/MaaWpfGui/Views/UI/TaskQueueView.xaml
+++ b/src/MaaWpfGui/Views/UI/TaskQueueView.xaml
@@ -373,7 +373,12 @@
                                             Padding="0,3"
                                             Command="{s:Action AddTaskQueueTask}"
                                             CommandParameter="{Binding TaskTypeList[9].Value}"
-                                            Header="{Binding TaskTypeList[9].Display}"
+                                            Header="{Binding TaskTypeList[9].Display}" />
+                                        <MenuItem
+                                            Padding="0,3"
+                                            Command="{s:Action AddTaskQueueTask}"
+                                            CommandParameter="{Binding TaskTypeList[10].Value}"
+                                            Header="{Binding TaskTypeList[10].Display}"
                                             Visibility="{c:Binding ShowDebugTask}" />
                                     </ContextMenu>
                                 </hc:ContextMenuButton.Menu>
@@ -606,6 +611,12 @@
                             DataContext="{Binding UserDataUpdateTask}"
                             IsEnabled="{Binding DataContext.Idle, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type UserControl}}}"
                             Visibility="{c:Binding DataContext.TaskSettingVisibilities.UserDataUpdate,
+                                                   RelativeSource={RelativeSource Mode=FindAncestor,
+                                                                                  AncestorType={x:Type UserControl}}}" />
+                        <taskQueue:DepotMaintainTaskUserControl
+                            DataContext="{Binding DepotMaintainTask}"
+                            IsEnabled="{Binding DataContext.Idle, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type UserControl}}}"
+                            Visibility="{c:Binding DataContext.TaskSettingVisibilities.DepotMaintain,
                                                    RelativeSource={RelativeSource Mode=FindAncestor,
                                                                                   AncestorType={x:Type UserControl}}}" />
                         <taskQueue:CustomUserControl DataContext="{Binding CustomTask}" Visibility="{c:Binding DataContext.TaskSettingVisibilities.Custom, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type UserControl}}}" />

--- a/src/MaaWpfGui/Views/UserControl/TaskQueue/DepotMaintainTaskUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/TaskQueue/DepotMaintainTaskUserControl.xaml
@@ -73,7 +73,7 @@
                 <DataTemplate>
                     <Expander HorizontalContentAlignment="Stretch" IsExpanded="{Binding IsExpanded}">
                         <Expander.Header>
-                            <Grid HorizontalAlignment="Stretch">
+                            <Grid HorizontalAlignment="Stretch" Background="Transparent">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="*" />
                                     <ColumnDefinition Width="Auto" />
@@ -94,7 +94,18 @@
                                     Command="{s:Action RemovePlan,
                                                        Target={x:Static taskQueue_vms:DepotMaintainTaskUserControlModel.Instance}}"
                                     CommandParameter="{Binding}"
-                                    DockPanel.Dock="Right" />
+                                    ToolTip="{DynamicResource Delete}">
+                                    <Button.Style>
+                                        <Style TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
+                                            <Setter Property="Visibility" Value="Collapsed" />
+                                            <Style.Triggers>
+                                                <DataTrigger Binding="{Binding IsMouseOver, RelativeSource={RelativeSource AncestorType={x:Type Grid}}}" Value="True">
+                                                    <Setter Property="Visibility" Value="Visible" />
+                                                </DataTrigger>
+                                            </Style.Triggers>
+                                        </Style>
+                                    </Button.Style>
+                                </Button>
                             </Grid>
                         </Expander.Header>
                         <Border

--- a/src/MaaWpfGui/Views/UserControl/TaskQueue/DepotMaintainTaskUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/TaskQueue/DepotMaintainTaskUserControl.xaml
@@ -78,17 +78,16 @@
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="*" />
                                         <ColumnDefinition Width="*" />
-                                        <ColumnDefinition Width="Auto" />
                                     </Grid.ColumnDefinitions>
 
-                                    <controls:TextBlock Grid.Column="0" Text="关卡" />
+                                    <controls:TextBlock Grid.Column="0" Text="{DynamicResource StageSelect}" />
                                     <Grid
                                         Grid.Column="1"
                                         Height="30"
                                         Margin="-10,0,0,0">
                                         <!--  当 IsStageManually 为 false 时显示 ComboBox  -->
                                         <ComboBox
-                                            ItemsSource="{Binding StageListSource, Source={x:Static ui_vms:TaskQueueViewModel.FightTask}}"
+                                            ItemsSource="{Binding StageListSource, Source={x:Static ui_vms:TaskQueueViewModel.DepotMaintainTask}}"
                                             ScrollViewer.CanContentScroll="False"
                                             SelectedValue="{Binding Stage}"
                                             SelectedValuePath="Value"
@@ -140,43 +139,9 @@
                                             Visibility="{c:Binding IsStageManually,
                                                                    Source={x:Static ui_vms:TaskQueueViewModel.DepotMaintainTask}}" />
                                     </Grid>
-
-                                    <Border Grid.Column="2">
-                                        <Border.Style>
-                                            <Style TargetType="Border">
-                                                <Setter Property="Visibility" Value="Collapsed" />
-                                                <Style.Triggers>
-                                                    <MultiDataTrigger>
-                                                        <MultiDataTrigger.Conditions>
-                                                            <Condition Binding="{Binding IsMouseOver, ElementName=StageItemGrid}" Value="True" />
-                                                            <Condition Binding="{c:Binding DataContext.UseAlternateStage, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type UserControl}}}" Value="True" />
-                                                        </MultiDataTrigger.Conditions>
-                                                        <Setter Property="Visibility" Value="Visible" />
-                                                    </MultiDataTrigger>
-                                                </Style.Triggers>
-                                            </Style>
-                                        </Border.Style>
-                                        <!--  删除按钮  -->
-                                        <Button
-                                            Grid.Column="1"
-                                            Padding="2"
-                                            VerticalAlignment="Stretch"
-                                            hc:IconElement.Geometry="{StaticResource CloseGeometry}"
-                                            hc:IconElement.Height="10"
-                                            hc:IconElement.Width="10"
-                                            hc:VisualElement.HighlightBackground="Transparent"
-                                            hc:VisualElement.HighlightForeground="{DynamicResource PrimaryBrush}"
-                                            Background="Transparent"
-                                            BorderThickness="0"
-                                            Command="{s:Action RemoveStageFromPlan}"
-                                            CommandParameter="{c:Binding DataContext,
-                                                                         RelativeSource={RelativeSource Self}}"
-                                            Visibility="{c:Binding 'DataContext.StagePlan.Count > 1',
-                                                                   RelativeSource={RelativeSource AncestorType={x:Type UserControl}}}" />
-                                    </Border>
                                 </Grid>
 
-                                <Grid>
+                                <Grid Margin="3,0">
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="Auto" MinWidth="100" />
                                         <ColumnDefinition Width="*" />

--- a/src/MaaWpfGui/Views/UserControl/TaskQueue/DepotMaintainTaskUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/TaskQueue/DepotMaintainTaskUserControl.xaml
@@ -18,8 +18,11 @@
     s:View.ActionTarget="{Binding}"
     mc:Ignorable="d">
     <StackPanel Visibility="{c:Binding !EnableAdvancedSettings, Source={x:Static ui_vms:TaskQueueViewModel.TaskSettingVisibilities}}">
-        <CheckBox Content="{DynamicResource DepotRecognition}" IsChecked="{Binding UpdateDepot}" />
-        <StackPanel Margin="0,10" Orientation="Horizontal">
+        <!--  FIXME: 任务开始前更新库存数据尚未实现，暂隐藏  -->
+        <!--<CheckBox Content="{DynamicResource DepotUpdateBeforeStart}" IsChecked="{Binding UpdateDepot}" />-->
+        <CheckBox Content="{DynamicResource DepotSkipDuringActivity}" IsChecked="{Binding SkipDuringActivity}" />
+        <CheckBox Margin="0,6,0,0" Content="{DynamicResource DepotSkipDuringResourceCollection}" IsChecked="{Binding SkipDuringResourceCollection}" />
+        <StackPanel Margin="0,6,0,0" Orientation="Horizontal">
             <CheckBox Content="{DynamicResource CustomStageCode}" IsChecked="{Binding IsStageManually}" />
             <controls:TooltipBlock TooltipText="{DynamicResource CustomStageCodeTip}" />
         </StackPanel>

--- a/src/MaaWpfGui/Views/UserControl/TaskQueue/DepotMaintainTaskUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/TaskQueue/DepotMaintainTaskUserControl.xaml
@@ -184,7 +184,7 @@
                                 <controls:TextBlock
                                     Grid.Row="1"
                                     Grid.Column="0"
-                                    Margin="0,p,6,0"
+                                    Margin="0,6,6,0"
                                     VerticalAlignment="Center"
                                     Text="{DynamicResource AssignedMaterial}" />
                                 <ComboBox

--- a/src/MaaWpfGui/Views/UserControl/TaskQueue/DepotMaintainTaskUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/TaskQueue/DepotMaintainTaskUserControl.xaml
@@ -1,0 +1,278 @@
+<UserControl
+    x:Class="MaaWpfGui.Views.UserControl.TaskQueue.DepotMaintainTaskUserControl"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:c="clr-namespace:CalcBinding;assembly=CalcBinding"
+    xmlns:controls="clr-namespace:MaaWpfGui.Styles.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:dd="urn:gong-wpf-dragdrop"
+    xmlns:hc="https://handyorg.github.io/handycontrol"
+    xmlns:helper="clr-namespace:MaaWpfGui.Helper"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:s="https://github.com/canton7/Stylet"
+    xmlns:taskQueue_vms="clr-namespace:MaaWpfGui.ViewModels.UserControl.TaskQueue"
+    xmlns:ui_vms="clr-namespace:MaaWpfGui.ViewModels.UI"
+    Height="600"
+    d:Background="White"
+    d:DataContext="{d:DesignInstance {x:Type taskQueue_vms:DepotMaintainTaskUserControlModel}}"
+    d:DesignWidth="220"
+    s:View.ActionTarget="{Binding}"
+    mc:Ignorable="d">
+    <StackPanel Visibility="{c:Binding !EnableAdvancedSettings, Source={x:Static ui_vms:TaskQueueViewModel.TaskSettingVisibilities}}">
+        <CheckBox Content="{DynamicResource DepotRecognition}" IsChecked="{Binding UpdateDepot}" />
+        <StackPanel Margin="0,10" Orientation="Horizontal">
+            <CheckBox Content="{DynamicResource CustomStageCode}" IsChecked="{Binding IsStageManually}" />
+            <controls:TooltipBlock TooltipText="{DynamicResource CustomStageCodeTip}" />
+        </StackPanel>
+        <controls:TextBlock
+            Margin="0,5,0,0"
+            HorizontalAlignment="Left"
+            Text="{Binding PlanInfo}"
+            TextWrapping="Wrap" />
+        <StackPanel Orientation="Horizontal">
+            <Button
+                Margin="6"
+                VerticalAlignment="Bottom"
+                d:IsHitTestVisible="True"
+                Command="{s:Action AddPlan}"
+                Content="添加"
+                IsHitTestVisible="{c:Binding !IsCurrentTaskRunning,
+                                             Source={x:Static ui_vms:TaskQueueViewModel.TaskSettingVisibilities}}" />
+            <Button
+                Margin="6"
+                VerticalAlignment="Bottom"
+                d:IsHitTestVisible="True"
+                Command="{s:Action CollapseAll}"
+                Content="折叠"
+                IsHitTestVisible="{c:Binding !IsCurrentTaskRunning,
+                                             Source={x:Static ui_vms:TaskQueueViewModel.TaskSettingVisibilities}}" />
+        </StackPanel>
+        <ListBox
+            Padding="0"
+            VerticalAlignment="Top"
+            HorizontalContentAlignment="Stretch"
+            d:ItemsSource="{d:SampleData ItemCount=2}"
+            dd:DragDrop.DragDropContext="{Binding RelativeSource={RelativeSource Self}}"
+            dd:DragDrop.IsDragSource="True"
+            dd:DragDrop.IsDropTarget="True"
+            BorderThickness="0"
+            ClipToBounds="False"
+            IsHitTestVisible="{c:Binding !IsCurrentTaskRunning,
+                                         Source={x:Static ui_vms:TaskQueueViewModel.TaskSettingVisibilities}}"
+            ItemsSource="{Binding Path=PlanList}"
+            PreviewMouseWheel="{s:Action RouteMouseWheelToParentExceptScrollable,
+                                         Target={x:Type helper:MouseWheelHelper}}">
+            <ListBox.ItemContainerStyle>
+                <Style BasedOn="{StaticResource NoSelectedHighlightListBoxItemStyle}" TargetType="{x:Type ListBoxItem}">
+                    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                    <Setter Property="Padding" Value="0" />
+                    <Setter Property="Margin" Value="1" />
+                </Style>
+            </ListBox.ItemContainerStyle>
+            <ListBox.ItemTemplate>
+                <DataTemplate>
+                    <Expander Header="{Binding Title}" IsExpanded="{Binding IsExpanded}">
+                        <Border BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1">
+                            <StackPanel>
+                                <Grid x:Name="StageItemGrid" Margin="0,0,0,-2">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
+
+                                    <controls:TextBlock Grid.Column="0" Text="关卡" />
+                                    <Grid
+                                        Grid.Column="1"
+                                        Height="30"
+                                        Margin="-10,0,0,0">
+                                        <!--  当 IsStageManually 为 false 时显示 ComboBox  -->
+                                        <ComboBox
+                                            ItemsSource="{Binding StageListSource, Source={x:Static ui_vms:TaskQueueViewModel.FightTask}}"
+                                            ScrollViewer.CanContentScroll="False"
+                                            SelectedValue="{Binding Stage}"
+                                            SelectedValuePath="Value"
+                                            Visibility="{c:Binding !IsStageManually,
+                                                                   Source={x:Static ui_vms:TaskQueueViewModel.DepotMaintainTask}}">
+
+                                            <ComboBox.ItemContainerStyle>
+                                                <Style BasedOn="{StaticResource ComboBoxItemBaseStyle}" TargetType="ComboBoxItem">
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding IsVisible}" Value="False">
+                                                            <Setter Property="Visibility" Value="Collapsed" />
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </ComboBox.ItemContainerStyle>
+                                            <ComboBox.ItemTemplate>
+                                                <DataTemplate>
+                                                    <TextBlock Text="{Binding Display}">
+                                                        <TextBlock.Style>
+                                                            <Style TargetType="TextBlock">
+                                                                <Style.Triggers>
+                                                                    <DataTrigger Binding="{Binding IsOutdated}" Value="True">
+                                                                        <Setter Property="TextDecorations" Value="Strikethrough" />
+                                                                        <Setter Property="Foreground" Value="{DynamicResource ErrorLogBrush}" />
+                                                                    </DataTrigger>
+                                                                    <DataTrigger Binding="{Binding IsOpen}" Value="False">
+                                                                        <Setter Property="Opacity" Value="0.5" />
+                                                                    </DataTrigger>
+                                                                    <DataTrigger Binding="{Binding IsOpen}" Value="True">
+                                                                        <Setter Property="Opacity" Value="1" />
+                                                                    </DataTrigger>
+                                                                </Style.Triggers>
+                                                            </Style>
+                                                        </TextBlock.Style>
+                                                    </TextBlock>
+                                                </DataTemplate>
+                                            </ComboBox.ItemTemplate>
+                                        </ComboBox>
+
+                                        <!--  当 IsStageManually 为 true 时显示 TextBox  -->
+                                        <TextBox
+                                            Height="30"
+                                            hc:InfoElement.Placeholder="{DynamicResource DefaultStage}"
+                                            IsEnabled="{c:Binding !IsStageItemDragging,
+                                                                  Source={x:Static ui_vms:TaskQueueViewModel.FightTask}}"
+                                            Opacity="{c:Binding 'IsOpen ? 1 : 0.5'}"
+                                            Text="{Binding Stage, UpdateSourceTrigger=PropertyChanged}"
+                                            ToolTip="{DynamicResource IsStageManuallyTip}"
+                                            Visibility="{c:Binding IsStageManually,
+                                                                   Source={x:Static ui_vms:TaskQueueViewModel.DepotMaintainTask}}" />
+                                    </Grid>
+
+                                    <Border Grid.Column="2">
+                                        <Border.Style>
+                                            <Style TargetType="Border">
+                                                <Setter Property="Visibility" Value="Collapsed" />
+                                                <Style.Triggers>
+                                                    <MultiDataTrigger>
+                                                        <MultiDataTrigger.Conditions>
+                                                            <Condition Binding="{Binding IsMouseOver, ElementName=StageItemGrid}" Value="True" />
+                                                            <Condition Binding="{c:Binding DataContext.UseAlternateStage, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type UserControl}}}" Value="True" />
+                                                        </MultiDataTrigger.Conditions>
+                                                        <Setter Property="Visibility" Value="Visible" />
+                                                    </MultiDataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </Border.Style>
+                                        <!--  删除按钮  -->
+                                        <Button
+                                            Grid.Column="1"
+                                            Padding="2"
+                                            VerticalAlignment="Stretch"
+                                            hc:IconElement.Geometry="{StaticResource CloseGeometry}"
+                                            hc:IconElement.Height="10"
+                                            hc:IconElement.Width="10"
+                                            hc:VisualElement.HighlightBackground="Transparent"
+                                            hc:VisualElement.HighlightForeground="{DynamicResource PrimaryBrush}"
+                                            Background="Transparent"
+                                            BorderThickness="0"
+                                            Command="{s:Action RemoveStageFromPlan}"
+                                            CommandParameter="{c:Binding DataContext,
+                                                                         RelativeSource={RelativeSource Self}}"
+                                            Visibility="{c:Binding 'DataContext.StagePlan.Count > 1',
+                                                                   RelativeSource={RelativeSource AncestorType={x:Type UserControl}}}" />
+                                    </Border>
+                                </Grid>
+
+                                <Grid>
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" MinWidth="100" />
+                                        <ColumnDefinition Width="*" />
+                                    </Grid.ColumnDefinitions>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition />
+                                        <RowDefinition />
+                                        <RowDefinition />
+                                        <RowDefinition />
+                                    </Grid.RowDefinitions>
+                                    <controls:TextBlock
+                                        Grid.Row="0"
+                                        Grid.Column="0"
+                                        Margin="22,0,0,0"
+                                        HorizontalAlignment="Left"
+                                        Text="{DynamicResource AssignedMaterial}" />
+                                    <ComboBox
+                                        Grid.Row="0"
+                                        Grid.Column="1"
+                                        Height="30"
+                                        Margin="3,2"
+                                        HorizontalContentAlignment="Stretch"
+                                        VerticalContentAlignment="Center"
+                                        s:View.ActionTarget="{Binding}"
+                                        DisplayMemberPath="Display"
+                                        DropDownClosed="{s:Action DropsListDropDownClosed}"
+                                        IsEditable="True"
+                                        IsTextSearchEnabled="False"
+                                        ItemsSource="{Binding DropsList, Source={x:Static ui_vms:TaskQueueViewModel.FightTask}}"
+                                        Loaded="{s:Action MakeComboBoxSearchable,
+                                                          Target={x:Type ui_vms:SettingsViewModel}}"
+                                        SelectedValue="{Binding DropId}"
+                                        SelectedValuePath="Value"
+                                        Text="{Binding DropName}" />
+                                    <controls:TextBlock
+                                        Grid.Row="1"
+                                        Grid.Column="0"
+                                        Margin="22,0,0,0"
+                                        HorizontalAlignment="Left"
+                                        Text="{DynamicResource TargetInventory}" />
+                                    <hc:NumericUpDown
+                                        Grid.Row="1"
+                                        Grid.Column="1"
+                                        Width="70"
+                                        Height="30"
+                                        Margin="3,2"
+                                        HorizontalAlignment="Left"
+                                        HorizontalContentAlignment="Center"
+                                        VerticalContentAlignment="Center"
+                                        Maximum="9999"
+                                        Minimum="0"
+                                        Value="{Binding DropCount, UpdateSourceTrigger=PropertyChanged}" />
+                                    <CheckBox
+                                        Grid.Row="2"
+                                        Grid.Column="0"
+                                        Margin="0,0,0,0"
+                                        HorizontalContentAlignment="Stretch"
+                                        Content="{DynamicResource UseSanityPotion}"
+                                        IsChecked="{Binding UseMedicine}" />
+                                    <hc:NumericUpDown
+                                        Grid.Row="2"
+                                        Grid.Column="1"
+                                        Width="70"
+                                        Height="30"
+                                        Margin="3,2"
+                                        HorizontalAlignment="Left"
+                                        HorizontalContentAlignment="Center"
+                                        VerticalContentAlignment="Center"
+                                        Maximum="999"
+                                        Minimum="0"
+                                        Value="{Binding MedicineCount, UpdateSourceTrigger=PropertyChanged}" />
+                                    <CheckBox
+                                        Grid.Row="3"
+                                        Grid.Column="0"
+                                        Margin="0,0,0,0"
+                                        HorizontalContentAlignment="Stretch"
+                                        Content="{DynamicResource UseOriginitePrime}"
+                                        IsChecked="{Binding UseStone}" />
+                                    <hc:NumericUpDown
+                                        Grid.Row="3"
+                                        Grid.Column="1"
+                                        Width="70"
+                                        Height="30"
+                                        Margin="3,2"
+                                        HorizontalAlignment="Left"
+                                        HorizontalContentAlignment="Center"
+                                        VerticalContentAlignment="Center"
+                                        Maximum="999"
+                                        Minimum="0"
+                                        Value="{Binding StoneCount, UpdateSourceTrigger=PropertyChanged}" />
+                                </Grid>
+                            </StackPanel>
+                        </Border>
+                    </Expander>
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+        </ListBox>
+    </StackPanel>
+</UserControl>

--- a/src/MaaWpfGui/Views/UserControl/TaskQueue/DepotMaintainTaskUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/TaskQueue/DepotMaintainTaskUserControl.xaml
@@ -18,10 +18,15 @@
     s:View.ActionTarget="{Binding}"
     mc:Ignorable="d">
     <StackPanel Visibility="{c:Binding !EnableAdvancedSettings, Source={x:Static ui_vms:TaskQueueViewModel.TaskSettingVisibilities}}">
-        <!--  FIXME: 任务开始前更新库存数据尚未实现，暂隐藏  -->
-        <!--<CheckBox Content="{DynamicResource DepotUpdateBeforeStart}" IsChecked="{Binding UpdateDepot}" />-->
-        <CheckBox Content="{DynamicResource DepotSkipDuringActivity}" IsChecked="{Binding SkipDuringActivity}" />
-        <CheckBox Margin="0,6,0,0" Content="{DynamicResource DepotSkipDuringResourceCollection}" IsChecked="{Binding SkipDuringResourceCollection}" />
+        <CheckBox Content="{DynamicResource DepotUpdateBeforeStart}" IsChecked="{Binding UpdateDepot}" />
+        <CheckBox
+            Margin="0,6,0,0"
+            Content="{DynamicResource DepotSkipDuringActivity}"
+            IsChecked="{Binding SkipDuringActivity}" />
+        <CheckBox
+            Margin="0,6,0,0"
+            Content="{DynamicResource DepotSkipDuringResourceCollection}"
+            IsChecked="{Binding SkipDuringResourceCollection}" />
         <StackPanel Margin="0,6,0,0" Orientation="Horizontal">
             <CheckBox Content="{DynamicResource CustomStageCode}" IsChecked="{Binding IsStageManually}" />
             <controls:TooltipBlock TooltipText="{DynamicResource CustomStageCodeTip}" />
@@ -99,7 +104,7 @@
                                     CommandParameter="{Binding}"
                                     ToolTip="{DynamicResource Delete}">
                                     <Button.Style>
-                                        <Style TargetType="Button" BasedOn="{StaticResource {x:Type Button}}">
+                                        <Style BasedOn="{StaticResource {x:Type Button}}" TargetType="Button">
                                             <Setter Property="Visibility" Value="Collapsed" />
                                             <Style.Triggers>
                                                 <DataTrigger Binding="{Binding IsMouseOver, RelativeSource={RelativeSource AncestorType={x:Type Grid}}}" Value="True">
@@ -236,7 +241,7 @@
                                     HorizontalAlignment="Left"
                                     HorizontalContentAlignment="Center"
                                     VerticalContentAlignment="Center"
-                                    Maximum="9999"
+                                    Maximum="1145141919"
                                     Minimum="0"
                                     Value="{Binding DropCount, UpdateSourceTrigger=PropertyChanged}" />
 

--- a/src/MaaWpfGui/Views/UserControl/TaskQueue/DepotMaintainTaskUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/TaskQueue/DepotMaintainTaskUserControl.xaml
@@ -12,7 +12,6 @@
     xmlns:s="https://github.com/canton7/Stylet"
     xmlns:taskQueue_vms="clr-namespace:MaaWpfGui.ViewModels.UserControl.TaskQueue"
     xmlns:ui_vms="clr-namespace:MaaWpfGui.ViewModels.UI"
-    Height="600"
     d:Background="White"
     d:DataContext="{d:DesignInstance {x:Type taskQueue_vms:DepotMaintainTaskUserControlModel}}"
     d:DesignWidth="220"
@@ -145,6 +144,7 @@
                                     <Grid.ColumnDefinitions>
                                         <ColumnDefinition Width="Auto" MinWidth="100" />
                                         <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="Auto" />
                                     </Grid.ColumnDefinitions>
                                     <Grid.RowDefinitions>
                                         <RowDefinition />
@@ -161,6 +161,7 @@
                                     <ComboBox
                                         Grid.Row="0"
                                         Grid.Column="1"
+                                        Grid.ColumnSpan="2"
                                         Height="30"
                                         Margin="3,2"
                                         HorizontalContentAlignment="Stretch"
@@ -185,6 +186,7 @@
                                     <hc:NumericUpDown
                                         Grid.Row="1"
                                         Grid.Column="1"
+                                        Grid.ColumnSpan="2"
                                         Width="70"
                                         Height="30"
                                         Margin="3,2"
@@ -204,6 +206,7 @@
                                     <hc:NumericUpDown
                                         Grid.Row="2"
                                         Grid.Column="1"
+                                        Grid.ColumnSpan="2"
                                         Width="70"
                                         Height="30"
                                         Margin="3,2"
@@ -232,6 +235,18 @@
                                         Maximum="999"
                                         Minimum="0"
                                         Value="{Binding StoneCount, UpdateSourceTrigger=PropertyChanged}" />
+                                    <Button
+                                        Grid.Row="3"
+                                        Grid.Column="2"
+                                        Width="25"
+                                        Margin="0"
+                                        Padding="0"
+                                        hc:IconElement.Geometry="{StaticResource DeleteTaskGeometry}"
+                                        hc:IconElement.Height="15"
+                                        hc:IconElement.Width="15"
+                                        Command="{s:Action RemovePlan,
+                                                           Target={x:Static taskQueue_vms:DepotMaintainTaskUserControlModel.Instance}}"
+                                        CommandParameter="{Binding}" />
                                 </Grid>
                             </StackPanel>
                         </Border>

--- a/src/MaaWpfGui/Views/UserControl/TaskQueue/DepotMaintainTaskUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/TaskQueue/DepotMaintainTaskUserControl.xaml
@@ -26,6 +26,7 @@
         <controls:TextBlock
             Margin="0,5,0,0"
             HorizontalAlignment="Left"
+            d:Text="1: 当前/上次 - 不选择 x0"
             Text="{Binding PlanInfo}"
             TextWrapping="Wrap" />
         <StackPanel Orientation="Horizontal">
@@ -34,7 +35,7 @@
                 VerticalAlignment="Bottom"
                 d:IsHitTestVisible="True"
                 Command="{s:Action AddPlan}"
-                Content="添加"
+                Content="{DynamicResource AddPlan}"
                 IsHitTestVisible="{c:Binding !IsCurrentTaskRunning,
                                              Source={x:Static ui_vms:TaskQueueViewModel.TaskSettingVisibilities}}" />
             <Button
@@ -42,7 +43,7 @@
                 VerticalAlignment="Bottom"
                 d:IsHitTestVisible="True"
                 Command="{s:Action CollapseAll}"
-                Content="折叠"
+                Content="{DynamicResource CollapseAll}"
                 IsHitTestVisible="{c:Binding !IsCurrentTaskRunning,
                                              Source={x:Static ui_vms:TaskQueueViewModel.TaskSettingVisibilities}}" />
         </StackPanel>
@@ -70,185 +71,203 @@
             </ListBox.ItemContainerStyle>
             <ListBox.ItemTemplate>
                 <DataTemplate>
-                    <Expander Header="{Binding Title}" IsExpanded="{Binding IsExpanded}">
-                        <Border BorderBrush="{DynamicResource BorderBrush}" BorderThickness="1">
-                            <StackPanel>
-                                <Grid x:Name="StageItemGrid" Margin="0,0,0,-2">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="*" />
-                                        <ColumnDefinition Width="*" />
-                                    </Grid.ColumnDefinitions>
+                    <Expander HorizontalContentAlignment="Stretch" IsExpanded="{Binding IsExpanded}">
+                        <Expander.Header>
+                            <Grid HorizontalAlignment="Stretch">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*" />
+                                    <ColumnDefinition Width="Auto" />
+                                </Grid.ColumnDefinitions>
+                                <controls:TextBlock
+                                    HorizontalAlignment="Left"
+                                    Text="{Binding Title}"
+                                    TextTrimming="CharacterEllipsis" />
+                                <Button
+                                    Grid.Column="1"
+                                    Width="25"
+                                    Height="25"
+                                    Margin="0,0,6,0"
+                                    Padding="0"
+                                    hc:IconElement.Geometry="{StaticResource DeleteTaskGeometry}"
+                                    hc:IconElement.Height="15"
+                                    hc:IconElement.Width="15"
+                                    Command="{s:Action RemovePlan,
+                                                       Target={x:Static taskQueue_vms:DepotMaintainTaskUserControlModel.Instance}}"
+                                    CommandParameter="{Binding}"
+                                    DockPanel.Dock="Right" />
+                            </Grid>
+                        </Expander.Header>
+                        <Border
+                            BorderBrush="{DynamicResource BorderBrush}"
+                            BorderThickness="1,0,1,1"
+                            CornerRadius="0,0,4,4">
+                            <Grid Margin="6">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="Auto" MinWidth="100" />
+                                    <ColumnDefinition Width="*" />
+                                </Grid.ColumnDefinitions>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="Auto" />
+                                </Grid.RowDefinitions>
 
-                                    <controls:TextBlock Grid.Column="0" Text="{DynamicResource StageSelect}" />
-                                    <Grid
-                                        Grid.Column="1"
-                                        Height="30"
-                                        Margin="-10,0,0,0">
-                                        <!--  当 IsStageManually 为 false 时显示 ComboBox  -->
-                                        <ComboBox
-                                            ItemsSource="{Binding StageListSource, Source={x:Static ui_vms:TaskQueueViewModel.DepotMaintainTask}}"
-                                            ScrollViewer.CanContentScroll="False"
-                                            SelectedValue="{Binding Stage}"
-                                            SelectedValuePath="Value"
-                                            Visibility="{c:Binding !IsStageManually,
-                                                                   Source={x:Static ui_vms:TaskQueueViewModel.DepotMaintainTask}}">
-
-                                            <ComboBox.ItemContainerStyle>
-                                                <Style BasedOn="{StaticResource ComboBoxItemBaseStyle}" TargetType="ComboBoxItem">
-                                                    <Style.Triggers>
-                                                        <DataTrigger Binding="{Binding IsVisible}" Value="False">
-                                                            <Setter Property="Visibility" Value="Collapsed" />
-                                                        </DataTrigger>
-                                                    </Style.Triggers>
-                                                </Style>
-                                            </ComboBox.ItemContainerStyle>
-                                            <ComboBox.ItemTemplate>
-                                                <DataTemplate>
-                                                    <TextBlock Text="{Binding Display}">
-                                                        <TextBlock.Style>
-                                                            <Style TargetType="TextBlock">
-                                                                <Style.Triggers>
-                                                                    <DataTrigger Binding="{Binding IsOutdated}" Value="True">
-                                                                        <Setter Property="TextDecorations" Value="Strikethrough" />
-                                                                        <Setter Property="Foreground" Value="{DynamicResource ErrorLogBrush}" />
-                                                                    </DataTrigger>
-                                                                    <DataTrigger Binding="{Binding IsOpen}" Value="False">
-                                                                        <Setter Property="Opacity" Value="0.5" />
-                                                                    </DataTrigger>
-                                                                    <DataTrigger Binding="{Binding IsOpen}" Value="True">
-                                                                        <Setter Property="Opacity" Value="1" />
-                                                                    </DataTrigger>
-                                                                </Style.Triggers>
-                                                            </Style>
-                                                        </TextBlock.Style>
-                                                    </TextBlock>
-                                                </DataTemplate>
-                                            </ComboBox.ItemTemplate>
-                                        </ComboBox>
-
-                                        <!--  当 IsStageManually 为 true 时显示 TextBox  -->
-                                        <TextBox
-                                            Height="30"
-                                            hc:InfoElement.Placeholder="{DynamicResource DefaultStage}"
-                                            IsEnabled="{c:Binding !IsStageItemDragging,
-                                                                  Source={x:Static ui_vms:TaskQueueViewModel.FightTask}}"
-                                            Opacity="{c:Binding 'IsOpen ? 1 : 0.5'}"
-                                            Text="{Binding Stage, UpdateSourceTrigger=PropertyChanged}"
-                                            ToolTip="{DynamicResource IsStageManuallyTip}"
-                                            Visibility="{c:Binding IsStageManually,
-                                                                   Source={x:Static ui_vms:TaskQueueViewModel.DepotMaintainTask}}" />
-                                    </Grid>
-                                </Grid>
-
-                                <Grid Margin="3,0">
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="Auto" MinWidth="100" />
-                                        <ColumnDefinition Width="*" />
-                                        <ColumnDefinition Width="Auto" />
-                                    </Grid.ColumnDefinitions>
-                                    <Grid.RowDefinitions>
-                                        <RowDefinition />
-                                        <RowDefinition />
-                                        <RowDefinition />
-                                        <RowDefinition />
-                                    </Grid.RowDefinitions>
-                                    <controls:TextBlock
-                                        Grid.Row="0"
-                                        Grid.Column="0"
-                                        Margin="22,0,0,0"
-                                        HorizontalAlignment="Left"
-                                        Text="{DynamicResource AssignedMaterial}" />
+                                <!--  关卡选择  -->
+                                <controls:TextBlock
+                                    Grid.Row="0"
+                                    Grid.Column="0"
+                                    Margin="0,0,6,0"
+                                    VerticalAlignment="Center"
+                                    Text="{DynamicResource StageSelect}" />
+                                <Grid
+                                    Grid.Row="0"
+                                    Grid.Column="1"
+                                    Height="30">
+                                    <!--  当 IsStageManually 为 false 时显示 ComboBox  -->
                                     <ComboBox
-                                        Grid.Row="0"
-                                        Grid.Column="1"
-                                        Grid.ColumnSpan="2"
-                                        Height="30"
-                                        Margin="3,2"
-                                        HorizontalContentAlignment="Stretch"
-                                        VerticalContentAlignment="Center"
-                                        s:View.ActionTarget="{Binding}"
-                                        DisplayMemberPath="Display"
-                                        DropDownClosed="{s:Action DropsListDropDownClosed}"
-                                        IsEditable="True"
-                                        IsTextSearchEnabled="False"
-                                        ItemsSource="{Binding DropsList, Source={x:Static ui_vms:TaskQueueViewModel.FightTask}}"
-                                        Loaded="{s:Action MakeComboBoxSearchable,
-                                                          Target={x:Type ui_vms:SettingsViewModel}}"
-                                        SelectedValue="{Binding DropId}"
+                                        ItemsSource="{Binding StageListSource, Source={x:Static ui_vms:TaskQueueViewModel.DepotMaintainTask}}"
+                                        ScrollViewer.CanContentScroll="False"
+                                        SelectedValue="{Binding Stage}"
                                         SelectedValuePath="Value"
-                                        Text="{Binding DropName}" />
-                                    <controls:TextBlock
-                                        Grid.Row="1"
-                                        Grid.Column="0"
-                                        Margin="22,0,0,0"
-                                        HorizontalAlignment="Left"
-                                        Text="{DynamicResource TargetInventory}" />
-                                    <hc:NumericUpDown
-                                        Grid.Row="1"
-                                        Grid.Column="1"
-                                        Grid.ColumnSpan="2"
-                                        Width="70"
+                                        Visibility="{c:Binding !IsStageManually,
+                                                               Source={x:Static ui_vms:TaskQueueViewModel.DepotMaintainTask}}">
+
+                                        <ComboBox.ItemContainerStyle>
+                                            <Style BasedOn="{StaticResource ComboBoxItemBaseStyle}" TargetType="ComboBoxItem">
+                                                <Style.Triggers>
+                                                    <DataTrigger Binding="{Binding IsVisible}" Value="False">
+                                                        <Setter Property="Visibility" Value="Collapsed" />
+                                                    </DataTrigger>
+                                                </Style.Triggers>
+                                            </Style>
+                                        </ComboBox.ItemContainerStyle>
+                                        <ComboBox.ItemTemplate>
+                                            <DataTemplate>
+                                                <TextBlock Text="{Binding Display}">
+                                                    <TextBlock.Style>
+                                                        <Style TargetType="TextBlock">
+                                                            <Style.Triggers>
+                                                                <DataTrigger Binding="{Binding IsOutdated}" Value="True">
+                                                                    <Setter Property="TextDecorations" Value="Strikethrough" />
+                                                                    <Setter Property="Foreground" Value="{DynamicResource ErrorLogBrush}" />
+                                                                </DataTrigger>
+                                                                <DataTrigger Binding="{Binding IsOpen}" Value="False">
+                                                                    <Setter Property="Opacity" Value="0.5" />
+                                                                </DataTrigger>
+                                                                <DataTrigger Binding="{Binding IsOpen}" Value="True">
+                                                                    <Setter Property="Opacity" Value="1" />
+                                                                </DataTrigger>
+                                                            </Style.Triggers>
+                                                        </Style>
+                                                    </TextBlock.Style>
+                                                </TextBlock>
+                                            </DataTemplate>
+                                        </ComboBox.ItemTemplate>
+                                    </ComboBox>
+
+                                    <!--  当 IsStageManually 为 true 时显示 TextBox  -->
+                                    <TextBox
                                         Height="30"
-                                        Margin="3,2"
-                                        HorizontalAlignment="Left"
-                                        HorizontalContentAlignment="Center"
-                                        VerticalContentAlignment="Center"
-                                        Maximum="9999"
-                                        Minimum="0"
-                                        Value="{Binding DropCount, UpdateSourceTrigger=PropertyChanged}" />
-                                    <CheckBox
-                                        Grid.Row="2"
-                                        Grid.Column="0"
-                                        Margin="0,0,0,0"
-                                        HorizontalContentAlignment="Stretch"
-                                        Content="{DynamicResource UseSanityPotion}"
-                                        IsChecked="{Binding UseMedicine}" />
-                                    <hc:NumericUpDown
-                                        Grid.Row="2"
-                                        Grid.Column="1"
-                                        Grid.ColumnSpan="2"
-                                        Width="70"
-                                        Height="30"
-                                        Margin="3,2"
-                                        HorizontalAlignment="Left"
-                                        HorizontalContentAlignment="Center"
-                                        VerticalContentAlignment="Center"
-                                        Maximum="999"
-                                        Minimum="0"
-                                        Value="{Binding MedicineCount, UpdateSourceTrigger=PropertyChanged}" />
-                                    <CheckBox
-                                        Grid.Row="3"
-                                        Grid.Column="0"
-                                        Margin="0,0,0,0"
-                                        HorizontalContentAlignment="Stretch"
-                                        Content="{DynamicResource UseOriginitePrime}"
-                                        IsChecked="{Binding UseStone}" />
-                                    <hc:NumericUpDown
-                                        Grid.Row="3"
-                                        Grid.Column="1"
-                                        Width="70"
-                                        Height="30"
-                                        Margin="3,2"
-                                        HorizontalAlignment="Left"
-                                        HorizontalContentAlignment="Center"
-                                        VerticalContentAlignment="Center"
-                                        Maximum="999"
-                                        Minimum="0"
-                                        Value="{Binding StoneCount, UpdateSourceTrigger=PropertyChanged}" />
-                                    <Button
-                                        Grid.Row="3"
-                                        Grid.Column="2"
-                                        Width="25"
-                                        Margin="0"
-                                        Padding="0"
-                                        hc:IconElement.Geometry="{StaticResource DeleteTaskGeometry}"
-                                        hc:IconElement.Height="15"
-                                        hc:IconElement.Width="15"
-                                        Command="{s:Action RemovePlan,
-                                                           Target={x:Static taskQueue_vms:DepotMaintainTaskUserControlModel.Instance}}"
-                                        CommandParameter="{Binding}" />
+                                        hc:InfoElement.Placeholder="{DynamicResource DefaultStage}"
+                                        IsEnabled="{c:Binding !IsStageItemDragging,
+                                                              Source={x:Static ui_vms:TaskQueueViewModel.FightTask}}"
+                                        Opacity="{c:Binding 'IsOpen ? 1 : 0.5'}"
+                                        Text="{Binding Stage, UpdateSourceTrigger=PropertyChanged}"
+                                        ToolTip="{DynamicResource IsStageManuallyTip}"
+                                        Visibility="{c:Binding IsStageManually,
+                                                               Source={x:Static ui_vms:TaskQueueViewModel.DepotMaintainTask}}" />
                                 </Grid>
-                            </StackPanel>
+
+                                <!--  指定材料  -->
+                                <controls:TextBlock
+                                    Grid.Row="1"
+                                    Grid.Column="0"
+                                    Margin="0,p,6,0"
+                                    VerticalAlignment="Center"
+                                    Text="{DynamicResource AssignedMaterial}" />
+                                <ComboBox
+                                    Grid.Row="1"
+                                    Grid.Column="1"
+                                    Height="30"
+                                    Margin="0,6,0,0"
+                                    HorizontalContentAlignment="Stretch"
+                                    VerticalContentAlignment="Center"
+                                    s:View.ActionTarget="{Binding}"
+                                    DisplayMemberPath="Display"
+                                    DropDownClosed="{s:Action DropsListDropDownClosed}"
+                                    IsEditable="True"
+                                    IsTextSearchEnabled="False"
+                                    ItemsSource="{Binding DropsList, Source={x:Static ui_vms:TaskQueueViewModel.FightTask}}"
+                                    Loaded="{s:Action MakeComboBoxSearchable,
+                                                      Target={x:Type ui_vms:SettingsViewModel}}"
+                                    SelectedValue="{Binding DropId}"
+                                    SelectedValuePath="Value"
+                                    Text="{Binding DropName}" />
+
+                                <!--  目标库存  -->
+                                <controls:TextBlock
+                                    Grid.Row="2"
+                                    Grid.Column="0"
+                                    Margin="0,6,6,0"
+                                    VerticalAlignment="Center"
+                                    Text="{DynamicResource TargetInventory}" />
+                                <hc:NumericUpDown
+                                    Grid.Row="2"
+                                    Grid.Column="1"
+                                    Width="70"
+                                    Height="30"
+                                    Margin="0,6,0,0"
+                                    HorizontalAlignment="Left"
+                                    HorizontalContentAlignment="Center"
+                                    VerticalContentAlignment="Center"
+                                    Maximum="9999"
+                                    Minimum="0"
+                                    Value="{Binding DropCount, UpdateSourceTrigger=PropertyChanged}" />
+
+                                <!--  使用药剂  -->
+                                <CheckBox
+                                    Grid.Row="3"
+                                    Grid.Column="0"
+                                    Margin="0,6,0,0"
+                                    VerticalAlignment="Center"
+                                    Content="{DynamicResource UseSanityPotion}"
+                                    IsChecked="{Binding UseMedicine}" />
+                                <hc:NumericUpDown
+                                    Grid.Row="3"
+                                    Grid.Column="1"
+                                    Width="70"
+                                    Height="30"
+                                    Margin="0,6,0,0"
+                                    HorizontalAlignment="Left"
+                                    HorizontalContentAlignment="Center"
+                                    VerticalContentAlignment="Center"
+                                    Maximum="999"
+                                    Minimum="0"
+                                    Value="{Binding MedicineCount, UpdateSourceTrigger=PropertyChanged}" />
+
+                                <!--  使用源石  -->
+                                <CheckBox
+                                    Grid.Row="4"
+                                    Grid.Column="0"
+                                    Margin="0,6,0,0"
+                                    VerticalAlignment="Center"
+                                    Content="{DynamicResource UseOriginitePrime}"
+                                    IsChecked="{Binding UseStone}" />
+                                <hc:NumericUpDown
+                                    Grid.Row="4"
+                                    Grid.Column="1"
+                                    Width="70"
+                                    Height="30"
+                                    Margin="0,6,0,0"
+                                    HorizontalAlignment="Left"
+                                    HorizontalContentAlignment="Center"
+                                    VerticalContentAlignment="Center"
+                                    Maximum="999"
+                                    Minimum="0"
+                                    Value="{Binding StoneCount, UpdateSourceTrigger=PropertyChanged}" />
+                            </Grid>
                         </Border>
                     </Expander>
                 </DataTemplate>

--- a/src/MaaWpfGui/Views/UserControl/TaskQueue/DepotMaintainTaskUserControl.xaml.cs
+++ b/src/MaaWpfGui/Views/UserControl/TaskQueue/DepotMaintainTaskUserControl.xaml.cs
@@ -1,0 +1,55 @@
+// <copyright file="DepotMaintainTaskUserControl.xaml.cs" company="MaaAssistantArknights">
+// Part of the MaaWpfGui project, maintained by the MaaAssistantArknights team (Maa Team)
+// Copyright (C) 2021-2025 MaaAssistantArknights Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License v3.0 only as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY
+// </copyright>
+
+using System.Windows;
+using System.Windows.Input;
+using MaaWpfGui.ViewModels.UI;
+
+namespace MaaWpfGui.Views.UserControl.TaskQueue;
+
+/// <summary>
+/// DepotMaintainTaskUserControl.xaml 的交互逻辑
+/// </summary>
+public partial class DepotMaintainTaskUserControl : System.Windows.Controls.UserControl
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DepotMaintainTaskUserControl"/> class.
+    /// </summary>
+    public DepotMaintainTaskUserControl()
+    {
+        InitializeComponent();
+    }
+
+    private void DragHandle_PreviewMouseLeftButtonDown(object sender, MouseButtonEventArgs e)
+    {
+        TaskQueueViewModel.FightTask.IsStageItemDragging = true;
+
+        // 拖拽松开时可能不经过 Button，在 Window 层兜底恢复
+        var window = Window.GetWindow(this);
+        window?.PreviewMouseLeftButtonUp += Window_PreviewMouseLeftButtonUp;
+    }
+
+    private void DragHandle_PreviewMouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+    {
+        TaskQueueViewModel.FightTask.IsStageItemDragging = false;
+    }
+
+    private void Window_PreviewMouseLeftButtonUp(object sender, MouseButtonEventArgs e)
+    {
+        TaskQueueViewModel.FightTask.IsStageItemDragging = false;
+        if (sender is Window window)
+        {
+            window.PreviewMouseLeftButtonUp -= Window_PreviewMouseLeftButtonUp;
+        }
+    }
+}


### PR DESCRIPTION
先打个底，缺删除plan，UI看看要不要调

## Summary by Sourcery

添加一个新的仓库维护任务类型，并提供相应的配置、序列化和 UI 集成，用于维护库存数量。

新功能：
- 引入 `DepotMaintainTask` 作为新的 `BaseTask` 类型，用于仓库（库存）维护工作流。
- 添加 `DepotMaintainTask` 用户控件和视图模型，用于配置库存维护计划，并将其序列化为战斗任务。
- 在任务队列和任务设置可见性配置中，将仓库维护暴露为可选任务。

增强：
- 将仓库维护计划与现有的战斗设置、掉落选择以及任务队列日志机制集成。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a new depot maintenance task type with corresponding configuration, serialization, and UI integration for maintaining inventory quantities.

New Features:
- Introduce DepotMaintainTask as a new BaseTask type for depot (inventory) maintenance workflows.
- Add DepotMaintainTask user control and view model to configure inventory maintenance plans and serialize them into fight tasks.
- Expose depot maintenance as a selectable task in the task queue and task settings visibility configuration.

Enhancements:
- Integrate depot maintenance planning with existing fight settings, drop selection, and task queue logging mechanisms.

</details>

## Summary by Sourcery

引入一个可配置的仓库维护任务，用于将库存数量维持在目标水平，并将其集成到任务队列和关卡管理流程中。

New Features:
- 添加 `DepotMaintainTask` 作为新的 `BaseTask` 类型和 `TaskType`，用于库存维护相关的工作流。
- 提供 `DepotMaintainTask` 的用户控件和视图模型，用于配置逐物品的维护计划，包括关卡和资源使用选项。
- 将仓库维护暴露为任务队列中的可选任务，并提供专用的可见性设置和本地化字符串。

Enhancements:
- 在任务开始时，使用最新的仓库库存重新计算战斗任务的掉落需求，该库存在普通战斗任务和仓库维护计划之间共享。
- 拓展关卡管理，用于跟踪活动期间和资源收集事件，从而在这些时间段内支持有条件地跳过仓库维护。
- 确保每个可搜索的 `ComboBox` 使用独立的集合视图，以防止不同控件之间的筛选互相干扰。
- 使仓库维护的关卡列表与客户端类型和全局关卡列表更新保持同步，包括对未开放或已过期关卡的处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a configurable depot maintenance task to keep inventory quantities at target levels and integrate it into the task queue and stage management flows.

New Features:
- Add DepotMaintainTask as a new BaseTask type and TaskType for inventory maintenance workflows.
- Provide a DepotMaintainTask user control and view model to configure per-item maintenance plans, including stages and resource usage options.
- Expose depot maintenance as a selectable task in the task queue with dedicated visibility settings and localization strings.

Enhancements:
- Recalculate fight task drop requirements at task start using the latest depot inventory, shared between normal fight tasks and depot maintenance plans.
- Extend stage management to track activity periods and resource-collection events, enabling conditional skipping of depot maintenance during these times.
- Ensure each searchable ComboBox uses an independent collection view to prevent cross-control filtering interference.
- Keep depot maintenance stage lists in sync with client type and global stage list updates, including handling of non-open or outdated stages.

</details>