### PR TITLE
feat: 界园商贾分队「刷源石锭」自动重投通宝刷诡意行商存款

### DIFF
--- a/resource/tasks/Roguelike/JieGarden.json
+++ b/resource/tasks/Roguelike/JieGarden.json
@@ -232,7 +232,7 @@
     "JieGarden@Roguelike@CoppersBox": {
         "Doc": "钱盒按钮",
         "template": "empty.png",
-        "roi": [348, 640, 465, 80],
+        "roi": [348, 640, 550, 80],
         "action": "ClickSelf"
     },
     "JieGarden@Roguelike@CoppersCloseBox": {
@@ -341,7 +341,8 @@
             ["花-圣迢封神", "花-圣诏封神"],
             ["衡-军.*", "衡-军屯垦"],
             ["衡-早热", "衡-旱热"],
-            ["厉[-—一]+字落", "厉-一字落"]
+            ["厉[-—一]+字落", "厉-一字落"],
+            [".*锁代币", "衡-触锁代币"]
         ]
     },
     "JieGarden@Roguelike@CoppersOpenBox": {
@@ -392,6 +393,37 @@
             "JieGarden@Roguelike@CloseEvent",
             "#self"
         ]
+    },
+    "JieGarden@Roguelike@CoppersRecastResultTokenOCR": {
+        "Doc": "商贾分队：投钱结果界面识别是否投出「触锁代币」（三名字横排）。baseTask 复用 CoppersNameOcrReplace 模糊规则适配低分辨率，规则把 *锁代币 归一为 衡-触锁代币",
+        "baseTask": "JieGarden@Roguelike@CoppersNameOcrReplace",
+        "roi": [90, 285, 925, 60],
+        "text": ["衡-触锁代币"],
+        "action": "DoNothing"
+    },
+    "JieGarden@Roguelike@CoppersRecastToResult": {
+        "Doc": "商贾分队：重投并停在投钱结果页（不点对号），由 C++ 先 OCR 判断触锁代币",
+        "baseTask": "JieGarden@Roguelike@CoppersRecast",
+        "template": "JieGarden@Roguelike@CoppersRecast.png",
+        "next": ["JieGarden@Roguelike@CoppersRecastConfirmToResult", "#self"]
+    },
+    "JieGarden@Roguelike@CoppersRecastConfirmToResult": {
+        "baseTask": "JieGarden@Roguelike@CoppersRecastConfirm-NoRetain",
+        "template": "JieGarden@Roguelike@CoppersRecastConfirm-NoRetain.png",
+        "next": ["JieGarden@Roguelike@CoppersRecastResultAppear", "#self"]
+    },
+    "JieGarden@Roguelike@CoppersRecastResultAppear": {
+        "Doc": "识别投钱结果弹窗出现但不点击，作为“重投到结果页”的终点。postDelay 等通宝名字渲染完再返回 C++ 做 OCR，否则会扫到空白漏判触锁代币",
+        "template": "JieGarden@Roguelike@StageEncounterDrawCopperResult.png",
+        "roi": [1033, 462, 153, 155],
+        "action": "DoNothing",
+        "postDelay": 1500
+    },
+    "JieGarden@Roguelike@CoppersRecastResultConfirm": {
+        "Doc": "点投钱结果对号（直开钱盒场景，不接掉落/交换尾链）",
+        "baseTask": "JieGarden@Roguelike@CoppersRecastResult",
+        "template": "JieGarden@Roguelike@StageEncounterDrawCopperResult.png",
+        "next": []
     },
     "JieGarden@Roguelike@CoppersTakeConfirm": {
         "Doc": ["交换通宝确认按钮 (用于插件 RoguelikeCoppersTaskPlugin 的确认操作) 插件出口 状态机的图参见 #16553"],

--- a/resource/tasks/Roguelike/base.json
+++ b/resource/tasks/Roguelike/base.json
@@ -235,8 +235,8 @@
     },
     "RoguelikeRecruitSwipeMaxTime": {
         "algorithm": "JustReturn",
-        "maxTimes_Doc": "这个参数是肉鸽招募时，向右划动的最大次数",
-        "maxTimes": 5
+        "maxTimes_Doc": "这个参数是肉鸽招募时，向右划动的最大次数（招募列表较长时 5 次翻不到底，提到 10；两处调用都有到底即停的提前退出，调大只在确有更多列时生效）",
+        "maxTimes": 10
     },
     "RoguelikeRefreshSupportBtnOcr": {
         "algorithm": "OcrDetect",

--- a/resource/tasks/Roguelike/routing.json
+++ b/resource/tasks/Roguelike/routing.json
@@ -15,6 +15,14 @@
         "rectMove": [800, 360, 0, 0],
         "specialParams": [200, 1, 2, 0]
     },
