### PR TITLE
fix: MaaFwAdb emulator extras config and input

### DIFF
--- a/src/MaaCore/Controller/MaaFwAdbController.cpp
+++ b/src/MaaCore/Controller/MaaFwAdbController.cpp
@@ -1,5 +1,9 @@
 #include "MaaFwAdbController.h"
 
+#include <algorithm>
+#include <chrono>
+#include <cctype>
+#include <cstdint>
 #include <thread>
 
 #include "Common/AsstMsg.h"
@@ -10,6 +14,154 @@
 
 namespace asst
 {
+namespace
+{
+struct MaaFwAdbConfig
+{
+    std::string json = "{}";
+    uint64_t screencap_methods = MaaAdbScreencapMethod::Default;
+    uint64_t input_methods = MaaAdbInputMethod::AdbShell | MaaAdbInputMethod::EmulatorExtras;
+    std::string screencap_method_name;
+};
+
+int get_mumu_index(const std::string& address)
+{
+    auto pos = address.find(":");
+    if (pos == std::string::npos) {
+        LogError << "address is invalid" << VAR(address);
+        return 0;
+    }
+
+    std::string port_str = address.substr(pos + 1);
+    if (port_str.empty() ||
+        !std::ranges::all_of(port_str, [](unsigned char c) -> bool { return std::isdigit(c); })) {
+        LogError << "port is invalid" << VAR(port_str);
+        return 0;
+    }
+
+    int port = std::stoi(port_str);
+    int mumu_index = 0;
+    if (port >= 16384) {
+        mumu_index = (port - 16384) / 32;
+    }
+    else if (port == 7555) {
+        LogWarn << "Port 7555 is deprecated for MuMu6, please use 16384 or above.";
+    }
+    else if (port >= 5555) {
+        mumu_index = (port - 5555) / 2;
+    }
+    LogInfo << VAR(port_str) << VAR(port) << VAR(mumu_index);
+    return mumu_index;
+}
+
+int get_ld_index(const std::string& address)
+{
+    constexpr std::string_view EmulatorPrefix = "emulator-";
+    constexpr int BaseEmulatorPort = 5554;
+    if (address.starts_with(EmulatorPrefix)) {
+        std::string port_str = address.substr(EmulatorPrefix.size());
+        if (port_str.empty() ||
+            !std::ranges::all_of(port_str, [](unsigned char c) -> bool { return std::isdigit(c); })) {
+            LogError << "emulator port is invalid" << VAR(port_str);
+            return 0;
+        }
+
+        int port = std::stoi(port_str);
+        int ld_index = (port - BaseEmulatorPort) / 2;
+        LogInfo << VAR(port_str) << VAR(port) << VAR(ld_index);
+        return ld_index;
+    }
+
+    constexpr std::string_view LocalhostPrefix = "127.0.0.1:";
+    constexpr int BaseAdbPort = 5555;
+    if (address.starts_with(LocalhostPrefix)) {
+        std::string port_str = address.substr(LocalhostPrefix.size());
+        if (port_str.empty() ||
+            !std::ranges::all_of(port_str, [](unsigned char c) -> bool { return std::isdigit(c); })) {
+            LogError << "adb port is invalid" << VAR(port_str);
+            return 0;
+        }
+
+        int port = std::stoi(port_str);
+        int ld_index = (port - BaseAdbPort) / 2;
+        LogInfo << VAR(port_str) << VAR(port) << VAR(ld_index);
+        return ld_index;
+    }
+
+    LogError << "address is invalid or unsupported" << VAR(address);
+    return 0;
+}
+
+MaaFwAdbConfig make_maa_fw_adb_config(const std::string& config, const std::string& address)
+{
+    if (config == "AVD") {
+        return { R"({"extras":{"avd":{"enable":true}}})" };
+    }
+
+    auto adb_cfg = Config.get_adb_cfg(config);
+    if (!adb_cfg || adb_cfg->extras.empty()) {
+        return {};
+    }
+
+    const auto& extras = adb_cfg->extras;
+    if (config == "MuMuEmulator12") {
+        std::string mumu_path = extras.get("path", "");
+        if (mumu_path.empty()) {
+            return {};
+        }
+
+        json::object mumu_config {
+            { "enable", true },
+            { "path", std::move(mumu_path) },
+            { "index", extras.contains("index") ? extras.get("index", 0) : get_mumu_index(address) },
+        };
+
+        json::value fw_config = json::object {
+            { "extras",
+              json::object {
+                  { "mumu", std::move(mumu_config) },
+              } },
+        };
+
+        return {
+            fw_config.to_string(),
+            MaaAdbScreencapMethod::EmulatorExtras,
+            MaaAdbInputMethod::AdbShell,
+            "MumuExtras",
+        };
+    }
+
+    if (config == "LDPlayer") {
+        std::string ld_path = extras.get("path", "");
+        if (ld_path.empty()) {
+            return {};
+        }
+
+        json::object ld_config {
+            { "enable", true },
+            { "path", std::move(ld_path) },
+            { "index", extras.contains("index") ? extras.get("index", 0) : get_ld_index(address) },
+            { "pid", extras.get("pid", 0) },
+        };
+
+        json::value fw_config = json::object {
+            { "extras",
+              json::object {
+                  { "ld", std::move(ld_config) },
+              } },
+        };
+
+        return {
+            fw_config.to_string(),
+            MaaAdbScreencapMethod::EmulatorExtras,
+            MaaAdbInputMethod::AdbShell,
+            "LDExtras",
+        };
+    }
+
+    return {};
+}
+} // namespace
 
 MaaFwAdbController::MaaFwAdbController(
     const AsstCallback& callback,
@@ -87,12 +239,14 @@ bool MaaFwAdbController::connect(const std::string& adb_path, const std::string&
         m_unit_handle = nullptr;
     }
 
+    auto maa_fw_config = make_maa_fw_adb_config(config, address);
+
     m_unit_handle = m_create_func(
         adb_path.c_str(),
         address.c_str(),
-        MaaAdbScreencapMethod::Default,
-        MaaAdbInputMethod::AdbShell | MaaAdbInputMethod::EmulatorExtras,
-        config == "AVD" ? "{\"extras\":{\"avd\":{\"enable\":true}}}" : "{}",
+        maa_fw_config.screencap_methods,
+        maa_fw_config.input_methods,
+        maa_fw_config.json.c_str(),
         // MaaAgentBinary目录
         utils::path_to_utf8_string(ResDir.get()).c_str());
 
@@ -140,6 +294,7 @@ bool MaaFwAdbController::connect(const std::string& adb_path, const std::string&
 
     // 尝试进行一次截图以获取屏幕分辨率
     cv::Mat image;
+    auto screencap_start = std::chrono::steady_clock::now();
     if (!m_unit_handle->screencap(image) || image.cols == 0 || image.rows == 0) {
         m_destroy_func(m_unit_handle);
         m_unit_handle = nullptr;
@@ -151,6 +306,9 @@ bool MaaFwAdbController::connect(const std::string& adb_path, const std::string&
             } | get_info_json());
         return false;
     }
+    auto screencap_cost = std::chrono::duration_cast<std::chrono::milliseconds>(
+                              std::chrono::steady_clock::now() - screencap_start)
+                              .count();
     m_screen_size = { image.cols, image.rows };
     LogInfo << "Connected to ADB. Screen size:" << m_screen_size.first << "x" << m_screen_size.second;
     callback(
@@ -169,6 +327,27 @@ bool MaaFwAdbController::connect(const std::string& adb_path, const std::string&
             { "what", "Connected" },
             { "why", "" },
         } | get_info_json());
+
+    if (!maa_fw_config.screencap_method_name.empty()) {
+        callback(
+            AsstMsg::ConnectionInfo,
+            json::object {
+                { "uuid", m_uuid },
+                { "what", "FastestWayToScreencap" },
+                { "details",
+                  json::object {
+                      { "method", maa_fw_config.screencap_method_name },
+                      { "cost", screencap_cost },
+                      { "alternatives",
+                        json::array {
+                            json::object {
+                                { "method", maa_fw_config.screencap_method_name },
+                                { "cost", std::to_string(screencap_cost) },
+                            },
+                        } },
+                  } },
+            });
+    }
     return true;
 }
 

--- a/src/MaaCore/Controller/MaaFwAdbController.cpp
+++ b/src/MaaCore/Controller/MaaFwAdbController.cpp
@@ -9,6 +9,7 @@
 #include "Common/AsstMsg.h"
 #include "Config/GeneralConfig.h"
 #include "Controller/MaaFwControlUnitInterface.h"
+#include "Controller/SwipeHelper.hpp"
 #include "Utils/Logger.hpp"
 #include "Utils/WorkingDir.hpp"
 
@@ -126,7 +127,7 @@ MaaFwAdbConfig make_maa_fw_adb_config(const std::string& config, const std::stri
         return {
             fw_config.to_string(),
             MaaAdbScreencapMethod::EmulatorExtras,
-            MaaAdbInputMethod::AdbShell,
+            MaaAdbInputMethod::AdbShell | MaaAdbInputMethod::EmulatorExtras,
             "MumuExtras",
         };
     }
@@ -420,6 +421,15 @@ bool MaaFwAdbController::click(const Point& p)
         LogWarn << "MaaAdbControlUnit is not initialized";
         return false;
     }
