### PR TITLE
rft: 无法显示系统通知时回退到软件内通知，启动时日志中的通知不可用提示改为 growl 提示

### DIFF
--- a/src/MaaWpfGui/Helper/ToastNotification.cs
+++ b/src/MaaWpfGui/Helper/ToastNotification.cs
@@ -291,7 +291,7 @@ public class ToastNotification : IDisposable
     {
         Execute.OnUIThread(() => {
             // TODO: 整理过时代码
-            if (!ConfigFactory.Root.GUI.UseNotify)
+            if (!ConfigFactory.Root.GUI.UseNotify || !ToastNotificationCheck().IsAvailable)
             {
                 Growl.Info(_notificationTitle + _contentCollection);
                 return;

--- a/src/MaaWpfGui/ViewModels/UI/RootViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/RootViewModel.cs
@@ -20,6 +20,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
+using HandyControl.Controls;
 using HandyControl.Data;
 using HandyControl.Tools;
 using JetBrains.Annotations;
@@ -93,7 +94,7 @@ public class RootViewModel : Conductor<Screen>.Collection.OneActive
         var (isAvailable, detail) = ToastNotification.ToastNotificationCheck();
         if (!isAvailable)
         {
-            Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetStringFormat("ToastNotificationUnavailable", detail), UiLogColor.Error);
+            Growl.Error(LocalizationHelper.GetStringFormat("ToastNotificationUnavailable", detail));
         }
     }
 


### PR DESCRIPTION
rft: 无法显示系统通知时回退到软件内通知，启动时日志中的通知不可用提示改为 growl 提示

## Summary by Sourcery

增强内容：
- 在使用系统通知之前，确保通知显示同时遵守用户配置以及运行时对 toast 的可用性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Ensure notification display honors both user configuration and runtime toast availability before using system notifications.

</details>