### PR TITLE
fix: 修正 MultiCopilotTaskPlugin 中的索引越界问题，仅在成功时自增

### DIFF
--- a/src/MaaCore/Task/Miscellaneous/MultiCopilotTaskPlugin.cpp
+++ b/src/MaaCore/Task/Miscellaneous/MultiCopilotTaskPlugin.cpp
@@ -16,13 +16,13 @@
 bool asst::MultiCopilotTaskPlugin::_run()
 {
     LogTraceFunction;
-    if (m_copilot_configs.size() < (size_t)m_index_current) {
+    if (m_copilot_configs.size() <= (size_t)m_index_current) {
         LogError << __FUNCTION__ << "configs size:" << m_copilot_configs.size() << ", current index:" << m_index_current
                  << ", out of range";
         return false;
     }
 
-    const auto& config = m_copilot_configs[m_index_current++];
+    const auto& config = m_copilot_configs[m_index_current];
 
     std::string file_name;
     if (!Copilot.load(config.copilot_file)) {
@@ -52,6 +52,9 @@ bool asst::MultiCopilotTaskPlugin::_run()
         ret = ret && ProcessTask(*this, { "RaidConfirm", "ChangeToRaidDifficulty" }).set_retry_times(20).run();
     }
 
+    if (ret) {
+        ++m_index_current;
+    }
     return ret;
 }
 


### PR DESCRIPTION
## Summary by Sourcery

在 MultiCopilotTaskPlugin 中防止越界访问，并且仅在成功运行后再推进当前配置索引。

Bug Fixes:
- 修复在 MultiCopilotTaskPlugin 中选择当前 copilot 配置时可能出现的索引越界访问问题。
- 确保当前 copilot 配置索引仅在任务成功执行后才递增，以避免跳过条目。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Guard against out-of-range access in MultiCopilotTaskPlugin and only advance the current config index after a successful run.

Bug Fixes:
- Fix potential index out-of-range access when selecting the current copilot configuration in MultiCopilotTaskPlugin.
- Ensure the current copilot configuration index is only incremented after a successful task execution to avoid skipping entries.

</details>