### PR TITLE
feat: 新增检测 MuMu 后台保活

### DIFF
--- a/src/MaaWpfGui/Helper/AchievementTrackerHelper.cs
+++ b/src/MaaWpfGui/Helper/AchievementTrackerHelper.cs
@@ -691,7 +691,7 @@ public class AchievementTrackerHelper : PropertyChangedBase
         FeatureExploration(id: AchievementIds.Pioneer2, group: AchievementIds.PioneerGroup, isHidden: true, groupIndex: 2), // 将 MAA 更新至内测版（隐藏）
         FeatureExploration(id: AchievementIds.Pioneer3, group: AchievementIds.PioneerGroup, isHidden: true, groupIndex: 3), // 使用未发布版本的 MAA（隐藏）
 
-        FeatureExploration(id: AchievementIds.MosquitoLeg, target: 5), // 使用「借助战打 OF-1」功能超过 5 次
+        FeatureExploration(id: AchievementIds.MosquitoLeg, target: 5), // 使用 ｢借助战打 OF-1｣ 功能超过 5 次
         FeatureExploration(id: AchievementIds.RealGacha, isHidden: true), // 真正的抽卡
         FeatureExploration(id: AchievementIds.PeekScreen, isHidden: true), // 窥屏
         FeatureExploration(id: AchievementIds.CustomizationMaster, isHidden: true), // 自定义背景

--- a/src/MaaWpfGui/Helper/EmulatorHelper.cs
+++ b/src/MaaWpfGui/Helper/EmulatorHelper.cs
@@ -16,6 +16,7 @@ using System;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
+using System.Text.Json;
 using System.Text.RegularExpressions;
 using MaaWpfGui.Constants;
 using MaaWpfGui.ViewModels.UI;
@@ -61,67 +62,84 @@ public class EmulatorHelper
     }
 
     /// <summary>
+    /// 将 MuMu 端口号转换为实例索引。
+    /// MuMu 端口分配公式：port = 16384 + (index % 32) * 32 + floor(index/32) * 4，
+    /// 简化后 index = ((k & 7) << 5) | (k >> 3)，其中 k = (port - 16384) / 4。
+    /// 参见 https://github.com/MaaAssistantArknights/MaaAssistantArknights/pull/17112
+    /// </summary>
+    /// <param name="port">MuMu ADB 端口号。</param>
+    /// <returns>实例索引。</returns>
+    private static int MuMuPortToIndex(int port)
+    {
+        int k = (port - 16384) / 4;
+        return ((k & 7) << 5) | (k >> 3);
+    }
+
+    /// <summary>
+    /// 从连接地址或 MuMu Bridge 连接配置推导 MuMu 模拟器实例索引。
+    /// </summary>
+    /// <param name="address">连接地址，如 127.0.0.1:16384。</param>
+    /// <returns>推导出的实例索引；无法推导时返回 null。</returns>
+    private static int? GetMuMuIndex(string address)
+    {
+        if (address == "127.0.0.1:16384")
+        {
+            return 0;
+        }
+
+        if (SettingsViewModel.ConnectSettings.MuMuEmulatorExtras.MuMuBridgeConnection)
+        {
+            return int.TryParse(SettingsViewModel.ConnectSettings.MuMuEmulatorExtras.Index, out var indexParse) ? indexParse : 0;
+        }
+
+        if (address.Contains(':'))
+        {
+            string portStr = address.Split(':')[1];
+            if (!int.TryParse(portStr, out int port))
+            {
+                _logger.Error("Failed to parse port from address {Address}", address);
+                return null;
+            }
+
+            return port switch
+            {
+                >= 16384 => MuMuPortToIndex(port),
+                7555 => 0,
+                >= 5555 => (port - 5555) / 2,
+                _ => null,
+            };
+        }
+
+        if (address.StartsWith("emulator-", StringComparison.OrdinalIgnoreCase))
+        {
+            string[] parts = address.Split('-');
+            if (parts.Length >= 2 && int.TryParse(parts[1], out int port))
+            {
+                return (port - 5554) / 2;
+            }
+
+            _logger.Error("Failed to parse port from emulator style address {Address}", address);
+            return null;
+        }
+
+        _logger.Error("Unsupported address format: {Address}", address);
+        return null;
+    }
+
+    /// <summary>
     /// 一个用于调用 MuMu 模拟器控制台关闭 MuMu 的方法
     /// </summary>
     /// <returns>是否关闭成功</returns>
     private static bool KillEmulatorMuMuEmulator()
     {
         string address = SettingsViewModel.ConnectSettings.ConnectAddress;
-        int emuIndex;
-        if (address == "127.0.0.1:16384")
+        int? emuIndexOpt = GetMuMuIndex(address);
+        if (emuIndexOpt is null)
         {
-            emuIndex = 0;
-        }
-        else if (SettingsViewModel.ConnectSettings.MuMuEmulatorExtras.MuMuBridgeConnection)
-        {
-            emuIndex = int.TryParse(SettingsViewModel.ConnectSettings.MuMuEmulatorExtras.Index, out var indexParse) ? indexParse : 0;
-        }
-        else if (address.Contains(':'))
-        {
-            string portStr = address.Split(':')[1];
-            if (int.TryParse(portStr, out int port))
-            {
-                switch (port)
-                {
-                    case >= 16384:
-                        emuIndex = (port - 16384) / 32;
-                        break;
-                    case 7555:
-                        emuIndex = 0;
-                        _logger.Warning("Port 7555 is deprecated for MuMu6, please use 16384 or above.");
-                        break;
-                    case >= 5555:
-                        emuIndex = (port - 5555) / 2;
-                        break;
-                    default:
-                        _logger.Error("Port {Port} is not valid for MuMu emulator", port);
-                        return false;
-                }
-            }
-            else
-            {
-                _logger.Error("Failed to parse port from address {Address}", address);
-                return false;
-            }
-        }
-        else if (address.StartsWith("emulator-", StringComparison.OrdinalIgnoreCase))
-        {
-            string[] parts = address.Split('-');
-            if (parts.Length >= 2 && int.TryParse(parts[1], out int port))
-            {
-                emuIndex = (port - 5554) / 2;
-            }
-            else
-            {
-                _logger.Error("Failed to parse port from emulator style address {Address}", address);
-                return false;
-            }
-        }
-        else
-        {
-            _logger.Error("Unsupported address format: {Address}", address);
             return false;
         }
+
+        int emuIndex = emuIndexOpt.Value;
 
         // 尝试找到正在运行的模拟器进程
         Process[] processes = Process.GetProcessesByName("MuMuNxDevice"); // 新版
@@ -551,6 +569,141 @@ public class EmulatorHelper
         }
 
         return KillEmulator();
+    }
+
+    /// <summary>
+    /// 检测 MuMu 模拟器的后台保活是否开启。
+    /// 通过 MuMuManager.exe 读取 app_keptlive 配置项。
+    /// </summary>
+    /// <returns>true 表示保活已开启（可能导致截图和操作异常），false 表示未开启或检测失败。</returns>
+    public static bool CheckMuMuKeepAlive()
+    {
+        try
+        {
+            // 从连接地址推导实例索引
+            string address = SettingsViewModel.ConnectSettings.ConnectAddress;
+            int? emuIndexOpt = GetMuMuIndex(address);
+            if (emuIndexOpt is null)
+            {
+                _logger.Information("Cannot determine MuMu index for keep alive check, address: {Address}", address);
+                return false;
+            }
+
+            int emuIndex = emuIndexOpt.Value;
+
+            // 查找 MuMuManager.exe 路径
+            string? consolePath = FindMuMuManagerPath();
+            if (consolePath == null)
+            {
+                _logger.Information("MuMuManager.exe not found, skip keep alive check");
+                return false;
+            }
+
+            // 调用 MuMuManager.exe setting -v {emuIndex} -k app_keptlive
+            // 返回 JSON 格式: { "app_keptlive": "true" }
+            var startInfo = new ProcessStartInfo(consolePath)
+            {
+                Arguments = $"setting -v {emuIndex} -k app_keptlive",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                CreateNoWindow = true,
+            };
+
+            using var process = Process.Start(startInfo);
+            if (process == null || !process.WaitForExit(5000))
+            {
+                _logger.Warning("MuMuManager.exe did not exit within timeout");
+                return false;
+            }
+
+            string output = process.StandardOutput.ReadToEnd().Trim();
+            _logger.Information("MuMuManager app_keptlive output: {Output}", output);
+
+            if (string.IsNullOrEmpty(output))
+            {
+                return false;
+            }
+
+            // 解析 JSON 输出
+            using var doc = JsonDocument.Parse(output);
+            if (doc.RootElement.TryGetProperty("app_keptlive", out var value))
+            {
+                return value.GetString() == "true";
+            }
+
+            return false;
+        }
+        catch (Exception e)
+        {
+            _logger.Warning("Failed to check MuMu keep alive: {EMessage}", e.Message);
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// 查找 MuMuManager.exe 的路径，优先从运行中的 MuMu 进程获取，回退到用户配置的安装路径。
+    /// </summary>
+    /// <returns>MuMuManager.exe 的完整路径，找不到则返回 null。</returns>
+    private static string? FindMuMuManagerPath()
+    {
+        // 优先从运行中的模拟器进程获取安装目录
+        Process[] processes = Process.GetProcessesByName("MuMuNxDevice");
+        if (processes.Length == 0)
+        {
+            processes = Process.GetProcessesByName("MuMuPlayer");
+        }
+
+        if (processes.Length > 0)
+        {
+            try
+            {
+                string? emulatorExePath = processes[0].MainModule?.FileName;
+                if (emulatorExePath != null)
+                {
+                    // 新版: nx_device\12.0\shell\MuMuNxDevice.exe → 上三级 = 安装目录
+                    // 旧版: shell\MuMuPlayer.exe → 上一级 = 安装目录
+                    var installPath = Path.GetFullPath(
+                        Path.GetFileName(emulatorExePath).Equals("MuMuNxDevice.exe", StringComparison.OrdinalIgnoreCase)
+                            ? Path.Combine(Path.GetDirectoryName(emulatorExePath)!, @"..\..\..")
+                            : Path.Combine(Path.GetDirectoryName(emulatorExePath)!, ".."));
+
+                    string newConsolePath = Path.Combine(installPath, @"nx_main\MuMuManager.exe");
+                    if (File.Exists(newConsolePath))
+                    {
+                        return newConsolePath;
+                    }
+
+                    string oldConsolePath = Path.Combine(installPath, @"shell\MuMuManager.exe");
+                    if (File.Exists(oldConsolePath))
+                    {
+                        return oldConsolePath;
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                _logger.Warning("Failed to get MuMu process module path: {EMessage}", e.Message);
+            }
+        }
+
+        // 回退：从用户配置的 MuMu 安装路径查找
+        string? configuredPath = SettingsViewModel.ConnectSettings.MuMuEmulatorExtras.EmulatorPath;
+        if (!string.IsNullOrEmpty(configuredPath) && Directory.Exists(configuredPath))
+        {
+            string newConsolePath = Path.Combine(configuredPath, @"nx_main\MuMuManager.exe");
+            if (File.Exists(newConsolePath))
+            {
+                return newConsolePath;
+            }
+
+            string oldConsolePath = Path.Combine(configuredPath, @"shell\MuMuManager.exe");
+            if (File.Exists(oldConsolePath))
+            {
+                return oldConsolePath;
+            }
+        }
+
+        return null;
     }
 
     /// <summary>

--- a/src/MaaWpfGui/Helper/EmulatorHelper.cs
+++ b/src/MaaWpfGui/Helper/EmulatorHelper.cs
@@ -62,6 +62,17 @@ public class EmulatorHelper
     }
 
     /// <summary>
+    /// 记录无效端口日志并返回 null。
+    /// </summary>
+    /// <param name="port">无效的端口号。</param>
+    /// <returns>始终返回 null。</returns>
+    private static int? InvalidMuMuPort(int port)
+    {
+        _logger.Error("Port {Port} is not valid for MuMu emulator", port);
+        return null;
+    }
+
+    /// <summary>
     /// 将 MuMu 端口号转换为实例索引。
     /// MuMu 端口分配公式：port = 16384 + (index % 32) * 32 + floor(index/32) * 4，
     /// 简化后 index = ((k & 7) << 5) | (k >> 3)，其中 k = (port - 16384) / 4。
@@ -106,7 +117,7 @@ public class EmulatorHelper
                 >= 16384 => MuMuPortToIndex(port),
                 7555 => 0,
                 >= 5555 => (port - 5555) / 2,
-                _ => null,
+                _ => InvalidMuMuPort(port),
             };
         }
 
@@ -612,7 +623,16 @@ public class EmulatorHelper
             using var process = Process.Start(startInfo);
             if (process == null || !process.WaitForExit(5000))
             {
-                _logger.Warning("MuMuManager.exe did not exit within timeout");
+                _logger.Warning("MuMuManager.exe did not exit within timeout, killing it");
+                try
+                {
+                    process?.Kill();
+                }
+                catch (Exception ex)
+                {
+                    _logger.Warning("Failed to kill MuMuManager.exe: {ExMessage}", ex.Message);
+                }
+
                 return false;
             }
 
@@ -624,11 +644,17 @@ public class EmulatorHelper
                 return false;
             }
 
-            // 解析 JSON 输出
+            // 解析 JSON 输出，兼容字符串和布尔两种格式
             using var doc = JsonDocument.Parse(output);
             if (doc.RootElement.TryGetProperty("app_keptlive", out var value))
             {
-                return value.GetString() == "true";
+                return value.ValueKind switch
+                {
+                    JsonValueKind.True => true,
+                    JsonValueKind.False => false,
+                    JsonValueKind.String => string.Equals(value.GetString(), "true", StringComparison.OrdinalIgnoreCase),
+                    _ => false,
+                };
             }
 
             return false;

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -789,11 +789,16 @@ public class AsstProxy
                 SettingsViewModel.ConnectSettings.ConnectAddress = _connectedAddress;
                 _lastConnectionError = string.Empty;
 
-                // 检测 MuMu 后台保活是否开启
-                if (SettingsViewModel.ConnectSettings.ConnectConfig == "MuMuEmulator12" &&
-                    EmulatorHelper.CheckMuMuKeepAlive())
+                // 检测 MuMu 后台保活是否开启（异步执行，避免阻塞 UI 线程）
+                if (SettingsViewModel.ConnectSettings.ConnectConfig == "MuMuEmulator12")
                 {
-                    Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("MuMuEmulator12KeepAliveOn"), UiLogColor.Warning);
+                    _ = Task.Run(() =>
+                    {
+                        if (EmulatorHelper.CheckMuMuKeepAlive())
+                        {
+                            Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("MuMuEmulator12KeepAliveOn"), UiLogColor.Warning);
+                        }
+                    });
                 }
 
                 break;

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -788,6 +788,14 @@ public class AsstProxy
                 _connectedAddress = details["details"]!["address"]!.ToString();
                 SettingsViewModel.ConnectSettings.ConnectAddress = _connectedAddress;
                 _lastConnectionError = string.Empty;
+
+                // 检测 MuMu 后台保活是否开启
+                if (SettingsViewModel.ConnectSettings.ConnectConfig == "MuMuEmulator12" &&
+                    EmulatorHelper.CheckMuMuKeepAlive())
+                {
+                    Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("MuMuEmulator12KeepAliveOn"), UiLogColor.Warning);
+                }
+
                 break;
 
             case "UnsupportedResolution":

--- a/src/MaaWpfGui/Models/PostActionSetting.cs
+++ b/src/MaaWpfGui/Models/PostActionSetting.cs
@@ -149,7 +149,7 @@ public class PostActionSetting : PropertyChangedBase
     private bool _exitEmulator;
 
     /// <summary>
-    /// Gets a value indicating whether PC 端（窗口绑定）无模拟器进程，完成后不可选择「退出模拟器」。
+    /// Gets a value indicating whether PC 端（窗口绑定）无模拟器进程，完成后不可选择 ｢退出模拟器｣。
     /// </summary>
     public bool ExitEmulatorOptionEnabled => !ConnectSettingsUserControlModel.Instance.UseAttachWindow;
 

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -714,6 +714,7 @@ Note:
     <system:String x:Key="MuMu12Index">Instance Number</system:String>
     <system:String x:Key="MuMu12Display">Display Number</system:String>
     <system:String x:Key="MuMuExtrasNotEnabledMessage">Mumu screenshot enhancement not enabled, please check related settings</system:String>
+    <system:String x:Key="MuMuEmulator12KeepAliveOn">MuMu emulator background keep-alive is enabled, which may cause screenshot failures and abnormal operations. Please disable "background keep-alive" (or "app keep-alive", etc.) in MuMu settings</system:String>
     <system:String x:Key="LdExtrasEnabled">Enable LD's screenshot enhancement mode</system:String>
     <system:String x:Key="LdPlayerEmulatorPathNotFound">LDPlayer emulator path not found.</system:String>
     <system:String x:Key="LdPlayerOpenglMissing">ldopengl64.dll was not found in the selected LDPlayer path. Please verify the installation directory.</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -36,7 +36,7 @@
     <system:String x:Key="ResourceVersion">リソースバーション</system:String>
     <system:String x:Key="ResourceDateTime">リソース日付</system:String>
     <system:String x:Key="Off">シャットダウン</system:String>
-    <system:String x:Key="ExternalNotificationTips">注:外部通知機能は現在、「すべてのタスクが完了しました」という通知のみを送信します。</system:String>
+    <system:String x:Key="ExternalNotificationTips">注:外部通知機能は現在、 ｢すべてのタスクが完了しました｣ という通知のみを送信します。</system:String>
     <system:String x:Key="ExternalNotificationSettings">外部通知</system:String>
     <system:String x:Key="ExternalNotificationEnabled">通知構成の有効化</system:String>
     <system:String x:Key="ExternalNotificationEnableDetails">詳細情報を出力</system:String>
@@ -86,8 +86,8 @@
     <system:String x:Key="UseGpuForInferenceTip">GPU 推論を利用することで、ごくわずかな GPU 使用率で CPU の負荷を大幅に軽減できます</system:String>
     <system:String x:Key="GpuOptionDisable">使用しない</system:String>
     <system:String x:Key="GpuOptionSystemDefault">システムデフォルトGPU</system:String>
-    <system:String x:Key="GpuDeprecatedMessage">現在選択されている推論加速 GPU（{0}）には互換性の問題があり、認識ミスやずれ、その他の予期しない不具合が発生する可能性があります。\n\n「{key=Settings} - {key=PerformanceSettings}」で別の GPU に変更することをおすすめします。</system:String>
-    <system:String x:Key="GpuDriverOutdatedMessage">現在選択されている推論加速 GPU（{0}）のドライバーバージョン（{1}、リリース日：{2}）は2年以上経過しており、互換性の問題が発生する可能性があります。\n\nグラフィックスドライバーを更新するか、「{key=Settings} - {key=PerformanceSettings}」で別の GPU に変更することをおすすめします。</system:String>
+    <system:String x:Key="GpuDeprecatedMessage">現在選択されている推論加速 GPU（{0}）には互換性の問題があり、認識ミスやずれ、その他の予期しない不具合が発生する可能性があります。\n\n ｢{key=Settings} - {key=PerformanceSettings}｣ で別の GPU に変更することをおすすめします。</system:String>
+    <system:String x:Key="GpuDriverOutdatedMessage">現在選択されている推論加速 GPU（{0}）のドライバーバージョン（{1}、リリース日：{2}）は2年以上経過しており、互換性の問題が発生する可能性があります。\n\nグラフィックスドライバーを更新するか、 ｢{key=Settings} - {key=PerformanceSettings}｣ で別の GPU に変更することをおすすめします。</system:String>
     <system:String x:Key="GpuAllowDeprecated">非推奨 GPU の使用を許可する</system:String>
     <system:String x:Key="Copy">コピー</system:String>
     <!--  Toast 不可用  -->
@@ -117,15 +117,15 @@
 ↓ 歯車を右クリックで操作一覧</system:String>
     <system:String x:Key="UserGuide">使用ガイド</system:String>
     <system:String x:Key="GuideDocumentationTitle">📖 公式サイトとドキュメント</system:String>
-    <system:String x:Key="GuideDocumentationPath">MAA の公式サイトと完全なドキュメントは「{key=Settings} - {key=AboutUs} - {key=Website}」でご覧いただけます。</system:String>
+    <system:String x:Key="GuideDocumentationPath">MAA の公式サイトと完全なドキュメントは ｢{key=Settings} - {key=AboutUs} - {key=Website}｣ でご覧いただけます。</system:String>
     <system:String x:Key="GuideIssueReportSubtitle">🔧 問題が発生した場合</system:String>
