### PR TITLE
perf: 在通宝页面滑动和选取之间添加延迟

### DIFF
--- a/src/MaaCore/Task/Roguelike/JieGarden/RoguelikeCoppersTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/JieGarden/RoguelikeCoppersTaskPlugin.cpp
@@ -498,6 +498,7 @@ void asst::RoguelikeCoppersTaskPlugin::click_copper_at_position(int col, int row
 
     // 再滑动到目标列
     swipe_copper_list_right(col - 1);
+    sleep(300);
 
     // 执行点击
     ctrler()->click(click_point);


### PR DESCRIPTION
偶尔会遇到因滑动回弹导致选取时未选中，添加此延迟以改善问题。

## Summary by Sourcery

Bug Fixes:
- 通过在执行铜点击之前短暂停顿，缓解因滑动回弹导致的遗漏选择问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Mitigate missed selections caused by swipe rebound by pausing briefly before performing the copper click.

</details>