### PR TITLE
feat: Android OCR 推理使用 NCNN

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,11 @@ if(INSTALL_FLATTEN)
     set(MaaCore_install_flatten_args RUNTIME DESTINATION . LIBRARY DESTINATION . PUBLIC_HEADER DESTINATION .)
 endif()
 
+# MAA only consumes ncnn on Android (other platforms use fastdeploy).
+# Opt in here, before MaaUtils is loaded, so the shared submodule stays neutral.
+if(ANDROID)
+    set(WITH_NCNN ON)
+endif()
 include(src/MaaUtils/MaaUtils.cmake)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/modules")
 include(${PROJECT_SOURCE_DIR}/cmake/config.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,11 +19,6 @@ if(INSTALL_FLATTEN)
     set(MaaCore_install_flatten_args RUNTIME DESTINATION . LIBRARY DESTINATION . PUBLIC_HEADER DESTINATION .)
 endif()
 
-# MAA only consumes ncnn on Android (other platforms use fastdeploy).
-# Opt in here, before MaaUtils is loaded, so the shared submodule stays neutral.
-if(ANDROID)
-    set(WITH_NCNN ON)
-endif()
 include(src/MaaUtils/MaaUtils.cmake)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake/modules")
 include(${PROJECT_SOURCE_DIR}/cmake/config.cmake)

--- a/src/MaaCore/CMakeLists.txt
+++ b/src/MaaCore/CMakeLists.txt
@@ -1,5 +1,12 @@
 file(GLOB_RECURSE maa_src *.h *.hpp *.cpp)
 
+# Exclude the platform-specific OCR implementation that is not needed on this target
+if(ANDROID)
+    list(FILTER maa_src EXCLUDE REGEX "OcrPack\\.cpp$")
+else()
+    list(FILTER maa_src EXCLUDE REGEX "OcrPackNcnn\\.cpp$")
+endif()
+
 if(WITH_MAC_SCK)
     if(APPLE)
         list(APPEND maa_src Controller/MacSCKHelper.mm)
@@ -25,7 +32,24 @@ target_compile_definitions(MaaCore PRIVATE ASST_WITH_MAC_SCK=$<BOOL:${WITH_MAC_S
 
 target_include_directories(MaaCore PUBLIC ${PROJECT_SOURCE_DIR}/include PRIVATE .)
 add_dependencies(MaaCore MaaUtils)
-target_link_libraries(MaaCore HeaderOnlyLibraries MaaUtils ${OpenCV_LIBS} fastdeploy_ppocr ONNXRuntime::ONNXRuntime ZLIB::ZLIB Boost::system)
+if(ANDROID)
+    # 直接链接 ncnn target，所有传递依赖（openmp、android、log 等）自动传播。
+    # ncnn 通过 INTERFACE_COMPILE_OPTIONS 带来 -fno-rtti/-fno-exceptions，
+    # MaaCore 需要 RTTI 和 exceptions，通过 set_property 移除这两个标志。
+    target_link_libraries(MaaCore
+        HeaderOnlyLibraries MaaUtils ${OpenCV_LIBS}
+        ncnn
+        ONNXRuntime::ONNXRuntime ZLIB::ZLIB Boost::system)
+    set_property(TARGET MaaCore PROPERTY NO_SYSTEM_FROM_IMPORTED TRUE)
+    # 移除 ncnn 传播的 -fno-rtti / -fno-exceptions
+    get_target_property(_ncnn_opts ncnn INTERFACE_COMPILE_OPTIONS)
+    if(_ncnn_opts)
+        list(REMOVE_ITEM _ncnn_opts "-fno-rtti" "-fno-exceptions")
+        set_target_properties(ncnn PROPERTIES INTERFACE_COMPILE_OPTIONS "${_ncnn_opts}")
+    endif()
+else()
+    target_link_libraries(MaaCore HeaderOnlyLibraries MaaUtils ${OpenCV_LIBS} fastdeploy_ppocr ONNXRuntime::ONNXRuntime ZLIB::ZLIB Boost::system)
+endif()
 
 if(WIN32)
     target_link_libraries(MaaCore ws2_32)
@@ -49,7 +73,9 @@ if(MSVC)
 endif()
 
 if(ANDROID)
-    target_link_libraries(MaaCore log dl)
+    # Logger.hpp 直接调用 __android_log_*，需显式链接 liblog；
+    # dl 由 ncnn 的 INTERFACE_LINK_LIBRARIES 传递，无需显式添加
+    target_link_libraries(MaaCore log)
 endif()
 
 file(GLOB_RECURSE MaaCore_PUBLIC_HEADERS ${PROJECT_SOURCE_DIR}/include/*.h)

--- a/src/MaaCore/CMakeLists.txt
+++ b/src/MaaCore/CMakeLists.txt
@@ -33,20 +33,12 @@ target_compile_definitions(MaaCore PRIVATE ASST_WITH_MAC_SCK=$<BOOL:${WITH_MAC_S
 target_include_directories(MaaCore PUBLIC ${PROJECT_SOURCE_DIR}/include PRIVATE .)
 add_dependencies(MaaCore MaaUtils)
 if(ANDROID)
-    # 直接链接 ncnn target，所有传递依赖（openmp、android、log 等）自动传播。
-    # ncnn 通过 INTERFACE_COMPILE_OPTIONS 带来 -fno-rtti/-fno-exceptions，
-    # MaaCore 需要 RTTI 和 exceptions，通过 set_property 移除这两个标志。
+    find_package(ncnn REQUIRED)
     target_link_libraries(MaaCore
         HeaderOnlyLibraries MaaUtils ${OpenCV_LIBS}
         ncnn
         ONNXRuntime::ONNXRuntime ZLIB::ZLIB Boost::system)
     set_property(TARGET MaaCore PROPERTY NO_SYSTEM_FROM_IMPORTED TRUE)
-    # 移除 ncnn 传播的 -fno-rtti / -fno-exceptions
-    get_target_property(_ncnn_opts ncnn INTERFACE_COMPILE_OPTIONS)
-    if(_ncnn_opts)
-        list(REMOVE_ITEM _ncnn_opts "-fno-rtti" "-fno-exceptions")
-        set_target_properties(ncnn PROPERTIES INTERFACE_COMPILE_OPTIONS "${_ncnn_opts}")
-    endif()
 else()
     target_link_libraries(MaaCore HeaderOnlyLibraries MaaUtils ${OpenCV_LIBS} fastdeploy_ppocr ONNXRuntime::ONNXRuntime ZLIB::ZLIB Boost::system)
 endif()

--- a/src/MaaCore/Config/Miscellaneous/OcrPack.cpp
+++ b/src/MaaCore/Config/Miscellaneous/OcrPack.cpp
@@ -1,3 +1,5 @@
+#ifndef __ANDROID__
+
 #include "OcrPack.h"
 
 #include <algorithm>
@@ -17,26 +19,34 @@ MAA_SUPPRESS_CV_WARNINGS_END
 #include "Utils/StringMisc.hpp"
 #include <ranges>
 
-asst::OcrPack::OcrPack() :
-    m_det(nullptr),
-    m_rec(nullptr),
-    m_ocr(nullptr)
+namespace asst
 {
-    LogTraceFunction;
-}
 
-asst::OcrPack::~OcrPack()
+struct OcrPack::Impl
+{
+    std::unique_ptr<fastdeploy::vision::ocr::DBDetector> det;
+    std::unique_ptr<fastdeploy::vision::ocr::Recognizer> rec;
+    std::unique_ptr<fastdeploy::pipeline::PPOCRv3> ocr;
+
+    std::filesystem::path det_model_path;
+    std::filesystem::path rec_model_path;
+    std::filesystem::path rec_label_path;
+};
+
+OcrPack::OcrPack() : m_impl(std::make_unique<Impl>()) {}
+
+OcrPack::~OcrPack()
 {
     LogTraceFunction;
     if (m_gpu_id) {
         // FIXME: leak fastdeploy objects to avoid crash (double free?)
-        (void)m_det.release();
-        (void)m_rec.release();
-        (void)m_ocr.release();
+        (void)m_impl->det.release();
+        (void)m_impl->rec.release();
+        (void)m_impl->ocr.release();
     }
 }
 
-bool asst::OcrPack::load(const std::filesystem::path& path)
+bool OcrPack::load(const std::filesystem::path& path)
 {
     LogTraceFunction;
     Log.info("load", path.lexically_relative(UserDir.get()));
@@ -45,33 +55,33 @@ bool asst::OcrPack::load(const std::filesystem::path& path)
     const auto det_dir = path / "det"_p;
     const auto det_model_file = det_dir / "inference.onnx"_p;
 
-    if (std::filesystem::exists(det_model_file) && m_det_model_path != det_model_file) {
-        m_det_model_path = det_model_file;
-        m_det = nullptr;
+    if (std::filesystem::exists(det_model_file) && m_impl->det_model_path != det_model_file) {
+        m_impl->det_model_path = det_model_file;
+        m_impl->det = nullptr;
     }
 
     const auto rec_dir = path / "rec"_p;
     const auto rec_model_file = rec_dir / "inference.onnx"_p;
     const auto rec_label_file = rec_dir / "keys.txt"_p;
 
-    if (std::filesystem::exists(rec_model_file) && m_rec_model_path != rec_model_file) {
-        m_rec_model_path = rec_model_file;
-        m_rec = nullptr;
+    if (std::filesystem::exists(rec_model_file) && m_impl->rec_model_path != rec_model_file) {
+        m_impl->rec_model_path = rec_model_file;
+        m_impl->rec = nullptr;
     }
-    if (std::filesystem::exists(rec_label_file) && m_rec_label_path != rec_label_file) {
-        m_rec_label_path = rec_label_file;
-        m_rec = nullptr;
-    }
-
-    if (m_det && m_rec) {
-        m_ocr = std::make_unique<fastdeploy::pipeline::PPOCRv3>(m_det.get(), m_rec.get());
+    if (std::filesystem::exists(rec_label_file) && m_impl->rec_label_path != rec_label_file) {
+        m_impl->rec_label_path = rec_label_file;
+        m_impl->rec = nullptr;
     }
 
-    return !m_det_model_path.empty() && !m_rec_model_path.empty() && !m_rec_label_path.empty();
+    if (m_impl->det && m_impl->rec) {
+        m_impl->ocr = std::make_unique<fastdeploy::pipeline::PPOCRv3>(m_impl->det.get(), m_impl->rec.get());
+    }
+
+    return !m_impl->det_model_path.empty() && !m_impl->rec_model_path.empty() && !m_impl->rec_label_path.empty();
 }
 
-asst::OcrPack::ResultsVec
-    asst::OcrPack::recognize(const cv::Mat& image, bool without_det, const std::optional<Rect>& base_roi)
+OcrPack::ResultsVec
+    OcrPack::recognize(const cv::Mat& image, bool without_det, const std::optional<Rect>& base_roi)
 {
     if (!check_and_load()) {
         Log.error(__FUNCTION__, "check_and_load failed");
@@ -87,12 +97,12 @@ asst::OcrPack::ResultsVec
     // 或等待两轮 Predict 卡个几十秒之后正常运行
     auto start_time = std::chrono::steady_clock::now();
     if (!without_det) {
-        m_ocr->Predict(image, &ocr_result);
+        m_impl->ocr->Predict(image, &ocr_result);
     }
     else {
         std::string rec_text;
         float rec_score = 0;
-        m_rec->Predict(image, &rec_text, &rec_score);
+        m_impl->rec->Predict(image, &rec_text, &rec_score);
         ocr_result.text.emplace_back(std::move(rec_text));
         ocr_result.rec_scores.emplace_back(rec_score);
     }
@@ -154,9 +164,9 @@ asst::OcrPack::ResultsVec
     return raw_results;
 }
 
-bool asst::OcrPack::check_and_load()
+bool OcrPack::check_and_load() const
 {
-    if (m_det && m_rec) {
+    if (m_impl->det && m_impl->rec) {
         return true;
     }
 
@@ -213,28 +223,32 @@ bool asst::OcrPack::check_and_load()
     Log.info("FastDeploy CPU mode with", cpu_threads, "threads");
 #endif
 
-    m_det = std::make_unique<fastdeploy::vision::ocr::DBDetector>(
-        platform::path_to_utf8_string(m_det_model_path),
+    m_impl->det = std::make_unique<fastdeploy::vision::ocr::DBDetector>(
+        platform::path_to_utf8_string(m_impl->det_model_path),
         std::string(),
         det_option,
         fastdeploy::ModelFormat::ONNX);
 
-    m_rec = std::make_unique<fastdeploy::vision::ocr::Recognizer>(
-        platform::path_to_utf8_string(m_rec_model_path),
+    m_impl->rec = std::make_unique<fastdeploy::vision::ocr::Recognizer>(
+        platform::path_to_utf8_string(m_impl->rec_model_path),
         std::string(),
-        platform::path_to_utf8_string(m_rec_label_path),
+        platform::path_to_utf8_string(m_impl->rec_label_path),
         rec_option,
         fastdeploy::ModelFormat::ONNX);
 
-    if (m_det && m_rec) {
-        m_ocr = std::make_unique<fastdeploy::pipeline::PPOCRv3>(m_det.get(), m_rec.get());
+    if (m_impl->det && m_impl->rec) {
+        m_impl->ocr = std::make_unique<fastdeploy::pipeline::PPOCRv3>(m_impl->det.get(), m_impl->rec.get());
     }
 
-    bool det_inited = m_det && m_det->Initialized();
-    bool rec_inited = m_rec && m_rec->Initialized();
-    bool ocr_inited = m_ocr && m_ocr->Initialized();
+    bool det_inited = m_impl->det && m_impl->det->Initialized();
+    bool rec_inited = m_impl->rec && m_impl->rec->Initialized();
+    bool ocr_inited = m_impl->ocr && m_impl->ocr->Initialized();
 
     Log.info("det", det_inited, "rec", rec_inited, "ocr", ocr_inited);
 
     return det_inited && rec_inited && ocr_inited;
 }
+
+} // namespace asst
+
+#endif // __ANDROID__

--- a/src/MaaCore/Config/Miscellaneous/OcrPack.cpp
+++ b/src/MaaCore/Config/Miscellaneous/OcrPack.cpp
@@ -164,7 +164,7 @@ OcrPack::ResultsVec
     return raw_results;
 }
 
-bool OcrPack::check_and_load() const
+bool OcrPack::check_and_load()
 {
     if (m_impl->det && m_impl->rec) {
         return true;

--- a/src/MaaCore/Config/Miscellaneous/OcrPack.h
+++ b/src/MaaCore/Config/Miscellaneous/OcrPack.h
@@ -34,7 +34,7 @@ public:
 protected:
     OcrPack();
 
-    bool check_and_load() const;
+    bool check_and_load();
 
     struct Impl;
     std::unique_ptr<Impl> m_impl;

--- a/src/MaaCore/Config/Miscellaneous/OcrPack.h
+++ b/src/MaaCore/Config/Miscellaneous/OcrPack.h
@@ -3,28 +3,13 @@
 #include "Common/AsstTypes.h"
 #include "Config/AbstractResource.h"
 
+#include <memory>
 #include <optional>
 #include <vector>
 
 namespace cv
 {
 class Mat;
-}
-
-namespace fastdeploy
-{
-namespace vision::ocr
-{
-class DBDetector;
-class Recognizer;
-}
-
-namespace pipeline
-{
-class PPOCRv3;
-}
-
-struct RuntimeOption;
 }
 
 namespace asst
@@ -49,16 +34,10 @@ public:
 protected:
     OcrPack();
 
-    bool check_and_load();
+    bool check_and_load() const;
 
-    std::unique_ptr<fastdeploy::vision::ocr::DBDetector> m_det;
-    std::unique_ptr<fastdeploy::vision::ocr::Recognizer> m_rec;
-    std::unique_ptr<fastdeploy::pipeline::PPOCRv3> m_ocr;
-
-    std::filesystem::path m_det_model_path;
-    std::filesystem::path m_rec_model_path;
-    std::filesystem::path m_rec_label_path;
-
+    struct Impl;
+    std::unique_ptr<Impl> m_impl;
     std::optional<int> m_gpu_id = std::nullopt;
 };
 

--- a/src/MaaCore/Config/Miscellaneous/OcrPackNcnn.cpp
+++ b/src/MaaCore/Config/Miscellaneous/OcrPackNcnn.cpp
@@ -1,0 +1,587 @@
+#ifdef __ANDROID__
+
+#include "OcrPack.h"
+
+#include "OcrPackNcnn.h"
+
+#include <algorithm>
+#include <filesystem>
+#include <thread>
+
+#include "MaaUtils/NoWarningCV.hpp"
+
+#include "Utils/Demangle.hpp"
+#include "Utils/Logger.hpp"
+#include "Utils/Platform.hpp"
+
+#include <cpu.h>
+
+namespace asst
+{
+
+struct OcrPack::Impl
+{
+    std::unique_ptr<OcrPackNcnn> ncnn;
+    std::filesystem::path det_model_path;
+    std::filesystem::path rec_model_path;
+    std::filesystem::path rec_label_path;
+};
+
+OcrPack::OcrPack() :
+    m_impl(std::make_unique<Impl>())
+{
+}
+
+OcrPack::~OcrPack()
+{
+    LogTraceFunction;
+}
+
+bool OcrPack::load(const std::filesystem::path& path)
+{
+    LogTraceFunction;
+    Log.info("load", path.lexically_relative(UserDir.get()));
+
+    using namespace asst::utils::path_literals;
+
+    const auto det_dir = path / "det"_p;
+    const auto det_model_file = det_dir / "det.ncnn.param"_p;
+    const auto rec_dir = path / "rec"_p;
+    const auto rec_model_file = rec_dir / "rec.ncnn.param"_p;
+    const auto rec_label_file = rec_dir / "keys.txt"_p;
+
+    if (std::filesystem::exists(det_model_file) && m_impl->det_model_path != det_model_file) {
+        m_impl->det_model_path = det_model_file;
+        m_impl->ncnn = nullptr;
+    }
+    if (std::filesystem::exists(rec_model_file) && m_impl->rec_model_path != rec_model_file) {
+        m_impl->rec_model_path = rec_model_file;
+        m_impl->ncnn = nullptr;
+    }
+    if (std::filesystem::exists(rec_label_file) && m_impl->rec_label_path != rec_label_file) {
+        m_impl->rec_label_path = rec_label_file;
+        m_impl->ncnn = nullptr;
+    }
+
+    return !m_impl->det_model_path.empty() && !m_impl->rec_model_path.empty() && !m_impl->rec_label_path.empty();
+}
+
+OcrPack::ResultsVec OcrPack::recognize(const cv::Mat& image, bool without_det, const std::optional<Rect>& base_roi)
+{
+    if (!check_and_load()) {
+        Log.error(__FUNCTION__, "check_and_load failed");
+        return { };
+    }
+
+    auto start_time = std::chrono::steady_clock::now();
+
+    auto raw_results = m_impl->ncnn->recognize(image, without_det);
+
+    auto costs =
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start_time).count();
+    std::string class_type = utils::demangle(typeid(*this).name());
+    if (!base_roi) {
+        Log.trace(class_type, raw_results, without_det ? "by OCR Rec" : "by OCR Pipeline", ", cost", costs, "ms");
+    }
+    else {
+        std::string output = "[";
+        for (size_t i = 0; i < raw_results.size(); ++i) {
+            if (i != 0) {
+                output += ", ";
+            }
+            output += std::format(
+                "{{ text: {}, rect: [ {} ({}), {} ({}), {}, {} ], score: {:.6f} }}",
+                raw_results[i].text,
+                raw_results[i].rect.x,
+                raw_results[i].rect.x + base_roi->x,
+                raw_results[i].rect.y,
+                raw_results[i].rect.y + base_roi->y,
+                raw_results[i].rect.width,
+                raw_results[i].rect.height,
+                raw_results[i].score);
+        }
+        output += "]";
+        Log.trace(class_type, output, without_det ? "by OCR Rec" : "by OCR Pipeline", ", cost", costs, "ms");
+    }
+    return raw_results;
+}
+
+bool OcrPack::check_and_load() const
+{
+    if (m_impl->ncnn && m_impl->ncnn->initialized()) {
+        return true;
+    }
+
+    LogTraceFunction;
+
+    int logical = std::max(1u, std::thread::hardware_concurrency());
+    int cpu_threads;
+    if (logical <= 2) {
+        cpu_threads = 1;
+    }
+    else if (logical <= 4) {
+        cpu_threads = 2;
+    }
+    else if (logical <= 12) {
+        cpu_threads = 3;
+    }
+    else {
+        cpu_threads = 4;
+    }
+
+    ncnn::set_cpu_powersave(2); // Android big.LITTLE：绑定大核
+
+    m_impl->ncnn = std::make_unique<OcrPackNcnn>();
+    m_impl->ncnn->set_cpu_threads(cpu_threads);
+
+    const auto det_bin = std::filesystem::path(m_impl->det_model_path).replace_extension("bin");
+    const auto rec_bin = std::filesystem::path(m_impl->rec_model_path).replace_extension("bin");
+    bool ok =
+        m_impl->ncnn->load(m_impl->det_model_path, det_bin, m_impl->rec_model_path, rec_bin, m_impl->rec_label_path);
+
+    Log.info("ncnn ocr inited", ok);
+    return ok;
+}
+
+} // namespace asst
+
+// ================================================================================
+//  OcrPackNcnn implementation
+// ================================================================================
+
+#include <array>
+#include <fstream>
+#include <utility>
+
+#include <ncnn/net.h>
+
+namespace
+{
+constexpr int kDetLimitSideLen = 960;
+constexpr float kDetMean[3] = { 0.485f * 255.f, 0.456f * 255.f, 0.406f * 255.f };
+constexpr float kDetNorm[3] = { 1.f / (0.229f * 255.f), 1.f / (0.224f * 255.f), 1.f / (0.225f * 255.f) };
+
+constexpr float kDetThresh = 0.3f;
+constexpr float kDetBoxThresh = 0.6f;
+constexpr float kDetUnclipRatio = 1.5f;
+constexpr int kDetMinSize = 3;
+constexpr int kDetMaxCandidates = 100;
+
+constexpr int kRecImgH = 48;
+constexpr int kRecImgW = 320;
+constexpr float kRecMean[3] = { 127.5f, 127.5f, 127.5f };
+constexpr float kRecNorm[3] = { 1.f / 127.5f, 1.f / 127.5f, 1.f / 127.5f };
+
+cv::Mat ensure_continuous_bgr(const cv::Mat& img)
+{
+    cv::Mat m = img;
+    if (m.channels() == 4) {
+        cv::cvtColor(m, m, cv::COLOR_BGRA2BGR);
+    }
+    else if (m.channels() == 1) {
+        cv::cvtColor(m, m, cv::COLOR_GRAY2BGR);
+    }
+    if (!m.isContinuous()) {
+        m = m.clone();
+    }
+    return m;
+}
+
+void order_box(const cv::Point2f in[4], cv::Point2f out[4])
+{
+    std::array<cv::Point2f, 4> pts = { in[0], in[1], in[2], in[3] };
+    std::ranges::sort(pts, [](const cv::Point2f& a, const cv::Point2f& b) { return a.x < b.x; });
+    cv::Point2f tl, bl, tr, br;
+    if (pts[1].y > pts[0].y) {
+        tl = pts[0];
+        bl = pts[1];
+    }
+    else {
+        tl = pts[1];
+        bl = pts[0];
+    }
+    if (pts[3].y > pts[2].y) {
+        tr = pts[2];
+        br = pts[3];
+    }
+    else {
+        tr = pts[3];
+        br = pts[2];
+    }
+    out[0] = tl;
+    out[1] = tr;
+    out[2] = br;
+    out[3] = bl;
+}
+
+float box_score(const cv::Mat& prob, const cv::Point2f box[4])
+{
+    const int w = prob.cols;
+    const int h = prob.rows;
+    float xs[4] = { box[0].x, box[1].x, box[2].x, box[3].x };
+    float ys[4] = { box[0].y, box[1].y, box[2].y, box[3].y };
+    int xmin = std::max(0, static_cast<int>(std::floor(*std::min_element(xs, xs + 4))));
+    int xmax = std::min(w - 1, static_cast<int>(std::ceil(*std::max_element(xs, xs + 4))));
+    int ymin = std::max(0, static_cast<int>(std::floor(*std::min_element(ys, ys + 4))));
+    int ymax = std::min(h - 1, static_cast<int>(std::ceil(*std::max_element(ys, ys + 4))));
+    if (xmax < xmin || ymax < ymin) {
+        return 0.f;
+    }
+    cv::Mat mask = cv::Mat::zeros(ymax - ymin + 1, xmax - xmin + 1, CV_8UC1);
+    std::array<cv::Point, 4> shifted;
+    for (int i = 0; i < 4; ++i) {
+        shifted[i] = cv::Point(static_cast<int>(box[i].x) - xmin, static_cast<int>(box[i].y) - ymin);
+    }
+    std::vector<std::vector<cv::Point>> polys = { { shifted.begin(), shifted.end() } };
+    cv::fillPoly(mask, polys, cv::Scalar(1));
+    if (cv::countNonZero(mask) == 0) {
+        return 0.f;
+    }
+    cv::Mat region = prob(cv::Rect(xmin, ymin, xmax - xmin + 1, ymax - ymin + 1));
+    return static_cast<float>(cv::mean(region, mask)[0]);
+}
+
+float poly_len(const cv::Point2f box[4])
+{
+    float s = 0.f;
+    for (int i = 0; i < 4; ++i) {
+        s += static_cast<float>(cv::norm(box[i] - box[(i + 1) % 4]));
+    }
+    return s;
+}
+} // namespace
+
+asst::OcrPackNcnn::OcrPackNcnn() = default;
+
+asst::OcrPackNcnn::~OcrPackNcnn() = default;
+
+bool asst::OcrPackNcnn::load(
+    const std::filesystem::path& det_param,
+    const std::filesystem::path& det_bin,
+    const std::filesystem::path& rec_param,
+    const std::filesystem::path& rec_bin,
+    const std::filesystem::path& keys_path)
+{
+    LogTraceFunction;
+
+    auto make_net =
+        [this](const std::filesystem::path& param, const std::filesystem::path& bin) -> std::unique_ptr<ncnn::Net> {
+        auto net = std::make_unique<ncnn::Net>();
+        net->opt.use_vulkan_compute = false;
+        net->opt.num_threads = m_cpu_threads;
+        net->opt.use_fp16_packed = false;
+        net->opt.use_fp16_storage = false;
+        net->opt.use_fp16_arithmetic = false;
+        if (net->load_param(platform::path_to_utf8_string(param).c_str()) != 0) {
+            Log.error("OcrPackNcnn load_param failed:", param);
+            return nullptr;
+        }
+        if (net->load_model(platform::path_to_utf8_string(bin).c_str()) != 0) {
+            Log.error("OcrPackNcnn load_model failed:", bin);
+            return nullptr;
+        }
+        return net;
+    };
+
+    m_det = make_net(det_param, det_bin);
+    m_rec = make_net(rec_param, rec_bin);
+    if (!m_det || !m_rec) {
+        m_loaded = false;
+        return false;
+    }
+
+    std::vector<std::string> keys;
+    {
+        std::ifstream ifs(keys_path, std::ios::binary);
+        if (!ifs.is_open()) {
+            Log.error("OcrPackNcnn open keys failed:", keys_path);
+            m_loaded = false;
+            return false;
+        }
+        std::string line;
+        bool first = true;
+        while (std::getline(ifs, line)) {
+            if (!line.empty() && line.back() == '\r') {
+                line.pop_back();
+            }
+            if (first) {
+                first = false;
+                if (line.size() >= 3 && static_cast<unsigned char>(line[0]) == 0xEF &&
+                    static_cast<unsigned char>(line[1]) == 0xBB && static_cast<unsigned char>(line[2]) == 0xBF) {
+                    line.erase(0, 3);
+                }
+            }
+            keys.push_back(line);
+        }
+    }
+
+    int num_classes = 0;
+    {
+        ncnn::Mat dummy(kRecImgW, kRecImgH, 3);
+        dummy.fill(0.f);
+        ncnn::Extractor ex = m_rec->create_extractor();
+        ex.input("in0", dummy);
+        ncnn::Mat out;
+        if (ex.extract("out0", out) != 0) {
+            Log.error("OcrPackNcnn rec probe extract failed");
+            m_loaded = false;
+            return false;
+        }
+        num_classes = out.w;
+        const float* row0 = out.row(0);
+        float s = 0.f;
+        float mn = row0[0];
+        for (int c = 0; c < num_classes; ++c) {
+            s += row0[c];
+            mn = std::min(mn, row0[c]);
+        }
+        m_rec_output_is_prob = (mn >= -1e-6f) && (std::abs(s - 1.f) < 1e-2f);
+    }
+
+    m_charset.clear();
+    m_charset.reserve(num_classes);
+    m_charset.emplace_back("<blank>");
+    for (auto& k : keys) {
+        m_charset.emplace_back(k);
+    }
+    if (num_classes == static_cast<int>(m_charset.size()) + 1) {
+        m_charset.emplace_back(" ");
+    }
+    if (num_classes != static_cast<int>(m_charset.size())) {
+        Log.warn("OcrPackNcnn charset size", m_charset.size(), "!= num_classes", num_classes, "; keys", keys.size());
+        if (num_classes > static_cast<int>(m_charset.size())) {
+            m_charset.resize(num_classes, "<unk>");
+        }
+        else {
+            m_charset.resize(num_classes);
+        }
+    }
+
+    m_loaded = true;
+    Log.info("OcrPackNcnn loaded, num_classes", num_classes, "charset", m_charset.size(), "threads", m_cpu_threads);
+    return true;
+}
+
+std::vector<asst::OcrPackNcnn::DetBox> asst::OcrPackNcnn::detect(const cv::Mat& image) const
+{
+    const int src_h = image.rows;
+    const int src_w = image.cols;
+
+    float ratio = 1.f;
+    if (std::max(src_h, src_w) > kDetLimitSideLen) {
+        ratio = static_cast<float>(kDetLimitSideLen) / std::max(src_h, src_w);
+    }
+    auto align32 = [](int v) {
+        return std::max(32, ((v + 31) / 32) * 32);
+    };
+    const int resize_h = align32(static_cast<int>(std::lround(src_h * ratio)));
+    const int resize_w = align32(static_cast<int>(std::lround(src_w * ratio)));
+    const float ratio_h = static_cast<float>(resize_h) / src_h;
+    const float ratio_w = static_cast<float>(resize_w) / src_w;
+
+    ncnn::Mat in =
+        ncnn::Mat::from_pixels_resize(image.data, ncnn::Mat::PIXEL_BGR2RGB, src_w, src_h, resize_w, resize_h);
+    in.substract_mean_normalize(kDetMean, kDetNorm);
+
+    ncnn::Mat out;
+    {
+        ncnn::Extractor ex = m_det->create_extractor();
+        ex.input("in0", in);
+        if (ex.extract("out0", out) != 0) {
+            Log.error("OcrPackNcnn det extract failed");
+            return { };
+        }
+    }
+    ncnn::Mat plane = out.channel(0);
+    cv::Mat prob(out.h, out.w, CV_32FC1, plane.data);
+
+    cv::Mat bitmap = prob > kDetThresh;
+
+    std::vector<std::vector<cv::Point>> contours;
+    cv::findContours(bitmap, contours, cv::RETR_LIST, cv::CHAIN_APPROX_SIMPLE);
+
+    std::vector<DetBox> results;
+    const int limit = std::min(static_cast<int>(contours.size()), kDetMaxCandidates);
+    for (int ci = 0; ci < limit; ++ci) {
+        const auto& contour = contours[ci];
+        if (contour.size() < 4) {
+            continue;
+        }
+        cv::RotatedRect rr = cv::minAreaRect(contour);
+        if (std::min(rr.size.width, rr.size.height) < kDetMinSize) {
+            continue;
+        }
+        cv::Point2f raw[4];
+        rr.points(raw);
+        cv::Point2f box[4];
+        order_box(raw, box);
+
+        const float score = box_score(prob, box);
+        if (score < kDetBoxThresh) {
+            continue;
+        }
+
+        const float area = static_cast<float>(std::abs(cv::contourArea(std::vector<cv::Point2f>(box, box + 4))));
+        const float length = poly_len(box);
+        if (length <= 0.f) {
+            continue;
+        }
+        const float dist = area * kDetUnclipRatio / length;
+
+        cv::RotatedRect rr2(rr.center, cv::Size2f(rr.size.width + 2.f * dist, rr.size.height + 2.f * dist), rr.angle);
+        if (std::min(rr2.size.width, rr2.size.height) < kDetMinSize + 2) {
+            continue;
+        }
+        cv::Point2f raw2[4];
+        rr2.points(raw2);
+        DetBox db;
+        order_box(raw2, db.pts);
+        db.score = score;
+        for (auto& p : db.pts) {
+            p.x = std::clamp(p.x / ratio_w, 0.f, static_cast<float>(src_w));
+            p.y = std::clamp(p.y / ratio_h, 0.f, static_cast<float>(src_h));
+        }
+        results.push_back(db);
+    }
+
+    std::ranges::sort(results, [](const DetBox& a, const DetBox& b) {
+        auto top = [](const DetBox& d) {
+            return std::min({ d.pts[0].y, d.pts[1].y, d.pts[2].y, d.pts[3].y });
+        };
+        auto left = [](const DetBox& d) {
+            return std::min({ d.pts[0].x, d.pts[1].x, d.pts[2].x, d.pts[3].x });
+        };
+        const int ra = static_cast<int>(std::lround(top(a) / 10.f));
+        const int rb = static_cast<int>(std::lround(top(b) / 10.f));
+        if (ra != rb) {
+            return ra < rb;
+        }
+        return left(a) < left(b);
+    });
+    return results;
+}
+
+cv::Mat asst::OcrPackNcnn::crop_rotated(const cv::Mat& image, const DetBox& box)
+{
+    const int w =
+        std::max(1, static_cast<int>(std::max(cv::norm(box.pts[0] - box.pts[1]), cv::norm(box.pts[2] - box.pts[3]))));
+    const int h =
+        std::max(1, static_cast<int>(std::max(cv::norm(box.pts[0] - box.pts[3]), cv::norm(box.pts[1] - box.pts[2]))));
+
+    const cv::Point2f src[4] = { box.pts[0], box.pts[1], box.pts[2], box.pts[3] };
+    const cv::Point2f dst[4] = { { 0, 0 },
+                                 { static_cast<float>(w), 0 },
+                                 { static_cast<float>(w), static_cast<float>(h) },
+                                 { 0, static_cast<float>(h) } };
+    const cv::Mat m = cv::getPerspectiveTransform(src, dst);
+    cv::Mat crop;
+    cv::warpPerspective(image, crop, m, cv::Size(w, h));
+    if (h > 0 && static_cast<float>(w) / h < 0.7f) {
+        cv::rotate(crop, crop, cv::ROTATE_90_COUNTERCLOCKWISE);
+    }
+    return crop;
+}
+
+std::pair<std::string, float> asst::OcrPackNcnn::recognize_line(const cv::Mat& line_in) const
+{
+    cv::Mat line = ensure_continuous_bgr(line_in);
+    if (line.empty()) {
+        return { std::string(), 0.f };
+    }
+
+    const float r = line.rows > 0 ? static_cast<float>(line.cols) / line.rows : 1.f;
+    int resized_w = std::clamp(static_cast<int>(std::ceil(kRecImgH * r)), 1, kRecImgW);
+    cv::Mat resized;
+    cv::resize(line, resized, cv::Size(resized_w, kRecImgH));
+
+    cv::Mat canvas(kRecImgH, kRecImgW, CV_8UC3, cv::Scalar(128, 128, 128));
+    resized.copyTo(canvas(cv::Rect(0, 0, resized_w, kRecImgH)));
+
+    ncnn::Mat in = ncnn::Mat::from_pixels(canvas.data, ncnn::Mat::PIXEL_BGR2RGB, kRecImgW, kRecImgH);
+    in.substract_mean_normalize(kRecMean, kRecNorm);
+
+    ncnn::Mat out;
+    {
+        ncnn::Extractor ex = m_rec->create_extractor();
+        ex.input("in0", in);
+        if (ex.extract("out0", out) != 0) {
+            Log.error("OcrPackNcnn rec extract failed");
+            return { std::string(), 0.f };
+        }
+    }
+    const int T = out.h;
+    const int nc = out.w;
+
+    std::string text;
+    float conf_sum = 0.f;
+    int conf_cnt = 0;
+    int prev = -1;
+    for (int t = 0; t < T; ++t) {
+        const float* row = out.row(t);
+        int best = 0;
+        float best_v = row[0];
+        for (int c = 1; c < nc; ++c) {
+            if (row[c] > best_v) {
+                best_v = row[c];
+                best = c;
+            }
+        }
+        float conf;
+        if (m_rec_output_is_prob) {
+            conf = best_v;
+        }
+        else {
+            float denom = 0.f;
+            for (int c = 0; c < nc; ++c) {
+                denom += std::exp(row[c] - best_v);
+            }
+            conf = denom > 0.f ? 1.f / denom : 0.f;
+        }
+        if (best != 0 && best != prev) {
+            if (best < static_cast<int>(m_charset.size())) {
+                text += m_charset[best];
+                conf_sum += conf;
+                ++conf_cnt;
+            }
+        }
+        prev = best;
+    }
+
+    const float mean_conf = conf_cnt > 0 ? conf_sum / conf_cnt : 0.f;
+    return { std::move(text), mean_conf };
+}
+
+asst::OcrPackNcnn::ResultsVec asst::OcrPackNcnn::recognize(const cv::Mat& image_in, bool without_det)
+{
+    if (!m_loaded) {
+        return { };
+    }
+    cv::Mat image = ensure_continuous_bgr(image_in);
+
+    ResultsVec results;
+
+    if (without_det) {
+        auto [text, score] = recognize_line(image);
+        results.emplace_back(Rect(0, 0, image.cols, image.rows), score, std::move(text));
+        return results;
+    }
+
+    const std::vector<DetBox> boxes = detect(image);
+    for (const auto& box : boxes) {
+        cv::Mat crop = crop_rotated(image, box);
+        if (crop.empty()) {
+            continue;
+        }
+        auto [text, score] = recognize_line(crop);
+        const float xs[4] = { box.pts[0].x, box.pts[1].x, box.pts[2].x, box.pts[3].x };
+        const float ys[4] = { box.pts[0].y, box.pts[1].y, box.pts[2].y, box.pts[3].y };
+        const int left = static_cast<int>(*std::min_element(xs, xs + 4));
+        const int right = static_cast<int>(*std::max_element(xs, xs + 4));
+        const int top = static_cast<int>(*std::min_element(ys, ys + 4));
+        const int bottom = static_cast<int>(*std::max_element(ys, ys + 4));
+        results.emplace_back(Rect(left, top, right - left, bottom - top), score, std::move(text));
+    }
+    return results;
+}
+
+#endif // __ANDROID__

--- a/src/MaaCore/Config/Miscellaneous/OcrPackNcnn.cpp
+++ b/src/MaaCore/Config/Miscellaneous/OcrPackNcnn.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <filesystem>
+#include <ranges>
 #include <thread>
 
 #include "MaaUtils/NoWarningCV.hpp"
@@ -106,7 +107,7 @@ OcrPack::ResultsVec OcrPack::recognize(const cv::Mat& image, bool without_det, c
     return raw_results;
 }
 
-bool OcrPack::check_and_load() const
+bool OcrPack::check_and_load()
 {
     if (m_impl->ncnn && m_impl->ncnn->initialized()) {
         return true;

--- a/src/MaaCore/Config/Miscellaneous/OcrPackNcnn.h
+++ b/src/MaaCore/Config/Miscellaneous/OcrPackNcnn.h
@@ -1,0 +1,75 @@
+#pragma once
+
+// Android 专用：用 ncnn 替代 fastdeploy 跑 PP-OCR（DBNet 检测 + SVTR 识别）。
+// 整文件用 __ANDROID__ 自守卫：非 Android 平台编译成空 TU，不产生任何符号，
+// 因此无需改动 MaaCore 的 file(GLOB_RECURSE) 规则。
+#ifdef __ANDROID__
+
+#include <filesystem>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "Common/AsstTypes.h"
+#include "MaaUtils/NoWarningCV.hpp" // DetBox 用到 cv::Point2f，需完整 cv 类型
+
+namespace ncnn
+{
+class Net;
+}
+
+namespace asst
+{
+// ncnn 版 OCR 引擎：与桌面端 fastdeploy 的 OcrPack 在行为/参数上对齐
+// （预处理 mean/std、DBNet 阈值/unclip、rec 归一化、CTC 解码均按 PP-OCRv3 默认值，
+//  已在 src/OCRBenchmark 用 onnxruntime 做基准逐像素/逐字符验证）。
+class OcrPackNcnn
+{
+public:
+    using Result = TextRect;
+    using ResultsVec = std::vector<Result>;
+
+    OcrPackNcnn();
+    ~OcrPackNcnn();
+
+    // det/rec 的 .ncnn.param/.bin + rec 的 keys.txt
+    bool load(
+        const std::filesystem::path& det_param,
+        const std::filesystem::path& det_bin,
+        const std::filesystem::path& rec_param,
+        const std::filesystem::path& rec_bin,
+        const std::filesystem::path& keys_path);
+
+    bool initialized() const { return m_loaded; }
+
+    void set_cpu_threads(int num) { m_cpu_threads = num > 0 ? num : 1; }
+
+    // without_det 时把整张 image 当作一行文本只跑 rec；否则 det -> 裁切 -> rec。
+    // 返回的 rect 为 4 点框的轴对齐外接矩形（与 fastdeploy 版语义一致）。
+    ResultsVec recognize(const cv::Mat& image, bool without_det);
+
+private:
+    // DBNet 检测出的一个候选框（已还原到原图坐标系）
+    struct DetBox
+    {
+        cv::Point2f pts[4]; // 左上、右上、右下、左下
+        float score = 0.f;
+    };
+
+    std::vector<DetBox> detect(const cv::Mat& image) const;
+    // 透视摆正裁出文本行（竖排自动旋正）
+    static cv::Mat crop_rotated(const cv::Mat& image, const DetBox& box);
+    // 单行文本识别：返回 (utf-8 文本, 平均置信度)
+    std::pair<std::string, float> recognize_line(const cv::Mat& line) const;
+
+    std::unique_ptr<ncnn::Net> m_det;
+    std::unique_ptr<ncnn::Net> m_rec;
+    std::vector<std::string> m_charset; // [<blank>] + keys (+ space)，按 rec 输出维度对齐
+    int m_cpu_threads = 2;
+    bool m_loaded = false;
+    bool m_rec_output_is_prob = false;
+};
+}
+
+#endif // __ANDROID__

--- a/src/MaaCore/Config/Miscellaneous/OcrPackNcnn.h
+++ b/src/MaaCore/Config/Miscellaneous/OcrPackNcnn.h
@@ -1,8 +1,5 @@
 #pragma once
 
-// Android 专用：用 ncnn 替代 fastdeploy 跑 PP-OCR（DBNet 检测 + SVTR 识别）。
-// 整文件用 __ANDROID__ 自守卫：非 Android 平台编译成空 TU，不产生任何符号，
-// 因此无需改动 MaaCore 的 file(GLOB_RECURSE) 规则。
 #ifdef __ANDROID__
 
 #include <filesystem>
@@ -21,9 +18,7 @@ class Net;
 
 namespace asst
 {
-// ncnn 版 OCR 引擎：与桌面端 fastdeploy 的 OcrPack 在行为/参数上对齐
-// （预处理 mean/std、DBNet 阈值/unclip、rec 归一化、CTC 解码均按 PP-OCRv3 默认值，
-//  已在 src/OCRBenchmark 用 onnxruntime 做基准逐像素/逐字符验证）。
+
 class OcrPackNcnn
 {
 public:

--- a/tools/maadeps-download.py
+++ b/tools/maadeps-download.py
@@ -10,7 +10,7 @@ from maadeps_download import detect_host_triplet
 from maadeps_download import main as download_main
 
 REPO = "MaaAssistantArknights/MaaDeps"
-VERSION = "v2.11.0"
+VERSION = "v2.13.1"
 
 parser = argparse.ArgumentParser()
 parser.add_argument("triplet", nargs="?")


### PR DESCRIPTION
NCNN deps
https://github.com/MaaAssistantArknights/MaaDeps/pull/40
https://github.com/MaaAssistantArknights/MaaDeps/pull/39

## Summary by Sourcery

添加一个基于 Android 的、使用 NCNN 的 OCR 实现，并将其接入构建系统，同时在非 Android 平台上保留现有基于 FastDeploy 的 OCR。

New Features:
- 为 Android 引入一个基于 NCNN 的 OCR 流水线实现，通过新的 `OcrPackNcnn` 引擎并经由 `OcrPack` 进行接线。
- 在 Android 上支持加载 NCNN 格式的 OCR 模型和标签，同时在其他平台上保持现有的 FastDeploy ONNX 模型加载逻辑不变。

Enhancements:
- 重构通用的 `OcrPack`，使用 pimpl 模式的 `Impl` 结构体，以分离平台相关的 OCR 后端并改进封装性。
- 调整 MaaCore 的 CMake 构建逻辑，以便在各个平台选择合适的 OCR 实现，并在 Android 上以正确的编译选项链接 NCNN。

Build:
- 在顶层 `CMakeLists` 中将 NCNN 的使用限制在 `ANDROID` 宏之后，仅为 Android 构建启用 `WITH_NCNN`。
- 更新 MaaCore 的 `CMakeLists`，在各个平台排除无关的 OCR 实现源码，并在 Android 上链接 NCNN 和 Android 日志库，同时在其他平台保持 FastDeploy 的链接方式不变。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add an Android-specific OCR implementation using NCNN and wire it into the build while keeping the existing FastDeploy-based OCR for non-Android platforms.

New Features:
- Introduce an NCNN-based OCR pipeline implementation for Android using a new OcrPackNcnn engine wired through OcrPack.
- Support loading NCNN-formatted OCR models and labels on Android while preserving the existing FastDeploy ONNX model loading on other platforms.

Enhancements:
- Refactor the generic OcrPack to use a pimpl Impl struct to separate platform-specific OCR backends and improve encapsulation.
- Adjust MaaCore CMake build logic to select the appropriate OCR implementation per platform and to link against NCNN on Android with correct compiler options.

Build:
- Gate NCNN usage behind ANDROID in the top-level CMakeLists and enable WITH_NCNN only for Android builds.
- Update MaaCore CMakeLists to exclude the non-relevant OCR implementation source per platform and to link against NCNN and Android log on Android while keeping FastDeploy linkage elsewhere.

</details>

## Summary by Sourcery

引入了按平台区分的 OCR 实现：非 Android 构建使用 FastDeploy，Android 构建使用 NCNN，并相应更新了构建配置和资源连接。

New Features:
- 为 Android 新增基于 NCNN 的 OCR 实现，通过新的 `OcrPackNcnn` 后端接入，并集成到现有的 `OcrPack` 接口中。

Enhancements:
- 重构 `OcrPack`，采用 pimpl 风格的 `Impl` 结构，以便可以干净地切换各个平台特定的 OCR 后端。

Build:
- 调整 `MaaCore` 的 CMake 配置，使其按平台仅编译和链接对应的 OCR 后端，并在 Android 构建中依赖 `ncnn`。
- 更新 `MaaDeps` 下载脚本，以获取包含所需 NCNN 资源的新版本依赖包。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a platform-specific OCR implementation split between FastDeploy for non-Android builds and NCNN for Android, with build and resource wiring updated accordingly.

New Features:
- Add an NCNN-based OCR implementation for Android via a new OcrPackNcnn backend and integrate it into the existing OcrPack interface.

Enhancements:
- Refactor OcrPack to use a pimpl-style Impl struct so platform-specific OCR backends can be swapped cleanly.

Build:
- Adjust MaaCore CMake configuration to compile and link only the relevant OCR backend per platform and to depend on ncnn for Android builds.
- Update MaaDeps download script to pull a newer dependency bundle containing the required NCNN assets.

</details>

## Summary by Sourcery

添加一个与平台相关的 OCR 实现：在 Android 上使用 NCNN，在其他平台上使用 FastDeploy，并相应更新构建和依赖配置。

新功能：
- 引入一个仅用于 Android 的、基于 NCNN 的 OCR 后端，通过现有的 `OcrPack` 接口接入。

改进：
- 重构 `OcrPack`，使用 pimpl 风格的 `Impl` 结构体，以便可以干净地替换平台相关的 OCR 后端。

构建：
- 在 MaaCore 中按平台选择并只编译对应的 OCR 实现：在 Android 上链接 NCNN，在其他平台上链接 FastDeploy。
- 提升 MaaDeps 的下载版本，以获取启用 NCNN 的资源。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a platform-specific OCR implementation, using NCNN on Android and FastDeploy on other platforms, and update the build and dependency configuration accordingly.

New Features:
- Introduce an Android-only NCNN-based OCR backend wired through the existing OcrPack interface.

Enhancements:
- Refactor OcrPack to use a pimpl-style Impl struct so platform-specific OCR backends can be swapped cleanly.

Build:
- Select and compile only the relevant OCR implementation per platform in MaaCore, linking NCNN on Android and FastDeploy elsewhere.
- Bump MaaDeps download version to pull NCNN-enabled assets.

</details>