### PR TITLE
fix: PC端签到后ESC关闭DirectX覆盖层活动页面

### DIFF
--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -951,13 +951,13 @@
         "next": ["Home"]
     },
     "StartUp": {
-        "Doc": "主界面确认 — maxTimes降到1以便快速通过，让ClosePCEventPage闭环接管弹窗处理",
+        "Doc": "主界面确认 — 多检测几次，一直在主界面才算完成",
         "template": "SwitchTheme@ToggleSettingsMenu.png",
         "action": "DoNothing",
         "roi": [227, 327, 159, 152],
         "postDelay": 1000,
-        "maxTimes": 1,
-        "next": ["StartUp", "StartUp@LoadingText", "StartUp@CloseAnnos#next", "ClosePCEventPage"]
+        "maxTimes": 3,
+        "next": ["StartUp", "StartUp@LoadingText", "StartUp@CloseAnnos#next"]
     },
     "ClosePCEventPage": {
         "Doc": "PC端活动页面右上角关闭 — 先点击关闭按钮，失败后进入ESC兜底",
@@ -992,31 +992,63 @@
         "algorithm": "JustReturn",
         "next": ["CloseAnno", "CloseAnnoTexas", "CloseAnnoSpecialAccess", "TodaysSupplies", "NotDownloadVoice"]
     },
