### PR TITLE
feat: 新增可通过手动修改配置文件开启 6 星自动公招，将是否招募和招募时间选项移入常规设置

### DIFF
--- a/src/MaaWpfGui/Configuration/Single/MaaTask/RecruitTask.cs
+++ b/src/MaaWpfGui/Configuration/Single/MaaTask/RecruitTask.cs
@@ -89,8 +89,15 @@ public class RecruitTask : BaseTask, IJsonOnDeserialized
 
     /// <summary>
     /// Gets or sets a value indicating whether 自动确认5星
+    /// 招募时间固定为 9:00（540 分钟）。
     /// </summary>
     public bool Level5Choose { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether 自动确认6星。
+    /// 仅作为配置文件可修改项，界面不可修改，招募时间固定为 9:00（540 分钟）。
+    /// </summary>
+    public bool Level6Choose { get; set; }
 
     /// <summary>
     /// Gets or sets a value indicating whether 3星时间
@@ -101,11 +108,6 @@ public class RecruitTask : BaseTask, IJsonOnDeserialized
     /// Gets or sets 4星时间
     /// </summary>
     public int Level4Time { get; set; } = 540;
-
-    /// <summary>
-    /// Gets or sets 5星时间
-    /// </summary>
-    public int Level5Time { get; set; } = 540;
 
     public void OnDeserialized()
     {

--- a/src/MaaWpfGui/Helper/ConfigConverter.cs
+++ b/src/MaaWpfGui/Helper/ConfigConverter.cs
@@ -290,7 +290,6 @@ public class ConfigConverter
                 recruitTask.Level4Choose = ConfigurationHelper.GetValue(ConfigurationKeys.RecruitChooseLevel4, true);
                 recruitTask.Level4Time = ConfigurationHelper.GetValue(ConfigurationKeys.ChooseLevel4Time, 540);
                 recruitTask.Level5Choose = ConfigurationHelper.GetValue(ConfigurationKeys.RecruitChooseLevel5, false);
-                recruitTask.Level5Time = ConfigurationHelper.GetValue(ConfigurationKeys.ChooseLevel5Time, 540);
                 ConfigurationHelper.DeleteValue(ConfigurationKeys.SelectExtraTags);
                 ConfigurationHelper.DeleteValue(ConfigurationKeys.AutoRecruitFirstList);
                 ConfigurationHelper.DeleteValue(ConfigurationKeys.RefreshLevel3);

--- a/src/MaaWpfGui/Models/AsstTasks/AsstRecruitTask.cs
+++ b/src/MaaWpfGui/Models/AsstTasks/AsstRecruitTask.cs
@@ -106,9 +106,14 @@ public class AsstRecruitTask : AsstBaseTask
     public int ChooseLevel4Time { get; set; }
 
     /// <summary>
-    /// Gets or sets 5 星招募时间
+    /// Gets 5 星招募时间。5 星仅支持 9:00（540 分钟）。
     /// </summary>
-    public int ChooseLevel5Time { get; set; }
+    public int ChooseLevel5Time { get; } = 540;
+
+    /// <summary>
+    /// Gets 6 星招募时间。6 星仅支持 9:00（540 分钟）。
+    /// </summary>
+    public int ChooseLevel6Time { get; } = 540;
 
     /// <summary>
     /// Gets or sets a value indicating whether 是否回报企鹅物流，默认 false
@@ -155,6 +160,7 @@ public class AsstRecruitTask : AsstBaseTask
                 ["3"] = ChooseLevel3Time,
                 ["4"] = ChooseLevel4Time,
                 ["5"] = ChooseLevel5Time,
+                ["6"] = ChooseLevel6Time,
             },
             ["report_to_penguin"] = ReportToPenguin,
             ["report_to_yituliu"] = ReportToYituliu,

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -1427,6 +1427,9 @@ Cache files (such as maps, operator avatars, etc.) need to be regenerated after 
     <system:String x:Key="AutoSelectLevel4">Auto confirm 4★</system:String>
     <system:String x:Key="AutoSelectLevel5">Auto confirm 5★</system:String>
     <system:String x:Key="AutoSelectLevel6">Auto confirm 6★</system:String>
+    <system:String x:Key="AutoSelectLevel6Tip">This option can only be enabled by editing the config file</system:String>
+    <system:String x:Key="AutoUseExpeditedTip" xml:space="preserve">Effective once only.
+Recruitment permits are consumed faster than acquired; normally the timer expires before the next recruit task runs. Use only in emergencies such as severe permit overflow</system:String>
     <system:String x:Key="PreserveTagsTip">Skip the recruitment and keep the slot when any selected tag is identified. Leave it empty to preserve none.</system:String>
     <!--  !AutoRecruitSettings  -->
     <!--  EasterEggs  -->

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -1428,6 +1428,9 @@ DEBUGディレクトリに保存される画像には数量制限があり、超
     <system:String x:Key="AutoSelectLevel4">星4を自動的に確認する</system:String>
     <system:String x:Key="AutoSelectLevel5">星5を自動的に確認する</system:String>
     <system:String x:Key="AutoSelectLevel6">星6を自動的に確認する</system:String>
+    <system:String x:Key="AutoSelectLevel6Tip">このオプションは設定ファイルの編集でのみ有効にできます</system:String>
+    <system:String x:Key="AutoUseExpeditedTip" xml:space="preserve">一度のみ有効です。
+求人許可の取得速度は消費速度より遅いため、通常は次の公招タスク実行時までに自然に時間が経過します。求人許可が大量に余っているなど、緊急時のみご使用ください</system:String>
     <system:String x:Key="PreserveTagsTip">選択したタグのいずれかを認識した場合、その募集をスキップして枠を残します。未選択の場合は何も保留しません。</system:String>
     <!--  !自動募集設定  -->
     <!--  EasterEggs  -->

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -1429,6 +1429,9 @@ DEBUG 디렉토리에 저장된 이미지는 수량 제한이 있으며 초과 �
     <system:String x:Key="AutoSelectLevel4">★4 자동 모집</system:String>
     <system:String x:Key="AutoSelectLevel5">★5 자동 모집</system:String>
     <system:String x:Key="AutoSelectLevel6">★6 자동 모집</system:String>
+    <system:String x:Key="AutoSelectLevel6Tip">이 옵션은 설정 파일 편집으로만 활성화할 수 있습니다</system:String>
+    <system:String x:Key="AutoUseExpeditedTip" xml:space="preserve">한 번만 유효합니다.
+모집 허가증 획득 속도가 소비 속도보다 느리므로, 일반적으로 다음 모집 작업 실행 시 자연스럽게 시간이 경과합니다. 모집 허가증이 대량 남는 등 비상 시에만 사용하세요</system:String>
     <system:String x:Key="PreserveTagsTip">선택한 태그 중 하나라도 인식되면 해당 모집을 건너뛰고 슬롯을 유지합니다. 비워 두면 어떤 태그도 보류하지 않습니다.</system:String>
     <!--  !AutoRecruitSettings  -->
     <!--  EasterEggs  -->

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -1428,6 +1428,9 @@ DEBUG 目录下保存的图片有数量限制，超出后会自动清理旧图�
     <system:String x:Key="AutoSelectLevel4">自动确认 4 星</system:String>
     <system:String x:Key="AutoSelectLevel5">自动确认 5 星</system:String>
     <system:String x:Key="AutoSelectLevel6">自动确认 6 星</system:String>
+    <system:String x:Key="AutoSelectLevel6Tip">仅可通过修改配置文件开启此选项</system:String>
+    <system:String x:Key="AutoUseExpeditedTip" xml:space="preserve">该选项仅生效一次。
+招募券获取速度低于消耗速度，正常情况下下一轮公招任务时自然已到招募时间，仅在招募券严重溢出等应急场景下使用</system:String>
     <system:String x:Key="PreserveTagsTip">识别到任一已选词条时跳过该次招募并保留该栏位；留空时不保留任何词条。</system:String>
     <!--  !AutoRecruitSettings  -->
     <!--  EasterEggs  -->

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -1428,6 +1428,9 @@ DEBUG 目錄下儲存的圖片有數量限制，超出後會自動清理舊圖�
     <system:String x:Key="AutoSelectLevel4">自動確認 4★</system:String>
     <system:String x:Key="AutoSelectLevel5">自動確認 5★</system:String>
     <system:String x:Key="AutoSelectLevel6">自動確認 6★</system:String>
+    <system:String x:Key="AutoSelectLevel6Tip">僅可透過修改設定檔來開啟此選項</system:String>
+    <system:String x:Key="AutoUseExpeditedTip" xml:space="preserve">該選項僅生效一次。
+招募券獲取速度低於消耗速度，正常情況下下一輪公招任務時自然已到招募時間，僅在招募券嚴重溢出等應急場景下使用</system:String>
     <system:String x:Key="PreserveTagsTip">辨識到任一已選 Tag 時，跳過該次招募並保留該欄位；留空時不保留任何 Tag。</system:String>
     <!--  !AutoRecruitSettings  -->
     <!--  EasterEggs  -->

--- a/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
@@ -417,7 +417,6 @@ public class ToolboxViewModel : Screen
             SetRecruitTime = RecruitAutoSetTime,
             ChooseLevel3Time = ChooseLevel3Time,
             ChooseLevel4Time = ChooseLevel4Time,
-            ChooseLevel5Time = ChooseLevel5Time,
             ServerType = Instances.SettingsViewModel.ServerType,
         };
         var (type, taskParams) = task.Serialize();

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/RecruitSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/RecruitSettingsUserControlModel.cs
@@ -189,6 +189,16 @@ public class RecruitSettingsUserControlModel : TaskSettingsViewModel, RecruitSet
         set => SetTaskConfig<RecruitTask>(t => t.Level5Choose == value, t => t.Level5Choose = value);
     }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether to choose level 6.
