### PR TITLE
fix(gui): 修复配置同步保存与异步保存的并发写入竞态

### DIFF
--- a/src/MaaWpfGui/Configuration/Factory/ConfigFactory.cs
+++ b/src/MaaWpfGui/Configuration/Factory/ConfigFactory.cs
@@ -380,20 +380,24 @@ public static class ConfigFactory
 
     private static bool Save(string? file = null, Root? root = null)
     {
-        lock (_lock)
+        // 与 SaveAsync 共用同一信号量，使同步保存与异步保存互斥，
+        // 避免二者并发写入同一配置文件，导致写入内容被截断/损坏（#16915）
+        _semaphore.Wait();
+        try
         {
-            try
-            {
-                File.WriteAllText(file ?? ConfigFile, JsonSerializer.Serialize(root ?? Root, _options));
-            }
-            catch (Exception e)
-            {
-                _logger.Error(e, "Failed to save configuration file.");
-                return false;
-            }
-
-            return true;
+            File.WriteAllText(file ?? ConfigFile, JsonSerializer.Serialize(root ?? Root, _options));
         }
+        catch (Exception e)
+        {
+            _logger.Error(e, "Failed to save configuration file.");
+            return false;
+        }
+        finally
+        {
+            _semaphore.Release();
+        }
+
+        return true;
     }
 
     private static async Task<bool> SaveAsync(string? file = null)


### PR DESCRIPTION
ConfigFactory 中 Save() 使用 _lock、SaveAsync() 使用 _semaphore，二者是相互 独立的同步原语，却都向同一配置文件写入。当收尾保存（Release 调用 Save）与防抖
异步保存（SaveAsync）窗口重叠时，可能并发写入同一文件，导致写入内容被截断/损坏，
下次启动反序列化失败而回退默认配置（疑似 #16915 主题被重置为默认的原因之一）。

让 Save() 改用与 SaveAsync() 相同的 _semaphore，使同步保存与异步保存互斥。 _lock 仍用于保护 Root 的延迟加载；调用顺序始终为 _lock -> _semaphore，不会死锁； Save() 仅由延迟加载与 Release 调用，二者均未持有 _semaphore，不存在重入。

Related to #16915

## Summary by Sourcery

Bug Fixes:
- 防止由于并发的同步和异步保存操作同时写入同一配置文件而导致的配置文件截断或损坏。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent configuration file truncation or corruption caused by concurrent synchronous and asynchronous saves writing to the same file.

</details>