### PR TITLE
feat: 自定义 Webhook 新增内置模板模式

### DIFF
--- a/resource/webhook_template/meow.json
+++ b/resource/webhook_template/meow.json
@@ -1,0 +1,40 @@
+{
+  "id": "meow",
+  "name": {
+    "default": "en-us",
+    "content": {
+      "zh-cn": "MeoW",
+      "en-us": "MeoW"
+    }
+  },
+  "description": {
+    "default": "en-us",
+    "content": {
+      "zh-cn": "MeoW 鸿蒙消息推送",
+      "en-us": "MeoW message push for HarmonyOS"
+    }
+  },
+  "url": "https://api.chuckfang.com/{nickname}",
+  "headers": "Content-Type: application/json",
+  "bodyTemplate": "{\"title\":\"{title}\",\"msg\":\"{content}\\n{time}\"}",
+  "userParameters": [
+    {
+      "key": "nickname",
+      "label": {
+        "default": "en-us",
+        "content": {
+          "zh-cn": "昵称",
+          "en-us": "Nickname"
+        }
+      },
+      "placeholder": {
+        "default": "en-us",
+        "content": {
+          "zh-cn": "输入你的 MeoW 昵称",
+          "en-us": "Enter your MeoW nickname"
+        }
+      },
+      "required": true
+    }
+  ]
+}

--- a/src/MaaWpfGui/Constants/ConfigurationKeys.cs
+++ b/src/MaaWpfGui/Constants/ConfigurationKeys.cs
@@ -324,6 +324,8 @@ public static class ConfigurationKeys
     public const string ExternalNotificationCustomWebhookUrl = "ExternalNotification.CustomWebhook.Url";
     public const string ExternalNotificationCustomWebhookBody = "ExternalNotification.CustomWebhook.Body";
     public const string ExternalNotificationCustomWebhookHeaders = "ExternalNotification.CustomWebhook.Headers";
+    public const string ExternalNotificationCustomWebhookSelectedTemplate = "ExternalNotification.CustomWebhook.SelectedTemplate";
+    public const string ExternalNotificationCustomWebhookTemplateParams = "ExternalNotification.CustomWebhook.TemplateParameters";
 
     public const string PerformanceUseGpu = "Performance.UseGpu";
     public const string PerformancePreferredGpuDescription = "Performance.PreferredGpuDescription";

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -78,6 +78,7 @@
     <system:String x:Key="ExternalNotificationCustomWebhook.Headers">Webhook Headers</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.Body">Message body template</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.Placeholders">Placeholders: {title}, {content}, {time}</system:String>
+    <system:String x:Key="ExternalNotificationCustomWebhook.Template">Webhook Template</system:String>
     <system:String x:Key="UseGpuForInference">Use GPU for inference acceleration</system:String>
     <system:String x:Key="UseGpuForInferenceTip">Using GPU inference can significantly reduce CPU load with minimal GPU usage</system:String>
     <system:String x:Key="GpuOptionDisable">Don’t use</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -78,6 +78,7 @@
     <system:String x:Key="ExternalNotificationCustomWebhook.Headers">Webhook Headers</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.Body">メッセージ本文</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.Placeholders">プレホルダー: {title}、{content}、{time}</system:String>
+    <system:String x:Key="ExternalNotificationCustomWebhook.Template">Webhook テンプレート</system:String>
     <system:String x:Key="UseGpuForInference">推論加速のためにGPUを使用する</system:String>
     <system:String x:Key="UseGpuForInferenceTip">GPU 推論を利用することで、ごくわずかな GPU 使用率で CPU の負荷を大幅に軽減できます</system:String>
     <system:String x:Key="GpuOptionDisable">使用しない</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -78,6 +78,7 @@
     <system:String x:Key="ExternalNotificationCustomWebhook.Headers">Webhook Headers</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.Body">메시지 본문 템플릿</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.Placeholders">플레이스홀더: {title}, {content}, {time}</system:String>
+    <system:String x:Key="ExternalNotificationCustomWebhook.Template">Webhook 템플릿</system:String>
     <system:String x:Key="UseGpuForInference">추론 가속화를 위해 GPU 사용</system:String>
     <system:String x:Key="UseGpuForInferenceTip">GPU 추론을 사용하면 매우 적은 GPU 점유로 CPU 부담을 크게 줄일 수 있습니다</system:String>
     <system:String x:Key="GpuOptionDisable">미사용</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -78,6 +78,7 @@
     <system:String x:Key="ExternalNotificationCustomWebhook.Headers">Webhook Headers</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.Body">消息体模板</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.Placeholders">可用占位符：{title}、{content}、{time}</system:String>