+
+    if (use_touch_down_up()) {
+        if (!m_unit_handle->touch_down(0, p.x, p.y, 1)) {
+            return false;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        return m_unit_handle->touch_up(0);
+    }
+
     return m_unit_handle->click(p.x, p.y);
 }
 
@@ -437,15 +447,105 @@ bool MaaFwAdbController::swipe(
     const Point& p1,
     const Point& p2,
     int duration,
-    bool extra_swipe [[maybe_unused]],
-    double slope_in [[maybe_unused]],
-    double slope_out [[maybe_unused]],
-    bool with_pause [[maybe_unused]])
+    bool extra_swipe,
+    double slope_in,
+    double slope_out,
+    bool with_pause)
 {
     LogTraceFunction;
     if (!m_unit_handle) {
         LogWarn << "MaaAdbControlUnit is not initialized";
         return false;
+    }
+
+    if (use_touch_down_up()) {
+        int x1 = p1.x, y1 = p1.y;
+        int x2 = p2.x, y2 = p2.y;
+
+        const auto width = m_screen_size.first;
+        const auto height = m_screen_size.second;
+        if (width > 0 && height > 0 && (x1 < 0 || x1 >= width || y1 < 0 || y1 >= height)) {
+            LogWarn << "swipe point1 is out of range" << x1 << y1;
+            x1 = std::clamp(x1, 0, width - 1);
+            y1 = std::clamp(y1, 0, height - 1);
+        }
+
+        if (!m_unit_handle->touch_down(0, x1, y1, 1)) {
+            LogError << "touch_down failed at swipe start point";
+            return false;
+        }
+
+        constexpr int TimeInterval = 5;
+        bool need_pause = with_pause;
+        const auto& opt = Config.get_options();
+
+        auto bounds_check = [width, height](int x, int y) {
+            if (width <= 0 || height <= 0) {
+                return true;
+            }
+            return x >= 0 && x < width && y >= 0 && y < height;
+        };
+
+        auto move_func = [this](int x, int y) -> bool {
+            if (!m_unit_handle->touch_move(0, x, y, 1)) {
+                return false;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(TimeInterval));
+            return true;
+        };
+
+        auto do_swipe = [&](int _x1, int _y1, int _x2, int _y2, int _duration) -> bool {
+            if (need_pause) {
+                auto pause_check = [&opt](int cur_x, int cur_y, int start_x, int start_y) {
+                    return std::sqrt(std::pow(cur_x - start_x, 2) + std::pow(cur_y - start_y, 2)) >
+                           opt.swipe_with_pause_required_distance;
+                };
+
+                return interpolate_swipe_with_pause(
+                    _x1,
+                    _y1,
+                    _x2,
+                    _y2,
+                    _duration,
+                    TimeInterval,
+                    slope_in,
+                    slope_out,
+                    move_func,
+                    bounds_check,
+                    pause_check,
+                    [&]() {
+                        need_pause = false;
+                        press_esc();
+                    });
+            }
+
+            return interpolate_swipe(
+                _x1,
+                _y1,
+                _x2,
+                _y2,
+                _duration,
+                TimeInterval,
+                slope_in,
+                slope_out,
+                move_func,
+                bounds_check);
+        };
+
+        if (!do_swipe(x1, y1, x2, y2, duration ? duration : opt.minitouch_swipe_default_duration)) {
+            LogError << "Failed during main swipe movement";
+            m_unit_handle->touch_up(0);
+            return false;
+        }
+
+        if (extra_swipe && opt.minitouch_extra_swipe_duration > 0) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(opt.minitouch_swipe_extra_end_delay));
+            if (!do_swipe(x2, y2, x2, y2 - opt.minitouch_extra_swipe_dist, opt.minitouch_extra_swipe_duration)) {
+                LogWarn << "Failed during extra swipe movement";
+            }
+        }
+
+        return m_unit_handle->touch_up(0);
     }
 
     return m_unit_handle->swipe(p1.x, p1.y, p2.x, p2.y, duration);
