### PR TITLE
fix: Reclaimation3 两件事

### DIFF
--- a/resource/tasks/RA/Reclamation3.json
+++ b/resource/tasks/RA/Reclamation3.json
@@ -134,7 +134,8 @@
         "text": ["请部署", "罗德岛", "采集基站"],
         "roi": [520, 54, 247, 38],
         "sub": ["RelaunchAnchor@RA@RA1-AlignMap*2"],
-        "next": ["RelaunchAnchor@RA@RA1-DeployGatheringBaseSwipe"]
+        "next": ["RelaunchAnchor@RA@RA1-DeployGatheringBaseSwipe"],
+        "subErrorIgnored": true
     },
     "RelaunchAnchor@RA@RA1-AlignMap": {
         "doc": "步骤 9：JustReturn Swipe，对齐地图",
@@ -142,7 +143,8 @@
         "action": "Swipe",
         "specificRect": [120, 580, 1, 1],
         "rectMove": [1920, 0, 1, 1],
-        "specialParams": [500, 0, 3, 0]
+        "specialParams": [500, 0, 3, 0],
+        "maxTimes": 2
     },
     "RelaunchAnchor@RA@RA1-DeployGatheringBaseSwipe": {
         "doc": "步骤 10：JustReturn Swipe，占位部署采集基站",
@@ -152,6 +154,7 @@
         "rectMove": [955, 300, 1, 1],
         "specialParams": [500, 0, 3, 0],
         "postDelay": 1000,
+        "maxTimes": 5,
         "next": ["RelaunchAnchor@RA@RA1-DeployGatheringBasePrompt", "RelaunchAnchor@RA@RA1-WaitDoubleSpeed"]
     },
     "RelaunchAnchor@RA@RA1-WaitDoubleSpeed": {
@@ -624,20 +627,23 @@
         "baseTask": "RelaunchAnchor@RA@RA1-DeployGatheringBasePrompt",
         "doc": "步骤 9：OCR 等待 <请部署罗德岛采集基站>",
         "sub": ["RelaunchAnchor@RA@RA4-AlignMap*2"],
-        "next": ["RelaunchAnchor@RA@RA4-DeployGatheringBaseSwipe"]
+        "next": ["RelaunchAnchor@RA@RA4-DeployGatheringBaseSwipe"],
+        "subErrorIgnored": true
     },
     "RelaunchAnchor@RA@RA4-AlignMap": {
         "doc": "步骤 10：JustReturn Swipe，对齐地图",
         "baseTask": "RelaunchAnchor@RA@RA1-AlignMap",
         "specificRect": [433, 123, 1, 1],
-        "rectMove": [749, 520, 1, 1]
+        "rectMove": [749, 520, 1, 1],
+        "maxTimes": 2
     },
     "RelaunchAnchor@RA@RA4-DeployGatheringBaseSwipe": {
         "baseTask": "RelaunchAnchor@RA@RA1-DeployGatheringBaseSwipe",
         "doc": "步骤 11：JustReturn Swipe，占位部署采集基站",
         "specificRect": [430, 630, 1, 1],
         "rectMove": [750, 340, 1, 1],
-        "next": ["RelaunchAnchor@RA@RA4-WaitDoubleSpeed"]
+        "maxTimes": 5,
+        "next": ["RelaunchAnchor@RA@RA4-DeployGatheringBasePrompt", "RelaunchAnchor@RA@RA4-WaitDoubleSpeed"]
     },
     "RelaunchAnchor@RA@RA4-WaitDoubleSpeed": {
         "doc": "步骤 12 前等待二倍速提示出现",
@@ -1324,7 +1330,8 @@
         "action": "DoNothing",
         "postDelay": 1000,
         "sub": ["RelaunchAnchor@RA@RA15-AlignMap2*2"],
-        "next": ["RelaunchAnchor@RA@RA15-DeployGatheringBaseSwipe"]
+        "next": ["RelaunchAnchor@RA@RA15-DeployGatheringBaseSwipe"],
+        "subErrorIgnored": true
     },
     "RelaunchAnchor@RA@RA15-AlignMap2": {
         "doc": "步骤 17.2：JustReturn 的 Swipe，对齐地图",
@@ -1333,7 +1340,8 @@
         "specificRect": [970, 110, 1, 1],
         "rectMove": [430, 550, 1, 1],
         "specialParams": [1000, 0, 3, 0],
-        "postDelay": 1000
+        "postDelay": 1000,
+        "maxTimes": 2
     },
     "RelaunchAnchor@RA@RA15-DeployGatheringBaseSwipe": {
         "doc": "步骤 18：JustReturn 的 Swipe，占位部署采集基站",
@@ -1343,6 +1351,7 @@
         "rectMove": [495, 414, 1, 1],
         "specialParams": [1000, 0, 3, 0],
         "postDelay": 4000,
+        "maxTimes": 5,
         "next": ["RelaunchAnchor@RA@RA15-AlignMapCheck", "RelaunchAnchor@RA@RA15-WaitDoubleSpeed"]
     },
     "RelaunchAnchor@RA@RA15-WaitDoubleSpeed": {

--- a/resource/tasks/RA/Reclamation3.json
+++ b/resource/tasks/RA/Reclamation3.json
@@ -164,7 +164,6 @@
         "template": "RelaunchAnchor@RA@DoubleSpeed.png",
         "action": "ClickSelf",
         "roi": [1060, 20, 80, 70],
-        "maskRange": [220, 255],
         "next": ["#self", "RelaunchAnchor@RA@RA1-DeployGatheringBaseWait"]
     },
     "RelaunchAnchor@RA@RA1-DeployGatheringBaseWait": {
@@ -650,7 +649,6 @@
         "algorithm": "MatchTemplate",
         "template": "RelaunchAnchor@RA@DoubleSpeed.png",
         "roi": [1060, 20, 80, 70],
-        "maskRange": [220, 255],
         "action": "ClickSelf",
         "preDelay": 500,
         "next": ["RelaunchAnchor@RA@RA4-ClickStone"]
@@ -1357,7 +1355,6 @@
         "template": "RelaunchAnchor@RA@DoubleSpeed.png",
         "action": "ClickSelf",
         "roi": [1060, 20, 80, 70],
-        "maskRange": [220, 255],
         "next": ["#self", "RelaunchAnchor@RA@RA15-WaitCost"]
     },
     "RelaunchAnchor@RA@RA15-WaitCost": {

--- a/resource/tasks/RA/Reclamation3.json
+++ b/resource/tasks/RA/Reclamation3.json
@@ -133,18 +133,25 @@
         "action": "DoNothing",
         "text": ["请部署", "罗德岛", "采集基站"],
         "roi": [520, 54, 247, 38],
-        "sub": ["RelaunchAnchor@RA@RA1-AlignMap*2"],
+        "sub": ["RelaunchAnchor@RA@RA1-AlignMap2"],
         "next": ["RelaunchAnchor@RA@RA1-DeployGatheringBaseSwipe"],
         "subErrorIgnored": true
     },
