### PR TITLE
rft: 统一停止逻辑

### DIFF
--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -1060,7 +1060,11 @@ public class AsstProxy
         switch (msg)
         {
             case AsstMsg.TaskChainStopped:
-                Instances.TaskQueueViewModel.SetStopped();
+                {
+                    // Copilot 场景下只有 CopilotWithScript 开启时才执行结束脚本，否则由 SetStopped 默认逻辑处理
+                    bool runScript = !isCopilotTaskChain || SettingsViewModel.GameSettings.CopilotWithScript;
+                    Instances.TaskQueueViewModel.SetStopped(runStopScript: runScript);
+                }
 
                 // UpdateTaskStatus(taskId, TaskStatus.Completed);
                 _tasksStatus.Clear();

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -873,6 +873,8 @@ Do not adjust the proxy multiplier setting in the game</system:String>
     <system:String x:Key="Waiting">Waiting for the mission completion…</system:String>
     <system:String x:Key="Stopping">Stopping……</system:String>
     <system:String x:Key="Stopped">Has stopped</system:String>
+    <system:String x:Key="StopTimeout">Stop timed out: Core did not respond to the stop request in time</system:String>
+    <system:String x:Key="RestartRecommendation">It is recommended to restart MAA to restore normal state</system:String>
     <system:String x:Key="UnknownErrorOccurs">Unknown error occurred</system:String>
     <system:String x:Key="SetSuccessfully">Set successfully</system:String>
     <system:String x:Key="SetFailed">Setting failed</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -874,6 +874,8 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="Waiting">ミッション終了を待っています……</system:String>
     <system:String x:Key="Stopping">動作停止中……</system:String>
     <system:String x:Key="Stopped">動作停止</system:String>
+    <system:String x:Key="StopTimeout">停止がタイムアウトしました。Core が停止要求に応答しませんでした</system:String>
+    <system:String x:Key="RestartRecommendation">MAA を再起動して正常な状態に戻すことをお勧めします</system:String>
     <system:String x:Key="UnknownErrorOccurs">不明なエラーが発生しました</system:String>
     <system:String x:Key="SetSuccessfully">設定に成功しました</system:String>
     <system:String x:Key="SetFailed">設定に失敗しました</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -875,6 +875,8 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="Waiting">전투가 끝나기를 기다리며……</system:String>
     <system:String x:Key="Stopping">중지 중……</system:String>
     <system:String x:Key="Stopped">중지됨</system:String>
+    <system:String x:Key="StopTimeout">중지 시간 초과: Core가 중지 요청에 시간 내 응답하지 않았습니다</system:String>
+    <system:String x:Key="RestartRecommendation">MAA를 다시 시작하여 정상 상태로 복원하는 것을 권장합니다</system:String>
     <system:String x:Key="UnknownErrorOccurs">예상치 못한 오류가 발생했습니다</system:String>
     <system:String x:Key="SetSuccessfully">설정 성공</system:String>
     <system:String x:Key="SetFailed">설정 실패</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -874,6 +874,8 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="Waiting">正在等待当前任务结束……</system:String>
     <system:String x:Key="Stopping">正在停止……</system:String>
     <system:String x:Key="Stopped">已停止</system:String>
+    <system:String x:Key="StopTimeout">停止超时，Core 未能及时响应停止请求</system:String>
+    <system:String x:Key="RestartRecommendation">建议重启 MAA 以恢复正常状态</system:String>
     <system:String x:Key="UnknownErrorOccurs">出现未知错误</system:String>
     <system:String x:Key="SetSuccessfully">设置成功</system:String>
     <system:String x:Key="SetFailed">设置失败</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -874,6 +874,8 @@ C:\\leidian\\LDPlayer9\n
     <system:String x:Key="Waiting">正在等待目前任務結束……</system:String>
     <system:String x:Key="Stopping">正在停止……</system:String>
     <system:String x:Key="Stopped">已停止</system:String>
+    <system:String x:Key="StopTimeout">停止逾時，Core 未能及時回應停止請求</system:String>
+    <system:String x:Key="RestartRecommendation">建議重啟 MAA 以恢復正常狀態</system:String>
     <system:String x:Key="UnknownErrorOccurs">出現未知錯誤</system:String>
     <system:String x:Key="SetSuccessfully">設定成功</system:String>
     <system:String x:Key="SetFailed">設定失敗</system:String>

--- a/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
@@ -1881,6 +1881,14 @@ public partial class CopilotViewModel : Screen
             return;
         }
 
+        // 连接期间用户可能已点停止，需在此处拦截
+        if (_runningState.GetStopping())
+        {
+            Instances.TaskQueueViewModel.SetStopped();
+            AddLog(LocalizationHelper.GetString("Stopped"));
+            return;
+        }
+
         var userAdditional = ParseUserAdditionals();
 
         bool ret;