@@ -491,12 +591,25 @@ bool MaaFwAdbController::press_esc()
         return false;
     }
 
+    if (use_key_down_up()) {
+        constexpr int EscKeyCode = 111;
+        if (!m_unit_handle->key_down(EscKeyCode)) {
+            return false;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        return m_unit_handle->key_up(EscKeyCode);
+    }
+
     return m_unit_handle->click_key(111); // KEYCODE_ESCAPE
 }
 
 ControlFeat::Feat MaaFwAdbController::support_features() const noexcept
 {
-    return ControlFeat::PRECISE_SWIPE;
+    auto feat = ControlFeat::PRECISE_SWIPE;
+    if (use_touch_down_up()) {
+        feat |= ControlFeat::SWIPE_WITH_PAUSE;
+    }
+    return feat;
 }
 
 std::pair<int, int> MaaFwAdbController::get_screen_res() const noexcept
@@ -509,6 +622,24 @@ void MaaFwAdbController::callback(AsstMsg msg, const json::value& details)
     if (m_callback) {
         m_callback(msg, details, m_inst);
     }
+}
+
+uint64_t MaaFwAdbController::get_maa_fw_features() const noexcept
+{
+    if (!m_unit_handle) {
+        return MaaFeature::None;
+    }
+    return m_unit_handle->get_features();
+}
+
+bool MaaFwAdbController::use_touch_down_up() const noexcept
+{
+    return get_maa_fw_features() & MaaFeature::UseMouseDownAndUpInsteadOfClick;
+}
+
+bool MaaFwAdbController::use_key_down_up() const noexcept
+{
+    return get_maa_fw_features() & MaaFeature::UseKeyboardDownAndUpInsteadOfClick;
 }
 
 } // namespace asst