-    <system:String x:Key="GuideViewLog">「{key=Settings} - {key=IssueReport} - {key=OpenDebugFolder}」にアクセスしてログを確認し、エラーの具体的な原因を把握できます。</system:String>
-    <system:String x:Key="GuideGenerateReport">「{key=Settings} - {key=IssueReport} - {key=GenerateSupportPayload}」を使用してエラーレポートを生成し、青い「{key=Issue}」リンクをクリックしてフィードバックを送信してください。</system:String>
+    <system:String x:Key="GuideViewLog"> ｢{key=Settings} - {key=IssueReport} - {key=OpenDebugFolder}｣ にアクセスしてログを確認し、エラーの具体的な原因を把握できます。</system:String>
+    <system:String x:Key="GuideGenerateReport"> ｢{key=Settings} - {key=IssueReport} - {key=GenerateSupportPayload}｣ を使用してエラーレポートを生成し、青い ｢{key=Issue}｣ リンクをクリックしてフィードバックを送信してください。</system:String>
     <system:String x:Key="GuideGitHubIssueTitle">⚠️ フィードバックガイドライン</system:String>
     <system:String x:Key="GuideGitHubIssueDescription">MAA Team は、Issue テンプレートの仕様に従って GitHub プラットフォームを通じてユーザーから提出されたフィードバックのみを受け付け、すべてのフィードバックの処理に関する決定権を留保します。</system:String>
     <system:String x:Key="GuideOpenSourceTitle">💡 オープンソースへの参加</system:String>
     <system:String x:Key="GuideOpenSourceDescription">オープンソースプロジェクトとして、ユーザーは AGPL-3.0 ライセンスの下で GitHub プラットフォーム上で MAA の開発に参加できます。MAA Team は、問題報告の代わりに価値あるコード貢献をすることを推奨しています。</system:String>
-    <system:String x:Key="GuideUserAgreement">MAA を使用することにより、「利用規約」に同意したものとみなされます。完全な規約は、公式サイトの下部のリンクからご覧いただけます。</system:String>
+    <system:String x:Key="GuideUserAgreement">MAA を使用することにより、 ｢利用規約｣ に同意したものとみなされます。完全な規約は、公式サイトの下部のリンクからご覧いただけます。</system:String>
     <system:String x:Key="RestartGuide">設定ガイドを再表示</system:String>
     <system:String x:Key="RestartGuidePrompt">設定ガイドはメイン画面に表示されます。今すぐアプリケーションを再起動しますか？</system:String>
     <!--  !設定ガイド  -->
@@ -163,9 +163,9 @@
     <system:String x:Key="InfrastModeNormal">通常モード</system:String>
     <system:String x:Key="InfrastModeRotation">一括シフト休暇</system:String>
     <system:String x:Key="InfrastModeRotationTip">一括シフト休暇を使用する前に、ゲーム内で{key=Operator}のシフト編成を手動で設定してください</system:String>
-    <system:String x:Key="InfrastModeRotationToolTip" xml:space="preserve">「{key=InfrastModeRotation}」の交代ロジックは、ゲーム内の基地右下にある「{key=InfrastModeRotation}」と全く同じです。
+    <system:String x:Key="InfrastModeRotationToolTip" xml:space="preserve"> ｢{key=InfrastModeRotation}｣ の交代ロジックは、ゲーム内の基地右下にある ｢{key=InfrastModeRotation}｣ と全く同じです。
 現在の班にいるオペレーターの中で、いずれかの士気が0になると、班全体が次の班に交代します。
-交代スケジュールをカスタマイズする場合は「{key=InfrastModeCustom}」をご利用ください。</system:String>
+交代スケジュールをカスタマイズする場合は ｢{key=InfrastModeCustom}｣ をご利用ください。</system:String>
     <system:String x:Key="InfrastModeCustom">カスタムされた基地構成</system:String>
     <system:String x:Key="DefaultInfrast">標準設定</system:String>
     <system:String x:Key="UserDefined">ユーザー定義</system:String>
@@ -221,17 +221,17 @@
     <system:String x:Key="StartingCoreChar">最初の{key=Operator}</system:String>
     <system:String x:Key="StartingCoreCharTip">記入がない場合はデフォルトの方針を使用します。</system:String>
     <system:String x:Key="RoguelikeStartingCoreCharNotFound">この{key=Operator}がbattle_dataにありません。</system:String>
-    <system:String x:Key="RoguelikeStartWithEliteTwo">「{key=StartingCoreChar}」直接昇進</system:String>
-    <system:String x:Key="RoguelikeOnlyStartWithEliteTwo">「{key=StartingCoreChar}」の昇進招集までリセマラし、戦闘を行わない</system:String>
+    <system:String x:Key="RoguelikeStartWithEliteTwo"> ｢{key=StartingCoreChar}｣ 直接昇進</system:String>
+    <system:String x:Key="RoguelikeOnlyStartWithEliteTwo"> ｢{key=StartingCoreChar}｣ の昇進招集までリセマラし、戦闘を行わない</system:String>
     <system:String x:Key="Roguelike3FirstFloorFoldartal">第一層遠見で指定された啓示板を取得し、戦闘を行わない</system:String>
     <system:String x:Key="Roguelike3NewSquad2StartingFoldartal">生活重視分隊で開始、指定された啓示板を取得する</system:String>
     <system:String x:Key="Roguelike3NewSquad2StartingFoldartalTip">最大3つ書き込み、半角セミコロン;で区切る</system:String>
     <system:String x:Key="RoguelikeCollapseList">崩壊パラダイムリスト</system:String>
-    <system:String x:Key="RoguelikeCollapseListTip">英語のセミコロン「;」で区切る、空白のままにするとデフォルトリストが使用されます。</system:String>
-    <system:String x:Key="RoguelikeUseSupportUnit">「{key=StartingCoreChar}」をサポートから選択</system:String>
-    <system:String x:Key="RoguelikeRequireStartingCoreChar">まず「{key=StartingCoreChar}」を入力してください</system:String>
+    <system:String x:Key="RoguelikeCollapseListTip">英語のセミコロン ｢;｣ で区切る、空白のままにするとデフォルトリストが使用されます。</system:String>
+    <system:String x:Key="RoguelikeUseSupportUnit"> ｢{key=StartingCoreChar}｣ をサポートから選択</system:String>
+    <system:String x:Key="RoguelikeRequireStartingCoreChar">まず ｢{key=StartingCoreChar}｣ を入力してください</system:String>
     <system:String x:Key="RoguelikeUseNonFriendSupport">戦友以外のサポートの使用を許可</system:String>
-    <system:String x:Key="RoguelikeDelayAbortUntilCombatComplete">自動ローグ 戦闘終了まえに「{key=Stop}」を遅らせる</system:String>
+    <system:String x:Key="RoguelikeDelayAbortUntilCombatComplete">自動ローグ 戦闘終了まえに ｢{key=Stop}｣ を遅らせる</system:String>
     <system:String x:Key="RoguelikeStopAtFinalBoss">第5階層のボスの手前で一時停止する</system:String>
     <system:String x:Key="RoguelikeStopAtMaxLevel">最大レベル達成時に停止</system:String>
     <system:String x:Key="RoguelikeStartWithSeed">シードから始める</system:String>
@@ -374,7 +374,7 @@
 3. 内部テスト版の問題をユーザーグループやコメントセクションなどの他の場所で議論しないでください。これにより公共のリソースが占有され、迅速なフィードバックと解決が妨げられます。
 4. 内部テスト版の更新方法を非開発ユーザーに共有しないでください。不要な混乱とリスクを避けるためです。
 
-「{key=Settings} - {key=IssueReport}」のリンクをクリックして、このポップアップをキャンセルできます。ご理解とご協力をお願いいたします！</system:String>
+ ｢{key=Settings} - {key=IssueReport}｣ のリンクをクリックして、このポップアップをキャンセルできます。ご理解とご協力をお願いいたします！</system:String>
     <system:String x:Key="UpdateCheck">更新チャネル</system:String>
     <system:String x:Key="UpdateCheckTip" xml:space="preserve">• {key=UpdateCheckBeta}: いくつかの小さなバグが含まれる可能性がありますが、新しい機能やテーマはより早くサポートされます。
 • {key=UpdateCheckStable}: バグは少なくなりますが、新機能や新しいテーマのサポートは遅くなります。新機能のサポートには数週間かかる場合があります。</system:String>
@@ -388,7 +388,7 @@
     <system:String x:Key="UpdateSourceTip" xml:space="preserve">
 🌏 {key=GlobalSource}を使用：
     • {key=UpdateCheckNow}：MAA Team による更新確認で、GitHub から更新パッケージを取得します。中国国内向けに直通ミラーも提供されています（ピーク時は帯域制限の可能性あり）
-    • {key=ResourceUpdate}：{key=MirrorChyan} による無料の更新確認が可能。設定画面で「{key=ResourceUpdate}」をクリックして GitHub から手動ダウンロード可能
+    • {key=ResourceUpdate}：{key=MirrorChyan} による無料の更新確認が可能。設定画面で ｢{key=ResourceUpdate}｣ をクリックして GitHub から手動ダウンロード可能
 
 🔑 {key=MirrorChyan}を使用：
     • CDK を入力すると、ソフトウェアとリソースの自動更新が有効になります
@@ -401,14 +401,14 @@
 📄 更新内容：
     • {key=UpdateCheckNow}：UI や機能のアップデートを含みます。すべての画面変更や新機能は{key=UpdateCheckNow}経由で提供されます
     • {key=ResourceUpdate}：自動戦闘用の新ステージ、ドロップ認識用アイコン、公募タグなどの素材データを含みます
-    • ナビホットパッチ：自動でトリガーされ、ホーム画面のヒントやイベントステージ入口を更新します。成功すると右上に「{key=ApiUpdateSuccess}」と表示されます
+    • ナビホットパッチ：自動でトリガーされ、ホーム画面のヒントやイベントステージ入口を更新します。成功すると右上に ｢{key=ApiUpdateSuccess}｣ と表示されます
 </system:String>
     <system:String x:Key="GlobalSource">グローバルソース</system:String>
     <system:String x:Key="ForceGithubGlobalSource">GitHub を強制使用</system:String>
     <system:String x:Key="ForceGithubGlobalSourceTip">更新を検出後、Githubから強制的に更新パッケージをダウンロード</system:String>
     <system:String x:Key="MirrorChyan">MirrorChyan</system:String>
-    <system:String x:Key="MirrorChyanSelectedButNoCdk">「{key=Settings} - {key=UpdateSettings}」に移動して MirrorChyan CDK を設定するか、グローバル ソースに切り替えてください。</system:String>
-    <system:String x:Key="MirrorChyanResourceUpdateTip">リソース更新 {0} が検出されました。「{key=Settings} - {key=UpdateSettings} - {key=ResourceUpdate}」に移動して手動で更新するか、MirrorChayn CDK を入力して自動的に更新してください。</system:String>
+    <system:String x:Key="MirrorChyanSelectedButNoCdk"> ｢{key=Settings} - {key=UpdateSettings}｣ に移動して MirrorChyan CDK を設定するか、グローバル ソースに切り替えてください。</system:String>
+    <system:String x:Key="MirrorChyanResourceUpdateTip">リソース更新 {0} が検出されました。 ｢{key=Settings} - {key=UpdateSettings} - {key=ResourceUpdate}｣ に移動して手動で更新するか、MirrorChayn CDK を入力して自動的に更新してください。</system:String>
     <system:String x:Key="MirrorChyanResourceUpdateShortTip">リソース更新 {0} が検出されました</system:String>
     <system:String x:Key="MirrorChyanCdkExpired">CDK の有効期限が切れました。新しい CDK を使用して認証してください。</system:String>
     <system:String x:Key="MirrorChyanCdkInvalid">CDK が無効です。入力が正しいか確認してください。</system:String>
@@ -418,8 +418,8 @@
     <system:String x:Key="MirrorChyanCdkRemainingDays">CDK の有効期限は残り {0} 日です。</system:String>
     <system:String x:Key="MirrorChyanCdkFetchFailed">CDK 情報の取得に失敗しました。前回正常に取得した結果を表示しています。</system:String>
     <system:String x:Key="NewVersionFoundTitle">新しいバージョンが見つかりました</system:String>
-    <system:String x:Key="NewVersionFoundDescDownloadingWithGlobalSource">「{key=GlobalSource}」からダウンロード中...</system:String>
-    <system:String x:Key="NewVersionFoundDescDownloadingWithMirrorChyan">「{key=MirrorChyan}」からダウンロード中...</system:String>
+    <system:String x:Key="NewVersionFoundDescDownloadingWithGlobalSource"> ｢{key=GlobalSource}｣ からダウンロード中...</system:String>
+    <system:String x:Key="NewVersionFoundDescDownloadingWithMirrorChyan"> ｢{key=MirrorChyan}｣ からダウンロード中...</system:String>
     <system:String x:Key="NewVersionFoundDescId" xml:space="preserve">バージョン: </system:String>
     <system:String x:Key="NewVersionFoundDescInfo" xml:space="preserve">内容: </system:String>
     <system:String x:Key="NewVersionFoundButtonGoWebpage">Webサイトで確認</system:String>
@@ -486,7 +486,7 @@ MAA は非インストール型のアプリケーションであり、レジス�
 レジストリの残留が気になる場合は、削除前にこのオプションを無効にしてください。
 </system:String>
     <system:String x:Key="LaunchOnSystemStartupAdminPrompt">
-        管理者権限での起動は、起動時の自動実行をサポートしていません。MAAを長時間管理者権限で実行することはお勧めしません。\n必要な場合は、「コントロールパネル &gt; Windowsツール &gt; タスクスケジューラ」に移動してカスタムタスクを作成してください。トリガーを設定する際に、「最も高い特権で実行」を必ず選択してください。
+        管理者権限での起動は、起動時の自動実行をサポートしていません。MAAを長時間管理者権限で実行することはお勧めしません。\n必要な場合は、 ｢コントロールパネル &gt; Windowsツール &gt; タスクスケジューラ｣ に移動してカスタムタスクを作成してください。トリガーを設定する際に、 ｢最も高い特権で実行｣ を必ず選択してください。
     </system:String>
     <system:String x:Key="RunTaskAfterLaunch">アプリの起動時に自動的に実行</system:String>
     <system:String x:Key="MinimizeAfterLaunch">アプリの起動時に自動的に最小化</system:String>
@@ -500,12 +500,12 @@ MAA は非インストール型のアプリケーションであり、レジス�
     <system:String x:Key="WaitForEmulator">エミュレータを待つ時間（秒）</system:String>
     <system:String x:Key="WaitForEmulatorFinish">待ち時間は終わりました</system:String>
     <system:String x:Key="EmulatorPath">エミュレータパス</system:String>
-    <system:String x:Key="SelectShortcutTip" xml:space="preserve">エミュレーター本体を選択（「{key=AdditionCommand}」起動パラメータでインスタンス指定可能）、または直接エミュレーター/ゲームのショートカットを選択できます。&#10;「{key=WakeUp}」タスクがエミュレーター起動遅延で失敗する場合、ゲームショートカットを使用し「{key=WaitForEmulator}」を延長することを推奨します。</system:String>
+    <system:String x:Key="SelectShortcutTip" xml:space="preserve">エミュレーター本体を選択（ ｢{key=AdditionCommand}｣ 起動パラメータでインスタンス指定可能）、または直接エミュレーター/ゲームのショートカットを選択できます。&#10; ｢{key=WakeUp}｣ タスクがエミュレーター起動遅延で失敗する場合、ゲームショートカットを使用し ｢{key=WaitForEmulator}｣ を延長することを推奨します。</system:String>
     <system:String x:Key="EmulatorPathSelectionErrorPrompt">バーでバーを注文したいですか？</system:String>
     <system:String x:Key="EmulatorPathSelectionErrorImSure">確かに間違って選択していないと思います</system:String>
     <system:String x:Key="EmulatorPathSelectionErrorSelectAgain">はい、もう一度選択します</system:String>
     <system:String x:Key="EmulatorPathNotExist">エミュレータのパスが存在しません</system:String>
-    <system:String x:Key="EmulatorPathEmptyWarning">エミュレータのパスが空です。「{key=RetryOnDisconnected}」と「{key=OpenEmulatorAfterLaunch}」のチェック状態がリセットされました</system:String>
+    <system:String x:Key="EmulatorPathEmptyWarning">エミュレータのパスが空です。 ｢{key=RetryOnDisconnected}｣ と ｢{key=OpenEmulatorAfterLaunch}｣ のチェック状態がリセットされました</system:String>
     <system:String x:Key="Select">選択</system:String>
     <system:String x:Key="Test">テスト</system:String>
     <system:String x:Key="ForcedReplaceAdb">ADB強制置き換え</system:String>
@@ -517,7 +517,7 @@ MAA は非インストール型のアプリケーションであり、レジス�
     <system:String x:Key="MaaFwAdbTouchMode">MaaFramework (実験機能)</system:String>
     <system:String x:Key="TouchModeTip" xml:space="preserve">ADB Input は、OS バージョンが古く Minitouch や MaaTouch を使用できない物理デバイス用です。他の2モードが使える場合は、ADB Input を選択しないでください。&#10;ADB Input のスワイプはズレやすいため、スワイプ速度が非常に遅く設定され、スワイプ距離も他の2モードと異なります。正確な座標制御が必要な場面では使用できません。</system:String>
     <system:String x:Key="AdditionCommand">追加コマンド</system:String>
-    <system:String x:Key="AdditionCommandTip" xml:space="preserve">エミュレーター起動パラメータの追加コマンド（例：「--instance 1」は 1 番インスタンス）。&#10;コマンド形式はエミュレーターにより異なり、通常はインスタンス番号やウィンドウモードなどを含みます。</system:String>
+    <system:String x:Key="AdditionCommandTip" xml:space="preserve">エミュレーター起動パラメータの追加コマンド（例： ｢--instance 1｣ は 1 番インスタンス）。&#10;コマンド形式はエミュレーターにより異なり、通常はインスタンス番号やウィンドウモードなどを含みます。</system:String>
     <system:String x:Key="StartsWithScript">スクリプトを使用して始めます</system:String>
     <system:String x:Key="EndsWithScript">終了時にスクリプトを使用します</system:String>
     <system:String x:Key="CopilotWithScript">自動戦闘時に上記のスクリプトを有効にする</system:String>
@@ -560,7 +560,7 @@ MAA は非インストール型のアプリケーションであり、レジス�
 {key=StartingCoreChar}: ウィシャデル
 
 1. ｢{key=IS4NewSquad3}｣：完全回避戦術を採用し、攻略を狙わない高速レベリングに適します
-2. ｢{key=IS4NewSquad6}｣を使用すると源石錐稼ぎ効率が向上しますが、戦略を「源石錐稼ぎ」に設定する必要があります
+2. ｢{key=IS4NewSquad6}｣を使用すると源石錐稼ぎ効率が向上しますが、戦略を ｢源石錐稼ぎ｣ に設定する必要があります
 3. 最高難易度がN15以上の場合、6★オペレーターの希望消費が+1になり、一部の分隊では開始時に6★オペレーターを招集できず、エラーや失敗を招く可能性があります</system:String>
     <system:String x:Key="RoguelikeThemeTipJieGarden" xml:space="preserve">{key=RoguelikeThemeJieGarden}推奨構成:
 
@@ -568,14 +568,14 @@ MAA は非インストール型のアプリケーションであり、レジス�
 {key=StartingRoles}: {key=SlowAndSteadyWinsTheRace}
 {key=StartingCoreChar}: ウィシャデル
 
