### PR TITLE
ci: AI changelog generation with auto PR creation

### DIFF
--- a/.github/workflows/release-preparation.yml
+++ b/.github/workflows/release-preparation.yml
@@ -76,13 +76,19 @@ jobs:
       - name: Write CHANGELOG.md from AI output
         if: steps.analysis.outcome == 'success'
         run: |
-          if [ -f answer.md ] && [ -s answer.md ]; then
-            cp answer.md CHANGELOG.md
-            echo "CHANGELOG.md updated from AI output ($(wc -l < CHANGELOG.md) lines)"
-            git diff --stat CHANGELOG.md
-          else
+          if [ ! -f answer.md ] || [ ! -s answer.md ]; then
             echo "::error::answer.md not found or empty, cannot update CHANGELOG.md"
             exit 1
+          fi
+
+          cp answer.md CHANGELOG.md
+          echo "CHANGELOG.md updated from AI output ($(wc -l < CHANGELOG.md) lines)"
+
+          if git diff --quiet CHANGELOG.md 2>/dev/null; then
+            echo "::warning::AI output is identical to existing CHANGELOG.md, no PR will be created"
+          else
+            echo "Changes detected:"
+            git diff --stat CHANGELOG.md
           fi
 
       - name: Create changelog PR

--- a/.github/workflows/release-preparation.yml
+++ b/.github/workflows/release-preparation.yml
@@ -67,12 +67,23 @@ jobs:
             你是 MAA 项目的 Changelog 生成专员。
 
             当前 Release PR 编号为 #{{issue_number}}（仓库 {{repository}}），请从该 PR 标题中提取目标版本号。
-            严格按照 .claude/skills/changelog/SKILL.md 中的规则：
+            严格按照 .claude/skills/changelog/SKILL.md 中的规则，分析 git 提交记录（tag 间的 commit 及其 diff）和现有 CHANGELOG.md，
+            生成完整的新版本 Changelog Markdown 并写到 {{answer_file}}。
 
-            1. 分析 git 提交记录（tag 间的 commit 及其 diff）和现有 CHANGELOG.md
-            2. 直接更新 CHANGELOG.md 文件
-            3. 把本次 Changelog 变更的简要说明写到 {{answer_file}}（将作为 PR 评论发布）
+            {{answer_file}} 的内容应当是可以直接替换 CHANGELOG.md 整个文件的完整内容（包含新版本和所有历史版本）。
           details-summary: 点击此处展开生成过程
+
+      - name: Write CHANGELOG.md from AI output
+        if: steps.analysis.outcome == 'success'
+        run: |
+          if [ -f answer.md ] && [ -s answer.md ]; then
+            cp answer.md CHANGELOG.md
+            echo "CHANGELOG.md updated from AI output ($(wc -l < CHANGELOG.md) lines)"
+            git diff --stat CHANGELOG.md
+          else
+            echo "::error::answer.md not found or empty, cannot update CHANGELOG.md"
+            exit 1
+          fi
 
       - name: Create changelog PR
         if: steps.analysis.outcome == 'success'

--- a/.github/workflows/release-preparation.yml
+++ b/.github/workflows/release-preparation.yml
@@ -7,107 +7,101 @@ on:
       - reopened
       - ready_for_review
   workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'Release PR number for changelog generation'
+        required: false
+        type: number
 
 jobs:
