### PR TITLE
ci: use ai-issue-analysis for automated changelog generation

### DIFF
--- a/.github/workflows/release-preparation.yml
+++ b/.github/workflows/release-preparation.yml
@@ -7,107 +7,66 @@ on:
       - reopened
       - ready_for_review
   workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number for changelog generation (workflow_dispatch only)'
+        required: false
+        type: number
 
 jobs:
-  # changelog 现已停用自动生成，改由 AI 根据 .claude/skills/changelog/SKILL.md 手动生成。
-  # 如需恢复自动生成，取消下方 generate-changelog job 的注释即可。
-  #
-  # generate-changelog:
-  #   name: Generate Changelog
-  #   # startsWith 表达式不区分大小写
-  #   # fork 守卫：自动化流程对 fork PR 无效（token 只读），提前短路以避免 runner 上的表达式注入
-  #   if: github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.draft == false && startsWith(github.event.pull_request.title, 'Release v')
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v7
-  #       with:
-  #         fetch-depth: 0
-  #         show-progress: false
-  #
-  #     - name: Extract release information
-  #       id: extract_tag
-  #       env:
-  #         PR_BODY: ${{ format('{0}/{1}', runner.temp, 'output' ) }}
-  #         PR_TITLE: ${{ github.event.pull_request.title }}
-  #         PR_URL: ${{ github.event.pull_request.html_url }}
-  #       run: |
-  #         tag_name=$(printf '%s' "$PR_TITLE" | sed -E 's/(Release|release)//' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
-  #         echo "tag_name=$tag_name" >> $GITHUB_OUTPUT
-  #
-  #         pr_title="docs: Auto Update Changelogs of "$tag_name
-  #         echo "pr_title=$pr_title" >> $GITHUB_OUTPUT
-  #
-  #         latest_stable_tag=$(git tag -l 'v*' | grep -v '-' | sort -V | tail -n 1) # 上一个 stable 版本
-  #         newest_tag=$(git describe --tags --match "v*" --abbrev=0) # 最新版本
-  #         echo "latest_stable_tag=$latest_stable_tag" >> $GITHUB_OUTPUT
-  #         echo "newest_tag=$newest_tag" >> $GITHUB_OUTPUT
-  #
-  #         if [[ $tag_name == *-* ]]; then # 判断新版本是否为 beta 版本
-  #           latest=$newest_tag            # 若是，则将 latest 参数设置为最新版本
-  #         else
-  #           latest=$latest_stable_tag     # 若否，则设置为上一个 stable 版本
-  #         fi
-  #
-  #         echo "latest=$latest" >> $GITHUB_OUTPUT
-  #
-  #         cat $GITHUB_OUTPUT
-  #
-  #         echo '======='
-  #
-  #         echo "Target PR: $PR_URL" >> $PR_BODY
-  #         echo '' >> $PR_BODY
-  #         echo '<details><summary>Debug information</summary>' >> $PR_BODY
-  #         echo '' >> $PR_BODY
-  #         echo '```' >> $PR_BODY
-  #         sed 's/=/: /1' $GITHUB_OUTPUT >> $PR_BODY
-  #         echo '```' >> $PR_BODY
-  #         echo '' >> $PR_BODY
-  #         echo '</details>' >> $PR_BODY
-  #
-  #         cat $PR_BODY
-  #
-  #     - name: Generate changelog
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #         TAG_NAME: ${{ steps.extract_tag.outputs.tag_name }}
-  #         LATEST: ${{ steps.extract_tag.outputs.latest }}
-  #       run: |
-  #         git switch dev-v2
-  #         python3 tools/ChangelogGenerator/changelog_generator.py --tag "$TAG_NAME" --latest "$LATEST"
-  #
-  #     - name: Commit changes
-  #       env:
-  #         TAG_NAME: ${{ steps.extract_tag.outputs.tag_name }}
-  #       run: |
-  #         git status
-  #
-  #         git config user.name "$GITHUB_ACTOR"
-  #         git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-  #         git add .
-  #
-  #         commit_msg="docs: Auto Generate Changelog of Release $TAG_NAME"
-  #         git commit -m "$commit_msg"
-  #
-  #     - name: Create changelog PR
-  #       uses: peter-evans/create-pull-request@v8
-  #       with:
-  #         sign-commits: true
-  #         token: ${{ secrets.GITHUB_TOKEN }}
-  #         title: ${{ steps.extract_tag.outputs.pr_title }}
-  #         body-path: ${{ format('{0}/{1}', runner.temp, 'output' ) }}
-  #         base: "dev-v2"
-  #         branch: "changelog"
-  #         delete-branch: true
-  #         reviewers: |
-  #           AnnAngela
-  #         assignees: |
-  #           AnnAngela
-  #
-  #     - name: Assign reviewers to release PR
-  #       uses: kentaro-m/auto-assign-action@v2.0.2
-  #       with:
-  #         configuration-path: ".github/release_reviewers.yaml"
+  generate-changelog:
+    name: Generate Changelog
+    if: |
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number != '') ||
+      (github.event.pull_request.head.repo.full_name == github.repository &&
+       github.event.pull_request.draft == false &&
+       startsWith(github.event.pull_request.title, 'Release v'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout with full history
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          show-progress: false
+
+      - name: Generate changelog with AI
+        id: analysis
+        continue-on-error: true
+        uses: MistEO/ai-issue-analysis@main
+        with:
+          agent: claude
+          api-key: ${{ secrets.BOT_AI_API_KEY }}
+          api-base-url: ${{ secrets.BOT_AI_API_BASE_URL }}
+          model: ${{ secrets.BOT_AI_MODEL }}
+          github-token: ${{ secrets.MAA_BOT_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+          checkout-repository: false
+          initial-comment-body: |
+            🤖 **AI 正在生成 Changelog...**
+
+            正在根据提交记录自动生成 Changelog，预计耗时约 10 分钟。
+          prompt-template: |
+            你是 MAA 项目的 Changelog 生成专员。
+
+            当前 Release PR 编号为 #{{issue_number}}（仓库 {{repository}}），请从该 PR 标题中提取目标版本号。
+            严格按照 .claude/skills/changelog/SKILL.md 中的规则，分析 git 提交记录（tag 间的 commit 及其 diff）和现有 CHANGELOG.md，生成新版本的 Changelog。
+
+            把最终生成的 Changelog Markdown 写到 {{answer_file}}。
+          details-summary: 点击此处展开生成过程
+
+      - name: Show outputs
+        if: always()
+        env:
+          COMMENT_ID: ${{ steps.analysis.outputs.comment-id }}
+          COMMENT_URL: ${{ steps.analysis.outputs.comment-url }}
+        run: |
+          echo "comment_id=$COMMENT_ID"
+          echo "comment_url=$COMMENT_URL"
+          echo "(Full agent-output and final-conclusion are available in the uploaded artifacts)"
 
   assign-release-reviewers:
     name: Assign Reviewers to Release PR
@@ -124,7 +83,6 @@ jobs:
 
   update-submodules:
     name: Update Submodules
-    # fork 守卫：同上，fork PR 的 token 只读，write 步骤必然失败
     if: github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.draft == false && startsWith(github.event.pull_request.title, 'Release v')
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Replace the old commented-out Python changelog generator with \i-issue-analysis@main\ action.

- Triggered on Release PR (title starts with \Release v\) or via workflow_dispatch with PR number
- Uses \.claude/skills/changelog/SKILL.md\ as the generation rule
- Posts generated changelog as a PR comment for review

Test: will trigger via workflow_dispatch to verify

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

将基于 AI 的变更日志生成任务集成到发布准备工作流中，可在发布 PR 上自动触发，也可通过手动 dispatch 触发。

Enhancements:
- 移除已弃用且被注释掉的、基于 Python 的变更日志生成流程，改用新的 AI 驱动流程。

CI:
- 新增一个 `generate-changelog` 任务，使用 `ai-issue-analysis` action 和基于 Claude 的规则，为发布 PR 生成并评论变更日志。
- 扩展 `release-preparation` 的 `workflow_dispatch`，允许接受一个可选的 PR 编号输入，用于手动运行变更日志生成。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate an AI-based changelog generation job into the release preparation workflow, triggered for release PRs or via manual dispatch.

Enhancements:
- Remove the deprecated, commented-out Python-based changelog generation flow in favor of the new AI-driven process.

CI:
- Add a generate-changelog job that uses the ai-issue-analysis action with Claude-based rules to generate and comment a changelog for release PRs.
- Extend the release-preparation workflow_dispatch to accept an optional PR number input for manual changelog generation runs.

</details>