-1. 戦略を「源石錐稼ぎ」にし、難易度を N3 以上または「MAX」に設定し、{key=StartingSquad}を｢{key=LeaderSquad}｣にすると指揮回避戦闘戦術が有効になります
-2. 指揮回避戦闘戦術を使うと源石錐稼ぎ効率が大幅に向上し、高速レベリング（攻略を狙わない）にも使用できますが、戦略を「源石錐稼ぎ」に設定する必要があります
+1. 戦略を ｢源石錐稼ぎ｣ にし、難易度を N3 以上または ｢MAX｣ に設定し、{key=StartingSquad}を｢{key=LeaderSquad}｣にすると指揮回避戦闘戦術が有効になります
+2. 指揮回避戦闘戦術を使うと源石錐稼ぎ効率が大幅に向上し、高速レベリング（攻略を狙わない）にも使用できますが、戦略を ｢源石錐稼ぎ｣ に設定する必要があります
 3. 解放済みの最高難易度が N3 未満、または関連知識を解放していない場合は指揮回避戦闘戦術を使用しないでください。エラーの原因になります
 4. 最高難易度が N15 以上の場合、6★オペレーターの希望消費が+1になり、一部の分隊では開始時に6★オペレーターを招集できず、エラーや失敗を招く可能性があります</system:String>
     <system:String x:Key="RoguelikeDifficulty">難易度</system:String>
-    <system:String x:Key="RoguelikeJieGardenDifficultyTip" xml:space="preserve">｢{key=RoguelikeThemeJieGarden}｣に関連する知識を解放すると、{key=LeaderSquad}で N3 以上の難易度を探索する際に「時の果て」を追加で携帯し、「一戦一跳」の貯蓄戦術を行えます。
-まだ解放していない場合は、N3 以上の難易度（「MAX」を含む）を選択しないでください。
-この機能を有効にするには、難易度を N3 以上に設定してください（「{key=NotSwitch} (-1)」を除く）。</system:String>
+    <system:String x:Key="RoguelikeJieGardenDifficultyTip" xml:space="preserve">｢{key=RoguelikeThemeJieGarden}｣に関連する知識を解放すると、{key=LeaderSquad}で N3 以上の難易度を探索する際に ｢時の果て｣ を追加で携帯し、 ｢一戦一跳｣ の貯蓄戦術を行えます。
+まだ解放していない場合は、N3 以上の難易度（ ｢MAX｣ を含む）を選択しないでください。
+この機能を有効にするには、難易度を N3 以上に設定してください（ ｢{key=NotSwitch} (-1)｣ を除く）。</system:String>
     <system:String x:Key="Strategy">ストラテジー</system:String>
     <system:String x:Key="StartTimesLimit">冒険をN回始めた後に停止する</system:String>
     <system:String x:Key="GoldTimesLimit">N回投資した後に停止する</system:String>
@@ -603,9 +603,9 @@ MAA は非インストール型のアプリケーションであり、レジス�
     <system:String x:Key="OnlyOnceADay">一日一回だけ</system:String>
     <system:String x:Key="CreditFight">サポートを借りて戦闘を行いポイントを獲得します</system:String>
     <system:String x:Key="CreditFightTip" xml:space="preserve">基地訪問後、OF-1でサポートを使用すると、30FP獲得できます。
-この機能は、ステージを「{key=DefaultStage}」に選択している場合は無効です。
+この機能は、ステージを ｢{key=DefaultStage}｣ に選択している場合は無効です。
 ステージOF-1がアンロックされていない場合は、チェックしないでください。</system:String>
-    <system:String x:Key="CreditFightWhenOF-1Warning">「{key=Fight}」タスクのステージリストに「{key=DefaultStage}」が存在するし、「{key=Mall}」タスクはOF-1での戦友サポート借用の戦闘をスキップします。タスク名: {0} (シーケンス番号 {1})、レベル シーケンス番号 {2}</system:String>
+    <system:String x:Key="CreditFightWhenOF-1Warning"> ｢{key=Fight}｣ タスクのステージリストに ｢{key=DefaultStage}｣ が存在するし、 ｢{key=Mall}｣ タスクはOF-1での戦友サポート借用の戦闘をスキップします。タスク名: {0} (シーケンス番号 {1})、レベル シーケンス番号 {2}</system:String>
     <system:String x:Key="HighPriority">優先購入（セミコロンで区切）</system:String>
     <system:String x:Key="Blacklist">ブラックリスト（セミコロンで区切）</system:String>
     <system:String x:Key="HighPriorityDefault">求人票</system:String>
@@ -621,7 +621,7 @@ MAA は非インストール型のアプリケーションであり、レジス�
     <system:String x:Key="ReceiveMail">すべてのメール報酬を受取</system:String>
     <system:String x:Key="ReceiveFreeGacha">リミテッドスカウトから毎日無料スカウトを行う</system:String>
     <system:String x:Key="ReceiveFreeGachaTip">無料スカウトがない場合はスカウトしない</system:String>
-    <system:String x:Key="GachaWarning">これは危険な機能であり、誤用につながる可能性があります\n「{key=Confirm}」ボタンを押すことで、起こりうる危険を理解し、それを引き受ける意思があるとみなされます</system:String>
+    <system:String x:Key="GachaWarning">これは危険な機能であり、誤用につながる可能性があります\n ｢{key=Confirm}｣ ボタンを押すことで、起こりうる危険を理解し、それを引き受ける意思があるとみなされます</system:String>
     <system:String x:Key="ReceiveOrundum">ラッキーウォールから毎日合成玉の報酬を受け取る</system:String>
     <system:String x:Key="ReceiveMining">期間限定の採掘許可で毎日合成玉の報酬を受け取る</system:String>
     <system:String x:Key="ReceiveSpecialAccess">スペシャルアクセス特典を集める</system:String>
@@ -637,7 +637,7 @@ MAA は非インストール型のポータブルソフトウェアで、通知�
 HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Notifications\Settings
 該当するパスのキーを削除してください。
 </system:String>
-    <system:String x:Key="HideCloseButton">「閉じる」ボタンを隠す</system:String>
+    <system:String x:Key="HideCloseButton"> ｢閉じる｣ ボタンを隠す</system:String>
     <system:String x:Key="WindowTitleScrollable">タイトルのスクロール機能</system:String>
     <system:String x:Key="MainTasksNullFunctionality">メインタスクの右クリック効果を反転</system:String>
     <system:String x:Key="MainTasksNullFunctionalityTip">デフォルト：1回のみ有効、チェック後：1回のみスキップ</system:String>
@@ -645,14 +645,14 @@ HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Notifications\Settin
     <system:String x:Key="UseCardLog">カードスタイルのログを使用</system:String>
     <system:String x:Key="MaxNumberOfLogThumbnails">ログサムネイルの最大数</system:String>
     <system:String x:Key="TitleBarDisplayContent">タイトルバー表示コンテンツ</system:String>
-    <system:String x:Key="CustomBackgroundTip">「background」フォルダを手動で作成し、background.png を配置すると背景画像をカスタマイズできます</system:String>
+    <system:String x:Key="CustomBackgroundTip"> ｢background｣ フォルダを手動で作成し、background.png を配置すると背景画像をカスタマイズできます</system:String>
     <system:String x:Key="UseLogItemDateFormat">カスタムログ日付形式</system:String>
     <system:String x:Key="LogItemDateFormatString">日付書式文字列</system:String>
     <system:String x:Key="PromptRestartForSettingsChange">変更を適用するためにすぐに再起動しますか？</system:String>
     <system:String x:Key="SwitchResolutionTip">エミュレータの解像度を1920x1080に変更!</system:String>
     <system:String x:Key="ResolutionInfoYoStarEN">エミュレータが1920x1080に設定されていることを確認してください</system:String>
     <system:String x:Key="AllowUseStoneSave">源石の数を割る保存状態を許可</system:String>
-    <system:String x:Key="AllowUseStoneSaveWarning">この機能は危険な機能と見なされます。「{key=Confirm}」ボタンを押すと、リスクを理解し、受け入れることに同意したと見なされます。</system:String>
+    <system:String x:Key="AllowUseStoneSaveWarning">この機能は危険な機能と見なされます。 ｢{key=Confirm}｣ ボタンを押すと、リスクを理解し、受け入れることに同意したと見なされます。</system:String>
     <system:String x:Key="UseAlternateStage">代替ステージを選択可能にする</system:String>
     <system:String x:Key="UseExpiringMedicine">N時間以内に期限が切れる回復剤を無制限に使用</system:String>
     <system:String x:Key="UseExpireMedicineForActivity">今週中に期限切れとなる正気回復ポーションは、アクティビティ終了の48時間以内に使用してください。</system:String>
@@ -664,8 +664,8 @@ HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Notifications\Settin
     <system:String x:Key="StagePlanTip">最初の開放したステージを実行します。すべてのステージが未開放の場合は、現在のタスクはスキップされます。\n現在実行中: {0}</system:String>
     <system:String x:Key="CustomStageCode">ステージ名を入力する</system:String>
     <system:String x:Key="CustomStageCodeTip" xml:space="preserve">(テスト機能)ステージ名と番号（例: 4-10、AP-5、H10-1-Hardなど）
-の両方がサポートされています。ステージの最後に「Normal/Hard」を入力すると難易度を切り替えできます（10〜14章は標準/厄難、15章以降は通常/険地）</system:String>
-    <!--ワンタイム代理SS一般パスとして「SSReopen-XX」を入力できます</system:String>-->
+の両方がサポートされています。ステージの最後に ｢Normal/Hard｣ を入力すると難易度を切り替えできます（10〜14章は標準/厄難、15章以降は通常/険地）</system:String>
+    <!--ワンタイム代理SS一般パスとして ｢SSReopen-XX｣ を入力できます</system:String>-->
     <system:String x:Key="AutoDetectConnection">接続自動認識</system:String>
     <system:String x:Key="AutoDetectConnectionNotSupported">この接続構成では自動接続検出はサポートされていません。手動でポート番号を入力してみてください</system:String>
     <system:String x:Key="AutoDetectConnectionTip" xml:space="preserve">このチェックボックスは、検出が完了するたびに自動的にチェックが外れますが、再検出が必要な場合は再度チェックを入れることができます。
@@ -678,8 +678,8 @@ HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Notifications\Settin
     <system:String x:Key="AccountSwitch">アカウントの切り替え</system:String>
     <system:String x:Key="AccountSwitchManualRun">今すぐ切り替える</system:String>
     <system:String x:Key="AccountSwitchTip" xml:space="preserve">切り替える必要があるアカウントを入力し、空白のままにしてアカウントの切り替えを停止します。
-ログインインターフェイスに表示される内容を入力します（「123****4567」など）。「123****4567」、「4567」または「23****45」を入力できます。
-繁体字中国語サーバーのアカウントはEメール形式です（「ab****01@gmail.com」など）。アスタリスクを含まない明文部分（「01@gmail」など）の入力を推奨します。
+ログインインターフェイスに表示される内容を入力します（ ｢123****4567｣ など）。 ｢123****4567｣ 、 ｢4567｣ または ｢23****45｣ を入力できます。
+繁体字中国語サーバーのアカウントはEメール形式です（ ｢ab****01@gmail.com｣ など）。アスタリスクを含まない明文部分（ ｢01@gmail｣ など）の入力を推奨します。
 公式(CN)、Bilibili、繁体字中国語サーバーのみをサポートします。サードパーティのログイン方式はサポートされていません。</system:String>
     <system:String x:Key="AdbPath">ADBパス</system:String>
     <system:String x:Key="AdbPathFileSelectionErrorPrompt">選択されたファイル名にADBが含まれていません。誤ったファイルを選択していないか、エミュレータ自体を選択していないか確認してください。</system:String>
@@ -715,6 +715,7 @@ C:\\Program Files\\Netease\\MuMuPlayer を入力してください。\n
     <system:String x:Key="MuMu12Index">インスタンス番号</system:String>
     <system:String x:Key="MuMu12Display">表示番号</system:String>
     <system:String x:Key="MuMuExtrasNotEnabledMessage">MuMu スクリーンショットの強化 が有効になっていません。関連する設定を確認してください</system:String>
+    <system:String x:Key="MuMuEmulator12KeepAliveOn">MuMu エミュレータのバックグラウンド常駐が有効になっています。スクリーンショットの失敗や操作異常が発生する可能性があります。MuMuの設定で ｢バックグラウンド常駐｣ （または ｢アプリ常駐｣ など）をオフにしてください</system:String>
     <system:String x:Key="LdExtrasEnabled">LD のスクリーンショット拡張モードを有効にする</system:String>
     <system:String x:Key="LdPlayerEmulatorPathNotFound">LDPlayer のインストールパスが見つかりません。</system:String>
     <system:String x:Key="LdPlayerOpenglMissing">選択した LDPlayer パスに ldopengl64.dll が見つかりません。インストールディレクトリを確認してください。</system:String>
@@ -732,12 +733,12 @@ C:\\leidian\\LDPlayer9
 縦画面状態でゲームを起動した後、横画面に切り替えると、画面の乱れ（ティアリング）などの問題が発生する可能性があります。
     </system:String>
     <system:String x:Key="LdEmulatorPath">LD エミュレータパス</system:String>
-    <system:String x:Key="LdManualSetIndex">「{key=LdIndex}」を手動で入力</system:String>
+    <system:String x:Key="LdManualSetIndex"> ｢{key=LdIndex}｣ を手動で入力</system:String>
     <system:String x:Key="LdIndex">インスタンス番号</system:String>
     <system:String x:Key="LdExtrasNotEnabledMessage">LD スクリーンショットの強化 が有効になっていません。関連する設定を確認してください</system:String>
     <system:String x:Key="RetryOnDisconnected">ADB接続が失敗した場合、エミュレータの起動を試みる</system:String>
     <system:String x:Key="RetryOnDisconnectedTip">再接続に失敗した後、エミュレータを再起動してみてください，バックグラウンドのタイムドタスクを使用し、終了時にエミュレータを終了させるタスクを設定する場合は、必ずチェックを入れること</system:String>
-    <system:String x:Key="RetryOnDisconnectedEmulatorPathEmptyError">エミュレータのパスが空です！「{key=Settings} - {key=StartupSettings} - {key=EmulatorPath}」を入力してから再度選択してください。</system:String>
+    <system:String x:Key="RetryOnDisconnectedEmulatorPathEmptyError">エミュレータのパスが空です！ ｢{key=Settings} - {key=StartupSettings} - {key=EmulatorPath}｣ を入力してから再度選択してください。</system:String>
     <system:String x:Key="AllowAdbRestart">接続失敗後にADBサーバーの再起動を試みる</system:String>
     <system:String x:Key="AllowAdbHardRestart">接続失敗後にADBプロセスの再起動を試みる</system:String>
     <!--  !設定  -->
@@ -844,7 +845,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="DaysLeftOpen" xml:space="preserve">公開日まで: </system:String>
     <system:String x:Key="Inventory">在庫</system:String>
     <system:String x:Key="InventoryUpdateTip">在庫データは ｢{key=Toolbox}-{key=DepotRecognition}｣ で更新できます</system:String>
-    <system:String x:Key="SpecifiedDropsInventoryUnavailable">タスク「{0}」では {key=TargetInventory} が有効ですが、利用可能な在庫データがないためスキップされました。｢{key=Toolbox}-{key=DepotRecognition}｣ で在庫を更新してください。</system:String>
+    <system:String x:Key="SpecifiedDropsInventoryUnavailable">タスク ｢{0}｣ では {key=TargetInventory} が有効ですが、利用可能な在庫データがないためスキップされました。｢{key=Toolbox}-{key=DepotRecognition}｣ で在庫を更新してください。</system:String>
     <system:String x:Key="LessThanOneDay">1日以内</system:String>
     <system:String x:Key="1-7">1-7</system:String>
     <system:String x:Key="CE-6">龍門幣-6(CE-6)</system:String>
@@ -889,7 +890,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="Running">動作中……</system:String>
     <system:String x:Key="TaskAppend.Skip">{0}: {1} タスクをスキップしました</system:String>
     <system:String x:Key="TaskAppend.Error">{0}: {1} タスクの追加に失敗しました</system:String>
-    <system:String x:Key="AdbReplacementTips">タスクが応答なしになる場合は、「{key=Settings} - {key=ConnectionSettings} - {key=ForcedReplaceAdb}」、もしくは ADB Input タッチモード をチェックしてください（お勧めしない）。</system:String>
+    <system:String x:Key="AdbReplacementTips">タスクが応答なしになる場合は、 ｢{key=Settings} - {key=ConnectionSettings} - {key=ForcedReplaceAdb}｣ 、もしくは ADB Input タッチモード をチェックしてください（お勧めしない）。</system:String>
     <system:String x:Key="Waiting">ミッション終了を待っています……</system:String>
     <system:String x:Key="Stopping">動作停止中……</system:String>
     <system:String x:Key="Stopped">動作停止</system:String>
@@ -920,7 +921,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="RecruitmentRecognitionTip">ヒント: スタート画面の公開求人とは、別々の機能になっています。使用する前にゲームの公開求人を手動で開いてください</system:String>
     <system:String x:Key="AutoSettingTime">募集期間を自動的に設定する</system:String>
     <system:String x:Key="RecruitmentShowPotential">潜在数を表示する（4/5/6★ Tags）</system:String>
-    <system:String x:Key="RecruitmentShowPotentialTips">情報を取得するために「{key=OperBoxRecognition}」を使用してください。</system:String>
+    <system:String x:Key="RecruitmentShowPotentialTips">情報を取得するために ｢{key=OperBoxRecognition}｣ を使用してください。</system:String>
     <system:String x:Key="AutoSelectLevel3Tags">星3タグを自動的に選択する</system:String>
     <system:String x:Key="AutoSelectLevel4Tags">星4タグを自動的に選択する</system:String>
     <system:String x:Key="AutoSelectLevel5Tags">星5タグを自動的に選択する</system:String>
@@ -945,7 +946,7 @@ C:\\leidian\\LDPlayer9
     <!--  Operator Recognition  -->
     <system:String x:Key="OperBoxRecognition">{key=Operator}</system:String>
     <system:String x:Key="OperBox">{key=OperBoxRecognition}</system:String>
-    <system:String x:Key="OperBoxRecognitionTip">「戦術要員」は、{key=Operator}識別の正確性に影響します。戦術要員の{key=Operator}の識別が誤っている場合は、自己判断してください。</system:String>
+    <system:String x:Key="OperBoxRecognitionTip"> ｢戦術要員｣ は、{key=Operator}識別の正確性に影響します。戦術要員の{key=Operator}の識別が誤っている場合は、自己判断してください。</system:String>
     <system:String x:Key="OperBoxHaveList">所有している: {0}</system:String>
     <system:String x:Key="OperBoxNotHaveList">所有していない: {0}</system:String>
     <system:String x:Key="StartToOperBoxRecognition">認識開始</system:String>
@@ -966,7 +967,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="VideoRecognition">映像</system:String>
     <system:String x:Key="StartToVideoRecognition">認識を始める</system:String>
     <system:String x:Key="OpenVideoRecognitionResult">ディレクトリを開く</system:String>
-    <system:String x:Key="VideoRecognitionTips" xml:space="preserve">映像認識のために、「{key=Copilot}」ページを開き、映像をドラッグしてください。
+    <system:String x:Key="VideoRecognitionTips" xml:space="preserve">映像認識のために、 ｢{key=Copilot}｣ ページを開き、映像をドラッグしてください。
 映像の解像度は16: 9である必要があり、黒枠、エミュレータ枠、特殊な形状、画面効果などが無いことを確認してください。</system:String>
     <!--  VideoRecognition  -->
     <!--  Gacha Recognition  -->
@@ -1009,14 +1010,14 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="MiniGame@PV">PV-花火実行委員会</system:String>
     <system:String x:Key="MiniGame@PVTip">選択したステージから自動でクリアします。最初のステージを選んだ場合は、イベントページの最左側から開始してください。その他のステージを選んだ場合は、位置を校正するために前のステージに一度入ってから戻ってください。</system:String>
     <system:String x:Key="MiniGame@SPA">堅守協定：盟約</system:String>
-    <system:String x:Key="MiniGame@SPATip" xml:space="preserve">イベントメイン画面（「単独演算」の場所）からタスクを開始
+    <system:String x:Key="MiniGame@SPATip" xml:space="preserve">イベントメイン画面（ ｢単独演算｣ の場所）からタスクを開始
 セーブデータがある場合は、まず手動で破棄する必要があります
-「逆境シミュレーション」までテスト済み
-より高い難易度をクリア済みで「逆境シミュレーション」または「標準シミュレーション」が表示されない場合、\n「逆境シミュレーション」難易度を手動で一度選択してください
-「標準シミュレーション」を手動でクリアすると、より早くスコアを稼げます
-レベル報酬のみ取得可能。「功績勲章」を入手するには全ての「主要目標」をクリアする必要があります</system:String>
+ ｢逆境シミュレーション｣ までテスト済み
+より高い難易度をクリア済みで ｢逆境シミュレーション｣ または ｢標準シミュレーション｣ が表示されない場合、\n ｢逆境シミュレーション｣ 難易度を手動で一度選択してください
+ ｢標準シミュレーション｣ を手動でクリアすると、より早くスコアを稼げます
+レベル報酬のみ取得可能。 ｢功績勲章｣ を入手するには全ての ｢主要目標｣ をクリアする必要があります</system:String>
     <system:String x:Key="MiniGame@OS">OS-カランド貿易 研究開発部</system:String>
