### PR TITLE
feat(webhook): Custom Webhook 添加 PushPlus 预置模板

### DIFF
--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -78,6 +78,10 @@
     <system:String x:Key="ExternalNotificationCustomWebhook.Headers">Webhook Headers</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.Body">Message body template</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.Placeholders">Placeholders: {title}, {content}, {time}</system:String>
+    <system:String x:Key="ExternalNotificationCustomWebhook.Presets">Preset Template</system:String>
+    <system:String x:Key="ExternalNotificationCustomWebhook.PresetsPlaceholders">Please replace placeholders wrapped in {} other than {title}, {content}, {time} (e.g. {nickname}) with actual values</system:String>
+    <system:String x:Key="ExternalNotificationCustomWebhook.TemplateCustom">Custom</system:String>
+    <system:String x:Key="ExternalNotificationCustomWebhook.TemplateMeoW">MeoW</system:String>
     <system:String x:Key="UseGpuForInference">Use GPU for inference acceleration</system:String>
     <system:String x:Key="UseGpuForInferenceTip">Using GPU inference can significantly reduce CPU load with minimal GPU usage</system:String>
     <system:String x:Key="GpuOptionDisable">Don’t use</system:String>

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -82,6 +82,7 @@
     <system:String x:Key="ExternalNotificationCustomWebhook.PresetsPlaceholders">Please replace placeholders wrapped in {} other than {title}, {content}, {time} (e.g. {nickname}) with actual values</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.TemplateCustom">Custom</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.TemplateMeoW">MeoW</system:String>
+    <system:String x:Key="ExternalNotificationCustomWebhook.TemplatePushPlus">PushPlus</system:String>
     <system:String x:Key="UseGpuForInference">Use GPU for inference acceleration</system:String>
     <system:String x:Key="UseGpuForInferenceTip">Using GPU inference can significantly reduce CPU load with minimal GPU usage</system:String>
     <system:String x:Key="GpuOptionDisable">Don’t use</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -82,6 +82,7 @@
     <system:String x:Key="ExternalNotificationCustomWebhook.PresetsPlaceholders">{title}、{content}、{time} 以外の {} で囲まれたプレースホルダー（例：{nickname}）を実際の値に置き換えてください</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.TemplateCustom">カスタム</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.TemplateMeoW">MeoW</system:String>
+    <system:String x:Key="ExternalNotificationCustomWebhook.TemplatePushPlus">PushPlus</system:String>
     <system:String x:Key="UseGpuForInference">推論加速のためにGPUを使用する</system:String>
     <system:String x:Key="UseGpuForInferenceTip">GPU 推論を利用することで、ごくわずかな GPU 使用率で CPU の負荷を大幅に軽減できます</system:String>
     <system:String x:Key="GpuOptionDisable">使用しない</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -78,6 +78,10 @@
     <system:String x:Key="ExternalNotificationCustomWebhook.Headers">Webhook Headers</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.Body">メッセージ本文</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.Placeholders">プレホルダー: {title}、{content}、{time}</system:String>
+    <system:String x:Key="ExternalNotificationCustomWebhook.Presets">プリセットテンプレート</system:String>
+    <system:String x:Key="ExternalNotificationCustomWebhook.PresetsPlaceholders">{title}、{content}、{time} 以外の {} で囲まれたプレースホルダー（例：{nickname}）を実際の値に置き換えてください</system:String>
+    <system:String x:Key="ExternalNotificationCustomWebhook.TemplateCustom">カスタム</system:String>
+    <system:String x:Key="ExternalNotificationCustomWebhook.TemplateMeoW">MeoW</system:String>
     <system:String x:Key="UseGpuForInference">推論加速のためにGPUを使用する</system:String>
     <system:String x:Key="UseGpuForInferenceTip">GPU 推論を利用することで、ごくわずかな GPU 使用率で CPU の負荷を大幅に軽減できます</system:String>
     <system:String x:Key="GpuOptionDisable">使用しない</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -78,6 +78,10 @@
     <system:String x:Key="ExternalNotificationCustomWebhook.Headers">Webhook Headers</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.Body">메시지 본문 템플릿</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.Placeholders">플레이스홀더: {title}, {content}, {time}</system:String>
