### PR TITLE
fix: ConfigFactory Save锁统一

### DIFF
--- a/src/MaaWpfGui/Configuration/Factory/ConfigFactory.cs
+++ b/src/MaaWpfGui/Configuration/Factory/ConfigFactory.cs
@@ -26,7 +26,6 @@ using System.Text.Json.Serialization.Metadata;
 using System.Text.Unicode;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Windows;
 using MaaWpfGui.Configuration.Converter;
 using MaaWpfGui.Configuration.Single;
 using MaaWpfGui.Configuration.Single.MaaTask;
@@ -163,7 +162,7 @@ public static class ConfigFactory
                 SpecificConfigBind(keyValue.Key, keyValue.Value);
             }
 
-            if (Save(_configBakFile, parsed))
+            if (Save(_configBakFile, parsed).GetAwaiter().GetResult())
             {
                 _logger.Information("{File} saved", _configBakFile);
             }
@@ -378,21 +377,22 @@ public static class ConfigFactory
         });
     }
 
-    private static bool Save(string? file = null, Root? root = null)
+    private static async Task<bool> Save(string? file = null, Root? root = null)
     {
-        lock (_lock)
+        await _semaphore.WaitAsync().ConfigureAwait(false);
+        try
         {
-            try
-            {
-                File.WriteAllText(file ?? ConfigFile, JsonSerializer.Serialize(root ?? Root, _options));
-            }
-            catch (Exception e)
-            {
-                _logger.Error(e, "Failed to save configuration file.");
-                return false;
-            }
-
+            await File.WriteAllTextAsync(file ?? ConfigFile, JsonSerializer.Serialize(root ?? Root, _options)).ConfigureAwait(false);
             return true;
+        }
+        catch (Exception e)
+        {
+            _logger.Error(e, "Failed to save configuration file.");
+            return false;
+        }
+        finally
+        {
+            _semaphore.Release();
         }
     }
 
@@ -425,16 +425,13 @@ public static class ConfigFactory
             _logger.Information("Waiting for save task to complete");
             _saveTask.Wait();
         }
-        lock (_lock)
+        if (Save().GetAwaiter().GetResult())
         {
-            if (Save())
-            {
-                _logger.Information("{File} saved", ConfigFile);
-            }
-            else
-            {
-                _logger.Warning("{File} save failed", ConfigFile);
-            }
+            _logger.Information("{File} saved", ConfigFile);
+        }
+        else
+        {
+            _logger.Warning("{File} save failed", ConfigFile);
         }
     }
 

--- a/src/MaaWpfGui/Configuration/Factory/ConfigFactory.cs
+++ b/src/MaaWpfGui/Configuration/Factory/ConfigFactory.cs
@@ -162,7 +162,7 @@ public static class ConfigFactory
                 SpecificConfigBind(keyValue.Key, keyValue.Value);
             }
 
-            if (Save(_configBakFile, parsed).GetAwaiter().GetResult())
+            if (Save(_configBakFile, parsed))
             {
                 _logger.Information("{File} saved", _configBakFile);
             }
@@ -377,12 +377,12 @@ public static class ConfigFactory
         });
     }
 
-    private static async Task<bool> Save(string? file = null, Root? root = null)
+    private static bool Save(string? file = null, Root? root = null)
     {
-        await _semaphore.WaitAsync().ConfigureAwait(false);
+        _semaphore.Wait();
         try
         {
-            await File.WriteAllTextAsync(file ?? ConfigFile, JsonSerializer.Serialize(root ?? Root, _options)).ConfigureAwait(false);
+            File.WriteAllText(file ?? ConfigFile, JsonSerializer.Serialize(root ?? Root, _options));
             return true;
         }
         catch (Exception e)
@@ -425,7 +425,7 @@ public static class ConfigFactory
             _logger.Information("Waiting for save task to complete");
             _saveTask.Wait();
         }
-        if (Save().GetAwaiter().GetResult())
+        if (Save())
         {
             _logger.Information("{File} saved", ConfigFile);
         }


### PR DESCRIPTION
## 由 Sourcery 提供的总结

使配置保存使用基于异步和信号量的机制，并确保最终保存时采用一致的锁定方式。

错误修复：
- 通过统一使用基于信号量的 `Save` 实现，防止在保存配置文件时可能出现的竞态条件和不一致的锁定问题。

增强内容：
- 重构配置的 `Save` 方法，使其异步化并使用异步文件 I/O，在需要的地方将调用方更新为以同步方式调用该方法。
- 从配置工厂中移除未使用的 WPF 命名空间导入。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过切换为基于信号量的保护机制来统一配置保存时的加锁方式，并将其一致地应用于同步保存和发布时（release-time）的保存。

Bug Fixes:
- 通过使用与其他地方相同的信号量来保护同步保存操作，防止配置保存时的竞态条件。

Enhancements:
- 优化配置保存逻辑，在使用信号量时采用 try/catch/finally 结构，并将保存成功或失败的日志记录逻辑集中化。
- 从配置工厂中移除未使用的 WPF 命名空间引用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify configuration save locking by switching to semaphore-based protection and apply it consistently to synchronous and release-time saves.

Bug Fixes:
- Prevent configuration save race conditions by guarding synchronous saves with the same semaphore used elsewhere.

Enhancements:
- Refine configuration save logic to use try/catch/finally around semaphore usage and centralize logging of save success or failure.
- Remove an unused WPF namespace import from the configuration factory.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过切换为基于信号量的保护机制来统一配置保存时的加锁方式，并将其一致地应用于同步保存和发布时（release-time）的保存。

Bug Fixes:
- 通过使用与其他地方相同的信号量来保护同步保存操作，防止配置保存时的竞态条件。

Enhancements:
- 优化配置保存逻辑，在使用信号量时采用 try/catch/finally 结构，并将保存成功或失败的日志记录逻辑集中化。
- 从配置工厂中移除未使用的 WPF 命名空间引用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify configuration save locking by switching to semaphore-based protection and apply it consistently to synchronous and release-time saves.

Bug Fixes:
- Prevent configuration save race conditions by guarding synchronous saves with the same semaphore used elsewhere.

Enhancements:
- Refine configuration save logic to use try/catch/finally around semaphore usage and centralize logging of save success or failure.
- Remove an unused WPF namespace import from the configuration factory.

</details>

</details>

</details>