-    <system:String x:Key="MiniGame@OSTip">イベントメイン画面（右下に「再建開始」がある場所）でタスクを開始します。</system:String>
+    <system:String x:Key="MiniGame@OSTip">イベントメイン画面（右下に ｢再建開始｣ がある場所）でタスクを開始します。</system:String>
     <system:String x:Key="MiniGame@RM-TR-1">再建画策 RM-TR-1</system:String>
     <system:String x:Key="MiniGame@RM-TR-1Tip" xml:space="preserve">チュートリアル終了後、前哨基地に入り、画面を一番左までスワイプしてください。</system:String>
     <system:String x:Key="MiniGame@RM-1">再建画策 RM-1</system:String>
@@ -1024,7 +1025,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="MiniGame@AT@ConversationRoom">AT - 相談室</system:String>
     <system:String x:Key="MiniGame@AT@ConversationRoomTip" xml:space="preserve">イベント画面（右下角に ｢営業開始｣ ボタンがあります）でタスクを開始します。</system:String>
     <system:String x:Key="MiniGame@ALL@GreenGrass">デュエルチャンネル：グリーングラスシティ</system:String>
-    <system:String x:Key="MiniGame@ALL@GreenGrassTip" xml:space="preserve">手動でチュートリアルの会話をスキップし、直接退出することができます。&#10;イベント画面（右下角に「試合観戦」ボタンがあります）でタスクを開始します。&#10;&#10;ダック卿の選択をフォローする。</system:String>
+    <system:String x:Key="MiniGame@ALL@GreenGrassTip" xml:space="preserve">手動でチュートリアルの会話をスキップし、直接退出することができます。&#10;イベント画面（右下角に ｢試合観戦｣ ボタンがあります）でタスクを開始します。&#10;&#10;ダック卿の選択をフォローする。</system:String>
     <system:String x:Key="MiniGame@ALL@HoneyFruit">デュエルチャンネル：ハニーデューシティ</system:String>
     <system:String x:Key="MiniGame@ALL@HoneyFruitTip" xml:space="preserve">{key=MiniGame@ALL@GreenGrassTip}</system:String>
     <system:String x:Key="MiniGame@ALL@IvyVine">デュエルチャンネル：アイヴィヴァインシティ</system:String>
@@ -1035,7 +1036,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="MiniGame@SecretFront@Event2">遊侠</system:String>
     <system:String x:Key="MiniGame@SecretFront@Event3">揺蕩う影</system:String>
     <system:String x:Key="MiniGame@SecretFront">隠密戦線</system:String>
-    <system:String x:Key="MiniGame@SecretFrontTip">小隊選択画面で開始します。セーブデータがある場合は手動で削除する必要があります。ゲーム内の「前の小隊からのデータを引き継ぐ」にチェックすることを推奨します。</system:String>
+    <system:String x:Key="MiniGame@SecretFrontTip">小隊選択画面で開始します。セーブデータがある場合は手動で削除する必要があります。ゲーム内の ｢前の小隊からのデータを引き継ぐ｣ にチェックすることを推奨します。</system:String>
     <system:String x:Key="MiniGameNameGreenTicketStore">緑チケット商店</system:String>
     <system:String x:Key="MiniGameNameGreenTicketStoreTip" xml:space="preserve">1階は全部購入。&#10;2階はスカウト券と求人票を購入のみ。</system:String>
     <system:String x:Key="MiniGameNameYellowTicketStore">黄チケット商店</system:String>
@@ -1066,7 +1067,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="FailedToLikeWebJson">エラーが発生しました、いいねに失敗しました。 : &lt;</system:String>
     <system:String x:Key="ThanksForLikeWebJson">感謝と評価！\nウェブページには既にコメント欄が開放されており、あなたのコメントを心待ちにしています！</system:String>
     <system:String x:Key="AutoSquad">自動編成</system:String>
-    <system:String x:Key="AutoSquadTip">自動編成では、一時的に「戦術要員」{key=Operator}を認識できません</system:String>
+    <system:String x:Key="AutoSquadTip">自動編成では、一時的に ｢戦術要員｣ {key=Operator}を認識できません</system:String>
     <system:String x:Key="SupportUnitUsage">戦友サポート借用</system:String>
     <system:String x:Key="SupportUnitUsage.Tip">1つ足りないくらいならまだ使えますが、2つ以上欠けている場合は別の攻略に替えたほうがいいでしょう。</system:String>
     <system:String x:Key="SupportUnitUsage.None">借用しない</system:String>
@@ -1078,7 +1079,7 @@ C:\\leidian\\LDPlayer9
 この項目を選択するとこれらのチェックをスキップしますが、タスクが正常に動作しなくなる可能性があります。
 オペレーターのエリートレベルはスキップできません。いずれかの条件をスキップした場合、戦闘後にオペレーションは自動的に評価されなくなります。</system:String>
     <system:String x:Key="AddUserAdditional">カスタム{key=Operator}追加</system:String>
-    <system:String x:Key="AddUserAdditionalTip">「;」はセパレータ、「,」で{key=Operator}の名前とスキルを区切ります。例: Surtr, 3; Eyjafjalla, 1</system:String>
+    <system:String x:Key="AddUserAdditionalTip"> ｢;｣ はセパレータ、 ｢,｣ で{key=Operator}の名前とスキルを区切ります。例: Surtr, 3; Eyjafjalla, 1</system:String>
     <system:String x:Key="UserAdditional.OperatorName">{key=Operator}名</system:String>
     <system:String x:Key="UserAdditional.Skill">スキル</system:String>
     <system:String x:Key="UserAdditional.Action">操作</system:String>
@@ -1093,7 +1094,7 @@ C:\\leidian\\LDPlayer9
   4. {key=ParadoxSimulation}: {key=Operator}リストから起動
 対応する画面から開始してください。章間のナビゲーションはサポートされていません。
 
-「{key=UseCopilotList}」を有効にすると、個々のジョブが自動的に「{key=CopilotList}」に追加されます。</system:String>
+ ｢{key=UseCopilotList}｣ を有効にすると、個々のジョブが自動的に ｢{key=CopilotList}｣ に追加されます。</system:String>
     <system:String x:Key="CopilotTaskRaidStage">（強襲）</system:String>
     <system:String x:Key="CopilotAddTask" xml:space="preserve">左クリックで通常難易度を追加
 右クリックしてレイドの難易度を追加します</system:String>
@@ -1131,10 +1132,10 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="CopilotTip">
         ヒント: \n\n
         1. この機能を使用前に、攻略ファイルと選択したステージタイプが一致していることを確認してください。\n\n
-        2. {key=MainStage}、{key=StoryCollection}、{key=SideStory}: 右下の「行動開始」ボタン画面で開始してください。\n\n
-        3. {key=SSS}: resource/copilot フォルダー内に複数の課題があります。まず手動で編成を行い、右下の「配置開始」ボタン画面で開始してください。「{key=LoopTimes}」と連携することもできます。\n\n
-        4. {key=ParadoxSimulation}: スキルを選択した後、スキル選択画面に「演算開始」ボタンが表示され、1/2 星{key=Operator}（スキルなし）が右下に「演算開始」ボタンを表示されて開始します。「{key=UseCopilotList}」を使用する場合、{key=Operator}リストの｢レベル/レアリティ｣タブから開始してください。\n\n
-        5. 「戦術要員」機能を有効にすると、「{key=AutoSquad}」の{key=Operator}選択に影響を与える可能性があります。「{key=AutoSquad}」を 使用する際は「戦術要員」をオフにするか、不足している{key=Operator}を手動で補充して編成を完成させることをお勧めします。\n\n
+        2. {key=MainStage}、{key=StoryCollection}、{key=SideStory}: 右下の ｢行動開始｣ ボタン画面で開始してください。\n\n
+        3. {key=SSS}: resource/copilot フォルダー内に複数の課題があります。まず手動で編成を行い、右下の ｢配置開始｣ ボタン画面で開始してください。 ｢{key=LoopTimes}｣ と連携することもできます。\n\n
+        4. {key=ParadoxSimulation}: スキルを選択した後、スキル選択画面に ｢演算開始｣ ボタンが表示され、1/2 星{key=Operator}（スキルなし）が右下に ｢演算開始｣ ボタンを表示されて開始します。 ｢{key=UseCopilotList}｣ を使用する場合、{key=Operator}リストの｢レベル/レアリティ｣タブから開始してください。\n\n
+        5.  ｢戦術要員｣ 機能を有効にすると、 ｢{key=AutoSquad}｣ の{key=Operator}選択に影響を与える可能性があります。 ｢{key=AutoSquad}｣ を 使用する際は ｢戦術要員｣ をオフにするか、不足している{key=Operator}を手動で補充して編成を完成させることをお勧めします。\n\n
         6. Copilot作業ステーションでは、入力欄の右側にある貼り付けボタンをクリックして、謎のコードを貼り付けることができます：\n
         • 2番目のボタンをクリック = 割り当てを追加。\n
         • 3番目のボタンをクリック = 割り当てセットを追加。\n\n
@@ -1160,9 +1161,9 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="CopilotTaskTypeMismatch">選択した作業が現在のタブと一致しません</system:String>
     <system:String x:Key="CopilotTasksWithEmptyName">ステージ名が空の作業があります</system:String>
     <system:String x:Key="CopilotCouldNotSaveFile" xml:space="preserve">コパイロットタスクをファイルに保存できませんでした: </system:String>
-    <system:String x:Key="CopilotStartWithEmptyList">タスクなしで「{key=UseCopilotList}」を使用した</system:String>
-    <system:String x:Key="CopilotSingleTaskWarning">「{key=UseCopilotList}」を使用して単一ジョブを実行しています。これは推奨されません。単一ジョブを直接実行してください。</system:String>
-    <system:String x:Key="CopilotTaskListMixedModeNotAllowed">「{key=UseCopilotList}」を使用中ですが、異なるジョブタイプの混在はサポートされていません。</system:String>
+    <system:String x:Key="CopilotStartWithEmptyList">タスクなしで ｢{key=UseCopilotList}｣ を使用した</system:String>
+    <system:String x:Key="CopilotSingleTaskWarning"> ｢{key=UseCopilotList}｣ を使用して単一ジョブを実行しています。これは推奨されません。単一ジョブを直接実行してください。</system:String>
+    <system:String x:Key="CopilotTaskListMixedModeNotAllowed"> ｢{key=UseCopilotList}｣ を使用中ですが、異なるジョブタイプの混在はサポートされていません。</system:String>
     <system:String x:Key="CopilotTaskTypeParseFailedSkipCheck">一部のジョブタイプの解析に失敗しました。タイプチェックをスキップします。</system:String>
     <system:String x:Key="CopilotIllegalOperName">オペレーター名が不正です: {0}</system:String>
     <!--  !Logs  -->
@@ -1174,7 +1175,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="ErrorDetails">詳細情報</system:String>
     <system:String x:Key="ErrorSolution">解決策</system:String>
     <system:String x:Key="ErrorSolutionMoveMaaExeOutOfFolder">MAA.exe ファイルを単独で移動しないでください。ソフトウェアの場所を変更する必要がある場合は、フォルダー全体を移動するか、このフォルダーに MAA.exe のショートカットを作成してから、ショートカットを別の場所にドラッグしてください。</system:String>
-    <system:String x:Key="ErrorSolutionCrash">ドキュメント「よくある問題 - クラッシュ」を参照してください。</system:String>
+    <system:String x:Key="ErrorSolutionCrash">ドキュメント ｢よくある問題 - クラッシュ｣ を参照してください。</system:String>
     <system:String x:Key="ErrorSolutionUpdatePackageExtractionFailed">アップデートパッケージの解凍に失敗しました。まずは MAA.exe の再起動をお試しください。問題が解決しない場合は、PC を再起動して再度お試しください。必要なファイルの削除が行われない可能性があるため、手動で解凍しないでください。</system:String>
     <system:String x:Key="ErrorSolutionReplaceAdb">エミュレータとADBを閉じるか、コンピューターを再起動してから、管理者権限でMAAを開いて操作してください。</system:String>
     <system:String x:Key="ErrorSolutionFailedToMove">ファイルが占有されています。コンピュータを再起動して再試行してください。</system:String>
@@ -1184,8 +1185,8 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="ErrorFeedbackLinkText">GitHub issueを作成する</system:String>
     <system:String x:Key="ErrorQqGroupLinkText">QQグループに入ります</system:String>
     <system:String x:Key="ErrorCrashMessageHeader">上記の問題により、プログラムが異常終了しました。</system:String>
-    <system:String x:Key="ErrorCrashMessageOpenLog">「{key=Settings} - {key=IssueReport} - {key=OpenDebugFolder}」に移動してログを確認し、エラーが発生した具体的な原因を確認できます。</system:String>
-    <system:String x:Key="ErrorCrashMessageGenerateReport">「{key=Settings} - {key=IssueReport} - {key=GenerateSupportPayload}」を使用してエラーレポートを生成し、青色の ｢{key=Issue}｣ リンクをクリックしてフィードバックを送信してください。</system:String>
+    <system:String x:Key="ErrorCrashMessageOpenLog"> ｢{key=Settings} - {key=IssueReport} - {key=OpenDebugFolder}｣ に移動してログを確認し、エラーが発生した具体的な原因を確認できます。</system:String>
+    <system:String x:Key="ErrorCrashMessageGenerateReport"> ｢{key=Settings} - {key=IssueReport} - {key=GenerateSupportPayload}｣ を使用してエラーレポートを生成し、青色の ｢{key=Issue}｣ リンクをクリックしてフィードバックを送信してください。</system:String>
     <system:String x:Key="ErrorCrashMessageHelpTip">他人に助けを求める場合は、このウィンドウのスクリーンショット、画面録画、写真、撮影した動画、手描きの図、写し書きした内容ではなく、生成されたエラーレポートファイルを送信してください。</system:String>
     <system:String x:Key="ErrorCrashDialogTitle">前回のクラッシュ原因</system:String>
     <system:String x:Key="CopyErrorMessage">エラー情報をコピーする</system:String>
@@ -1210,7 +1211,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="TryToReconnect">エミュレータが切断、再接続を行います</system:String>
     <system:String x:Key="ReconnectSuccess">再接続に成功、タスクを続行します</system:String>
     <system:String x:Key="ReconnectFailed">再接続に失敗、切断されました！</system:String>
-    <system:String x:Key="TouchModeNotAvailable">タッチモードは利用できません。「{key=Settings} - {key=ConnectionSettings}」に入って、他のタッチモードに変更してください。</system:String>
+    <system:String x:Key="TouchModeNotAvailable">タッチモードは利用できません。 ｢{key=Settings} - {key=ConnectionSettings}｣ に入って、他のタッチモードに変更してください。</system:String>
     <system:String x:Key="ScreencapFailed">スクリーンキャプチャに失敗しました。繰り返し発生する場合は、エミュレータの再起動または変更をお試しください！</system:String>
     <system:String x:Key="FastestWayToScreencap">スクリーンショット テストには: {0}ms ({1})</system:String>
     <system:String x:Key="FastestWayToScreencapWarningTip">スクリーンキャップには時間がかかるため(平均: {0}ms)、自動戦闘機能 (Auto I.S. など) を使用すると異常な動作が発生する可能性があります。MuMuやLDPlayerを使用している場合は、スクリーンショット拡張を試してください。</system:String>
@@ -1287,7 +1288,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="BoskyDoubts">スポット: 雑疑</system:String>
     <system:String x:Key="BoskyDisaster">スポット: 禍乱</system:String>
     <system:String x:Key="RoguelikeCoppersExchange">通宝交換: {0} → {1}</system:String>
-    <system:String x:Key="RoguelikeCoppersRecognitionError">通宝認識失敗: 「{0}」</system:String>
+    <system:String x:Key="RoguelikeCoppersRecognitionError">通宝認識失敗:  ｢{0}｣ </system:String>
     <system:String x:Key="RoguelikeEvent">イベント:</system:String>
     <system:String x:Key="RoguelikeEncounterOptions">{0} 件の選択肢を検出しました:</system:String>
     <system:String x:Key="RoguelikeEncounterEnabledOption">選択可能な選択肢: {0}</system:String>
@@ -1359,7 +1360,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="MoveCamera">カメラ移動</system:String>
     <system:String x:Key="DrawCard">オペレーター配分</system:String>
     <system:String x:Key="CheckIfStartOver">再開確認</system:String>
-    <system:String x:Key="UnsupportedLevel">サポートされていないステージです。ステージ名を確認するか、「{key=Settings} - {key=UpdateSettings} - {key=ResourceUpdate}」に移動してリソースバージョンを更新してみてください！</system:String>
+    <system:String x:Key="UnsupportedLevel">サポートされていないステージです。ステージ名を確認するか、 ｢{key=Settings} - {key=UpdateSettings} - {key=ResourceUpdate}｣ に移動してリソースバージョンを更新してみてください！</system:String>
     <system:String x:Key="UnsupportedSkill">{0} のスキル {1} はサポートされないので、スキルを選択されなくなります。</system:String>
     <system:String x:Key="RecruitTagsDetected" xml:space="preserve">認識結果: </system:String>
     <system:String x:Key="ConnectFailed">接続失敗</system:String>
@@ -1367,7 +1368,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="TryToStartEmulator">エミュレータを起動しようとしています</system:String>
     <system:String x:Key="RestartAdb">ADBサーバーの再起動を試みています</system:String>
     <system:String x:Key="HardRestartAdb">ADBプロセスの再起動を試みています</system:String>
-    <system:String x:Key="CheckSettings">「接続設定を確認」→「エミュレーターとADBを再起動してみる」→「コンピュータを再起動」してください</system:String>
+    <system:String x:Key="CheckSettings"> ｢接続設定を確認｣ → ｢エミュレーターとADBを再起動してみる｣ → ｢コンピュータを再起動｣ してください</system:String>
     <system:String x:Key="AttachWindowNotFound">ウィンドウ "{0}" が見つかりません。ゲームが起動していることを確認してください</system:String>
     <system:String x:Key="AttachWindowMultipleFound">{0} 個の "{1}" ウィンドウが見つかりました。最初のものを使用します</system:String>
     <system:String x:Key="AttachWindowFound">ウィンドウ "{0}" が見つかりました</system:String>
@@ -1453,7 +1454,7 @@ DEBUGディレクトリに保存される画像には数量制限があり、超
     <system:String x:Key="PreserveTagsTip">選択したタグのいずれかを認識した場合、その募集をスキップして枠を残します。未選択の場合は何も保留しません。</system:String>
     <!--  !自動募集設定  -->
     <!--  EasterEggs  -->
-    <system:String x:Key="BuyWineOnAprilFoolsDay">尊敬なるドクター、クロージャ様のお店で「酒」の新しいリストがあると聞いたことがありませんか？一緒に確認しませんか？</system:String>
+    <system:String x:Key="BuyWineOnAprilFoolsDay">尊敬なるドクター、クロージャ様のお店で ｢酒｣ の新しいリストがあると聞いたことがありませんか？一緒に確認しませんか？</system:String>
     <system:String x:Key="Burping">うぅ……オエッ</system:String>
     <system:String x:Key="DrunkAndStaggering">あれ、ドクター。どうしてそんなフラフラと歩いておられるのですか？</system:String>
     <system:String x:Key="Hangover">つ、次は飲みすぎないようにしないと……</system:String>
@@ -1461,10 +1462,10 @@ DEBUGディレクトリに保存される画像には数量制限があり、超
     <system:String x:Key="EasterEggsRules" xml:space="preserve">1. MAA の正式版にはデバッグモードはありません。実行中にデバッグオプションが表示された場合は、すぐにソフトウェアを閉じ、それをクリックせず、最寄りの MAA 開発者に連絡してください。\n
 2. インフラのシフト変更は自動です。{key=Operator}が 72 時間以上連続して働いている場合は、手動でシフトを調整し、システム時間が正しいか確認してください。\n
 3. 公開募集のタグは変更されません。カウントダウンが終了する前にタグが変更された場合は、募集を続けず、MAA を再起動してから操作してください。\n