-    "StartUp@CloseAnno": {
-        "baseTask": "CloseAnno",
-        "template": "CloseAnno.png",
-        "next": [
-            "StartUp",
-            "StartUp@LoadingText",
-            "StartUp@CloseAnnoTexas",
-            "StartUp@CloseAnnoSpecialAccess",
-            "StartUp@TodaysSupplies",
-            "StartUp@NotDownloadVoice",
-            "MainThemes#next",
-            "ClosePCEventPageEsc"
-        ]
-    },
     "StartUp@TodaysSupplies": {
         "baseTask": "TodaysSupplies",
+        "next": ["StartUp@TodaysSuppliesPostCheck"]
+    },
+    "StartUp@TodaysSuppliesPostCheck": {
+        "Doc": "今日配给领取后先判定主页，未到主页则优先关闭签到/物资层",
+        "algorithm": "JustReturn",
+        "next": ["StartUp", "StartUp@LoadingText", "StartUp@TodaysSuppliesCloseAnno"]
+    },
+    "StartUp@TodaysSuppliesCloseAnno": {
+        "Doc": "今日配给后置关闭 — 最多关闭两层签到/物资弹窗，之后再进入活动页兜底",
+        "template": "empty.png",
+        "action": "ClickSelf",
+        "roi": [1100, 0, 180, 200],
+        "postDelay": 1000,
+        "maxTimes": 2,
+        "next": ["StartUp", "StartUp@LoadingText", "StartUp@TodaysSuppliesCloseAnno"],
+        "exceededNext": ["StartUp@TodaysSuppliesEventPageCheck"]
+    },
+    "StartUp@TodaysSuppliesEventPageCheck": {
+        "Doc": "今日配给后置二次主页判定 — 仍未到主页时按 PC 活动页处理",
+        "algorithm": "JustReturn",
+        "next": ["StartUp", "StartUp@LoadingText", "ClosePCEventPage"]
+    },
+    "StartUp@AfterLoadingIcon": {
+        "Doc": "开始唤醒加载后候选 — 先处理主页/签到/明确弹窗，再进入 PC 活动页兜底，最后普通公告关闭",
+        "algorithm": "JustReturn",
         "next": [
             "StartUp",
             "StartUp@LoadingText",
+            "StartUp@TodaysSupplies",
             "StartUp@CloseAnnoTexas",
             "StartUp@CloseAnnoSpecialAccess",
             "StartUp@NotDownloadVoice",
-            "MainThemes#next",
-            "ClosePCEventPage"
+            "ClosePCEventPage",
+            "StartUp@CloseAnno"
         ]
+    },
+    "StartUp@GameStart@LoadingIcon": {
+        "baseTask": "LoadingIcon",
+        "template": "LoadingIcon.png",
+        "next": ["StartUp@GameStart@LoadingIcon", "StartUp@AfterLoadingIcon"]
+    },
+    "StartUp@StartToWakeUp@LoadingIcon": {
+        "baseTask": "LoadingIcon",
+        "template": "LoadingIcon.png",
+        "next": ["StartUp@StartToWakeUp@LoadingIcon", "StartUp@AfterLoadingIcon"]
+    },
+    "StartUp@StartLoginBServer@LoadingIcon": {
+        "baseTask": "LoadingIcon",
+        "template": "LoadingIcon.png",
+        "next": ["StartUp@StartLoginBServer@LoadingIcon", "StartUp@AfterLoadingIcon"]
+    },
+    "StartUp@StartUpConnectingFlag@LoadingIcon": {
+        "baseTask": "LoadingIcon",
+        "template": "LoadingIcon.png",
+        "next": ["StartUp@StartUpConnectingFlag@LoadingIcon", "StartUp@AfterLoadingIcon"]
     },
     "MainThemes": {
         "Doc": "使用本任务时带上 #next",

--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -849,8 +849,7 @@
             "CloseAnnos#next",
             "OfflineConfirm",
             "GameStartCheckResourceOCR",
-            "GameStartUpdateOCR",
-            "ClosePCEventPage"
+            "GameStartUpdateOCR"
         ]
     },
     "LeidianGoogleFrameworkConfirm": {
@@ -883,7 +882,8 @@
             "StartUpBegin@LoadingIcon",
             "StartUp@ReturnButtons#next",
             "StartUp@EndOfAction",
-            "StartUp@PRTS#next"
+            "StartUp@PRTS#next",
+            "ClosePCEventPage"
         ]
     },
     "GameStart": {

--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -882,8 +882,7 @@
             "StartUpBegin@LoadingIcon",
             "StartUp@ReturnButtons#next",
             "StartUp@EndOfAction",
-            "StartUp@PRTS#next",
-            "ClosePCEventPage"
+            "StartUp@PRTS#next"
         ]
     },
     "GameStart": {
@@ -952,21 +951,23 @@
         "next": ["Home"]
     },
     "StartUp": {
-        "Doc": "有时候明明已经在主界面了，停了一小会又弹个窗。多检测几次，一直在主界面才算完成",
+        "Doc": "主界面确认 — maxTimes降到1以便快速通过，让ClosePCEventPage闭环接管弹窗处理",
         "template": "SwitchTheme@ToggleSettingsMenu.png",
         "action": "DoNothing",
         "roi": [227, 327, 159, 152],
         "postDelay": 1000,
-        "maxTimes": 3,
+        "maxTimes": 1,
         "next": ["StartUp", "StartUp@LoadingText", "StartUp@CloseAnnos#next", "ClosePCEventPage"]
     },
     "ClosePCEventPage": {
+        "Doc": "PC端活动页面ESC关闭 — 按ESC后延迟等待动画结束，再闭环检查主界面/弹窗",
         "algorithm": "JustReturn",
         "action": "PressEsc",
+        "postDelay": 1000,
         "maxTimes": 3,
-        "next": ["StartUp"],
-        "on_error_next": ["StartUpConnectingFlag", "MainThemes#next", "CloseAnnos#next", "OfflineConfirm"],
-        "exceededNext": ["StartUpConnectingFlag", "MainThemes#next", "CloseAnnos#next", "OfflineConfirm"]
+        "next": ["StartUp", "StartUp@LoadingText", "MainThemes#next", "CloseAnnos#next", "ClosePCEventPage"],
+        "on_error_next": ["StartUp"],
+        "exceededNext": ["StartUp"]
     },
     "CloseAnnos": {
         "algorithm": "JustReturn",

--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -844,6 +844,7 @@
             "StartToWakeUp",
             "StartToWakeUpOCR",
             "StartLoginBServer",
+            "ClosePCEventPage",
             "StartUpConnectingFlag",
             "MainThemes#next",
             "CloseAnnos#next",
@@ -958,6 +959,11 @@
         "postDelay": 1000,
         "maxTimes": 3,
         "next": ["StartUp", "StartUp@LoadingText", "StartUp@CloseAnnos#next"]
+    },
+    "ClosePCEventPage": {
+        "algorithm": "JustReturn",
+        "action": "PressEsc",
+        "next": ["StartUpConnectingFlag", "MainThemes#next", "CloseAnnos#next", "OfflineConfirm"]
     },
     "CloseAnnos": {
         "algorithm": "JustReturn",

--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -844,13 +844,13 @@
             "StartToWakeUp",
             "StartToWakeUpOCR",
             "StartLoginBServer",
-            "ClosePCEventPage",
             "StartUpConnectingFlag",
             "MainThemes#next",
             "CloseAnnos#next",
             "OfflineConfirm",
             "GameStartCheckResourceOCR",
-            "GameStartUpdateOCR"
+            "GameStartUpdateOCR",
+            "ClosePCEventPage"
         ]
     },
     "LeidianGoogleFrameworkConfirm": {
@@ -958,12 +958,15 @@
         "roi": [227, 327, 159, 152],
         "postDelay": 1000,
         "maxTimes": 3,
-        "next": ["StartUp", "StartUp@LoadingText", "StartUp@CloseAnnos#next"]
+        "next": ["StartUp", "StartUp@LoadingText", "StartUp@CloseAnnos#next", "ClosePCEventPage"]
     },
     "ClosePCEventPage": {
         "algorithm": "JustReturn",
         "action": "PressEsc",
-        "next": ["StartUpConnectingFlag", "MainThemes#next", "CloseAnnos#next", "OfflineConfirm"]
+        "maxTimes": 3,
+        "next": ["StartUp"],
+        "on_error_next": ["ClosePCEventPage"],
+        "exceededNext": ["StartUpConnectingFlag", "MainThemes#next", "CloseAnnos#next", "OfflineConfirm"]
     },
     "CloseAnnos": {
         "algorithm": "JustReturn",

--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -960,18 +960,63 @@
         "next": ["StartUp", "StartUp@LoadingText", "StartUp@CloseAnnos#next", "ClosePCEventPage"]
     },
     "ClosePCEventPage": {
+        "Doc": "PC端活动页面右上角关闭 — 先点击关闭按钮，失败后进入ESC兜底",
+        "algorithm": "JustReturn",
+        "action": "ClickRect",
+        "specificRect": [1180, 20, 100, 120],
+        "postDelay": 1000,
+        "maxTimes": 1,
+        "next": ["StartUp", "StartUp@LoadingText", "MainThemes#next", "ClosePCEventPageEsc"],
+        "exceededNext": ["ClosePCEventPageEsc"]
+    },
+    "ClosePCEventPageEsc": {
         "Doc": "PC端活动页面ESC关闭 — 按ESC后延迟等待动画结束，再闭环检查主界面/弹窗",
         "algorithm": "JustReturn",
         "action": "PressEsc",
         "postDelay": 1000,
         "maxTimes": 3,
-        "next": ["StartUp", "StartUp@LoadingText", "MainThemes#next", "CloseAnnos#next", "ClosePCEventPage"],
+        "next": [
+            "StartUp",
+            "StartUp@LoadingText",
+            "MainThemes#next",
+            "StartUp@CloseAnnoTexas",
+            "StartUp@CloseAnnoSpecialAccess",
+            "StartUp@TodaysSupplies",
+            "StartUp@NotDownloadVoice",
+            "ClosePCEventPageEsc"
+        ],
         "on_error_next": ["StartUp"],
         "exceededNext": ["StartUp"]
     },
     "CloseAnnos": {
         "algorithm": "JustReturn",
         "next": ["CloseAnno", "CloseAnnoTexas", "CloseAnnoSpecialAccess", "TodaysSupplies", "NotDownloadVoice"]
+    },
+    "StartUp@CloseAnno": {
+        "baseTask": "CloseAnno",
+        "template": "CloseAnno.png",
+        "next": [
+            "StartUp",
+            "StartUp@LoadingText",
+            "StartUp@CloseAnnoTexas",
+            "StartUp@CloseAnnoSpecialAccess",
+            "StartUp@TodaysSupplies",
+            "StartUp@NotDownloadVoice",
+            "MainThemes#next",
+            "ClosePCEventPageEsc"
+        ]
+    },
+    "StartUp@TodaysSupplies": {
+        "baseTask": "TodaysSupplies",
+        "next": [
+            "StartUp",
+            "StartUp@LoadingText",
+            "StartUp@CloseAnnoTexas",
+            "StartUp@CloseAnnoSpecialAccess",
+            "StartUp@NotDownloadVoice",
+            "MainThemes#next",
+            "ClosePCEventPage"
+        ]
     },
     "MainThemes": {
         "Doc": "使用本任务时带上 #next",

--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -919,7 +919,7 @@
     "StartToWakeUpOCR": {
         "baseTask": "StartToWakeUp",
         "algorithm": "OcrDetect",
-        "text": ["开始唤醒", "登录", "登", "录"],
+        "text": ["开始唤醒", "登录", "登", "录", "签到"],
         "fullMatch": true,
         "roi": [373, 145, 535, 430]
     },
@@ -965,7 +965,7 @@
         "action": "PressEsc",
         "maxTimes": 3,
         "next": ["StartUp"],
-        "on_error_next": ["ClosePCEventPage"],
+        "on_error_next": ["StartUpConnectingFlag", "MainThemes#next", "CloseAnnos#next", "OfflineConfirm"],
         "exceededNext": ["StartUpConnectingFlag", "MainThemes#next", "CloseAnnos#next", "OfflineConfirm"]
     },
     "CloseAnnos": {

--- a/src/MaaCore/Common/AsstTypes.h
+++ b/src/MaaCore/Common/AsstTypes.h
@@ -500,6 +500,7 @@ enum class ProcessTaskAction
     Stop = 0x400,      // 停止当前Task
     Swipe = 0x1000,    // 滑动
     Input = 0x2000,    // 输入文本
+    PressEsc = 0x4000, // 按 ESC 键
 };
 
 inline ProcessTaskAction get_action_type(std::string action_str)
