### PR TITLE
feat: add option to disable fps log warnings

### DIFF
--- a/src/MaaWpfGui/Constants/ConfigurationKeys.cs
+++ b/src/MaaWpfGui/Constants/ConfigurationKeys.cs
@@ -83,6 +83,7 @@ public static class ConfigurationKeys
     public const string AllowAdbHardRestart = "Connect.AllowADBHardRestart";
     public const string AdbLiteEnabled = "Connect.AdbLiteEnabled";
     public const string KillAdbOnExit = "Connect.KillAdbOnExit";
+    public const string DisableEmulatorFpsLogs = "Connect.DisableEmulatorFpsLogs";
     public const string TouchMode = "Connect.TouchMode";
     public const string AdbReplaced = "Connect.AdbReplaced";
 

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -1030,21 +1030,29 @@ public class AsstProxy
                     break;
                 }
 
+                string? fpsLogKey = null;
+                string fpsLogColor = UiLogColor.Warning;
+
                 if (fpsInt < 30)
                 {
-                    Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetStringFormat("EmulatorFpsErrorTip", fpsInt), UiLogColor.Error);
-                    Instances.CopilotViewModel.AddLog(LocalizationHelper.GetStringFormat("EmulatorFpsErrorTip", fpsInt), UiLogColor.Error, showTime: false);
+                    fpsLogKey = "EmulatorFpsErrorTip";
+                    fpsLogColor = UiLogColor.Error;
                 }
                 else if (fpsInt < 60)
                 {
-                    Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetStringFormat("EmulatorFpsWarningTip", fpsInt), UiLogColor.Warning);
-                    Instances.CopilotViewModel.AddLog(LocalizationHelper.GetStringFormat("EmulatorFpsWarningTip", fpsInt), UiLogColor.Warning, showTime: false);
+                    fpsLogKey = "EmulatorFpsWarningTip";
                 }
                 else if (fpsInt > 60 && !HasPrintedFpsHighTip)
                 {
-                    Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetStringFormat("EmulatorFpsHighTip", fpsInt), UiLogColor.Warning);
-                    Instances.CopilotViewModel.AddLog(LocalizationHelper.GetStringFormat("EmulatorFpsHighTip", fpsInt), UiLogColor.Warning, showTime: false);
+                    fpsLogKey = "EmulatorFpsHighTip";
                     HasPrintedFpsHighTip = true;
+                }
+
+                if (fpsLogKey is not null && !SettingsViewModel.GuiSettings.DisableEmulatorFpsLogs)
+                {
+                    var fpsLogMsg = LocalizationHelper.GetStringFormat(fpsLogKey, fpsInt);
+                    Instances.TaskQueueViewModel.AddLog(fpsLogMsg, fpsLogColor);
+                    Instances.CopilotViewModel.AddLog(fpsLogMsg, fpsLogColor, showTime: false);
                 }
 
                 break;

--- a/src/MaaWpfGui/Properties/DesignTimeResources.xaml
+++ b/src/MaaWpfGui/Properties/DesignTimeResources.xaml
@@ -3,7 +3,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:hc="https://handyorg.github.io/handycontrol">
     <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="/MAA;component/Res/Localizations/zh-cn.xaml" />
+        <ResourceDictionary Source="/MAA;component/Res/Localizations/en-us.xaml" />
         <hc:IntellisenseResources Source="/HandyControl;Component/DesignTime/DesignTimeResources.xaml" />
     </ResourceDictionary.MergedDictionaries>
 </ResourceDictionary>

--- a/src/MaaWpfGui/Properties/DesignTimeResources.xaml
+++ b/src/MaaWpfGui/Properties/DesignTimeResources.xaml
@@ -3,7 +3,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:hc="https://handyorg.github.io/handycontrol">
     <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="/MAA;component/Res/Localizations/en-us.xaml" />