-4. MAA はフレンドリクエストを送信しません。「MAA_System」からフレンドリクエストを受け取った場合は、承認せず、そのアカウントを削除してください。\n
+4. MAA はフレンドリクエストを送信しません。 ｢MAA_System｣ からフレンドリクエストを受け取った場合は、承認せず、そのアカウントを削除してください。\n
 5. ローグライクの支援は提案のみを提供します。ゲームが存在しないオプションを自動的に選択した場合は、強制終了してクライアントを再起動してください。\n
-6. MAA のログファイルに文字化けが含まれているべきではありません。「ERROR: データ解析に失敗しました」以外のエラー情報がログに表示された場合は、ログを削除してソフトウェアを再インストールしてください。\n
-7. ナイトモードは安全です。ただし、MAA が午前 3 時 33 分に自動的に起動して「不明なタスク」を実行した場合は、電源を抜き、日の出まで待ってから使用してください。\n
+6. MAA のログファイルに文字化けが含まれているべきではありません。 ｢ERROR: データ解析に失敗しました｣ 以外のエラー情報がログに表示された場合は、ログを削除してソフトウェアを再インストールしてください。\n
+7. ナイトモードは安全です。ただし、MAA が午前 3 時 33 分に自動的に起動して ｢不明なタスク｣ を実行した場合は、電源を抜き、日の出まで待ってから使用してください。\n
 8. 最後のルールは存在しません。このルールを見た場合は、それを忘れて、通常どおり MAA を使用してください。\n
 9. MAA 内で炒...锟斤拷拷拷拷喜报拷拷拷饭 をクリックしないでください。\n
 10. MirrorChyan親切です。少しの代償を払うだけで、彼女の保護を受けることができます。\n
@@ -1490,7 +1491,7 @@ DEBUGディレクトリに保存される画像には数量制限があり、超
     <system:String x:Key="ApiUpdateFailed">ホットアップデートデータの取得に失敗しました</system:String>
     <system:String x:Key="ApiCacheLoaded">ローカルキャッシュデータを使用しています</system:String>
     <system:String x:Key="GameResourceUpdating">ゲームリソースが更新中です。</system:String>
-    <system:String x:Key="GameResourceUpdatingMirrorChyan">「{key=MirrorChyan}」からリソース {0} を更新しています...</system:String>
+    <system:String x:Key="GameResourceUpdatingMirrorChyan"> ｢{key=MirrorChyan}｣ からリソース {0} を更新しています...</system:String>
     <system:String x:Key="GameResourceUpdatePreparing">索引の作成中</system:String>
     <system:String x:Key="GameResourceNotModified">ゲームリソースが更新されました。</system:String>
     <system:String x:Key="GameResourceUpdated">ゲームリソースが更新されました。</system:String>
@@ -1539,9 +1540,9 @@ DEBUGディレクトリに保存される画像には数量制限があり、超
 
 前提条件：メインストーリーでRA-1をクリア済み
 
-マップでRA-1を開き、右下に「建設開始」が表示されたらタスクを開始すると自動でループします
+マップでRA-1を開き、右下に ｢建設開始｣ が表示されたらタスクを開始すると自動でループします
 
-注意：「初期追加携帯アイテム」に関連するテクノロジーをアンロックしている場合、基地内で初期追加携帯アイテムの原因となる施設（食品供給所、飲料供給所、獣舎など）を解体してください
+注意： ｢初期追加携帯アイテム｣ に関連するテクノロジーをアンロックしている場合、基地内で初期追加携帯アイテムの原因となる施設（食品供給所、飲料供給所、獣舎など）を解体してください
 
 タスクの流れ：精耕細作、建設、資源納入、決済を自動実行
     </system:String>
@@ -1552,15 +1553,15 @@ DEBUGディレクトリに保存される画像には数量制限があり、超
 
 前提条件：
 1. メインストーリーを進めてRA-4をクリア済みの状態にする
-2. 「計画経営」をアンロックする
-3. 自分でヴィシャデルを持っている場合、手動でステージを開いて一度編成を行う。ヴィシャデルよりもコストが低い任意の5人のオペレーター＋ヴィシャデルとし、ヴィシャデルを6番目（最後に選択する枠）に配置する。その後、勧誘を確定し、今回の建設を中止して「建設開始」から開始する。
-4. サポートのヴィシャデルを使用する場合、ヴィシャデルがスナイパーサポートのトップページに表示されていることを確認する（フレンドを考慮）。手動でステージを開き、ヴィシャデルよりもコストが低い任意の5人のオペレーターを編成し、6番目にサポートのヴィシャデルを選択して勧誘を確定する。その後、今回の建設を中止して「建設開始」から開始する（先頭5枠にオペレーターがおり、6番目が空いていることを確認する）。
+2.  ｢計画経営｣ をアンロックする
+3. 自分でヴィシャデルを持っている場合、手動でステージを開いて一度編成を行う。ヴィシャデルよりもコストが低い任意の5人のオペレーター＋ヴィシャデルとし、ヴィシャデルを6番目（最後に選択する枠）に配置する。その後、勧誘を確定し、今回の建設を中止して ｢建設開始｣ から開始する。
+4. サポートのヴィシャデルを使用する場合、ヴィシャデルがスナイパーサポートのトップページに表示されていることを確認する（フレンドを考慮）。手動でステージを開き、ヴィシャデルよりもコストが低い任意の5人のオペレーターを編成し、6番目にサポートのヴィシャデルを選択して勧誘を確定する。その後、今回の建設を中止して ｢建設開始｣ から開始する（先頭5枠にオペレーターがおり、6番目が空いていることを確認する）。
 
-マップでRA-4を開き、右下に「建設開始」が表示されたらタスクを開始すると自動でループします
+マップでRA-4を開き、右下に ｢建設開始｣ が表示されたらタスクを開始すると自動でループします
 
-注意：「初期追加携帯アイテム」に関連するテクノロジーをアンロックしている場合、基地内で初期追加携帯アイテムの原因となる施設（食品供給所、飲料供給所、獣舎など）を解体してください
+注意： ｢初期追加携帯アイテム｣ に関連するテクノロジーをアンロックしている場合、基地内で初期追加携帯アイテムの原因となる施設（食品供給所、飲料供給所、獣舎など）を解体してください
 
-タスクの流れ：「計画経営」で得た赤金を使ってエリアを解放し、ヴィシャデルでボス討伐を完了する
+タスクの流れ： ｢計画経営｣ で得た赤金を使ってエリアを解放し、ヴィシャデルでボス討伐を完了する
     </system:String>
     <system:String x:Key="ReclamationTipRelaunchAnchorRA15" xml:space="preserve">
 報酬目安：1回あたり約 500 トークン＋統括ポイント、所要時間約 3 分
@@ -1572,9 +1573,9 @@ DEBUGディレクトリに保存される画像には数量制限があり、超
 2. 聖聆初雪を所持している場合、手動で RA-15 を開いて一度編成する。先鋒5体（育成不要）＋聖聆初雪を最後に選択し、編成を保存してステージを退出する
 3. サポートの聖聆初雪を使う場合、聖聆初雪が術師サポート一覧の先頭ページにいることを確認する（友達登録を推奨）
 
-マップでRA-15を開き、右下に「建設開始」が表示されたらタスクを開始すると自動でループします
+マップでRA-15を開き、右下に ｢建設開始｣ が表示されたらタスクを開始すると自動でループします
 
-注意： 「初期追加携帯アイテム」に関連するテクノロジーをアンロックしている場合、基地内で初期追加携帯アイテムの原因となる施設（食品供給所、飲料供給所、獣舎など）を解体してください
+注意：  ｢初期追加携帯アイテム｣ に関連するテクノロジーをアンロックしている場合、基地内で初期追加携帯アイテムの原因となる施設（食品供給所、飲料供給所、獣舎など）を解体してください
 
 タスクの流れ： サポートオペレーターを使用して 60 キルミッションを自動実行
     </system:String>
@@ -1583,7 +1584,7 @@ DEBUGディレクトリに保存される画像には数量制限があり、超
 生息演算のサポートはまだ初期段階にありますので、ご利用の際は以下の点にご注意ください：
 
  初期設定でポイントを稼ぐ：（既存のセーブデータが削除されることに注意してください）
-  0.ポイントがいっぱいになると「タスク完了」が出力され、タスクは自動的に停止します
+  0.ポイントがいっぱいになると ｢タスク完了｣ が出力され、タスクは自動的に停止します
   1. 理論的には、タスクは、セーブデータの有無に関係なく、ポイント獲得のためのどの時点からでもタスクを開始できる。
   2. 生息演算の編成に{key=Operator}を入れることができるが、テストしていないのでお勧めしない。
   3. ナビゲーションがまだ書かれていないので、生息演算の画面以外の場所からタスクを開始することはできない。
@@ -1609,7 +1610,7 @@ MAA を新しい独立したフォルダーに解凍するか、MAA に属さな
 • その他のシステム依存関係が不足している
 
 まず、アーカイブが完全に解凍されているかご確認ください。
-「{key=Confirm}」をクリックすると VC++ ランタイムのインストール/更新を試みて MAA を終了します（他の原因の場合は無効）。「{key=Cancel}」をクリックすると直接終了します。
+ ｢{key=Confirm}｣ をクリックすると VC++ ランタイムのインストール/更新を試みて MAA を終了します（他の原因の場合は無効）。 ｢{key=Cancel}｣ をクリックすると直接終了します。
     </system:String>
     <system:String x:Key="MultiInstanceUnderSamePath" xml:space="preserve">同じパスの下で起動できるのは1つのインスタンスのみ！
 MAA を複数開くには、新しい MAA を他のフォルダにコピーし、異なる MAA、同じ adb、異なるシミュレータアドレスを使用して複数の操作を行うように設定します。
@@ -1660,7 +1661,7 @@ MAA を複数開くには、新しい MAA を他のフォルダにコピーし�
     <system:String x:Key="Achievement.SanitySpender3.Conditions">自動作戦を 1000 回達成する</system:String>
 
     <system:String x:Key="Achievement.QuickCloser.Title">YOLO!</system:String>
-    <system:String x:Key="Achievement.QuickCloser.Description">「私は自分がやっていることを知っている。」――あるユーザーがクリックする前に。</system:String>
+    <system:String x:Key="Achievement.QuickCloser.Description"> ｢私は自分がやっていることを知っている。｣ ――あるユーザーがクリックする前に。</system:String>
     <system:String x:Key="Achievement.QuickCloser.Conditions">1秒以内にポップアップを閉じる（おそらく見ていなかったのでしょう）</system:String>
 
     <system:String x:Key="Achievement.TacticalRetreat.Title">臨陣脱逃</system:String>
@@ -1696,7 +1697,7 @@ MAA を複数開くには、新しい MAA を他のフォルダにコピーし�
     <system:String x:Key="Achievement.Martian.Conditions">リソースまたはバージョンの時間が3ヶ月以上経過している</system:String>
     <system:String x:Key="Achievement.Martian.ConditionsTip">リソースまたはバージョンの時間が{0}ヶ月以上経過している</system:String>
 
-    <system:String x:Key="ConfigurationRecoveredNotification">対象の設定「{0}」が見つからないため、現在の設定から複製しました。すべての設定をご確認ください</system:String>
+    <system:String x:Key="ConfigurationRecoveredNotification">対象の設定 ｢{0}｣ が見つからないため、現在の設定から複製しました。すべての設定をご確認ください</system:String>
     <system:String x:Key="ConfigurationBrokenCaption">設定破損</system:String>
 
     <system:String x:Key="Achievement.AnnouncementStubbornClick.Title">頑固者</system:String>
@@ -1733,11 +1734,11 @@ MAA を複数開くには、新しい MAA を他のフォルダにコピーし�
 
     <system:String x:Key="Achievement.SanityExpire.Title">もうすぐ期限切れ</system:String>
     <system:String x:Key="Achievement.SanityExpire.Description">急いで！！！</system:String>
-    <system:String x:Key="Achievement.SanityExpire.Conditions">「{key=UseExpiringMedicine}」を使用し、1回のタスクで 8 本以上の期限切れ理性回復剤を使用する</system:String>
+    <system:String x:Key="Achievement.SanityExpire.Conditions"> ｢{key=UseExpiringMedicine}｣ を使用し、1回のタスクで 8 本以上の期限切れ理性回復剤を使用する</system:String>
 
     <system:String x:Key="Achievement.OverLimitAgent.Title">限界を超える代理</system:String>
     <system:String x:Key="Achievement.OverLimitAgent.Description">大道を磨り減らすような代理タスクを実行しました。</system:String>
-    <system:String x:Key="Achievement.OverLimitAgent.Conditions">1回の「{key=Combat}」タスクで 100 回以上自動作戦を行う。</system:String>
+    <system:String x:Key="Achievement.OverLimitAgent.Conditions">1回の ｢{key=Combat}｣ タスクで 100 回以上自動作戦を行う。</system:String>
 
     <system:String x:Key="Achievement.MirrorChyanFirstUse.Title">Mirror～～☆</system:String>
     <system:String x:Key="Achievement.MirrorChyanFirstUse.Description">{key=MirrorChyan}です！これで私たちは助かります！</system:String>
@@ -1753,31 +1754,31 @@ MAA を複数開くには、新しい MAA を他のフォルダにコピーし�
 
     <system:String x:Key="Achievement.MapOutdated.Title">せっかち者</system:String>
     <system:String x:Key="Achievement.MapOutdated.Description">急いでいることは分かっていますが、少しお待ちください。</system:String>
-    <system:String x:Key="Achievement.MapOutdated.Conditions">リソースを更新せずに「{key=Copilot}」を使用する</system:String>
+    <system:String x:Key="Achievement.MapOutdated.Conditions">リソースを更新せずに ｢{key=Copilot}｣ を使用する</system:String>
 
     <system:String x:Key="Achievement.UseCopilot1.Title">課題をコピー</system:String>
     <system:String x:Key="Achievement.UseCopilot1.Description">本当に放置してクリアしました。</system:String>
-    <system:String x:Key="Achievement.UseCopilot1.Conditions">「{key=Copilot}」機能で 1 回クリアする</system:String>
+    <system:String x:Key="Achievement.UseCopilot1.Conditions"> ｢{key=Copilot}｣ 機能で 1 回クリアする</system:String>
 
     <system:String x:Key="Achievement.UseCopilot2.Title">ずっと放置</system:String>
     <system:String x:Key="Achievement.UseCopilot2.Description">イベントを全部MAAに任せました。</system:String>
-    <system:String x:Key="Achievement.UseCopilot2.Conditions">「{key=Copilot}」機能で 10 回クリアする</system:String>
+    <system:String x:Key="Achievement.UseCopilot2.Conditions"> ｢{key=Copilot}｣ 機能で 10 回クリアする</system:String>
 
     <system:String x:Key="Achievement.UseCopilot3.Title">次回の調査も非常に簡単</system:String>
     <system:String x:Key="Achievement.UseCopilot3.Description">最後までボスの仕組みが分かりませんでした。</system:String>
-    <system:String x:Key="Achievement.UseCopilot3.Conditions">「{key=Copilot}」機能で 100 回クリアする</system:String>
+    <system:String x:Key="Achievement.UseCopilot3.Conditions"> ｢{key=Copilot}｣ 機能で 100 回クリアする</system:String>
 
     <system:String x:Key="Achievement.RecruitNoSixStar.Title">玄学無効</system:String>
     <system:String x:Key="Achievement.RecruitNoSixStar.Description">事はここまでです、まずは寝ましょう。</system:String>
-    <system:String x:Key="Achievement.RecruitNoSixStar.Conditions">「{key=Recruiting}」中に6星のタグが 500 回出なかった</system:String>
+    <system:String x:Key="Achievement.RecruitNoSixStar.Conditions"> ｢{key=Recruiting}｣ 中に6星のタグが 500 回出なかった</system:String>
 
     <system:String x:Key="Achievement.RecruitNoSixStarStreak.Title">MAAがやったに違いない！</system:String>
     <system:String x:Key="Achievement.RecruitNoSixStarStreak.Description">乆乆乆乆乆乆乆乆乆乆！</system:String>
-    <system:String x:Key="Achievement.RecruitNoSixStarStreak.Conditions">「{key=Recruiting}」中に6星のタグが 500 回連続で出なかった</system:String>
+    <system:String x:Key="Achievement.RecruitNoSixStarStreak.Conditions"> ｢{key=Recruiting}｣ 中に6星のタグが 500 回連続で出なかった</system:String>
 
     <system:String x:Key="Achievement.MosquitoLeg.Title">少しずつ積み上げていく</system:String>
     <system:String x:Key="Achievement.MosquitoLeg.Description">あなたは少しずつ積み上げていくことの大切さを深く理解しています。</system:String>
-    <system:String x:Key="Achievement.MosquitoLeg.Conditions">「{key=CreditFight}」機能を5回以上使用する</system:String>
+    <system:String x:Key="Achievement.MosquitoLeg.Conditions"> ｢{key=CreditFight}｣ 機能を5回以上使用する</system:String>
 
     <system:String x:Key="Achievement.Pioneer1.Title">テストパイオニア</system:String>
     <system:String x:Key="Achievement.Pioneer1.Description">あなたはテスト中のバージョンを先行体験しました。</system:String>
@@ -1793,10 +1794,10 @@ MAA を複数開くには、新しい MAA を他のフォルダにコピーし�
 
     <system:String x:Key="Achievement.Irreplaceable.Title">替代不可</system:String>
     <system:String x:Key="Achievement.Irreplaceable.Description">たぶん、別の作業を変更すべきですか？</system:String>
-    <system:String x:Key="Achievement.Irreplaceable.Conditions">「{key=Copilot} - {key=AutoSquad}」使用時、少なくとも2名の{key=Operator}が不足している。</system:String>
+    <system:String x:Key="Achievement.Irreplaceable.Conditions"> ｢{key=Copilot} - {key=AutoSquad}｣ 使用時、少なくとも2名の{key=Operator}が不足している。</system:String>
 
     <system:String x:Key="Achievement.SnapshotChallenge1.Title">高遅延危機</system:String>
-    <system:String x:Key="Achievement.SnapshotChallenge1.Description">「kale」</system:String>
+    <system:String x:Key="Achievement.SnapshotChallenge1.Description"> ｢kale｣ </system:String>
     <system:String x:Key="Achievement.SnapshotChallenge1.Conditions">平均スクリーンショット時間が 800ms を超えている</system:String>
 
     <system:String x:Key="Achievement.SnapshotChallenge2.Title">少し遅くないですか？</system:String>
@@ -1837,35 +1838,35 @@ MAA を複数開くには、新しい MAA を他のフォルダにコピーし�
 
     <system:String x:Key="Achievement.RoguelikeGamePass1.Title">初めて終点に到達</system:String>
     <system:String x:Key="Achievement.RoguelikeGamePass1.Description">その場所を……辿り着くできるならば……</system:String>
-    <system:String x:Key="Achievement.RoguelikeGamePass1.Conditions">MAAで「{key=AutoRoguelike}」を 1 回クリアする</system:String>
+    <system:String x:Key="Achievement.RoguelikeGamePass1.Conditions">MAAで ｢{key=AutoRoguelike}｣ を 1 回クリアする</system:String>
 
     <system:String x:Key="Achievement.RoguelikeGamePass2.Title">再び終点に到達</system:String>
     <system:String x:Key="Achievement.RoguelikeGamePass2.Description">この道はもう何度も通りました。</system:String>
-    <system:String x:Key="Achievement.RoguelikeGamePass2.Conditions">MAAで「{key=AutoRoguelike}」を 5 回クリアする</system:String>
+    <system:String x:Key="Achievement.RoguelikeGamePass2.Conditions">MAAで ｢{key=AutoRoguelike}｣ を 5 回クリアする</system:String>
 
     <system:String x:Key="Achievement.RoguelikeGamePass3.Title">終点常連</system:String>
     <system:String x:Key="Achievement.RoguelikeGamePass3.Description">目を閉じても歩けます。</system:String>
-    <system:String x:Key="Achievement.RoguelikeGamePass3.Conditions">MAAで「{key=AutoRoguelike}」を 10 回クリアする</system:String>
+    <system:String x:Key="Achievement.RoguelikeGamePass3.Conditions">MAAで ｢{key=AutoRoguelike}｣ を 10 回クリアする</system:String>
 
     <system:String x:Key="Achievement.RoguelikeRetreat.Title">失敗は成功の母である</system:String>
     <system:String x:Key="Achievement.RoguelikeRetreat.Description">いつか成功の岸に到達するために、失敗は成功の階段です。</system:String>