@@ -2164,23 +2172,15 @@ public partial class CopilotViewModel : Screen
     /// Stops copilot.
     /// UI 绑定的方法
     /// </summary>
-    public void Stop()
+    public async void Stop()
     {
-        if (SettingsViewModel.GameSettings.CopilotWithScript && SettingsViewModel.GameSettings.ManualStopWithScript)
+        // 等待 Core 实际停止；回调或超时自动 SetStopped（脚本由 proxy 回调按 CopilotWithScript 设置判断）
+        AddLog(LocalizationHelper.GetString("Stopping"));
+        await Instances.TaskQueueViewModel.Stop();
+        if (_runningState.GetIdle() && !_runningState.GetStopping())
         {
-            Task.Run(() => SettingsViewModel.GameSettings.RunScript("EndsWithScript", showLog: false));
-            if (!string.IsNullOrWhiteSpace(SettingsViewModel.GameSettings.EndsWithScript))
-            {
-                Instances.CopilotViewModel.AddLog(LocalizationHelper.GetString("EndsWithScript"));
-            }
+            AddLog(LocalizationHelper.GetString("Stopped"));
         }
-
-        if (!Instances.AsstProxy.AsstStop())
-        {
-            _logger.Warning("Failed to stop Asst");
-        }
-
-        _runningState.SetIdle(true);
     }
 
     private bool IsDataFromWeb { get => field; set => SetAndNotify(ref field, value); }

--- a/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
@@ -1884,7 +1884,7 @@ public partial class CopilotViewModel : Screen
         // 连接期间用户可能已点停止，需在此处拦截
         if (_runningState.GetStopping())
         {
-            Instances.TaskQueueViewModel.SetStopped();
+            Instances.TaskQueueViewModel.SetStopped(SettingsViewModel.GameSettings.CopilotWithScript);
             AddLog(LocalizationHelper.GetString("Stopped"));
             return;
         }

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -1834,7 +1834,7 @@ public class TaskQueueViewModel : Screen
         */
 
         // 一般是点了“停止”按钮了
-        if (_runningState.Stopping)
+        if (_runningState.GetStopping())
         {
             SetStopped();
             return;
@@ -1846,7 +1846,7 @@ public class TaskQueueViewModel : Screen
         }
 
         // 一般是点了“停止”按钮了
-        if (_runningState.Stopping)
+        if (_runningState.GetStopping())
         {
             SetStopped();
             return;
@@ -1968,15 +1968,21 @@ public class TaskQueueViewModel : Screen
     }
 
     /// <summary>
-    /// <para>通常要和 <see cref="SetStopped()"/> 一起使用，除非能保证回调消息能收到 `AsstMsg.TaskChainStopped`</para>
-    /// <para>This is usually done with <see cref="SetStopped()"/> Unless you are guaranteed to receive the callback message `AsstMsg.TaskChainStopped`</para>
+    /// <para>通知 Core 停止当前任务并等待其完成。</para>
+    /// <para>通常 Core 停止后会发送 <c>TaskChainStopped</c> 回调，由 <see cref="AsstProxy"/> 调用 <see cref="SetStopped"/> 恢复 UI 状态。</para>
+    /// <para>若未通过任务链调用 Core（如 Peep），则不会收到回调，需在调用 <see cref="Stop"/> 后手动调用 <see cref="SetStopped"/>。</para>
+    /// <para>超时后会自动调用 <see cref="SetStopped"/> 强制恢复 UI 状态。</para>
+    /// <para>Notifies Core to stop the current task and waits for completion.</para>
+    /// <para>Normally Core sends <c>TaskChainStopped</c> callback after stopping, and <see cref="AsstProxy"/> calls <see cref="SetStopped"/> to reset UI state.</para>
+    /// <para>If Core was not invoked via task chain (e.g. Peep), no callback will be received; caller must manually call <see cref="SetStopped"/> after <see cref="Stop"/>.</para>
+    /// <para>On timeout, <see cref="SetStopped"/> is called automatically to force-reset UI state.</para>
     /// </summary>
     /// <param name="timeout">Timeout millisecond</param>
     /// <returns>A <see cref="Task"/>
     /// <para>尝试等待 core 成功停止运行，默认超时时间一分钟</para>
     /// <para>Try to wait for the core to stop running, the default timeout is one minute</para>
     /// </returns>
-    public async Task<bool> Stop(int timeout = 60 * 1000)
+    public async Task Stop(int timeout = 60 * 1000)
     {
         _runningState.SetStopping(true);
         AddLog(LocalizationHelper.GetString("Stopping"), splitMode: LogCardSplitMode.Both);
@@ -1994,7 +2000,13 @@ public class TaskQueueViewModel : Screen
             count++;
         }
 