+    "RoguelikeRouting-MoveToLeftmost": {
+        "doc": "向右滑动把地图拉到最左（露出 init 节点）。商贾分队开局已投出触锁代币时跳过开盒，地图未被复位到初始位置，需先滑到最左，使 MoveRightToPeek 的起点与重投路径一致；滑动距离取大值，到最左会被夹住不会越界",
+        "algorithm": "JustReturn",
+        "action": "Swipe",
+        "specificRect": [350, 360, 0, 0],
+        "rectMove": [1150, 360, 0, 0],
+        "specialParams": [200, 1, 2, 0]
+    },
     "RoguelikeRoutingAction": {
         "algorithm": "JustReturn"
     },
@@ -181,6 +189,32 @@
             "JieGarden@RoguelikeMapNode-YiTrader.png",
             "JieGarden@RoguelikeMapNode-Scheme.png"
         ]
+    },
+    "JieGarden@RoguelikeRouting-RefreshNode": {
+        "Doc": "界园刷新键与萨卡兹相同，复用萨卡兹模板在竖条 roi 内精确匹配后 ClickSelf（之前用 JustReturn 盲点会随机落在按钮下方空白处，故刷新无效）",
+        "roi": [796, 130, 50, 170],
+        "template": "Sarkaz@RoguelikeRouting-RefreshNode.png",
+        "action": "ClickSelf",
+        "next": ["JieGarden@RoguelikeRouting-ConfirmToRefreshNode"]
+    },
+    "JieGarden@RoguelikeRouting-ConfirmToRefreshNode": {
+        "Doc": "刷新节点的确认按钮。界园弹窗是「是否消耗1次[衡-触锁代币]的效果，刷新该节点?」，按钮文字为“确认”（非萨卡兹的“确定”），位置在底部偏右红色按钮",
+        "algorithm": "OcrDetect",
+        "roi": [920, 468, 210, 62],
+        "text": ["确认"],
+        "action": "ClickSelf",
+        "postDelay": 300,
+        "next": ["JieGarden@RoguelikeRouting-WaitAfterRefreshNode", "Stop"]
+    },
+    "JieGarden@RoguelikeRouting-WaitAfterRefreshNode": {
+        "baseTask": "LoadingText",
+        "postDelay": 300,
+        "next": ["#self", "Stop"]
+    },
+    "JieGarden@RoguelikeRoutingAction-StageTraderEnter": {
+        "Doc": "进入诡意行商(StageTrader)。其 next 链已自动包含 StageTraderInvestSystem 存款 + 离开",
+        "algorithm": "JustReturn",
+        "next": ["JieGarden@Roguelike@StageTraderEnter"]
     },
     "JieGarden@RoguelikeRoutingAction-ExitThenAbandon": {
         "algorithm": "JustReturn",

--- a/src/MaaCore/Task/Roguelike/Map/RoguelikeRoutingTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/Map/RoguelikeRoutingTaskPlugin.cpp
@@ -619,7 +619,7 @@ bool asst::RoguelikeRoutingTaskPlugin::recast_until_token_cast()
         return true;
     }
 
-    // 票券很少，设安全上限兜底，避免死循环
+    // 游戏内重投最多 4 次（票券上限），+1 作为 OCR 失败时的安全兜底，避免死循环
     constexpr int max_recast_times = 5;
 
     // 打开钱盒

