### PR TITLE
fix: 视频识别

### DIFF
--- a/src/MaaCore/Task/Experiment/VisionToolkit.cpp
+++ b/src/MaaCore/Task/Experiment/VisionToolkit.cpp
@@ -5,6 +5,9 @@ namespace asst::experiment // 不知道写namespace合适不合适，反正AI这
 {
 cv::Mat VisionToolkit::normalize_battlefield_frame(const cv::Mat& frame)
 {
+    if (frame.empty() || frame.rows <= 0 || frame.cols <= 0) {
+        return frame;
+    }
     int raw_w = frame.cols;
     int raw_h = frame.rows;
     double target_ratio = 1280.0 / 720.0;

--- a/src/MaaCore/Task/Experiment/VisionToolkit.cpp
+++ b/src/MaaCore/Task/Experiment/VisionToolkit.cpp
@@ -6,7 +6,7 @@ namespace asst::experiment // 不知道写namespace合适不合适，反正AI这
 cv::Mat VisionToolkit::normalize_battlefield_frame(const cv::Mat& frame)
 {
     if (frame.empty() || frame.rows <= 0 || frame.cols <= 0) {
-        return frame;
+        return cv::Mat::zeros(720, 1280, CV_8UC3);
     }
     int raw_w = frame.cols;
     int raw_h = frame.rows;
@@ -92,4 +92,5 @@ BattlefieldMatcher::ResultOpt
     }
 
     return ui_analyzer.analyze();
+}
 }

