### PR TITLE
fix: suppress -Wc11-extensions for OpenCV 4.12 CV_XADD on Android

### DIFF
--- a/src/MaaCore/CMakeLists.txt
+++ b/src/MaaCore/CMakeLists.txt
@@ -41,6 +41,9 @@ if(ANDROID)
         polyclipping::polyclipping
         ONNXRuntime::ONNXRuntime ZLIB::ZLIB Boost::system)
     set_property(TARGET MaaCore PROPERTY NO_SYSTEM_FROM_IMPORTED TRUE)
+    # OpenCV 4.12 起 cvdef.h 的 CV_XADD 在 Android clang 上展开为 _Atomic（C11 扩展），
+    # 由于 NO_SYSTEM_FROM_IMPORTED 使 OpenCV 头不走 -isystem，-Wpedantic -Werror 下会报错
+    target_compile_options(MaaCore PRIVATE -Wno-c11-extensions)
 else()
     target_link_libraries(MaaCore HeaderOnlyLibraries MaaUtils ${OpenCV_LIBS} fastdeploy_ppocr ONNXRuntime::ONNXRuntime ZLIB::ZLIB Boost::system)
 endif()


### PR DESCRIPTION
Fixes the Android (x64/arm64) build failures in #17391 (run 29929900409).

## Root cause

- MaaDeps v2.14.1 (MaaDeps#44) bumped vcpkg to 2025.12.12, which upgraded opencv4 from 4.11.0 to 4.12.0.
- OpenCV 4.12 removed `!defined __ANDROID__` from the clang branch of `CV_XADD` in `cvdef.h`, so Android clang now expands it to `__c11_atomic_fetch_add((_Atomic(int)*)...)`. `_Atomic` is a C11 extension in C++ mode.
- MaaCore builds with `-Wpedantic -Werror`, and the Android branch sets `NO_SYSTEM_FROM_IMPORTED TRUE`, so OpenCV headers are included via `-I` instead of `-isystem` and their warnings are promoted to errors. Other platforms are unaffected (MSVC takes the `_InterlockedExchangeAdd` branch; elsewhere imported-target headers stay `-isystem`).

## Fix

Add `-Wno-c11-extensions` to MaaCore on Android only. The NDK clang fully supports `__c11_atomic_fetch_add`; the warning is purely a pedantic language-compat note.

## Summary by Sourcery

放宽 Android 平台上 MaaCore 的严格警告处理，以支持在 OpenCV 4.12 上进行构建。

Bug 修复：
- 解决在使用 `-Wpedantic -Werror` 编译时，由于 OpenCV 4.12 头文件中的 C11 扩展警告导致的 Android MaaCore 构建失败问题。

构建：
- 在 MaaCore 的 Android 构建中添加 `-Wno-c11-extensions`，以屏蔽来自 OpenCV 的严格 C11 扩展警告。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Relax pedantic warning handling for MaaCore on Android to allow building against OpenCV 4.12.

Bug Fixes:
- Resolve Android MaaCore build failures caused by C11 extension warnings in OpenCV 4.12 headers when compiled with -Wpedantic -Werror.

Build:
- Add -Wno-c11-extensions to MaaCore Android builds to suppress pedantic C11 extension warnings from OpenCV.

</details>