### PR TITLE
fix: 基建产物收取时因loading遮挡跳过

### DIFF
--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -2385,7 +2385,7 @@
     "InfrastNotification": {
         "roi": [1100, 0, 180, 300],
         "action": "ClickSelf",
-        "next": ["InfrastReward", "InfrastExitReward"]
+        "next": ["InfrastReward", "InfrastReward@LoadingText", "InfrastExitReward"]
     },
     "InfrastReward": {
         "algorithm": "OcrDetect",
@@ -2394,7 +2394,7 @@
         "roi": [0, 600, 800, 118],
         "postDelay": 1000,
         "postDelay_Doc": "UI 更新之后给这 b 玩意也加了动画，会点到一键换班",
-        "next": ["InfrastReward", "InfrastExitReward"]
+        "next": ["InfrastReward", "InfrastReward@LoadingText", "InfrastExitReward"]
     },
     "InfrastExitReward": {
         "Doc": "干员疲劳、线索收集 是不能一键收获的，所以要先退出一键收获的界面，这里点击的是控制中枢左侧那一片空白的区域",

--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -2385,7 +2385,7 @@
     "InfrastNotification": {
         "roi": [1100, 0, 180, 300],
         "action": "ClickSelf",
-        "next": ["InfrastReward", "InfrastReward@LoadingText", "InfrastExitReward"]
+        "next": ["InfrastReward", "InfrastNotification@LoadingText", "InfrastExitReward"]
     },
     "InfrastReward": {
         "algorithm": "OcrDetect",


### PR DESCRIPTION
### 问题
https://www.bilibili.com/video/BV17ojU6jEk2 里对应log：

20:34:00，MAA 识别到 InfrastNotification，点开了右上角待办。
```
389856: Click with scaled coordinates (1178, 102) 1
389858: SubTaskCompleted ... "task":"InfrastNotification"
```
因为loading遮挡（视频46s），没ocr到文字，直接走 InfrastExitReward ，点击左侧空白退出待办。
```
389862: asst::WordOcr [{ text: , rect: [ 598 (598), 35 (635), 17, 18 ], score: 0.000000 }]
389863: SubTaskStart ... "task":"InfrastExitReward","action":"ClickRect"
389864: Click with scaled coordinates (274, 136) 1
389866: SubTaskCompleted ... "task":"InfrastExitReward"
```
### 解决

在`InfrastNotification` 和 `InfrastReward` 的 next 中， `InfrastReward` 未命中、执行 `InfrastExitReward` 之前插入一个 loading 等待。正常能看到 `可收获 / 订单交付 / 员信赖` 时会直接点击，不会因为 loading 判定抢先而拖慢成功路径。只有收取项没命中、但底部出现 `正在提交 / 反馈至神经` 时，才会进入 loading 等待；loading 消失后再回到 `InfrastReward` 判断，最后仍然保留 `InfrastExitReward` 退出兜底。

fix: #17208

## Summary by Sourcery

错误修复：
- 防止在加载叠加层导致区块文本检测被阻挡、从而尚未识别奖励时，跳过基础设施奖励的收集。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent infrastructure reward collection from being skipped when loading overlays block text detection before rewards are recognized.

</details>