### PR TITLE
perf: 账号切换增加是否启用勾选框

### DIFF
--- a/src/MaaWpfGui/Configuration/Single/MaaTask/StartUpTask.cs
+++ b/src/MaaWpfGui/Configuration/Single/MaaTask/StartUpTask.cs
@@ -11,18 +11,25 @@
 // but WITHOUT ANY WARRANTY
 // </copyright>
 #nullable enable
+using System.Text.Json.Serialization;
 using static MaaWpfGui.Main.AsstProxy;
 
 namespace MaaWpfGui.Configuration.Single.MaaTask;
 
-public class StartUpTask : BaseTask
+public class StartUpTask : BaseTask, IJsonOnDeserialized
 {
     public StartUpTask() => TaskType = TaskType.StartUp;
 
     public string AccountName { get; set; } = string.Empty;
 
     /// <summary>
-    /// Gets or sets a value indicating whether 启用账号切换。null 表示尚未迁移的旧配置。
+    /// Gets or sets a value indicating whether 启用账号切换。null 表示尚未迁移的旧配置，迁移后不再为 null。
     /// </summary>
     public bool? AccountSwitchEnabled { get; set; }
+
+    public void OnDeserialized()
+    {
+        // v6.14.0-b2 新增一次性配置迁移：旧配置没有这个字段（json 中不存在，反序列化后为 null），此时按是否已有账号名决定初始值
+        AccountSwitchEnabled ??= !string.IsNullOrEmpty(AccountName);
+    }
 }

--- a/src/MaaWpfGui/Configuration/Single/MaaTask/StartUpTask.cs
+++ b/src/MaaWpfGui/Configuration/Single/MaaTask/StartUpTask.cs
@@ -20,4 +20,9 @@ public class StartUpTask : BaseTask
     public StartUpTask() => TaskType = TaskType.StartUp;
 
     public string AccountName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether 启用账号切换。null 表示尚未迁移的旧配置。
+    /// </summary>
+    public bool? AccountSwitchEnabled { get; set; }
 }

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/StartUpSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/StartUpSettingsUserControlModel.cs
@@ -46,6 +46,24 @@ public class StartUpSettingsUserControlModel : TaskSettingsViewModel, StartUpSet
         }
     }
 
+    public bool AccountSwitchEnabled
+    {
+        get
+        {
+            var task = GetTaskConfig<StartUpTask>();
+            if (task.AccountSwitchEnabled is bool v)
+            {
+                return v;
+            }
+
+            // 一次性配置迁移：旧配置未设置该字段时，若已有账号名则自动勾选，否则默认关
+            var migrated = !string.IsNullOrEmpty(task.AccountName);
+            SetTaskConfig<StartUpTask>(t => t.AccountSwitchEnabled == migrated, t => t.AccountSwitchEnabled = migrated);
+            return migrated;
+        }
+        set => SetTaskConfig<StartUpTask>(t => t.AccountSwitchEnabled == value, t => t.AccountSwitchEnabled = value);
+    }
+
     // UI 绑定的方法
     [UsedImplicitly]
     public async void AccountSwitchManualRun()
@@ -88,7 +106,8 @@ public class StartUpSettingsUserControlModel : TaskSettingsViewModel, StartUpSet
 
             var clientType = SettingsViewModel.GameSettings.ClientType;
             var accountName = !SettingsViewModel.ConnectSettings.UseAttachWindow &&
-                clientType is ClientType.Official or ClientType.Bilibili or ClientType.Txwy
+                clientType is ClientType.Official or ClientType.Bilibili or ClientType.Txwy &&
+                startUp.AccountSwitchEnabled == true
                     ? startUp.AccountName
                     : string.Empty;
 

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/StartUpSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/StartUpSettingsUserControlModel.cs
@@ -48,19 +48,7 @@ public class StartUpSettingsUserControlModel : TaskSettingsViewModel, StartUpSet
 
     public bool AccountSwitchEnabled
     {
-        get
-        {
-            var task = GetTaskConfig<StartUpTask>();
-            if (task.AccountSwitchEnabled is bool v)
-            {
-                return v;
-            }
-
-            // 一次性配置迁移：旧配置未设置该字段时，若已有账号名则自动勾选，否则默认关
-            var migrated = !string.IsNullOrEmpty(task.AccountName);
-            SetTaskConfig<StartUpTask>(t => t.AccountSwitchEnabled == migrated, t => t.AccountSwitchEnabled = migrated);
-            return migrated;
-        }
+        get => GetTaskConfig<StartUpTask>().AccountSwitchEnabled ?? false;
         set => SetTaskConfig<StartUpTask>(t => t.AccountSwitchEnabled == value, t => t.AccountSwitchEnabled = value);
     }
 
@@ -107,7 +95,7 @@ public class StartUpSettingsUserControlModel : TaskSettingsViewModel, StartUpSet
             var clientType = SettingsViewModel.GameSettings.ClientType;
             var accountName = !SettingsViewModel.ConnectSettings.UseAttachWindow &&
                 clientType is ClientType.Official or ClientType.Bilibili or ClientType.Txwy &&
