### PR TITLE
feat: 添加 MeoW 推送通知支持

### DIFF
--- a/src/MaaWpfGui/Constants/ConfigurationKeys.cs
+++ b/src/MaaWpfGui/Constants/ConfigurationKeys.cs
@@ -324,6 +324,7 @@ public static class ConfigurationKeys
     public const string ExternalNotificationCustomWebhookUrl = "ExternalNotification.CustomWebhook.Url";
     public const string ExternalNotificationCustomWebhookBody = "ExternalNotification.CustomWebhook.Body";
     public const string ExternalNotificationCustomWebhookHeaders = "ExternalNotification.CustomWebhook.Headers";
+    public const string ExternalNotificationMeoWNickname = "ExternalNotification.MeoW.Nickname";
 
     public const string PerformanceUseGpu = "Performance.UseGpu";
     public const string PerformancePreferredGpuDescription = "Performance.PreferredGpuDescription";

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -78,6 +78,7 @@
     <system:String x:Key="ExternalNotificationCustomWebhook.Headers">Webhook Headers</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.Body">Message body template</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.Placeholders">Placeholders: {title}, {content}, {time}</system:String>
+    <system:String x:Key="ExternalNotificationMeoWNickname">MeoW Nickname</system:String>
     <system:String x:Key="UseGpuForInference">Use GPU for inference acceleration</system:String>
     <system:String x:Key="UseGpuForInferenceTip">Using GPU inference can significantly reduce CPU load with minimal GPU usage</system:String>
     <system:String x:Key="GpuOptionDisable">Don’t use</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -78,6 +78,7 @@
     <system:String x:Key="ExternalNotificationCustomWebhook.Headers">Webhook Headers</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.Body">メッセージ本文</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.Placeholders">プレホルダー: {title}、{content}、{time}</system:String>
+    <system:String x:Key="ExternalNotificationMeoWNickname">MeoW ニックネーム</system:String>
     <system:String x:Key="UseGpuForInference">推論加速のためにGPUを使用する</system:String>
     <system:String x:Key="UseGpuForInferenceTip">GPU 推論を利用することで、ごくわずかな GPU 使用率で CPU の負荷を大幅に軽減できます</system:String>
     <system:String x:Key="GpuOptionDisable">使用しない</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -78,6 +78,7 @@
     <system:String x:Key="ExternalNotificationCustomWebhook.Headers">Webhook Headers</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.Body">메시지 본문 템플릿</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.Placeholders">플레이스홀더: {title}, {content}, {time}</system:String>
+    <system:String x:Key="ExternalNotificationMeoWNickname">MeoW 닉네임</system:String>
     <system:String x:Key="UseGpuForInference">추론 가속화를 위해 GPU 사용</system:String>
     <system:String x:Key="UseGpuForInferenceTip">GPU 추론을 사용하면 매우 적은 GPU 점유로 CPU 부담을 크게 줄일 수 있습니다</system:String>
     <system:String x:Key="GpuOptionDisable">미사용</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -78,6 +78,7 @@
     <system:String x:Key="ExternalNotificationCustomWebhook.Headers">Webhook Headers</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.Body">消息体模板</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.Placeholders">可用占位符：{title}、{content}、{time}</system:String>
+    <system:String x:Key="ExternalNotificationMeoWNickname">MeoW 昵称</system:String>
     <system:String x:Key="UseGpuForInference">使用 GPU 加速推理</system:String>
     <system:String x:Key="UseGpuForInferenceTip">使用 GPU 推理能够以极低的 GPU 占用显著降低 CPU 的负担</system:String>
     <system:String x:Key="GpuOptionDisable">不使用</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -78,6 +78,7 @@
     <system:String x:Key="ExternalNotificationCustomWebhook.Headers">Webhook Headers</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.Body">訊息本文範本</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.Placeholders">可用佔位符：{title}、{content}、{time}</system:String>