+    /// 仅作为配置项暴露，界面不可修改（IsEnabled=False），招募时间固定为 9:00。
+    /// </summary>
+    public bool ChooseLevel6
+    {
+        get => GetTaskConfig<RecruitTask>().Level6Choose;
+        set => SetTaskConfig<RecruitTask>(t => t.Level6Choose == value, t => t.Level6Choose = value);
+    }
+
     #region 公招时间
     [PropertyDependsOn(nameof(ChooseLevel3Time))]
     public int ChooseLevel3Hour
@@ -244,33 +254,7 @@ public class RecruitSettingsUserControlModel : TaskSettingsViewModel, RecruitSet
         }
     }
 
-    [PropertyDependsOn(nameof(ChooseLevel5Time))]
-    public int ChooseLevel5Hour
-    {
-        get => ChooseLevel5Time / 60;
-        set => ChooseLevel5Time = (value * 60) + ChooseLevel5Min;
-    }
-
-    [PropertyDependsOn(nameof(ChooseLevel5Time))]
-    public int ChooseLevel5Min
-    {
-        get => (ChooseLevel5Time % 60) / 10 * 10;
-        set => ChooseLevel5Time = (ChooseLevel5Hour * 60) + value;
-    }
-
-    public int ChooseLevel5Time
-    {
-        get => GetTaskConfig<RecruitTask>().Level5Time;
-        set {
-            value = value switch {
-                < 60 => 9 * 60,
-                > 9 * 60 => 60,
-                _ => value / 10 * 10,
-            };
-
-            SetTaskConfig<RecruitTask>(t => t.Level5Time == value, t => t.Level5Time = value);
-        }
-    }
+    // 5 星、6 星公招时间固定为 9:00，不提供可修改的绑定属性。
     #endregion 公招时间
 
     public override void RefreshUI(BaseTask baseTask)
