### PR TITLE
perf: 持久化储存主题色避免启动时闪烁

### DIFF
--- a/src/MaaWpfGui/Configuration/Global/GUI.cs
+++ b/src/MaaWpfGui/Configuration/Global/GUI.cs
@@ -86,6 +86,12 @@ public class GUI : INotifyPropertyChanged
 
     public string BackgroundMonetCustomColor { get; set; } = "#326CF3";
 
+    /// <summary>
+    /// 自动取色模式上次提取到的主色（HEX），用于下次启动时同步恢复调色板，避免闪烁。
+    /// 自定义模式的颜色也写入此缓存，使启动时不论何种模式都能即时恢复。
+    /// </summary>
+    public string BackgroundMonetCachedColor { get; set; } = string.Empty;
+
     [UsedImplicitly]
     public void OnPropertyChanged(string propertyName, object before, object after)
     {

--- a/src/MaaWpfGui/Res/Styles/CheckBox.xaml
+++ b/src/MaaWpfGui/Res/Styles/CheckBox.xaml
@@ -1,6 +1,18 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-    <Style x:Key="ErrorHighlightCheckBoxStyle" BasedOn="{StaticResource {x:Type CheckBox}}" TargetType="CheckBox">
+    <Style
+        x:Key="MaaCheckBoxDefaultStyle"
+        BasedOn="{StaticResource CheckBoxBaseStyle}"
+        TargetType="{x:Type CheckBox}">
+        <Setter Property="Background" Value="{DynamicResource RegionBrushOpacity50}" />
+    </Style>
+
+    <Style BasedOn="{StaticResource MaaCheckBoxDefaultStyle}" TargetType="{x:Type CheckBox}" />
+
+    <Style
+        x:Key="ErrorHighlightCheckBoxStyle"
+        BasedOn="{StaticResource MaaCheckBoxDefaultStyle}"
+        TargetType="CheckBox">
         <Style.Triggers>
             <Trigger Property="IsChecked" Value="True">
                 <Setter Property="Foreground" Value="{DynamicResource ErrorLogBrush}" />

--- a/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
@@ -361,7 +361,8 @@ public class SettingsViewModel : Screen
         GuiSettings.SwitchDarkMode();
 
         // 主题初始化完成后，若莫奈取色已开启，恢复调色板（必须在主题切换之后执行）
-        BackgroundSettings.UpdateMonet();
+        // 跳过防抖延迟，避免界面先闪烁原版颜色再显示莫奈主题
+        BackgroundSettings.UpdateMonet(skipDebounce: true);
     }
 
     private void InitConnectConfig()

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/BackgroundSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/BackgroundSettingsUserControlModel.cs
@@ -260,6 +260,37 @@ public class BackgroundSettingsUserControlModel : PropertyChangedBase
     private Color? _lastExtractedColor;
 
     /// <summary>