--- a/src/MaaCore/Task/Roguelike/Map/RoguelikeRoutingTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/Map/RoguelikeRoutingTaskPlugin.cpp
@@ -13,6 +13,7 @@
 #include "Vision/Matcher.h"
 #include "Vision/Miscellaneous/PixelAnalyzer.h"
 #include "Vision/MultiMatcher.h"
+#include "Vision/OCRer.h"
 
 bool asst::RoguelikeRoutingTaskPlugin::load_params([[maybe_unused]] const json::value& params)
 {
@@ -49,6 +50,11 @@ bool asst::RoguelikeRoutingTaskPlugin::load_params([[maybe_unused]] const json::
     }
 
     if (theme == RoguelikeTheme::JieGarden) {
+        // 商贾分队 + 刷源石锭：重投通宝刷出诡意行商存款（两条件缺一不可，由游戏机制决定）
+        if (mode == RoguelikeMode::Investment && squad == "商贾分队") {
+            m_routing_strategy = RoutingStrategy::JieGarden_MerchantRecast;
+            return true;
+        }
         if (((mode == RoguelikeMode::Investment && squad == "指挥分队") ||
              (mode == RoguelikeMode::Collectible && params.get("collectible_mode_squad", squad) == "指挥分队")) &&
             m_config->get_difficulty() >= 3) {
@@ -66,6 +72,8 @@ void asst::RoguelikeRoutingTaskPlugin::reset_in_run_variables()
     m_need_generate_map = true;
     m_selected_column = 0;
     m_selected_x = 0;
+    m_token_cast_at_start = false;
+    m_start_auto_cast_checked = false;
 }
 
 bool asst::RoguelikeRoutingTaskPlugin::verify(const AsstMsg msg, const json::value& details) const
@@ -82,6 +90,15 @@ bool asst::RoguelikeRoutingTaskPlugin::verify(const AsstMsg msg, const json::val
     }
 
     if (task_name == m_config->get_theme() + "@Roguelike@Routing") {
+        m_verify_start_auto_cast = false;
+        return true;
+    }
+
+    // 商贾分队：进图后游戏自动投钱，结果弹窗由 RandomPickAfterNextLevel 点确定关闭。
+    // 在它点掉之前拦一次（每局仅一次），OCR 判断开局是否已投出「触锁代币」。
+    if (m_routing_strategy == RoutingStrategy::JieGarden_MerchantRecast && !m_start_auto_cast_checked &&
+        task_name == m_config->get_theme() + "@Roguelike@RandomPickAfterNextLevel") {
+        m_verify_start_auto_cast = true;
         return true;
     }
 
@@ -91,6 +108,12 @@ bool asst::RoguelikeRoutingTaskPlugin::verify(const AsstMsg msg, const json::val
 bool asst::RoguelikeRoutingTaskPlugin::_run()
 {
     LogTraceFunction;
+
+    // 商贾分队：本次由开局自投结果弹窗触发，先 OCR 判断再放行其点确定（见 detect_start_auto_cast）
+    if (m_verify_start_auto_cast) {
+        detect_start_auto_cast();
+        return true;
+    }
 
     switch (m_routing_strategy) {
     case RoutingStrategy::Sarkaz_FastInvestment:
@@ -247,6 +270,43 @@ bool asst::RoguelikeRoutingTaskPlugin::_run()
 
         refresh_following_combat_nodes();
         navigate_route();
+        break;
+
+    case RoutingStrategy::JieGarden_MerchantRecast:
+        if (m_need_generate_map) {
+            // 1. 循环重投通宝，直到“衡-触锁代币”已投出（票券耗尽则回退）
+            if (recast_until_token_cast()) {
+                // 开局自投路径跳过了开盒，地图未被复位到初始位置（重投路径靠开/关钱盒复位到最左）。
+                // 先手动把地图滑到最左，使下面 MoveRightToPeek 的起点与重投路径一致，否则 update_map
+                // 测到的第一列横坐标整体左偏（实测 321→121），update_selected_x 仍按 m_origin_x
+                // 选点会点空、刷新键点不到。
+                if (m_token_cast_at_start) {
+                    ProcessTask(*this, { "RoguelikeRouting-MoveToLeftmost" }).run();
+                }
+                // 2. 解析地图并选中战斗节点后刷新：refresh_following_combat_nodes 会先 click 选中节点、
+                //    再点刷新键并确认；触锁代币使被刷新节点变为诡意行商，且刷新后该节点仍处于选中态
+                ProcessTask(*this, { "RoguelikeRouting-MoveRightToPeek" }).run();
+                {
+                    const cv::Mat map_image = ctrler()->get_image();
+                    update_map(map_image, RoguelikeMap::INIT_INDEX + 1);
+                }
+                m_selected_column = m_map.get_node_column(m_map.get_curr_pos());
+                update_selected_x();
+                refresh_following_combat_nodes(/*only_first=*/true);
+                // 3. 节点仍选中，直接进入诡意行商（不再寻路另选节点）；存款由 InvestPlugin 自动完成，之后走 else 退出
+                Task.set_task_base("RoguelikeRoutingAction", "JieGarden@RoguelikeRoutingAction-StageTraderEnter");
+            }
+            else {
+                // 票券耗尽仍未投出：放弃本轮、退出重开下一轮
+                // （若想“正常打完本轮”，可在此改为回退通用投资/避战策略）
+                Task.set_task_base("RoguelikeRoutingAction", "JieGarden@RoguelikeRoutingAction-ExitThenAbandon");
+            }
+            m_need_generate_map = false;
+        }
+        else {
+            // 存款完成 -> 退出放弃，进入下一轮
+            Task.set_task_base("RoguelikeRoutingAction", "JieGarden@RoguelikeRoutingAction-ExitThenAbandon");
+        }
         break;
 
     default:
@@ -471,7 +531,7 @@ void asst::RoguelikeRoutingTaskPlugin::generate_edges(
     }
 }
 
-void asst::RoguelikeRoutingTaskPlugin::refresh_following_combat_nodes()
+void asst::RoguelikeRoutingTaskPlugin::refresh_following_combat_nodes(bool only_first)
 {
     LogTraceFunction;
 
@@ -520,7 +580,77 @@ void asst::RoguelikeRoutingTaskPlugin::refresh_following_combat_nodes()
             const Matcher::Result& match_results = node_analyzer.get_result();
             m_map.set_node_type(next_node, RoguelikeMapInfo.templ2type(theme, match_results.templ_name));
         }
+
+        // 商贾分队：触锁代币只够刷 1 次，刷完第一个战斗节点即停，保持该节点选中以便直接进店
+        if (only_first) {
+            break;
+        }
     }
+}
+
+void asst::RoguelikeRoutingTaskPlugin::detect_start_auto_cast()
+{
+    LogTraceFunction;
+    // 每局只检测一次（RandomPickAfterNextLevel 会点 #self 多次匹配，避免重复 OCR/等待）
+    m_start_auto_cast_checked = true;
+
+    // 自投结果弹窗与重投结果页同一 UI（对号同在 [1033,462] 处）。
+    // 等通宝名字渲染完再 OCR，否则会扫到空白漏判（复用重投结果页的等待时长）。
+    sleep(Task.get("JieGarden@Roguelike@CoppersRecastResultAppear")->post_delay);
+
+    OCRer token_ocr(ctrler()->get_image());
+    token_ocr.set_task_info("JieGarden@Roguelike@CoppersRecastResultTokenOCR");
+    if (token_ocr.analyze().has_value()) {
+        m_token_cast_at_start = true;
+        LogInfo << __FUNCTION__ << "| 开局自动投已投出「触锁代币」，将跳过开盒重投";
+    }
+    else {
+        LogInfo << __FUNCTION__ << "| 开局自动投未投出「触锁代币」，进图后照常开盒重投";
+    }
+}
+
+bool asst::RoguelikeRoutingTaskPlugin::recast_until_token_cast()
+{
+    LogTraceFunction;
+
+    // 开局自动投已投出「触锁代币」：无需开盒重投，直接沿用（省票券、避免重投覆盖掉它）
+    if (m_token_cast_at_start) {
+        LogInfo << __FUNCTION__ << "| 开局已投出「触锁代币」，跳过开盒重投";
+        return true;
+    }
+
+    // 票券很少，设安全上限兜底，避免死循环
+    constexpr int max_recast_times = 5;
+
+    // 打开钱盒
+    if (!ProcessTask(*this, { "JieGarden@Roguelike@CoppersOpenBox" }).run()) {
+        LogWarn << __FUNCTION__ << "| 无法打开钱盒，放弃重投";
+        return false;
+    }
+
+    bool cast = false;
+    for (int i = 0; i < max_recast_times; ++i) {
+        // 重投并停在投钱结果页（不点对号）；票券耗尽/重投键不可用时 run() 返回 false
+        if (!ProcessTask(*this, { "JieGarden@Roguelike@CoppersRecastToResult" }).run()) {
+            LogWarn << __FUNCTION__ << "| 重投不可用（票券耗尽?），停止重投";
+            break;
+        }
+        // 一次性 OCR 投钱结果页是否投出了「触锁代币」（结果页含三个名字，任一命中即可）
+        OCRer token_ocr(ctrler()->get_image());
+        token_ocr.set_task_info("JieGarden@Roguelike@CoppersRecastResultTokenOCR");
+        const bool found = token_ocr.analyze().has_value();
+        // 点对号确认/关闭结果页（不接掉落交换尾链）
+        ProcessTask(*this, { "JieGarden@Roguelike@CoppersRecastResultConfirm" }).run();
+        if (found) {
+            LogInfo << __FUNCTION__ << "| 第 " << (i + 1) << " 次重投已投出「触锁代币」";
+            cast = true;
+            break;
+        }
+    }
+
+    // 无论是否投出，都退出钱盒回到地图（刷新节点/进商店等后续操作需在地图界面进行）
+    ProcessTask(*this, { "JieGarden@Roguelike@CoppersCloseBox" }).run();
+    return cast;
 }
 
 void asst::RoguelikeRoutingTaskPlugin::navigate_route()

--- a/src/MaaCore/Task/Roguelike/Map/RoguelikeRoutingTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/Map/RoguelikeRoutingTaskPlugin.h
@@ -23,6 +23,7 @@ public:
         Sarkaz_FastInvestment,           // 点刺成锭分队快速投资
         JieGarden_FastPassWithBattle,    // 指挥分队一战快速投资/烧水
         JieGarden_FastPassWithoutBattle, // 指挥分队无战快速投资/烧水
+        JieGarden_MerchantRecast,        // 商贾分队重投通宝刷诡意行商存款
     };
 
 protected:
@@ -54,7 +55,13 @@ private:
         const cv::Mat& image,
         const int& node_x,
         std::optional<std::reference_wrapper<cv::Mat>> image_draw_opt = std::nullopt);
