### PR TITLE
fix: 修复源石碎片补货确认未生效

### DIFF
--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -2513,8 +2513,7 @@
     "ReplenishToMax": {
         "action": "ClickSelf",
         "roi": [882, 128, 165, 149],
-        "postDelay": 1000,
-        "next": ["ReplenishToMaxConfirm", "Stop"]
+        "postDelay": 1000
     },
     "ReplenishToMaxConfirm": {
         "action": "ClickSelf",

--- a/src/MaaCore/Task/Infrast/ReplenishOriginiumShardTaskPlugin.cpp
+++ b/src/MaaCore/Task/Infrast/ReplenishOriginiumShardTaskPlugin.cpp
@@ -1,6 +1,10 @@
 #include "ReplenishOriginiumShardTaskPlugin.h"
 
+#include "Controller/Controller.h"
+#include "InfrastAbstractTask.h"
 #include "Task/ProcessTask.h"
+#include "Utils/Logger.hpp"
+#include "Vision/Matcher.h"
 
 bool asst::ReplenishOriginiumShardTaskPlugin::verify(AsstMsg msg, const json::value& details) const
 {
@@ -19,6 +23,50 @@ bool asst::ReplenishOriginiumShardTaskPlugin::verify(AsstMsg msg, const json::va
 
 bool asst::ReplenishOriginiumShardTaskPlugin::_run()
 {
-    ProcessTask task(*this, { "ReplenishToMax" });
-    return task.run();
+    auto has_replenish_confirm_button = [&]() {
+        Matcher confirm_analyzer(ctrler()->get_image());
+        confirm_analyzer.set_task_info("ReplenishToMaxConfirm");
+        return static_cast<bool>(confirm_analyzer.analyze());
+    };
+
+    constexpr int ReplenishMaxTimes = 3;
+    for (int replenish_retry = 0; replenish_retry < ReplenishMaxTimes; ++replenish_retry) {
+        ProcessTask replenish_task(*this, { "ReplenishToMax" });
+        replenish_task.set_retry_times(InfrastAbstractTask::TaskRetryTimes);
+        if (!replenish_task.run()) {
+            Log.warn("replenish to max failed", replenish_retry);
+            continue;
+        }
+
+        bool confirm_button_appeared = false;
+        for (int confirm_retry = 0; confirm_retry < ReplenishMaxTimes; ++confirm_retry) {
+            if (confirm_retry != 0 && !has_replenish_confirm_button()) {
+                return true;
+            }
+
+            ProcessTask confirm_task(*this, { "ReplenishToMaxConfirm" });
+            confirm_task.set_retry_times(InfrastAbstractTask::TaskRetryTimes);
+            if (!confirm_task.run()) {
+                Log.warn("replenish confirm button not found", replenish_retry, confirm_retry);
+                break;
+            }
+            confirm_button_appeared = true;
+
+            sleep(500);
+            if (!has_replenish_confirm_button()) {
+                return true;
+            }
+
+            Log.warn("failed to confirm replenish to max", replenish_retry, confirm_retry);
+        }
+
+        // 确认按钮出现后只重试确认，不再重复点击“最多”。
+        if (confirm_button_appeared) {
+            Log.warn("failed to confirm replenish to max after retries", replenish_retry);
+            return false;
+        }
+    }
+
+    Log.warn("failed to replenish originium shard");
+    return false;
 }

--- a/src/MaaCore/Task/Interface/InfrastTask.cpp
+++ b/src/MaaCore/Task/Interface/InfrastTask.cpp
@@ -38,6 +38,7 @@ asst::InfrastTask::InfrastTask(const AsstCallback& callback, Assistant* inst) :
     m_infrast_begin_task_ptr->register_plugin<ScreenshotTaskPlugin>();
     m_queue_rotation_task->set_tasks({ "InfrastEnterRotation" }).set_ignore_error(true);
     m_replenish_task_ptr = m_mfg_task_ptr->register_plugin<ReplenishOriginiumShardTaskPlugin>();
+    m_replenish_task_ptr->set_retry_times(0);
     m_info_task_ptr->set_ignore_error(true);
     m_mfg_task_ptr->set_ignore_error(true);
     m_trade_task_ptr->set_ignore_error(true);


### PR DESCRIPTION
## 问题

源石碎片自动补货会依次点击“最多”和蓝勾，但原有流程只确认按钮曾被识别和点击，没有检查提交后蓝勾是否真正消失。

问题日志中，MAA 在 11:14:54.208 点击补货蓝勾。随后没有识别到 `LoadingText`，任务直接进入 `Stop`，并在 11:14:56.052 将补货插件标记为完成：

```text
[2026-07-14 11:14:54.207][TRC][Px5204][Tx8297] match_templ | ReplenishToMaxConfirm.png [opencv] score: 0.999028 rect: [ 904, 554, 92, 87 ] roi: [ 854, 504, 192, 187 ]
[2026-07-14 11:14:54.208][INF][Px5204][Tx8297] Assistant::append_callback | SubTaskStart {"class":"asst::ProcessTask","details":{"action":"ClickSelf","algorithm":"MatchTemplate","exec_times":1,"max_times":2147483647,"result":{"rect":[904,554,92,87],"score":0.999028,"template":"ReplenishToMaxConfirm.png"},"task":"ReplenishToMaxConfirm"},"first":["ReplenishToMax"],"pre_task":"ReplenishToMax","subtask":"ProcessTask","taskchain":"Infrast","taskid":5,"uuid":"b44ec86418809d32"}
[2026-07-14 11:14:54.208][TRC][Px5204][Tx8297] Click with scaled coordinates (933, 558) 1.25
[2026-07-14 11:14:55.810][INF][Px5204][Tx8297] {"class":"asst::ProcessTask","cur_task":"ReplenishToMaxConfirm","details":{"cur_retry":0,"retry_times":20,"to_be_recognized":["ReplenishToMaxConfirm@LoadingText","Stop"]},"first":["ReplenishToMax"],"pre_task":"ReplenishToMax","subtask":"ProcessTask","taskchain":"Infrast","taskid":5}
[2026-07-14 11:14:56.052][INF][Px5204][Tx8297] Assistant::append_callback | SubTaskStart {"class":"asst::ProcessTask","details":{"action":"Stop","algorithm":"JustReturn","exec_times":1,"max_times":2147483647,"result":{},"task":"Stop"},"first":["ReplenishToMax"],"pre_task":"ReplenishToMaxConfirm","subtask":"ProcessTask","taskchain":"Infrast","taskid":5,"uuid":"b44ec86418809d32"}
[2026-07-14 11:14:56.052][INF][Px5204][Tx8297] Assistant::append_callback | SubTaskCompleted {"class":"asst::ReplenishOriginiumShardTaskPlugin","details":{},"subtask":"ReplenishOriginiumShardTask","taskchain":"Infrast","taskid":5,"uuid":"b44ec86418809d32"}
```

之后 MAA 继续换人并离开制造站。出现 11:15:37.605 的计划确认弹窗，说明实际并未点到蓝勾。

<img width="960" alt="尚未执行新的制造计划，是否确认离开设施" src="https://github.com/user-attachments/assets/bfa3fe27-c1a5-4369-a0f9-09da73d0ff75" />

这个弹窗不在现有基建换班流程的处理范围内，任务因此无法继续。

## 原因

原有补货任务是一条连续的 `ProcessTask`：

```text
ReplenishToMax
→ ReplenishToMaxConfirm
→ ReplenishToMaxConfirm@LoadingText / Stop
```

`ReplenishToMaxConfirm` 被点击后，流程只尝试识别提交中的文字。没有识别到 `LoadingText` 时，`Stop` 会正常结束任务。此时蓝勾可能仍然存在，但补货插件已经返回成功。

补货插件也没有独立设置重试次数。若直接在现有 `_run()` 末尾增加失败返回，插件会继承默认的二十次外层重试，导致整段补货反复执行。

## Fix

本次将补货拆分为“选择数量”和“提交确认”两个状态：

```text
点击“最多”
    ↓
识别到补货蓝勾
    ↓
点击蓝勾
    ↓
等待 LoadingText 结束
    ↓
再次匹配补货蓝勾
    ├─ 蓝勾消失：补货完成
    └─ 蓝勾仍在：只重试确认
```

`ReplenishToMax` 现在只负责点击“最多”。点击完成后必须识别到 `ReplenishToMaxConfirm`，才能进入确认状态，避免蓝勾尚未出现时提前结束任务。

进入确认状态后，流程继续使用原有 `ReplenishToMaxConfirm` 和 `LoadingText`。每次点击完成都会再次匹配同一份蓝勾模板。蓝勾消失后才返回成功；蓝勾仍然存在时只重新点击确认，不会再次点击“最多”。

重试范围保持在当前补货插件内：

| 状态 | 上限 | 达到上限后的处理 |
| --- | ---: | --- |
| 点击“最多”并等待蓝勾 | 3 轮 | 补货插件失败 |
| 点击蓝勾并复核消失 | 3 次 | 补货插件失败 |
| 单个节点的图像识别 | 3 次 | 进入当前状态的下一次尝试 |
| 补货插件外层重试 | `retry_times = 0` | 不重复执行整段 `_run()` |

补货最终失败只会结束 `ReplenishOriginiumShardTaskPlugin`。插件返回值不会传递给制造站主任务，因此制造站仍会继续换班。

需要注意的行为变化：若进入房间时库存已满或没有可补充的原料，点击“最多”不会产生待提交变更，蓝勾不会出现。旧流程在这种情况下会静默结束，本次修改后会在三轮尝试后记录 SubTaskError。该错误仅结束补货插件本身，换班流程不受影响。

本次改动只影响开启了源石碎片自动补货的制造站流程；resource/global 各海外客户端没有对 ReplenishToMax 的覆写，ConfirmProductChange 仅复用模板图片而非任务节点。

## 测试

已构建并完成实际运行测试。

### 正常补货

正常运行时，“最多”和蓝勾依次匹配成功。确认完成、蓝勾消失后，补货插件正常结束：

```text
[2026-07-15 00:53:29.641][TRC][Px35180][Tx38517] match_templ | ReplenishToMax.png [opencv] score: 0.930702 rect: [ 932, 178, 65, 49 ] roi: [ 882, 128, 165, 149 ]
[2026-07-15 00:53:31.016][TRC][Px35180][Tx38517] match_templ | ReplenishToMaxConfirm.png [opencv] score: 0.999085 rect: [ 904, 554, 92, 87 ] roi: [ 854, 504, 192, 187 ]
[2026-07-15 00:53:33.761][INF][Px35180][Tx38517] Assistant::append_callback | SubTaskCompleted {"class":"asst::ReplenishOriginiumShardTaskPlugin","details":{},"subtask":"ReplenishOriginiumShardTask","taskchain":"Infrast","taskid":2,"uuid":"564688fd8a657262"}
```

### 蓝勾无法识别

测试中故意使蓝勾识别失败（修改roi）。日志记录了第 0、1、2 轮尝试，达到三轮上限后补货插件报错：

```text
[2026-07-15 00:49:01.086][WRN][Px35180][Tx38517] replenish confirm button not found 0 0
[2026-07-15 00:49:05.043][WRN][Px35180][Tx38517] replenish confirm button not found 1 0
[2026-07-15 00:49:09.194][WRN][Px35180][Tx38517] replenish confirm button not found 2 0
[2026-07-15 00:49:09.194][WRN][Px35180][Tx38517] failed to replenish originium shard
[2026-07-15 00:49:09.695][INF][Px35180][Tx38517] Assistant::append_callback | SubTaskError {"class":"asst::ReplenishOriginiumShardTaskPlugin","details":{},"subtask":"ReplenishOriginiumShardTask","taskchain":"Infrast","taskid":1,"uuid":"564688fd8a657262"}
[2026-07-15 00:49:09.695][INF][Px35180][Tx38517] Assistant::append_callback | SubTaskExtraInfo {"class":"asst::InfrastMfgTask","details":{"facility":"Mfg","index":1,"product":"OriginStone"},"subtask":"InfrastMfgTask","taskchain":"Infrast","taskid":1,"uuid":"564688fd8a657262","what":"ProductOfFacility"}
```

`SubTaskError` 后紧接着出现制造站的 `ProductOfFacility` 回调，说明失败只结束补货插件，制造站继续执行。

### 蓝勾点击未生效

测试时临时将 `ReplenishToMaxConfirm` 改为 `ClickRect`，并设置 `specificRect=[867,100,1,1]`，使自动点击故意偏离蓝勾。
（该 ClickRect 配置仅用于测试，提交的代码中保持 ClickSelf）
前两次点击后蓝勾仍然存在，流程持续停留在确认状态。随后手动点击蓝勾，下一次复核发现模板消失，补货插件完成并继续换人：

```text
[2026-07-15 01:02:54.554][TRC][Px57316][Tx63668] match_templ | ReplenishToMaxConfirm.png [opencv] score: 0.999085 rect: [ 904, 554, 92, 87 ] roi: [ 854, 504, 192, 187 ]
[2026-07-15 01:02:54.554][WRN][Px57316][Tx63668] failed to confirm replenish to max 0 0
[2026-07-15 01:02:57.780][TRC][Px57316][Tx63668] match_templ | ReplenishToMaxConfirm.png [opencv] score: 0.999087 rect: [ 904, 554, 92, 87 ] roi: [ 854, 504, 192, 187 ]
[2026-07-15 01:02:57.781][WRN][Px57316][Tx63668] failed to confirm replenish to max 0 1
[2026-07-15 01:02:58.062][INF][Px57316][Tx63668] Assistant::append_callback | SubTaskCompleted {"class":"asst::ReplenishOriginiumShardTaskPlugin","details":{},"subtask":"ReplenishOriginiumShardTask","taskchain":"Infrast","taskid":1,"uuid":"564688fd8a657262"}
[2026-07-15 01:02:58.062][INF][Px57316][Tx63668] Assistant::append_callback | SubTaskExtraInfo {"class":"asst::InfrastMfgTask","details":{"facility":"Mfg","index":1,"product":"OriginStone"},"subtask":"InfrastMfgTask","taskchain":"Infrast","taskid":1,"uuid":"564688fd8a657262","what":"ProductOfFacility"}
```

Fixes #17332

## 由 Sourcery 总结

改进源石碎片的自动补给流程，以在确认操作上进行校验，并在确认点击失败时避免阻塞制造轮转。

Bug 修复：
- 在点击补给确认按钮后，新增对其消失状态的检查，从而避免确认失败时制造计划处于未提交状态并导致任务停滞。
- 在库存已满或无材料的情况下，通过抛出插件错误来避免静默报告成功，同时保持制造轮转继续运行。

增强改进：
- 将补给流程拆分为数量选择和确认两个独立步骤，并在内部为确认步骤加入有上限的重试逻辑，重点针对确认环节，而不是反复重跑整个流程。
- 限制补给插件的外部重试次数，防止补给失败导致多次完整执行流程或影响主要制造任务流。
- 增加围绕补给与确认失败的日志记录，以便诊断自动补给相关问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve Originium shard auto-replenish workflow to verify confirmation and avoid blocking manufacturing rotation when the confirm click fails.

Bug Fixes:
- Ensure the replenish confirm button disappearance is checked after clicking so failed confirmations no longer leave manufacturing plans unsubmitted and stall the task.
- Prevent full-inventory or no-material cases from silently reporting success by surfacing a plugin error while keeping the manufacturing rotation running.

Enhancements:
- Split the replenish process into separate quantity selection and confirmation steps with bounded, internal retry logic focused on confirmation instead of repeating the whole workflow.
- Limit external retries of the replenish plugin so failed replenishment does not cause repeated full-run executions or affect the main manufacturing task flow.
- Add logging around replenish and confirm failures to aid diagnosis of auto-replenish issues.

</details>