+    <system:String x:Key="ExternalNotificationMeoWNickname">MeoW 暱稱</system:String>
     <system:String x:Key="UseGpuForInference">使用 GPU 加速推理</system:String>
     <system:String x:Key="UseGpuForInferenceTip">使用 GPU 推理能以極低的 GPU 佔用顯著降低 CPU 的負擔</system:String>
     <system:String x:Key="GpuOptionDisable">不使用</system:String>

--- a/src/MaaWpfGui/Services/Notification/ExternalNotificationService.cs
+++ b/src/MaaWpfGui/Services/Notification/ExternalNotificationService.cs
@@ -44,6 +44,7 @@ public static class ExternalNotificationService
                 "SMTP" => new SmtpNotificationProvider(),
                 "Bark" => new BarkNotificationProvider(Instances.HttpService),
                 "Qmsg" => new QmsgNotificationProvider(Instances.HttpService),
+                "MeoW" => new MeoWNotificationProvider(Instances.HttpService),
                 _ => new DummyNotificationProvider(),
             };
 

--- a/src/MaaWpfGui/Services/Notification/MeoWNotificationProvider.cs
+++ b/src/MaaWpfGui/Services/Notification/MeoWNotificationProvider.cs
@@ -1,0 +1,71 @@
+// <copyright file="MeoWNotificationProvider.cs" company="MaaAssistantArknights">
+// Part of the MaaWpfGui project, maintained by the MaaAssistantArknights team (Maa Team)
+// Copyright (C) 2021-2025 MaaAssistantArknights Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License v3.0 only as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY
+// </copyright>
+
+#nullable enable
+using System;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MaaWpfGui.Services.Web;
+using MaaWpfGui.ViewModels.UI;
+using Serilog;
+
+namespace MaaWpfGui.Services.Notification;
+
+public class MeoWNotificationProvider(IHttpService httpService) : IExternalNotificationProvider
+{
+    private const string MeoWApiBase = "https://api.chuckfang.com";
+
+    private readonly ILogger _logger = Log.ForContext<MeoWNotificationProvider>();
+
+    public async Task<bool> SendAsync(string title, string content)
+    {
+        var nickname = SettingsViewModel.ExternalNotificationSettings.MeoWNickname;
+        if (string.IsNullOrWhiteSpace(nickname))
+        {
+            _logger.Warning("Failed to send MeoW notification, nickname is empty");
+            return false;
+        }
+
+        var url = $"{MeoWApiBase}/{Uri.EscapeDataString(nickname)}";
+
+        try
+        {
+            var response = await httpService.PostAsJsonAsync(new Uri(url), new { title, msg = content });
+            if (response == null)
+            {
+                _logger.Warning("Failed to send MeoW notification, response is null");
+                return false;
+            }
+
+            using var json = JsonDocument.Parse(response);
+            var root = json.RootElement;
+            var isSuccess = root.TryGetProperty("status", out var statusElement)
+                && statusElement.TryGetInt32(out var status)
+                && status == 200;
+
+            if (isSuccess)
+            {
+                return true;
+            }
+
+            var statusValue = statusElement.ValueKind == JsonValueKind.Undefined ? "missing" : statusElement.GetRawText();
+            _logger.Warning("Failed to send MeoW notification, status: {Status}, response: {Response}", statusValue, response);
+        }
+        catch (Exception ex)
+        {
+            _logger.Error(ex, "Exception occurred while sending MeoW notification.");
+        }
+
+        return false;
+    }
+}

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/ExternalNotificationSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/ExternalNotificationSettingsUserControlModel.cs
@@ -100,6 +100,7 @@ public class ExternalNotificationSettingsUserControlModel : PropertyChangedBase
             "Bark",
             "Qmsg",
             "Gotify",
+            "MeoW",
             "Custom Webhook"
         ];
 
@@ -220,6 +221,14 @@ public class ExternalNotificationSettingsUserControlModel : PropertyChangedBase
         set => SetAndNotify(ref _customWebhookEnabled, value);
     }
 
