### PR TITLE
feat(RA): 新增沙洲遗闻有存档推进天数模式

### DIFF
--- a/resource/tasks/RA/Reclamation2.json
+++ b/resource/tasks/RA/Reclamation2.json
@@ -319,6 +319,15 @@
         "specialParams": [500, 0, 3, 0],
         "next": ["Reclamation2ExSwipeAndClickProduct#next"]
     },
+    "Reclamation2Advance": {
+        "algorithm": "JustReturn",
+        "sub": [
+            "Reclamation2ExSkipDays",
+            "Reclamation2ExSkipDaysBeginNewDay"
+        ],
+        "Doc": "新增模式：有存档，通过推进天数刷物资和生息点数；cpp入口",
+        "next": ["#self"]
+    },
     "Reclamation2ProsperityMax": {
         "roi": [789, 475, 154, 122],
         "next": ["Reclamation2ProsperityMaxSkipDayClickContinue"]

--- a/resource/tasks/RA/plugin/Tales.json
+++ b/resource/tasks/RA/plugin/Tales.json
@@ -712,6 +712,11 @@
         "algorithm": "JustReturn",
         "next": ["Tales@RA@PNS-Commence", "Tales@RA@PNS-Resume", "Tales@RA@PNS-Navigation"]
     },
+    "Tales@RA@AdvanceInSave": {
+        "doc": "生息演算「沙洲遗闻」有存档推进天数刷物资任务入口",
+        "algorithm": "JustReturn",
+        "next": ["Reclamation2Advance"]
+    },
     "Tales@RA@ProsperityReachLimit": {
         "doc": "模板任务: 已完成生存周期, 生息点数达到上限, 点击 MAX 图案位置",
         "template": "Tales@RA@Max.png",

--- a/src/MaaCore/Task/Reclamation/ReclamationConfig.cpp
+++ b/src/MaaCore/Task/Reclamation/ReclamationConfig.cpp
@@ -48,6 +48,10 @@ bool asst::ReclamationConfig::verify_and_load_params(const json::value& params)
             m_mode = TalesMode::ProsperityInSave;
             break;
 
+        case static_cast<int>(TalesMode::AdvanceInSave):
+            m_mode = TalesMode::AdvanceInSave;
+            break;
+
         default:
             Log.error(__FUNCTION__, "| Invalid Tales mode", modeInt);
             return false;

--- a/src/MaaCore/Task/Reclamation/ReclamationConfig.h
+++ b/src/MaaCore/Task/Reclamation/ReclamationConfig.h
@@ -17,6 +17,7 @@ enum class TalesMode
 {
     ProsperityNoSave = 0, // 0 - 无存档刷繁荣点数
     ProsperityInSave = 1, // 1 - 有存档刷繁荣点数
+    AdvanceInSave = 2, // 2 - 有存档推进天数刷物资
 };
 
 enum class RelaunchAnchorMode

--- a/src/MaaWpfGui/Configuration/Single/MaaTask/ReclamationTask.cs
+++ b/src/MaaWpfGui/Configuration/Single/MaaTask/ReclamationTask.cs
@@ -81,6 +81,11 @@ public enum ReclamationMode
     ProsperityInSave = 1,
 
     /// <summary>
+    /// #沙洲遗闻, 有存档，通过推进天数刷物资和生息点数
+    /// </summary>
+    AdvanceInSave = 2,
+
+    /// <summary>
     /// #重启锚点, RA-1
     /// </summary>
     RA1 = 1 << 4,

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -781,6 +781,7 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="ReclamationModeRA15">RA-15</system:String>
     <system:String x:Key="ReclamationModeProsperityNoSave">无存档，通过进出关卡刷生息点数</system:String>
     <system:String x:Key="ReclamationModeProsperityInSave">有存档，通过组装支援道具刷生息点数</system:String>
+    <system:String x:Key="ReclamationModeAdvanceInSave">有存档，通过推进天数刷物资和生息点数</system:String>
     <system:String x:Key="ReclamationIncrementMode">增加方式</system:String>
     <system:String x:Key="ReclamationIncrementModeClick">连点</system:String>
     <system:String x:Key="ReclamationIncrementModeHold">长按</system:String>

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/ReclamationSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/ReclamationSettingsUserControlModel.cs
@@ -74,6 +74,7 @@ public class ReclamationSettingsUserControlModel : TaskSettingsViewModel, Reclam
             ModeList = [
                 new() { Display = LocalizationHelper.GetString("ReclamationModeProsperityNoSave"), Value = Mode.ProsperityNoSave },
                 new() { Display = LocalizationHelper.GetString("ReclamationModeProsperityInSave"), Value = Mode.ProsperityInSave },
+                new() { Display = LocalizationHelper.GetString("ReclamationModeAdvanceInSave"), Value = Mode.AdvanceInSave },
             ];
         }
         else if (ReclamationTheme == Theme.RelaunchAnchor)


### PR DESCRIPTION
在沙洲遗闻中新增了一个刷取点数的选项，让已有毕业存档的玩家可以在和平难度下自动推进天数，以无限刷取基地产出的物资。

## Summary by Sourcery

新增一种回收模式，允许在现有的《Sandstorm Tales》存档中推进天数，以刷取材料和繁荣点数。

新功能：
- 为《Sandstorm Tales》引入 `AdvanceInSave` 模式，在现有存档上自动推进天数以进行资源刷取。

增强内容：
- 将新的 `AdvanceInSave` 模式接入配置、UI 模式选择和本地化，用于回收任务。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a new Reclamation mode that allows advancing days in existing Sandstorm Tales saves to farm materials and prosperity points.

New Features:
- Introduce the AdvanceInSave mode for Sandstorm Tales to automatically advance days on existing saves for resource farming.

Enhancements:
- Wire the new AdvanceInSave mode through configuration, UI mode selection, and localization for Reclamation tasks.

</details>