### PR TITLE
ci: 优化Avalonia构建工作流触发条件

### DIFF
--- a/.github/workflows/ci-avalonia.yml
+++ b/.github/workflows/ci-avalonia.yml
@@ -4,28 +4,34 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
+      - ".github/workflows/ci-avalonia.yml"
+      - "3rdparty/include/**"
+      - "cmake/**"
       - "src/MAAUnified"
       - "src/MAAUnified/**"
       - "src/MaaCore/**"
       - "src/MaaUtils/**"
       - "include/**"
-      - "resource/**"
       - "tools/maadeps-download.py"
       - "CMakeLists.txt"
       - "CMakePresets.json"
+      - "!**/*.md"
   push:
     branches:
-      - dev
+      - dev-v2
     paths:
+      - ".github/workflows/ci-avalonia.yml"
+      - "3rdparty/include/**"
+      - "cmake/**"
       - "src/MAAUnified"
       - "src/MAAUnified/**"
       - "src/MaaCore/**"
       - "src/MaaUtils/**"
       - "include/**"
-      - "resource/**"
       - "tools/maadeps-download.py"
       - "CMakeLists.txt"
       - "CMakePresets.json"
+      - "!**/*.md"
 
 jobs:
   meta:


### PR DESCRIPTION
- push 触发改为 dev-v2 分支。
 - 不再在仅有 resources 更改时触发。
 - 新增该文件本身和cmake、3rdparty触发条件，不再在仅md文件更改时触发，与 ci.yml 保持一致。

~另外这玩意失败概率有点高啊~

## 由 Sourcery 提供的摘要

调整 Avalonia CI 工作流的触发条件，以更好地匹配相关的源码变更和分支使用情况。

CI：
- 将 Avalonia CI 的 push 触发分支从 `dev` 限制为 `dev-v2`。
- 当仅有 Markdown 或资源文件发生变更时跳过运行；同时确保对工作流文件、CMake、第三方依赖（3rdparty includes）以及核心源码路径的变更仍会触发构建。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust Avalonia CI workflow triggers to better match relevant source changes and branch usage.

CI:
- Limit Avalonia CI push triggers to the dev-v2 branch instead of dev.
- Exclude runs when only markdown or resource files change while ensuring the workflow, CMake, 3rdparty includes, and core source paths still trigger builds.

</details>