### PR TITLE
修复MAAUnified CI 选错ref的问题

### DIFF
--- a/.github/workflows/ci-avalonia.yml
+++ b/.github/workflows/ci-avalonia.yml
@@ -39,13 +39,17 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.out.outputs.tag }}
+      checkout_sha: ${{ steps.out.outputs.checkout_sha }}
     steps:
       - id: out
+        env:
+          CHECKOUT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: |
+          echo "checkout_sha=${CHECKOUT_SHA}" >> "$GITHUB_OUTPUT"
           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
             echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
           else
-            echo "tag=preview-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+            echo "tag=preview-${CHECKOUT_SHA::7}" >> "$GITHUB_OUTPUT"
           fi
 
   build:
@@ -77,6 +81,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.meta.outputs.checkout_sha }}
 
       - name: Fetch required submodules
         shell: bash


### PR DESCRIPTION
CI Build MAAUnified (Avalonia + MaaCore Runtime) 中，原本用了默认选项，会跑锚定 submodule 的 PR merge ref。现在改成了跑自动更新的 PR head

## 由 Sourcery 提供的总结

CI：
- 调整 Avalonia 的 CI 工作流程，根据 PR 的 head SHA 计算标签和检出引用，并在构建的检出步骤中使用该引用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

CI:
- Adjust the Avalonia CI workflow to compute a tag and checkout reference based on the PR head SHA and use it for the build checkout step.

</details>