@@ -510,6 +511,7 @@ inline ProcessTaskAction get_action_type(std::string action_str)
         { "clickself", ProcessTaskAction::ClickSelf }, { "clickrect", ProcessTaskAction::ClickRect },
         { "stop", ProcessTaskAction::Stop },           { "swipe", ProcessTaskAction::Swipe },
         { "input", ProcessTaskAction::Input },
+        { "pressesc", ProcessTaskAction::PressEsc },
     };
     if (auto it = action_map.find(action_str); it != action_map.end()) {
         return it->second;
@@ -524,6 +526,7 @@ inline std::string enum_to_string(ProcessTaskAction action)
         { ProcessTaskAction::BasicClick, "BasicClick" }, { ProcessTaskAction::ClickSelf, "ClickSelf" },
         { ProcessTaskAction::ClickRect, "ClickRect" },   { ProcessTaskAction::Stop, "Stop" },
         { ProcessTaskAction::Swipe, "Swipe" },           { ProcessTaskAction::Input, "Input" },
+        { ProcessTaskAction::PressEsc, "PressEsc" },
     };
     if (auto it = action_map.find(action); it != action_map.end()) {
         return it->second;

--- a/src/MaaCore/Controller/Win32Controller.cpp
+++ b/src/MaaCore/Controller/Win32Controller.cpp
@@ -353,7 +353,11 @@ bool Win32Controller::press_esc()
     inputs[1].type = INPUT_KEYBOARD;
     inputs[1].ki.wVk = VK_ESCAPE;
     inputs[1].ki.dwFlags = KEYEVENTF_KEYUP;
-    SendInput(2, inputs, sizeof(INPUT));
+    UINT sent = SendInput(2, inputs, sizeof(INPUT));
+    if (sent != 2) {
+        Log.warn("press_esc: SendInput did not send all events, sent:", sent,
+                 "expected: 2, last_error:", GetLastError());
+    }
 
     return ret;
 }

