### PR TITLE
ci: Update GitHub push action version comment in workflow

### DIFF
--- a/.github/workflows/blame-ignore.yml
+++ b/.github/workflows/blame-ignore.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Push changes
         if: ${{ steps.check_changes.outcome == 'failure' }}
-        uses: ad-m/github-push-action@881a6320fdb16eb5318c5054f31c218aec2b324c # master as of 2026-05-06
+        uses: ad-m/github-push-action@881a6320fdb16eb5318c5054f31c218aec2b324c # v1.3.0
         with:
           branch: ${{ github.ref }}
           github_token: ${{ secrets.MAA_RESOURCE_SYNC }}

--- a/.github/workflows/optimize-templates.yml
+++ b/.github/workflows/optimize-templates.yml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Push changes
         if: steps.check_push.outputs.is_pr != 'True' && steps.commit_changes.outputs.have_commits == 'True' && github.repository_owner == 'MaaAssistantArknights'
-        uses: ad-m/github-push-action@881a6320fdb16eb5318c5054f31c218aec2b324c # master as of 2026-05-06
+        uses: ad-m/github-push-action@881a6320fdb16eb5318c5054f31c218aec2b324c # v1.3.0
         with:
           github_token: ${{ secrets.MAA_RESOURCE_SYNC }}
           branch: ${{ github.ref }}

--- a/.github/workflows/res-update-game.yml
+++ b/.github/workflows/res-update-game.yml
@@ -306,7 +306,7 @@ jobs:
 
       - name: Push changes
         if: steps.add_files.outputs.have_commits == 'True'
-        uses: ad-m/github-push-action@881a6320fdb16eb5318c5054f31c218aec2b324c # master as of 2026-05-06
+        uses: ad-m/github-push-action@881a6320fdb16eb5318c5054f31c218aec2b324c # v1.3.0
         with:
           branch: ${{ github.ref }}
           github_token: ${{ secrets.MAA_RESOURCE_SYNC }}


### PR DESCRIPTION
## Summary by Sourcery

CI:
- 在多个工作流中更新注释，将对过时的 `master` 引用替换为对 `ad-m/github-push-action` `v1.3.0` 版本的引用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Update comments in multiple workflows to reference ad-m/github-push-action version v1.3.0 instead of a dated master reference.

</details>