+    <system:String x:Key="ExternalNotificationCustomWebhook.Presets">사전 설정 템플릿</system:String>
+    <system:String x:Key="ExternalNotificationCustomWebhook.PresetsPlaceholders">{title}, {content}, {time} 외에 {}로 감싸진 플레이스홀더(예: {nickname})를 실제 값으로 바꿔주세요</system:String>
+    <system:String x:Key="ExternalNotificationCustomWebhook.TemplateCustom">사용자 정의</system:String>
+    <system:String x:Key="ExternalNotificationCustomWebhook.TemplateMeoW">MeoW</system:String>
     <system:String x:Key="UseGpuForInference">추론 가속화를 위해 GPU 사용</system:String>
     <system:String x:Key="UseGpuForInferenceTip">GPU 추론을 사용하면 매우 적은 GPU 점유로 CPU 부담을 크게 줄일 수 있습니다</system:String>
     <system:String x:Key="GpuOptionDisable">미사용</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -82,6 +82,7 @@
     <system:String x:Key="ExternalNotificationCustomWebhook.PresetsPlaceholders">{title}, {content}, {time} 외에 {}로 감싸진 플레이스홀더(예: {nickname})를 실제 값으로 바꿔주세요</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.TemplateCustom">사용자 정의</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.TemplateMeoW">MeoW</system:String>
+    <system:String x:Key="ExternalNotificationCustomWebhook.TemplatePushPlus">PushPlus</system:String>
     <system:String x:Key="UseGpuForInference">추론 가속화를 위해 GPU 사용</system:String>
     <system:String x:Key="UseGpuForInferenceTip">GPU 추론을 사용하면 매우 적은 GPU 점유로 CPU 부담을 크게 줄일 수 있습니다</system:String>
     <system:String x:Key="GpuOptionDisable">미사용</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -82,6 +82,7 @@
     <system:String x:Key="ExternalNotificationCustomWebhook.PresetsPlaceholders">请将预置模板中除 {title}、{content}、{time} 以外的 {} 占位符（如 {nickname}）替换为实际值</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.TemplateCustom">自定义</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.TemplateMeoW">MeoW</system:String>
+    <system:String x:Key="ExternalNotificationCustomWebhook.TemplatePushPlus">PushPlus</system:String>
     <system:String x:Key="UseGpuForInference">使用 GPU 加速推理</system:String>
     <system:String x:Key="UseGpuForInferenceTip">使用 GPU 推理能够以极低的 GPU 占用显著降低 CPU 的负担</system:String>
     <system:String x:Key="GpuOptionDisable">不使用</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -78,6 +78,10 @@
     <system:String x:Key="ExternalNotificationCustomWebhook.Headers">Webhook Headers</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.Body">消息体模板</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.Placeholders">可用占位符：{title}、{content}、{time}</system:String>
+    <system:String x:Key="ExternalNotificationCustomWebhook.Presets">预置模板</system:String>
+    <system:String x:Key="ExternalNotificationCustomWebhook.PresetsPlaceholders">请将预置模板中除 {title}、{content}、{time} 以外的 {} 占位符（如 {nickname}）替换为实际值</system:String>
+    <system:String x:Key="ExternalNotificationCustomWebhook.TemplateCustom">自定义</system:String>
+    <system:String x:Key="ExternalNotificationCustomWebhook.TemplateMeoW">MeoW</system:String>
     <system:String x:Key="UseGpuForInference">使用 GPU 加速推理</system:String>
     <system:String x:Key="UseGpuForInferenceTip">使用 GPU 推理能够以极低的 GPU 占用显著降低 CPU 的负担</system:String>
     <system:String x:Key="GpuOptionDisable">不使用</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -82,6 +82,7 @@
     <system:String x:Key="ExternalNotificationCustomWebhook.PresetsPlaceholders">請將預製模板中除 {title}、{content}、{time} 以外的 {} 佔位符（如 {nickname}）替換為實際值</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.TemplateCustom">自訂</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.TemplateMeoW">MeoW</system:String>
