### PR TITLE
fix: 避免损坏的仓库模板导致程序崩溃 / prevent crashes from invalid depot templates

### DIFF
--- a/src/MaaCore/Config/TemplResource.cpp
+++ b/src/MaaCore/Config/TemplResource.cpp
@@ -134,6 +134,12 @@ const cv::Mat& asst::TemplResource::get_templ(const std::string& name)
         }
 
         cv::Mat templ = MAA_NS::imread(path_iter->second);
+        if (templ.empty()) {
+            Log.error(__FUNCTION__, "failed to load templ", name, "path:", path_iter->second);
+#ifdef ASST_DEBUG
+            throw std::runtime_error("failed to load templ: " + name);
+#endif
+        }
         m_templs.emplace(name, std::move(templ));
     }
     return m_templs.at(name);

--- a/src/MaaCore/Task/Miscellaneous/DepotRecognitionTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/DepotRecognitionTask.cpp
@@ -44,7 +44,10 @@ bool asst::DepotRecognitionTask::analyze_basic_items()
     DepotImageAnalyzer analyzer(ctrler()->get_image());
     analyzer.set_item_ids({ "4002", "4003", "4001", "3003", "4006" }); // 源石 合成玉 龙门币 赤金 采购凭证（红票）
     analyzer.set_is_basic(true);
-    if (!analyzer.analyze()) {
+    const bool analyzed = analyzer.analyze();
+    callback_invalid_templates(analyzer.get_invalid_template_ids());
+    if (!analyzed) {
+        DepotImageAnalyzer::clear_cached_templates();
         return false;
     }
 
@@ -72,7 +75,9 @@ bool asst::DepotRecognitionTask::swipe_and_analyze()
         // 因为滑动不是完整的一页，有可能上一次识别过的物品，这次仍然在页面中
         // 所以这个 begin pos 不能设置
         // analyzer.set_match_begin_pos(pre_pos);
-        if (!analyzer.analyze()) {
+        const bool analyzed = analyzer.analyze();
+        callback_invalid_templates(analyzer.get_invalid_template_ids());
+        if (!analyzed) {
             break;
         }
         size_t cur_pos = analyzer.get_match_begin_pos();
@@ -89,6 +94,17 @@ bool asst::DepotRecognitionTask::swipe_and_analyze()
     }
     DepotImageAnalyzer::clear_cached_templates();
     return !m_all_items.empty();
+}
+
+void asst::DepotRecognitionTask::callback_invalid_templates(const std::vector<std::string>& item_ids)
+{
+    if (item_ids.empty()) {
+        return;
+    }
+
+    json::value info = basic_info_with_what("DepotTemplateLoadError");
+    info["details"]["item_ids"] = json::array(item_ids);
+    callback(AsstMsg::SubTaskError, info);
 }
 
 void asst::DepotRecognitionTask::callback_analyze_result(bool done)

--- a/src/MaaCore/Task/Miscellaneous/DepotRecognitionTask.h
+++ b/src/MaaCore/Task/Miscellaneous/DepotRecognitionTask.h
@@ -18,6 +18,7 @@ protected:
 
     bool swipe_and_analyze();
     bool analyze_basic_items();
+    void callback_invalid_templates(const std::vector<std::string>& item_ids);
     void callback_analyze_result(bool done);
     void swipe();
     std::unordered_map<std::string, ItemInfo> m_all_items;