-  # changelog 现已停用自动生成，改由 AI 根据 .claude/skills/changelog/SKILL.md 手动生成。
-  # 如需恢复自动生成，取消下方 generate-changelog job 的注释即可。
-  #
-  # generate-changelog:
-  #   name: Generate Changelog
-  #   # startsWith 表达式不区分大小写
-  #   # fork 守卫：自动化流程对 fork PR 无效（token 只读），提前短路以避免 runner 上的表达式注入
-  #   if: github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.draft == false && startsWith(github.event.pull_request.title, 'Release v')
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout repository
-  #       uses: actions/checkout@v7
-  #       with:
-  #         fetch-depth: 0
-  #         show-progress: false
-  #
-  #     - name: Extract release information
-  #       id: extract_tag
-  #       env:
-  #         PR_BODY: ${{ format('{0}/{1}', runner.temp, 'output' ) }}
-  #         PR_TITLE: ${{ github.event.pull_request.title }}
-  #         PR_URL: ${{ github.event.pull_request.html_url }}
-  #       run: |
-  #         tag_name=$(printf '%s' "$PR_TITLE" | sed -E 's/(Release|release)//' | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
-  #         echo "tag_name=$tag_name" >> $GITHUB_OUTPUT
-  #
-  #         pr_title="docs: Auto Update Changelogs of "$tag_name
-  #         echo "pr_title=$pr_title" >> $GITHUB_OUTPUT
-  #
-  #         latest_stable_tag=$(git tag -l 'v*' | grep -v '-' | sort -V | tail -n 1) # 上一个 stable 版本
-  #         newest_tag=$(git describe --tags --match "v*" --abbrev=0) # 最新版本
-  #         echo "latest_stable_tag=$latest_stable_tag" >> $GITHUB_OUTPUT
-  #         echo "newest_tag=$newest_tag" >> $GITHUB_OUTPUT
-  #
-  #         if [[ $tag_name == *-* ]]; then # 判断新版本是否为 beta 版本
-  #           latest=$newest_tag            # 若是，则将 latest 参数设置为最新版本
-  #         else
-  #           latest=$latest_stable_tag     # 若否，则设置为上一个 stable 版本
-  #         fi
-  #
-  #         echo "latest=$latest" >> $GITHUB_OUTPUT
-  #
-  #         cat $GITHUB_OUTPUT
-  #
-  #         echo '======='
-  #
-  #         echo "Target PR: $PR_URL" >> $PR_BODY
-  #         echo '' >> $PR_BODY
-  #         echo '<details><summary>Debug information</summary>' >> $PR_BODY
-  #         echo '' >> $PR_BODY
-  #         echo '```' >> $PR_BODY
-  #         sed 's/=/: /1' $GITHUB_OUTPUT >> $PR_BODY
-  #         echo '```' >> $PR_BODY
-  #         echo '' >> $PR_BODY
-  #         echo '</details>' >> $PR_BODY
-  #
-  #         cat $PR_BODY
-  #
-  #     - name: Generate changelog
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #         TAG_NAME: ${{ steps.extract_tag.outputs.tag_name }}
-  #         LATEST: ${{ steps.extract_tag.outputs.latest }}
-  #       run: |
-  #         git switch dev-v2
-  #         python3 tools/ChangelogGenerator/changelog_generator.py --tag "$TAG_NAME" --latest "$LATEST"
-  #
-  #     - name: Commit changes
-  #       env:
-  #         TAG_NAME: ${{ steps.extract_tag.outputs.tag_name }}
-  #       run: |
-  #         git status
-  #
-  #         git config user.name "$GITHUB_ACTOR"
-  #         git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
-  #         git add .
-  #
-  #         commit_msg="docs: Auto Generate Changelog of Release $TAG_NAME"
-  #         git commit -m "$commit_msg"
-  #
-  #     - name: Create changelog PR
-  #       uses: peter-evans/create-pull-request@v8
-  #       with:
-  #         sign-commits: true
-  #         token: ${{ secrets.GITHUB_TOKEN }}
-  #         title: ${{ steps.extract_tag.outputs.pr_title }}
-  #         body-path: ${{ format('{0}/{1}', runner.temp, 'output' ) }}
-  #         base: "dev-v2"
-  #         branch: "changelog"
-  #         delete-branch: true
-  #         reviewers: |
-  #           AnnAngela
-  #         assignees: |
-  #           AnnAngela
-  #
-  #     - name: Assign reviewers to release PR
-  #       uses: kentaro-m/auto-assign-action@v2.0.2
-  #       with:
-  #         configuration-path: ".github/release_reviewers.yaml"
+  generate-changelog:
+    name: Generate Changelog
+    if: |
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number != '') ||
+      (github.event.pull_request.head.repo.full_name == github.repository &&
+       github.event.pull_request.draft == false &&
+       startsWith(github.event.pull_request.title, 'Release v'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Checkout dev-v2 with full history
+        uses: actions/checkout@v4
+        with:
+          ref: dev-v2
+          fetch-depth: 0
+          show-progress: false
+
+      - name: Extract version from Release PR
+        id: version
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          title="${PR_TITLE:-$(gh pr view "$PR_NUMBER" --json title -q .title)}"
+          version=$(echo "$title" | sed -E 's/[Rr]elease\s*//')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Release version: $version"
+
+      - name: Generate changelog with AI
+        id: analysis
+        continue-on-error: true
+        uses: MistEO/ai-issue-analysis@main
+        with:
+          agent: claude
+          api-key: ${{ secrets.BOT_AI_API_KEY }}
+          api-base-url: ${{ secrets.BOT_AI_API_BASE_URL }}
+          model: ${{ secrets.BOT_AI_MODEL }}
+          github-token: ${{ secrets.MAA_BOT_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+          checkout-repository: false
+          initial-comment-body: |
+            🤖 **AI 正在生成 Changelog...**
+
+            正在根据提交记录自动生成 Changelog，预计耗时约 10 分钟。
+          prompt-template: |
+            你是 MAA 项目的 Changelog 生成专员。
+
+            当前 Release PR 编号为 #{{issue_number}}（仓库 {{repository}}），请从该 PR 标题中提取目标版本号。
+            严格按照 .claude/skills/changelog/SKILL.md 中的规则：
+
+            1. 分析 git 提交记录（tag 间的 commit 及其 diff）和现有 CHANGELOG.md
+            2. 直接更新 CHANGELOG.md 文件
+            3. 把本次 Changelog 变更的简要说明写到 {{answer_file}}（将作为 PR 评论发布）
+          details-summary: 点击此处展开生成过程
+
+      - name: Create changelog PR
+        if: steps.analysis.outcome == 'success'
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "docs: Auto Generate Changelog of Release ${{ steps.version.outputs.version }}"
+          sign-commits: true
+          title: "docs: Auto Update Changelogs of ${{ steps.version.outputs.version }}"
+          body: |
+            Auto-generated changelog for **${{ steps.version.outputs.version }}**.
+
+            Target Release PR: #${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+          base: dev-v2
+          branch: changelog
+          delete-branch: true
+          add-paths: CHANGELOG.md
+          reviewers: |
+            AnnAngela
+          assignees: |
+            AnnAngela
+
+      - name: Show outputs
+        if: always()
+        env:
+          COMMENT_URL: ${{ steps.analysis.outputs.comment-url }}
+        run: |
+          echo "comment_url=$COMMENT_URL"
+          echo "(Full agent-output and final-conclusion are available in the uploaded artifacts)"
 
   assign-release-reviewers:
     name: Assign Reviewers to Release PR
@@ -124,7 +118,6 @@ jobs:
 
   update-submodules:
     name: Update Submodules
-    # fork 守卫：同上，fork PR 的 token 只读，write 步骤必然失败
     if: github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.draft == false && startsWith(github.event.pull_request.title, 'Release v')
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Use ai-issue-analysis@main to auto-generate changelog and create a PR.

Flow:
1. Triggered on Release PR or via workflow_dispatch with PR number
2. AI reads git history + existing CHANGELOG.md, follows .claude/skills/changelog/SKILL.md
3. AI updates CHANGELOG.md directly and posts a summary as PR comment
4. peter-evans/create-pull-request commits CHANGELOG.md changes and opens a PR

Testing with workflow_dispatch against Release PR #17210.

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

使用集成在发布准备流水线中的基于 AI 的分析步骤，为发布工作流自动生成变更日志并创建 PR。

新功能：
- 引入一个 `generate-changelog` 任务，可由发布 PR 事件触发，也可通过 `workflow_dispatch` 手动触发，并支持可选的 PR 编号输入。
- 添加由 AI 驱动的变更日志生成：读取 Git 历史和现有的 `CHANGELOG.md`，更新该文件，并发布摘要评论。
- 自动创建一个专用的变更日志 PR，将生成的 `CHANGELOG.md` 变更提交到 `dev-v2` 分支。

改进：
- 用新的 AI 驱动工作流替换旧的、已被注释掉的基于 Python 的变更日志生成流程。
- 为变更日志任务显式授予 `contents`、`pull-requests` 和 `issues` 权限，并添加超时时间以提高可靠性和安全性。
- 通过移除过时的注释来简化发布准备工作流，并让 `assign-release-reviewers` 和子模块更新任务专注于发布 PR。

CI：
- 扩展 `release-preparation` 的 `workflow_dispatch` 触发器，使其接受 PR 编号输入，以进行定向的变更日志生成。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Automate changelog generation and PR creation for release workflows using an AI-based analysis step integrated into the release-preparation pipeline.

New Features:
- Introduce a generate-changelog job that can be triggered by release PR events or manually via workflow_dispatch with an optional PR number input.
- Add AI-driven changelog generation that reads git history and existing CHANGELOG.md, updates the file, and posts a summary comment.
- Automatically create a dedicated changelog PR with the generated CHANGELOG.md changes targeting the dev-v2 branch.

Enhancements:
- Replace the old, commented-out Python-based changelog generator flow with the new AI-powered workflow.
- Grant explicit contents, pull-requests, and issues permissions to the changelog job and add a timeout to improve reliability and safety.
- Simplify the release-preparation workflow by removing outdated comments and keeping the assign-release-reviewers and submodule update jobs focused on release PRs.

CI:
- Extend the release-preparation workflow_dispatch trigger to accept a PR number input for targeted changelog generation.

</details>