### PR TITLE
feat: MuMu 截图增强支持 emulator-5xxx 格式端口

### DIFF
--- a/src/MaaCore/Controller/AdbController.cpp
+++ b/src/MaaCore/Controller/AdbController.cpp
@@ -204,14 +204,20 @@ std::optional<int> asst::AdbController::get_mumu_index(const std::string& addres
     // 实例索引 = (port - 5554) / 2
     if (address.starts_with("emulator-")) {
         constexpr int base_emulator_port = 5554;
-        std::string port_str = address.substr(9); // after "emulator-"
-        if (port_str.empty() || !std::ranges::all_of(port_str, [](const char& c) -> bool { return std::isdigit(c); })) {
-            Log.error("emulator port is invalid", port_str);
+        std::string_view port_sv = std::string_view(address).substr(9); // after "emulator-"
+        int port = 0;
+        if (!utils::chars_to_number<int, true>(port_sv, port)) {
+            Log.error("emulator port is invalid", port_sv);
             return std::nullopt;
         }
-        int port = std::stoi(port_str);
+        // emulator 控制台端口从 5554 起步进 2（5554, 5556, ...），
+        // 奇数端口是 adb 端口而非控制台端口，不在 emulator-xxxx 格式中出现
+        if (port < base_emulator_port || (port - base_emulator_port) % 2 != 0) {
+            Log.error("emulator port is out of range or not aligned", port);
+            return std::nullopt;
+        }
         int mumu_index = (port - base_emulator_port) / 2;
-        LogInfo << VAR(port_str) << VAR(port) << VAR(mumu_index);
+        LogInfo << VAR(port_sv) << VAR(port) << VAR(mumu_index);
         return mumu_index;
     }
 
@@ -304,14 +310,20 @@ std::optional<int> asst::AdbController::get_ld_index(const std::string& address)
     // emulator-5554
     if (address.starts_with("emulator-")) {
         constexpr int base_emulator_port = 5554;
-        std::string port_str = address.substr(9); // after "emulator-"
-        if (port_str.empty() || !std::ranges::all_of(port_str, [](char c) { return std::isdigit(c); })) {
-            Log.error("emulator port is invalid", port_str);
+        std::string_view port_sv = std::string_view(address).substr(9); // after "emulator-"
+        int port = 0;
+        if (!utils::chars_to_number<int, true>(port_sv, port)) {
+            Log.error("emulator port is invalid", port_sv);
             return std::nullopt;
         }
-        int port = std::stoi(port_str);
+        // emulator 控制台端口从 5554 起步进 2（5554, 5556, ...），
+        // 奇数端口是 adb 端口而非控制台端口，不在 emulator-xxxx 格式中出现
+        if (port < base_emulator_port || (port - base_emulator_port) % 2 != 0) {
+            Log.error("emulator port is out of range or not aligned", port);
+            return std::nullopt;
+        }
         int index = (port - base_emulator_port) / 2;
-        LogInfo << VAR(port_str) << VAR(port) << VAR(index);
+        LogInfo << VAR(port_sv) << VAR(port) << VAR(index);
         return index;
     }
 

--- a/src/MaaCore/Controller/AdbController.cpp
+++ b/src/MaaCore/Controller/AdbController.cpp
@@ -196,20 +196,35 @@ void asst::AdbController::callback(AsstMsg msg, const json::value& details)
     }
 }
 
-int asst::AdbController::get_mumu_index(const std::string& address)
+std::optional<int> asst::AdbController::get_mumu_index(const std::string& address)
 {
     LogTrace << VAR(address);
+
+    // 新版 MuMu 支持 emulator-xxxx 格式的设备号（如 emulator-5554），
+    // 实例索引 = (port - 5554) / 2
+    if (address.starts_with("emulator-")) {
+        constexpr int base_emulator_port = 5554;
+        std::string port_str = address.substr(9); // after "emulator-"
+        if (port_str.empty() || !std::ranges::all_of(port_str, [](const char& c) -> bool { return std::isdigit(c); })) {
+            Log.error("emulator port is invalid", port_str);
+            return std::nullopt;
+        }
+        int port = std::stoi(port_str);
+        int mumu_index = (port - base_emulator_port) / 2;
+        LogInfo << VAR(port_str) << VAR(port) << VAR(mumu_index);
+        return mumu_index;
+    }
 
     auto pos = address.find(":");
     if (pos == std::string::npos) {
         Log.error("address is invalid", address);
-        return 0;
+        return std::nullopt;
     }
 
     std::string port_str = address.substr(pos + 1);
     if (port_str.empty() || !std::ranges::all_of(port_str, [](const char& c) -> bool { return std::isdigit(c); })) {
         Log.error("port is invalid", port_str);
-        return 0;
+        return std::nullopt;
     }
     int port = std::stoi(port_str);
     int mumu_index = 0;
@@ -232,6 +247,10 @@ int asst::AdbController::get_mumu_index(const std::string& address)
     }
     else if (port >= 5555) {
         mumu_index = (port - 5555) / 2;
+    }
+    else {
+        Log.error("port is not in a valid MuMu range", port);
+        return std::nullopt;
     }
     LogInfo << VAR(port_str) << VAR(port) << VAR(mumu_index);
     return mumu_index;
@@ -257,7 +276,12 @@ void asst::AdbController::init_mumu_extras(const AdbCfg& adb_cfg, const std::str
         m_mumu_extras.init(mumu_path, adb_cfg.extras.get("index", 0));
     }
     else {
-        m_mumu_extras.init(mumu_path, get_mumu_index(address));
+        auto mumu_index = get_mumu_index(address);
+        if (!mumu_index) {
+            LogError << "Failed to parse MuMu index from address, skip MumuExtras init" << VAR(address);
+            return;
+        }
+        m_mumu_extras.init(mumu_path, mumu_index.value());
     }
 #endif
 }
