### PR TITLE
ci: optimize MAAUnified build by reusing MaaCore artifacts

### DIFF
--- a/.github/workflows/ci-avalonia.yml
+++ b/.github/workflows/ci-avalonia.yml
@@ -1,108 +1,52 @@
-name: Build MAAUnified (Avalonia + MaaCore Runtime)
+name: MAAUnified Quick Tests
 
 on:
   workflow_dispatch:
   pull_request:
     paths:
       - ".github/workflows/ci-avalonia.yml"
-      - "3rdparty/include/**"
-      - "cmake/**"
-      - "src/MAAUnified"
       - "src/MAAUnified/**"
-      - "src/MaaCore/**"
-      - "src/MaaUtils/**"
-      - "include/**"
-      - "tools/maadeps-download.py"
-      - "CMakeLists.txt"
-      - "CMakePresets.json"
       - "!**/*.md"
   push:
     branches:
       - dev-v2
     paths:
       - ".github/workflows/ci-avalonia.yml"
-      - "3rdparty/include/**"
-      - "cmake/**"
-      - "src/MAAUnified"
       - "src/MAAUnified/**"
-      - "src/MaaCore/**"
-      - "src/MaaUtils/**"
-      - "include/**"
-      - "tools/maadeps-download.py"
-      - "CMakeLists.txt"
-      - "CMakePresets.json"
       - "!**/*.md"
 
-jobs:
-  meta:
-    name: Resolve version tag
-    runs-on: ubuntu-latest
-    outputs:
-      tag: ${{ steps.out.outputs.tag }}
-      checkout_sha: ${{ steps.out.outputs.checkout_sha }}
-    steps:
-      - id: out
-        env:
-          CHECKOUT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-        run: |
-          echo "checkout_sha=${CHECKOUT_SHA}" >> "$GITHUB_OUTPUT"
-          if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-            echo "tag=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
-          else
-            echo "tag=preview-${CHECKOUT_SHA::7}" >> "$GITHUB_OUTPUT"
-          fi
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.head.repo.full_name || github.repository }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
 