-                startUp.AccountSwitchEnabled == true
+                startUp.AccountSwitchEnabled is true
                     ? startUp.AccountName
                     : string.Empty;
 

--- a/src/MaaWpfGui/Views/UserControl/TaskQueue/StartUpTaskUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/TaskQueue/StartUpTaskUserControl.xaml
@@ -20,39 +20,37 @@
     mc:Ignorable="d">
     <StackPanel>
         <StackPanel Visibility="{c:Binding !UseAttachWindow, Source={x:Static settings_vms:ConnectSettingsUserControlModel.Instance}}">
-            <Grid Margin="0,5" Visibility="{c:Binding 'ClientType == &quot;Official&quot; or ClientType == &quot;Bilibili&quot; or ClientType == &quot;txwy&quot;', Source={x:Static settings_vms:GameSettingsUserControlModel.Instance}}">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition />
-                    <ColumnDefinition Width="Auto" />
-                </Grid.ColumnDefinitions>
+            <StackPanel Visibility="{c:Binding 'ClientType == &quot;Official&quot; or ClientType == &quot;Bilibili&quot; or ClientType == &quot;txwy&quot;', Source={x:Static settings_vms:GameSettingsUserControlModel.Instance}}">
                 <StackPanel
+                    Margin="0,5"
                     HorizontalAlignment="Left"
-                    VerticalAlignment="Top"
                     Orientation="Horizontal">
-                    <TextBlock
-                        Margin="8,0,0,0"
-                        Text="{DynamicResource AccountSwitch}"
-                        Visibility="Hidden" />
-                    <controls:TooltipBlock Margin="0,0,5,0" TooltipText="{DynamicResource AccountSwitchTip}" />
+                    <CheckBox Content="{DynamicResource AccountSwitch}" IsChecked="{Binding AccountSwitchEnabled}" />
+                    <controls:TooltipBlock TooltipText="{DynamicResource AccountSwitchTip}" />
                 </StackPanel>
-                <hc:TextBox
-                    Grid.Column="0"
-                    hc:BorderElement.CornerRadius="4,0,0,4"
-                    hc:TitleElement.Title="{DynamicResource AccountSwitch}"
-                    IsReadOnly="{c:Binding !Idle,
-                                           Source={x:Static helper:Instances.SettingsViewModel}}"
-                    Text="{Binding AccountName, UpdateSourceTrigger=PropertyChanged}" />
-                <Button
-                    Grid.Column="1"
-                    Padding="12,1,12,1"
-                    HorizontalAlignment="Center"
-                    VerticalAlignment="Bottom"
-                    hc:BorderElement.CornerRadius="0,4,4,0"
-                    BorderThickness="0,1,1,1"
-                    Command="{s:Action AccountSwitchManualRun}"
-                    Content="{DynamicResource AccountSwitchManualRun}"
-                    IsEnabled="{c:Binding 'AccountName != &quot;&quot;'}" />
-            </Grid>
+                <Grid Margin="0,5" Visibility="{c:Binding AccountSwitchEnabled}">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition />
+                        <ColumnDefinition Width="Auto" />
+                    </Grid.ColumnDefinitions>
+                    <TextBox
+                        Grid.Column="0"
+                        hc:BorderElement.CornerRadius="4,0,0,4"
+                        IsReadOnly="{c:Binding !Idle,
+                                               Source={x:Static helper:Instances.SettingsViewModel}}"
+                        Text="{Binding AccountName, UpdateSourceTrigger=PropertyChanged}" />
+                    <Button
+                        Grid.Column="1"
+                        Padding="12,1,12,1"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Bottom"
+                        hc:BorderElement.CornerRadius="0,4,4,0"
+                        BorderThickness="0,1,1,1"
+                        Command="{s:Action AccountSwitchManualRun}"
+                        Content="{DynamicResource AccountSwitchManualRun}"
+                        IsEnabled="{c:Binding 'AccountName != &quot;&quot;'}" />
+                </Grid>
+            </StackPanel>
 
             <controls:TextBlock
                 Margin="0,5"


### PR DESCRIPTION
## Summary by Sourcery

在启动任务设置中添加可配置的账号切换启用标志，并将其接入账号选择逻辑。

New Features:
- 在启动任务配置中引入 `AccountSwitchEnabled` 选项，并在启动设置视图模型中对外暴露该选项。

Enhancements:
- 通过检测账号名称是否存在来推断账号切换启用状态，从而迁移现有的启动任务配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable enable flag for account switching in startup task settings and wire it into account selection logic.

New Features:
- Introduce an AccountSwitchEnabled option in startup task configuration and expose it in the startup settings view model.

Enhancements:
- Migrate existing startup task configurations by inferring the account switch enable state from the presence of an account name.

</details>