### PR TITLE
fix: infrast enter office

### DIFF
--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -2678,7 +2678,7 @@
         "template": "OfficeMini.png",
         "maskRange": [1, 255],
         "roi": [627, 160, 653, 404],
-        "templThreshold": 0.95
+        "templThreshold": 0.9
     },
     "InfrastProcessing": {
         "maskRange": [1, 255],


### PR DESCRIPTION
Lower threshold for easier match. The original threshold was too high that it filtered out the only match here:

```
multi_match |  result: [{ template: OfficeMini.png, rect: [ 1032, 367, 62, 51 ], score: 0.939398 }] roi: [ 627, 160, 653, 404 ]
```

This fixes #16127 .

## 由 Sourcery 提供的摘要

错误修复：
- 降低办公室入口任务的匹配阈值，以避免有效匹配被错误过滤掉。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Lower the matching threshold for the office entrance task so valid matches are no longer incorrectly filtered out.

</details>