### PR TITLE
ci: 同步主工作流修改至nightly

### DIFF
--- a/.github/workflows/release-nightly-ota.yml
+++ b/.github/workflows/release-nightly-ota.yml
@@ -192,19 +192,18 @@ jobs:
           cmake --install build --config RelWithDebInfo
 
       - name: Download MaaFramework
-        if: matrix.arch == 'x64'
         uses: robinraju/release-downloader@v1
         with:
           repository: MaaXYZ/MaaFramework
           tag: v5.9.2
-          fileName: "*win-x86_64*.zip"
+          fileName: ${{ matrix.arch == 'arm64' && '*win-aarch64*.zip' || '*win-x86_64*.zip' }}
           extract: true
           out-file-path: MaaFramework-temp
 
-      - name: Copy MaaWin32ControlUnit
-        if: matrix.arch == 'x64'
+      - name: Copy ControlUnits
         run: |
           cp MaaFramework-temp/bin/*Win32ControlUnit* install/
+          cp MaaFramework-temp/bin/*AdbControlUnit* install/
 
       - name: Generate global.json
         shell: bash
@@ -271,6 +270,7 @@ jobs:
           rm -rf install/*.pdb
           rm -rf install/msvc-debug
           rm -rf install/*.h
+          rm -rf install/*.bak
 
           cp tools/DependencySetup_依赖库安装.bat install
 


### PR DESCRIPTION
## Summary by Sourcery

对夜间 OTA 发布工作流进行调整，使其与主 CI 配置在 MaaFramework 的下载与打包方面保持一致。

New Features:
- 在夜间 OTA 工作流中支持为 x64 和 arm64 构建下载 MaaFramework 归档文件。

Enhancements:
- 在组装夜间 OTA 安装制品时，将 AdbControlUnit 二进制文件与 Win32ControlUnit 一同包含进去。
- 从最终的夜间 OTA 安装目录中排除备份文件，以保持制品干净整洁。

CI:
- 更新夜间 OTA 的 GitHub Actions 工作流逻辑，在选择 MaaFramework 发布资产时能够感知架构类型。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align nightly OTA release workflow with main CI configuration for MaaFramework downloads and packaging.

New Features:
- Support downloading MaaFramework archives for both x64 and arm64 builds in the nightly OTA workflow.

Enhancements:
- Include AdbControlUnit binaries alongside Win32ControlUnit when assembling nightly OTA installation artifacts.
- Exclude backup files from the final nightly OTA install directory to keep artifacts clean.

CI:
- Update nightly OTA GitHub Actions workflow logic to be architecture-aware when selecting MaaFramework release assets.

</details>