+    private bool _meowEnabled = false;
+
+    public bool MeoWEnabled
+    {
+        get => _meowEnabled;
+        set => SetAndNotify(ref _meowEnabled, value);
+    }
+
     public void UpdateExternalNotificationProvider()
     {
         ServerChanEnabled = _enabledExternalNotificationProviders.Contains("ServerChan");
@@ -232,6 +241,7 @@ public class ExternalNotificationSettingsUserControlModel : PropertyChangedBase
         QmsgEnabled = _enabledExternalNotificationProviders.Contains("Qmsg");
         GotifyEnabled = _enabledExternalNotificationProviders.Contains("Gotify");
         CustomWebhookEnabled = _enabledExternalNotificationProviders.Contains("Custom Webhook");
+        MeoWEnabled = _enabledExternalNotificationProviders.Contains("MeoW");
     }
 
     #endregion External Enable
@@ -569,6 +579,18 @@ public class ExternalNotificationSettingsUserControlModel : PropertyChangedBase
             SetAndNotify(ref _customWebhookHeaders, value);
             value = SimpleEncryptionHelper.Encrypt(value);
             ConfigurationHelper.SetValue(ConfigurationKeys.ExternalNotificationCustomWebhookHeaders, value);
+        }
+    }
+
+    private string _meowNickname = SimpleEncryptionHelper.Decrypt(ConfigurationHelper.GetValue(ConfigurationKeys.ExternalNotificationMeoWNickname, string.Empty));
+
+    public string MeoWNickname
+    {
+        get => _meowNickname;
+        set {
+            SetAndNotify(ref _meowNickname, value);
+            value = SimpleEncryptionHelper.Encrypt(value);
+            ConfigurationHelper.SetValue(ConfigurationKeys.ExternalNotificationMeoWNickname, value);
         }
     }
 

--- a/src/MaaWpfGui/Views/UserControl/Settings/ExternalNotificationSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/Settings/ExternalNotificationSettingsUserControl.xaml
@@ -30,6 +30,7 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
         <!--<controls:TextBlock
@@ -487,6 +488,20 @@
 
         <StackPanel
             Grid.Row="11"
+            Orientation="Vertical"
+            Visibility="{c:Binding MeoWEnabled}">
+            <hc:Divider Content="MeoW" />
+            <hc:TextBox
+                x:Name="MeoWNickname"
+                Width="400"
+                Height="30"
+                Margin="10"
+                hc:InfoElement.Title="{DynamicResource ExternalNotificationMeoWNickname}"
+                Text="{c:Binding MeoWNickname}" />
+        </StackPanel>
+
+        <StackPanel
+            Grid.Row="12"
             Orientation="Vertical"
             Visibility="{c:Binding CustomWebhookEnabled}">
             <hc:Divider Content="{DynamicResource ExternalNotificationCustomWebhook}" />


### PR DESCRIPTION
添加 MeoW 推送服务（通过 https://api.chuckfang.com/{昵称} 发送 POST JSON 通知）， 作为 MAA 外部通知的新推送渠道。

- 新增 MeoWNotificationProvider 实现 IExternalNotificationProvider 接口
- 在 ExternalNotificationService 中注册 MeoW 推送
- 配置键、ViewModel 属性、XAML 界面、本地化字符串

之前在群里提过但是有大佬说 Custom Webhook 可以实现所以之前就先没做，直到又一次忘了电脑密码强制重置导致加密配置全丢了之后感觉还是做一个吧。

## 由 Sourcery 提供的总结

将 MeoW 添加为一个新的外部推送通知渠道，并集成到现有的通知系统中。

新功能：
- 引入 MeoW 外部通知提供方，使用已配置的昵称向 MeoW API 发送 JSON POST 请求。
- 在外部通知设置界面中公开 MeoW 的启用开关和昵称设置，并支持配置持久化和本地化。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add MeoW as a new external push notification channel integrated into the existing notification system.

New Features:
- Introduce a MeoW external notification provider that sends JSON POST requests to the MeoW API using a configured nickname.
- Expose MeoW enablement and nickname settings in the external notification settings UI with persisted configuration and localization.

</details>