### PR TITLE
fix(gui): 修复 MuMu 12 任务完成后无法关闭模拟器

### DIFF
--- a/src/MaaWpfGui/Helper/EmulatorHelper.cs
+++ b/src/MaaWpfGui/Helper/EmulatorHelper.cs
@@ -132,9 +132,7 @@ public class EmulatorHelper
 
         if (processes.Length == 0)
         {
-            // 找不到模拟器进程，说明模拟器已经关闭，视为关闭成功（#17061）
-            _logger.Information("No running MuMu emulator process found; treating as already closed.");
-            return true;
+            return false;
         }
 
         ProcessModule? processModule;
@@ -178,69 +176,21 @@ public class EmulatorHelper
 
         if (consolePath != null)
         {
-            // MuMu 12 使用 `control -v {index} shutdown` 关闭模拟器；旧的 `api -v {index} shutdown_player` 已不再生效（#17061）
-            using (var consoleProcess = Process.Start(new ProcessStartInfo(consolePath)
+            ProcessStartInfo startInfo = new ProcessStartInfo(consolePath)
             {
                 Arguments = $"control -v {emuIndex} shutdown",
                 CreateNoWindow = true,
                 UseShellExecute = false,
-            }))
+            };
+            var process = Process.Start(startInfo);
+            if (process != null && process.WaitForExit(5000))
             {
-                consoleProcess?.WaitForExit(5000);
-            }
-
-            _logger.Information("Sent shutdown command to MuMu emulator at index {EmuIndex}. Console path: {ConsolePath}", emuIndex, consolePath);
-
-            // 控制台命令返回并不代表模拟器已经关闭，需要确认真正的模拟器进程（MuMuNxDevice/MuMuPlayer）是否退出（#17061）
-            bool allExited = true;
-            foreach (var emulatorProcess in processes)
-            {
-                try
-                {
-                    if (!emulatorProcess.WaitForExit(10000))
-                    {
-                        allExited = false;
-                    }
-                }
-                catch (Exception e)
-                {
-                    _logger.Warning("Failed to wait for the MuMu emulator process to exit: {Message}", e.Message);
-                    allExited = false;
-                }
-            }
-
-            if (allExited)
-            {
-                _logger.Information("MuMu emulator at index {EmuIndex} closed through console.", emuIndex);
+                _logger.Information("Emulator at index {EmuIndex} closed through console. Console path: {ConsolePath}", emuIndex, consolePath);
                 return true;
             }
 
-            // 控制台命令未能真正关闭模拟器，回退为直接结束模拟器进程（#17061）
-            _logger.Warning("MuMu emulator process is still running after the console shutdown command; killing it directly.");
-            bool allKilled = true;
-            foreach (var emulatorProcess in processes)
-            {
-                try
-                {
-                    if (!emulatorProcess.HasExited)
-                    {
-                        emulatorProcess.Kill();
-                        emulatorProcess.WaitForExit(5000);
-                    }
-
-                    if (!emulatorProcess.HasExited)
-                    {
-                        allKilled = false;
-                    }
-                }
-                catch (Exception e)
-                {
-                    _logger.Warning("Failed to kill the MuMu emulator process directly: {Message}", e.Message);
-                    allKilled = false;
-                }
-            }
-
-            return allKilled || KillEmulatorByWindow();
+            _logger.Warning("Console process at index {EmuIndex} did not exit within the specified timeout. Killing emulator by window. Console path: {ConsolePath}", emuIndex, consolePath);
+            return KillEmulatorByWindow();
         }
 
         _logger.Error("MuMuManager.exe not found in expected locations (new or old). Trying to kill emulator by window.");

--- a/src/MaaWpfGui/Helper/EmulatorHelper.cs
+++ b/src/MaaWpfGui/Helper/EmulatorHelper.cs
@@ -132,7 +132,9 @@ public class EmulatorHelper
 
         if (processes.Length == 0)
         {
-            return false;
+            // 找不到模拟器进程，说明模拟器已经关闭，视为关闭成功（#17061）
+            _logger.Information("No running MuMu emulator process found; treating as already closed.");
+            return true;
         }
 
         ProcessModule? processModule;