@@ -307,7 +291,6 @@ public class RecruitSettingsUserControlModel : TaskSettingsViewModel, RecruitSet
                 PreserveTags = preserveTags,
                 ChooseLevel3Time = recruit.Level3Time,
                 ChooseLevel4Time = recruit.Level4Time,
-                ChooseLevel5Time = recruit.Level5Time,
                 ReportToPenguin = SettingsViewModel.GameSettings.EnablePenguin,
                 ReportToYituliu = SettingsViewModel.GameSettings.EnableYituliu,
                 PenguinId = SettingsViewModel.GameSettings.PenguinId,
@@ -326,11 +309,17 @@ public class RecruitSettingsUserControlModel : TaskSettingsViewModel, RecruitSet
                 task.ConfirmList.Add(4);
             }
 
-            // ReSharper disable once InvertIf
             if (recruit.Level5Choose)
             {
                 task.SelectList.Add(5);
                 task.ConfirmList.Add(5);
+            }
+
+            // 6 星仅参与确认，招募时间固定 9:00，界面不可修改
+            if (recruit.Level6Choose)
+            {
+                task.SelectList.Add(6);
+                task.ConfirmList.Add(6);
             }
 
             return taskId switch {

--- a/src/MaaWpfGui/Views/UserControl/TaskQueue/RecruitSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/TaskQueue/RecruitSettingsUserControl.xaml
@@ -17,16 +17,92 @@
     mc:Ignorable="d">
     <StackPanel>
         <StackPanel Visibility="{c:Binding !EnableAdvancedSettings, Source={x:Static ui_vms:TaskQueueViewModel.TaskSettingVisibilities}}">
-            <StackPanel Margin="0,10" Orientation="Horizontal">
-                <CheckBox Content="{DynamicResource AutoUseExpedited}" IsChecked="{Binding UseExpeditedWithNull}" />
-                <controls:TooltipBlock TooltipText="{DynamicResource CheckBoxesNotSaved}" />
-            </StackPanel>
-
             <hc:NumericUpDown
                 Margin="0,5"
+                HorizontalAlignment="Left"
                 hc:InfoElement.Title="{DynamicResource RecruitMaxTimes}"
                 Minimum="0"
                 Value="{Binding RecruitMaxTimes}" />
+
+            <StackPanel Margin="0,10" Orientation="Horizontal">
+                <CheckBox Content="{DynamicResource AutoUseExpedited}" IsChecked="{Binding UseExpeditedWithNull}" />
+                <controls:TooltipBlock TooltipText="{DynamicResource AutoUseExpeditedTip}" />
+            </StackPanel>
+
+            <CheckBox
+                Margin="0,10"
+                Content="{DynamicResource AutoSelectLevel3}"
+                IsChecked="{Binding ChooseLevel3}" />
+            <StackPanel
+                Height="30"
+                IsEnabled="{c:Binding ChooseLevel3}"
+                Orientation="Horizontal">
+                <hc:NumericUpDown
+                    Width="55"
+                    Maximum="9"
+                    Minimum="1"
+                    ValueFormat="00"
+                    Value="{Binding ChooseLevel3Hour}" />
+                <controls:TextBlock Margin="5" Text=":" />
+                <hc:NumericUpDown
+                    Width="55"
+                    Increment="10"
+                    Maximum="50"
+                    Minimum="0"
+                    ValueFormat="00"
+                    Value="{Binding ChooseLevel3Min}" />
+            </StackPanel>
+            <CheckBox
+                Margin="0,10"
+                Content="{DynamicResource AutoSelectLevel4}"
+                IsChecked="{Binding ChooseLevel4}" />
+            <StackPanel
+                Height="30"
+                IsEnabled="{c:Binding ChooseLevel4}"
+                Orientation="Horizontal">
+                <hc:NumericUpDown
+                    Width="55"
+                    Maximum="9"
+                    Minimum="1"
+                    ValueFormat="00"
+                    Value="{Binding ChooseLevel4Hour}" />
+                <controls:TextBlock Margin="5" Text=":" />
+                <hc:NumericUpDown
+                    Width="55"
+                    Increment="10"
+                    Maximum="50"
+                    Minimum="0"
+                    ValueFormat="00"
+                    Value="{Binding ChooseLevel4Min}" />
+            </StackPanel>
+            <CheckBox
+                Margin="0,10"
+                Content="{DynamicResource AutoSelectLevel5}"
+                IsChecked="{Binding ChooseLevel5}" />
+            <StackPanel
+                Height="30"
+                IsEnabled="False"
+                Orientation="Horizontal">
+                <hc:NumericUpDown ValueFormat="00" Value="9" />
+                <controls:TextBlock Margin="5" Text=":" />
+                <hc:NumericUpDown ValueFormat="00" Value="0" />
+            </StackPanel>
+            <StackPanel Orientation="Horizontal">
+                <CheckBox
+                    Margin="0,10"
+                    Content="{DynamicResource AutoSelectLevel6}"
+                    IsChecked="{Binding ChooseLevel6}"
+                    IsEnabled="{Binding ChooseLevel6}" />
+                <controls:TooltipBlock TooltipText="{DynamicResource AutoSelectLevel6Tip}" />
+            </StackPanel>
+            <StackPanel
+                Height="30"
+                IsEnabled="False"
+                Orientation="Horizontal">
+                <hc:NumericUpDown ValueFormat="00" Value="9" />
+                <controls:TextBlock Margin="5" Text=":" />
+                <hc:NumericUpDown ValueFormat="00" Value="0" />
+            </StackPanel>
         </StackPanel>
 
         <StackPanel Visibility="{c:Binding EnableAdvancedSettings, Source={x:Static ui_vms:TaskQueueViewModel.TaskSettingVisibilities}}">
@@ -83,80 +159,6 @@
                     SelectionMode="Multiple"
                     Visibility="{c:Binding PreserveTagEnabled}" />
             </StackPanel>
-            <CheckBox
-                Margin="0,10"
-                Content="{DynamicResource AutoSelectLevel3}"
-                IsChecked="{Binding ChooseLevel3}" />
-            <StackPanel
-                Height="30"
-                IsEnabled="{c:Binding ChooseLevel3}"
-                Orientation="Horizontal">
-                <hc:NumericUpDown
-                    Width="55"
-                    Maximum="9"
-                    Minimum="1"
-                    ValueFormat="00"
-                    Value="{Binding ChooseLevel3Hour}" />
-                <controls:TextBlock Margin="5" Text=":" />
-                <hc:NumericUpDown
-                    Width="55"
-                    Increment="10"
-                    Maximum="50"
-                    Minimum="0"
-                    ValueFormat="00"
-                    Value="{Binding ChooseLevel3Min}" />
-            </StackPanel>
-            <CheckBox
-                Margin="0,10"
-                Content="{DynamicResource AutoSelectLevel4}"
-                IsChecked="{Binding ChooseLevel4}" />
-            <StackPanel
-                Height="30"
-                IsEnabled="{c:Binding ChooseLevel4}"
-                Orientation="Horizontal">
-                <hc:NumericUpDown
-                    Width="55"
-                    Maximum="9"
-                    Minimum="1"
-                    ValueFormat="00"
-                    Value="{Binding ChooseLevel4Hour}" />
-                <controls:TextBlock Margin="5" Text=":" />
-                <hc:NumericUpDown
-                    Width="55"
-                    Increment="10"
-                    Maximum="50"
-                    Minimum="0"
-                    ValueFormat="00"
-                    Value="{Binding ChooseLevel4Min}" />
-            </StackPanel>
-            <CheckBox
-                Margin="0,10"
-                Content="{DynamicResource AutoSelectLevel5}"
-                IsChecked="{Binding ChooseLevel5}" />
-            <StackPanel
-                Height="30"
-                IsEnabled="{c:Binding ChooseLevel5}"
-                Orientation="Horizontal">
-                <hc:NumericUpDown
-                    Width="55"
-                    Maximum="9"
-                    Minimum="1"
-                    ValueFormat="00"
-                    Value="{Binding ChooseLevel5Hour}" />
-                <controls:TextBlock Margin="5" Text=":" />
-                <hc:NumericUpDown
-                    Width="55"
-                    Increment="10"
-                    Maximum="50"
-                    Minimum="0"
-                    ValueFormat="00"
-                    Value="{Binding ChooseLevel5Min}" />
-            </StackPanel>
-            <CheckBox
-                Margin="0,10"
-                Content="{DynamicResource AutoSelectLevel6}"
-                IsChecked="False"
-                IsEnabled="False" />
         </StackPanel>
     </StackPanel>
 </UserControl>


### PR DESCRIPTION
## 由 Sourcery 提供的摘要

添加基于配置的 6★ 自动公招支持，并将高稀有度公招的时间简化为固定的 9:00 行为。

新特性：
- 允许通过配置文件启用自动 6★ 公招，在选择与确认时参与，并使用固定的 9:00 计时器。

增强与改进：
- 将 5★ 和 6★ 公招统一简化为始终使用固定的 9:00 计时器，而不在 UI 中暴露可调节的时间设置。
- 调整公招设置的绑定、序列化以及配置迁移逻辑，以反映可编辑的 5★ 时间被移除，以及在通用设置中新增 6★ 相关选项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configuration-driven support for 6‑star auto recruitment and simplify high-rarity recruitment timing to fixed 9:00 behavior.

New Features:
- Allow enabling automatic 6‑star recruitment via the configuration file, participating in selection and confirmation with a fixed 9:00 timer.

Enhancements:
- Simplify 5‑star and 6‑star recruitment to always use a fixed 9:00 timer without exposing adjustable time settings in the UI.
- Adjust recruitment settings bindings, serialization, and configuration migration to reflect the removal of editable 5‑star time and the addition of 6‑star options in common settings.

</details>