--- a/src/MaaCore/Controller/Win32Controller.cpp
+++ b/src/MaaCore/Controller/Win32Controller.cpp
@@ -335,7 +335,27 @@ bool Win32Controller::inject_input_event(const InputEvent& event)
 bool Win32Controller::press_esc()
 {
     LogTraceFunction;
-    return unit_click_key(VK_ESCAPE); // VK_ESCAPE = 0x1B, defined in WinUser.h
+
+    // 先尝试 DLL 方式（SendMessage/PostMessage）
+    bool ret = unit_click_key(VK_ESCAPE);
+
+    // 再尝试将窗口拉到前台
+    if (m_hwnd) {
+        SetForegroundWindow(static_cast<HWND>(m_hwnd));
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+
+    // 使用 SendInput 发送系统级按键（DirectInput 可以捕获）
+    // SendInput 比 keybd_event 更可靠，且正确支持 UIPI
+    INPUT inputs[2] = {};
+    inputs[0].type = INPUT_KEYBOARD;
+    inputs[0].ki.wVk = VK_ESCAPE;
+    inputs[1].type = INPUT_KEYBOARD;
+    inputs[1].ki.wVk = VK_ESCAPE;
+    inputs[1].ki.dwFlags = KEYEVENTF_KEYUP;
+    SendInput(2, inputs, sizeof(INPUT));
+
+    return ret;
 }
 
 ControlFeat::Feat Win32Controller::support_features() const noexcept

--- a/src/MaaCore/Task/ProcessTask.cpp
+++ b/src/MaaCore/Task/ProcessTask.cpp
@@ -222,6 +222,9 @@ ProcessTask::NodeStatus ProcessTask::run_action(const HitDetail& hits) const
             task->high_resolution_swipe_fix);
         return NodeStatus::Success;
     }