+    <system:String x:Key="ExternalNotificationCustomWebhook.Template">Webhook 模板</system:String>
     <system:String x:Key="UseGpuForInference">使用 GPU 加速推理</system:String>
     <system:String x:Key="UseGpuForInferenceTip">使用 GPU 推理能够以极低的 GPU 占用显著降低 CPU 的负担</system:String>
     <system:String x:Key="GpuOptionDisable">不使用</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -78,6 +78,7 @@
     <system:String x:Key="ExternalNotificationCustomWebhook.Headers">Webhook Headers</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.Body">訊息本文範本</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.Placeholders">可用佔位符：{title}、{content}、{time}</system:String>
+    <system:String x:Key="ExternalNotificationCustomWebhook.Template">Webhook 模板</system:String>
     <system:String x:Key="UseGpuForInference">使用 GPU 加速推理</system:String>
     <system:String x:Key="UseGpuForInferenceTip">使用 GPU 推理能以極低的 GPU 佔用顯著降低 CPU 的負擔</system:String>
     <system:String x:Key="GpuOptionDisable">不使用</system:String>

--- a/src/MaaWpfGui/Services/Notification/CustomWebhookLocalizedString.cs
+++ b/src/MaaWpfGui/Services/Notification/CustomWebhookLocalizedString.cs
@@ -1,0 +1,47 @@
+// <copyright file="CustomWebhookLocalizedString.cs" company="MaaAssistantArknights">
+// Part of the MaaWpfGui project, maintained by the MaaAssistantArknights team (Maa Team)
+// Copyright (C) 2021-2025 MaaAssistantArknights Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License v3.0 only as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY
+// </copyright>
+
+#nullable enable
+using System.Collections.Generic;
+using System.Linq;
+using MaaWpfGui.Constants;
+using MaaWpfGui.Helper;
+using Newtonsoft.Json;
+
+namespace MaaWpfGui.Services.Notification;
+
+public class CustomWebhookLocalizedString
+{
+    public string Default { get; set; } = "en-us";
+
+    public Dictionary<string, string> Content { get; set; } = [];
+
+    [JsonIgnore]
+    public string Resolved => Resolve();
+
+    private string Resolve()
+    {
+        var lang = ConfigurationHelper.GetGlobalValue(ConfigurationKeys.Localization, LocalizationHelper.DefaultLanguage);
+        if (Content.TryGetValue(lang, out var val))
+        {
+            return val;
+        }
+
+        if (Content.TryGetValue(Default, out val))
+        {
+            return val;
+        }
+
+        return Content.Values.FirstOrDefault() ?? string.Empty;
+    }
+}

--- a/src/MaaWpfGui/Services/Notification/CustomWebhookNotificationProvider.cs
+++ b/src/MaaWpfGui/Services/Notification/CustomWebhookNotificationProvider.cs
@@ -50,6 +50,14 @@ public class CustomWebhookNotificationProvider(IHttpService httpService) : IExte
             .Select(line => line.Split(':', 2))
             .Where(parts => parts.Length == 2)
             .ToDictionary(p => p[0].Trim(), p => p[1].Trim());
+
+        // Content-Type is a content header, must be set on HttpContent not HttpRequestMessage
+        if (headers.TryGetValue("Content-Type", out var contentType))
+        {
+            requestContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(contentType);
+            headers.Remove("Content-Type");
+        }
+
         var response = await httpService.PostAsync(new(webhookUrl), requestContent, headers);
 
         if (response == null)

--- a/src/MaaWpfGui/Services/Notification/CustomWebhookNotificationProvider.cs
+++ b/src/MaaWpfGui/Services/Notification/CustomWebhookNotificationProvider.cs
@@ -15,6 +15,7 @@
 using System;
 using System.Linq;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
 using MaaWpfGui.Services.Web;
@@ -38,6 +39,12 @@ public class CustomWebhookNotificationProvider(IHttpService httpService) : IExte
             return false;
         }
 
+        if (!SettingsViewModel.ExternalNotificationSettings.ValidateTemplateParameters(out var errorMessage))
+        {
+            _logger.Warning("Custom Webhook failed to send: {Error}", errorMessage);
+            return false;
+        }
+
         // 占位符替换
         string now = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss");
         string body = bodyTemplate
@@ -49,12 +56,19 @@ public class CustomWebhookNotificationProvider(IHttpService httpService) : IExte
         var headers = webhookHeaders.Replace("\r", string.Empty).Split('\n', StringSplitOptions.RemoveEmptyEntries)
             .Select(line => line.Split(':', 2))
             .Where(parts => parts.Length == 2)