-        return !Instances.AsstProxy.AsstRunning();
+        if (Instances.AsstProxy.AsstRunning())
+        {
+            // 超时：Core 未在超时内停止，强制恢复 UI 状态
+            _logger.Warning("Stop timeout, force resetting UI state");
+            AddLog(LocalizationHelper.GetString("StopTimeout") + "\n" + LocalizationHelper.GetString("RestartRecommendation"), UiLogColor.Error);
+            SetStopped();
+        }
     }
 
     // UI 绑定的方法
@@ -2029,10 +2041,22 @@ public class TaskQueueViewModel : Screen
 
     public bool RoguelikeInCombatAndShowWait { get => field; set => SetAndNotify(ref field, value); }
 
-    public void SetStopped()
+    /// <summary>
+    /// 重置 UI 状态为已停止。
+    /// </summary>
+    /// <param name="runStopScript">是否执行结束脚本。</param>
+    /// <returns>是否实际执行了状态重置（false 表示被幂等保护跳过）。</returns>
+    public bool SetStopped(bool runStopScript = true)
     {
+        // 幂等保护：已经空闲且不在停止中，跳过
+        // 防止超时 SetStopped 后 Core 延迟回调再次触发导致打断新任务
+        if (_runningState.GetIdle() && !_runningState.GetStopping())
+        {
+            return false;
+        }
+
         SleepManagement.AllowSleep();
-        if (SettingsViewModel.GameSettings.ManualStopWithScript)
+        if (runStopScript && SettingsViewModel.GameSettings.ManualStopWithScript)
         {
             Task.Run(() => SettingsViewModel.GameSettings.RunScript("EndsWithScript"));
         }
@@ -2047,6 +2071,7 @@ public class TaskQueueViewModel : Screen
         _runningState.SetIdle(true);
 
         // 只抑制“本轮任务期间”的自动开启；任务结束后应允许下一轮自动开启 LiveView。
+        return true;
     }
 
     public bool EnableSetFightParams { get; set; } = true;

--- a/src/MaaWpfGui/Views/UI/CopilotView.xaml
+++ b/src/MaaWpfGui/Views/UI/CopilotView.xaml
@@ -288,7 +288,7 @@
                             Height="50"
                             Command="{s:Action Stop}"
                             Content="{DynamicResource Stop}"
-                            IsEnabled="{c:Binding Inited}"
+                            IsEnabled="{c:Binding 'Inited and !Stopping'}"
                             Visibility="{c:Binding !Idle}" />
                     </Grid>
                     <StackPanel


### PR DESCRIPTION
## Summary by Sourcery

统一并加固任务队列与 copilot 之间的停止流程，确保 UI 状态、脚本以及 Core 回调都能被一致且幂等地处理。

Bug 修复：
- 通过幂等的 UI 停止处理，防止由于延迟到达的 Core 停止回调打断新任务。
- 确保 copilot 在连接过程中遵守全局停止请求，并且只有在 UI 实际恢复为空闲状态时才记录停止完成日志。
- 处理 Core 停止超时时，通过强制重置 UI 状态并向用户提示重启建议。

增强：
- 优化停止语义，使 `TaskQueueViewModel.Stop` 负责 Core 停止、超时和 UI 重置，而不是返回状态标记。
- 使 `SetStopped` 具备幂等性并可配置为可选跳过停止脚本，从而允许 copilot 与普通任务链采用不同行为。
- 通过 `TaskQueueViewModel` 路由 `TaskChainStopped` 处理逻辑，并基于设置对 copilot 任务链进行有条件的脚本执行。
- 将 Copilot 的停止行为与共享停止逻辑对齐，并移除重复的脚本运行代码。

文档：
- 改进围绕停止行为、Core 回调以及在非任务链场景下必须使用 `SetStopped` 的相关 XML 文档说明。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify and harden the stop flow between task queue and copilot so UI state, scripts, and Core callbacks are handled consistently and idempotently.

Bug Fixes:
- Prevent new tasks from being interrupted by delayed Core stop callbacks via idempotent UI stop handling.
- Ensure copilot respects global stop requests during connection and logs stop completion only when the UI actually returns to idle.
- Handle Core stop timeouts by force-resetting UI state and surfacing a restart recommendation to the user.

Enhancements:
- Refine stop semantics so TaskQueueViewModel.Stop manages Core stopping, timeouts, and UI reset instead of returning a status flag.
- Make SetStopped idempotent and configurable to optionally skip stop scripts, allowing different behavior for copilot vs normal task chains.
- Route TaskChainStopped handling through TaskQueueViewModel with conditional script execution for copilot task chains based on settings.
- Align Copilot stop behavior with the shared stop logic and remove duplicated script‑running code.

Documentation:
- Improve XML documentation around the stop behavior, Core callbacks, and required SetStopped usage in non‑task‑chain scenarios.

</details>