### PR TITLE
fix: Bark icon 未被输出到body

### DIFF
--- a/src/MaaWpfGui/Services/Notification/BarkNotificationProvider.cs
+++ b/src/MaaWpfGui/Services/Notification/BarkNotificationProvider.cs
@@ -81,7 +81,7 @@ public class BarkNotificationProvider(IHttpService httpService) : IExternalNotif
         public string Group { get; } = "MaaAssistantArknights";
 
         [JsonPropertyName("icon")]
-        public string Icon { get => "https://cdn.jsdelivr.net/gh/MaaAssistantArknights/design@main/v2/icons/maa-logo_256x256.png"; }
+        public string Icon { get; } = "https://cdn.jsdelivr.net/gh/MaaAssistantArknights/design@main/v2/icons/maa-logo_256x256.png";
 
         // ReSharper restore UnusedAutoPropertyAccessor.Local
         // ReSharper restore UnusedMember.Local

--- a/src/MaaWpfGui/Services/Notification/BarkNotificationProvider.cs
+++ b/src/MaaWpfGui/Services/Notification/BarkNotificationProvider.cs
@@ -81,7 +81,7 @@ public class BarkNotificationProvider(IHttpService httpService) : IExternalNotif
         public string Group { get; } = "MaaAssistantArknights";
 
         [JsonPropertyName("icon")]
-        public static string Icon { get => "https://cdn.jsdelivr.net/gh/MaaAssistantArknights/design@main/v2/icons/maa-logo_256x256.png"; }
+        public string Icon { get => "https://cdn.jsdelivr.net/gh/MaaAssistantArknights/design@main/v2/icons/maa-logo_256x256.png"; }
 
         // ReSharper restore UnusedAutoPropertyAccessor.Local
         // ReSharper restore UnusedMember.Local


### PR DESCRIPTION
BarkPostContent 里定义了 Icon 为 static 属性，按 System.Text.Json 的常规行为，静态属性不会作为实例 JSON 字段序列化，故去除 Icon 字段的 static 属性，确保其正确被序列化，以向 Bark 客户端发送携带 MAA icon 的通知。

## Summary by Sourcery

Bug Fixes:
- 修复 Bark 通知在序列化为 JSON 负载时缺少图标 URL 的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix Bark notifications missing the icon URL in the serialized JSON payload.

</details>