-    <system:String x:Key="Achievement.RoguelikeRetreat.Conditions">MAAで「{key=AutoRoguelike}」を 100 回放棄する</system:String>
+    <system:String x:Key="Achievement.RoguelikeRetreat.Conditions">MAAで ｢{key=AutoRoguelike}｣ を 100 回放棄する</system:String>
 
     <system:String x:Key="Achievement.RoguelikeGoldMax.Title">満杯した</system:String>
     <system:String x:Key="Achievement.RoguelikeGoldMax.Description">カノット、あなたの店で一番高いものを出して！</system:String>
     <system:String x:Key="Achievement.RoguelikeGoldMax.Conditions">ローグライクで、源石錐投資が999に到達する</system:String>
 
     <system:String x:Key="Achievement.CopilotLikeGiven1.Title">励ましの一言</system:String>
-    <system:String x:Key="Achievement.CopilotLikeGiven1.Description">「Like」は作者への最大の励ましです！</system:String>
-    <system:String x:Key="Achievement.CopilotLikeGiven1.Conditions">作業に 1 回「Like」を付ける</system:String>
+    <system:String x:Key="Achievement.CopilotLikeGiven1.Description"> ｢Like｣ は作者への最大の励ましです！</system:String>
+    <system:String x:Key="Achievement.CopilotLikeGiven1.Conditions">作業に 1 回 ｢Like｣ を付ける</system:String>
 
     <system:String x:Key="Achievement.CopilotLikeGiven2.Title">積極的な交流</system:String>
-    <system:String x:Key="Achievement.CopilotLikeGiven2.Description">「Like」を10回付けて、コミュニティに積極的に参加しています。</system:String>
-    <system:String x:Key="Achievement.CopilotLikeGiven2.Conditions">作業に累計 10 回「Like」を付ける</system:String>
+    <system:String x:Key="Achievement.CopilotLikeGiven2.Description"> ｢Like｣ を10回付けて、コミュニティに積極的に参加しています。</system:String>
+    <system:String x:Key="Achievement.CopilotLikeGiven2.Conditions">作業に累計 10 回 ｢Like｣ を付ける</system:String>
 
     <system:String x:Key="Achievement.CopilotLikeGiven3.Title">いいね達人</system:String>
-    <system:String x:Key="Achievement.CopilotLikeGiven3.Description">「Like」を50回付けたあなたは、すでに「Like」の達人です！</system:String>
-    <system:String x:Key="Achievement.CopilotLikeGiven3.Conditions">作業に累計 50 回「Like」を付ける</system:String>
+    <system:String x:Key="Achievement.CopilotLikeGiven3.Description"> ｢Like｣ を50回付けたあなたは、すでに ｢Like｣ の達人です！</system:String>
+    <system:String x:Key="Achievement.CopilotLikeGiven3.Conditions">作業に累計 50 回 ｢Like｣ を付ける</system:String>
 
     <system:String x:Key="Achievement.TaskStartCancel.Title">まさにジジジジジ</system:String>
     <system:String x:Key="Achievement.TaskStartCancel.Description">ああ、合っている、合っていない、ああ、合っている、合っていない…</system:String>
@@ -1873,7 +1874,7 @@ MAA を複数開くには、新しい MAA を他のフォルダにコピーし�
 
     <system:String x:Key="Achievement.CopilotError.Title">あらら</system:String>
     <system:String x:Key="Achievement.CopilotError.Description">事故が起きました…</system:String>
-    <system:String x:Key="Achievement.CopilotError.Conditions">「{key=Copilot}」中にエラーが発生</system:String>
+    <system:String x:Key="Achievement.CopilotError.Conditions"> ｢{key=Copilot}｣ 中にエラーが発生</system:String>
 
     <system:String x:Key="Achievement.LongTaskTimeout.Title">長いタスク</system:String>
     <system:String x:Key="Achievement.LongTaskTimeout.Description">少し待ってみませんか？</system:String>
@@ -1909,19 +1910,19 @@ MAA を複数開くには、新しい MAA を他のフォルダにコピーし�
 
     <system:String x:Key="Achievement.RoguelikeN04.Title">簡単なこと</system:String>
     <system:String x:Key="Achievement.RoguelikeN04.Description">この難易度は私を困らせることはできない。</system:String>
-    <system:String x:Key="Achievement.RoguelikeN04.Conditions">「{key=AutoRoguelike}」で、任意のテーマで N4 難易度以上をクリアする</system:String>
+    <system:String x:Key="Achievement.RoguelikeN04.Conditions"> ｢{key=AutoRoguelike}｣ で、任意のテーマで N4 難易度以上をクリアする</system:String>
 
     <system:String x:Key="Achievement.RoguelikeN08.Title">困難に挑戦する</system:String>
     <system:String x:Key="Achievement.RoguelikeN08.Description">困難を恐れない。</system:String>
-    <system:String x:Key="Achievement.RoguelikeN08.Conditions">「{key=AutoRoguelike}」で、任意のテーマで N8 難易度以上をクリアする</system:String>
+    <system:String x:Key="Achievement.RoguelikeN08.Conditions"> ｢{key=AutoRoguelike}｣ で、任意のテーマで N8 難易度以上をクリアする</system:String>
 
     <system:String x:Key="Achievement.RoguelikeN12.Title">人間を超越</system:String>
     <system:String x:Key="Achievement.RoguelikeN12.Description">普通の人よりも上手くプレイしています。</system:String>
-    <system:String x:Key="Achievement.RoguelikeN12.Conditions">「{key=AutoRoguelike}」で、任意のテーマで N12 難易度以上をクリアする</system:String>
+    <system:String x:Key="Achievement.RoguelikeN12.Conditions"> ｢{key=AutoRoguelike}｣ で、任意のテーマで N12 難易度以上をクリアする</system:String>
 
     <system:String x:Key="Achievement.RoguelikeN15.Title">仙術杯選手</system:String>
     <system:String x:Key="Achievement.RoguelikeN15.Description">本物の仙術だなあ。</system:String>
-    <system:String x:Key="Achievement.RoguelikeN15.Conditions">「{key=AutoRoguelike}」で、任意のテーマで N15 難易度以上をクリアする</system:String>
+    <system:String x:Key="Achievement.RoguelikeN15.Conditions"> ｢{key=AutoRoguelike}｣ で、任意のテーマで N15 難易度以上をクリアする</system:String>
 
     <system:String x:Key="Achievement.LogSupervisor.Title">スーパーバイザー</system:String>
     <system:String x:Key="Achievement.LogSupervisor.Description">MAAのログを見つめていると、自動戦闘の成功率が上がるらしい。</system:String>
@@ -1981,7 +1982,7 @@ MAA を複数開くには、新しい MAA を他のフォルダにコピーし�
 
     <system:String x:Key="Achievement.WarehouseKeeper.Title">私は倉庫管理員！</system:String>
     <system:String x:Key="Achievement.WarehouseKeeper.Description">MAAがMAAを見つけた！</system:String>
-    <system:String x:Key="Achievement.WarehouseKeeper.Conditions">オペレーター認識にオペレーター「パラス」が含まれる</system:String>
+    <system:String x:Key="Achievement.WarehouseKeeper.Conditions">オペレーター認識にオペレーター ｢パラス｣ が含まれる</system:String>
 
     <system:String x:Key="Achievement.NotFound404.Title">404！</system:String>
     <system:String x:Key="Achievement.NotFound404.Description">このタスクは見つからないようです。</system:String>
@@ -2005,31 +2006,31 @@ MAA を複数開くには、新しい MAA を他のフォルダにコピーし�
 
     <system:String x:Key="Achievement.PallasStarter.Title">パラス推し</system:String>
     <system:String x:Key="Achievement.PallasStarter.Description">偉大なる戦士たちよ、私はあなたたちのそばにいて、ともに勇んで戦おう。</system:String>
-    <system:String x:Key="Achievement.PallasStarter.Conditions">ローグライクでパラスを「{key=StartingCoreChar}」にする</system:String>
+    <system:String x:Key="Achievement.PallasStarter.Conditions">ローグライクでパラスを ｢{key=StartingCoreChar}｣ にする</system:String>
 
     <system:String x:Key="Achievement.PallasCheers.Title">パラスに一杯</system:String>
     <system:String x:Key="Achievement.PallasCheers.Description">次はもう飲みすぎちゃだめだよ。。。</system:String>
-    <system:String x:Key="Achievement.PallasCheers.Conditions">「{key=AchievementSettings}」でパラスのアイコンをクリックする</system:String>
+    <system:String x:Key="Achievement.PallasCheers.Conditions"> ｢{key=AchievementSettings}｣ でパラスのアイコンをクリックする</system:String>
 
     <system:String x:Key="Achievement.SortingMaster.Title">並べ替えマスター</system:String>
     <system:String x:Key="Achievement.SortingMaster.Description">これもドラッグできるの？</system:String>
-    <system:String x:Key="Achievement.SortingMaster.Conditions">マウスで「{key=Farming}」のタスクまたは設定項目の順序をドラッグして変更する</system:String>
+    <system:String x:Key="Achievement.SortingMaster.Conditions">マウスで ｢{key=Farming}｣ のタスクまたは設定項目の順序をドラッグして変更する</system:String>
 
     <system:String x:Key="Achievement.TimeManagementMaster.Title">時間管理マスター</system:String>
     <system:String x:Key="Achievement.TimeManagementMaster.Description">わずかな時間も無駄にしない。</system:String>
-    <system:String x:Key="Achievement.TimeManagementMaster.Conditions">「{key=ScheduleSettings}」のすべてのタイマーをチェックする</system:String>
+    <system:String x:Key="Achievement.TimeManagementMaster.Conditions"> ｢{key=ScheduleSettings}｣ のすべてのタイマーをチェックする</system:String>
 
     <system:String x:Key="Achievement.DoubleSync.Title">人も物もきっちり</system:String>
     <system:String x:Key="Achievement.DoubleSync.Description">人員も把握して、物資も数え終えた。</system:String>
-    <system:String x:Key="Achievement.DoubleSync.Conditions">1回の「{key=UserDataUpdate}」でオペレーターと倉庫を同時に同期する</system:String>
+    <system:String x:Key="Achievement.DoubleSync.Conditions">1回の ｢{key=UserDataUpdate}｣ でオペレーターと倉庫を同時に同期する</system:String>
 
     <system:String x:Key="Achievement.ResumeRecord.Title">記録再開</system:String>
     <system:String x:Key="Achievement.ResumeRecord.Description">こんなに間が空いたけど、ようやく記録をつなげられた。</system:String>
-    <system:String x:Key="Achievement.ResumeRecord.Conditions">少なくとも7日間同期していない状態から、再び「{key=UserDataUpdate}」を1回完了する</system:String>
+    <system:String x:Key="Achievement.ResumeRecord.Conditions">少なくとも7日間同期していない状態から、再び ｢{key=UserDataUpdate}｣ を1回完了する</system:String>
 
     <system:String x:Key="Achievement.ChangelogReader.Title">まず更新内容を確認</system:String>
     <system:String x:Key="Achievement.ChangelogReader.Description">新バージョンは急いで入れなくてもいいが、何が変わったかは見ておきたい。</system:String>
-    <system:String x:Key="Achievement.ChangelogReader.Conditions">「{key=ShowChangelog}」を手動で1回開く</system:String>
+    <system:String x:Key="Achievement.ChangelogReader.Conditions"> ｢{key=ShowChangelog}｣ を手動で1回開く</system:String>
 
     <system:String x:Key="Achievement.LatestVersionInspector.Title">空振りチェッカー</system:String>
     <system:String x:Key="Achievement.LatestVersionInspector.Description">空振りだったけど、少なくとも安心はできた。</system:String>
@@ -2045,31 +2046,31 @@ MAA を複数開くには、新しい MAA を他のフォルダにコピーし�
 
     <system:String x:Key="Achievement.AchievementObserver.Title">実績観測者</system:String>
     <system:String x:Key="Achievement.AchievementObserver.Description">自分が何をしてきたか見てみよう。</system:String>
-    <system:String x:Key="Achievement.AchievementObserver.Conditions">「{key=AchievementList}」を1回開く</system:String>
+    <system:String x:Key="Achievement.AchievementObserver.Conditions"> ｢{key=AchievementList}｣ を1回開く</system:String>
 
     <system:String x:Key="Achievement.DisappearTrick.Title">消失トリック</system:String>
     <system:String x:Key="Achievement.DisappearTrick.Description">見えなければ、気にもならない。</system:String>
-    <system:String x:Key="Achievement.DisappearTrick.Conditions">「{key=MinimizeToTray}」を有効にする</system:String>
+    <system:String x:Key="Achievement.DisappearTrick.Conditions"> ｢{key=MinimizeToTray}｣ を有効にする</system:String>
 
     <system:String x:Key="Achievement.TitleTweaker.Title">タイトルいじり</system:String>
     <system:String x:Key="Achievement.TitleTweaker.Description">このタイトルは、自分の思いどおりにしたい。</system:String>
-    <system:String x:Key="Achievement.TitleTweaker.Conditions">「{key=TitleBarDisplayContent}」を1回変更する</system:String>
+    <system:String x:Key="Achievement.TitleTweaker.Conditions"> ｢{key=TitleBarDisplayContent}｣ を1回変更する</system:String>
 
     <system:String x:Key="Achievement.AllChannelBroadcast.Title">全チャンネル放送</system:String>
     <system:String x:Key="Achievement.AllChannelBroadcast.Description">これでもう誰も見逃せない。</system:String>
-    <system:String x:Key="Achievement.AllChannelBroadcast.Conditions">「{key=ExternalNotificationSettings}」ですべてのプラットフォームを同時に有効にする</system:String>
+    <system:String x:Key="Achievement.AllChannelBroadcast.Conditions"> ｢{key=ExternalNotificationSettings}｣ ですべてのプラットフォームを同時に有効にする</system:String>
 
     <system:String x:Key="Achievement.BackstageExplorer.Title">バックヤード探検家</system:String>
     <system:String x:Key="Achievement.BackstageExplorer.Description">裏で何が記録されているか見てみよう。</system:String>
-    <system:String x:Key="Achievement.BackstageExplorer.Conditions">「{key=OpenDebugFolder}」を1回使う</system:String>
+    <system:String x:Key="Achievement.BackstageExplorer.Conditions"> ｢{key=OpenDebugFolder}｣ を1回使う</system:String>
 
     <system:String x:Key="Achievement.ConnectionTester.Title">接続テスター</system:String>
     <system:String x:Key="Achievement.ConnectionTester.Description">先に一度見ておかないと、どうも落ち着かない。</system:String>
-    <system:String x:Key="Achievement.ConnectionTester.Conditions">「{key=ScreenshotTest}」を1回成功させ、スクリーンショットを表示する</system:String>
+    <system:String x:Key="Achievement.ConnectionTester.Conditions"> ｢{key=ScreenshotTest}｣ を1回成功させ、スクリーンショットを表示する</system:String>
 
     <system:String x:Key="Achievement.OneMoreLook.Title">もう一度見る</system:String>
     <system:String x:Key="Achievement.OneMoreLook.Description">せっかく見たんだから、もう1枚更新しよう。</system:String>
-    <system:String x:Key="Achievement.OneMoreLook.Conditions">「{key=ScreenshotTest}」のプレビュー画像でもう一度クリックして、スクリーンショットを更新する</system:String>
+    <system:String x:Key="Achievement.OneMoreLook.Conditions"> ｢{key=ScreenshotTest}｣ のプレビュー画像でもう一度クリックして、スクリーンショットを更新する</system:String>
 
     <system:String x:Key="Achievement.QueueExpansion.Title">隊列拡張</system:String>
     <system:String x:Key="Achievement.QueueExpansion.Description">まずはフローを組み上げよう。</system:String>
@@ -2085,7 +2086,7 @@ MAA を複数開くには、新しい MAA を他のフォルダにコピーし�
 
     <system:String x:Key="Achievement.PrivateDormManager.Title">プライベート宿舎管理人</system:String>
     <system:String x:Key="Achievement.PrivateDormManager.Description">シフト表はもちろん自分のものを使う。</system:String>
-    <system:String x:Key="Achievement.PrivateDormManager.Conditions">「{key=InfrastModeCustom}」を1回正常に読み込む</system:String>
+    <system:String x:Key="Achievement.PrivateDormManager.Conditions"> ｢{key=InfrastModeCustom}｣ を1回正常に読み込む</system:String>
 
     <system:String x:Key="Achievement.OperatorRoster.Title">名簿</system:String>
     <system:String x:Key="Achievement.OperatorRoster.Description">この一覧、先に1部保存しておこう。</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -715,6 +715,7 @@ C:\\Program Files\\Netease\\MuMuPlayer으로 입력해야 합니다.\n
     <system:String x:Key="MuMu12Index">인스턴스 번호</system:String>
     <system:String x:Key="MuMu12Display">표시 번호</system:String>
     <system:String x:Key="MuMuExtrasNotEnabledMessage">MuMu 스크린샷 강화 기능이 활성화되지 않았습니다. 관련 설정을 확인하세요</system:String>
+    <system:String x:Key="MuMuEmulator12KeepAliveOn">MuMu 에뮬레이터 백그라운드 유지가 활성화되어 있습니다. 스크린샷 실패 및 작동 오류가 발생할 수 있습니다. MuMu 설정에서 "백그라운드 유지"(또는 "앱 유지" 등)를 비활성화하세요</system:String>
     <system:String x:Key="LdExtrasEnabled">LD 스크린샷 강화 기능 활성화</system:String>
     <system:String x:Key="LdPlayerEmulatorPathNotFound">LDPlayer 에뮬레이터 경로를 찾을 수 없습니다.</system:String>
     <system:String x:Key="LdPlayerOpenglMissing">선택한 LDPlayer 경로에서 ldopengl64.dll을 찾을 수 없습니다. 설치 디렉터리를 확인하세요.</system:String>
@@ -1036,7 +1037,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="MiniGame@SecretFront@Event2">레인저</system:String>
     <system:String x:Key="MiniGame@SecretFront@Event3">수상한 그림자</system:String>
     <system:String x:Key="MiniGame@SecretFront">비밀 전선</system:String>
-    <system:String x:Key="MiniGame@SecretFrontTip">소대 선택 화면에서 시작합니다. 기존 세이브 데이터가 있으면 수동으로 삭제해야 합니다.\n게임 내 「이전 소대의 데이터 전승받기」 옵션을 체크하는 것을 권장합니다.</system:String>
+    <system:String x:Key="MiniGame@SecretFrontTip">소대 선택 화면에서 시작합니다. 기존 세이브 데이터가 있으면 수동으로 삭제해야 합니다.\n게임 내  ｢이전 소대의 데이터 전승받기｣  옵션을 체크하는 것을 권장합니다.</system:String>
     <system:String x:Key="MiniGameNameGreenTicketStore">자격증명서 상점</system:String>
     <system:String x:Key="MiniGameNameGreenTicketStoreTip" xml:space="preserve">1단계는 전부 구매하고&#10;2단계는 헤드헌팅 허가증과 모집 허가증을 구매해요</system:String>
     <system:String x:Key="MiniGameNameYellowTicketStore">고급증명서 상점</system:String>
@@ -1161,7 +1162,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="CopilotTaskTypeMismatch">선택한 작업이 현재 탭과 일치하지 않습니다</system:String>
     <system:String x:Key="CopilotTasksWithEmptyName">스테이지 이름이 비어 있는 작업이 있습니다</system:String>
     <system:String x:Key="CopilotCouldNotSaveFile" xml:space="preserve">부조종사 작업을 파일에 저장할 수 없습니다.: </system:String>
-    <system:String x:Key="CopilotStartWithEmptyList">작업 없이 ｢{key=UseCopilotList}」를 사용 중입니다.</system:String>
+    <system:String x:Key="CopilotStartWithEmptyList">작업 없이 ｢{key=UseCopilotList}｣ 를 사용 중입니다.</system:String>
     <system:String x:Key="CopilotSingleTaskWarning">｢{key=UseCopilotList}｣를 사용하여 단일 작업을 실행하는 것은 권장되지 않습니다. 단일 작업은 직접 실행해 주세요.</system:String>
     <system:String x:Key="CopilotTaskListMixedModeNotAllowed">현재 ｢{key=UseCopilotList}｣를 사용 중입니다. 서로 다른 작업 유형을 혼합하는 것은 지원되지 않습니다.</system:String>
     <system:String x:Key="CopilotTaskTypeParseFailedSkipCheck">일부 작업 유형을 해석하지 못했습니다. 유형 검사를 건너뜁니다.</system:String>
