### PR TITLE
feat(notification): 添加 PushPlus 通知渠道支持

### DIFF
--- a/src/MaaWpfGui/Constants/ConfigurationKeys.cs
+++ b/src/MaaWpfGui/Constants/ConfigurationKeys.cs
@@ -324,6 +324,8 @@ public static class ConfigurationKeys
     public const string ExternalNotificationCustomWebhookUrl = "ExternalNotification.CustomWebhook.Url";
     public const string ExternalNotificationCustomWebhookBody = "ExternalNotification.CustomWebhook.Body";
     public const string ExternalNotificationCustomWebhookHeaders = "ExternalNotification.CustomWebhook.Headers";
+    public const string ExternalNotificationPushPlusToken = "ExternalNotification.PushPlus.Token";
+    public const string ExternalNotificationPushPlusTemplate = "ExternalNotification.PushPlus.Template";
 
     public const string PerformanceUseGpu = "Performance.UseGpu";
     public const string PerformancePreferredGpuDescription = "Performance.PreferredGpuDescription";

--- a/src/MaaWpfGui/Services/Notification/ExternalNotificationService.cs
+++ b/src/MaaWpfGui/Services/Notification/ExternalNotificationService.cs
@@ -44,6 +44,7 @@ public static class ExternalNotificationService
                 "SMTP" => new SmtpNotificationProvider(),
                 "Bark" => new BarkNotificationProvider(Instances.HttpService),
                 "Qmsg" => new QmsgNotificationProvider(Instances.HttpService),
+                "PushPlus" => new PushPlusNotificationProvider(Instances.HttpService),
                 _ => new DummyNotificationProvider(),
             };
 

--- a/src/MaaWpfGui/Services/Notification/PushPlusNotificationProvider.cs
+++ b/src/MaaWpfGui/Services/Notification/PushPlusNotificationProvider.cs
@@ -1,0 +1,104 @@
+// <copyright file="PushPlusNotificationProvider.cs" company="MaaAssistantArknights">
+// Part of the MaaWpfGui project, maintained by the MaaAssistantArknights team (Maa Team)
+// Copyright (C) 2021-2025 MaaAssistantArknights Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License v3.0 only as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY
+// </copyright>
+
+using System;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MaaWpfGui.Services.Web;
+using MaaWpfGui.ViewModels.UI;
+using Serilog;
+
+namespace MaaWpfGui.Services.Notification;
+
+public class PushPlusNotificationProvider(IHttpService httpService) : IExternalNotificationProvider
+{
+    private readonly ILogger _logger = Log.ForContext<PushPlusNotificationProvider>();
+
+    public async Task<bool> SendAsync(string title, string content)
+    {
+        var token = SettingsViewModel.ExternalNotificationSettings.PushPlusToken;
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            _logger.Warning("Failed to send PushPlus notification, token is empty");
+            return false;
+        }
+
+        var template = SettingsViewModel.ExternalNotificationSettings.PushPlusTemplate;
+        if (string.IsNullOrWhiteSpace(template))
+        {
+            template = "html";
+        }
+
+        try
+        {
+            const string url = "http://www.pushplus.plus/send";
+
+            var requestBody = new PushPlusPostContent
+            {
+                Token = token,
+                Title = title,
+                Content = content,
+                Template = template,
+            };
+
+            var json = JsonSerializer.Serialize(requestBody);
+            var response = await httpService.PostAsync(new(url), new StringContent(json, Encoding.UTF8, "application/json"));
+            var responseContent = await response.Content.ReadAsStringAsync();
+
+            var responseRoot = JsonDocument.Parse(responseContent).RootElement;
+            if (responseRoot.TryGetProperty("code", out var codeElement) && codeElement.TryGetInt32(out var code))
+            {
+                if (code == 200)
+                {
+                    _logger.Information("PushPlus notification sent successfully.");
+                    return true;
+                }
+
+                var msg = responseRoot.TryGetProperty("msg", out var msgElement) ? msgElement.GetString() : "Unknown error";
+                _logger.Warning("Failed to send PushPlus notification, code: {Code}, msg: {Message}", code, msg);
+            }
+            else
+            {
+                _logger.Warning("Failed to send PushPlus notification, unknown response: {ResponseContent}", responseContent);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.Error(ex, "Exception occurred while sending PushPlus notification.");
+        }
+
+        return false;
+    }
+
+    private class PushPlusPostContent
+    {
+        // ReSharper disable UnusedAutoPropertyAccessor.Local
+        // ReSharper disable UnusedMember.Local
+        [System.Text.Json.Serialization.JsonPropertyName("token")]
+        public string Token { get; set; } = string.Empty;
+
+        [System.Text.Json.Serialization.JsonPropertyName("title")]
+        public string Title { get; set; } = string.Empty;
+
+        [System.Text.Json.Serialization.JsonPropertyName("content")]
+        public string Content { get; set; } = string.Empty;
+
+        [System.Text.Json.Serialization.JsonPropertyName("template")]
+        public string Template { get; set; } = "html";
+
+        // ReSharper restore UnusedAutoPropertyAccessor.Local
+        // ReSharper restore UnusedMember.Local
+    }
+}

