### PR TITLE
fix: handle PC event page after startup loading

### DIFF
--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -882,7 +882,8 @@
             "StartUpBegin@LoadingIcon",
             "StartUp@ReturnButtons#next",
             "StartUp@EndOfAction",
-            "StartUp@PRTS#next"
+            "StartUp@PRTS#next",
+            "ClosePCEventPage"
         ]
     },
     "GameStart": {
@@ -918,7 +919,7 @@
     "StartToWakeUpOCR": {
         "baseTask": "StartToWakeUp",
         "algorithm": "OcrDetect",
-        "text": ["开始唤醒", "登录", "登", "录"],
+        "text": ["开始唤醒", "登录", "登", "录", "签到"],
         "fullMatch": true,
         "roi": [373, 145, 535, 430]
     },
@@ -951,7 +952,7 @@
         "next": ["Home"]
     },
     "StartUp": {
-        "Doc": "有时候明明已经在主界面了，停了一小会又弹个窗。多检测几次，一直在主界面才算完成",
+        "Doc": "主界面确认 — 多检测几次，一直在主界面才算完成",
         "template": "SwitchTheme@ToggleSettingsMenu.png",
         "action": "DoNothing",
         "roi": [227, 327, 159, 152],
@@ -959,9 +960,94 @@
         "maxTimes": 3,
         "next": ["StartUp", "StartUp@LoadingText", "StartUp@CloseAnnos#next"]
     },
+    "ClosePCEventPage": {
+        "Doc": "PC端活动页面兜底检查 — 由插件识别左上角模糊主页图标，命中后通过ESC关闭",
+        "algorithm": "JustReturn",
+        "action": "DoNothing",
+        "postDelay": 0,
+        "maxTimes": 1,
+        "next": ["ClosePCEventPageEsc"],
+        "exceededNext": ["ClosePCEventPageEsc"]
+    },
+    "ClosePCEventPageEsc": {
+        "Doc": "PC端活动页面ESC关闭 — 按ESC后延迟等待动画结束，再闭环检查主界面/弹窗",
+        "algorithm": "JustReturn",
+        "action": "DoNothing",
+        "postDelay": 1000,
+        "maxTimes": 3,
+        "next": [
+            "StartUp",
+            "StartUp@LoadingText",
+            "MainThemes#next",
+            "StartUp@CloseAnnoTexas",
+            "StartUp@CloseAnnoSpecialAccess",
+            "StartUp@TodaysSupplies",
+            "StartUp@NotDownloadVoice",
+            "ClosePCEventPageEsc"
+        ],
+        "on_error_next": ["StartUp@AfterLoadingIcon"],
+        "exceededNext": ["StartUp@AfterLoadingIcon"]
+    },
     "CloseAnnos": {
         "algorithm": "JustReturn",
         "next": ["CloseAnno", "CloseAnnoTexas", "CloseAnnoSpecialAccess", "TodaysSupplies", "NotDownloadVoice"]
+    },
+    "StartUp@TodaysSupplies": {
+        "baseTask": "TodaysSupplies",
+        "next": ["StartUp@TodaysSuppliesPostCheck"]
+    },
+    "StartUp@TodaysSuppliesPostCheck": {
+        "Doc": "今日配给领取后先判定主页，未到主页则优先关闭签到/物资层",
+        "algorithm": "JustReturn",
+        "next": ["StartUp", "StartUp@LoadingText", "StartUp@TodaysSuppliesCloseAnno"]
+    },
+    "StartUp@TodaysSuppliesCloseAnno": {
+        "Doc": "今日配给后置关闭 — 最多关闭两层签到/物资弹窗，之后再进入活动页兜底",
+        "template": "empty.png",
+        "action": "ClickSelf",
+        "roi": [1100, 0, 180, 200],
+        "postDelay": 1000,
+        "maxTimes": 2,
+        "next": ["StartUp", "StartUp@LoadingText", "StartUp@TodaysSuppliesCloseAnno"],
+        "exceededNext": ["StartUp@TodaysSuppliesEventPageCheck"]
+    },
+    "StartUp@TodaysSuppliesEventPageCheck": {
+        "Doc": "今日配给后置二次主页判定 — 仍未到主页时按 PC 活动页处理",
+        "algorithm": "JustReturn",
+        "next": ["StartUp", "StartUp@LoadingText", "ClosePCEventPage"]
+    },
+    "StartUp@AfterLoadingIcon": {
+        "Doc": "开始唤醒加载后候选 — 先处理主页/签到/明确弹窗，再进入 PC 活动页兜底，最后普通公告关闭",
+        "algorithm": "JustReturn",
+        "next": [
+            "StartUp",
+            "StartUp@LoadingText",
+            "StartUp@TodaysSupplies",
+            "StartUp@CloseAnnoTexas",
+            "StartUp@CloseAnnoSpecialAccess",
+            "StartUp@NotDownloadVoice",
+            "ClosePCEventPage"
+        ]
+    },
+    "StartUp@GameStart@LoadingIcon": {
+        "baseTask": "LoadingIcon",
+        "template": "LoadingIcon.png",
+        "next": ["StartUp@GameStart@LoadingIcon", "StartUp@AfterLoadingIcon"]
+    },
+    "StartUp@StartToWakeUp@LoadingIcon": {
+        "baseTask": "LoadingIcon",
+        "template": "LoadingIcon.png",
+        "next": ["StartUp@StartToWakeUp@LoadingIcon", "StartUp@AfterLoadingIcon"]
+    },
+    "StartUp@StartLoginBServer@LoadingIcon": {
+        "baseTask": "LoadingIcon",
+        "template": "LoadingIcon.png",
+        "next": ["StartUp@StartLoginBServer@LoadingIcon", "StartUp@AfterLoadingIcon"]
+    },
+    "StartUp@StartUpConnectingFlag@LoadingIcon": {
+        "baseTask": "LoadingIcon",
+        "template": "LoadingIcon.png",
+        "next": ["StartUp@StartUpConnectingFlag@LoadingIcon", "StartUp@AfterLoadingIcon"]
     },
     "MainThemes": {
         "Doc": "使用本任务时带上 #next",

--- a/src/MaaCore/Controller/Win32Controller.cpp
+++ b/src/MaaCore/Controller/Win32Controller.cpp
@@ -338,6 +338,36 @@ bool Win32Controller::press_esc()
     return unit_click_key(VK_ESCAPE); // VK_ESCAPE = 0x1B, defined in WinUser.h
 }
 