-            .ToDictionary(p => p[0].Trim(), p => p[1].Trim());
+            .ToDictionary(p => p[0].Trim(), p => p[1].Trim(), StringComparer.OrdinalIgnoreCase);
 
-        // Content-Type is a content header, must be set on HttpContent not HttpRequestMessage
         if (headers.TryGetValue("Content-Type", out var contentType))
         {
-            requestContent.Headers.ContentType = new System.Net.Http.Headers.MediaTypeHeaderValue(contentType);
+            try
+            {
+                requestContent.Headers.ContentType = new MediaTypeHeaderValue(contentType);
+            }
+            catch (FormatException ex)
+            {
+                _logger.Warning(ex, "Invalid Content-Type header value '{ContentType}', falling back to default", contentType);
+            }
+
             headers.Remove("Content-Type");
         }
 

--- a/src/MaaWpfGui/Services/Notification/CustomWebhookTemplate.cs
+++ b/src/MaaWpfGui/Services/Notification/CustomWebhookTemplate.cs
@@ -1,0 +1,41 @@
+// <copyright file="CustomWebhookTemplate.cs" company="MaaAssistantArknights">
+// Part of the MaaWpfGui project, maintained by the MaaAssistantArknights team (Maa Team)
+// Copyright (C) 2021-2025 MaaAssistantArknights Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License v3.0 only as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY
+// </copyright>
+
+#nullable enable
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace MaaWpfGui.Services.Notification;
+
+public class CustomWebhookTemplate
+{
+    public string Id { get; set; } = string.Empty;
+
+    public CustomWebhookLocalizedString Name { get; set; } = new();
+
+    public CustomWebhookLocalizedString? Description { get; set; }
+
+    public string Url { get; set; } = string.Empty;
+
+    public string Headers { get; set; } = string.Empty;
+
+    public string BodyTemplate { get; set; } = string.Empty;
+
+    public List<CustomWebhookTemplateParameter> UserParameters { get; set; } = [];
+
+    [JsonIgnore]
+    public string DisplayName => Name?.Resolved ?? Id;
+
+    [JsonIgnore]
+    public string? DisplayDescription => Description?.Resolved;
+}

--- a/src/MaaWpfGui/Services/Notification/CustomWebhookTemplateManager.cs
+++ b/src/MaaWpfGui/Services/Notification/CustomWebhookTemplateManager.cs
@@ -118,8 +118,9 @@ public static class CustomWebhookTemplateManager
             var all = JsonConvert.DeserializeObject<Dictionary<string, Dictionary<string, string>>>(stored);
             return all?.GetValueOrDefault(templateId) ?? [];
         }
-        catch
+        catch (Exception ex)
         {
+            Log.Warning(ex, "Failed to deserialize webhook template parameters for {TemplateId}", templateId);
             return [];
         }
     }
@@ -141,9 +142,9 @@ public static class CustomWebhookTemplateManager
                 ConfigurationKeys.ExternalNotificationCustomWebhookTemplateParams,
                 JsonConvert.SerializeObject(all));
         }
-        catch
+        catch (Exception ex)
         {
-            // ignore
+            Log.Warning(ex, "Failed to serialize webhook template parameters for {TemplateId}", templateId);
         }
     }
 