+        <ResourceDictionary Source="/MAA;component/Res/Localizations/zh-cn.xaml" />
         <hc:IntellisenseResources Source="/HandyControl;Component/DesignTime/DesignTimeResources.xaml" />
     </ResourceDictionary.MergedDictionaries>
 </ResourceDictionary>

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -1225,6 +1225,7 @@ Right-click to clear inactive jobs</system:String>
     <system:String x:Key="EmulatorFpsWarningTip">Emulator refresh rate is set to {0} FPS, below the game's native frame rate (60 FPS). Background frame rate reduction may be enabled or the rate is set too low. It is recommended to set the emulator frame rate to 60 FPS</system:String>
     <system:String x:Key="EmulatorFpsErrorTip">Emulator refresh rate is set too low ({0} FPS), which may cause tasks to malfunction. Please turn off background frame rate reduction and set the frame rate to 60 FPS</system:String>
     <system:String x:Key="EmulatorFpsHighTip">Emulator refresh rate is set to {0} FPS, above the game's native frame rate cap (60 FPS). This may be the emulator's frame interpolation feature, which can cause visual artifacts or unstable recognition. It is recommended to disable frame interpolation and set the frame rate to 60 FPS</system:String>
+    <system:String x:Key="DisableEmulatorFpsLogs">Disable FPS warnings</system:String>
     <system:String x:Key="IdentifyTheMistakes">Recognition error</system:String>
     <system:String x:Key="TaskError" xml:space="preserve">Task error:&#160;</system:String>
     <system:String x:Key="CombatError">Combat error</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -1226,6 +1226,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="EmulatorFpsWarningTip">エミュレータの設定フレームレートが {0} FPS で、ゲームのネイティブフレームレート（60 FPS）を下回っています。バックグラウンドのフレームレート低下が有効になっているか、フレームレートの設定が低すぎる可能性があります。エミュレータのフレームレートを 60 FPS に設定することを推奨します</system:String>
     <system:String x:Key="EmulatorFpsErrorTip">エミュレータの設定フレームレートが低すぎます（{0} FPS）。タスクが異常になる可能性があります。エミュレータの設定でバックグラウンドのフレームレート低下をオフにし、フレームレートを 60 FPS に設定してください</system:String>
     <system:String x:Key="EmulatorFpsHighTip">エミュレータの設定フレームレートが {0} FPS で、ゲームのネイティブフレームレート上限（60 FPS）を上回っています。これはエミュレータのフレーム補間機能の可能性があり、画面の異常や認識の不安定化を招くことがあります。フレーム補間を無効にし、フレームレートを 60 FPS に設定することを推奨します</system:String>
+    <system:String x:Key="DisableEmulatorFpsLogs">エミュレータのFPS警告を無効にする</system:String>
     <system:String x:Key="IdentifyTheMistakes">認識エラー</system:String>
     <system:String x:Key="TaskError" xml:space="preserve">タスクエラー: </system:String>
     <system:String x:Key="CombatError">戦闘エラー</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -1227,6 +1227,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="EmulatorFpsWarningTip">에뮬레이터 설정 주사율이 {0} FPS로 게임의 기본 프레임 속도(60 FPS)보다 낮습니다. 백그라운드 프레임 저하가 활성화되어 있거나 주사율이 너무 낮게 설정되어 있을 수 있습니다. 에뮬레이터 프레임 속도를 60 FPS로 설정하는 것을 권장합니다</system:String>
     <system:String x:Key="EmulatorFpsErrorTip">에뮬레이터 설정 주사율이 너무 낮습니다 ({0} FPS). 작업에 문제가 발생할 수 있습니다. 에뮬레이터 설정에서 백그라운드 프레임 저하를 끄고 프레임 속도를 60 FPS로 설정해 주세요</system:String>
     <system:String x:Key="EmulatorFpsHighTip">에뮬레이터 설정 주사율이 {0} FPS로 게임의 기본 프레임 속도 상한(60 FPS)을 초과합니다. 이는 에뮬레이터의 프레임 보간 기능일 수 있으며, 화면 왜곡이나 인식 불안정을 유발할 수 있습니다. 프레임 보간을 비활성화하고 프레임 속도를 60 FPS로 설정하는 것을 권장합니다</system:String>