+bool Win32Controller::press_esc_with_foreground()
+{
+    LogTraceFunction;
+
+    bool ret = unit_click_key(VK_ESCAPE);
+
+    if (m_hwnd) {
+        SetForegroundWindow(static_cast<HWND>(m_hwnd));
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+
+    INPUT inputs[2] = {};
+    inputs[0].type = INPUT_KEYBOARD;
+    inputs[0].ki.wVk = VK_ESCAPE;
+    inputs[1].type = INPUT_KEYBOARD;
+    inputs[1].ki.wVk = VK_ESCAPE;
+    inputs[1].ki.dwFlags = KEYEVENTF_KEYUP;
+
+    const UINT sent = SendInput(2, inputs, sizeof(INPUT));
+    if (sent != 2) {
+        Log.warn(
+            "press_esc_with_foreground: SendInput did not send all events, sent:",
+            sent,
+            "expected: 2, last_error:",
+            GetLastError());
+    }
+
+    return ret || sent == 2;
+}
+
 ControlFeat::Feat Win32Controller::support_features() const noexcept
 {
     return ControlFeat::PRECISE_SWIPE;

--- a/src/MaaCore/Controller/Win32Controller.h
+++ b/src/MaaCore/Controller/Win32Controller.h
@@ -63,6 +63,7 @@ public: // ControllerAPI 接口
     virtual bool inject_input_event(const InputEvent& event) override;
 
     virtual bool press_esc() override;
+    bool press_esc_with_foreground();
     virtual ControlFeat::Feat support_features() const noexcept override;
 
     virtual std::pair<int, int> get_screen_res() const noexcept override;

--- a/src/MaaCore/Task/Interface/StartUpEventPagePlugin.cpp
+++ b/src/MaaCore/Task/Interface/StartUpEventPagePlugin.cpp
@@ -1,0 +1,103 @@
+#include "StartUpEventPagePlugin.h"
+
+#include <algorithm>
+#include <array>
+
+#include "Controller/Controller.h"
+#include "Controller/Win32Controller.h"
+#include "MaaUtils/NoWarningCV.hpp"
+#include "Utils/Logger.hpp"
+
+bool asst::StartUpEventPagePlugin::verify(AsstMsg msg, const json::value& details) const
+{
+    if (msg != AsstMsg::SubTaskCompleted || details.get("subtask", std::string()) != "ProcessTask") {
+        return false;
+    }
+
+    const std::string task = details.get("details", "task", "");
+    return task == EscTaskName || task.ends_with("@" + std::string(EscTaskName));
+}
+
+bool asst::StartUpEventPagePlugin::_run()
+{
+    const cv::Mat image = ctrler()->get_image();
+    if (!is_pc_event_page(image)) {
+        Log.info(__FUNCTION__, "| PC event page icon pattern not detected, skip ESC fallback");
+        return true;
+    }
+
+    Log.info(__FUNCTION__, "| PC event page icon pattern detected, press ESC");
+#ifdef _WIN32
+    if (auto* win32_controller = dynamic_cast<Win32Controller*>(ctrler()->get_underlying())) {
+        return win32_controller->press_esc_with_foreground();
+    }
+#endif
+    return ctrler()->press_esc();
+}
+
+bool asst::StartUpEventPagePlugin::is_pc_event_page(const cv::Mat& image)
+{
+    if (image.empty()) {
+        return false;
+    }
+
+    const double scale = image.cols / 1280.0;
+    const int roi_width = std::clamp(static_cast<int>(330 * scale), 1, image.cols);
+    const int roi_height = std::clamp(static_cast<int>(95 * scale), 1, image.rows);
+    const cv::Rect roi(0, 0, roi_width, roi_height);
+
+    cv::Mat hsv;
+    cv::cvtColor(image(roi), hsv, cv::COLOR_BGR2HSV);
+
+    cv::Mat mask;
+    cv::inRange(hsv, cv::Scalar(0, 0, 145), cv::Scalar(179, 85, 255), mask);
+    const cv::Mat kernel = cv::getStructuringElement(cv::MORPH_ELLIPSE, cv::Size(3, 3));
+    cv::morphologyEx(mask, mask, cv::MORPH_OPEN, kernel);
+
+    cv::Mat labels;
+    cv::Mat stats;
+    cv::Mat centroids;
+    const int component_count = cv::connectedComponentsWithStats(mask, labels, stats, centroids, 8);
+
+    std::vector<double> icon_centers;
+    const int min_area = std::max(80, static_cast<int>(80 * scale * scale));
+    const int max_area = std::max(min_area + 1, static_cast<int>(5000 * scale * scale));
+    const int min_size = std::max(8, static_cast<int>(8 * scale));
+    const int max_size = std::max(min_size + 1, static_cast<int>(70 * scale));
+    const int max_top = static_cast<int>(70 * scale);
+
+    for (int index = 1; index < component_count; ++index) {
+        const int y = stats.at<int>(index, cv::CC_STAT_TOP);
+        const int width = stats.at<int>(index, cv::CC_STAT_WIDTH);
+        const int height = stats.at<int>(index, cv::CC_STAT_HEIGHT);
+        const int area = stats.at<int>(index, cv::CC_STAT_AREA);
+
+        if (area < min_area || area > max_area || width < min_size || width > max_size || height < min_size ||
+            height > max_size || y > max_top) {
+            continue;
+        }
+
+        icon_centers.emplace_back(centroids.at<double>(index, 0));
+    }
+
+    std::ranges::sort(icon_centers);
+
+    std::vector<double> separated_centers;
+    const double min_gap = 35 * scale;
+    for (const double center : icon_centers) {
+        if (separated_centers.empty() || center - separated_centers.back() >= min_gap) {
+            separated_centers.emplace_back(center);
+        }
+    }
+
+    Log.info(
+        __FUNCTION__,
+        "| detected top-left icon components:",
+        separated_centers.size(),
+        "image:",
+        image.cols,
+        "x",
+        image.rows);
+
+    return separated_centers.size() >= 3;
+}

--- a/src/MaaCore/Task/Interface/StartUpEventPagePlugin.h
+++ b/src/MaaCore/Task/Interface/StartUpEventPagePlugin.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "Task/AbstractTaskPlugin.h"
+
+namespace cv
+{
+class Mat;
+}
+
+namespace asst
+{
+class StartUpEventPagePlugin final : public AbstractTaskPlugin
+{
+public:
+    using AbstractTaskPlugin::AbstractTaskPlugin;
+    virtual ~StartUpEventPagePlugin() override = default;
+
+    virtual bool verify(AsstMsg msg, const json::value& details) const override;
+
+protected:
+    virtual bool _run() override;
+
+private:
+    static bool is_pc_event_page(const cv::Mat& image);
+
+    static constexpr std::string_view EscTaskName = "ClosePCEventPageEsc";
+};
+}

--- a/src/MaaCore/Task/Interface/StartUpTask.cpp
+++ b/src/MaaCore/Task/Interface/StartUpTask.cpp
@@ -5,6 +5,7 @@
 #include "Config/GeneralConfig.h"
 #include "Task/Miscellaneous/AccountSwitchTask.h"
 #include "Task/Miscellaneous/StartGameTaskPlugin.h"
+#include "Task/Interface/StartUpEventPagePlugin.h"
 #include "Task/ProcessTask.h"
 #include "Utils/Logger.hpp"
 
@@ -23,6 +24,7 @@ asst::StartUpTask::StartUpTask(const AsstCallback& callback, Assistant* inst) :
         .set_times_limit("StartButton1", 0)
         .set_task_delay(Config.get_options().task_delay * 2)
         .set_retry_times(50);
+    m_start_up_task_ptr->register_plugin<StartUpEventPagePlugin>();
     m_start_game_task_ptr->set_retry_times(0);
     m_account_switch_task_ptr->set_retry_times(0);
 }


### PR DESCRIPTION
## 变更说明

修复 PC 端开始唤醒流程中，首次进入游戏后活动页可能无法关闭，导致 `StartUp` 卡住的问题。

本次改动将 PC 活动页关闭从任务 action 调整为 StartUp 专用插件处理：

- 新增 `StartUpEventPagePlugin`
  - 仅在 `ClosePCEventPageEsc` 任务完成后触发
  - 通过截图检测左上角模糊的主页图标特征，判断当前是否为 PC 活动页
  - 只有确认命中 PC 活动页时才发送 ESC
- 移除原先的通用 `PressEsc` action 方案
- 未修改全局 `Win32Controller::press_esc()` 行为
- 将 `ClosePCEventPage` 保留为 StartUp 后置兜底节点，避免影响原有签到、公告关闭流程
- 保留今日配给后的专用关闭链路：
  - 先处理 `TodaysSupplies`
  - 再关闭签到/物资层
  - 最后才进入 PC 活动页 ESC 兜底

## 背景

PC 活动页在部分情况下无法通过普通模板关闭，并且活动页会覆盖主界面，导致 `StartUp` 无法识别主页并持续重试。

之前的方案曾尝试直接点击右上角或使用通用 `PressEsc` action，但存在以下问题：

- 固定点击位置不稳定
- 通用 `PressEsc` action 影响范围较大
- 仅依赖前序任务未匹配来判断活动页，容易误判签到页或其他弹窗

因此这次改为在 StartUp 流程中显式增加活动页兜底节点，并由插件二次确认当前画面是否符合 PC 活动页特征。

## 验证

本地验证：

- `cmake --build D:\MAA_Code\build --config RelWithDebInfo --target MaaCore smoke_test --parallel 4` 通过
- `D:\MAA_Code\build\bin\RelWithDebInfo\smoke_test.exe` 通过
- 连续多天手动测试开始唤醒全流程通过

手动测试覆盖：

- 从启动游戏开始完整 StartUp 流程
- 今日配给 / 签到领取流程
- 今日配给领取后关闭签到/物资层
- PC 活动页出现后通过 ESC 关闭
- 活动页关闭后成功回到主页并完成 StartUp

最近日志表现：

- 2026-06-30：StartUp 完成
- 2026-07-01：StartUp 完成
- 活动页识别命中后执行 ESC
- ESC 后成功识别主页并完成 StartUp
- 未出现 `TaskChainError`
- 未出现资源加载失败
- 未出现 `SendInput` 失败