--- a/src/MaaWpfGui/Services/Notification/PushPlusNotificationProvider.cs
+++ b/src/MaaWpfGui/Services/Notification/PushPlusNotificationProvider.cs
@@ -26,6 +26,16 @@ public class PushPlusNotificationProvider(IHttpService httpService) : IExternalN
 {
     private readonly ILogger _logger = Log.ForContext<PushPlusNotificationProvider>();
 
+    /// <summary>
+    /// PushPlus API endpoint
+    /// </summary>
+    private const string PushPlusApiUrl = "https://www.pushplus.plus/send";
+
+    /// <summary>
+    /// Default template for PushPlus notifications
+    /// </summary>
+    public const string DefaultTemplate = "html";
+
     public async Task<bool> SendAsync(string title, string content)
     {
         var token = SettingsViewModel.ExternalNotificationSettings.PushPlusToken;
@@ -38,13 +48,11 @@ public class PushPlusNotificationProvider(IHttpService httpService) : IExternalN
         var template = SettingsViewModel.ExternalNotificationSettings.PushPlusTemplate;
         if (string.IsNullOrWhiteSpace(template))
         {
-            template = "html";
+            template = DefaultTemplate;
         }
 
         try
         {
-            const string url = "http://www.pushplus.plus/send";
-
             var requestBody = new PushPlusPostContent
             {
                 Token = token,
@@ -54,7 +62,14 @@ public class PushPlusNotificationProvider(IHttpService httpService) : IExternalN
             };
 
             var json = JsonSerializer.Serialize(requestBody);
-            var response = await httpService.PostAsync(new(url), new StringContent(json, Encoding.UTF8, "application/json"));
+            var response = await httpService.PostAsync(new(PushPlusApiUrl), new StringContent(json, Encoding.UTF8, "application/json"));
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.Warning("PushPlus notification failed with HTTP status: {StatusCode}", response.StatusCode);
+                return false;
+            }
+
             var responseContent = await response.Content.ReadAsStringAsync();
 
             var responseRoot = JsonDocument.Parse(responseContent).RootElement;

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/ExternalNotificationSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/ExternalNotificationSettingsUserControlModel.cs
@@ -100,7 +100,8 @@ public class ExternalNotificationSettingsUserControlModel : PropertyChangedBase
             "Bark",
             "Qmsg",
             "Gotify",
-            "Custom Webhook"
+            "Custom Webhook",
+            "PushPlus"
         ];
 
     public static List<string> ExternalNotificationProvidersShow => ExternalNotificationProviders;
@@ -220,6 +221,14 @@ public class ExternalNotificationSettingsUserControlModel : PropertyChangedBase
         set => SetAndNotify(ref _customWebhookEnabled, value);
     }
 