@@ -1185,8 +1186,8 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="ErrorFeedbackLinkText">GitHub에 issue 생성</system:String>
     <system:String x:Key="ErrorQqGroupLinkText">QQ 그룹 가입</system:String>
     <system:String x:Key="ErrorCrashMessageHeader">위 문제로 인해 프로그램이 비정상 종료되었습니다.</system:String>
-    <system:String x:Key="ErrorCrashMessageOpenLog">「{key=Settings} - {key=IssueReport} - {key=OpenDebugFolder}」로 로그를 확인하고 오류가 발생한 구체적인 원인을 확인할 수 있습니다.</system:String>
-    <system:String x:Key="ErrorCrashMessageGenerateReport">「{key=Settings} - {key=IssueReport} - {key=GenerateSupportPayload}」을 사용하여 오류 보고서를 생성한 후, 파란색 ｢{key=Issue}｣ 링크를 클릭하여 피드백을 제출해 주세요.</system:String>
+    <system:String x:Key="ErrorCrashMessageOpenLog"> ｢{key=Settings} - {key=IssueReport} - {key=OpenDebugFolder}｣ 로 로그를 확인하고 오류가 발생한 구체적인 원인을 확인할 수 있습니다.</system:String>
+    <system:String x:Key="ErrorCrashMessageGenerateReport"> ｢{key=Settings} - {key=IssueReport} - {key=GenerateSupportPayload}｣ 을 사용하여 오류 보고서를 생성한 후, 파란색 ｢{key=Issue}｣ 링크를 클릭하여 피드백을 제출해 주세요.</system:String>
     <system:String x:Key="ErrorCrashMessageHelpTip">다른 사람에게 도움을 요청할 경우, 이 창의 스크린샷, 화면 녹화, 화면 사진, 촬영한 영상, 손그림, 옮겨 적은 내용이 아니라 생성된 오류 보고서 파일을 보내 주세요.</system:String>
     <system:String x:Key="ErrorCrashDialogTitle">마지막 충돌 원인</system:String>
     <system:String x:Key="CopyErrorMessage">오류 메시지 복사</system:String>
@@ -1733,7 +1734,7 @@ MAA를 독립된 새 폴더에 압축 해제하거나, MAA에 속하지 않는 D
 
     <system:String x:Key="Achievement.SanityExpire.Title">배신자!</system:String>
     <system:String x:Key="Achievement.SanityExpire.Description">유통기한이 다 될 때까지 뭐 하셨어요? 너무해요!</system:String>
-    <system:String x:Key="Achievement.SanityExpire.Conditions">「{key=UseExpiringMedicine}」 기능으로 한 번에 8개 이상의 이성 회복제 사용</system:String>
+    <system:String x:Key="Achievement.SanityExpire.Conditions"> ｢{key=UseExpiringMedicine}｣  기능으로 한 번에 8개 이상의 이성 회복제 사용</system:String>
 
     <system:String x:Key="Achievement.OverLimitAgent.Title">스테이지 파괴자</system:String>
     <system:String x:Key="Achievement.OverLimitAgent.Description">이제 여기는 눈감고도 돌 수 있겠어요</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -117,15 +117,15 @@
 ↓ 右键齿轮显示更多操作</system:String>
     <system:String x:Key="UserGuide">使用指引</system:String>
     <system:String x:Key="GuideDocumentationTitle">📖 官网与文档</system:String>
-    <system:String x:Key="GuideDocumentationPath">您可以在「{key=Settings} - {key=AboutUs} - {key=Website}」找到 MAA 的官方网站和完整文档。</system:String>
+    <system:String x:Key="GuideDocumentationPath">您可以在 ｢{key=Settings} - {key=AboutUs} - {key=Website}｣ 找到 MAA 的官方网站和完整文档。</system:String>
     <system:String x:Key="GuideIssueReportSubtitle">🔧 遇到问题时</system:String>
-    <system:String x:Key="GuideViewLog">您可以前往「{key=Settings} - {key=IssueReport} - {key=OpenDebugFolder}」查看日志，了解错误发生的具体原因。</system:String>
-    <system:String x:Key="GuideGenerateReport">请使用「{key=Settings} - {key=IssueReport} - {key=GenerateSupportPayload}」生成错误报告，并点击蓝色的「{key=Issue}」链接提交反馈。</system:String>
+    <system:String x:Key="GuideViewLog">您可以前往 ｢{key=Settings} - {key=IssueReport} - {key=OpenDebugFolder}｣ 查看日志，了解错误发生的具体原因。</system:String>
+    <system:String x:Key="GuideGenerateReport">请使用 ｢{key=Settings} - {key=IssueReport} - {key=GenerateSupportPayload}｣ 生成错误报告，并点击蓝色的 ｢{key=Issue}｣ 链接提交反馈。</system:String>
     <system:String x:Key="GuideGitHubIssueTitle">⚠️ 反馈规范</system:String>
     <system:String x:Key="GuideGitHubIssueDescription">MAA Team 仅受理用户通过 GitHub 平台依照 Issue 模板规范提交的反馈，并保留对所有反馈的处理决定权。</system:String>
     <system:String x:Key="GuideOpenSourceTitle">💡 参与开源</system:String>
     <system:String x:Key="GuideOpenSourceDescription">作为开源项目，用户可依据 AGPL-3.0 许可证在 GitHub 平台参与 MAA 的开发。MAA Team 鼓励用户通过更有价值的代码贡献代替问题反馈。</system:String>
-    <system:String x:Key="GuideUserAgreement">使用 MAA 即表示您同意遵守「用户协议」，完整协议内容可在官网底部的链接中查看。</system:String>
+    <system:String x:Key="GuideUserAgreement">使用 MAA 即表示您同意遵守 ｢用户协议｣，完整协议内容可在官网底部的链接中查看。</system:String>
     <system:String x:Key="RestartGuide">重看设置指引</system:String>
     <system:String x:Key="RestartGuidePrompt">设置指引将在主界面显示，是否立即重启应用？</system:String>
     <!--  !设置指引  -->
@@ -163,9 +163,9 @@
     <system:String x:Key="InfrastModeNormal">常规模式</system:String>
     <system:String x:Key="InfrastModeRotation">队列轮换</system:String>
     <system:String x:Key="InfrastModeRotationTip">使用队列轮换需提前在游戏中设置好队列</system:String>
-    <system:String x:Key="InfrastModeRotationToolTip" xml:space="preserve">｢{key=InfrastModeRotation}｣ 的换班逻辑与游戏内基建右下角的「{key=InfrastModeRotation}」完全一致：
+    <system:String x:Key="InfrastModeRotationToolTip" xml:space="preserve">｢{key=InfrastModeRotation}｣ 的换班逻辑与游戏内基建右下角的 ｢{key=InfrastModeRotation}｣ 完全一致：
 当当前班次中任意干员心情值为 0 时，会整队替换为下一班干员。
-若需自定义轮换班次，请使用「{key=InfrastModeCustom}」。</system:String>
+若需自定义轮换班次，请使用 ｢{key=InfrastModeCustom}｣。</system:String>
     <system:String x:Key="InfrastModeCustom">自定义基建配置</system:String>
     <system:String x:Key="DefaultInfrast">内置配置</system:String>
     <system:String x:Key="UserDefined">自定义</system:String>
@@ -401,7 +401,7 @@
 📄 更新说明：
     • {key=UpdateCheckNow}：包含界面与功能更新。界面改动、新功能需通过{key=UpdateCheckNow}获得
     • {key=ResourceUpdate}：包含自动战斗新关卡、掉落识别图标、公招干员标签等素材数据
-    • 导航热更：自动触发，用于更新主界面提示与活动关卡入口。成功后右上角会显示「{key=ApiUpdateSuccess}」
+    • 导航热更：自动触发，用于更新主界面提示与活动关卡入口。成功后右上角会显示 ｢{key=ApiUpdateSuccess}｣
 </system:String>
     <system:String x:Key="GlobalSource">海外源</system:String>
     <system:String x:Key="ForceGithubGlobalSource">强制使用 GitHub</system:String>
@@ -715,6 +715,7 @@ C:\\Program Files\\Netease\\MuMuPlayer。\n
     <system:String x:Key="MuMu12Index">实例编号</system:String>
     <system:String x:Key="MuMu12Display">屏幕编号</system:String>
     <system:String x:Key="MuMuExtrasNotEnabledMessage">Mumu 截图增强未生效，请检查相关设置</system:String>
+    <system:String x:Key="MuMuEmulator12KeepAliveOn">检测到 MuMu 模拟器开启了后台保活，可能导致截图失败和操作异常，请在 MuMu 设置中关闭 ｢后台保活｣（或 ｢应用保活｣ ｢后台挂机时保活运行｣ 等）</system:String>
     <system:String x:Key="LdExtrasEnabled">启用 LD 截图增强模式</system:String>
     <system:String x:Key="LdPlayerEmulatorPathNotFound">未找到 LDPlayer 模拟器路径。</system:String>
     <system:String x:Key="LdPlayerOpenglMissing">在所选 LDPlayer 路径中未找到 ldopengl64.dll，请确认安装目录。</system:String>
@@ -844,7 +845,7 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="DaysLeftOpen" xml:space="preserve">剩余天数: </system:String>
     <system:String x:Key="Inventory">库存</system:String>
     <system:String x:Key="InventoryUpdateTip">可通过 ｢{key=Toolbox}-{key=DepotRecognition}｣ 更新库存数据</system:String>
-    <system:String x:Key="SpecifiedDropsInventoryUnavailable">任务「{0}」启用了 {key=TargetInventory}，但当前没有可用的库存数据，已跳过。可通过 ｢{key=Toolbox}-{key=DepotRecognition}｣ 更新库存。</system:String>
+    <system:String x:Key="SpecifiedDropsInventoryUnavailable">任务 ｢{0}｣ 启用了 {key=TargetInventory}，但当前没有可用的库存数据，已跳过。可通过 ｢{key=Toolbox}-{key=DepotRecognition}｣ 更新库存。</system:String>
     <system:String x:Key="LessThanOneDay">不到 1 天</system:String>
     <system:String x:Key="1-7">1-7</system:String>
     <system:String x:Key="CE-6">龙门币-6/5</system:String>
@@ -1184,8 +1185,8 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="ErrorFeedbackLinkText">创建 GitHub issue</system:String>
     <system:String x:Key="ErrorQqGroupLinkText">加入 QQ 群</system:String>
     <system:String x:Key="ErrorCrashMessageHeader">以上问题导致程序异常退出。</system:String>
-    <system:String x:Key="ErrorCrashMessageOpenLog">您可以前往「{key=Settings} - {key=IssueReport} - {key=OpenDebugFolder}」查看日志，了解错误发生的具体原因。</system:String>
-    <system:String x:Key="ErrorCrashMessageGenerateReport">请使用「{key=Settings} - {key=IssueReport} - {key=GenerateSupportPayload}」生成错误报告，并点击蓝色的 ｢{key=Issue}｣ 链接提交反馈。</system:String>
+    <system:String x:Key="ErrorCrashMessageOpenLog">您可以前往 ｢{key=Settings} - {key=IssueReport} - {key=OpenDebugFolder}｣ 查看日志，了解错误发生的具体原因。</system:String>
+    <system:String x:Key="ErrorCrashMessageGenerateReport">请使用 ｢{key=Settings} - {key=IssueReport} - {key=GenerateSupportPayload}｣ 生成错误报告，并点击蓝色的 ｢{key=Issue}｣ 链接提交反馈。</system:String>
     <system:String x:Key="ErrorCrashMessageHelpTip">如果向他人寻求帮助，请发送生成的错误报告文件，而不是发送此窗口的截图、录屏视频、屏幕照片、拍摄的视频、手绘图片或誊抄的画面内容。</system:String>
     <system:String x:Key="ErrorCrashDialogTitle">上次程序崩溃原因</system:String>
     <system:String x:Key="CopyErrorMessage">复制错误信息</system:String>
@@ -1733,7 +1734,7 @@ DEBUG 目录下保存的图片有数量限制，超出后会自动清理旧图�
 
     <system:String x:Key="Achievement.SanityExpire.Title">要过期了</system:String>
     <system:String x:Key="Achievement.SanityExpire.Description">赶紧冲哇！！！</system:String>
-    <system:String x:Key="Achievement.SanityExpire.Conditions">使用「{key=UseExpiringMedicine}」，单次任务使用 8 瓶及以上临期理智药</system:String>
+    <system:String x:Key="Achievement.SanityExpire.Conditions">使用 ｢{key=UseExpiringMedicine}｣，单次任务使用 8 瓶及以上临期理智药</system:String>
 
     <system:String x:Key="Achievement.OverLimitAgent.Title">超限代理</system:String>
     <system:String x:Key="Achievement.OverLimitAgent.Description">你进行了一次能将大道磨灭的代理任务。</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -117,15 +117,15 @@
 ↓ 右鍵齒輪顯示更多操作</system:String>
     <system:String x:Key="UserGuide">使用指引</system:String>
     <system:String x:Key="GuideDocumentationTitle">📖 官網與文件</system:String>
-    <system:String x:Key="GuideDocumentationPath">您可以在「{key=Settings} - {key=AboutUs} - {key=Website}」找到 MAA 的官方網站和完整文件。</system:String>
+    <system:String x:Key="GuideDocumentationPath">您可以在 ｢{key=Settings} - {key=AboutUs} - {key=Website}｣ 找到 MAA 的官方網站和完整文件。</system:String>
     <system:String x:Key="GuideIssueReportSubtitle">🔧 遇到問題時</system:String>
-    <system:String x:Key="GuideViewLog">您可以前往「{key=Settings} - {key=IssueReport} - {key=OpenDebugFolder}」查看日誌，了解錯誤發生的具體原因。</system:String>
-    <system:String x:Key="GuideGenerateReport">請使用「{key=Settings} - {key=IssueReport} - {key=GenerateSupportPayload}」生成錯誤報告，並點擊藍色的「{key=Issue}」連結提交回饋。</system:String>
+    <system:String x:Key="GuideViewLog">您可以前往 ｢{key=Settings} - {key=IssueReport} - {key=OpenDebugFolder}｣ 查看日誌，了解錯誤發生的具體原因。</system:String>
+    <system:String x:Key="GuideGenerateReport">請使用 ｢{key=Settings} - {key=IssueReport} - {key=GenerateSupportPayload}｣ 生成錯誤報告，並點擊藍色的 ｢{key=Issue}｣ 連結提交回饋。</system:String>
     <system:String x:Key="GuideGitHubIssueTitle">⚠️ 回饋規範</system:String>
     <system:String x:Key="GuideGitHubIssueDescription">MAA Team 僅受理使用者透過 GitHub 平台依照 Issue 範本規範提交的回饋，並保留對所有回饋的處理決定權。</system:String>
     <system:String x:Key="GuideOpenSourceTitle">💡 參與開源</system:String>
     <system:String x:Key="GuideOpenSourceDescription">作為開源專案，使用者可依據 AGPL-3.0 許可證在 GitHub 平台參與 MAA 的開發。MAA Team 鼓勵使用者透過更有價值的程式碼貢獻代替問題回饋。</system:String>
-    <system:String x:Key="GuideUserAgreement">使用 MAA 即表示您同意遵守「用戶協議」，完整協議內容可在官網底部的連結中查看。</system:String>
+    <system:String x:Key="GuideUserAgreement">使用 MAA 即表示您同意遵守 ｢用戶協議｣ ，完整協議內容可在官網底部的連結中查看。</system:String>
     <system:String x:Key="RestartGuide">重看設定指引</system:String>
     <system:String x:Key="RestartGuidePrompt">設定指引將在主介面顯示，是否立即重啟應用程式？</system:String>
     <!--  !設定指引  -->
@@ -163,9 +163,9 @@
     <system:String x:Key="InfrastModeNormal">一般模式</system:String>
     <system:String x:Key="InfrastModeRotation">隊列輪換</system:String>
     <system:String x:Key="InfrastModeRotationTip">使用隊列輪換需提前在遊戲中設定好隊列</system:String>
-    <system:String x:Key="InfrastModeRotationToolTip" xml:space="preserve">「{key=InfrastModeRotation}」的換班邏輯與遊戲內基建右下角的「{key=InfrastModeRotation}」完全一致：
+    <system:String x:Key="InfrastModeRotationToolTip" xml:space="preserve"> ｢{key=InfrastModeRotation}｣ 的換班邏輯與遊戲內基建右下角的 ｢{key=InfrastModeRotation}｣ 完全一致：
 當目前班次中任意幹員心情值為 0 時，會整隊替換為下一班幹員。
-若需自定義輪換班次，請使用「{key=InfrastModeCustom}」。</system:String>
+若需自定義輪換班次，請使用 ｢{key=InfrastModeCustom}｣ 。</system:String>
     <system:String x:Key="InfrastModeCustom">自定義基建配置</system:String>
     <system:String x:Key="DefaultInfrast">內建配置</system:String>
     <system:String x:Key="UserDefined">自定義</system:String>
@@ -388,7 +388,7 @@
     <system:String x:Key="UpdateSourceTip" xml:space="preserve">
 🌏 使用 {key=GlobalSource}：
     • {key=UpdateCheckNow}：由 MAA Team 提供更新偵測，從 GitHub 下載更新壓縮檔案，中國國內同步提供直連鏡像站（頻寬有限，高峰時段可能受限）
-    • {key=ResourceUpdate}：由 {key=MirrorChyan} 提供免費的更新偵測，可手動在設定中點擊「{key=ResourceUpdate}」從 GitHub 下載
+    • {key=ResourceUpdate}：由 {key=MirrorChyan} 提供免費的更新偵測，可手動在設定中點擊 ｢{key=ResourceUpdate}｣ 從 GitHub 下載
 
 🔑 使用 {key=MirrorChyan}：
     • 填寫 CDK 後，支援軟體與資源的自動更新
@@ -401,7 +401,7 @@
 📄 更新說明：
     • {key=UpdateCheckNow}：包含介面與功能更新。介面改動、新功能需透過 {key=UpdateCheckNow} 取得
     • {key=ResourceUpdate}：包含自動作戰新關卡、掉落辨識圖示、公招幹員標籤等素材資料
-    • 導航熱更新：自動觸發，用於更新主介面提示與活動關卡入口。成功後右上角會顯示「{key=ApiUpdateSuccess}」
+    • 導航熱更新：自動觸發，用於更新主介面提示與活動關卡入口。成功後右上角會顯示 ｢{key=ApiUpdateSuccess}｣ 
 </system:String>
     <system:String x:Key="GlobalSource">全域來源</system:String>
     <system:String x:Key="ForceGithubGlobalSource">強制使用 GitHub</system:String>
@@ -605,7 +605,7 @@ D:\
     <system:String x:Key="CreditFightTip" xml:space="preserve">訪問好友後借助戰打一把 OF-1 賺 30 信用。
 關卡選擇為 ｢{key=DefaultStage}｣ 時此功能無效。
 別傳 ｢火藍之心｣ 關卡 OF-1 未解鎖時請勿勾選。</system:String>
-    <system:String x:Key="CreditFightWhenOF-1Warning">當「{key=Fight}」任務關卡清單中已包含「{key=DefaultStage}」時，「{key=Mall}」任務將不再借助戰打一把 OF-1。任務名稱: {0} (序號{1}), 關卡序號 {2}</system:String>
+    <system:String x:Key="CreditFightWhenOF-1Warning">當 ｢{key=Fight}｣ 任務關卡清單中已包含 ｢{key=DefaultStage}｣ 時， ｢{key=Mall}｣ 任務將不再借助戰打一把 OF-1。任務名稱: {0} (序號{1}), 關卡序號 {2}</system:String>
     <system:String x:Key="HighPriority">優先購買（子字串即可，分號分隔）</system:String>
     <system:String x:Key="Blacklist">黑名單（子字串即可，分號分隔）</system:String>
     <system:String x:Key="HighPriorityDefault">招聘許可</system:String>
