### PR TITLE
[WIP] feat: add send all clues option

### DIFF
--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -3272,6 +3272,13 @@
         "postDelay": 1000,
         "next": ["InfrastClueQuickSendDuplicates", "SelectClue", "CloseSendClue"]
     },
+    "SendAllClues": {
+        "action": "ClickSelf",
+        "roi": [1160, 320, 80, 90],
+        "maskRange": [1, 255],
+        "postDelay": 1000,
+        "next": ["SelectClue", "CloseSendClue"]
+    },
     "SelectClue": {
         "action": "ClickSelf",
         "roi": [99, 222, 177, 147],

--- a/src/MaaCore/Task/Infrast/InfrastReceptionTask.cpp
+++ b/src/MaaCore/Task/Infrast/InfrastReceptionTask.cpp
@@ -327,6 +327,12 @@ bool asst::InfrastReceptionTask::send_clue()
     return task.set_retry_times(20).run();
 }
 
+bool asst::InfrastReceptionTask::send_all_clues()
+{
+    ProcessTask task(*this, { "SendAllClues" });
+    return task.set_retry_times(20).run();
+}
+
 bool asst::InfrastReceptionTask::shift()
 {
     LogTraceFunction;

--- a/src/MaaCore/Task/Infrast/InfrastReceptionTask.h
+++ b/src/MaaCore/Task/Infrast/InfrastReceptionTask.h
@@ -17,6 +17,8 @@ public:
 
     void set_send_clue(bool value) noexcept { m_send_clue = value; }
 
+    void set_send_all_clues(bool value) noexcept { m_send_all_clues = value; }
+
 protected:
     virtual bool _run() override;
     virtual bool on_run_fails() override;
@@ -42,5 +44,6 @@ private:
     bool m_receive_message_board = true;
     bool m_enable_clue_exchange = true;
     bool m_send_clue = true;
+    bool m_send_all_clues = false;
 };
 }

--- a/src/MaaCore/Task/Interface/InfrastTask.cpp
+++ b/src/MaaCore/Task/Interface/InfrastTask.cpp
@@ -175,6 +175,9 @@ bool asst::InfrastTask::set_params(const json::value& params)
     bool reception_send_clue = params.get("reception_send_clue", true);
     m_reception_task_ptr->set_send_clue(reception_send_clue);
 
+    bool reception_send_clue = params.get("reception_send_all_clues", true);
+    m_reception_task_ptr->set_send_all_clues(reception_send_all_clues);
+
     bool replenish = params.get("replenish", false);
     m_replenish_task_ptr->set_enable(replenish);
 


### PR DESCRIPTION
## Summary by Sourcery

为基础设施接收添加发送所有线索的配置和任务支持。

新功能：
- 在基础设施接收任务中引入发送所有线索的操作。
- 允许通过 InfrastTask JSON 参数配置发送所有线索的行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configuration and task support for sending all clues in infrastructure reception.

New Features:
- Introduce a send-all-clues operation in the infrastructure reception task.
- Allow configuring the send-all-clues behavior via InfrastTask JSON parameters.

</details>