+    private bool _pushPlusEnabled = false;
+
+    public bool PushPlusEnabled
+    {
+        get => _pushPlusEnabled;
+        set => SetAndNotify(ref _pushPlusEnabled, value);
+    }
+
     public void UpdateExternalNotificationProvider()
     {
         ServerChanEnabled = _enabledExternalNotificationProviders.Contains("ServerChan");
@@ -232,6 +241,7 @@ public class ExternalNotificationSettingsUserControlModel : PropertyChangedBase
         QmsgEnabled = _enabledExternalNotificationProviders.Contains("Qmsg");
         GotifyEnabled = _enabledExternalNotificationProviders.Contains("Gotify");
         CustomWebhookEnabled = _enabledExternalNotificationProviders.Contains("Custom Webhook");
+        PushPlusEnabled = _enabledExternalNotificationProviders.Contains("PushPlus");
     }
 
     #endregion External Enable
@@ -569,6 +579,29 @@ public class ExternalNotificationSettingsUserControlModel : PropertyChangedBase
             SetAndNotify(ref _customWebhookHeaders, value);
             value = SimpleEncryptionHelper.Encrypt(value);
             ConfigurationHelper.SetValue(ConfigurationKeys.ExternalNotificationCustomWebhookHeaders, value);
+        }
+    }
+
+    private string _pushPlusToken = SimpleEncryptionHelper.Decrypt(ConfigurationHelper.GetValue(ConfigurationKeys.ExternalNotificationPushPlusToken, string.Empty));
+
+    public string PushPlusToken
+    {
+        get => _pushPlusToken;
+        set {
+            SetAndNotify(ref _pushPlusToken, value);
+            value = SimpleEncryptionHelper.Encrypt(value);
+            ConfigurationHelper.SetValue(ConfigurationKeys.ExternalNotificationPushPlusToken, value);
+        }
+    }
+
+    private string _pushPlusTemplate = ConfigurationHelper.GetValue(ConfigurationKeys.ExternalNotificationPushPlusTemplate, "html");
+
+    public string PushPlusTemplate
+    {
+        get => _pushPlusTemplate;
+        set {
+            SetAndNotify(ref _pushPlusTemplate, value);
+            ConfigurationHelper.SetValue(ConfigurationKeys.ExternalNotificationPushPlusTemplate, value);
         }
     }
 

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/ExternalNotificationSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/ExternalNotificationSettingsUserControlModel.cs
@@ -594,7 +594,7 @@ public class ExternalNotificationSettingsUserControlModel : PropertyChangedBase
         }
     }
 
-    private string _pushPlusTemplate = ConfigurationHelper.GetValue(ConfigurationKeys.ExternalNotificationPushPlusTemplate, "html");
+    private string _pushPlusTemplate = ConfigurationHelper.GetValue(ConfigurationKeys.ExternalNotificationPushPlusTemplate, PushPlusNotificationProvider.DefaultTemplate);
 
     public string PushPlusTemplate
     {


### PR DESCRIPTION
**新增 PushPlus（推送加）通知渠道**

### 变更内容
- 新增 `PushPlusNotificationProvider`，支持通过 PushPlus 发送微信推送
- 在 `ExternalNotificationService` 中添加 PushPlus 映射
- 在 `ConfigurationKeys` 中添加 PushPlus 配置键
- 在 `ExternalNotificationSettingsUserControlModel` 中添加 PushPlus 配置属性

### PushPlus API
- 请求地址：`http://www.pushplus.plus/send`
- 请求方式：POST，JSON 格式
- 支持模板：html/txt/json/markdown

## Summary by Sourcery

添加 PushPlus 作为新的外部通知通道，用于通过 PushPlus 发送通知。

新功能：
- 引入 `PushPlusNotificationProvider`，通过 PushPlus API 发送通知。
- 在 UI 中将 PushPlus 暴露为可选择的外部通知提供者，并支持配置 token 和模板设置。

增强：
- 扩展外部通知提供者映射和配置键，以支持新的 PushPlus 通道。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add PushPlus as a new external notification channel for sending notifications via PushPlus.

New Features:
- Introduce PushPlusNotificationProvider to send notifications through the PushPlus API.
- Expose PushPlus as a selectable external notification provider with configurable token and template settings in the UI.

Enhancements:
- Extend external notification provider mapping and configuration keys to support the new PushPlus channel.

</details>