@@ -715,6 +715,7 @@ C:\\Program Files\\Netease\\MuMuPlayer\n
     <system:String x:Key="MuMu12Index">實例編號</system:String>
     <system:String x:Key="MuMu12Display">螢幕編號</system:String>
     <system:String x:Key="MuMuExtrasNotEnabledMessage">Mumu 截圖增強未生效，請檢查相關設定</system:String>
+    <system:String x:Key="MuMuEmulator12KeepAliveOn">偵測到 MuMu 模擬器開啟了背景保活，可能導致截圖失敗和操作異常，請在 MuMu 設定中關閉 ｢背景保活｣（或 ｢應用保活｣ ｢背景掛機時保活運行｣ 等）</system:String>
     <system:String x:Key="LdExtrasEnabled">啟用 LD 截圖增強模式</system:String>
     <system:String x:Key="LdPlayerEmulatorPathNotFound">找不到 LDPlayer 模擬器路徑。</system:String>
     <system:String x:Key="LdPlayerOpenglMissing">在所選 LDPlayer 路徑中未找到 ldopengl64.dll，請確認安裝目錄。</system:String>
@@ -844,7 +845,7 @@ C:\\leidian\\LDPlayer9\n
     <system:String x:Key="DaysLeftOpen" xml:space="preserve">剩餘天數: </system:String>
     <system:String x:Key="Inventory">庫存</system:String>
     <system:String x:Key="InventoryUpdateTip">可透過 ｢{key=Toolbox}-{key=DepotRecognition}｣ 更新庫存數據</system:String>
-    <system:String x:Key="SpecifiedDropsInventoryUnavailable">任務「{0}」啟用了 {key=TargetInventory}，但目前沒有可用的庫存資料，已跳過。可透過 ｢{key=Toolbox}-{key=DepotRecognition}｣ 更新庫存。</system:String>
+    <system:String x:Key="SpecifiedDropsInventoryUnavailable">任務 ｢{0}｣ 啟用了 {key=TargetInventory}，但目前沒有可用的庫存資料，已跳過。可透過 ｢{key=Toolbox}-{key=DepotRecognition}｣ 更新庫存。</system:String>
     <system:String x:Key="LessThanOneDay">不到 1 天</system:String>
     <system:String x:Key="1-7">1-7</system:String>
     <system:String x:Key="CE-6">龍門幣-6/5</system:String>
@@ -1009,22 +1010,22 @@ C:\\leidian\\LDPlayer9\n
     <system:String x:Key="MiniGame@PV">PV-煙花籌委會</system:String>
     <system:String x:Key="MiniGame@PVTip">從所選關卡開始並自動通關。若選擇第一關，則從活動頁面最左側開始；若選擇其他關卡，請先進入上一關再返回以校準位置。</system:String>
     <system:String x:Key="MiniGame@SPA">衛戍協議：盟約</system:String>
-    <system:String x:Key="MiniGame@SPATip" xml:space="preserve">在活動主介面（有「獨立模擬」處）開始任務。
+    <system:String x:Key="MiniGame@SPATip" xml:space="preserve">在活動主介面（有 ｢獨立模擬｣ 處）開始任務。
 在有存檔時需要先手動放棄
-最高只測試過「險境模擬」
-如果已通關更高難度導致看不到「險境模擬」或「標準模擬」，需手動選擇一次「險境模擬」難度
-手動通關「標準模擬」可以更快刷分。
-只能刷等級獎勵，拿蝕刻章得打完所有的「關鍵目標」。</system:String>
+最高只測試過 ｢險境模擬｣ 
+如果已通關更高難度導致看不到 ｢險境模擬｣ 或 ｢標準模擬｣ ，需手動選擇一次 ｢險境模擬｣ 難度
+手動通關 ｢標準模擬｣ 可以更快刷分。
+只能刷等級獎勵，拿蝕刻章得打完所有的 ｢關鍵目標｣ 。</system:String>
     <system:String x:Key="MiniGame@OS">OS-喀蘭貿易技術研發部</system:String>
     <system:String x:Key="MiniGame@OSTip">在活動主介面（右下角有 ｢開始重建｣ 處）開始任務。</system:String>
     <system:String x:Key="MiniGame@RM-TR-1">次生方案 RM-TR-1</system:String>
     <system:String x:Key="MiniGame@RM-TR-1Tip" xml:space="preserve">完成新手教學後進入前哨支點，滑動到介面最左側。</system:String>
     <system:String x:Key="MiniGame@RM-1">次生方案 RM-1</system:String>
-    <system:String x:Key="MiniGame@RM-1Tip" xml:space="preserve">刷 RM-TR-1 大約 3 小時，營造策略中，將「石材開採」線點到底；&#10;特約任命指定維什戴爾，然後盡量精二專三，攜帶 1 技能；&#10;帶滿 12 個幹員，其餘 11 個的費用需要低於維什戴爾；&#10;生產模組各帶 1 個，手動進入關卡並退出；&#10;讓 RM-1 位於螢幕中央，執行 MAA。</system:String>
+    <system:String x:Key="MiniGame@RM-1Tip" xml:space="preserve">刷 RM-TR-1 大約 3 小時，營造策略中，將 ｢石材開採｣ 線點到底；&#10;特約任命指定維什戴爾，然後盡量精二專三，攜帶 1 技能；&#10;帶滿 12 個幹員，其餘 11 個的費用需要低於維什戴爾；&#10;生產模組各帶 1 個，手動進入關卡並退出；&#10;讓 RM-1 位於螢幕中央，執行 MAA。</system:String>
     <system:String x:Key="MiniGame@AT@ConversationRoom">AT-相談室</system:String>
-    <system:String x:Key="MiniGame@AT@ConversationRoomTip" xml:space="preserve">在活動主介面（右下角有「開始營業」處）開始任務。</system:String>
+    <system:String x:Key="MiniGame@AT@ConversationRoomTip" xml:space="preserve">在活動主介面（右下角有 ｢開始營業｣ 處）開始任務。</system:String>
     <system:String x:Key="MiniGame@ALL@GreenGrass">爭鋒頻道：青草城</system:String>
-    <system:String x:Key="MiniGame@ALL@GreenGrassTip" xml:space="preserve">手動跳過教學對話，然後可以直接退出。&#10;在活動主介面（右下角有「加入賽事」處）開始任務。&#10;&#10;跟著鴨總喝口湯。</system:String>
+    <system:String x:Key="MiniGame@ALL@GreenGrassTip" xml:space="preserve">手動跳過教學對話，然後可以直接退出。&#10;在活動主介面（右下角有 ｢加入賽事｣ 處）開始任務。&#10;&#10;跟著鴨總喝口湯。</system:String>
     <system:String x:Key="MiniGame@ALL@HoneyFruit">爭鋒頻道：蜜果城</system:String>
     <system:String x:Key="MiniGame@ALL@HoneyFruitTip" xml:space="preserve">{key=MiniGame@ALL@GreenGrassTip}</system:String>
     <system:String x:Key="MiniGame@ALL@IvyVine">爭鋒頻道：綠藤城</system:String>
@@ -1035,9 +1036,9 @@ C:\\leidian\\LDPlayer9\n
     <system:String x:Key="MiniGame@SecretFront@Event2">遊俠</system:String>
     <system:String x:Key="MiniGame@SecretFront@Event3">詭影迷蹤</system:String>
     <system:String x:Key="MiniGame@SecretFront">隱秘戰線</system:String>
-    <system:String x:Key="MiniGame@SecretFrontTip">在選擇小隊介面開始，如有存檔須手動刪除。&#10;第一次打請先看完教學後關閉。&#10;推薦勾選遊戲內「繼承上一支隊伍發回的資料」。</system:String>
+    <system:String x:Key="MiniGame@SecretFrontTip">在選擇小隊介面開始，如有存檔須手動刪除。&#10;第一次打請先看完教學後關閉。&#10;推薦勾選遊戲內 ｢繼承上一支隊伍發回的資料｣ 。</system:String>
     <system:String x:Key="MiniGameNameGreenTicketStore">綠票商店</system:String>
-    <system:String x:Key="MiniGameNameGreenTicketStoreTip" xml:space="preserve">第 1 層全買。&#10;第 2 層買「尋訪憑證」和「招聘許可」。</system:String>
+    <system:String x:Key="MiniGameNameGreenTicketStoreTip" xml:space="preserve">第 1 層全買。&#10;第 2 層買 ｢尋訪憑證｣ 和 ｢招聘許可｣ 。</system:String>
     <system:String x:Key="MiniGameNameYellowTicketStore">黃票商店</system:String>
     <system:String x:Key="MiniGameNameYellowTicketStoreTip" xml:space="preserve">請確保自己至少有 258 張黃票。</system:String>
     <system:String x:Key="MiniGameNameSsStore">活動商店</system:String>
@@ -1133,7 +1134,7 @@ C:\\leidian\\LDPlayer9\n
         1. 使用前請確認作業與所選擇的關卡類型一致。\n\n
         2. {key=MainStage}、{key=StoryCollection}、{key=SideStory}：請在關卡介面右下角顯示 ｢開始行動｣ 按鈕的畫面啟動。\n\n
         3. {key=SSS}：resource/copilot 資料夾內建多份作業。請先手動編隊，在右下角顯示 ｢開始部署｣ 按鈕的介面啟動，可配合 ｢{key=LoopTimes}｣。\n\n
-        4. {key=ParadoxSimulation}：選好技能後，在技能選擇介面顯示 ｢開始模擬｣ 按鈕的畫面啟動；1/2★ {key=Operator}（無技能）在右下角顯示 ｢開始模擬｣ 按鈕的介面啟動。若使用 ｢{key=UseCopilotList}｣，請從{key=Operator}列表的「等級 / 稀有度」標籤頁啟動。\n\n
+        4. {key=ParadoxSimulation}：選好技能後，在技能選擇介面顯示 ｢開始模擬｣ 按鈕的畫面啟動；1/2★ {key=Operator}（無技能）在右下角顯示 ｢開始模擬｣ 按鈕的介面啟動。若使用 ｢{key=UseCopilotList}｣，請從{key=Operator}列表的 ｢等級 / 稀有度｣ 標籤頁啟動。\n\n
         5. {key=Operator}若被標記為 ｢特別關注｣，可能影響 ｢{key=AutoSquad}｣ 的辨識與選擇。建議使用 ｢{key=AutoSquad}｣ 時移除特別關注，或在報錯後關閉 ｢{key=AutoSquad}｣，並依據提示手動補充缺少的{key=Operator}。\n\n
         6. Copilot 作業站的神秘代碼可透過輸入框右側的貼上按鈕貼上：\n
         • 點選第 2 個按鈕 = 新增作業。\n
@@ -1184,9 +1185,9 @@ C:\\leidian\\LDPlayer9\n
     <system:String x:Key="ErrorFeedbackLinkText">建立 GitHub Issue</system:String>
     <system:String x:Key="ErrorQqGroupLinkText">加入 QQ 群</system:String>
     <system:String x:Key="ErrorCrashMessageHeader">以上問題導致程式異常關閉。</system:String>
-    <system:String x:Key="ErrorCrashMessageOpenLog">您可以前往「{key=Settings} - {key=IssueReport} - {key=OpenDebugFolder}」查看日誌，了解錯誤發生的具體原因。</system:String>
-    <system:String x:Key="ErrorCrashMessageGenerateReport">請使用「{key=Settings} - {key=IssueReport} - {key=GenerateSupportPayload}」產生錯誤報告，並點擊藍色的 ｢{key=Issue}｣ 連結提交回報。</system:String>
-    <system:String x:Key="ErrorCrashMessageHelpTip">若要尋求協助，請直接傳送產生的 「錯誤報告檔案」；請勿傳送此視窗的截圖、錄影、螢幕照片、翻拍影片、手繪圖片或抄寫的內容。</system:String>
+    <system:String x:Key="ErrorCrashMessageOpenLog">您可以前往 ｢{key=Settings} - {key=IssueReport} - {key=OpenDebugFolder}｣ 查看日誌，了解錯誤發生的具體原因。</system:String>
+    <system:String x:Key="ErrorCrashMessageGenerateReport">請使用 ｢{key=Settings} - {key=IssueReport} - {key=GenerateSupportPayload}｣ 產生錯誤報告，並點擊藍色的 ｢{key=Issue}｣ 連結提交回報。</system:String>
+    <system:String x:Key="ErrorCrashMessageHelpTip">若要尋求協助，請直接傳送產生的  ｢錯誤報告檔案｣ ；請勿傳送此視窗的截圖、錄影、螢幕照片、翻拍影片、手繪圖片或抄寫的內容。</system:String>
     <system:String x:Key="ErrorCrashDialogTitle">上次程式崩潰原因</system:String>
     <system:String x:Key="CopyErrorMessage">複製錯誤資訊</system:String>
     <!--  !ErrorView  -->
@@ -1539,7 +1540,7 @@ DEBUG 目錄下儲存的圖片有數量限制，超出後會自動清理舊圖�
 
 前置條件：主線已通關 RA-1
 
-在大地圖打開 RA-1，右下角出現「開啟建設」時啟動任務即可自動循環
+在大地圖打開 RA-1，右下角出現 ｢開啟建設｣ 時啟動任務即可自動循環
 
 注意：如果已解鎖開局額外攜帶物品的相關科技，請將基地內會導致開局額外攜帶物品的設施拆除，如食品供給站、飲品供給站、獸欄等
 
@@ -1556,7 +1557,7 @@ DEBUG 目錄下儲存的圖片有數量限制，超出後會自動清理舊圖�
 3. 如果自己有維什戴爾，請手動打開關卡並配隊一次，保證為任意 5 個費用比維什戴爾低的幹員+ 維什戴爾，且維什戴爾位於六號位即最後一個選的人，然後確認招募，放棄本次建設並在開始建設處開始
 4. 如果使用助戰維什戴爾，請保證維什戴爾在狙擊助戰首頁（考慮摯友），請手動打開關卡編入任意 5 個費用比維什戴爾低的幹員，六號位選擇維什戴爾助戰後確認招募，放棄本次建設並在開始建設處開始（保證隊伍前五位有人且六號位為空）
 
-在大地圖打開 RA-4，右下角出現「開啟建設」時啟動任務即可自動循環
+在大地圖打開 RA-4，右下角出現 ｢開啟建設｣ 時啟動任務即可自動循環
 
 注意：如果已解鎖開局額外攜帶物品的相關科技，請將基地內會導致開局額外攜帶物品的設施拆除，如食品供給站、飲品供給站、獸欄等
 
@@ -1572,7 +1573,7 @@ DEBUG 目錄下儲存的圖片有數量限制，超出後會自動清理舊圖�
 2. 如果自己有聖聆初雪，請手動打開 RA-15 並配隊一次。選擇五先鋒（無練度要求）+ 聖聆初雪，且初雪位於最後一位，儲存配隊後退出關卡
 3. 如果使用助戰聖聆初雪，請確認聖聆初雪位於術士助戰首頁（考慮摯友）
 
-在大地圖打開 RA-15，右下角出現「開啟建設」時啟動任務即可自動循環
+在大地圖打開 RA-15，右下角出現 ｢開啟建設｣ 時啟動任務即可自動循環
 
 注意： 如果已解鎖開局額外攜帶物品的相關科技，請將基地內會導致開局額外攜帶物品的設施拆除，如食品供給站、飲品供給站、獸欄等
 
@@ -1660,7 +1661,7 @@ DEBUG 目錄下儲存的圖片有數量限制，超出後會自動清理舊圖�
     <system:String x:Key="Achievement.SanitySpender3.Conditions">完成 1000 次代理通關</system:String>
 
     <system:String x:Key="Achievement.QuickCloser.Title">YOLO!</system:String>
-    <system:String x:Key="Achievement.QuickCloser.Description">「我知道我在做什麼。」—— 某使用者在點擊之前。</system:String>
+    <system:String x:Key="Achievement.QuickCloser.Description"> ｢我知道我在做什麼。｣ —— 某使用者在點擊之前。</system:String>
     <system:String x:Key="Achievement.QuickCloser.Conditions">1 秒內關閉彈出視窗（你大概根本沒看吧）</system:String>
 
     <system:String x:Key="Achievement.TacticalRetreat.Title">臨陣脫逃</system:String>
@@ -1733,7 +1734,7 @@ DEBUG 目錄下儲存的圖片有數量限制，超出後會自動清理舊圖�
 
     <system:String x:Key="Achievement.SanityExpire.Title">要過期了</system:String>
     <system:String x:Key="Achievement.SanityExpire.Description">趕緊衝哇！！</system:String>
-    <system:String x:Key="Achievement.SanityExpire.Conditions">使用「{key=UseExpiringMedicine}」，單次任務使用 8 瓶及以上即期理智藥</system:String>
+    <system:String x:Key="Achievement.SanityExpire.Conditions">使用 ｢{key=UseExpiringMedicine}｣ ，單次任務使用 8 瓶及以上即期理智藥</system:String>
 
     <system:String x:Key="Achievement.OverLimitAgent.Title">超限代理</system:String>
     <system:String x:Key="Achievement.OverLimitAgent.Description">你進行了一次能將大道磨滅的代理任務。</system:String>
@@ -1796,7 +1797,7 @@ DEBUG 目錄下儲存的圖片有數量限制，超出後會自動清理舊圖�
     <system:String x:Key="Achievement.Irreplaceable.Conditions">使用 ｢{key=Copilot} - {key=AutoSquad}｣ 時，缺少至少兩名{key=Operator}</system:String>
 
     <system:String x:Key="Achievement.SnapshotChallenge1.Title">高 ping 戰士</system:String>
-    <system:String x:Key="Achievement.SnapshotChallenge1.Description">「卡了」</system:String>
+    <system:String x:Key="Achievement.SnapshotChallenge1.Description"> ｢卡了｣ </system:String>
     <system:String x:Key="Achievement.SnapshotChallenge1.Conditions">平均截圖用時超過 800ms</system:String>
 
     <system:String x:Key="Achievement.SnapshotChallenge2.Title">是不是有點太慢了</system:String>
@@ -1981,7 +1982,7 @@ DEBUG 目錄下儲存的圖片有數量限制，超出後會自動清理舊圖�
 
     <system:String x:Key="Achievement.WarehouseKeeper.Title">我是倉管！</system:String>
     <system:String x:Key="Achievement.WarehouseKeeper.Description">牛牛找到了牛牛！</system:String>
-    <system:String x:Key="Achievement.WarehouseKeeper.Conditions">幹員辨識中包含幹員「帕拉斯」</system:String>
+    <system:String x:Key="Achievement.WarehouseKeeper.Conditions">幹員辨識中包含幹員 ｢帕拉斯｣ </system:String>
 
     <system:String x:Key="Achievement.NotFound404.Title">404！</system:String>
     <system:String x:Key="Achievement.NotFound404.Description">這個任務似乎找不到了</system:String>

--- a/src/MaaWpfGui/Services/StageManager.cs
+++ b/src/MaaWpfGui/Services/StageManager.cs
@@ -279,7 +279,7 @@ public class StageManager
     {
         return new()
         {
-            // 「当前/上次」关卡导航
+            // ｢当前/上次｣ 关卡导航
             { string.Empty, new() { Display = LocalizationHelper.GetString("DefaultStage"), Value = string.Empty } },
 
             // 周一和周日的关卡提示


### PR DESCRIPTION
## Summary by Sourcery

添加 MuMu 模拟器保活检测功能，并优化 MuMu 实例索引及相关界面文案。

新功能：
- 通过 `MuMuManager` 检测 MuMu 模拟器后台保活状态，并在 `MuMuEmulator12` 连接启用保活时向用户发出警告。

增强与改进：
- 统一并改进根据连接地址和端口推导 MuMu 模拟器实例索引的逻辑。
- 通过探测正在运行的模拟器进程来增强对 `MuMuManager.exe` 的发现机制，并在失败时回退到用户配置的安装路径。
- 打磨若干中文界面文案和注释，使与带引号功能名及导航标签相关的表述更加一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add MuMu emulator keep-alive detection and refine MuMu instance indexing and related UI text.

New Features:
- Detect MuMu emulator background keep-alive status via MuMuManager and warn users when it is enabled for MuMuEmulator12 connections.

Enhancements:
- Unify and improve MuMu emulator instance index deduction from connection addresses and ports.
- Enhance MuMuManager.exe discovery by probing running emulator processes and falling back to user-configured installation paths.
- Polish several Chinese UI strings and comments for consistency around quoted feature names and navigation labels.

</details>