--- a/src/MaaWpfGui/Services/Notification/CustomWebhookTemplateManager.cs
+++ b/src/MaaWpfGui/Services/Notification/CustomWebhookTemplateManager.cs
@@ -1,0 +1,154 @@
+// <copyright file="CustomWebhookTemplateManager.cs" company="MaaAssistantArknights">
+// Part of the MaaWpfGui project, maintained by the MaaAssistantArknights team (Maa Team)
+// Copyright (C) 2021-2025 MaaAssistantArknights Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License v3.0 only as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY
+// </copyright>
+
+#nullable enable
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using MaaWpfGui.Constants;
+using MaaWpfGui.Helper;
+using Newtonsoft.Json;
+using Serilog;
+
+namespace MaaWpfGui.Services.Notification;
+
+public static class CustomWebhookTemplateManager
+{
+    private static List<CustomWebhookTemplate>? _templates;
+    private static readonly object _lock = new();
+
+    private static string TemplateDir =>
+        Path.Combine(PathsHelper.ResourceDir, "webhook_template");
+
+    public static List<CustomWebhookTemplate> LoadTemplates()
+    {
+        if (_templates != null)
+        {
+            return _templates;
+        }
+
+        lock (_lock)
+        {
+            if (_templates != null)
+            {
+                return _templates;
+            }
+
+            var list = new List<CustomWebhookTemplate>
+            {
+                new()
+                {
+                    Id = "__custom__",
+                    Name = new CustomWebhookLocalizedString
+                    {
+                        Default = "en-us",
+                        Content = new()
+                        {
+                            ["zh-cn"] = "自定义",
+                            ["en-us"] = "Custom",
+                            ["zh-tw"] = "自訂",
+                            ["ja-jp"] = "カスタム",
+                            ["ko-kr"] = "사용자 정의",
+                        },
+                    },
+                },
+            };
+
+            if (Directory.Exists(TemplateDir))
+            {
+                foreach (var file in Directory.GetFiles(TemplateDir, "*.json"))
+                {
+                    try
+                    {
+                        var json = File.ReadAllText(file);
+                        var template = JsonConvert.DeserializeObject<CustomWebhookTemplate>(json);
+                        if (template != null && !string.IsNullOrEmpty(template.Id))
+                        {
+                            list.Add(template);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Warning(ex, "Failed to load webhook template: {File}", file);
+                    }
+                }
+            }
+
+            _templates = list;
+            return list;
+        }
+    }
+
+    public static CustomWebhookTemplate? FindTemplate(string id)
+    {
+        return LoadTemplates().FirstOrDefault(t => t.Id == id);
+    }
+
+    public static string ApplyParameters(string raw, Dictionary<string, string> parameters)
+    {
+        if (string.IsNullOrEmpty(raw) || parameters == null)
+        {
+            return raw;
+        }
+
+        foreach (var (key, value) in parameters)
+        {
+            raw = raw.Replace($"{{{key}}}", value ?? string.Empty);
+        }
+
+        return raw;
+    }
+
+    public static Dictionary<string, string> GetAllParameters(string templateId)
+    {
+        var stored = ConfigurationHelper.GetValue(ConfigurationKeys.ExternalNotificationCustomWebhookTemplateParams, "{}");
+        try
+        {
+            var all = JsonConvert.DeserializeObject<Dictionary<string, Dictionary<string, string>>>(stored);
+            return all?.GetValueOrDefault(templateId) ?? [];
+        }
+        catch
+        {
+            return [];
+        }
+    }
+
+    public static void SetParameter(string templateId, string key, string value)
+    {
+        var stored = ConfigurationHelper.GetValue(ConfigurationKeys.ExternalNotificationCustomWebhookTemplateParams, "{}");
+        try
+        {
+            var all = JsonConvert.DeserializeObject<Dictionary<string, Dictionary<string, string>>>(stored)
+                      ?? [];
+            if (!all.ContainsKey(templateId))
+            {
+                all[templateId] = [];
+            }
+
+            all[templateId][key] = value;
+            ConfigurationHelper.SetValue(
+                ConfigurationKeys.ExternalNotificationCustomWebhookTemplateParams,
+                JsonConvert.SerializeObject(all));
+        }
+        catch
+        {
+            // ignore
+        }
+    }
+
+    public static void Invalidate()
+    {
+        _templates = null;
+    }
+}

--- a/src/MaaWpfGui/Services/Notification/CustomWebhookTemplateParameter.cs
+++ b/src/MaaWpfGui/Services/Notification/CustomWebhookTemplateParameter.cs
@@ -1,0 +1,34 @@
+// <copyright file="CustomWebhookTemplateParameter.cs" company="MaaAssistantArknights">
+// Part of the MaaWpfGui project, maintained by the MaaAssistantArknights team (Maa Team)
+// Copyright (C) 2021-2025 MaaAssistantArknights Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License v3.0 only as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY
+// </copyright>
+
+#nullable enable
+using Newtonsoft.Json;
+
+namespace MaaWpfGui.Services.Notification;
+
+public class CustomWebhookTemplateParameter
+{
+    public string Key { get; set; } = string.Empty;
+
+    public CustomWebhookLocalizedString Label { get; set; } = new();
+
+    public CustomWebhookLocalizedString? Placeholder { get; set; }
+
+    public bool Required { get; set; }
+
+    [JsonIgnore]
+    public string DisplayLabel => Label?.Resolved ?? Key;
+
+    [JsonIgnore]
+    public string? DisplayPlaceholder => Placeholder?.Resolved;
+}

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/ExternalNotificationSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/ExternalNotificationSettingsUserControlModel.cs
@@ -48,6 +48,12 @@ public class ExternalNotificationSettingsUserControlModel : PropertyChangedBase
     [UsedImplicitly]
     public static void ExternalNotificationSendTest()
     {
+        if (!Instance.ValidateTemplateParameters(out var errorMessage))
+        {
+            ToastNotification.ShowDirect(errorMessage);
+            return;
+        }
+
         ExternalNotificationService.Send(
             LocalizationHelper.GetString("ExternalNotificationSendTestTitle"),
             LocalizationHelper.GetString("ExternalNotificationSendTestContent"),
@@ -722,6 +728,27 @@ public class ExternalNotificationSettingsUserControlModel : PropertyChangedBase
             vm.ParameterChanged += OnTemplateParameterChanged;
             TemplateParameters.Add(vm);
         }
+    }
+
+    public bool ValidateTemplateParameters(out string? errorMessage)
+    {
+        errorMessage = null;
+
+        if (!IsCustomWebhookTemplateMode)
+        {
+            return true;
+        }
+
+        foreach (var p in TemplateParameters)
+        {
+            if (p.Required && string.IsNullOrWhiteSpace(p.Value))
+            {
+                errorMessage = p.DisplayLabel + ": " + LocalizationHelper.GetString("ExternalNotificationSendFail");
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private void OnTemplateParameterChanged()

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/ExternalNotificationSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/ExternalNotificationSettingsUserControlModel.cs
@@ -14,6 +14,7 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using JetBrains.Annotations;
 using MaaWpfGui.Constants;
@@ -31,6 +32,14 @@ public class ExternalNotificationSettingsUserControlModel : PropertyChangedBase
     static ExternalNotificationSettingsUserControlModel()
     {
         Instance = new();
+    }
+
+    public ExternalNotificationSettingsUserControlModel()
+    {
+        if (IsCustomWebhookTemplateMode)
+        {
+            PopulateTemplateParameters();
+        }
     }
 
     public static ExternalNotificationSettingsUserControlModel Instance { get; }
@@ -536,12 +545,51 @@ public class ExternalNotificationSettingsUserControlModel : PropertyChangedBase
         }
     }
 
+    // Webhook Template
+    private List<CustomWebhookTemplate>? _webhookTemplateList;
+
+    public List<CustomWebhookTemplate> WebhookTemplateList => _webhookTemplateList ??= CustomWebhookTemplateManager.LoadTemplates();
+
+    private string _customWebhookSelectedTemplate = ConfigurationHelper.GetValue(ConfigurationKeys.ExternalNotificationCustomWebhookSelectedTemplate, "__custom__");
+
+    public string CustomWebhookSelectedTemplate
+    {
+        get => _customWebhookSelectedTemplate;
+        set
+        {
+            SetAndNotify(ref _customWebhookSelectedTemplate, value);
+            OnCustomWebhookSelectedTemplateChanged();
+        }
+    }
+
+    public bool IsCustomWebhookTemplateMode => CustomWebhookSelectedTemplate != "__custom__";
+
+    public ObservableCollection<WebhookParameterViewModel> TemplateParameters { get; } = [];
+
     private string _customWebhookUrl = SimpleEncryptionHelper.Decrypt(ConfigurationHelper.GetValue(ConfigurationKeys.ExternalNotificationCustomWebhookUrl, string.Empty));
 
     public string CustomWebhookUrl
     {
-        get => _customWebhookUrl;
-        set {
+        get
+        {
+            if (!IsCustomWebhookTemplateMode)
+            {
+                return _customWebhookUrl;
+            }
+
+            var template = CustomWebhookTemplateManager.FindTemplate(CustomWebhookSelectedTemplate);
+            return template == null
+                ? _customWebhookUrl
+                : CustomWebhookTemplateManager.ApplyParameters(template.Url, BuildParameterDict());
+        }
+
+        set
+        {
+            if (IsCustomWebhookTemplateMode)
+            {
+                return;
+            }
+
             SetAndNotify(ref _customWebhookUrl, value);
             value = SimpleEncryptionHelper.Encrypt(value);
             ConfigurationHelper.SetValue(ConfigurationKeys.ExternalNotificationCustomWebhookUrl, value);
@@ -552,8 +600,26 @@ public class ExternalNotificationSettingsUserControlModel : PropertyChangedBase
 
     public string CustomWebhookBody
     {
-        get => _customWebhookBody;
-        set {
+        get
+        {
+            if (!IsCustomWebhookTemplateMode)
+            {
+                return _customWebhookBody;
+            }
+
+            var template = CustomWebhookTemplateManager.FindTemplate(CustomWebhookSelectedTemplate);
+            return template == null
+                ? _customWebhookBody
+                : CustomWebhookTemplateManager.ApplyParameters(template.BodyTemplate, BuildParameterDict());
+        }
+
+        set
+        {
+            if (IsCustomWebhookTemplateMode)
+            {
+                return;
+            }
+
             SetAndNotify(ref _customWebhookBody, value);
             value = SimpleEncryptionHelper.Encrypt(value);
             ConfigurationHelper.SetValue(ConfigurationKeys.ExternalNotificationCustomWebhookBody, value);
@@ -564,12 +630,135 @@ public class ExternalNotificationSettingsUserControlModel : PropertyChangedBase
 
     public string CustomWebhookHeaders
     {
-        get => _customWebhookHeaders;
-        set {
+        get
+        {
+            if (!IsCustomWebhookTemplateMode)
+            {
+                return _customWebhookHeaders;
+            }
+
+            var template = CustomWebhookTemplateManager.FindTemplate(CustomWebhookSelectedTemplate);
+            return template == null
+                ? _customWebhookHeaders
+                : CustomWebhookTemplateManager.ApplyParameters(template.Headers, BuildParameterDict());
+        }
+
+        set
+        {
+            if (IsCustomWebhookTemplateMode)
+            {
+                return;
+            }
+
             SetAndNotify(ref _customWebhookHeaders, value);
             value = SimpleEncryptionHelper.Encrypt(value);
             ConfigurationHelper.SetValue(ConfigurationKeys.ExternalNotificationCustomWebhookHeaders, value);
         }
+    }
+
+    private Dictionary<string, string> BuildParameterDict()
+    {
+        var dict = new Dictionary<string, string>();
+        foreach (var p in TemplateParameters)
+        {
+            dict[p.Key] = p.Value;
+        }
+
+        return dict;
+    }
+
+    private void OnCustomWebhookSelectedTemplateChanged()
+    {
+        ConfigurationHelper.SetValue(
+            ConfigurationKeys.ExternalNotificationCustomWebhookSelectedTemplate,
+            CustomWebhookSelectedTemplate);
+
+        foreach (var p in TemplateParameters)
+        {
+            p.ParameterChanged -= OnTemplateParameterChanged;
+        }
+
+        TemplateParameters.Clear();
+
+        if (!IsCustomWebhookTemplateMode)
+        {
+            _customWebhookUrl = SimpleEncryptionHelper.Decrypt(
+                ConfigurationHelper.GetValue(ConfigurationKeys.ExternalNotificationCustomWebhookUrl, string.Empty));
+            _customWebhookHeaders = SimpleEncryptionHelper.Decrypt(
+                ConfigurationHelper.GetValue(ConfigurationKeys.ExternalNotificationCustomWebhookHeaders, string.Empty));
+            _customWebhookBody = SimpleEncryptionHelper.Decrypt(
+                ConfigurationHelper.GetValue(ConfigurationKeys.ExternalNotificationCustomWebhookBody, string.Empty));
+        }
+        else
+        {
+            PopulateTemplateParameters();
+        }
+
+        NotifyOfPropertyChange(nameof(CustomWebhookUrl));
+        NotifyOfPropertyChange(nameof(CustomWebhookHeaders));
+        NotifyOfPropertyChange(nameof(CustomWebhookBody));
+        NotifyOfPropertyChange(nameof(IsCustomWebhookTemplateMode));
+    }
+
+    private void PopulateTemplateParameters()
+    {
+        var template = CustomWebhookTemplateManager.FindTemplate(CustomWebhookSelectedTemplate);
+        if (template == null)
+        {
+            return;
+        }
+
+        var savedParams = CustomWebhookTemplateManager.GetAllParameters(template.Id);
+        foreach (var param in template.UserParameters)
+        {
+            var vm = new WebhookParameterViewModel
+            {
+                Key = param.Key,
+                DisplayLabel = param.DisplayLabel,
+                DisplayPlaceholder = param.DisplayPlaceholder,
+                Required = param.Required,
+                Value = savedParams.GetValueOrDefault(param.Key) ?? string.Empty,
+            };
+            vm.ParameterChanged += OnTemplateParameterChanged;
+            TemplateParameters.Add(vm);
+        }
+    }
+
+    private void OnTemplateParameterChanged()
+    {
+        foreach (var p in TemplateParameters)
+        {
+            CustomWebhookTemplateManager.SetParameter(CustomWebhookSelectedTemplate, p.Key, p.Value);
+        }
+
+        NotifyOfPropertyChange(nameof(CustomWebhookUrl));
+        NotifyOfPropertyChange(nameof(CustomWebhookHeaders));
+        NotifyOfPropertyChange(nameof(CustomWebhookBody));
+    }
+
+    public class WebhookParameterViewModel : PropertyChangedBase
+    {
+        public string Key { get; set; } = string.Empty;
+
+        public string DisplayLabel { get; set; } = string.Empty;
+
+        public string? DisplayPlaceholder { get; set; }
+
+        public bool Required { get; set; }
+
+        private string _value = string.Empty;
+
+        public string Value
+        {
+            get => _value;
+            set
+            {
+                SetAndNotify(ref _value, value);
+                ParameterChanged?.Invoke();
+            }
+        }
+
+        public event Action? ParameterChanged;
     }
 
     // FIXME: 不知道为什么 TextBox 在高度变化时会导致 ScrollViewer 的偏移位置变成 0，直接锁到第一个元素去了。在编辑的时候先给它禁用了

--- a/src/MaaWpfGui/Views/UserControl/Settings/ExternalNotificationSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/Settings/ExternalNotificationSettingsUserControl.xaml
@@ -490,6 +490,30 @@
             Orientation="Vertical"
             Visibility="{c:Binding CustomWebhookEnabled}">
             <hc:Divider Content="{DynamicResource ExternalNotificationCustomWebhook}" />
+            <StackPanel Orientation="Horizontal" Margin="10,10,0,10">
+                <hc:ComboBox
+                    Width="300"
+                    hc:InfoElement.Title="{DynamicResource ExternalNotificationCustomWebhook.Template}"
+                    ItemsSource="{Binding WebhookTemplateList}"
+                    SelectedValue="{Binding CustomWebhookSelectedTemplate}"
+                    DisplayMemberPath="DisplayName"
+                    SelectedValuePath="Id" />
+            </StackPanel>
+            <ItemsControl ItemsSource="{Binding TemplateParameters}"
+                          Visibility="{c:Binding IsCustomWebhookTemplateMode}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate>
+                        <StackPanel Orientation="Horizontal">
+                            <hc:TextBox
+                                Width="300"
+                                Margin="10,5,10,5"
+                                hc:InfoElement.Title="{Binding DisplayLabel}"
+                                hc:InfoElement.Placeholder="{Binding DisplayPlaceholder}"
+                                Text="{Binding Value, UpdateSourceTrigger=PropertyChanged}" />
+                        </StackPanel>
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
             <StackPanel Orientation="Horizontal">
                 <hc:TextBox
                     x:Name="CustomWebhookUrl"
@@ -497,7 +521,8 @@
                     Height="30"
                     Margin="10,10,0,10"
                     hc:InfoElement.Title="{DynamicResource ExternalNotificationCustomWebhook.Url}"
-                    Text="{c:Binding CustomWebhookUrl}" />
+                    Text="{c:Binding CustomWebhookUrl}"
+                    IsReadOnly="{c:Binding IsCustomWebhookTemplateMode}" />
                 <!--  整个相同控件占位，保持控件长度一致  -->
                 <controls:TooltipBlock Visibility="Hidden" />
             </StackPanel>
@@ -507,7 +532,8 @@
                     MinHeight="20"
                     Margin="10,10,0,10"
                     hc:InfoElement.Title="{DynamicResource ExternalNotificationCustomWebhook.Headers}"
-                    Text="{c:Binding CustomWebhookHeaders}" />
+                    Text="{c:Binding CustomWebhookHeaders}"
+                    IsReadOnly="{c:Binding IsCustomWebhookTemplateMode}" />
                 <!--  整个相同控件占位，保持控件长度一致  -->
                 <controls:TooltipBlock Visibility="Hidden" />
             </StackPanel>
@@ -523,7 +549,8 @@
                     GotFocus="{s:Action CustomWebhookBodyGotFocus}"
                     LostFocus="{s:Action CustomWebhookBodyLostFocus}"
                     Text="{c:Binding CustomWebhookBody}"
-                    TextWrapping="Wrap" />
+                    TextWrapping="Wrap"
+                    IsReadOnly="{c:Binding IsCustomWebhookTemplateMode}" />
                 <controls:TooltipBlock TooltipText="{DynamicResource ExternalNotificationCustomWebhook.Placeholders}" />
             </StackPanel>
         </StackPanel>


### PR DESCRIPTION
新增 Webhook 模板系统，支持在自定义配置与内置模板间切换。
模板以独立 JSON 文件定义于 resource/webhook_template/ 目录，
含内联多语言支持，首期内置 MeoW 平台模板。
修改内容:
- 新增 CustomWebhookTemplate / CustomWebhookLocalizedString 等模型
- 新增 CustomWebhookTemplateManager 模板加载与管理
- 修改外部通知设置 UI 增加模板选择器与参数输入区
- 修复 Content-Type 等请求头适配问题

## Summary by Sourcery

引入用于外部通知的 Webhook 模板模式，允许用户在完全自定义的 Webhook 与从 JSON 资源加载的预定义参数化模板之间切换。

新功能：
- 新增可自定义的 Webhook 模板模型，支持本地化名称/描述、URL/请求头/请求体模板，以及从资源 JSON 文件加载的用户自定义参数。
- 新增 Webhook 模板管理器，用于发现、缓存和应用模板，包括占位符替换以及在配置中按模板持久化参数。
- 扩展外部通知设置界面，支持选择 Webhook 模板并编辑其参数，并根据所选模板动态生成 Webhook 的 URL、请求头和请求体。

缺陷修复：
- 确保自定义 Webhook 通知的 `Content-Type` 请求头应用到 HTTP 内容对象上，而不是只保留在请求头中。

改进：
- 为 Webhook 模板标签和描述增加支持本地化的字符串处理，并与现有语言配置集成。
- 通过用于自定义 Webhook 设置的新配置键，持久化已选 Webhook 模板 ID 及其参数值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a webhook template mode for external notifications, allowing users to switch between fully custom webhooks and predefined, parameterized templates loaded from JSON resources.

New Features:
- Add a customizable webhook template model with localized names/descriptions, URL/header/body templates, and user-defined parameters loaded from resource JSON files.
- Add a webhook template manager to discover, cache, and apply templates, including placeholder substitution and per-template parameter persistence in configuration.
- Extend the external notification settings UI to support selecting a webhook template and editing its parameters, dynamically deriving the webhook URL, headers, and body from the chosen template.

Bug Fixes:
- Ensure the Content-Type header for custom webhook notifications is applied to the HTTP content object instead of remaining only on the request headers.

Enhancements:
- Add localization-aware string handling for webhook template labels and descriptions, integrated with the existing language configuration.
- Persist the selected webhook template ID and its parameter values via new configuration keys for custom webhook settings.

</details>

新功能：
- 添加自定义 webhook 模板模型，支持本地化名称、描述以及从资源目录中的 JSON 文件加载的用户自定义参数。
- 添加模板管理器，用于发现、缓存和应用 webhook 模板，包括参数替换以及按模板持久化参数。
- 扩展外部通知设置界面（UI），以支持选择 webhook 模板、编辑其参数，并根据所选模板动态生成 URL、请求头和请求体。

错误修复：
- 确保自定义 webhook 通知的 Content-Type 请求头被正确应用到 HTTP 内容本身，而不是仅应用到请求头。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入用于外部通知的 Webhook 模板模式，允许用户在完全自定义的 Webhook 与从 JSON 资源加载的预定义参数化模板之间切换。

新功能：
- 新增可自定义的 Webhook 模板模型，支持本地化名称/描述、URL/请求头/请求体模板，以及从资源 JSON 文件加载的用户自定义参数。
- 新增 Webhook 模板管理器，用于发现、缓存和应用模板，包括占位符替换以及在配置中按模板持久化参数。
- 扩展外部通知设置界面，支持选择 Webhook 模板并编辑其参数，并根据所选模板动态生成 Webhook 的 URL、请求头和请求体。

缺陷修复：
- 确保自定义 Webhook 通知的 `Content-Type` 请求头应用到 HTTP 内容对象上，而不是只保留在请求头中。

改进：
- 为 Webhook 模板标签和描述增加支持本地化的字符串处理，并与现有语言配置集成。
- 通过用于自定义 Webhook 设置的新配置键，持久化已选 Webhook 模板 ID 及其参数值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a webhook template mode for external notifications, allowing users to switch between fully custom webhooks and predefined, parameterized templates loaded from JSON resources.

New Features:
- Add a customizable webhook template model with localized names/descriptions, URL/header/body templates, and user-defined parameters loaded from resource JSON files.
- Add a webhook template manager to discover, cache, and apply templates, including placeholder substitution and per-template parameter persistence in configuration.
- Extend the external notification settings UI to support selecting a webhook template and editing its parameters, dynamically deriving the webhook URL, headers, and body from the chosen template.

Bug Fixes:
- Ensure the Content-Type header for custom webhook notifications is applied to the HTTP content object instead of remaining only on the request headers.

Enhancements:
- Add localization-aware string handling for webhook template labels and descriptions, integrated with the existing language configuration.
- Persist the selected webhook template ID and its parameter values via new configuration keys for custom webhook settings.

</details>

</details>