### PR TITLE
fix: suppress -Wc11-extensions for OpenCV 4.12 CV_XADD on Android

### DIFF
--- a/src/MaaCore/CMakeLists.txt
+++ b/src/MaaCore/CMakeLists.txt
@@ -41,6 +41,7 @@ if(ANDROID)
         polyclipping::polyclipping
         ONNXRuntime::ONNXRuntime ZLIB::ZLIB Boost::system)
     set_property(TARGET MaaCore PROPERTY NO_SYSTEM_FROM_IMPORTED TRUE)
+    target_compile_options(MaaCore PRIVATE -Wno-c11-extensions)
 else()
     target_link_libraries(MaaCore HeaderOnlyLibraries MaaUtils ${OpenCV_LIBS} fastdeploy_ppocr ONNXRuntime::ONNXRuntime ZLIB::ZLIB Boost::system)
 endif()


### PR DESCRIPTION
OpenCV 4.12 (MaaDeps v2.14.1) 的 `CV_XADD` 在 Android clang 上展开为 `_Atomic`（C11 扩展），在 `-Wpedantic -Werror` 下编译失败。为 Android 添加 `-Wno-c11-extensions` 修复 #17391 的 Android CI。

## Summary by Sourcery

Build:
- 在 MaaCore 的 Android 目标中添加 `-Wno-c11-extensions`，以在使用 clang 时屏蔽来自 OpenCV 的 C11 扩展警告。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Build:
- Add -Wno-c11-extensions to MaaCore Android target to suppress C11 extension warnings from OpenCV on clang.

</details>