### PR TITLE
Release v6.12.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v6.12.0
+## v6.12.1
 
 ### Highlights
 
@@ -37,6 +37,16 @@ Supports the enhanced screenshot path for MuMu 6.0 Android 15, improving screens
 以下是详细内容：
 
 <details open>
+<summary><b>v6.12.1 (2026-06-11)</b></summary>
+
+### 修复 | Fix
+
+* 修复多作业模式关卡导航选错关卡无法重选、关卡名复核失效等多项问题 @status102 @ABA2396
+* 修复界园事件内通宝交换后无法正确处理事件结束页 (#16936) @ZiyinLin
+
+</details>
+
+<details>
 <summary><b>v6.12.0 (2026-06-11)</b></summary>
 
 ### 新增 | New

--- a/resource/global/YoStarEN/resource/version.json
+++ b/resource/global/YoStarEN/resource/version.json
@@ -1,11 +1,11 @@
 {
     "activity": {
-        "name": "Exodus from the Pale Sea - Rerun",
-        "time": 1780657200
+        "name": "Trials for Navigator",
+        "time": 1781175600
     },
     "gacha": {
         "pool": "Confirmation, Completion, Conduction",
         "time": 1780671600
     },
-    "last_updated": "2026-06-05 15:27:16.000"
+    "last_updated": "2026-06-11 11:33:55.000"
 }

--- a/resource/tasks/Roguelike/JieGarden.json
+++ b/resource/tasks/Roguelike/JieGarden.json
@@ -148,7 +148,7 @@
         "Doc": "放弃交换通宝的确认按钮",
         "baseTask": "JieGarden@Roguelike@CoppersListDialogConfirm",
         "template": "JieGarden@Roguelike@CoppersListDialogConfirm.png",
-        "next": ["JieGarden@Roguelike@CoppersTakeFlag#next", "#self"]
+        "next": ["JieGarden@Roguelike@DropsFlag", "JieGarden@Roguelike@CloseEvent", "#self"]
     },
     "JieGarden@Roguelike@CoppersAbandonExchange": {
         "Doc": "放弃交换通宝按钮",

--- a/src/MaaCore/Task/Interface/CopilotTask.cpp
+++ b/src/MaaCore/Task/Interface/CopilotTask.cpp
@@ -22,7 +22,7 @@ asst::CopilotTask::CopilotTask(const AsstCallback& callback, Assistant* inst) :
 {
     LogTraceFunction;
 
-    m_multi_copilot_plugin_ptr->set_retry_times(0);
+    m_multi_copilot_plugin_ptr->set_retry_times(20);
     m_multi_copilot_plugin_ptr->set_battle_task_ptr(m_battle_task_ptr);
     m_subtasks.emplace_back(m_multi_copilot_plugin_ptr);
 

--- a/src/MaaCore/Task/Miscellaneous/MultiCopilotTaskPlugin.cpp
+++ b/src/MaaCore/Task/Miscellaneous/MultiCopilotTaskPlugin.cpp
@@ -64,8 +64,16 @@ bool asst::MultiCopilotTaskPlugin::navigate_to_stage(const std::string& stage_na
     }
 
     const auto& task = Task.get<OcrTaskInfo>(stage_name + "@ClickStageName");
-    std::tuple<int, int, int> threshold_low { task->bin_threshold[0], task->bin_threshold[1], task->bin_threshold[2] };
-    std::tuple<int, int, int> threshold_high { task->bin_threshold[3], task->bin_threshold[4], task->bin_threshold[5] };
+    std::tuple<int, int, int> threshold_low {
+        task->special_params[0],
+        task->special_params[1],
+        task->special_params[2],
+    };
+    std::tuple<int, int, int> threshold_high {
+        task->special_params[3],
+        task->special_params[4],
+        task->special_params[5],
+    };
     auto stages = find_stage(image, threshold_low, threshold_high);
     auto it = std::ranges::find_if(stages, [&](const OcrPack::Result& r) { return r.text == stage_name; });
     if (it != stages.end()) {
@@ -135,7 +143,7 @@ asst::OCRer::ResultsVec asst::MultiCopilotTaskPlugin::find_stage(
     std::tuple<int, int, int> threshold_high)
 {
     cv::Mat gray;
-    cv::cvtColor(image, gray, cv::COLOR_BGR2GRAY);
+    cv::cvtColor(image, gray, cv::COLOR_BGR2HSV);
     auto [l1, l2, l3] = threshold_low;
     auto [h1, h2, h3] = threshold_high;
     cv::inRange(gray, cv::Scalar(l1, l2, l3), cv::Scalar(h1, h2, h3), gray);

--- a/src/MaaCore/Task/Miscellaneous/MultiCopilotTaskPlugin.cpp
+++ b/src/MaaCore/Task/Miscellaneous/MultiCopilotTaskPlugin.cpp
@@ -94,6 +94,9 @@ bool asst::MultiCopilotTaskPlugin::navigate_to_stage(const std::string& stage_na
     }
 
     for (int i = 0; i < m_max_retry; ++i) {
+        if (need_exit()) {
+            return false;
+        }
         ProcessTask(*this, { "Copilot@StageNavigationSlowlySwipeLeft" }).set_retry_times(20).run();
         sleep(Config.get_options().task_delay);
         image = ctrler()->get_image();
@@ -108,7 +111,9 @@ bool asst::MultiCopilotTaskPlugin::navigate_to_stage(const std::string& stage_na
 
     // 划 10 次到最右，然后扫有无初见剧情
     auto plot_task = ProcessTask(*this, { "Copilot@ChapterSwipeToTheRightAndPlot" });
-    plot_task.set_retry_times(20);
+    if (need_exit()) {
+        return false;
+    }
     if (plot_task.run()) {
         sleep(Config.get_options().task_delay);
         image = ctrler()->get_image();

--- a/src/MaaCore/Task/Miscellaneous/MultiCopilotTaskPlugin.cpp
+++ b/src/MaaCore/Task/Miscellaneous/MultiCopilotTaskPlugin.cpp
@@ -171,7 +171,7 @@ asst::OCRer::ResultsVec asst::MultiCopilotTaskPlugin::find_stage(
 bool asst::MultiCopilotTaskPlugin::is_stage_detail_opened(const cv::Mat& image)
 {
     PipelineAnalyzer match(image);
-    match.set_tasks({ "ClickedCorrectStageOrSwipe" });
+    match.set_tasks({ "StartButton1" });
     return match.analyze().has_value();
 }
 

--- a/src/MaaCore/Task/Miscellaneous/MultiCopilotTaskPlugin.cpp
+++ b/src/MaaCore/Task/Miscellaneous/MultiCopilotTaskPlugin.cpp
@@ -177,7 +177,7 @@ bool asst::MultiCopilotTaskPlugin::confirm_stage_name(const cv::Mat& image, cons
                std::ranges::any_of(ret_opt.value(), [&](const OcrPack::Result& r) { return r.text == stage_name; });
     };
     OCRer ocr(image);
-    ocr.set_task_info("ClickStageName");
+    ocr.set_task_info("ClickedCorrectStage");
     if (ocr_check(ocr.analyze())) {
         return true;
     }
@@ -185,7 +185,7 @@ bool asst::MultiCopilotTaskPlugin::confirm_stage_name(const cv::Mat& image, cons
     for (int i = 0; i < m_max_retry; ++i) {
         sleep(Config.get_options().task_delay);
         OCRer re_OCR(ctrler()->get_image());
-        re_OCR.set_task_info("ClickStageName");
+        re_OCR.set_task_info("ClickedCorrectStage");
         if (ocr_check(re_OCR.analyze())) {
             return true;
         }

--- a/src/MaaCore/Task/Miscellaneous/MultiCopilotTaskPlugin.cpp
+++ b/src/MaaCore/Task/Miscellaneous/MultiCopilotTaskPlugin.cpp
@@ -60,7 +60,10 @@ bool asst::MultiCopilotTaskPlugin::navigate_to_stage(const std::string& stage_na
     auto image = ctrler()->get_image();
 
     if (is_stage_detail_opened(image)) { // 关卡介绍已展开
-        return confirm_stage_name(image, stage_name);
+        bool ret = confirm_stage_name(image, stage_name);
+        if (ret) {
+            return true;
+        }
     }
 
     const auto& task = Task.get<OcrTaskInfo>(stage_name + "@ClickStageName");
@@ -187,7 +190,7 @@ bool asst::MultiCopilotTaskPlugin::confirm_stage_name(const cv::Mat& image, cons
         return true;
     }
 
-    for (int i = 0; i < m_max_retry; ++i) {
+    for (int i = 0; i < 3; ++i) {
         sleep(Config.get_options().task_delay);
         OCRer re_OCR(ctrler()->get_image());
         re_OCR.set_task_info("ClickedCorrectStage");
@@ -195,8 +198,7 @@ bool asst::MultiCopilotTaskPlugin::confirm_stage_name(const cv::Mat& image, cons
             return true;
         }
     }
-    LogError << __FUNCTION__ << "confirm stage name failed after retrying " << m_max_retry
-             << " times, stage name:" << stage_name;
+    LogError << __FUNCTION__ << "confirm stage name failed after retrying 3 times, stage name:" << stage_name;
     return false;
 }
 

--- a/src/MaaCore/Vision/OCRer.cpp
+++ b/src/MaaCore/Vision/OCRer.cpp
@@ -47,7 +47,7 @@ OCRer::ResultsVecOpt OCRer::analyze() const
         cv::rectangle(m_image_draw, make_rect<cv::Rect>(res.rect), cv::Scalar(0, 255, 0), 2);
         cv::putText(
             m_image_draw,
-            std::to_string(res.score),
+            std::to_string(res.score) + " | " + res.text,
             cv::Point(res.rect.x, res.rect.y - 5),
             cv::FONT_HERSHEY_SIMPLEX,
             0.7,


### PR DESCRIPTION
## Summary by Sourcery

调整多协作助手任务中的阶段导航颜色阈值参数和 OCR 调试输出。

Enhancements:
- 在 `MultiCopilotTaskPlugin` 中，用 `special_params` 代替 `bin_threshold` 来配置阶段颜色阈值。
- 将阶段检测的阶段图像预处理从灰度转换为 HSV 颜色空间。
- 扩展 OCR 调试绘制，在分数旁边同时显示识别到的文本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust stage navigation color thresholding parameters and OCR debugging output for multi-copilot tasks.

Enhancements:
- Use special_params instead of bin_threshold for stage color threshold configuration in MultiCopilotTaskPlugin.
- Switch stage image preprocessing from grayscale to HSV color space for stage detection.
- Extend OCR debug drawing to include recognized text alongside the score.

</details>