+    <system:String x:Key="ExternalNotificationCustomWebhook.TemplatePushPlus">PushPlus</system:String>
     <system:String x:Key="UseGpuForInference">使用 GPU 加速推理</system:String>
     <system:String x:Key="UseGpuForInferenceTip">使用 GPU 推理能以極低的 GPU 佔用顯著降低 CPU 的負擔</system:String>
     <system:String x:Key="GpuOptionDisable">不使用</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -78,6 +78,10 @@
     <system:String x:Key="ExternalNotificationCustomWebhook.Headers">Webhook Headers</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.Body">訊息本文範本</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.Placeholders">可用佔位符：{title}、{content}、{time}</system:String>
+    <system:String x:Key="ExternalNotificationCustomWebhook.Presets">預製模板</system:String>
+    <system:String x:Key="ExternalNotificationCustomWebhook.PresetsPlaceholders">請將預製模板中除 {title}、{content}、{time} 以外的 {} 佔位符（如 {nickname}）替換為實際值</system:String>
+    <system:String x:Key="ExternalNotificationCustomWebhook.TemplateCustom">自訂</system:String>
+    <system:String x:Key="ExternalNotificationCustomWebhook.TemplateMeoW">MeoW</system:String>
     <system:String x:Key="UseGpuForInference">使用 GPU 加速推理</system:String>
     <system:String x:Key="UseGpuForInferenceTip">使用 GPU 推理能以極低的 GPU 佔用顯著降低 CPU 的負擔</system:String>
     <system:String x:Key="GpuOptionDisable">不使用</system:String>

--- a/src/MaaWpfGui/Services/Notification/WebhookPresetTemplate.cs
+++ b/src/MaaWpfGui/Services/Notification/WebhookPresetTemplate.cs
@@ -32,7 +32,7 @@ public class WebhookPresetTemplate
     // 新增模板时，必须在所有语言的 Localizations/*.xaml 中添加对应的 NameResourceKey 字符串
     public string DisplayName => LocalizationHelper.GetString(NameResourceKey);
 
-    public static List<WebhookPresetTemplate> BuiltInTemplates { get; } =
+    private static readonly List<WebhookPresetTemplate> _builtInTemplates =
     [
         new()
         {
@@ -44,7 +44,10 @@ public class WebhookPresetTemplate
             Id = "meow",
             NameResourceKey = "ExternalNotificationCustomWebhook.TemplateMeoW",
             Url = "https://api.chuckfang.com/{nickname}",
+            Headers = "Content-Type: application/json",
             BodyTemplate = "{\"title\":\"{title}\",\"msg\":\"{content}\\n{time}\"}",
         },
     ];
+
+    public static IReadOnlyList<WebhookPresetTemplate> BuiltInTemplates => _builtInTemplates;
 }

--- a/src/MaaWpfGui/Services/Notification/WebhookPresetTemplate.cs
+++ b/src/MaaWpfGui/Services/Notification/WebhookPresetTemplate.cs
@@ -44,7 +44,6 @@ public class WebhookPresetTemplate
             Id = "meow",
             NameResourceKey = "ExternalNotificationCustomWebhook.TemplateMeoW",
             Url = "https://api.chuckfang.com/{nickname}",
-            Headers = "Content-Type: application/json",
             BodyTemplate = "{\"title\":\"{title}\",\"msg\":\"{content}\\n{time}\"}",
         },
     ];