--- a/src/MaaCore/Task/Experiment/VisionToolkit.cpp
+++ b/src/MaaCore/Task/Experiment/VisionToolkit.cpp
@@ -1,0 +1,92 @@
+#include "VisionToolkit.h"
+#include "Vision/Battle/BattlefieldMatcher.h"
+
+namespace asst::experiment // 不知道写namespace合适不合适，反正AI这么建议的，先放这了
+{
+cv::Mat VisionToolkit::normalize_battlefield_frame(const cv::Mat& frame)
+{
+    int raw_w = frame.cols;
+    int raw_h = frame.rows;
+    double target_ratio = 1280.0 / 720.0;
+
+    double current_ratio = static_cast<double>(raw_w) / raw_h;
+
+    cv::Mat stitched = cv::Mat::zeros(720, 1280, frame.type());
+
+    if (current_ratio > target_ratio) {
+        // 对于宽屏锁定高度为 720
+        double scale_h = 720.0 / raw_h;
+        cv::Mat resized;
+        cv::resize(frame, resized, cv::Size(), scale_h, scale_h, cv::INTER_AREA);
+
+        int new_w = resized.cols;
+
+        // 计算需要挖掉的总宽度，以及每个切口需要挖掉的宽度
+        int redundant_w = new_w - 1280;
+        int cut_w = redundant_w / 2;
+
+        int q1 = new_w / 4;     // 左 1/4 处
+        int q3 = new_w * 3 / 4; // 右 3/4 处
+
+        // 从 0 到 1/4
+        int left_w = q1 - cut_w / 2;
+        cv::Mat left_part = resized(cv::Rect(0, 0, left_w, 720)).clone();
+
+        // 从 1/4 到 3/4 (挖掉左右切口宽度的一半)
+        int center_start = q1 + cut_w / 2;
+        int center_w = (q3 - cut_w / 2) - center_start;
+        cv::Mat center_part = resized(cv::Rect(center_start, 0, center_w, 720)).clone();
+
+        // 从 3/4 到画面最右侧
+        int right_start = q3 + cut_w / 2;
+        int right_w = new_w - right_start;
+        cv::Mat right_part =
+            resized(cv::Rect(right_start, 0, right_w, 720) & cv::Rect(0, 0, resized.cols, 720)).clone();
+
+        // 贴到 1280x720 的画布上
+        int current_x = 0;
+        left_part.copyTo(stitched(cv::Rect(current_x, 0, left_w, 720)));
+
+        current_x += left_w;
+        center_part.copyTo(stitched(cv::Rect(current_x, 0, center_w, 720)));
+
+        current_x += center_w;
+        int remaining_space = stitched.cols - current_x;
+        int final_w = std::min(right_part.cols, remaining_space);
+        right_part(cv::Rect(0, 0, final_w, 720)).copyTo(stitched(cv::Rect(current_x, 0, final_w, 720)));
+    }
+    else {
+        // 窄屏锁定宽度 1280 保留顶部和底部 UI
+        double scale_w = 1280.0 / raw_w;
+        cv::Mat resized;
+        cv::resize(frame, resized, cv::Size(), scale_w, scale_w, cv::INTER_AREA);
+
+        int new_h = resized.rows;
+
+        cv::Mat top_360 = resized(cv::Rect(0, 0, 1280, 360));
+        cv::Mat bottom_360 = resized(cv::Rect(0, new_h - 360, 1280, 360));
+
+        top_360.copyTo(stitched(cv::Rect(0, 0, 1280, 360)));
+        bottom_360.copyTo(stitched(cv::Rect(0, 360, 1280, 360)));
+    }
+
+    return stitched;
+}
+
+BattlefieldMatcher::ResultOpt
+    VisionToolkit::analyze_battlefield_ui(const cv::Mat& frame, std::optional<int> total_kills)
+{
+    cv::Mat standard_frame = normalize_battlefield_frame(frame);
+
+    BattlefieldMatcher ui_analyzer(standard_frame);
+
+    if (total_kills.has_value()) {
+        ui_analyzer.set_object_of_interest({ .flag = true, .kills = true, .speed_button = true });
+        ui_analyzer.set_total_kills_prompt(total_kills.value());
+    }
+    else {
+        ui_analyzer.set_object_of_interest({ .flag = true, .kills = false, .speed_button = true });
+    }
+
+    return ui_analyzer.analyze();
+}

--- a/src/MaaCore/Task/Experiment/VisionToolkit.h
+++ b/src/MaaCore/Task/Experiment/VisionToolkit.h
@@ -21,7 +21,7 @@ public:
      * @brief 自动化战场 UI 分析流程（识别 flag, kills(传入total_kills), speed_button 等）
      * @param frame 输入的原始设备画面
      * @param total_kills[可选] 传入的当前总击杀提示数
-     * @return 自动推导 BattlefieldMatcher::ResultOpt 的返回类型（通常为 std::optional 或特定结果结构体）
+     * @return BattlefieldMatcher::ResultOpt 类型，通常为 std::optional 包裹的战场分析结果结构体
      */
     static BattlefieldMatcher::ResultOpt
         analyze_battlefield_ui(const cv::Mat& frame, std::optional<int> total_kills = std::nullopt);

--- a/src/MaaCore/Task/Experiment/VisionToolkit.h
+++ b/src/MaaCore/Task/Experiment/VisionToolkit.h
@@ -21,7 +21,7 @@ public:
      * @brief 自动化战场 UI 分析流程（识别 flag, kills(传入total_kills), speed_button 等）
      * @param frame 输入的原始设备画面
      * @param total_kills[可选] 传入的当前总击杀提示数
-     * @return 自动推导 BattlefieldMatcher::analyze() 的返回类型（通常为 std::optional 或特定结果结构体）
+     * @return 自动推导 BattlefieldMatcher::ResultOpt 的返回类型（通常为 std::optional 或特定结果结构体）
      */
     static BattlefieldMatcher::ResultOpt
         analyze_battlefield_ui(const cv::Mat& frame, std::optional<int> total_kills = std::nullopt);

--- a/src/MaaCore/Task/Experiment/VisionToolkit.h
+++ b/src/MaaCore/Task/Experiment/VisionToolkit.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "Vision/Battle/BattlefieldMatcher.h"
+#include <memory>
+#include <opencv2/opencv.hpp>
+
+namespace asst::experiment
+{
+
+class VisionToolkit
+{
+public:
+    /**
+     * @brief 将任意分辨率/屏幕比例的画面,硬派适配至标准的 720p (1280x720), 此方法适用于组件的识别
+     * @param frame 输入的原始设备画面
+     * @return cv::Mat 适配后的 720p 标准画面
+     */
+    static cv::Mat normalize_battlefield_frame(const cv::Mat& frame);
+
+    /**
+     * @brief 自动化战场 UI 分析流程（识别 flag, kills(传入total_kills), speed_button 等）
+     * @param frame 输入的原始设备画面
+     * @param total_kills[可选] 传入的当前总击杀提示数
+     * @return 自动推导 BattlefieldMatcher::analyze() 的返回类型（通常为 std::optional 或特定结果结构体）
+     */
+    static BattlefieldMatcher::ResultOpt
+        analyze_battlefield_ui(const cv::Mat& frame, std::optional<int> total_kills = std::nullopt);
+};
+
+} // namespace asst::experiment


### PR DESCRIPTION
## 描述
本次提交新增了 VisionToolkit 类，旨在解决不同设备分辨率和屏幕比例（宽屏/窄屏）下战场 UI 识别的一致性问题。通过将原始画面适配至标准的 1280x720 分辨率，确保后续的 BattlefieldMatcher 能够基于统一的坐标系进行识别。

### 主要改动
1. 新增 normalize_battlefield_frame 方法：

- 宽屏处理：锁定高度为 720，通过裁剪画面左右两侧冗余部分，保留核心视觉区域，将其映射至 1280x720 画布。

- 窄屏处理：锁定宽度为 1280，保留顶部和底部 UI 区域，进行垂直拼接适配。

2. 新增 analyze_battlefield_ui 流程：
- 返回值与analyze一致，支持的检测为flag, kills, speed_button，击杀数的传递是可选的

### 备注
1. 是否使用`namespace asst::experiment`还得请佬斟酌，AI建议我这么用
2. 代码通过了3440*380 的考验：
<img width="6518" height="720" alt="g_11" src="https://github.com/user-attachments/assets/dfe9ad3c-111a-4303-a2e1-9bf671bd5c7a" />
经过处理后可以得到
<img width="1280" height="720" alt="g" src="https://github.com/user-attachments/assets/4748eae1-1899-46bb-9f96-b9d71197e30a" />
<img width="455" height="254" alt="image" src="https://github.com/user-attachments/assets/6848eebe-a695-4932-91d5-c81d9aab5577" />

日志如下

```
[2026-06-10 21:11:51.933][TRC][Px52580][Tx54750]  asst::BattlefieldMatcher::pause_button_analyze count 575 threshold 200
[2026-06-10 21:11:52.001][TRC][Px52580][Tx54750]  match_templ |  [opencv] score: 0.843462 rect: [ 334, 10, 48, 41 ] roi: [ 0, 0, 600, 70 ]
[2026-06-10 21:11:52.149][TRC][Px52580][Tx54750]  asst::CharOcr [{ text: 0/11, rect: [ 0 (556), 0 (20), 49, 20 ], score: 0.929398 }] by OCR Rec , cost 128 ms
[2026-06-10 21:11:52.154][TRC][Px52580][Tx54750]  Proceed [{ text: 0/11, rect: [ 556, 20, 49, 20 ], score: 0.929398 }]
[2026-06-10 21:11:52.156][TRC][Px52580][Tx54750]  Kills: 0 / 11
[2026-06-10 21:11:52.157][TRC][Px52580][Tx54750]  asst::BattlefieldMatcher::speed_button_analyze count 268 threshold 160
```

3. 原始图像固定高度为720后，暂停按钮与右侧距离恒定为95px，测试数据如下（暂停按钮标定由MAAFw Support插件模板匹配取得

<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/84816/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/84816/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">
</head>

<body link="#0563C1" vlink="#954F72">


宽 | 高 | box（高固定720）
-- | -- | --
1680 | 720 | [1585, 36, 47, 36]
1920 | 864 | [1505, 36, 47, 36]
2560 | 1080 | [1612, 36, 47, 36]
3440 | 1440 | [1625, 36, 47, 36]
1280 | 720 | [1185, 36, 47, 36]
1600 | 900 | [1185, 36, 47, 36]
1920 | 1080 | [1185, 36, 47, 36]
2560 | 1440 | [1185, 36, 47, 36]
3440 | 380 | [6423, 36, 47, 36]



</body>

</html>

## 接下来的方向

小地图目前对齐方式已知
<img width="1587" height="1004" alt="屏幕截图 2026-05-01 225004" src="https://github.com/user-attachments/assets/aecd4934-da5d-4969-a360-50dd1a87e38f" />

即：窄屏长对齐，长屏高对齐

但是操作干员时视角缩放依然存在问题，目前不知道变换关系

## 由 Sourcery 提供的总结

添加一个用于规范化战场画面并分析战斗 UI 的实验性视觉工具包。

新功能：
- 在 `asst::experiment` 下引入 `VisionToolkit` 辅助类，用于与视觉相关的实用功能。
- 支持将任意分辨率的战场画面规范化到标准的 1280x720 布局，以进行 UI 识别。
- 提供高级 API，使用 `BattlefieldMatcher` 分析战斗 UI 元素，如旗帜、击杀计数和加速按钮。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add an experimental vision toolkit for normalizing battlefield frames and analyzing battle UI.

New Features:
- Introduce VisionToolkit helper class under asst::experiment for vision-related utilities.
- Support normalization of arbitrary-resolution battlefield frames into a standard 1280x720 layout for UI recognition.
- Provide a high-level API to analyze battlefield UI elements such as flag, kill count, and speed button using BattlefieldMatcher.

</details>

## Summary by Sourcery

引入一个实验性的视觉工具包，用于将战场画面规范化为标准的 1280x720 布局，并在不同屏幕分辨率和纵横比下，为战场 UI 分析提供统一的 API。

新功能：
- 在 experimental 任务命名空间下添加 `VisionToolkit` 类，用于承载与视觉相关的工具方法。
- 支持将任意分辨率的战场截图归一化为一致的 1280x720 战场画面，以便进行 UI 识别。
- 提供辅助 API，在规范化后的画面上使用 `BattlefieldMatcher` 分析战场 UI 元素（旗帜、可选击杀计数、加速按钮）。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce an experimental vision toolkit to normalize battlefield frames to a standard 1280x720 layout and provide a unified API for battlefield UI analysis across different screen resolutions and aspect ratios.

New Features:
- Add VisionToolkit class under the experimental task namespace to host vision-related utilities.
- Support normalization of arbitrary-resolution battlefield screenshots into a consistent 1280x720 battlefield frame suitable for UI recognition.
- Expose a helper API to analyze battlefield UI elements (flag, optional kill count, speed button) using BattlefieldMatcher on the normalized frame.

</details>