### PR TITLE
fix: split Telegram notifications by log entry boundaries when messag…

### DIFF
--- a/src/MaaWpfGui/Services/Notification/TelegramNotificationProvider.cs
+++ b/src/MaaWpfGui/Services/Notification/TelegramNotificationProvider.cs
@@ -14,10 +14,12 @@
 #nullable enable
 
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using MaaWpfGui.Services.Web;
 using MaaWpfGui.ViewModels.UI;
@@ -29,6 +31,11 @@ public class TelegramNotificationProvider(IHttpService httpService) : IExternalN
 {
     private readonly ILogger _logger = Log.ForContext<TelegramNotificationProvider>();
 
+    private const int MaxMessageLength = 3900;
+
+    // Matches "[timestamp][color]" at the start of a log entry line
+    private static readonly Regex LogEntryRegex = new(@"^\[[^\]]+\]\[[^\]]+\]", RegexOptions.Compiled | RegexOptions.Multiline);
+
     public async Task<bool> SendAsync(string title, string content)
     {
         var botToken = SettingsViewModel.ExternalNotificationSettings.TelegramBotToken;
@@ -36,14 +43,86 @@ public class TelegramNotificationProvider(IHttpService httpService) : IExternalN
         var topicId = SettingsViewModel.ExternalNotificationSettings.TelegramTopicId;
 
         var uri = $"https://api.telegram.org/bot{botToken}/sendMessage";
+        var fullMessage = $"{title}: {content}";
 
+        // Short enough — send as-is
+        if (fullMessage.Length <= MaxMessageLength)
+        {
+            return await SendMessageAsync(uri, chatId, topicId, fullMessage);
+        }
+
+        // Too long — split by log entry boundaries ([timestamp][color])
+        var maxContentLength = MaxMessageLength - title.Length - ": ".Length;
+        var parts = SplitByLogEntries(content, maxContentLength);
+        var allSuccess = true;
+        foreach (var part in parts)
+        {
+            if (!await SendMessageAsync(uri, chatId, topicId, $"{title}: {part}"))
+            {
+                allSuccess = false;
+            }
+        }
+
+        return allSuccess;
+    }
+
+    /// <summary>
+    /// Split content into sub-messages by log entry boundaries ([timestamp][color]).
+    /// Each sub-message fits within maxLength. Only splits — does not modify content.
+    /// </summary>
+    private static List<string> SplitByLogEntries(string segment, int maxLength)
+    {
+        // Find entry start positions
+        var entryStarts = new List<int>();
+        foreach (Match match in LogEntryRegex.Matches(segment))
+        {
+            // Align to line start
+            var lineStart = segment.LastIndexOf('\n', match.Index);
+            lineStart = lineStart < 0 ? 0 : lineStart + 1;
+            if (entryStarts.Count == 0 || entryStarts[^1] != lineStart)
+            {
+                entryStarts.Add(lineStart);
+            }
+        }
+
+        if (entryStarts.Count == 0)
+        {
+            return [segment];
+        }
+
+        // Group consecutive entries into chunks that fit maxLength
+        var parts = new List<string>();
+        var chunkStart = entryStarts[0];
+        for (var i = 0; i < entryStarts.Count; i++)
+        {
+            var entryEnd = i + 1 < entryStarts.Count ? entryStarts[i + 1] : segment.Length;
+            var chunkEnd = entryEnd;
+
+            // If adding this entry would exceed limit, flush current chunk
+            if (chunkEnd - chunkStart > maxLength && chunkStart < entryStarts[i])
+            {
+                parts.Add(segment[chunkStart..entryStarts[i]]);
+                chunkStart = entryStarts[i];
+            }
+        }
+
+        // Flush remaining
+        if (chunkStart < segment.Length)
+        {
+            parts.Add(segment[chunkStart..]);
+        }
+
+        return parts;
+    }
+
+    private async Task<bool> SendMessageAsync(string uri, string chatId, string topicId, string message)
+    {
         var postContent = new TelegramPostContent
         {
             ChatId = chatId,
-            Content = $"{title}: {content}",
+            Content = message,
         };
 
-        // Only add the topic ID if one is provided
         if (!string.IsNullOrEmpty(topicId))
         {
             postContent.TopicId = topicId;


### PR DESCRIPTION
fix: split Telegram notifications by log entry boundaries when message is too long

Telegram Bot API has a message length limit of 4096 characters. When
MAA generates long task chain logs, the message can exceed this limit
and cause a 400 BadRequest error.

Instead of hard truncating, this fix splits the message by log entry
boundaries ([timestamp][color] pattern) and sends each part as a
separate Telegram message. Short messages are still sent as-is.

The splitting only cuts at entry boundaries — it does not modify the
original text.

Fix #17161

## Summary by Sourcery

通过在日志条目边界处分割消息，而不是发送单个超大负载，来处理较长的 Telegram 通知消息，将其拆分为多条消息发送。

Bug Fixes:
- 通过对较长日志输出进行安全拆分，确保消息遵守 Telegram 的长度限制，从而防止 Telegram 通知发送失败。

Enhancements:
- 引入基于日志条目的消息拆分方式，在发送多段 Telegram 通知时保持可读性和结构性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle long Telegram notification messages by splitting them into multiple messages at log entry boundaries instead of sending a single oversized payload.

Bug Fixes:
- Prevent Telegram notification failures by ensuring messages respect Telegram's length limits through safe splitting of long log outputs.

Enhancements:
- Introduce log entry–aware message splitting to preserve readability and structure when sending multi-part Telegram notifications.

</details>