+    "RelaunchAnchor@RA@RA1-InitAlignMap": {
+        "doc": "步骤 9：对齐地图",
+        "algorithm": "JustReturn",
+        "sub": ["RelaunchAnchor@RA@RA1-AlignMap*2"],
+        "next": ["RelaunchAnchor@RA@DeployGatheringBaseSwipe"],
+        "maxTimes": 1,
+        "exceededNext": ["RelaunchAnchor@RA@DeployGatheringBaseSwipe"]
+    },
     "RelaunchAnchor@RA@RA1-AlignMap": {
-        "doc": "步骤 9：JustReturn Swipe，对齐地图",
+        "doc": "步骤 9/12：JustReturn Swipe，对齐地图",
         "algorithm": "JustReturn",
         "action": "Swipe",
         "specificRect": [120, 580, 1, 1],
         "rectMove": [1920, 0, 1, 1],
-        "specialParams": [500, 0, 3, 0],
-        "maxTimes": 2
+        "specialParams": [500, 0, 3, 0]
     },
     "RelaunchAnchor@RA@RA1-DeployGatheringBaseSwipe": {
         "doc": "步骤 10：JustReturn Swipe，占位部署采集基站",
@@ -626,16 +633,22 @@
     "RelaunchAnchor@RA@RA4-DeployGatheringBasePrompt": {
         "baseTask": "RelaunchAnchor@RA@RA1-DeployGatheringBasePrompt",
         "doc": "步骤 9：OCR 等待 <请部署罗德岛采集基站>",
-        "sub": ["RelaunchAnchor@RA@RA4-AlignMap*2"],
-        "next": ["RelaunchAnchor@RA@RA4-DeployGatheringBaseSwipe"],
+        "sub": ["RelaunchAnchor@RA@RA4-InitAlignMap*2"],
+        "next": ["RelaunchAnchor@RA@RA4-InitAlignMap"],
         "subErrorIgnored": true
     },
+    "RelaunchAnchor@RA@RA4-InitAlignMap": {
+        "doc": "步骤 10：对齐地图（只跑一次）",
+        "baseTask": "RelaunchAnchor@RA@RA1-InitAlignMap",
+        "sub": ["RelaunchAnchor@RA@RA4-AlignMap*2"],
+        "next": ["RelaunchAnchor@RA@RA4-DeployGatheringBaseSwipe"],
+        "exceededNext": ["RelaunchAnchor@RA@RA4-DeployGatheringBaseSwipe"]
+    },
     "RelaunchAnchor@RA@RA4-AlignMap": {
-        "doc": "步骤 10：JustReturn Swipe，对齐地图",
+        "doc": "步骤 10.1：JustReturn Swipe，对齐地图",
         "baseTask": "RelaunchAnchor@RA@RA1-AlignMap",
         "specificRect": [433, 123, 1, 1],
-        "rectMove": [749, 520, 1, 1],
-        "maxTimes": 2
+        "rectMove": [749, 520, 1, 1]
     },
     "RelaunchAnchor@RA@RA4-DeployGatheringBaseSwipe": {
         "baseTask": "RelaunchAnchor@RA@RA1-DeployGatheringBaseSwipe",
@@ -1331,7 +1344,8 @@
         "postDelay": 1000,
         "sub": ["RelaunchAnchor@RA@RA15-AlignMap2*2"],
         "next": ["RelaunchAnchor@RA@RA15-DeployGatheringBaseSwipe"],
-        "subErrorIgnored": true
+        "maxTimes": 1,
+        "exceededNext": ["RelaunchAnchor@RA@RA15-DeployGatheringBaseSwipe"]
     },
     "RelaunchAnchor@RA@RA15-AlignMap2": {
         "doc": "步骤 17.2：JustReturn 的 Swipe，对齐地图",
@@ -1340,8 +1354,7 @@
         "specificRect": [970, 110, 1, 1],
         "rectMove": [430, 550, 1, 1],
         "specialParams": [1000, 0, 3, 0],
-        "postDelay": 1000,
-        "maxTimes": 2
+        "postDelay": 1000
     },
     "RelaunchAnchor@RA@RA15-DeployGatheringBaseSwipe": {
         "doc": "步骤 18：JustReturn 的 Swipe，占位部署采集基站",


### PR DESCRIPTION
## Reclaimation3 DoubleSpeed 去除 maskRange

我们知道 CV_TM_CCOEFF_NORMED 的 cost function 为

R(x,y)= \frac{ \sum_{x',y'} (T'(x',y') \cdot I'(x+x',y+y')) }{ \sqrt{\sum_{x',y'}T'(x',y')^2 \cdot \sum_{x',y'} I'(x+x',y+y')^2} }

其中 T' 和 I' 分别为剧中到平均值的 template 和 image。如果采用一个已知只对应 template 中单独一个色块的 maskRange，那 template 就会被简化成一个平色调，失去大部分的辨识能力。

Fix #16939.

See-Also: https://github.com/MaaAssistantArknights/MaaAssistantArknights/issues/16939#issuecomment-4844273645

## fix: RA4 增加重试 swipe 逻辑；Re3 增加 maxTimes 限制

* 相比别的 RA，RA4 不知道为什么缺了重试识别“请部署罗德岛采集基站”的部分，因此在偶尔拖动失败的时候会挂
* maxTimes = 5 用于限制过多尝试拖动不存在的基站，降低迷惑场合（比一次多两次呢）
* maxTimes = 2 + subErrorIgnored 用于限制 AlignMap 次数，防止重试拖动基站的时候再拖动地图到不知道什么地方

本地已测试正常情况和有基地建筑干扰情况。

美中不足的是不能让maxTimes: 5这个变成错误信息，只能显示成正常停止。

## Summary by Sourcery

Bug Fixes:
- 从 Reclamation3 双倍速模板配置中移除 mask 范围，以修复不正确或不可靠的匹配行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Remove the mask range from the Reclamation3 double-speed template configuration to fix incorrect or unreliable matching behavior.

</details>