### PR TITLE
fix: perhaps vue fix?

### DIFF
--- a/docs/en-us/protocol/callback-schema.md
+++ b/docs/en-us/protocol/callback-schema.md
@@ -114,8 +114,7 @@ Todo
   Fastest screenshot method found, `details` structure:
   - `method` (string, required): Fastest screenshot method.
   - `cost` (number, required): Time cost in milliseconds.
-  - `alternatives` (array<object>, required): All candidate methods and their costs.
-
+  - `alternatives` (array`<object>`, required): All candidate methods and their costs.
 - `ScreencapCost`  
   Screenshot cost statistics (reported every 10 screenshots), `details` structure:
   - `min` (number, required): Minimum cost in milliseconds.

--- a/docs/en-us/protocol/integration.md
+++ b/docs/en-us/protocol/integration.md
@@ -733,7 +733,7 @@ Whether to enable this task.
 ::: field name="filename" type="string"  
 Path to a single job JSON file, mutually exclusive with copilot_list (required, choose one); both relative and absolute paths are supported.  
 :::  
-::: field name="copilot_list" type="array<object>"  
+::: field name="copilot_list" type="array`<object>`"  
 List of jobs, mutually exclusive with filename (required, choose one); when both filename and copilot_list are present, copilot_list will be ignored; set_params can only be executed once when this parameter is in effect.
 <br>
 Each object contains:
@@ -759,7 +759,7 @@ Each object contains:
   <br>
   An integer between 0–4: 0 means the current formation, 1–4 refer to the 1st–4th formations.  
   :::  
-  ::: field name="user_additional" type="array<object>" optional default="[]"  
+  ::: field name="user_additional" type="array`<object>`" optional default="[]"  
   Custom additional operators list. Only effective when formation is true.
   <br>
   Each object contains:

--- a/docs/ja-jp/protocol/callback-schema.md
+++ b/docs/ja-jp/protocol/callback-schema.md
@@ -117,7 +117,7 @@ Todo
    最速のスクリーンショット方式が見つかりました、`details` 構造：
   - `method` (string, required): 最速のスクリーンショット方式。
   - `cost` (number, required): 所要時間（ミリ秒）。
-  - `alternatives` (array<object>, required): 全候補方式とその所要時間。
+  - `alternatives` (array`<object>`, required): 全候補方式とその所要時間。
 
 - `ScreencapCost`  
    スクリーンショット所要時間統計（10回ごとに報告）、`details` 構造：

--- a/docs/ja-jp/protocol/integration.md
+++ b/docs/ja-jp/protocol/integration.md
@@ -733,7 +733,7 @@ Sarkaz テーマ、Investment モード、「破棘成金分隊」または「�
 ::: field name="filename" type="string"  
 単一作業 JSON ファイルのパス。copilot_list と二択（必須）。相対/絶対パスの両方対応。  
 :::  
-::: field name="copilot_list" type="array<object>"  
+::: field name="copilot_list" type="array`<object>`"  
 作業リスト。filename と二択（必須）。filename と copilot_list が同時に存在する場合、copilot_list を無視。このパラメータが有効な場合、set_params は 1 回のみ実行可能。
 <br>
 各オブジェクトには以下を含みます：
@@ -759,7 +759,7 @@ Sarkaz テーマ、Investment モード、「破棘成金分隊」または「�
   <br>
   0～4 の整数。0 は現在の編成を意味し、1～4 は第 1～第 4 編成を表します。  
   :::  
-  ::: field name="user_additional" type="array<object>" optional default="[]"  
+  ::: field name="user_additional" type="array`<object>`" optional default="[]"  
   カスタム追加オペレーター リスト。formation が true の場合のみ有効。
   <br>
   各オブジェクトには以下を含みます：

