### PR TITLE
修复PC应用宝 横屏没有处理

### DIFF
--- a/resource/config.json
+++ b/resource/config.json
@@ -105,6 +105,7 @@
             "baseConfig": "CapWithShell",
             "displayId": "[Adb] -s [AdbSerial] shell \"dumpsys activity activities | awk '/^Display #/{match($0,/[0-9]+/); id=substr($0,RSTART,RLENGTH)} /packageName=[PackageName]/{print \\\"mDisplayId:\\\" id; }'\"",
             "display": "[Adb] -s [AdbSerial] shell \"wm size -d [DisplayId] | grep -o -E [0-9]+\"",
+            "orientation": "[Adb] -s [AdbSerial] shell \"dumpsys input | grep -E 'Viewport .*displayId=[DisplayId],' | head -1 | grep -o 'orientation=[0-3]' | grep -o '[0-3]'\"",
             "screencapRawByNC": "[Adb] -s [AdbSerial] shell \"screencap -d [DisplayId] | nc -w 3 [NcAddress] [NcPort]\"",
             "screencapRawWithGzip": "[Adb] -s [AdbSerial] shell \"screencap -d [DisplayId] | gzip -1\"",
             "screencapEncode": "[Adb] -s [AdbSerial] shell screencap -d [DisplayId] -p",


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 调整 PC 应用宝 配置，以正确处理横屏方向显示。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Adjust PC 应用宝 configuration to correctly handle landscape screen orientation.

</details>