--- a/src/MaaCore/Controller/MaaFwAdbController.h
+++ b/src/MaaCore/Controller/MaaFwAdbController.h
@@ -65,6 +65,9 @@ private:
 
     MaaFwAdbControlUnitAPI* m_unit_handle = nullptr;
     bool init_library();
+    uint64_t get_maa_fw_features() const noexcept;
+    bool use_touch_down_up() const noexcept;
+    bool use_key_down_up() const noexcept;
 
     AsstCallback m_callback = nullptr;
     void callback(AsstMsg msg, const json::value& details);

--- a/src/MaaCore/Controller/MaaFwControlUnitInterface.h
+++ b/src/MaaCore/Controller/MaaFwControlUnitInterface.h
@@ -67,8 +67,9 @@ public:
 namespace MaaFeature
 {
 constexpr uint64_t None = 0;
-constexpr uint64_t UseMouseDownAndUpInsteadOfClick = 1ULL << 1;
-constexpr uint64_t UseKeyboardDownAndUpInsteadOfClick = 1ULL << 2;
+constexpr uint64_t UseMouseDownAndUpInsteadOfClick = 1ULL;
+constexpr uint64_t UseKeyboardDownAndUpInsteadOfClick = 1ULL << 1;
+constexpr uint64_t NoScalingTouchPoints = 1ULL << 2;
 } // namespace MaaFeature
 
 // 与 MaaFramework 的 MaaAdbScreencapMethod 兼容的常量