--- a/src/MaaCore/Vision/Miscellaneous/DepotImageAnalyzer.cpp
+++ b/src/MaaCore/Vision/Miscellaneous/DepotImageAnalyzer.cpp
@@ -64,7 +64,6 @@ void asst::DepotImageAnalyzer::prepare_cached_templates()
         try {
             cv::Mat templ = TemplResource::get_instance().get_templ(item_id).clone();
             if (templ.empty()) {
-                Log.error(__FUNCTION__, "templ is empty:", item_id);
                 record_invalid_template(item_id);
                 continue;
             }
@@ -367,7 +366,6 @@ int asst::DepotImageAnalyzer::match_quantity(const ItemInfo& item)
     auto task_ptr = Task.get<MatchTaskInfo>("DepotQuantity");
     auto item_templ = TemplResource::get_instance().get_templ(item.item_id);
     if (item_templ.empty()) {
-        Log.error(__FUNCTION__, "templ is empty:", item.item_id);
         record_invalid_template(item.item_id);
         return 0;
     }

--- a/src/MaaCore/Vision/Miscellaneous/DepotImageAnalyzer.cpp
+++ b/src/MaaCore/Vision/Miscellaneous/DepotImageAnalyzer.cpp
@@ -13,12 +13,24 @@
 #include <exception>
 #include <numbers>
 
+namespace
+{
+constexpr int QuantityMaskWidth = 80;
+constexpr int QuantityMaskHeight = 50;
+
+bool is_depot_template_size_valid(const cv::Mat& templ)
+{
+    return templ.cols >= QuantityMaskWidth && templ.rows >= QuantityMaskHeight;
+}
+}
+
 bool asst::DepotImageAnalyzer::analyze()
 {
     LogTraceFunction;
 
     m_all_items_roi.clear();
     m_result.clear();
+    m_invalid_template_ids.clear();
 
     if (m_cached_templs.empty()) {
         prepare_cached_templates();
@@ -48,20 +60,17 @@ void asst::DepotImageAnalyzer::prepare_cached_templates()
 {
     LogTraceFunction;
 
-    static constexpr int QuantityMaskWidth = 80;
-    static constexpr int QuantityMaskHeight = 50;
-
     for (const auto& item_id : get_ordered_item_ids()) {
         try {
             cv::Mat templ = TemplResource::get_instance().get_templ(item_id).clone();
             if (templ.empty()) {
                 Log.error(__FUNCTION__, "templ is empty:", item_id);
-                m_invalid_template_ids.emplace_back(item_id);
+                record_invalid_template(item_id);
                 continue;
             }
-            if (templ.cols < QuantityMaskWidth || templ.rows < QuantityMaskHeight) {
+            if (!is_depot_template_size_valid(templ)) {
                 Log.error(__FUNCTION__, "templ is too small:", item_id, "size:", templ.cols, "x", templ.rows);
-                m_invalid_template_ids.emplace_back(item_id);
+                record_invalid_template(item_id);
                 continue;
             }
 
@@ -77,8 +86,16 @@ void asst::DepotImageAnalyzer::prepare_cached_templates()
         }
         catch (const std::exception& e) {
             Log.error(__FUNCTION__, "failed to prepare templ:", item_id, "error:", e.what());
-            m_invalid_template_ids.emplace_back(item_id);
+            record_invalid_template(item_id);
         }
+    }
+}
+
+void asst::DepotImageAnalyzer::record_invalid_template(const std::string& item_id)
+{
+    if (std::find(m_invalid_template_ids.begin(), m_invalid_template_ids.end(), item_id) ==
+        m_invalid_template_ids.end()) {
+        m_invalid_template_ids.emplace_back(item_id);
     }
 }
 
@@ -351,9 +368,31 @@ int asst::DepotImageAnalyzer::match_quantity(const ItemInfo& item)
     auto item_templ = TemplResource::get_instance().get_templ(item.item_id);
     if (item_templ.empty()) {
         Log.error(__FUNCTION__, "templ is empty:", item.item_id);
+        record_invalid_template(item.item_id);
         return 0;
     }
     auto item_image = m_image_resized(make_rect<cv::Rect>(item.rect));
+    if (!is_depot_template_size_valid(item_templ) || item_templ.size() != item_image.size() ||
+        item_templ.type() != item_image.type()) {
+        Log.error(
+            __FUNCTION__,
+            "templ is incompatible:",
+            item.item_id,
+            "templ size:",
+            item_templ.cols,
+            "x",
+            item_templ.rows,
+            "item size:",
+            item_image.cols,
+            "x",
+            item_image.rows,
+            "templ type:",
+            item_templ.type(),
+            "item type:",
+            item_image.type());
+        record_invalid_template(item.item_id);
+        return 0;
+    }
     cv::Mat quotient;
     cv::divide(
         item_image + cv::Scalar { 1, 1, 1 }, // I've forgot why I should plus 1 here

--- a/src/MaaCore/Vision/Miscellaneous/DepotImageAnalyzer.cpp
+++ b/src/MaaCore/Vision/Miscellaneous/DepotImageAnalyzer.cpp
@@ -48,6 +48,9 @@ void asst::DepotImageAnalyzer::prepare_cached_templates()
 {
     LogTraceFunction;
 
+    static constexpr int QuantityMaskWidth = 80;
+    static constexpr int QuantityMaskHeight = 50;
+
     for (const auto& item_id : get_ordered_item_ids()) {
         try {
             cv::Mat templ = TemplResource::get_instance().get_templ(item_id).clone();
@@ -56,7 +59,7 @@ void asst::DepotImageAnalyzer::prepare_cached_templates()
                 m_invalid_template_ids.emplace_back(item_id);
                 continue;
             }
-            if (templ.cols < 80 || templ.rows < 50) {
+            if (templ.cols < QuantityMaskWidth || templ.rows < QuantityMaskHeight) {
                 Log.error(__FUNCTION__, "templ is too small:", item_id, "size:", templ.cols, "x", templ.rows);
                 m_invalid_template_ids.emplace_back(item_id);
                 continue;
@@ -64,7 +67,11 @@ void asst::DepotImageAnalyzer::prepare_cached_templates()
 
             const cv::Scalar mean_color = cv::mean(templ(get_center_rect(templ)));
             // 抹去右下角 80x50 区域（防止影响匹配）
-            templ(cv::Rect { templ.cols - 80, templ.rows - 50, 80, 50 }) = cv::Scalar { 0, 0, 0 };
+            templ(
+                cv::Rect { templ.cols - QuantityMaskWidth,
+                           templ.rows - QuantityMaskHeight,
+                           QuantityMaskWidth,
+                           QuantityMaskHeight }) = cv::Scalar { 0, 0, 0 };
             m_template_mean_colors[item_id] = mean_color;
             m_cached_templs[item_id] = std::move(templ);
         }

--- a/src/MaaCore/Vision/Miscellaneous/DepotImageAnalyzer.cpp
+++ b/src/MaaCore/Vision/Miscellaneous/DepotImageAnalyzer.cpp
@@ -10,6 +10,7 @@
 #include "Vision/RegionOCRer.h"
 
 #include <algorithm>
+#include <exception>
 #include <numbers>
 
 bool asst::DepotImageAnalyzer::analyze()
@@ -48,11 +49,29 @@ void asst::DepotImageAnalyzer::prepare_cached_templates()
     LogTraceFunction;
 
     for (const auto& item_id : get_ordered_item_ids()) {
-        cv::Mat templ = TemplResource::get_instance().get_templ(item_id).clone();
-        m_template_mean_colors[item_id] = cv::mean(templ(get_center_rect(templ)));
-        // 抹去右下角 80x50 区域（防止影响匹配）
-        templ(cv::Rect { templ.cols - 80, templ.rows - 50, 80, 50 }) = cv::Scalar { 0, 0, 0 };
-        m_cached_templs[item_id] = std::move(templ);
+        try {
+            cv::Mat templ = TemplResource::get_instance().get_templ(item_id).clone();
+            if (templ.empty()) {
+                Log.error(__FUNCTION__, "templ is empty:", item_id);
+                m_invalid_template_ids.emplace_back(item_id);
+                continue;
+            }
+            if (templ.cols < 80 || templ.rows < 50) {
+                Log.error(__FUNCTION__, "templ is too small:", item_id, "size:", templ.cols, "x", templ.rows);
+                m_invalid_template_ids.emplace_back(item_id);
+                continue;
+            }
+
+            const cv::Scalar mean_color = cv::mean(templ(get_center_rect(templ)));
+            // 抹去右下角 80x50 区域（防止影响匹配）
+            templ(cv::Rect { templ.cols - 80, templ.rows - 50, 80, 50 }) = cv::Scalar { 0, 0, 0 };
+            m_template_mean_colors[item_id] = mean_color;
+            m_cached_templs[item_id] = std::move(templ);
+        }
+        catch (const std::exception& e) {
+            Log.error(__FUNCTION__, "failed to prepare templ:", item_id, "error:", e.what());
+            m_invalid_template_ids.emplace_back(item_id);
+        }
     }
 }
 
@@ -323,6 +342,10 @@ int asst::DepotImageAnalyzer::match_quantity(const ItemInfo& item)
 {
     auto task_ptr = Task.get<MatchTaskInfo>("DepotQuantity");
     auto item_templ = TemplResource::get_instance().get_templ(item.item_id);
+    if (item_templ.empty()) {
+        Log.error(__FUNCTION__, "templ is empty:", item.item_id);
+        return 0;
+    }
     auto item_image = m_image_resized(make_rect<cv::Rect>(item.rect));
     cv::Mat quotient;
     cv::divide(

--- a/src/MaaCore/Vision/Miscellaneous/DepotImageAnalyzer.h
+++ b/src/MaaCore/Vision/Miscellaneous/DepotImageAnalyzer.h
@@ -32,6 +32,7 @@ public:
     void set_is_basic(bool is_basic) noexcept { m_is_basic = is_basic; }
 
     const auto& get_result() const noexcept { return m_result; }
+    const auto& get_invalid_template_ids() const noexcept { return m_invalid_template_ids; }
 
     static void clear_cached_templates()
     {
@@ -71,6 +72,7 @@ private:
 #endif
     std::vector<Rect> m_all_items_roi;
     std::unordered_map<std::string, ItemInfo> m_result;
+    std::vector<std::string> m_invalid_template_ids;
 
     inline static std::unordered_map<std::string, cv::Mat> m_cached_templs;
     inline static std::unordered_map<std::string, cv::Scalar> m_template_mean_colors;

--- a/src/MaaCore/Vision/Miscellaneous/DepotImageAnalyzer.h
+++ b/src/MaaCore/Vision/Miscellaneous/DepotImageAnalyzer.h
@@ -43,6 +43,7 @@ public:
 private:
     void resize();
     void prepare_cached_templates();
+    void record_invalid_template(const std::string& item_id);
     const std::vector<std::string>& get_ordered_item_ids() const;
     static double color_diff(const cv::Scalar& a, const cv::Scalar& b);
     static std::vector<std::string> filter_candidates_by_color(

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -1491,6 +1491,20 @@ public class AsstProxy
                 Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("DropRecognitionError"), UiLogColor.Error);
                 break;
 
+            case "DepotRecognitionTask":
+                {
+                    if (details["what"]?.ToString() != "DepotTemplateLoadError")
+                    {
+                        break;
+                    }
+
+                    var itemIds = details["details"]?["item_ids"]?.Values<string>().Where(id => !string.IsNullOrEmpty(id)) ?? [];
+                    Instances.TaskQueueViewModel.AddLog(
+                        LocalizationHelper.GetStringFormat("DepotTemplateLoadError", string.Join(", ", itemIds)),
+                        UiLogColor.Error);
+                    break;
+                }
+
             case "ReportToPenguinStats":
                 {
                     var why = details["why"]!.ToString();

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -939,6 +939,7 @@ Right Click: Select Target Process</system:String>
     <system:String x:Key="Depot">{key=DepotRecognition}</system:String>
     <system:String x:Key="LastSyncTime">Last Sync Time</system:String>
     <system:String x:Key="DepotRecognitionTip">This function is still in testing. If you encounter any unexpected results, please zip the ｢debug/depot｣ folder in the installation path and submit an issue on GitHub</system:String>
+    <system:String x:Key="DepotTemplateLoadError">Depot recognition templates failed to load ({0}). Some items will be skipped. The resource files may be corrupted; please download the complete resource package again and overwrite the resource folder.</system:String>
     <system:String x:Key="StartToDepotRecognition">Start to Identify</system:String>
     <system:String x:Key="ExportToArkplanner">Arkplanner</system:String>
     <system:String x:Key="ExportToLolicon">Arkntools</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -940,6 +940,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="Depot">{key=DepotRecognition}</system:String>
     <system:String x:Key="LastSyncTime">前回同期時間</system:String>
     <system:String x:Key="DepotRecognitionTip">この機能はまだテスト版です。エラーが発生/統計情報に問題があれば、debug/depotフォルダを圧縮し、issueを提出してください~</system:String>
+    <system:String x:Key="DepotTemplateLoadError">倉庫認識用テンプレートの読み込みに失敗しました（{0}）。一部のアイテムはスキップされます。リソースが破損している可能性があるため、完全なリソースパッケージを再ダウンロードし、resource フォルダーに上書きしてください。</system:String>
     <system:String x:Key="StartToDepotRecognition">認識開始</system:String>
     <system:String x:Key="ExportToArkplanner">Arkplanner</system:String>
     <system:String x:Key="ExportToLolicon">Arkntools</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -941,6 +941,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="Depot">{key=DepotRecognition}</system:String>
     <system:String x:Key="LastSyncTime">마지막 동기화 시간</system:String>
     <system:String x:Key="DepotRecognitionTip">이 기능은 현재 테스트 중입니다. 내보내기 전 인식 결과가 맞는지 확인 후 사용하세요\n만약 오류가 있다면 MAA 경로 내 debug 폴더 안의 depot 폴더 전체를 압축해서 Github의 issue로 올려주세요</system:String>
+    <system:String x:Key="DepotTemplateLoadError">창고 인식 템플릿을 불러오지 못했습니다({0}). 일부 아이템은 건너뜁니다. 리소스 파일이 손상되었을 수 있으므로 전체 리소스 패키지를 다시 다운로드하여 resource 폴더에 덮어쓰세요.</system:String>
     <system:String x:Key="StartToDepotRecognition">인식 시작</system:String>
     <system:String x:Key="ExportToArkplanner">Arkplanner</system:String>
     <system:String x:Key="ExportToLolicon">Arkntools</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -940,6 +940,7 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="Depot">{key=DepotRecognition}</system:String>
     <system:String x:Key="LastSyncTime">上次同步时间</system:String>
     <system:String x:Key="DepotRecognitionTip">该功能尚处于测试阶段，请检查结果是否准确再行使用。若有误，欢迎打包 debug/depot 文件夹后向我们提交 issue ~</system:String>
+    <system:String x:Key="DepotTemplateLoadError">仓库识别模板加载失败（{0}），将跳过这些物品。资源文件可能已损坏，请重新下载完整资源包并覆盖 resource 文件夹。</system:String>
     <system:String x:Key="StartToDepotRecognition">开始识别</system:String>
     <system:String x:Key="ExportToArkplanner">企鹅物流刷图规划</system:String>
     <system:String x:Key="ExportToLolicon">明日方舟工具箱</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -940,6 +940,7 @@ C:\\leidian\\LDPlayer9\n
     <system:String x:Key="Depot">{key=DepotRecognition}</system:String>
     <system:String x:Key="LastSyncTime">上次同步時間</system:String>
     <system:String x:Key="DepotRecognitionTip">該功能尚處於測試階段，請檢查結果是否準確再行使用。若有誤，歡迎打包 debug/depot 資料夾後向我們提交 issue ~</system:String>
+    <system:String x:Key="DepotTemplateLoadError">倉庫辨識範本載入失敗（{0}），將略過這些物品。資源檔案可能已損壞，請重新下載完整資源包並覆蓋 resource 資料夾。</system:String>
     <system:String x:Key="StartToDepotRecognition">開始辨識</system:String>
     <system:String x:Key="ExportToArkplanner">企鵝物流刷圖規劃</system:String>
     <system:String x:Key="ExportToLolicon">明日方舟工具箱</system:String>


### PR DESCRIPTION
## 说明

仓库识别加载到空白或尺寸异常的物品模板时，`DepotImageAnalyzer::prepare_cached_templates()` 会继续处理模板，触发 OpenCV ROI 断言并导致 Core 崩溃。

<!-- Remove module: others -->

对仓库模板增加以下处理：

- 跳过空白、尺寸不足或处理时抛出异常的模板，并在日志中记录物品 ID 和错误原因。
- 仅缓存成功处理的模板，避免留下不完整的缓存数据。
- 通过 `SubTaskError` 将异常模板 ID 发送给 WPF，在右侧日志面板显示红色警告。
- 补充简体中文、繁体中文、英语、日语和韩语提示，引导用户重新下载完整资源包并覆盖 `resource` 文件夹。
- 其余有效物品仍可继续识别，不再因单个损坏模板导致整个程序崩溃。

## 原因

遇到损坏模板时， `DepotImageAnalyzer::prepare_cached_templates()` 会因 OpenCV ROI 越界触发 `SIGABRT`。

原实现没有检查模板是否为空或尺寸是否足够，仍会计算模板中心区域并裁剪右下角 `80×50` 区域。资源文件缺失或损坏时，这些操作会产生非法 ROI。

## 验证

使用损坏的仓库模板执行仓库识别：

- Core 正确记录异常模板 ID，并发送 `DepotTemplateLoadError` 回调。
- WPF 右侧日志面板显示对应的本地化红色警告。
- 仓库任务正常完成，进程退出码为 `0`，未再发生崩溃。
- 连续复用同一分析器时，第二次分析不会残留上一次的异常模板 ID。

<details>
<summary>English</summary>

## Summary

Depot recognition could crash the Core when an item template was empty, undersized, or otherwise invalid. `DepotImageAnalyzer::prepare_cached_templates()` continued processing the invalid image and triggered an OpenCV ROI assertion.

This PR:

- Skips empty, undersized, and invalid depot templates while logging the affected item IDs.
- Updates the template caches only after successful preparation.
- Reports invalid template IDs to WPF through `SubTaskError`.
- Shows a localized red warning in the task log for all five supported languages.
- Continues recognizing valid items instead of terminating the process.

## Verification

Tested depot recognition with an intentionally corrupted template:

- Core logged the invalid item ID and sent a `DepotTemplateLoadError` callback.
- WPF displayed the corresponding localized error message in red.
- The depot task completed normally with exit code `0`, without crashing.
- Reusing the same analyzer did not retain invalid template IDs from the previous pass.

</details>

Fixes #17346

## Summary by Sourcery

安全处理无效的仓库模板，防止在识别仓库时发生崩溃，并将错误反馈到 UI。

Bug Fixes:
- 在缓存准备阶段跳过空的或尺寸过小的仓库模板，以避免触发 OpenCV ROI 断言并导致崩溃。
- 在数量匹配时针对空的物品模板进行防护，防止处理无效图像。

Enhancements:
- 在分析器中跟踪无效的仓库模板物品 ID，当分析失败时清理已缓存模板，以避免缓存状态不完整。
- 通过 SubTaskError 回调通知 WPF 仓库模板加载错误，并在任务日志中以红色本地化警告的形式显示错误，覆盖所有支持的语言。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle invalid depot templates safely to prevent crashes during depot recognition and surface errors to the UI.

Bug Fixes:
- Skip empty or undersized depot templates during cache preparation to avoid OpenCV ROI assertions and crashes.
- Guard quantity matching against empty item templates to prevent processing invalid images.

Enhancements:
- Track invalid depot template item IDs in the analyzer and clear cached templates when analysis fails to avoid incomplete cache state.
- Notify WPF of depot template load errors via SubTaskError callbacks and display localized red warnings in the task log across all supported languages.

</details>