+    case ProcessTaskAction::PressEsc:
+        exec_press_esc_task();
+        return NodeStatus::Success;
     case ProcessTaskAction::DoNothing:
         return NodeStatus::Success;
     case ProcessTaskAction::Stop:
@@ -425,6 +428,11 @@ void ProcessTask::exec_click_task(const Rect& matched_rect) const
 void ProcessTask::exec_input_task(const std::string& text) const
 {
     ctrler()->input(text);
+}
+
+void ProcessTask::exec_press_esc_task() const
+{
+    ctrler()->press_esc();
 }
 
 void ProcessTask::exec_swipe_task(

--- a/src/MaaCore/Task/ProcessTask.h
+++ b/src/MaaCore/Task/ProcessTask.h
@@ -72,6 +72,7 @@ protected:
 
     void exec_click_task(const Rect& matched_rect) const;
     void exec_input_task(const std::string& text) const;
+    void exec_press_esc_task() const;
     void exec_swipe_task(
         const Rect& r1,
         const Rect& r2,


### PR DESCRIPTION
签到后弹出的活动页使用DirectX覆盖层渲染，MAA截图无法捕获、鼠标
无法操控。此提交在签到流程(StartUpThemes)后无条件按ESC关闭覆盖层。

C++改动:
- Win32Controller::press_esc(): 先SetForegroundWindow拉到前台， 再用SendInput发送系统级ESC按键，确保DirectInput能捕获到
- 新增ProcessTaskAction::PressEsc枚举和对应action处理

任务链改动:
- 新增ClosePCEventPage任务(JustReturn+PressEsc)
- 放在StartUpThemes.next的StartLoginBServer之后， 确保签到完成后再按ESC，不影响正常主界面识别流程

## Summary by Sourcery

确保 PC 客户端在启动主题后，可以通过按下 ESC 关闭登录 DirectX 叠加层活动页面，从而恢复正常的自动化控制。

Enhancements:
- 通过结合窗口前置与系统级 `SendInput` 事件，增强 Win32 ESC 键处理，以改善对 DirectInput 的捕获效果。
- 添加新的 `ProcessTaskAction::PressEsc` 动作及对应的任务执行钩子，以实现可复用的按 ESC 行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure PC client sign-in DirectX overlay activity page is closed via ESC after startup themes to restore normal automation control.

Enhancements:
- Enhance Win32 ESC key handling by combining window foregrounding and system-level SendInput events for better DirectInput capture.
- Add a new ProcessTaskAction::PressEsc action and corresponding task execution hook for reusable ESC-press behavior.

</details>