-    void refresh_following_combat_nodes();
+    // only_first=true 时仅刷新第一个战斗后继节点即停（商贾分队触锁代币只够刷 1 次）
+    void refresh_following_combat_nodes(bool only_first = false);
+    // 商贾分队：循环重投通宝，直到投钱结果页 OCR 到「触锁代币」；票券耗尽则返回 false
+    bool recast_until_token_cast();
+    // 商贾分队：进图后游戏自动投钱，其结果弹窗被 RandomPickAfterNextLevel 点确定之前先 OCR 一次，
+    // 判断开局是否已投出「触锁代币」，是则置 m_token_cast_at_start，重投阶段直接跳过
+    void detect_start_auto_cast();
     void navigate_route();
     void update_selected_x();
 
@@ -64,18 +71,23 @@ private:
     RoutingStrategy m_routing_strategy = RoutingStrategy::None;
     RoguelikeMap m_map;
     bool m_need_generate_map = true;
-    size_t m_selected_column = 0;  // 当前选中节点所在列
-    int m_selected_x = 0;          // 当前选中节点的横坐标 (Rect.x)
+    size_t m_selected_column = 0; // 当前选中节点所在列
+    int m_selected_x = 0;         // 当前选中节点的横坐标 (Rect.x)
 
-    int m_origin_x = 0;            // 第一列节点的默认横坐标 (Rect.x)
-    int m_middle_x = 0;            // 中间列节点的默认横坐标 (Rect.x)
-    int m_last_x = 0;              // 最后列节点的默认横坐标 (Rect.x)
-    int m_node_width = 0;          // 节点 Rect.width
-    int m_node_height = 0;         // 节点 Rect.height
-    int m_column_offset = 0;       // 两列节点之间的距离
-    int m_nameplate_offset = 0;    // 节点 Rect 下边缘到节点铭牌下边缘的距离
-    int m_roi_margin = 0;          // roi 的 margin offset
-    int m_direction_threshold = 0; // 节点间连线方向判定的阈值
+    // 商贾分队开局自动投：
+    bool m_token_cast_at_start = false;            // 开局自动投是否已投出「触锁代币」（true 则免开盒重投）
+    bool m_start_auto_cast_checked = false;        // 本局是否已检测过开局自投（只检测一次）
+    mutable bool m_verify_start_auto_cast = false; // 本次 verify 命中的是开局自投拦截而非地图寻路
+
+    int m_origin_x = 0;                            // 第一列节点的默认横坐标 (Rect.x)
+    int m_middle_x = 0;                            // 中间列节点的默认横坐标 (Rect.x)
+    int m_last_x = 0;                              // 最后列节点的默认横坐标 (Rect.x)
+    int m_node_width = 0;                          // 节点 Rect.width
+    int m_node_height = 0;                         // 节点 Rect.height
+    int m_column_offset = 0;                       // 两列节点之间的距离
+    int m_nameplate_offset = 0;                    // 节点 Rect 下边缘到节点铭牌下边缘的距离
+    int m_roi_margin = 0;                          // roi 的 margin offset
+    int m_direction_threshold = 0;                 // 节点间连线方向判定的阈值
 
     // view-related
     int m_left_most_column_x_in_view = 0;

