### PR TITLE
fix(gui): 释放 StartSettings 中未释放的 Process 对象

### DIFF
--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/StartSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/StartSettingsUserControlModel.cs
@@ -329,7 +329,7 @@ public class StartSettingsUserControlModel : PropertyChangedBase
         try
         {
             var (fileName, arguments) = ResolveShortcut(EmulatorPath);
-            Process process = new Process {
+            using Process process = new Process {
                 StartInfo = new ProcessStartInfo(fileName, arguments) {
                     UseShellExecute = false,
                 },
@@ -398,7 +398,7 @@ public class StartSettingsUserControlModel : PropertyChangedBase
             UseShellExecute = false,
         };
 
-        Process process = new Process {
+        using Process process = new Process {
             StartInfo = processStartInfo,
         };
 
@@ -430,7 +430,7 @@ public class StartSettingsUserControlModel : PropertyChangedBase
             UseShellExecute = false,
         };
 
-        Process process = new Process { StartInfo = processStartInfo, };
+        using Process process = new Process { StartInfo = processStartInfo, };
 
         process.Start();
         process.StandardInput.WriteLine($"\"{adbPath}\" disconnect {address}");


### PR DESCRIPTION
StartEmulator / RestartAdb / ReconnectByAdb 中 new 出来的 Process 对象在使用后 未被释放，会泄漏进程相关句柄（CA2000）。改为 using 声明，使其在作用域结束时
释放。释放 Process 托管对象只回收本地句柄，不会终止已启动的进程，因此对仿真器
的 fire-and-forget 启动也是安全的。

不改动 catch 兜底里的静态 Process.Start，以及 GetProcesses() 的查询写法。

## Summary by Sourcery

Bug Fixes:
- 释放用于启动模拟器和执行 ADB 命令的 Process 对象，以修复句柄泄漏警告（CA2000）。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Dispose Process objects used for starting the emulator and ADB commands to fix handle leakage warnings (CA2000).

</details>