### PR TITLE
fix: 部分设备界园树洞是非境识别错误

### DIFF
--- a/resource/tasks/Roguelike/JieGarden.json
+++ b/resource/tasks/Roguelike/JieGarden.json
@@ -1301,7 +1301,7 @@
             ["汝吾(门)?", "_default"],
             ["见字祠", "_default"],
             ["始末陵", "_default"],
-            ["是非境", "_boskyPassageDefault"]
+            ["是非(境|坍)", "_boskyPassageDefault"]
         ],
         "roi": [627, 14, 71, 28],
         "withoutDet": true,
@@ -1318,7 +1318,7 @@
             ["汝吾(门)?", "_pragmatic"],
             ["见字祠", "_default"],
             ["始末陵", "_default"],
-            ["是非境", "_boskyPassageDefault"]
+            ["是非(境|坍)", "_boskyPassageDefault"]
         ],
         "roi": [627, 14, 71, 28],
         "withoutDet": true,
@@ -1334,7 +1334,7 @@
             ["汝吾(门)?", "_restart"],
             ["见字祠", "_restart"],
             ["始末陵", "_restart"],
-            ["是非境", "_leaveBoskyPassage"]
+            ["是非(境|坍)", "_leaveBoskyPassage"]
         ],
         "roi": [627, 14, 71, 28],
         "withoutDet": true,
@@ -1351,7 +1351,7 @@
             ["汝吾(门)?", "_restart"],
             ["见字祠", "_restart"],
             ["始末陵", "_restart"],
-            ["是非境", "_leaveBoskyPassage"]
+            ["是非(境|坍)", "_leaveBoskyPassage"]
         ],
         "roi": [627, 14, 71, 28],
         "withoutDet": true,
@@ -1368,7 +1368,7 @@
             ["汝吾(门)?", "_restart"],
             ["见字祠", "_restart"],
             ["始末陵", "_restart"],
-            ["是非境", "_leaveBoskyPassage"]
+            ["是非(境|坍)", "_leaveBoskyPassage"]
         ],
         "roi": [627, 14, 71, 28],
         "withoutDet": true,
@@ -1384,7 +1384,7 @@
             ["汝吾(门)?", "_restart"],
             ["见字祠", "_restart"],
             ["始末陵", "_restart"],
-            ["是非境", "_boskyPassageDefault"]
+            ["是非(境|坍)", "_boskyPassageDefault"]
         ],
         "roi": [627, 14, 71, 28],
         "withoutDet": true,
@@ -1400,7 +1400,7 @@
             ["汝吾(门)?", "_exit"],
             ["见字祠", "_exit"],
             ["始末陵", "_exit"],
-            ["是非境", "_leaveBoskyPassage"]
+            ["是非(境|坍)", "_leaveBoskyPassage"]
         ],
         "roi": [627, 14, 71, 28],
         "withoutDet": true,
@@ -1417,7 +1417,7 @@
             ["汝吾(门)?", "_exit"],
             ["见字祠", "_exit"],
             ["始末陵", "_exit"],
-            ["是非境", "_leaveBoskyPassage"]
+            ["是非(境|坍)", "_leaveBoskyPassage"]
         ],
         "roi": [627, 14, 71, 28],
         "withoutDet": true,
@@ -1433,7 +1433,7 @@
             ["汝吾(门)?", "_default"],
             ["见字祠", "_default"],
             ["始末陵", "_default"],
-            ["是非境", "_boskyPassageDefault"]
+            ["是非(境|坍)", "_boskyPassageDefault"]
         ],
         "roi": [627, 14, 71, 28],
         "withoutDet": true,
@@ -1449,7 +1449,7 @@
             ["汝吾(门)?", "_default"],
             ["见字祠", "_default"],
             ["始末陵", "_default"],
-            ["是非境", "_boskyPassageDefault"]
+            ["是非(境|坍)", "_boskyPassageDefault"]
         ],
         "roi": [627, 14, 71, 28],
         "withoutDet": true,


### PR DESCRIPTION
设备差异渲染字体会细一点，二值化后直接缺胳膊少腿了
<img width="494" height="190" alt="ce8577cfb6f8ca95217c4544c13e0f15" src="https://github.com/user-attachments/assets/1b62275d-5068-46ac-988b-64f01cc36d4c" />
<img width="667" height="224" alt="6d6b74211ce3c2c5e10b77ccf75f097f" src="https://github.com/user-attachments/assets/00d1c964-d824-4556-a61e-00f0ed2861bd" />

## Summary by Sourcery

Bug Fixes:
- 修复在字体渲染较细的设备上对 JieGarden 界面的误识别问题，该问题会导致二值化图像处理遗漏部分字符。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix misrecognition of the JieGarden interface on devices where font rendering is thinner, causing binary image processing to miss parts of characters.

</details>