### PR DESCRIPTION
## Summary

Fixes MaaFramework ADB control for emulator extras, especially MuMu:

- Translate MAA emulator extras config into the JSON schema expected by MaaFramework `MaaAdbControlUnit`.
- Report the fastest screencap method back to MAA when emulator extras are selected.
- Respect MaaFramework control-unit feature flags and synthesize input with `touch_down`/`touch_move`/`touch_up` or key down/up when required.

## Root Cause

`MaaFwAdbController` previously passed `{}` for non-AVD configs, so MuMu/LDPlayer extras configured by the GUI never reached MaaFramework. That made MuMu enhanced screenshot unavailable under `TouchMode = MaaFwAdb`.

After enabling MuMu emulator extras input, MaaFramework's MuMu extras control unit advertises that click should be performed with down/up events instead of `click()`. `MaaFwAdbController` did not handle that feature flag, so direct `click()` could fail even though the control unit was initialized.

## Validation

Validated locally on Windows with MuMu 12 and `TouchMode = MaaFwAdb`:

- Built `MaaCore` with CMake `RelWithDebInfo` successfully.
- `git diff --check` passed.
- GUI reported fastest screenshot as `MumuExtras` with 7ms cost.
- Core log showed `MaaFwAdbController` and `MaaAdbControlUnit`, not MaaTouch.
- Auto battle completed successfully with `MaaFwAdbController::click`/`swipe` calls.

## Summary by Sourcery

将 MaaFramework 的 ADB 模拟器附加配置和特性开关集成到 `MaaFwAdbController` 中，以改进模拟器截屏和输入行为。

New Features:
- 支持 MuMu 12 和 LDPlayer 模拟器附加配置：将 GUI 中的 ADB 配置转换为 `MaaAdbControlUnit` 所需的 JSON 模式，并传递合适的截屏和输入方法。
- 当使用模拟器附加配置时，将所选择的最快截屏方式及其性能开销回传给 GUI。

Bug Fixes:
- 确保 `MaaFwAdbController` 遵循 MaaFramework 控制单元的特性开关，在需要时使用 `touch_down` / `touch_move` / `touch_up` 和按键按下/抬起替代点击操作，从而避免在使用模拟器附加配置时发生输入失败。

Enhancements:
- 从 `MaaFwAdbController` 暴露 MaaFramework 的特性开关，并在支持触控输入时声明对 `SWIPE_WITH_PAUSE` 的支持。
- 通过复用既有的插值辅助函数来改进 ADB 上的滑动处理，以实现精确滑动，包括可选的额外滑动和停顿行为。
- 在未显式配置时，根据 ADB 地址推导 MuMu 和 LDPlayer 的模拟器实例索引，从而提高附加配置的健壮性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate MaaFramework ADB emulator extras configuration and feature flags into MaaFwAdbController to improve emulator screencap and input behavior.

New Features:
- Support MuMu 12 and LDPlayer emulator extras by translating GUI ADB configs into the JSON schema required by MaaAdbControlUnit and passing appropriate screencap and input methods.
- Report the selected fastest screencap method and its cost back to the GUI when emulator extras are used.

Bug Fixes:
- Ensure MaaFwAdbController honors MaaFramework control-unit feature flags to use touch_down/touch_move/touch_up and key down/up instead of click when required, preventing input failures with emulator extras.

Enhancements:
- Expose MaaFramework feature flags from MaaFwAdbController and advertise SWIPE_WITH_PAUSE support when touch-based input is available.
- Improve swipe handling over ADB by reusing existing interpolation helpers for precise swipes, including optional extra swipe and pause behavior.
- Derive emulator instance indices for MuMu and LDPlayer from ADB addresses when not explicitly configured, improving robustness of extras configuration.

</details>