@@ -273,7 +297,7 @@ void asst::AdbController::set_mumu_package(const std::string& client_type)
 #endif
 }
 
-int asst::AdbController::get_ld_index(const std::string& address)
+std::optional<int> asst::AdbController::get_ld_index(const std::string& address)
 {
     LogTrace << VAR(address);
 
@@ -283,7 +307,7 @@ int asst::AdbController::get_ld_index(const std::string& address)
         std::string port_str = address.substr(9); // after "emulator-"
         if (port_str.empty() || !std::ranges::all_of(port_str, [](char c) { return std::isdigit(c); })) {
             Log.error("emulator port is invalid", port_str);
-            return 0;
+            return std::nullopt;
         }
         int port = std::stoi(port_str);
         int index = (port - base_emulator_port) / 2;
@@ -298,7 +322,7 @@ int asst::AdbController::get_ld_index(const std::string& address)
         std::string port_str = address.substr(pos + 1);
         if (port_str.empty() || !std::ranges::all_of(port_str, [](char c) { return std::isdigit(c); })) {
             Log.error("adb port is invalid", port_str);
-            return 0;
+            return std::nullopt;
         }
         int port = std::stoi(port_str);
         int index = (port - base_adb_port) / 2;
@@ -307,7 +331,7 @@ int asst::AdbController::get_ld_index(const std::string& address)
     }
 
     Log.error("address is invalid or unsupported", address);
-    return 0;
+    return std::nullopt;
 }
 
 void asst::AdbController::init_ld_extras(const AdbCfg& adb_cfg, const std::string& address)
@@ -328,7 +352,12 @@ void asst::AdbController::init_ld_extras(const AdbCfg& adb_cfg, const std::strin
         ld_index = adb_cfg.extras.get("index", 0);
     }
     else {
-        ld_index = get_ld_index(address);
+        auto ld_index_opt = get_ld_index(address);
+        if (!ld_index_opt) {
+            LogError << "Failed to parse LD index from address, skip LDExtras init" << VAR(address);
+            return;
+        }
+        ld_index = ld_index_opt.value();
     }
     int ld_pid = adb_cfg.extras.get("pid", 0);
     m_ld_extras.init(ld_path, ld_index, ld_pid, m_width, m_height);

--- a/src/MaaCore/Controller/AdbController.h
+++ b/src/MaaCore/Controller/AdbController.h
@@ -4,6 +4,7 @@
 
 #include <chrono>
 #include <deque>
+#include <optional>
 #include <random>
 
 #include "Platform/PlatformFactory.h"
@@ -138,11 +139,11 @@ protected:
 
     virtual void clear_info() noexcept;
     void callback(AsstMsg msg, const json::value& details);
-    static int get_mumu_index(const std::string& address);
+    static std::optional<int> get_mumu_index(const std::string& address);
     void init_mumu_extras(const AdbCfg& adb_cfg, const std::string& address);
     void set_mumu_package(const std::string& client_type);
     void init_ld_extras(const AdbCfg& adb_cfg, const std::string& address);
-    static int get_ld_index(const std::string& address);
+    static std::optional<int> get_ld_index(const std::string& address);
 
     // 转换 data 中的 CRLF 为 LF：有些模拟器自带的 adb，exec-out 输出的 \n 会被替换成 \r\n，
     // 导致解码错误，所以这里转一下回来（点名批评 mumu 和雷电）


### PR DESCRIPTION
## Summary by Sourcery

为 MuMu 和 LD 模拟器添加更安全的索引解析，并将 MuMu 支持扩展到 emulator 风格端口。

New Features:
- 在初始化 extras 时，支持使用 emulator-xxxx 风格端口寻址的 MuMu 实例。

Bug Fixes:
- 当无法从 ADB 地址可靠解析出模拟器索引时，避免初始化 MuMu 和 LD 的 extras。

Enhancements:
- 通过对 MuMu 和 LD 的 ADB 地址进行更严格的校验来增强稳健性：对于无效或超出范围的端口，不再回退为索引 0，而是返回无索引。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add safer index parsing for MuMu and LD emulators and extend MuMu support to emulator-style ports.

New Features:
- Support MuMu instances addressed with emulator-xxxx style ports when initializing extras.

Bug Fixes:
- Avoid initializing MuMu and LD extras when the emulator index cannot be reliably parsed from the ADB address.

Enhancements:
- Strengthen validation of MuMu and LD ADB addresses by returning no index for invalid or out-of-range ports instead of falling back to zero.

</details>