### PR TITLE
fix: 对齐 OcrPackNcnn det 缩放算法与 fastdeploy

### DIFF
--- a/src/MaaCore/Config/Miscellaneous/OcrPackNcnn.cpp
+++ b/src/MaaCore/Config/Miscellaneous/OcrPackNcnn.cpp
@@ -372,11 +372,15 @@ std::vector<asst::OcrPackNcnn::DetBox> asst::OcrPackNcnn::detect(const cv::Mat& 
     if (std::max(src_h, src_w) > kDetLimitSideLen) {
         ratio = static_cast<float>(kDetLimitSideLen) / std::max(src_h, src_w);
     }
-    auto align32 = [](int v) {
-        return std::max(32, ((v + 31) / 32) * 32);
+    // 与 fastdeploy 的 OcrDetectorGetInfo 对齐
+    // 之前用 ceil 对齐：小 ROI 上 ceil 会过度横向拉伸（如 106→128 比 round 的 106→96 多拉 ~21%），
+    // 改变文字长宽比，使 DBNet 概率脊偏扁、检测框竖向过紧而切掉小字首笔，导致 rec 误识
+    // （实测「聚羽之地」被读成「袭羽之地」；改 round 后框 16px→20px，两个字段均正确且置信度更高）。
+    auto align32 = [](const int v) {
+        return std::max(32, static_cast<int>(std::round(v / 32.f)) * 32);
     };
-    const int resize_h = align32(static_cast<int>(std::lround(src_h * ratio)));
-    const int resize_w = align32(static_cast<int>(std::lround(src_w * ratio)));
+    const int resize_h = align32(static_cast<int>(src_h * ratio));
+    const int resize_w = align32(static_cast<int>(src_w * ratio));
     const float ratio_h = static_cast<float>(resize_h) / src_h;
     const float ratio_w = static_cast<float>(resize_w) / src_w;
 


### PR DESCRIPTION
- 小 ROI 下 ceil 直接就爆了，识别会出现问题

## Summary by Sourcery

Bug Fixes:
- 通过将检测阶段的缩放对齐方式从基于向上取整的放大，切换为与 fastdeploy 兼容的基于四舍五入的对齐方式，修复在小 ROI 上 OCR 检测不正确的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix incorrect OCR detection on small ROIs by switching the det resize alignment from ceil-based upscaling to fastdeploy-compatible rounding-based alignment.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- 通过将检测阶段的缩放对齐方式从基于向上取整的放大，切换为与 fastdeploy 兼容的基于四舍五入的对齐方式，修复在小 ROI 上 OCR 检测不正确的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix incorrect OCR detection on small ROIs by switching the det resize alignment from ceil-based upscaling to fastdeploy-compatible rounding-based alignment.

</details>

</details>