--- a/src/MaaWpfGui/Services/Notification/WebhookPresetTemplate.cs
+++ b/src/MaaWpfGui/Services/Notification/WebhookPresetTemplate.cs
@@ -1,0 +1,50 @@
+// <copyright file="WebhookPresetTemplate.cs" company="MaaAssistantArknights">
+// Part of the MaaWpfGui project, maintained by the MaaAssistantArknights team (Maa Team)
+// Copyright (C) 2021-2025 MaaAssistantArknights Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License v3.0 only as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY
+// </copyright>
+
+#nullable enable
+using System.Collections.Generic;
+using MaaWpfGui.Helper;
+
+namespace MaaWpfGui.Services.Notification;
+
+public class WebhookPresetTemplate
+{
+    public string Id { get; init; } = string.Empty;
+
+    public string NameResourceKey { get; init; } = string.Empty;
+
+    public string Url { get; init; } = string.Empty;
+
+    public string Headers { get; init; } = string.Empty;
+
+    public string BodyTemplate { get; init; } = string.Empty;
+
+    // 新增模板时，必须在所有语言的 Localizations/*.xaml 中添加对应的 NameResourceKey 字符串
+    public string DisplayName => LocalizationHelper.GetString(NameResourceKey);
+
+    public static List<WebhookPresetTemplate> BuiltInTemplates { get; } =
+    [
+        new()
+        {
+            Id = "__custom__",
+            NameResourceKey = "ExternalNotificationCustomWebhook.TemplateCustom",
+        },
+        new()
+        {
+            Id = "meow",
+            NameResourceKey = "ExternalNotificationCustomWebhook.TemplateMeoW",
+            Url = "https://api.chuckfang.com/{nickname}",
+            BodyTemplate = "{\"title\":\"{title}\",\"msg\":\"{content}\\n{time}\"}",
+        },
+    ];
+}

--- a/src/MaaWpfGui/Services/Notification/WebhookPresetTemplate.cs
+++ b/src/MaaWpfGui/Services/Notification/WebhookPresetTemplate.cs
@@ -46,6 +46,14 @@ public class WebhookPresetTemplate
             Url = "https://api.chuckfang.com/{nickname}",
             BodyTemplate = "{\"title\":\"{title}\",\"msg\":\"{content}\\n{time}\"}",
         },
+        new()
+        {
+            Id = "pushplus",
+            NameResourceKey = "ExternalNotificationCustomWebhook.TemplatePushPlus",
+            Url = "https://www.pushplus.plus/send",
+            Headers = "Content-Type: application/json",
+            BodyTemplate = "{\"token\":\"{your_token}\",\"title\":\"{title}\",\"content\":\"{content}\",\"template\":\"html\"}",
+        },
     ];
 
     public static IReadOnlyList<WebhookPresetTemplate> BuiltInTemplates => _builtInTemplates;

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/ExternalNotificationSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/ExternalNotificationSettingsUserControlModel.cs
@@ -572,7 +572,7 @@ public class ExternalNotificationSettingsUserControlModel : PropertyChangedBase
         }
     }
 
-    public List<WebhookPresetTemplate> PresetTemplateList => WebhookPresetTemplate.BuiltInTemplates;
+    public IReadOnlyList<WebhookPresetTemplate> PresetTemplateList => WebhookPresetTemplate.BuiltInTemplates;
 
     private string _selectedPresetTemplateId = "__custom__";
 
@@ -582,6 +582,11 @@ public class ExternalNotificationSettingsUserControlModel : PropertyChangedBase
         set
         {
             if (!SetAndNotify(ref _selectedPresetTemplateId, value))
+            {
+                return;
+            }
+
+            if (value == "__custom__")
             {
                 return;
             }

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/ExternalNotificationSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/ExternalNotificationSettingsUserControlModel.cs
@@ -572,6 +572,36 @@ public class ExternalNotificationSettingsUserControlModel : PropertyChangedBase
         }
     }
 