-  build:
-    name: Build ${{ matrix.name }}
-    needs: meta
+jobs:
+  test:
+    name: .NET Tests (${{ matrix.name }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - name: windows-x64
-            os: windows-2025-vs2026
-            rid: win-x64
-            self_contained: true
-            cmake_preset: windows-publish-x64
-            maadeps_triplet: x64-windows
           - name: linux-x64
             os: ubuntu-latest
-            rid: linux-x64
-            self_contained: true
-            cmake_preset: linux-publish-x64
-            maadeps_triplet: x64-linux
-          - name: macos-x64
-            os: macos-latest
-            rid: osx-x64
-            self_contained: true
-            cmake_preset: macos-publish-x64
-            maadeps_triplet: x64-osx
+          - name: windows-x64
+            os: windows-2025-vs2026
 
     steps:
       - uses: actions/checkout@v7
         with:
-          ref: ${{ needs.meta.outputs.checkout_sha }}
+          show-progress: false
 
       - name: Fetch required submodules
         shell: bash
-        run: bash ./.github/scripts/sync-optional-submodules.sh --init --depth 1 src/MAAUnified src/MaaUtils
+        run: bash ./.github/scripts/sync-optional-submodules.sh --init --depth 1 src/MAAUnified
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: "10.0.x"
 
-      - name: Setup Python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.x"
-
-      - name: Restore app
-        run: dotnet restore src/MAAUnified/App/MAAUnified.App.csproj
-
       - name: Restore tests
-        if: matrix.name != 'macos-x64'
         run: dotnet restore src/MAAUnified/Tests/MAAUnified.Tests.csproj
 
       - name: Run Linux baseline consistency gate
@@ -137,65 +81,9 @@ jobs:
           --filter "FullyQualifiedName~PlatformWindowsNativeSmokeTests"
 
       - name: Upload test result artifacts on failure
-        if: failure() && matrix.name != 'macos-x64'
+        if: failure()
         uses: actions/upload-artifact@v7
         with:
           name: MAAUnified-TestResults-${{ matrix.name }}
           path: TestResults/${{ matrix.name }}/*.trx
           if-no-files-found: ignore
-
-      - name: Bootstrap MaaDeps
-        run: python tools/maadeps-download.py ${{ matrix.maadeps_triplet }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build MaaCore runtime
-        run: |
-          cmake --preset ${{ matrix.cmake_preset }} -DINSTALL_PYTHON=OFF -DMAA_HASH_VERSION='${{ needs.meta.outputs.tag }}'
-          cmake --build --preset ${{ matrix.cmake_preset }}
-          cmake --install build --config RelWithDebInfo
-
-      - name: Publish MAAUnified app
-        run: dotnet publish src/MAAUnified/App/MAAUnified.App.csproj -c Release -r ${{ matrix.rid }} --self-contained ${{ matrix.self_contained }} -o publish
-
-      - name: Merge MaaCore runtime (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          Copy-Item install\* publish\ -Recurse -Force
-          if (!(Test-Path "publish\MaaCore.dll")) { throw "MaaCore.dll not found in publish output." }
-          if (!(Test-Path "publish\resource")) { throw "resource directory not found in publish output." }
-
-      - name: Merge MaaCore runtime (Unix)
-        if: runner.os != 'Windows'
-        shell: bash
-        run: |
-          cp -a install/. publish/
-          if [[ "$RUNNER_OS" == "Linux" ]]; then
-            test -f publish/libMaaCore.so
-          else
-            test -f publish/libMaaCore.dylib
-          fi
-          test -d publish/resource
-
-      - name: Package (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          New-Item -ItemType Directory -Path release -Force | Out-Null
-          $name = "MAAUnified-${{ needs.meta.outputs.tag }}-${{ matrix.name }}"
-          Compress-Archive -Path publish\* -DestinationPath "release\$name.zip"
-
-      - name: Package (Unix)
-        if: runner.os != 'Windows'
-        shell: bash
-        run: |
-          mkdir -p release
-          name="MAAUnified-${{ needs.meta.outputs.tag }}-${{ matrix.name }}"
-          tar -czf "release/${name}.tar.gz" -C publish .
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: MAAUnified-${{ matrix.name }}
-          path: release/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,16 @@ jobs:
           cp MaaFramework-temp/bin/*Win32ControlUnit* install/
           cp MaaFramework-temp/bin/*AdbControlUnit* install/
 
+      - name: Upload MaaCore runtime for downstream jobs
+        uses: actions/upload-artifact@v7
+        with:
+          name: MAARuntime-win-${{ matrix.arch }}
+          path: |
+            install/
+            !install/*.h
+            !install/*.pdb
+            !install/msvc-debug/
+
       - name: Generate global.json
         shell: bash
         run: |
@@ -288,6 +298,12 @@ jobs:
       - name: Copy ControlUnits
         run: |
           cp MaaFramework-temp/bin/*AdbControlUnit* install/
+
+      - name: Upload MaaCore runtime for downstream jobs
+        uses: actions/upload-artifact@v7
+        with:
+          name: MAARuntime-linux-${{ matrix.arch }}
+          path: install/
 
       - name: Setup cross compile toolchains for CLI
         uses: ./src/maa-cli/.github/actions/setup
@@ -489,6 +505,12 @@ jobs:
           name: MAACore-macos-${{ matrix.arch }}
           path: "install/*.dylib"
 
+      - name: Upload MaaCore runtime for downstream jobs
+        uses: actions/upload-artifact@v7
+        with:
+          name: MAARuntime-macos-${{ matrix.arch }}
+          path: install/
+
   macOS-GUI:
     name: Build GUI for macOS
     needs: [meta, macOS-Core]
@@ -651,6 +673,139 @@ jobs:
           name: MAA-macos-universal
           path: ${{ startsWith(github.ref, 'refs/tags/v') && 'release/MAA*' || 'src/MaaMacGui/MAA.xcarchive/**' }}
 
+  avalonia:
+    name: Build MAAUnified (Avalonia) ${{ matrix.name }}
+    needs: [meta, windows, ubuntu, macOS-Core]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: win-x64
+            os: windows-2025-vs2026
+            rid: win-x64
+            runtime_artifact: MAARuntime-win-x64
+          - name: linux-x64
+            os: ubuntu-latest
+            rid: linux-x64
+            runtime_artifact: MAARuntime-linux-x86_64
+          - name: macos-x64
+            os: macos-latest
+            rid: osx-x64
+            runtime_artifact: MAARuntime-macos-x86_64
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          show-progress: false
+
+      - name: Fetch required submodules
+        shell: bash
+        run: bash ./.github/scripts/sync-optional-submodules.sh --init --depth 1 src/MAAUnified
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Restore app
+        run: dotnet restore src/MAAUnified/App/MAAUnified.App.csproj
+
+      - name: Restore tests
+        if: matrix.name != 'macos-x64'
+        run: dotnet restore src/MAAUnified/Tests/MAAUnified.Tests.csproj
+
+      - name: Run Linux baseline consistency gate
+        if: matrix.name == 'linux-x64'
+        run: >
+          dotnet test src/MAAUnified/Tests/MAAUnified.Tests.csproj -c Release --no-restore --disable-build-servers -m:1
+          --results-directory TestResults/${{ matrix.name }}
+          --logger "trx;LogFileName=baseline-consistency.trx"
+          --filter "FullyQualifiedName~BaselineContractTests|FullyQualifiedName~BaselineCoverageTests|FullyQualifiedName~BaselineRenderSyncTests|FullyQualifiedName~ParityMatrixSyncTests"
+
+      - name: Run Linux full MAAUnified test gate
+        if: matrix.name == 'linux-x64'
+        run: >
+          dotnet test src/MAAUnified/Tests/MAAUnified.Tests.csproj -c Release --no-restore --disable-build-servers -m:1
+          --results-directory TestResults/${{ matrix.name }}
+          --logger "trx;LogFileName=full-maaunified-tests.trx"
+
+      - name: Run Windows platform capability contract gate
+        if: matrix.name == 'win-x64'
+        run: >
+          dotnet test src/MAAUnified/Tests/MAAUnified.Tests.csproj -c Release --no-restore --disable-build-servers -m:1
+          --results-directory TestResults/${{ matrix.name }}
+          --logger "trx;LogFileName=platform-capability-contract.trx"
+          --filter "FullyQualifiedName~PlatformCapabilityContractTests"
+
+      - name: Run Windows native capability smoke gate
+        if: matrix.name == 'win-x64'
+        run: >
+          dotnet test src/MAAUnified/Tests/MAAUnified.Tests.csproj -c Release --no-restore --disable-build-servers -m:1
+          --results-directory TestResults/${{ matrix.name }}
+          --logger "trx;LogFileName=platform-windows-native-smoke.trx"
+          --filter "FullyQualifiedName~PlatformWindowsNativeSmokeTests"
+
+      - name: Upload test result artifacts on failure
+        if: failure() && matrix.name != 'macos-x64'
+        uses: actions/upload-artifact@v7
+        with:
+          name: MAAUnified-TestResults-${{ matrix.name }}
+          path: TestResults/${{ matrix.name }}/*.trx
+          if-no-files-found: ignore
+
+      - name: Download MaaCore runtime
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ matrix.runtime_artifact }}
+          path: install
+
+      - name: Publish MAAUnified app
+        run: dotnet publish src/MAAUnified/App/MAAUnified.App.csproj -c Release -r ${{ matrix.rid }} --self-contained true -o publish
+
+      - name: Merge MaaCore runtime (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          Copy-Item install\* publish\ -Recurse -Force
+          if (!(Test-Path "publish\MaaCore.dll")) { throw "MaaCore.dll not found in publish output." }
+          if (!(Test-Path "publish\resource")) { throw "resource directory not found in publish output." }
+
+      - name: Merge MaaCore runtime (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          cp -a install/. publish/
+          if [[ "$RUNNER_OS" == "Linux" ]]; then
+            test -f publish/libMaaCore.so
+          else
+            test -f publish/libMaaCore.dylib
+          fi
+          test -d publish/resource
+
+      - name: Package (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Path release -Force | Out-Null
+          $name = "MAAUnified-${{ needs.meta.outputs.tag }}-${{ matrix.name }}"
+          Compress-Archive -Path publish\* -DestinationPath "release\$name.zip"
+
+      - name: Package (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          mkdir -p release
+          name="MAAUnified-${{ needs.meta.outputs.tag }}-${{ matrix.name }}"
+          tar -czf "release/${name}.tar.gz" -C publish .
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: MAAUnified-${{ matrix.name }}
+          path: release/*
+
   release:
     name: Publish Release
     if: startsWith(github.ref, 'refs/tags/v')
@@ -666,6 +821,8 @@ jobs:
         run: |
           mv -vf assets/changelog/* .
           rm -rf assets/MAACore-macos-*
+          rm -rf assets/MAARuntime-*
+          rm -rf assets/MAAUnified-*
           cd assets
           # find . -type f | xargs mv -fvt .
           find . -type f | while read f; do mv -fvt . $f; done


### PR DESCRIPTION
## Summary

- ci-avalonia.yml previously rebuilt MaaCore from source on every run, duplicating ~15 min of cmake compile work already done by ci.yml
- Now ci.yml uploads \MAARuntime-*\ intermediate artifacts after cmake install
- New \valonia\ job in ci.yml downloads those artifacts and only does .NET publish + packaging
- ci-avalonia.yml simplified to a fast .NET-only test runner (~2-3 min instead of ~15-20 min)

## Changes

| File | What changed |
|------|-------------|
| \.github/workflows/ci.yml\ | Added \MAARuntime-*\ artifact uploads in windows/ubuntu/macOS-Core jobs; added new \valonia\ matrix job |
| \.github/workflows/ci-avalonia.yml\ | Stripped to pure .NET test workflow (no cmake/MaaCore build) |

## Savings

- Eliminates duplicate MaaCore builds for win-x64, linux-x64, macos-x64 on every PR
- Reduces ci-avalonia.yml runtime from ~15-20 min to ~2-3 min
- Total CI compute savings: ~45-60 min per run (3 platforms x 15 min)

## Test plan

- [ ] ci.yml Release Pipeline runs successfully (MaaCore + Avalonia jobs)
- [ ] ci-avalonia.yml Quick Tests pass (no MaaCore dependency)
- [ ] Avalonia artifacts are produced correctly with MaaCore runtime merged
- [ ] Release job cleanup excludes intermediate artifacts


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

通过复用 MaaCore 运行时工件用于 Avalonia 构建，并将独立的 Avalonia 工作流简化为轻量级的 .NET 测试门禁，以优化 CI 工作流。

CI：
- 从 Windows、Linux 和 macOS 的核心构建任务中上传 MaaCore 运行时工件，以便下游工作流复用。
- 在主 CI 流水线中新增基于矩阵的 Avalonia 任务，用于运行 MAAUnified 测试、合并 MaaCore 运行时工件、打包并在各平台发布 MAAUnified 构建。
- 将 `ci-avalonia.yml` 简化为一个只依赖 .NET 的快速测试工作流，通过并发控制运行，不再构建、打包或发布 MaaCore 或 MAAUnified 工件。
- 更新发布任务中的清理逻辑，从汇总的资源目录中移除新引入的 MAARuntime 和 MAAUnified 资源。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize CI workflows by reusing MaaCore runtime artifacts for Avalonia builds and simplifying the standalone Avalonia workflow into a lightweight .NET test gate.

CI:
- Upload MaaCore runtime artifacts from Windows, Linux, and macOS core build jobs for reuse by downstream workflows.
- Add a matrix-based Avalonia job in the main CI pipeline to run MAAUnified tests, merge MaaCore runtime artifacts, package, and publish MAAUnified builds across platforms.
- Simplify ci-avalonia.yml into a concurrency-controlled, .NET-only quick test workflow that no longer builds, packages, or publishes MaaCore or MAAUnified artifacts.
- Update the release job cleanup to remove newly introduced MAARuntime and MAAUnified assets from the aggregated assets directory.

</details>

CI：
- 从 Windows、Linux 和 macOS 的核心构建任务中上传 MaaCore 运行时产物，以便下游工作流复用。
- 在主 CI 流水线中添加 Avalonia 矩阵任务，用于构建、测试、合并 MaaCore 运行时、打包并跨平台发布 MAAUnified 构件。
- 将独立的 ci-avalonia 工作流简化为仅运行 .NET 测试的轻量级门禁任务，并加入并发控制，移除 MaaCore 的构建、打包和发布职责。
- 更新发布任务，以便从聚合的资源目录中清理新的 MAARuntime 和 MAAUnified 构件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过复用 MaaCore 运行时工件用于 Avalonia 构建，并将独立的 Avalonia 工作流简化为轻量级的 .NET 测试门禁，以优化 CI 工作流。

CI：
- 从 Windows、Linux 和 macOS 的核心构建任务中上传 MaaCore 运行时工件，以便下游工作流复用。
- 在主 CI 流水线中新增基于矩阵的 Avalonia 任务，用于运行 MAAUnified 测试、合并 MaaCore 运行时工件、打包并在各平台发布 MAAUnified 构建。
- 将 `ci-avalonia.yml` 简化为一个只依赖 .NET 的快速测试工作流，通过并发控制运行，不再构建、打包或发布 MaaCore 或 MAAUnified 工件。
- 更新发布任务中的清理逻辑，从汇总的资源目录中移除新引入的 MAARuntime 和 MAAUnified 资源。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Optimize CI workflows by reusing MaaCore runtime artifacts for Avalonia builds and simplifying the standalone Avalonia workflow into a lightweight .NET test gate.

CI:
- Upload MaaCore runtime artifacts from Windows, Linux, and macOS core build jobs for reuse by downstream workflows.
- Add a matrix-based Avalonia job in the main CI pipeline to run MAAUnified tests, merge MaaCore runtime artifacts, package, and publish MAAUnified builds across platforms.
- Simplify ci-avalonia.yml into a concurrency-controlled, .NET-only quick test workflow that no longer builds, packages, or publishes MaaCore or MAAUnified artifacts.
- Update the release job cleanup to remove newly introduced MAARuntime and MAAUnified assets from the aggregated assets directory.

</details>

</details>