+    /// 从配置中读取上次持久化的自动取色主色。
+    /// 启动时先用它同步应用调色板，避免界面先闪烁原版颜色。
+    /// </summary>
+    /// <returns>持久化缓存的颜色；无缓存或格式无效时返回 null。</returns>
+    private static Color? LoadCachedMonetColor()
+    {
+        var hex = ConfigFactory.Root.GUI.BackgroundMonetCachedColor;
+        if (string.IsNullOrEmpty(hex))
+        {
+            return null;
+        }
+
+        try
+        {
+            return (Color)ColorConverter.ConvertFromString(hex);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// 将自动提取的主色持久化到配置，供下次启动时同步恢复。
+    /// </summary>
+    private static void SaveCachedMonetColor(Color color)
+    {
+        ConfigFactory.Root.GUI.BackgroundMonetCachedColor = ThemeHelper.Color2HexString(color);
+    }
+
+    /// <summary>
     /// 打开 HandyControl ColorPicker 弹窗让用户选择自定义颜色。
     /// </summary>
     public void SelectMonetColor()
@@ -275,6 +306,7 @@ public class BackgroundSettingsUserControlModel : PropertyChangedBase
         picker.Confirmed += (_, e) => {
             var color = e.Info;
             BackgroundMonetCustomColor = ThemeHelper.Color2HexString(color);
+            SaveCachedMonetColor(color);
             UpdateMonet();
             dialog.Close();
         };
@@ -302,10 +334,11 @@ public class BackgroundSettingsUserControlModel : PropertyChangedBase
     /// 根据当前配置执行莫奈取色逻辑。
     /// 自动 / 自定义模式都会将计算放到后台线程，仅资源写入在 UI 线程。
     /// </summary>
-    public void UpdateMonet()
+    /// <param name="skipDebounce">是否跳过防抖延迟。初始化时应传 true 以避免界面先闪烁原版颜色。</param>
+    public void UpdateMonet(bool skipDebounce = false)
     {
         _monetUpdateCts?.Cancel();
-        _ = UpdateMonetAsync(CancellationToken.None);
+        _ = UpdateMonetAsync(CancellationToken.None, skipDebounce);
     }
 
     /// <summary>
@@ -313,16 +346,21 @@ public class BackgroundSettingsUserControlModel : PropertyChangedBase
     /// 所有异常均在方法内部捕获并记录，避免 fire-and-forget 调用产生未观察异常。
     /// </summary>
     /// <param name="cancellationToken">取消令牌。</param>
-    private async Task UpdateMonetAsync(CancellationToken cancellationToken)
+    /// <param name="skipDebounce">是否跳过防抖延迟。</param>
+    private async Task UpdateMonetAsync(CancellationToken cancellationToken, bool skipDebounce = false)
     {
         // 防抖延迟：等待 150ms，期间若被取消则直接返回
-        try
+        // 初始化时跳过延迟，避免界面先显示原版颜色再切换为莫奈主题（闪烁）
+        if (!skipDebounce)
         {
-            await Task.Delay(MonetDebounceMs, cancellationToken).ConfigureAwait(true);
-        }
-        catch (OperationCanceledException)
-        {
-            return;
+            try
+            {
+                await Task.Delay(MonetDebounceMs, cancellationToken).ConfigureAwait(true);
+            }
+            catch (OperationCanceledException)
+            {
+                return;
+            }
         }
 
         try
@@ -332,6 +370,14 @@ public class BackgroundSettingsUserControlModel : PropertyChangedBase
                 ThemeHelper.RevertMonetPalette();
                 NotifyOfPropertyChange(nameof(CurrentMonetColor));
                 return;
+            }
+
+            // 启动时先用持久化缓存的主色同步应用调色板，避免界面先闪烁原版颜色
+            if (skipDebounce && LoadCachedMonetColor() is { } cached)
+            {
+                _lastExtractedColor = cached;
+                ThemeHelper.ApplyMonetPalette(cached, BackgroundOpacity);
+                NotifyOfPropertyChange(nameof(CurrentMonetColor));
             }
 
             if (BackgroundMonetMode == MonetModeType.Custom)
@@ -379,6 +425,9 @@ public class BackgroundSettingsUserControlModel : PropertyChangedBase
 
         // 直接使用提取到的原始主色生成调色板
         _lastExtractedColor = rawColor;
+
+        // 持久化提取结果，下次启动时可同步恢复，避免闪烁
+        SaveCachedMonetColor(rawColor);
 
         await ThemeHelper.ApplyMonetPaletteAsync(rawColor, BackgroundOpacity, cancellationToken);
 


### PR DESCRIPTION
## Summary by Sourcery

持久化并重用 Monet 背景主题的主色，以便 UI 在启动时能够立即恢复调色板，避免短暂显示默认主题。

New Features:
- 添加配置字段，用于缓存自动模式和自定义模式下最近一次的 Monet 背景主色。
- 在设置初始化期间，从缓存的主色恢复 Monet 调色板，以便在启动时立即应用主题。

Enhancements:
- 允许 Monet 背景更新在初始化阶段跳过防抖延迟，以避免可见的主题闪烁。
- 持久化自动提取的 Monet 颜色，使后续启动可以复用这些颜色而无需重新计算。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Persist and reuse the Monet background theme primary color so the UI can restore the palette immediately on startup and avoid a flash of the default theme.

New Features:
- Add configuration field to cache the last Monet background primary color for both auto and custom modes.
- Restore the Monet palette from the cached primary color during settings initialization to immediately apply the theme on startup.

Enhancements:
- Allow Monet background updates to skip debounce delays during initialization to prevent visible theme flicker.
- Persist automatically extracted Monet colors so future launches can reuse them without recomputation.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

持久化并重用 Monet 背景主题的主色，以便 UI 在启动时能够立即恢复调色板，避免短暂显示默认主题。

New Features:
- 添加配置字段，用于缓存自动模式和自定义模式下最近一次的 Monet 背景主色。
- 在设置初始化期间，从缓存的主色恢复 Monet 调色板，以便在启动时立即应用主题。

Enhancements:
- 允许 Monet 背景更新在初始化阶段跳过防抖延迟，以避免可见的主题闪烁。
- 持久化自动提取的 Monet 颜色，使后续启动可以复用这些颜色而无需重新计算。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Persist and reuse the Monet background theme primary color so the UI can restore the palette immediately on startup and avoid a flash of the default theme.

New Features:
- Add configuration field to cache the last Monet background primary color for both auto and custom modes.
- Restore the Monet palette from the cached primary color during settings initialization to immediately apply the theme on startup.

Enhancements:
- Allow Monet background updates to skip debounce delays during initialization to prevent visible theme flicker.
- Persist automatically extracted Monet colors so future launches can reuse them without recomputation.

</details>

</details>