+    public List<WebhookPresetTemplate> PresetTemplateList => WebhookPresetTemplate.BuiltInTemplates;
+
+    private string _selectedPresetTemplateId = "__custom__";
+
+    public string SelectedPresetTemplateId
+    {
+        get => _selectedPresetTemplateId;
+        set
+        {
+            if (!SetAndNotify(ref _selectedPresetTemplateId, value))
+            {
+                return;
+            }
+
+            var template = WebhookPresetTemplate.BuiltInTemplates.FirstOrDefault(t => t.Id == value);
+            if (template == null)
+            {
+                return;
+            }
+
+            CustomWebhookUrl = template.Url;
+            CustomWebhookBody = template.BodyTemplate;
+            CustomWebhookHeaders = template.Headers;
+
+            NotifyOfPropertyChange(nameof(CustomWebhookUrl));
+            NotifyOfPropertyChange(nameof(CustomWebhookBody));
+            NotifyOfPropertyChange(nameof(CustomWebhookHeaders));
+        }
+    }
+
     // FIXME: 不知道为什么 TextBox 在高度变化时会导致 ScrollViewer 的偏移位置变成 0，直接锁到第一个元素去了。在编辑的时候先给它禁用了
     // 不要用 static，s:Action 找不到
     public void CustomWebhookBodyGotFocus() => Instances.SettingsViewModel.AllowScrollOffsetChange = false;

--- a/src/MaaWpfGui/Views/UserControl/Settings/ExternalNotificationSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/Settings/ExternalNotificationSettingsUserControl.xaml
@@ -490,6 +490,16 @@
             Orientation="Vertical"
             Visibility="{c:Binding CustomWebhookEnabled}">
             <hc:Divider Content="{DynamicResource ExternalNotificationCustomWebhook}" />
+            <StackPanel Orientation="Horizontal" Margin="10,10,0,10">
+                <hc:ComboBox
+                    Width="300"
+                    hc:InfoElement.Title="{DynamicResource ExternalNotificationCustomWebhook.Presets}"
+                    ItemsSource="{Binding PresetTemplateList}"
+                    SelectedValue="{Binding SelectedPresetTemplateId}"
+                    DisplayMemberPath="DisplayName"
+                    SelectedValuePath="Id" />
+                <controls:TooltipBlock TooltipText="{DynamicResource ExternalNotificationCustomWebhook.PresetsPlaceholders}" />
+            </StackPanel>
             <StackPanel Orientation="Horizontal">
                 <hc:TextBox
                     x:Name="CustomWebhookUrl"


### PR DESCRIPTION
## 变更内容

基于 #17081 的预置模板功能，新增 PushPlus（推送加）预置模板。

### WebhookPresetTemplate.cs
- 在 `_builtInTemplates` 列表中添加 PushPlus 模板条目
- URL: `https://www.pushplus.plus/send`
- Headers: `Content-Type: application/json`
- Body: `{"token":"{your_token}","title":"{title}","content":"{content}","template":"html"}`

### 本地化（5 种语言）
- zh-cn / zh-tw / en-us / ja-jp / ko-kr：添加 `ExternalNotificationCustomWebhook.TemplatePushPlus` 字符串

### 使用说明
选择 PushPlus 预置模板后，URL / Headers / Body 会自动填入，用户只需将 `{your_token}` 替换为自己的 PushPlus token 即可。

## Summary by Sourcery

在外部通知设置中添加预设 Webhook 模板支持，包括新的 PushPlus 模板及其对应的界面绑定和本地化内容。

新功能：
- 为 PushPlus 通知引入预定义的 Webhook 模板，其中包含 URL、请求头和请求体占位符。
- 在外部通知设置中提供可选择的 Webhook 预设模板列表，可自动填充自定义 Webhook 字段。

增强：
- 为 Webhook 预设模板名称在所有受支持语言中添加本地化条目。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add preset webhook templates support in the external notification settings, including a new PushPlus template and corresponding UI bindings and localizations.

New Features:
- Introduce a predefined webhook template for PushPlus notifications with URL, headers, and body placeholders.
- Expose a selectable list of webhook preset templates in external notification settings that automatically populate custom webhook fields.

Enhancements:
- Add localization entries for webhook preset template names across supported languages.

</details>