+    <system:String x:Key="DisableEmulatorFpsLogs">에뮬레이터 FPS 경고 비활성화</system:String>
     <system:String x:Key="IdentifyTheMistakes">인식 오류</system:String>
     <system:String x:Key="TaskError" xml:space="preserve">작업 오류: </system:String>
     <system:String x:Key="CombatError">작전 오류</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -1226,6 +1226,7 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="EmulatorFpsWarningTip">检测到模拟器设置帧率为 {0} FPS，低于游戏原生帧率（60 FPS），可能开启了后台降帧或帧率设置过低，建议将模拟器帧率设置为 60 FPS</system:String>
     <system:String x:Key="EmulatorFpsErrorTip">检测到模拟器设置帧率过低（{0} FPS），可能导致任务异常，请关闭模拟器后台降帧并将帧率设置为 60 FPS</system:String>
     <system:String x:Key="EmulatorFpsHighTip">检测到模拟器设置帧率为 {0} FPS，高于游戏原生帧率上限（60 FPS），可能是模拟器插帧功能，可能导致画面异常或识别不稳定，建议关闭插帧并将帧率设置为 60 FPS</system:String>
+    <system:String x:Key="DisableEmulatorFpsLogs">禁用模拟器帧率警告</system:String>
     <system:String x:Key="IdentifyTheMistakes">识别错误</system:String>
     <system:String x:Key="TaskError" xml:space="preserve">任务出错: </system:String>
     <system:String x:Key="CombatError">战斗出错</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -407,7 +407,7 @@
 📄 更新說明：
     • {key=UpdateCheckNow}：包含介面與功能更新。介面改動、新功能需透過 {key=UpdateCheckNow} 取得
     • {key=ResourceUpdate}：包含自動作戰新關卡、掉落辨識圖示、公招幹員標籤等素材資料
-    • 導航熱更新：自動觸發，用於更新主介面提示與活動關卡入口。成功後右上角會顯示 ｢{key=ApiUpdateSuccess}｣ 
+    • 導航熱更新：自動觸發，用於更新主介面提示與活動關卡入口。成功後右上角會顯示 ｢{key=ApiUpdateSuccess}｣
 </system:String>
     <system:String x:Key="GlobalSource">全域來源</system:String>
     <system:String x:Key="ForceGithubGlobalSource">強制使用 GitHub</system:String>
@@ -1019,7 +1019,7 @@ C:\\leidian\\LDPlayer9\n
     <system:String x:Key="MiniGame@SPA">衛戍協議：盟約</system:String>
     <system:String x:Key="MiniGame@SPATip" xml:space="preserve">在活動主介面（有 ｢獨立模擬｣ 處）開始任務。
 在有存檔時需要先手動放棄
-最高只測試過 ｢險境模擬｣ 
+最高只測試過 ｢險境模擬｣
 如果已通關更高難度導致看不到 ｢險境模擬｣ 或 ｢標準模擬｣ ，需手動選擇一次 ｢險境模擬｣ 難度
 手動通關 ｢標準模擬｣ 可以更快刷分。
 只能刷等級獎勵，拿蝕刻章得打完所有的 ｢關鍵目標｣ 。</system:String>
@@ -1226,6 +1226,7 @@ C:\\leidian\\LDPlayer9\n
     <system:String x:Key="EmulatorFpsWarningTip">偵測到模擬器設定幀率為 {0} FPS，低於遊戲原生幀率（60 FPS），可能開啟了背景降幀或幀率設定過低，建議將模擬器幀率設定為 60 FPS</system:String>
     <system:String x:Key="EmulatorFpsErrorTip">偵測到模擬器設定幀率過低（{0} FPS），可能導致任務異常，請關閉模擬器背景降幀並將幀率設定為 60 FPS</system:String>
     <system:String x:Key="EmulatorFpsHighTip">偵測到模擬器設定幀率為 {0} FPS，高於遊戲原生幀率上限（60 FPS），可能是模擬器插幀功能，可能導致畫面異常或辨識不穩定，建議關閉插幀並將幀率設定為 60 FPS</system:String>
+    <system:String x:Key="DisableEmulatorFpsLogs">停用模擬器幀率警告</system:String>
     <system:String x:Key="IdentifyTheMistakes">辨識錯誤</system:String>
     <system:String x:Key="TaskError" xml:space="preserve">任務出錯: </system:String>
     <system:String x:Key="CombatError">戰鬥出錯</system:String>

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/GuiSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/GuiSettingsUserControlModel.cs
@@ -131,7 +131,7 @@ public class GuiSettingsUserControlModel : PropertyChangedBase
     private bool _disableEmulatorFpsLogs = ConfigurationHelper.GetValue(ConfigurationKeys.DisableEmulatorFpsLogs, false);
 
     /// <summary>
