### PR TITLE
fix: 修复使用莫奈取色的吸管工具后二次打开页面崩溃

### DIFF
--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/BackgroundSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/BackgroundSettingsUserControlModel.cs
@@ -308,10 +308,17 @@ public class BackgroundSettingsUserControlModel : PropertyChangedBase
             BackgroundMonetCustomColor = ThemeHelper.Color2HexString(color);
             SaveCachedMonetColor(color);
             UpdateMonet();
-            dialog.Close();
+            Cleanup();
         };
 
-        picker.Canceled += (_, _) => dialog.Close();
+        picker.Canceled += (_, _) => Cleanup();
+        return;
+
+        void Cleanup()
+        {
+            dialog.Close();
+            picker.Dispose();
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
fix #17264

## Summary by Sourcery

Bug Fixes:
- 确保在完成或取消选择后关闭 Monet 颜色选择器对话框并释放其资源，以避免后续页面崩溃。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure the Monet color picker dialog is closed and its resources disposed when selection is completed or canceled to avoid subsequent page crashes.

</details>