### PR TITLE
fix(core): string_replace_all_in_place 在 from 为空时不再死循环

### DIFF
--- a/src/MaaCore/Utils/StringMisc.hpp
+++ b/src/MaaCore/Utils/StringMisc.hpp
@@ -35,6 +35,11 @@ template <IsSomeKindOfString StringT>
 inline constexpr void
     string_replace_all_in_place(StringT& str, detail::sv_type<StringT> from, detail::sv_type<StringT> to)
 {
+    // 空的 from 会使 str.find(from, pos) 始终返回 pos，导致无限循环（字符串还会无限增长）。
+    // 空模式没有有意义的“全部替换”语义，直接返回。
+    if (from.empty()) {
+        return;
+    }
     for (size_t pos(0);; pos += to.length()) {
         if ((pos = str.find(from, pos)) == StringT::npos) {
             return;


### PR DESCRIPTION
当 from 为空字符串时，str.find(from, pos) 总是返回 pos，循环永远无法到达 npos：若 to 非空则每轮在 pos 处插入 to 并使字符串无限增长，若 to 也为空则
pos 始终停在 0，两种情况都会死循环（卡死并耗尽内存）。

空模式没有有意义的“全部替换”语义，故在函数开头对空 from 直接返回。其余
重载（pair / initializer_list）都委托到该函数，一并受益。

（StringMisc 的单元测试正由 #16317 单独补充，可在其中加入 from 为空的用例。）

## Summary by Sourcery

Bug Fixes:
- 通过在 `from` 模式为空字符串时提前返回，避免 `string_replace_all_in_place` 出现无限循环和内存无限增长的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Avoid infinite loops and unbounded memory growth in string_replace_all_in_place when the from pattern is an empty string by returning early.

</details>