-    /// Gets or sets a value indicating whether to show emulator FPS warnings and errors.
+    /// Gets or sets a value indicating whether to disable emulator FPS warnings and errors.
     /// </summary>
     public bool DisableEmulatorFpsLogs
     {

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/GuiSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/GuiSettingsUserControlModel.cs
@@ -128,6 +128,20 @@ public class GuiSettingsUserControlModel : PropertyChangedBase
         }
     }
 
+    private bool _disableEmulatorFpsLogs = ConfigurationHelper.GetValue(ConfigurationKeys.DisableEmulatorFpsLogs, false);
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to show emulator FPS warnings and errors.
+    /// </summary>
+    public bool DisableEmulatorFpsLogs
+    {
+        get => _disableEmulatorFpsLogs;
+        set {
+            SetAndNotify(ref _disableEmulatorFpsLogs, value);
+            ConfigurationHelper.SetValue(ConfigurationKeys.DisableEmulatorFpsLogs, value.ToString());
+        }
+    }
+
     private bool _hideCloseButton = ConfigurationHelper.GetGlobalValue(ConfigurationKeys.HideCloseButton, false);
 
     /// <summary>

--- a/src/MaaWpfGui/Views/UserControl/Settings/GuiSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/Settings/GuiSettingsUserControl.xaml
@@ -61,6 +61,10 @@
                     Margin="8"
                     Content="{DynamicResource WindowTitleScrollable}"
                     IsChecked="{Binding WindowTitleScrollable}" />
+                <CheckBox
+                    Margin="8"
+                    Content="{DynamicResource DisableEmulatorFpsLogs}"
+                    IsChecked="{Binding DisableEmulatorFpsLogs}" />
                 <StackPanel Margin="8" Orientation="Horizontal">
                     <CheckBox MaxWidth="200" IsChecked="{Binding MainTasksInvertNullFunction}">
                         <controls:TextBlock Text="{DynamicResource MainTasksNullFunctionality}" TextWrapping="Wrap" />
@@ -152,6 +156,7 @@
                         hc:ListBoxAttach.SelectedItems="{Binding WindowTitleSelectShowList}"
                         DisplayMemberPath="Value"
                         ItemsSource="{Binding WindowTitleAllShowDict}" />
+                    <TextBox TextWrapping="Wrap" Text="TextBox" Width="120"/>
                 </StackPanel>
                 <Button
                     Width="180"

--- a/src/MaaWpfGui/Views/UserControl/Settings/GuiSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/Settings/GuiSettingsUserControl.xaml
@@ -156,7 +156,6 @@
                         hc:ListBoxAttach.SelectedItems="{Binding WindowTitleSelectShowList}"
                         DisplayMemberPath="Value"
                         ItemsSource="{Binding WindowTitleAllShowDict}" />
-                    <TextBox TextWrapping="Wrap" Text="TextBox" Width="120"/>
                 </StackPanel>
                 <Button
                     Width="180"


### PR DESCRIPTION
## Summary by Sourcery

在图形界面中添加一个可配置选项，用于屏蔽模拟器 FPS 警告和错误日志。

New Features:
- 引入一个 GUI 设置，允许用户禁用与模拟器 FPS 相关的日志消息。

Enhancements:
- 统一集中生成模拟器 FPS 日志，以遵从新的禁用设置，同时在启用时保持现有的警告/错误行为不变。

Documentation:
- 更新本地化的 UI 文本资源，以记录新的模拟器 FPS 日志可见性设置。

Chores:
- 在应用程序设置中注册一个新的配置键，用于控制模拟器 FPS 日志的可见性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a configurable option to suppress emulator FPS warning and error logs in the GUI.

New Features:
- Introduce a GUI setting that allows users to disable emulator FPS-related log messages.

Enhancements:
- Centralize emulator FPS log generation to respect the new disable setting while preserving existing warning/error behavior when enabled.

Documentation:
- Update localized UI text resources to document the new emulator FPS log visibility setting.

Chores:
- Register a new configuration key for controlling emulator FPS log visibility in application settings.

</details>