--- a/docs/ko-kr/protocol/callback-schema.md
+++ b/docs/ko-kr/protocol/callback-schema.md
@@ -125,7 +125,7 @@ typedef void(ASST_CALL* AsstCallback)(int msg, const char* details, void* custom
   가장 빠른 스크린샷 방식을 찾음, `details` 구조:
   - `method` (string, required): 가장 빠른 스크린샷 방식.
   - `cost` (number, required): 소요 시간 (밀리초).
-  - `alternatives` (array<object>, required): 모든 후보 방식과 소요 시간.
+  - `alternatives` (array`<object>`, required): 모든 후보 방식과 소요 시간.
 
 - `ScreencapCost`  
   스크린샷 소요 시간 통계 (10회마다 보고), `details` 구조:

--- a/docs/ko-kr/protocol/integration.md
+++ b/docs/ko-kr/protocol/integration.md
@@ -722,7 +722,7 @@ Sarkaz 테마, Investment 모드, "연금술 분대" 또는 "지원 분대"일 �
 ::: field name="filename" type="string"  
 단일 작전 JSON 파일 경로, copilot_list와 택일(필수); 상대/절대 경로 모두 가능  
 :::  
-::: field name="copilot_list" type="array<object>"  
+::: field name="copilot_list" type="array`<object>`"  
 작전 목록, filename과 택일(필수); filename과 copilot_list 동시 존재 시 copilot_list 무시; 이 파라미터 유효 시 set_params는 1회만 실행 가능
 <br>
 각 객체 포함:
@@ -748,7 +748,7 @@ Sarkaz 테마, Investment 모드, "연금술 분대" 또는 "지원 분대"일 �
   <br>
   0–4 정수, 0은 현재 편성 선택, 1-4는 제1, 2, 3, 4 편성  
   :::  
-  ::: field name="user_additional" type="array<object>" optional default="[]"  
+  ::: field name="user_additional" type="array`<object>`" optional default="[]"  
   사용자 정의 추가 오퍼레이터 목록. `formation`이 true일 때 유효
   <br>
   각 객체 포함:

--- a/docs/zh-cn/protocol/callback-schema.md
+++ b/docs/zh-cn/protocol/callback-schema.md
@@ -125,7 +125,7 @@ typedef void(ASST_CALL* AsstCallback)(int msg, const char* details, void* custom
   已找到最快的截图方式，`details` 结构如下：
   - `method` (string, required): 最快的截图方式。
   - `cost` (number, required): 耗时，单位毫秒。
-  - `alternatives` (array``<object>``, required): 各候选方式及其耗时。
+  - `alternatives` (array`<object>`, required): 各候选方式及其耗时。
 
 - `ScreencapCost`  
   截图耗时统计（每 10 次截图回传一次），`details` 结构如下：

--- a/docs/zh-cn/protocol/callback-schema.md
+++ b/docs/zh-cn/protocol/callback-schema.md
@@ -125,7 +125,7 @@ typedef void(ASST_CALL* AsstCallback)(int msg, const char* details, void* custom
   已找到最快的截图方式，`details` 结构如下：
   - `method` (string, required): 最快的截图方式。
   - `cost` (number, required): 耗时，单位毫秒。
-  - `alternatives` (array<object>, required): 各候选方式及其耗时。
+  - `alternatives` (array``<object>``, required): 各候选方式及其耗时。
 
 - `ScreencapCost`  
   截图耗时统计（每 10 次截图回传一次），`details` 结构如下：

--- a/docs/zh-cn/protocol/integration.md
+++ b/docs/zh-cn/protocol/integration.md
@@ -733,7 +733,7 @@ Tag 等级（大于等于 3）和对应的希望招募时限，单位为分钟�
 ::: field name="filename" type="string"  
 单一作业 JSON 文件的路径，与 copilot_list 二选一（必填）；相对路径与绝对路径均可。  
 :::  
-::: field name="copilot_list" type="array<object>"  
+::: field name="copilot_list" type="array`<object>`"  
 作业列表，与 filename 二选一（必填）；当 filename 与 copilot_list 同时存在时，忽视 copilot_list；此参数生效时仅可执行 set_params 一次。
 <br>
 每个对象包含：
@@ -759,7 +759,7 @@ Tag 等级（大于等于 3）和对应的希望招募时限，单位为分钟�
   <br>
   为 0–4 的整数，其中 0 表示选择当前编队，1-4 分别表示第一、二、三、四编队。  
   :::  
-  ::: field name="user_additional" type="array<object>" optional default="[]"  
+  ::: field name="user_additional" type="array`<object>`" optional default="[]"  
   自定义追加干员列表。仅在 formation 为 true 时有效。
   <br>
   每个对象包含：

--- a/docs/zh-tw/protocol/callback-schema.md
+++ b/docs/zh-tw/protocol/callback-schema.md
@@ -125,7 +125,7 @@ typedef void(ASST_CALL* AsstCallback)(int msg, const char* details, void* custom
    已找到最快的截圖方式，`details` 結構如下：
   - `method` (string, required): 最快的截圖方式。
   - `cost` (number, required): 耗時，單位毫秒。
-  - `alternatives` (array<object>, required): 各候選方式及其耗時。
+  - `alternatives` (array`<object>`, required): 各候選方式及其耗時。
 
 - `ScreencapCost`  
    截圖耗時統計（每 10 次截圖回傳一次），`details` 結構如下：

--- a/docs/zh-tw/protocol/integration.md
+++ b/docs/zh-tw/protocol/integration.md
@@ -733,7 +733,7 @@ Tag 等級（大於等於 3）對應的期望招募時限（單位：分鐘）�
 ::: field name="filename" type="string"  
 單一作業 json 檔案路徑。與 `copilot_list` 二選一（必填），支援相對路徑與絕對路徑。  
 :::  
-::: field name="copilot_list" type="array<object>"  
+::: field name="copilot_list" type="array`<object>`"  
 作業列表。與 `filename` 二選一（必填）。若兩者同時存在，將忽略 `copilot_list`。此參數起作用時，僅可執行 `set_params` 一次。
 <br>
 每個物件包含：
@@ -759,7 +759,7 @@ Tag 等級（大於等於 3）對應的期望招募時限（單位：分鐘）�
   <br>
   範圍為 0–4 的整數，其中 0 表示選擇目前編隊，1-4 分別代表第一、二、三、四編隊。  
   :::  
-  ::: field name="user_additional" type="array<object>" optional default="[]"  
+  ::: field name="user_additional" type="array`<object>`" optional default="[]"  
   自定義追加幹員清單。僅在 `formation` 為 `true` 時有效。
   <br>
   每個物件包含：

--- a/src/MaaWpfGui/MaaWpfGui.csproj
+++ b/src/MaaWpfGui/MaaWpfGui.csproj
@@ -3,7 +3,6 @@
   <!-- Project -->
   <PropertyGroup>
     <TargetFramework>net10.0-windows10.0.17763.0</TargetFramework>
-    <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
     <RuntimeIdentifier Condition="$(Platform)=='x64'">win-x64</RuntimeIdentifier>
     <RuntimeIdentifier Condition="$(Platform)=='ARM64'">win-arm64</RuntimeIdentifier>
     <OutputType>WinExe</OutputType>

--- a/src/MaaWpfGui/MaaWpfGui.csproj
+++ b/src/MaaWpfGui/MaaWpfGui.csproj
@@ -3,6 +3,7 @@
   <!-- Project -->
   <PropertyGroup>
     <TargetFramework>net10.0-windows10.0.17763.0</TargetFramework>
+    <RuntimeIdentifiers>win-x64;win-arm64</RuntimeIdentifiers>
     <RuntimeIdentifier Condition="$(Platform)=='x64'">win-x64</RuntimeIdentifier>
     <RuntimeIdentifier Condition="$(Platform)=='ARM64'">win-arm64</RuntimeIdentifier>
     <OutputType>WinExe</OutputType>


### PR DESCRIPTION
https://github.com/MaaAssistantArknights/MaaAssistantArknights/actions/runs/28898064478/job/85727647628
Runs fine @ABA2396

## Summary by Sourcery

在多个本地化版本中澄清协议文档中数组字段的类型注解。

文档：
- 更新所有受支持语言中的集成协议文档，对 `copilot_list` 和 `user_additional` 等字段统一使用“对象数组”类型标注方式。
- 对所有受支持语言中的回调模式文档进行统一，将 `alternatives` 描述为使用相同类型标注方式的“对象数组”。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Clarify protocol documentation type annotations for array fields across multiple locales.

Documentation:
- Update integration protocol docs in all supported languages to use consistent array-of-object type notation for fields like `copilot_list` and `user_additional`.
- Align callback schema docs in all supported languages to describe `alternatives` as an array of objects using the same type notation.

</details>