@@ -176,21 +178,69 @@ public class EmulatorHelper
 
         if (consolePath != null)
         {
-            ProcessStartInfo startInfo = new ProcessStartInfo(consolePath)
+            // MuMu 12 使用 `control -v {index} shutdown` 关闭模拟器；旧的 `api -v {index} shutdown_player` 已不再生效（#17061）
+            using (var consoleProcess = Process.Start(new ProcessStartInfo(consolePath)
             {
-                Arguments = $"api -v {emuIndex} shutdown_player",
+                Arguments = $"control -v {emuIndex} shutdown",
                 CreateNoWindow = true,
                 UseShellExecute = false,
-            };
-            var process = Process.Start(startInfo);
-            if (process != null && process.WaitForExit(5000))
+            }))
             {
-                _logger.Information("Emulator at index {EmuIndex} closed through console. Console path: {ConsolePath}", emuIndex, consolePath);
+                consoleProcess?.WaitForExit(5000);
+            }
+
+            _logger.Information("Sent shutdown command to MuMu emulator at index {EmuIndex}. Console path: {ConsolePath}", emuIndex, consolePath);
+
+            // 控制台命令返回并不代表模拟器已经关闭，需要确认真正的模拟器进程（MuMuNxDevice/MuMuPlayer）是否退出（#17061）
+            bool allExited = true;
+            foreach (var emulatorProcess in processes)
+            {
+                try
+                {
+                    if (!emulatorProcess.WaitForExit(10000))
+                    {
+                        allExited = false;
+                    }
+                }
+                catch (Exception e)
+                {
+                    _logger.Warning("Failed to wait for the MuMu emulator process to exit: {Message}", e.Message);
+                    allExited = false;
+                }
+            }
+
+            if (allExited)
+            {
+                _logger.Information("MuMu emulator at index {EmuIndex} closed through console.", emuIndex);
                 return true;
             }
 
-            _logger.Warning("Console process at index {EmuIndex} did not exit within the specified timeout. Killing emulator by window. Console path: {ConsolePath}", emuIndex, consolePath);
-            return KillEmulatorByWindow();
+            // 控制台命令未能真正关闭模拟器，回退为直接结束模拟器进程（#17061）
+            _logger.Warning("MuMu emulator process is still running after the console shutdown command; killing it directly.");
+            bool allKilled = true;
+            foreach (var emulatorProcess in processes)
+            {
+                try
+                {
+                    if (!emulatorProcess.HasExited)
+                    {
+                        emulatorProcess.Kill();
+                        emulatorProcess.WaitForExit(5000);
+                    }
+
+                    if (!emulatorProcess.HasExited)
+                    {
+                        allKilled = false;
+                    }
+                }
+                catch (Exception e)
+                {
+                    _logger.Warning("Failed to kill the MuMu emulator process directly: {Message}", e.Message);
+                    allKilled = false;
+                }
+            }
+
+            return allKilled || KillEmulatorByWindow();
         }
 
         _logger.Error("MuMuManager.exe not found in expected locations (new or old). Trying to kill emulator by window.");


### PR DESCRIPTION
KillEmulatorMuMuEmulator12 存在多处问题，导致“任务完成后退出模拟器”对 MuMu 12 失效（#17061：日志显示已通过控制台关闭，但 1.5s 内即可重连，模拟器实际并未关闭）：

1. 找不到模拟器进程时返回 false；进程已不存在本应视为关闭成功，改为返回 true。
2. 使用了已失效的 `api -v {index} shutdown_player`；MuMu 12 应使用 `control -v {index} shutdown`（见 MuMuManager 命令行说明）。
3. 仅判断 MuMuManager.exe（控制台工具）是否退出，从不确认真正的模拟器进程 （MuMuNxDevice/MuMuPlayer）是否结束；改为等待并确认模拟器进程退出。
4. 控制台关闭失败时只回退到按窗口关闭；增加直接 Process.Kill 模拟器进程的回退， 仍失败再按窗口关闭。

感谢 @lingwateryang 在 issue 中给出的详细分析。

## Summary by Sourcery

在从图形界面（GUI）关闭时，提高 MuMu 12 模拟器关闭的可靠性。

Bug 修复：
- 将缺失的 MuMu 模拟器进程视为已关闭，而不是报告关闭失败。
- 更新 MuMu 12 控制台关闭命令，并在确认模拟器进程实际退出后再认为关闭成功。
- 增加回退机制：在退回到基于窗口的关闭方式之前，强制结束仍在残留的 MuMu 模拟器进程。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve MuMu 12 emulator shutdown reliability when closing from the GUI.

Bug Fixes:
- Treat missing MuMu emulator processes as already closed instead of reporting shutdown failure.
- Update the MuMu 12 console shutdown command and wait for emulator processes to actually exit before considering shutdown successful.
- Add a fallback that force-kills lingering MuMu emulator processes before falling back to window-based shutdown.

</details>