--- a/src/MaaCore/Task/Roguelike/RoguelikeConfig.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeConfig.cpp
@@ -73,6 +73,11 @@ bool asst::RoguelikeConfig::verify_and_load_params(const json::value& params)
         }
         // 界园指挥分队特殊策略
         if (m_theme == "JieGarden") {
+            // 商贾分队投资：设为 FastPass 策略以触发 Routing 任务，联动 RoguelikeRoutingTaskPlugin 的 MerchantRecast
+            // 分支
+            if (m_mode == RoguelikeMode::Investment && params.get("squad", "") == "商贾分队") {
+                Task.set_task_base(strategy_task, "JieGarden@Roguelike@StrategyChange_mode1-FastPass");
+            }
             if (m_mode == RoguelikeMode::Investment && params.get("squad", "") == "指挥分队" && m_difficulty >= 3) {
                 // 启用特殊策略，联动 RoguelikeRoutingTaskPlugin
                 Task.set_task_base(strategy_task, "JieGarden@Roguelike@StrategyChange_mode1-FastPass");

--- a/src/MaaCore/Task/Roguelike/RoguelikeCustomStartTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeCustomStartTaskPlugin.cpp
@@ -140,7 +140,7 @@ bool asst::RoguelikeCustomStartTaskPlugin::hijack_squad()
     // 商贾分队固定在分队列表末尾：先快速划到底，省去逐页 OCR 一个个找（每页 HijackSquad postDelay 1s）。
     // 列表到底后再划无副作用，商贾分队仍停在最右侧，随后由下方循环识别并点击。
     if (squad == "商贾分队") {
-        constexpr size_t SwipeToEndTimes = 6;
+        constexpr size_t SwipeToEndTimes = 6; // 实测：5 次有小概率翻不到底，7 次过多，6 次刚好
         for (size_t i = 0; i != SwipeToEndTimes; ++i) {
             if (need_exit()) {
                 return false;

--- a/src/MaaCore/Task/Roguelike/RoguelikeCustomStartTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeCustomStartTaskPlugin.cpp
@@ -137,6 +137,18 @@ bool asst::RoguelikeCustomStartTaskPlugin::hijack_squad()
             .run();
     }
 
+    // 商贾分队固定在分队列表末尾：先快速划到底，省去逐页 OCR 一个个找（每页 HijackSquad postDelay 1s）。
+    // 列表到底后再划无副作用，商贾分队仍停在最右侧，随后由下方循环识别并点击。
+    if (squad == "商贾分队") {
+        constexpr size_t SwipeToEndTimes = 6;
+        for (size_t i = 0; i != SwipeToEndTimes; ++i) {
+            if (need_exit()) {
+                return false;
+            }
+            ProcessTask(*this, { "Roguelike@SquadSlowlySwipeToTheRight" }).run();
+        }
+    }
+
     constexpr size_t SwipeTimes = 7;
     for (size_t i = 0; i != SwipeTimes; ++i) {
         if (need_exit()) {

--- a/src/MaaCore/Task/Roguelike/RoguelikeRecruitTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeRecruitTaskPlugin.cpp
@@ -103,6 +103,12 @@ bool asst::RoguelikeRecruitTaskPlugin::_run()
         }
     }
 
+    // 商贾分队刷源石锭：全程只刷诡意行商存款、不打仗，开局招谁都不影响结果，直接放弃招募省时间
+    if (theme == RoguelikeTheme::JieGarden && mode == RoguelikeMode::Investment && squad == "商贾分队") {
+        ProcessTask(*this, { "JieGarden@RoguelikeRecruit-GiveUp" }).run();
+        return true;
+    }
+
     // 刷常乐节点保存路上招募券
     // 只在非开局招募时保存招募券
     if (theme == RoguelikeTheme::JieGarden && mode == RoguelikeMode::FindPlaytime && !m_initail_recruit) {


### PR DESCRIPTION
## 简介

为界园肉鸽（IS5）新增 **商贾分队 + 刷源石锭（投资模式）** 的全自动流程：自动重投通宝直到投出「衡-触锁代币」，用它把战斗节点刷新为「诡意行商」，进店将源石锭存入存款后退出，循环下一轮。仅在 **商贾分队 + 刷源石锭** 下启用（游戏机制限制，两者缺一不可）。

顺带补齐 Mac 端缺失的开局分队，见PR：MaaAssistantArknights/MaaMacGui#97。
修复招募翻页 / 分队选择两处小问题。

## 主要功能：商贾分队自动重投存款

新增 routing 策略 `JieGarden_MerchantRecast`（`RoguelikeRoutingTaskPlugin`），完整链路：

1. **开局自投检测** — 进图第一层时游戏会自动投一次通宝，结果弹窗在开盒前就被 `RandomPickAfterNextLevel` 点掉。在它点「确定」之前先 OCR 一次，若开局已投出「触锁代币」则跳过后续开盒重投（省票券，且避免把已投出的代币覆盖掉）。
2. **重投通宝** — 否则打开钱盒循环重投（安全上限 5 次），每次停在投钱结果页 OCR 判断是否投出；票券耗尽仍未投出则退出放弃本轮。
3. **刷新节点** — 投出后选中并刷新第一个战斗节点（触锁代币只够刷 1 次），该节点变为「诡意行商」且保持选中。
4. **进店存款** — 直接进入诡意行商，由投资插件自动存款，完成后退出。

### 关键实现点
- 投钱结果页三枚通宝横排，三个位置都 OCR 且 roi 适当放大以兼容不同分辨率；低分辨率下复用 `CoppersNameOcrReplace` 模糊匹配规则（`*锁代币 → 衡-触锁代币`）。
- 刷新键复用萨卡兹模板与竖条 roi；界园确认按钮文字为「确认」（非萨卡兹的「确定」）。
- 重投与刷新分属钱盒/地图两个界面，重投后需关盒回到地图再刷新。
- 开局自投路径跳过了开盒，地图未被复位到初始位置，刷新前需先 `MoveToLeftmost` 划到最左，使节点坐标与重投路径一致。
- 商贾分队全程不打仗，开局直接跳过招募以省时间。

## 其他改动
- **招募向右翻页上限 5 → 10**：招募列表较长时 5 次翻不到底；两处调用本就有「到底即停」的提前退出，调大仅在确有更多列时生效，无副作用。
- **分队选择直接拖到末尾**：商贾分队固定在分队列表末尾，选它时先快速划到底再识别，省去逐页 OCR 逐个查找。

## 涉及文件

**Core / 资源（本仓库）**
- `src/MaaCore/Task/Roguelike/RoguelikeConfig.cpp` — 商贾分队+投资的策略 gate
- `src/MaaCore/Task/Roguelike/Map/RoguelikeRoutingTaskPlugin.{h,cpp}` — `JieGarden_MerchantRecast` 策略主体（重投 / 开局自投检测 / 刷首个战斗节点 / 进店退出）
- `src/MaaCore/Task/Roguelike/RoguelikeRecruitTaskPlugin.cpp` — 商贾分队跳过招募
- `src/MaaCore/Task/Roguelike/RoguelikeCustomStartTaskPlugin.cpp` — 分队选择拖到底
- `resource/tasks/Roguelike/JieGarden.json` — 重投状态机 / 结果页 OCR / 模糊匹配 / 钱盒按钮 roi
- `resource/tasks/Roguelike/routing.json` — 刷新节点 / 确认 / 进店 / `MoveToLeftmost`
- `resource/tasks/Roguelike/base.json` — 招募翻页上限 5→10

## 限制 / 说明
- 仅 **商贾分队 + 刷源石锭** 生效；其他分队 / 模式不受影响。
- routing 插件目前仍是界园 / 萨卡兹第一层的实验性功能，本 PR 在其框架内扩展。

## 测试
真机迭代验证：**重投路径** 与 **开局已投出路径** 两条完整链路（开盒重投 / 跳过开盒 → 刷新 → 诡意行商 → 进店存款 → 退出）均已跑通。

🤖 Generated with [[Claude Code](https://claude.com/claude-code)](https://claude.com/claude-code)

## Summary by Sourcery

为「JieGarden 商队投资」轮次新增一套自动化路线策略，用于反复重铸铜币、将战斗关卡刷新为商人节点并存入源石锭，同时优化编队选择并跳过不必要的招募步骤。

New Features:
- 引入 `JieGarden_MerchantRecast` 路线策略，实现自动重铸铜币，直到获得指定凭证，同时将首个战斗节点刷新为商人节点，并进入商店存入源石锭，用于商队投资轮次。
- 通过 OCR 在关卡开始时检测并复用初始自动施放凭证，如果该凭证已获得则跳过重铸流程。

Enhancements:
- 在启用商队重铸策略时，仅对首个后继战斗节点进行刷新，确保刷新后的商人节点保持被选中以便直接进入商店。
- 优化自定义开局编队选择，在选择商队编队时通过快速滑动直接到达队列末尾，避免逐页 OCR 扫描。
- 对 JieGarden 商队投资轮次完全跳过招募流程，因为不需要战斗，从而减少不必要的操作步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add an automated routing strategy for JieGarden merchant squad investment runs to repeatedly recast coppers, refresh a combat node into a trader, and deposit Originium ingots, while optimizing squad selection and skipping unnecessary recruitment.

New Features:
- Introduce the JieGarden_MerchantRecast routing strategy that automates recasting coppers until a specific token is obtained, refreshes the first combat node into a trader node, and enters the shop to deposit ingots for merchant squad investment runs.
- Detect and reuse the initial auto-cast token at stage start via OCR so that already-obtained tokens skip the recast flow.

Enhancements:
- Limit combat-node refreshing to only the first successor when using the merchant recast strategy, ensuring the refreshed trader node stays selected for direct shop entry.
- Optimize custom start squad selection by fast-swiping to the end of the squad list when choosing the merchant squad to avoid page-by-page OCR scanning.
- Skip recruitment entirely for JieGarden merchant investment runs since combat is not required, reducing unnecessary steps.

</details>