### PR TITLE
feat: 自动战斗自动编队使用干员识别结果预匹配

### DIFF
--- a/src/MaaCore/Task/Interface/CopilotTask.cpp
+++ b/src/MaaCore/Task/Interface/CopilotTask.cpp
@@ -254,6 +254,11 @@ std::vector<asst::OperBoxInfo> asst::CopilotTask::parse_operbox_data(const std::
     for (auto& item : own_opers) {
         OperBoxInfo info;
         info.id = item.get("id", std::string());
+        if (BattleData.find_oper_by_id(info.id) == nullptr) {
+            Log.error("OperBox data contains invalid oper id:", info.id);
+            result.clear();
+            break;
+        }
         info.name = item.get("name", std::string());
         info.elite = item.get("elite", 0);
         info.level = item.get("level", 0);

--- a/src/MaaCore/Task/Interface/CopilotTask.cpp
+++ b/src/MaaCore/Task/Interface/CopilotTask.cpp
@@ -73,6 +73,8 @@ bool asst::CopilotTask::set_params(const json::value& params)
     auto support_unit_usage = static_cast<SupportUnitUsage>(
         params.get("support_unit_usage", static_cast<int>(SupportUnitUsage::None))); // 助战干员使用模式
     std::string support_unit_name = params.get("support_unit_name", std::string());
+    bool operbox_assist = params.get("operbox_assist", false);                       // 是否启用已有干员辅助编队
+    std::string operbox_data_path = params.get("operbox_data_path", std::string());  // 已有干员辅助编队数据路径
 
     auto filename_opt = params.find<std::string>("filename");
     auto multi_tasks_opt = params.find<json::array>("copilot_list"); // 多任务列表
@@ -153,6 +155,8 @@ bool asst::CopilotTask::set_params(const json::value& params)
     m_formation_task_ptr->set_ignore_requirements(ignore_requirements);
     m_formation_task_ptr->set_support_unit_usage(support_unit_usage);
     m_formation_task_ptr->set_specific_support_unit(support_unit_name);
+    m_formation_task_ptr->set_operbox_assist_enabled(operbox_assist);
+    m_formation_task_ptr->set_operbox_assist_path(operbox_data_path);
 
     if (auto opt = params.find<json::array>("user_additional"); with_formation && add_user_additional && opt) {
         std::vector<std::pair<std::string, int>> user_additional;

--- a/src/MaaCore/Task/Interface/CopilotTask.cpp
+++ b/src/MaaCore/Task/Interface/CopilotTask.cpp
@@ -2,6 +2,7 @@
 
 #include "Arknights-Tile-Pos/TileCalc2.hpp"
 
+#include "Common/AsstBattleDef.h"
 #include "Config/Miscellaneous/BattleDataConfig.h"
 #include "Config/Miscellaneous/CopilotConfig.h"
 #include "Config/TaskData.h"
@@ -10,6 +11,7 @@
 #include "Task/Miscellaneous/BattleProcessTask.h"
 #include "Task/Miscellaneous/MultiCopilotTaskPlugin.h"
 #include "Task/ProcessTask.h"
+#include "Utils/BipartiteMatch.hpp"
 #include "Utils/Logger.hpp"
 #include "Utils/Platform.hpp"
 
@@ -23,6 +25,7 @@ asst::CopilotTask::CopilotTask(const AsstCallback& callback, Assistant* inst) :
     LogTraceFunction;
 
     m_multi_copilot_plugin_ptr->set_retry_times(0);
+    m_multi_copilot_plugin_ptr->set_formation_task_ptr(m_formation_task_ptr);
     m_multi_copilot_plugin_ptr->set_battle_task_ptr(m_battle_task_ptr);
     m_subtasks.emplace_back(m_multi_copilot_plugin_ptr);
 
@@ -74,6 +77,18 @@ bool asst::CopilotTask::set_params(const json::value& params)
         params.get("support_unit_usage", static_cast<int>(SupportUnitUsage::None))); // 助战干员使用模式
     std::string support_unit_name = params.get("support_unit_name", std::string());
     std::string operbox_data_path = params.get("operbox_data_path", std::string());  // 干员辅助编队数据路径, 为空则禁用
+    std::optional<std::vector<OperBoxInfo>> operbox_data = std::nullopt;
+
+    if (!operbox_data_path.empty()) {
+        operbox_data = parse_operbox_data(operbox_data_path);
+        if (operbox_data->empty()) {
+            LogError << __FUNCTION__ << "| OperBox data is empty, cannot perform precheck";
+            json::value info = basic_info_with_what("OperboxDataParseFailed");
+            callback(AsstMsg::SubTaskError, info);
+            return false;
+        }
+        std::sort(operbox_data->begin(), operbox_data->end(), OperBoxInfo::SortCmp {});
+    }
 
     auto filename_opt = params.find<std::string>("filename");
     auto multi_tasks_opt = params.find<json::array>("copilot_list"); // 多任务列表
@@ -89,6 +104,19 @@ bool asst::CopilotTask::set_params(const json::value& params)
         if (!copilot_opt) {
             return false;
         }
+        if (operbox_data.has_value()) {
+            const auto& assignment_opt = operbox_precheck(
+                *operbox_data,
+                Copilot.get_data().groups,
+                support_unit_usage != SupportUnitUsage::None);
+            if (!assignment_opt) {
+                return false;
+            }
+            m_formation_task_ptr->set_assigned_groups(std::move(assignment_opt));
+        }
+        else {
+            m_formation_task_ptr->set_assigned_groups(std::nullopt);
+        }
         m_stage_name = Copilot.get_stage_name();
         if (!m_battle_task_ptr->set_stage_name(m_stage_name)) {
             Log.error("Not support stage");
@@ -100,11 +128,29 @@ bool asst::CopilotTask::set_params(const json::value& params)
         m_battle_task_ptr->set_wait_until_end(true);
         auto configs = static_cast<std::vector<MultiCopilotConfig>>(*multi_tasks_opt);
         std::vector<MultiCopilotTaskPlugin::MultiCopilotConfig> configs_cvt;
+        std::unordered_map<std::string, std::shared_ptr<battle::copilot::OperUsageGroups>> operbox_assignments;
         for (const auto& [id, filename, nav_name, is_raid] : configs) {
             MultiCopilotTaskPlugin::MultiCopilotConfig config_cvt;
             auto copilot_opt = parse_copilot_filename(filename);
             if (!copilot_opt) {
                 return false;
+            }
+            config_cvt.assigned_groups = nullptr;
+            if (operbox_data.has_value()) {
+                if (operbox_assignments.find(filename) != operbox_assignments.end()) {
+                    config_cvt.assigned_groups = operbox_assignments[filename];
+                }
+                else {
+                    const auto& assignment_opt = operbox_precheck(
+                        *operbox_data,
+                        Copilot.get_data().groups,
+                        support_unit_usage != SupportUnitUsage::None);
+                    if (!assignment_opt) {
+                        return false;
+                    }
+                    config_cvt.assigned_groups = std::make_shared<OperUsageGroups>(std::move(assignment_opt.value()));
+                    operbox_assignments[filename] = config_cvt.assigned_groups;
+                }
             }
             const auto& stage_name = Copilot.get_stage_name();
             const auto& map_data = Tile.find(stage_name);
@@ -154,21 +200,6 @@ bool asst::CopilotTask::set_params(const json::value& params)
     m_formation_task_ptr->set_ignore_requirements(ignore_requirements);
     m_formation_task_ptr->set_support_unit_usage(support_unit_usage);
     m_formation_task_ptr->set_specific_support_unit(support_unit_name);
-    if (operbox_data_path.empty()) {
-        m_formation_task_ptr->set_operbox_data(std::nullopt);
-    }
-    else {
-        std::vector<OperBoxInfo> operbox_data;
-        operbox_data = parse_operbox_data(operbox_data_path);
-        if (operbox_data.empty()) {
-            LogError << __FUNCTION__ << "| OperBox data is empty, cannot perform precheck";
-            json::value info = basic_info_with_what("OperboxDataParseFailed");
-            callback(AsstMsg::SubTaskError, info);
-            return false;
-        }
-        std::sort(operbox_data.begin(), operbox_data.end(), OperBoxInfo::SortCmp {});
-        m_formation_task_ptr->set_operbox_data(std::move(operbox_data));
-    }
 
     if (auto opt = params.find<json::array>("user_additional"); with_formation && add_user_additional && opt) {
         std::vector<std::pair<std::string, int>> user_additional;
@@ -262,4 +293,214 @@ std::vector<asst::OperBoxInfo> asst::CopilotTask::parse_operbox_data(const std::
     }
 
     return result;
+}
+
+using asst::battle::copilot::OperUsageGroups;
+
+std::optional<OperUsageGroups> asst::CopilotTask::operbox_precheck(
+    const std::vector<OperBoxInfo>& operbox_data,
+    const OperUsageGroups& formation,
+    bool use_support_unit)
+{
+    LogTraceFunction;
+    using asst::battle::copilot::OperUsageGroup;
+    OperUsageGroups groups = formation;
+    if (groups.empty()) {
+        return groups;
+    }
+
+    auto can_match = [](const OperUsageGroup& group, const OperBoxInfo& info) { // 目前只考虑忽略干员练度情况
+        if (!info.own || info.id.empty()) {
+            return false;
+        }
+        auto it = std::ranges::find_if(group.opers, [&](const battle::OperUsage& op) {
+            // !!! 要用干员的 id 而不是 name，干员识别的 name 可能不是中文
+            if (BattleData.get_id(op.role, op.name) != info.id) {
+                return false;
+            }
+            if (op.requirements.elite <= 0 && op.requirements.level <= 0) {
+                return true;
+            }
+            return info.elite >= op.requirements.elite;
+        });
+        return it != group.opers.end();
+    };
+
+    // 使用二分图最大权匹配算法，尝试将干员组与可用干员进行匹配
+    auto result =
+        algorithm::bipartite::bipartite_max_match<OperUsageGroup, OperBoxInfo>(groups, operbox_data, can_match);
+
+    LogInfo << __FUNCTION__ << "| matched" << result.matched.size() << "groups, unmatched"
+            << result.unmatched_left.size() << "groups";
+
+    // 匹配的干员组
+    std::unordered_map<std::string, std::string> assigned;
+    {
+        json::array matched_groups;
+        for (const auto& [left, right] : result.matched) {
+            assigned[groups[left].name] = operbox_data[right].id;
+            std::string oper_name = BattleData.find_oper_by_id(operbox_data[right].id)->name;
+            auto req_it = std::ranges::find_if(groups[left].opers, [&](const battle::OperUsage& op) {
+                return BattleData.get_id(op.role, op.name) == operbox_data[right].id;
+            });
+            LogInfo << __FUNCTION__ << "| Matched group:" << groups[left].name << "with oper:" << oper_name
+                    << ". Usage elite:" << req_it->requirements.elite << ", level:" << req_it->requirements.level
+                    << ", skill:" << req_it->skill << ". Operbox elite:" << operbox_data[right].elite
+                    << ", level:" << operbox_data[right].level;
+            matched_groups.emplace_back(
+                std::unordered_map<std::string, std::string> { { "group_name", groups[left].name },
+                                                               { "oper_name", oper_name } });
+        }
+        if (!matched_groups.empty()) {
+            json::value info = basic_info_with_what("BattleFormationOperboxMatched");
+            info["details"]["matched_groups"] = std::move(matched_groups);
+            callback(AsstMsg::SubTaskExtraInfo, info);
+        }
+    }
+
+    // 没有未匹配的干员组
+    if (result.unmatched_left.empty()) {
+        for (const auto& [left, right] : result.matched) {
+            auto req_it = std::ranges::find_if(groups[left].opers, [&](const battle::OperUsage& op) {
+                return BattleData.get_id(op.role, op.name) == operbox_data[right].id;
+            });
+            groups[left].opers = { *req_it }; // 只保留匹配的干员
+        }
+        return groups;
+    }
+
+    // 只有一个未匹配的干员组
+    if (result.unmatched_left.size() == 1) {
+        std::string unmatched_group_name = groups[result.unmatched_left[0]].name;
+        if (!use_support_unit) {
+            json::value info = basic_info_with_what("BattleFormationOperbox1Unmatched");
+            info["details"]["group_name"] = unmatched_group_name;
+            callback(AsstMsg::SubTaskExtraInfo, info);
+            return std::nullopt;
+        }
+
+        // 枚举作业中所有干员，尝试借助战
+        // 不能改图结构，因为可能你有一个精1的干员，但作业1个组要求精1的干员，另1个要求精2的同名干员，借助战的干员可能是精2的，网络流做不了
+        // 不知道这么写效率够不够，应该是常数很小的O(n^4)，可能跟O(n^3)的差不多
+        std::unordered_set<std::string> candidate_ids;
+        for (const auto& group : groups) {
+            for (const auto& op : group.opers) {
+                auto id = BattleData.get_id(op.role, op.name);
+                if (!id.empty()) {
+                    candidate_ids.insert(id);
+                }
+            }
+        }
+
+        auto try_borrow = [&](const std::string& borrow_id) -> bool {
+            auto cur_data = operbox_data;
+            std::erase_if(cur_data, [&](const OperBoxInfo& o) { return o.id == borrow_id; });
+            OperBoxInfo fake_oper {};
+            fake_oper.id = borrow_id;
+            auto oper_ptr = BattleData.find_oper_by_id(borrow_id);
+            fake_oper.name = oper_ptr->name;
+            fake_oper.rarity = oper_ptr->rarity;
+            fake_oper.elite = (fake_oper.rarity >= 3) + (fake_oper.rarity >= 4); // magic: 满练
+            fake_oper.level = 30 + (fake_oper.elite * 25) + (fake_oper.rarity > 3) * 10 * (fake_oper.rarity - 5);
+            fake_oper.potential = 6;
+            fake_oper.own = true;
+            auto insert_pos = std::ranges::lower_bound(cur_data, fake_oper, OperBoxInfo::SortCmp {}) - cur_data.begin();
+            cur_data.insert(cur_data.begin() + insert_pos, std::move(fake_oper));
+
+            auto retry =
+                algorithm::bipartite::bipartite_max_match<OperUsageGroup, OperBoxInfo>(groups, cur_data, can_match);
+
+            if (!retry.unmatched_left.empty()) {
+                return false;
+            }
+            std::unordered_map<std::string, std::string> new_assigned;
+            for (const auto& [left, right] : retry.matched) {
+                if (cur_data[right].id == borrow_id) {
+                    LogInfo << __FUNCTION__ << "| borrow" << BattleData.find_oper_by_id(borrow_id)->name << "for"
+                            << groups[left].name;
+                    unmatched_group_name = groups[left].name;
+                    for (auto& oper : groups[left].opers) {
+                        oper.status = battle::OperStatus::Unavailable;
+                    }
+                }
+                else {
+                    new_assigned[groups[left].name] = cur_data[right].id;
+                    auto req_it = std::ranges::find_if(groups[left].opers, [&](const battle::OperUsage& op) {
+                        return BattleData.get_id(op.role, op.name) == cur_data[right].id;
+                    });
+                    groups[left].opers = { *req_it }; // 只保留匹配的干员
+                }
+            }
+            if (assigned != new_assigned) {
+                LogInfo << __FUNCTION__ << "| assigned groups changed after borrow, update:";
+                json::value info = basic_info_with_what("BattleFormationOperboxMatched");
+                json::array assigned_groups;
+                for (const auto& group : groups) {
+                    if (new_assigned.find(group.name) == new_assigned.end()) {
+                        continue;
+                    }
+                    const auto& oper_id = new_assigned[group.name];
+                    auto oper_it =
+                        std::ranges::find_if(operbox_data, [&](const OperBoxInfo& op) { return op.id == oper_id; });
+                    auto req_it = std::ranges::find_if(group.opers, [&](const battle::OperUsage& op) {
+                        return BattleData.get_id(op.role, op.name) == oper_id;
+                    });
+                    LogInfo << __FUNCTION__ << "| Matched group:" << group.name << "with oper:" << oper_it->name
+                            << ". Usage elite:" << req_it->requirements.elite
+                            << ", level:" << req_it->requirements.level << ", skill:" << req_it->skill
+                            << ". Operbox elite:" << oper_it->elite << ", level:" << oper_it->level;
+                    assigned_groups.emplace_back(
+                        std::unordered_map<std::string, std::string> { { "group_name", group.name },
+                                                                       { "oper_name", oper_it->name } });
+                }
+                info["details"]["matched_groups"] = std::move(assigned_groups);
+                callback(AsstMsg::SubTaskExtraInfo, info);
+            }
+            json::value info = basic_info_with_what("BattleFormationOperbox1Unmatched");
+            info["details"]["group_name"] = unmatched_group_name;
+            info["details"]["may_borrow_oper"] = BattleData.find_oper_by_id(borrow_id)->name;
+            callback(AsstMsg::SubTaskExtraInfo, info);
+            return true;
+        };
+
+        auto& unmatched_group = groups[result.unmatched_left[0]];
+        for (const auto& op : unmatched_group.opers) {
+            if (need_exit()) {
+                break;
+            }
+            auto borrow_id = BattleData.get_id(op.role, op.name);
+            if (borrow_id.empty() || !candidate_ids.erase(borrow_id)) {
+                continue;
+            }
+            if (try_borrow(borrow_id)) {
+                return groups;
+            }
+        }
+        for (const auto& borrow_id : candidate_ids) {
+            if (need_exit()) {
+                break;
+            }
+            if (try_borrow(borrow_id)) {
+                return groups;
+            }
+        }
+        json::value info = basic_info_with_what("BattleFormationOperbox1Unmatched");
+        info["details"]["group_name"] = unmatched_group_name;
+        callback(AsstMsg::SubTaskExtraInfo, info);
+        return std::nullopt;
+    }
+
+    // 多个未匹配的干员组
+    {
+        json::array unmatched_groups;
+        LogInfo << __FUNCTION__ << "|" << result.unmatched_left.size() << "slots unmatched, aborting formation";
+        for (size_t idx : result.unmatched_left) {
+            LogInfo << __FUNCTION__ << "| Unmatched slot:" << groups[idx].name;
+            unmatched_groups.emplace_back(groups[idx].name);
+        }
+        json::value info = basic_info_with_what("OperboxMultipleUnmatched");
+        info["details"]["unmatched_groups"] = std::move(unmatched_groups);
+        callback(AsstMsg::SubTaskError, info);
+    }
+    return std::nullopt;
 }

--- a/src/MaaCore/Task/Interface/CopilotTask.cpp
+++ b/src/MaaCore/Task/Interface/CopilotTask.cpp
@@ -163,14 +163,14 @@ bool asst::CopilotTask::set_params(const json::value& params)
         if (!operbox_data_path.empty()) {
             operbox_data = parse_operbox_data(operbox_data_path);
             if (operbox_data.empty()) {
-                Log.error("OperBox data is empty, cannot perform precheck");
+                LogError << __FUNCTION__ << "| OperBox data is empty, cannot perform precheck";
                 json::value info = basic_info_with_what("OperboxDataParseFailed");
                 callback(AsstMsg::SubTaskError, info);
                 return false;
             }
         }
         else {
-            Log.error("CopilotTask set_params failed, operbox_assist is enabled but operbox_data_path is empty");
+            LogError << __FUNCTION__ << "| Operbox_assist is enabled but operbox_data_path is empty";
             return false;
         }
         std::sort(operbox_data.begin(), operbox_data.end(), OperBoxInfo::SortCmp {});
@@ -244,7 +244,7 @@ std::vector<asst::OperBoxInfo> asst::CopilotTask::parse_operbox_data(const std::
     std::vector<OperBoxInfo> result;
     auto json_opt = json::open(utils::path(path), true, true);
     if (!json_opt) {
-        Log.error("Failed to open OperBox data file:", path);
+        LogError << __FUNCTION__ << "| Failed to open OperBox data file:" << path;
         return result;
     }
 
@@ -255,7 +255,7 @@ std::vector<asst::OperBoxInfo> asst::CopilotTask::parse_operbox_data(const std::
         OperBoxInfo info;
         info.id = item.get("id", std::string());
         if (BattleData.find_oper_by_id(info.id) == nullptr) {
-            Log.error("OperBox data contains invalid oper id:", info.id);
+            LogError << __FUNCTION__ << "| OperBox data contains invalid oper id:" << info.id;
             result.clear();
             break;
         }

--- a/src/MaaCore/Task/Interface/CopilotTask.cpp
+++ b/src/MaaCore/Task/Interface/CopilotTask.cpp
@@ -73,8 +73,7 @@ bool asst::CopilotTask::set_params(const json::value& params)
     auto support_unit_usage = static_cast<SupportUnitUsage>(
         params.get("support_unit_usage", static_cast<int>(SupportUnitUsage::None))); // 助战干员使用模式
     std::string support_unit_name = params.get("support_unit_name", std::string());
-    bool operbox_assist = params.get("operbox_assist", false);                       // 是否启用已有干员辅助编队
-    std::string operbox_data_path = params.get("operbox_data_path", std::string());  // 已有干员辅助编队数据路径
+    std::string operbox_data_path = params.get("operbox_data_path", std::string());  // 干员辅助编队数据路径, 为空则禁用
 
     auto filename_opt = params.find<std::string>("filename");
     auto multi_tasks_opt = params.find<json::array>("copilot_list"); // 多任务列表
@@ -155,22 +154,16 @@ bool asst::CopilotTask::set_params(const json::value& params)
     m_formation_task_ptr->set_ignore_requirements(ignore_requirements);
     m_formation_task_ptr->set_support_unit_usage(support_unit_usage);
     m_formation_task_ptr->set_specific_support_unit(support_unit_name);
-    if (!operbox_assist) {
+    if (operbox_data_path.empty()) {
         m_formation_task_ptr->set_operbox_data(std::nullopt);
     }
     else {
         std::vector<OperBoxInfo> operbox_data;
-        if (!operbox_data_path.empty()) {
-            operbox_data = parse_operbox_data(operbox_data_path);
-            if (operbox_data.empty()) {
-                LogError << __FUNCTION__ << "| OperBox data is empty, cannot perform precheck";
-                json::value info = basic_info_with_what("OperboxDataParseFailed");
-                callback(AsstMsg::SubTaskError, info);
-                return false;
-            }
-        }
-        else {
-            LogError << __FUNCTION__ << "| Operbox_assist is enabled but operbox_data_path is empty";
+        operbox_data = parse_operbox_data(operbox_data_path);
+        if (operbox_data.empty()) {
+            LogError << __FUNCTION__ << "| OperBox data is empty, cannot perform precheck";
+            json::value info = basic_info_with_what("OperboxDataParseFailed");
+            callback(AsstMsg::SubTaskError, info);
             return false;
         }
         std::sort(operbox_data.begin(), operbox_data.end(), OperBoxInfo::SortCmp {});

--- a/src/MaaCore/Task/Interface/CopilotTask.cpp
+++ b/src/MaaCore/Task/Interface/CopilotTask.cpp
@@ -155,8 +155,27 @@ bool asst::CopilotTask::set_params(const json::value& params)
     m_formation_task_ptr->set_ignore_requirements(ignore_requirements);
     m_formation_task_ptr->set_support_unit_usage(support_unit_usage);
     m_formation_task_ptr->set_specific_support_unit(support_unit_name);
-    m_formation_task_ptr->set_operbox_assist_enabled(operbox_assist);
-    m_formation_task_ptr->set_operbox_assist_path(operbox_data_path);
+    if (!operbox_assist) {
+        m_formation_task_ptr->set_operbox_data(std::nullopt);
+    }
+    else {
+        std::vector<OperBoxInfo> operbox_data;
+        if (!operbox_data_path.empty()) {
+            operbox_data = parse_operbox_data(operbox_data_path);
+            if (operbox_data.empty()) {
+                Log.error("OperBox data is empty, cannot perform precheck");
+                json::value info = basic_info_with_what("OperboxDataParseFailed");
+                callback(AsstMsg::SubTaskError, info);
+                return false;
+            }
+        }
+        else {
+            Log.error("CopilotTask set_params failed, operbox_assist is enabled but operbox_data_path is empty");
+            return false;
+        }
+        std::sort(operbox_data.begin(), operbox_data.end(), OperBoxInfo::SortCmp {});
+        m_formation_task_ptr->set_operbox_data(std::move(operbox_data));
+    }
 
     if (auto opt = params.find<json::array>("user_additional"); with_formation && add_user_additional && opt) {
         std::vector<std::pair<std::string, int>> user_additional;
@@ -216,4 +235,33 @@ std::optional<std::filesystem::path> asst::CopilotTask::parse_copilot_filename(c
         return std::nullopt;
     }
     return path;
+}
+
+std::vector<asst::OperBoxInfo> asst::CopilotTask::parse_operbox_data(const std::string& path)
+{
+    LogTraceFunction;
+
+    std::vector<OperBoxInfo> result;
+    auto json_opt = json::open(utils::path(path), true, true);
+    if (!json_opt) {
+        Log.error("Failed to open OperBox data file:", path);
+        return result;
+    }
+
+    auto& json_obj = json_opt.value();
+    auto own_opers = json_obj.get("own_opers", json::array());
+
+    for (auto& item : own_opers) {
+        OperBoxInfo info;
+        info.id = item.get("id", std::string());
+        info.name = item.get("name", std::string());
+        info.elite = item.get("elite", 0);
+        info.level = item.get("level", 0);
+        info.potential = item.get("potential", 0);
+        info.rarity = item.get("rarity", 0);
+        info.own = item.get("own", false);
+        result.emplace_back(std::move(info));
+    }
+
+    return result;
 }

--- a/src/MaaCore/Task/Interface/CopilotTask.h
+++ b/src/MaaCore/Task/Interface/CopilotTask.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "Task/InterfaceTask.h"
+#include "Vision/Miscellaneous/OperBoxImageAnalyzer.h"
 
 #include <memory>
 #include <meojson/json.hpp>
@@ -38,6 +39,7 @@ public:
 
 private:
     std::optional<std::filesystem::path> parse_copilot_filename(const std::string& name);
+    std::vector<OperBoxInfo> parse_operbox_data(const std::string& path);
 
     std::shared_ptr<MultiCopilotTaskPlugin> m_multi_copilot_plugin_ptr = nullptr;
     std::shared_ptr<ProcessTask> m_medicine_task_ptr = nullptr;

--- a/src/MaaCore/Task/Interface/CopilotTask.h
+++ b/src/MaaCore/Task/Interface/CopilotTask.h
@@ -40,6 +40,11 @@ public:
 private:
     std::optional<std::filesystem::path> parse_copilot_filename(const std::string& name);
     std::vector<OperBoxInfo> parse_operbox_data(const std::string& path);
+    using OperUsageGroups = asst::battle::copilot::OperUsageGroups;
+    std::optional<OperUsageGroups> operbox_precheck(
+        const std::vector<OperBoxInfo>& operbox_data,
+        const OperUsageGroups& formation,
+        bool use_support_unit);
 
     std::shared_ptr<MultiCopilotTaskPlugin> m_multi_copilot_plugin_ptr = nullptr;
     std::shared_ptr<ProcessTask> m_medicine_task_ptr = nullptr;

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -1098,3 +1098,35 @@ std::optional<std::string> asst::BattleFormationTask::add_support_unit_from_supp
 
     return std::nullopt;
 }
+
+std::vector<asst::OperBoxInfo> asst::BattleFormationTask::parse_operbox_data(const std::string& path)
+{
+    LogTraceFunction;
+
+    std::vector<OperBoxInfo> result;
+    auto json_opt = json::open(path, true, true);
+    if (!json_opt) {
+        Log.error("Failed to open OperBox data file:", path);
+        return result;
+    }
+
+    auto& own_opers = json_opt->get("own_opers");
+    if (!own_opers.is_array()) {
+        Log.error("Missing own_opers array in OperBox data");
+        return result;
+    }
+
+    for (auto& item : own_opers.as_array()) {
+        OperBoxInfo info;
+        info.id = item.get("id", std::string());
+        info.name = item.get("name", std::string());
+        info.elite = item.get("elite", 0);
+        info.level = item.get("level", 0);
+        info.potential = item.get("potential", 0);
+        info.rarity = item.get("rarity", 0);
+        info.own = item.get("own", false);
+        result.emplace_back(std::move(info));
+    }
+
+    return result;
+}

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -640,7 +640,7 @@ bool asst::BattleFormationTask::select_opers_in_cur_page(const std::vector<OperG
         const auto& iter = std::ranges::find_if(groups, [&](OperGroup* group) {
             if (m_operbox_assist_enabled) {
                 if (auto it = m_operbox_assigned.find(group->name);
-                    it != m_operbox_assigned.end() && it->second == res.text) {
+                    it != m_operbox_assigned.end() && it->second == BattleData.get_id(res.text)) {
                     auto sel = std::ranges::find_if(group->opers, is_selectable);
                     if (sel == group->opers.end()) {
                         return false;
@@ -1213,7 +1213,7 @@ bool asst::BattleFormationTask::do_operbox_precheck()
     std::unordered_map<std::string, std::string> assigned;
     json::array matched_groups;
     for (const auto& [left, right] : result.matched) {
-        assigned[flat_groups[left].name] = oper_data[right].name;
+        assigned[flat_groups[left].name] = oper_data[right].id;
         Log.info("  Matched group:", flat_groups[left].name, "with oper:", oper_data[right].name);
         matched_groups.emplace_back(
             std::unordered_map<std::string, std::string> { { "group_name", flat_groups[left].name },
@@ -1273,7 +1273,7 @@ bool asst::BattleFormationTask::do_operbox_precheck()
                         m_operbox_unmatched_group = flat_groups[left].name;
                     }
                     else {
-                        new_assigned[flat_groups[left].name] = cur_data[right].name;
+                        new_assigned[flat_groups[left].name] = cur_data[right].id;
                     }
                 }
                 m_operbox_assigned = std::move(new_assigned);

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -1222,14 +1222,16 @@ bool asst::BattleFormationTask::do_operbox_precheck()
         "groups");
 
     // 匹配的干员组
+    const auto& all_chars = BattleData.get_all_chars();
     std::unordered_map<std::string, std::string> assigned;
     json::array matched_groups;
     for (const auto& [left, right] : result.matched) {
         assigned[flat_groups[left].name] = oper_data[right].id;
-        Log.info("  Matched group:", flat_groups[left].name, "with oper:", oper_data[right].name);
+        std::string oper_name = all_chars.at(oper_data[right].id)->name;
+        Log.info("  Matched group:", flat_groups[left].name, "with oper:", oper_name);
         matched_groups.emplace_back(
             std::unordered_map<std::string, std::string> { { "group_name", flat_groups[left].name },
-                                                           { "oper_name", oper_data[right].name } });
+                                                           { "oper_name", oper_name } });
     }
     if (!matched_groups.empty()) {
         json::value info = basic_info_with_what("BattleFormationOperboxMatched");
@@ -1295,6 +1297,20 @@ bool asst::BattleFormationTask::do_operbox_precheck()
                     else {
                         new_assigned[flat_groups[left].name] = cur_data[right].id;
                     }
+                }
+                if (assigned != new_assigned) {
+                    Log.info("OperBox precheck: assigned changed after borrow, update");
+                    json::value info = basic_info_with_what("BattleFormationOperboxMatched");
+                    json::array assigned_groups;
+                    for (const auto& [group_name, oper_id] : new_assigned) {
+                        std::string oper_name = all_chars.at(oper_id)->name;
+                        Log.info("  Matched group:", group_name, "with oper:", oper_name);
+                        assigned_groups.emplace_back(
+                            std::unordered_map<std::string, std::string> { { "group_name", group_name },
+                                                                           { "oper_name", oper_name } });
+                    }
+                    info["details"]["matched_groups"] = std::move(assigned_groups);
+                    callback(AsstMsg::SubTaskExtraInfo, info);
                 }
                 m_operbox_assigned = std::move(new_assigned);
                 json::value info = basic_info_with_what("BattleFormationOperbox1Unmatched");

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -1233,7 +1233,6 @@ bool asst::BattleFormationTask::do_operbox_precheck()
             }
         }
 
-        const auto& all_chars = BattleData.get_all_chars();
         auto try_borrow = [&](const std::string& borrow_id) -> bool {
             auto cur_data = oper_data;
             std::erase_if(cur_data, [&](const OperBoxInfo& o) { return o.id == borrow_id; });

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -1239,7 +1239,7 @@ bool asst::BattleFormationTask::do_operbox_precheck()
             fake_oper.id = borrow_id;
             fake_oper.name = all_chars.at(borrow_id)->name;
             fake_oper.rarity = all_chars.at(borrow_id)->rarity;
-            fake_oper.elite = fake_oper.rarity / 4 + (fake_oper.rarity > 2); // magic: 满练
+            fake_oper.elite = (fake_oper.rarity >= 3) + (fake_oper.rarity >= 4); // magic: 满练
             fake_oper.level = 30 + (fake_oper.elite * 25) + (fake_oper.rarity > 3) * 10 * (fake_oper.rarity - 5);
             fake_oper.potential = 6;
             fake_oper.own = true;
@@ -1286,6 +1286,9 @@ bool asst::BattleFormationTask::do_operbox_precheck()
 
         auto& unmatched_group = flat_groups[result.unmatched_left[0]];
         for (const auto& op : unmatched_group.opers) {
+            if (need_exit()) {
+                break;
+            }
             auto borrow_id = BattleData.get_id(op.name);
             if (borrow_id.empty() || !candidate_ids.erase(borrow_id)) {
                 continue;
@@ -1295,6 +1298,9 @@ bool asst::BattleFormationTask::do_operbox_precheck()
             }
         }
         for (const auto& borrow_id : candidate_ids) {
+            if (need_exit()) {
+                break;
+            }
             if (try_borrow(borrow_id)) {
                 return true;
             }

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -1171,26 +1171,24 @@ bool asst::BattleFormationTask::do_operbox_precheck()
         return true;
     }
 
-    // 使用二分图最大权匹配算法，尝试将干员组与可用干员进行匹配
-    auto result = algorithm::bipartite::bipartite_max_match<OperGroup, OperBoxInfo>(
-        flat_groups,
-        oper_data,
-        [](const OperGroup& group, const OperBoxInfo& info) {
-            if (!info.own || info.id.empty()) {
+    auto can_match = [](const OperGroup& group, const OperBoxInfo& info) {
+        if (!info.own || info.id.empty()) {
+            return false;
+        }
+        auto it = std::ranges::find_if(group.second, [&](const battle::OperUsage& op) {
+            if (BattleData.get_id(op.name) != info.id) { // ! 用的是干员的 id 而不是 name，干员识别的 name 可能不是中文
                 return false;
             }
-            auto it = std::ranges::find_if(group.second, [&](const battle::OperUsage& op) {
-                if (BattleData.get_id(op.name) !=
-                    info.id) { // ! 用的是干员的 id 而不是 name，干员识别的 name 可能不是中文
-                    return false;
-                }
-                if (op.requirements.elite <= 0 && op.requirements.level <= 0) {
-                    return true;
-                }
-                return info.elite >= op.requirements.elite;
-            });
-            return it != group.second.end();
+            if (op.requirements.elite <= 0 && op.requirements.level <= 0) {
+                return true;
+            }
+            return info.elite >= op.requirements.elite;
         });
+        return it != group.second.end();
+    };
+
+    // 使用二分图最大权匹配算法，尝试将干员组与可用干员进行匹配
+    auto result = algorithm::bipartite::bipartite_max_match<OperGroup, OperBoxInfo>(flat_groups, oper_data, can_match);
 
     Log.info(
         "OperBox precheck: matched",
@@ -1224,16 +1222,57 @@ bool asst::BattleFormationTask::do_operbox_precheck()
 
     // 只有一个未匹配的干员组
     if (result.unmatched_left.size() == 1) {
-        m_operbox_assigned = std::move(assigned);
         m_operbox_unmatched_group = flat_groups[result.unmatched_left[0]].first;
-        Log.info("OperBox precheck: ", m_operbox_unmatched_group, " unmatched, need support unit");
+        if (m_support_unit_usage == SupportUnitUsage::None) {
+            json::value info = basic_info_with_what("BattleFormationOperbox1Unmatched");
+            info["details"]["group_name"] = m_operbox_unmatched_group;
+            callback(AsstMsg::SubTaskExtraInfo, info);
+            return false;
+        }
+
+        // 枚举作业中所有候选的未拥有干员，尝试借助战
+        // 不能改图结构，因为可能你有一个精1的干员，但作业1个组要求精1的干员，另1个要求精2的同名干员，借战的干员可能是精2的，网络流做不了
+        // 不知道这么写效率够不够，应该是常数很小的O(n^4)，可能跟O(n^3)的差不多
+        std::unordered_set<std::string> candidate_ids;
+        for (const auto& group : flat_groups) {
+            for (const auto& op : group.second) {
+                candidate_ids.insert(BattleData.get_id(op.name));
+            }
+        }
+
+        for (const auto& borrow_id : candidate_ids) {
+            auto cur_data = oper_data;
+            std::erase_if(cur_data, [&](const OperBoxInfo& o) { return o.id == borrow_id; });
+            auto fake_idx = cur_data.size();
+            cur_data.push_back(
+                { .id = borrow_id, .elite = 2, .own = true }); // 借助战干员，精英化等级设为2，保证能匹配上
+
+            auto retry =
+                algorithm::bipartite::bipartite_max_match<OperGroup, OperBoxInfo>(flat_groups, cur_data, can_match);
+
+            if (retry.unmatched_left.empty()) {
+                std::unordered_map<std::string, std::string> new_assigned;
+                for (const auto& [left, right] : retry.matched) {
+                    if (right == fake_idx) {
+                        Log.info("OperBox precheck: borrow", borrow_id, "for", flat_groups[left].first);
+                        m_operbox_unmatched_group = flat_groups[left].first;
+                    }
+                    else {
+                        new_assigned[flat_groups[left].first] = cur_data[right].name;
+                    }
+                }
+                m_operbox_assigned = std::move(new_assigned);
+                json::value info = basic_info_with_what("BattleFormationOperbox1Unmatched");
+                info["details"]["group_name"] = m_operbox_unmatched_group;
+                info["details"]["may_borrow_oper"] = BattleData.get_all_chars().at(borrow_id)->name;
+                callback(AsstMsg::SubTaskExtraInfo, info);
+                return true;
+            }
+        }
         json::value info = basic_info_with_what("BattleFormationOperbox1Unmatched");
         info["details"]["group_name"] = m_operbox_unmatched_group;
         callback(AsstMsg::SubTaskExtraInfo, info);
-        if (m_support_unit_usage == SupportUnitUsage::None) {
-            return false; // 如果不允许使用助战干员，则直接返回失败
-        }
-        return true;
+        return false;
     }
 
     // 多个未匹配的干员组

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -236,6 +236,16 @@ void asst::BattleFormationTask::formation_with_last_opers()
         const battle::OperNameTag& oper_tag = it->first;
         const std::string& group_name = it->second;
 
+        if (m_operbox_assist_enabled) {
+            // compare_formation 后剩下的是完全相同的干员组, 但是可能预匹配结果不同
+            auto pre_assigned_it = m_operbox_assigned.find(group_name);
+            if (pre_assigned_it == m_operbox_assigned.end() ||
+                pre_assigned_it->second != BattleData.get_id(oper_name)) {
+                ++it;
+                continue; // 该干员不是这次预匹配的干员, 跳过
+            }
+        }
+
         const auto& oper_in_page_it = std::ranges::find_if(opers_result, [&](const QuickFormationOper& op) {
             return !op.is_selected && op.role == oper_tag.role && op.text == oper_tag.name;
         }); // 编队页中的干员

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -1173,38 +1173,7 @@ bool asst::BattleFormationTask::do_operbox_precheck()
         return false;
     }
 
-    std::sort(oper_data.begin(), oper_data.end(), [](const OperBoxInfo& a, const OperBoxInfo& b) {
-        if (a.elite != b.elite) {
-            return a.elite > b.elite;
-        }
-        if (a.level != b.level) {
-            return a.level > b.level;
-        }
-        if (a.rarity != b.rarity) {
-            return a.rarity > b.rarity;
-        }
-        if (a.potential != b.potential) {
-            return a.potential > b.potential;
-        }
-        auto get_id_num = [](const std::string& id) {
-            auto first_underscore = id.find('_');
-            if (first_underscore == std::string::npos) {
-                return 0;
-            }
-            auto second_underscore = id.find('_', first_underscore + 1);
-            if (second_underscore == std::string::npos) {
-                return 0;
-            }
-            std::string num_str = id.substr(first_underscore + 1, second_underscore - first_underscore - 1);
-            try {
-                return std::stoi(num_str);
-            }
-            catch (...) {
-                return 0;
-            }
-        };
-        return get_id_num(a.id) > get_id_num(b.id);
-    });
+    std::sort(oper_data.begin(), oper_data.end(), OperBoxInfo::SortCmp {});
 
     std::vector<OperGroup> flat_groups;
     for (const auto& [role, oper_groups] : m_formation) {
@@ -1301,7 +1270,8 @@ bool asst::BattleFormationTask::do_operbox_precheck()
             fake_oper.level = 30 + (fake_oper.elite * 25) + (fake_oper.rarity > 3) * 10 * (fake_oper.rarity - 5);
             fake_oper.potential = 6;
             fake_oper.own = true;
-            cur_data.push_back(std::move(fake_oper));
+            auto insert_pos = std::ranges::lower_bound(cur_data, fake_oper, OperBoxInfo::SortCmp {}) - cur_data.begin();
+            cur_data.insert(cur_data.begin() + insert_pos, std::move(fake_oper));
 
             auto retry =
                 algorithm::bipartite::bipartite_max_match<OperGroup, OperBoxInfo>(flat_groups, cur_data, can_match);

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -725,7 +725,7 @@ bool asst::BattleFormationTask::select_opers_in_cur_page(const std::vector<OperG
             sleep(delay);
         }
         oper->status = battle::OperStatus::Selected;
-        m_opers_in_formation->emplace(battle::OperNameTag { oper->role, oper->name }, (*iter)->name);
+        m_opers_in_formation->emplace(battle::OperNameTag { res.role, res.text }, (*iter)->name);
         json::value info = basic_info_with_what("BattleFormationSelected");
         auto& details = info["details"];
         details["selected"] = oper->name;

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -11,7 +11,6 @@
 #include "Controller/Controller.h"
 #include "MaaUtils/ImageIo.h"
 #include "Task/ProcessTask.h"
-#include "Utils/BipartiteMatch.hpp"
 #include "Utils/Logger.hpp"
 #include "Vision/Matcher.h"
 #include "Vision/Miscellaneous/OperNameAnalyzer.h"
@@ -60,9 +59,6 @@ bool asst::BattleFormationTask::_run()
 
     m_used_support_unit = false;
     if (!parse_formation()) {
-        return false;
-    }
-    if (!do_operbox_precheck()) {
         return false;
     }
     if (compare_formation()) { // 与上一个作业的编队进行对比，相同则跳过
@@ -856,6 +852,9 @@ bool asst::BattleFormationTask::parse_formation()
     if (m_data_resource == DataResource::SSSCopilot) {
         groups = &SSSCopilot.get_data().groups;
     }
+    if (m_assigned_groups) {
+        groups = &m_assigned_groups.value();
+    }
 
     std::swap(m_formation, m_formation_last);
     m_formation.clear();
@@ -1102,219 +1101,4 @@ std::optional<std::string> asst::BattleFormationTask::add_support_unit_from_supp
     }
 
     return std::nullopt;
-}
-
-bool asst::BattleFormationTask::do_operbox_precheck()
-{
-    LogTraceFunction;
-
-    if (!is_operbox_for_assignment()) {
-        return true;
-    }
-    const auto& oper_data = *m_operbox_data;
-
-    std::vector<OperGroup*> flat_groups;
-    for (auto& [role, oper_groups] : m_formation) {
-        for (auto& group : oper_groups) {
-            flat_groups.emplace_back(&group);
-        }
-    }
-    if (flat_groups.empty()) {
-        return true;
-    }
-
-    auto can_match = [](OperGroup* group, const OperBoxInfo& info) { // 目前只考虑忽略干员练度情况
-        if (!info.own || info.id.empty()) {
-            return false;
-        }
-        auto it = std::ranges::find_if(group->opers, [&](const battle::OperUsage& op) {
-            // !!! 要用干员的 id 而不是 name，干员识别的 name 可能不是中文
-            if (BattleData.get_id(op.role, op.name) != info.id) {
-                return false;
-            }
-            if (op.requirements.elite <= 0 && op.requirements.level <= 0) {
-                return true;
-            }
-            return info.elite >= op.requirements.elite;
-        });
-        return it != group->opers.end();
-    };
-
-    // 使用二分图最大权匹配算法，尝试将干员组与可用干员进行匹配
-    auto result = algorithm::bipartite::bipartite_max_match<OperGroup*, OperBoxInfo>(flat_groups, oper_data, can_match);
-
-    LogInfo << __FUNCTION__ << "| matched" << result.matched.size() << "groups, unmatched"
-            << result.unmatched_left.size() << "groups";
-
-    // 匹配的干员组
-    std::unordered_map<std::string, std::string> assigned;
-    json::array matched_groups;
-    for (const auto& [left, right] : result.matched) {
-        assigned[flat_groups[left]->name] = oper_data[right].id;
-        std::string oper_name = BattleData.find_oper_by_id(oper_data[right].id)->name;
-        auto req_it = std::ranges::find_if(flat_groups[left]->opers, [&](const battle::OperUsage& op) {
-            return BattleData.get_id(op.role, op.name) == oper_data[right].id;
-        });
-        LogInfo << __FUNCTION__ << "| Matched group:" << flat_groups[left]->name << "with oper:" << oper_name
-                << ". Usage elite:" << req_it->requirements.elite << ", level:" << req_it->requirements.level
-                << ", skill:" << req_it->skill << ". Operbox elite:" << oper_data[right].elite
-                << ", level:" << oper_data[right].level;
-        matched_groups.emplace_back(
-            std::unordered_map<std::string, std::string> { { "group_name", flat_groups[left]->name },
-                                                           { "oper_name", oper_name } });
-    }
-    if (!matched_groups.empty()) {
-        json::value info = basic_info_with_what("BattleFormationOperboxMatched");
-        info["details"]["matched_groups"] = std::move(matched_groups);
-        callback(AsstMsg::SubTaskExtraInfo, info);
-    }
-
-    // 没有未匹配的干员组
-    if (result.unmatched_left.empty()) {
-        for (const auto& [left, right] : result.matched) {
-            auto req_it = std::ranges::find_if(flat_groups[left]->opers, [&](const battle::OperUsage& op) {
-                return BattleData.get_id(op.role, op.name) == oper_data[right].id;
-            });
-            flat_groups[left]->opers = { *req_it }; // 只保留匹配的干员
-        }
-        return true;
-    }
-
-    // 只有一个未匹配的干员组
-    std::string unmatched_group_name;
-    if (result.unmatched_left.size() == 1) {
-        unmatched_group_name = flat_groups[result.unmatched_left[0]]->name;
-        if (m_support_unit_usage == SupportUnitUsage::None) {
-            json::value info = basic_info_with_what("BattleFormationOperbox1Unmatched");
-            info["details"]["group_name"] = unmatched_group_name;
-            callback(AsstMsg::SubTaskExtraInfo, info);
-            return false;
-        }
-
-        // 枚举作业中所有干员，尝试借助战
-        // 不能改图结构，因为可能你有一个精1的干员，但作业1个组要求精1的干员，另1个要求精2的同名干员，借助战的干员可能是精2的，网络流做不了
-        // 不知道这么写效率够不够，应该是常数很小的O(n^4)，可能跟O(n^3)的差不多
-        std::unordered_set<std::string> candidate_ids;
-        for (const auto& group : flat_groups) {
-            for (const auto& op : group->opers) {
-                auto id = BattleData.get_id(op.role, op.name);
-                if (!id.empty()) {
-                    candidate_ids.insert(id);
-                }
-            }
-        }
-
-        auto try_borrow = [&](const std::string& borrow_id) -> bool {
-            auto cur_data = oper_data;
-            std::erase_if(cur_data, [&](const OperBoxInfo& o) { return o.id == borrow_id; });
-            OperBoxInfo fake_oper {};
-            fake_oper.id = borrow_id;
-            auto oper_ptr = BattleData.find_oper_by_id(borrow_id);
-            fake_oper.name = oper_ptr->name;
-            fake_oper.rarity = oper_ptr->rarity;
-            fake_oper.elite = (fake_oper.rarity >= 3) + (fake_oper.rarity >= 4); // magic: 满练
-            fake_oper.level = 30 + (fake_oper.elite * 25) + (fake_oper.rarity > 3) * 10 * (fake_oper.rarity - 5);
-            fake_oper.potential = 6;
-            fake_oper.own = true;
-            auto insert_pos = std::ranges::lower_bound(cur_data, fake_oper, OperBoxInfo::SortCmp {}) - cur_data.begin();
-            cur_data.insert(cur_data.begin() + insert_pos, std::move(fake_oper));
-
-            auto retry =
-                algorithm::bipartite::bipartite_max_match<OperGroup*, OperBoxInfo>(flat_groups, cur_data, can_match);
-
-            if (!retry.unmatched_left.empty()) {
-                return false;
-            }
-            std::unordered_map<std::string, std::string> new_assigned;
-            for (const auto& [left, right] : retry.matched) {
-                if (cur_data[right].id == borrow_id) {
-                    LogInfo << __FUNCTION__ << "| borrow" << BattleData.find_oper_by_id(borrow_id)->name << "for"
-                            << flat_groups[left]->name;
-                    unmatched_group_name = flat_groups[left]->name;
-                    for (auto& oper : flat_groups[left]->opers) {
-                        oper.status = battle::OperStatus::Unavailable;
-                    }
-                }
-                else {
-                    new_assigned[flat_groups[left]->name] = cur_data[right].id;
-                    auto req_it = std::ranges::find_if(flat_groups[left]->opers, [&](const battle::OperUsage& op) {
-                        return BattleData.get_id(op.role, op.name) == cur_data[right].id;
-                    });
-                    flat_groups[left]->opers = { *req_it }; // 只保留匹配的干员
-                }
-            }
-            if (assigned != new_assigned) {
-                LogInfo << __FUNCTION__ << "| assigned groups changed after borrow, update:";
-                json::value info = basic_info_with_what("BattleFormationOperboxMatched");
-                json::array assigned_groups;
-                for (const auto& group : flat_groups) {
-                    if (new_assigned.find(group->name) == new_assigned.end()) {
-                        continue;
-                    }
-                    const auto& oper_id = new_assigned[group->name];
-                    auto oper_it =
-                        std::ranges::find_if(oper_data, [&](const OperBoxInfo& op) { return op.id == oper_id; });
-                    auto req_it = std::ranges::find_if(group->opers, [&](const battle::OperUsage& op) {
-                        return BattleData.get_id(op.role, op.name) == oper_id;
-                    });
-                    LogInfo << __FUNCTION__ << "| Matched group:" << group->name << "with oper:" << oper_it->name
-                            << ". Usage elite:" << req_it->requirements.elite
-                            << ", level:" << req_it->requirements.level << ", skill:" << req_it->skill
-                            << ". Operbox elite:" << oper_it->elite << ", level:" << oper_it->level;
-                    assigned_groups.emplace_back(
-                        std::unordered_map<std::string, std::string> { { "group_name", group->name },
-                                                                       { "oper_name", oper_it->name } });
-                }
-                info["details"]["matched_groups"] = std::move(assigned_groups);
-                callback(AsstMsg::SubTaskExtraInfo, info);
-            }
-            json::value info = basic_info_with_what("BattleFormationOperbox1Unmatched");
-            info["details"]["group_name"] = unmatched_group_name;
-            info["details"]["may_borrow_oper"] = BattleData.find_oper_by_id(borrow_id)->name;
-            callback(AsstMsg::SubTaskExtraInfo, info);
-            return true;
-        };
-
-        auto& unmatched_group = flat_groups[result.unmatched_left[0]];
-        for (const auto& op : unmatched_group->opers) {
-            if (need_exit()) {
-                break;
-            }
-            auto borrow_id = BattleData.get_id(op.role, op.name);
-            if (borrow_id.empty() || !candidate_ids.erase(borrow_id)) {
-                continue;
-            }
-            if (try_borrow(borrow_id)) {
-                return true;
-            }
-        }
-        for (const auto& borrow_id : candidate_ids) {
-            if (need_exit()) {
-                break;
-            }
-            if (try_borrow(borrow_id)) {
-                return true;
-            }
-        }
-        json::value info = basic_info_with_what("BattleFormationOperbox1Unmatched");
-        info["details"]["group_name"] = unmatched_group_name;
-        callback(AsstMsg::SubTaskExtraInfo, info);
-        return false;
-    }
-
-    // 多个未匹配的干员组
-    json::array unmatched_groups;
-    LogInfo << __FUNCTION__ << "|" << result.unmatched_left.size() << "slots unmatched, aborting formation";
-    for (size_t idx : result.unmatched_left) {
-        LogInfo << __FUNCTION__ << "| Unmatched slot:" << flat_groups[idx]->name;
-        unmatched_groups.emplace_back(flat_groups[idx]->name);
-    }
-    {
-        json::value info = basic_info();
-        info["why"] = "OperboxMultipleUnmatched";
-        info["details"] = json::object { { "unmatched_groups", std::move(unmatched_groups) },
-                                         { "matched_groups", std::move(matched_groups) } };
-        callback(AsstMsg::SubTaskError, info);
-    }
-    return false;
 }

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -1178,12 +1178,8 @@ bool asst::BattleFormationTask::do_operbox_precheck()
     // 使用二分图最大权匹配算法，尝试将干员组与可用干员进行匹配
     auto result = algorithm::bipartite::bipartite_max_match<OperGroup, OperBoxInfo>(flat_groups, oper_data, can_match);
 
-    Log.info(
-        "OperBox precheck: matched",
-        result.matched.size(),
-        "groups, unmatched",
-        result.unmatched_left.size(),
-        "groups");
+    LogInfo << __FUNCTION__ << "| matched" << result.matched.size() << "groups, unmatched"
+            << result.unmatched_left.size() << "groups";
 
     // 匹配的干员组
     std::unordered_map<std::string, std::string> assigned;
@@ -1191,7 +1187,7 @@ bool asst::BattleFormationTask::do_operbox_precheck()
     for (const auto& [left, right] : result.matched) {
         assigned[flat_groups[left].name] = oper_data[right].id;
         std::string oper_name = BattleData.find_oper_by_id(oper_data[right].id)->name;
-        Log.info("  Matched group:", flat_groups[left].name, "with oper:", oper_name);
+        LogInfo << __FUNCTION__ << "| Matched group:" << flat_groups[left].name << "with oper:" << oper_name;
         matched_groups.emplace_back(
             std::unordered_map<std::string, std::string> { { "group_name", flat_groups[left].name },
                                                            { "oper_name", oper_name } });
@@ -1254,7 +1250,7 @@ bool asst::BattleFormationTask::do_operbox_precheck()
                 std::unordered_map<std::string, std::string> new_assigned;
                 for (const auto& [left, right] : retry.matched) {
                     if (cur_data[right].id == borrow_id) {
-                        Log.info("OperBox precheck: borrow", borrow_id, "for", flat_groups[left].name);
+                        LogInfo << __FUNCTION__ << "| borrow" << borrow_id << "for" << flat_groups[left].name;
                         m_operbox_unmatched_group = flat_groups[left].name;
                     }
                     else {
@@ -1262,12 +1258,12 @@ bool asst::BattleFormationTask::do_operbox_precheck()
                     }
                 }
                 if (assigned != new_assigned) {
-                    Log.info("OperBox precheck: assigned changed after borrow, update");
+                    LogInfo << __FUNCTION__ << "| assigned changed after borrow, update:";
                     json::value info = basic_info_with_what("BattleFormationOperboxMatched");
                     json::array assigned_groups;
                     for (const auto& [group_name, oper_id] : new_assigned) {
                         std::string oper_name = BattleData.find_oper_by_id(oper_id)->name;
-                        Log.info("  Matched group:", group_name, "with oper:", oper_name);
+                        LogInfo << __FUNCTION__ << "| Matched group:" << group_name << "with oper:" << oper_name;
                         assigned_groups.emplace_back(
                             std::unordered_map<std::string, std::string> { { "group_name", group_name },
                                                                            { "oper_name", oper_name } });
@@ -1314,9 +1310,9 @@ bool asst::BattleFormationTask::do_operbox_precheck()
 
     // 多个未匹配的干员组
     json::array unmatched_groups;
-    Log.info("OperBox precheck:", result.unmatched_left.size(), "slots unmatched, aborting formation");
+    LogInfo << __FUNCTION__ << "|" << result.unmatched_left.size() << "slots unmatched, aborting formation";
     for (size_t idx : result.unmatched_left) {
-        Log.info("  Unmatched slot:", flat_groups[idx].name);
+        LogInfo << __FUNCTION__ << "| Unmatched slot:" << flat_groups[idx].name;
         unmatched_groups.emplace_back(flat_groups[idx].name);
     }
     {

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -292,9 +292,17 @@ bool asst::BattleFormationTask::add_formation(battle::Role role, const std::vect
         if (select_opers_in_cur_page(oper_group)) {
             has_error = false;
             bool exit = std::ranges::all_of(oper_group, [&](OperGroup* group) {
-                return !has_oper_unchecked(group->opers) ||
-                       (m_operbox_assist_enabled && group->name == m_operbox_unmatched_group);
-            }); // 该职业下的所有干员组都已选中, 或者是operbox未匹配的组, 直接退出
+                if (m_operbox_assist_enabled && group->name == m_operbox_unmatched_group) {
+                    // Mark as missing so the existing support-unit filling logic can build required_opers.
+                    for (auto& oper : group->opers) {
+                        if (oper.status == battle::OperStatus::Unchecked) {
+                            oper.status = battle::OperStatus::Missing;
+                        }
+                    }
+                    return true;
+                }
+                return !has_oper_unchecked(group->opers);
+            }); // 该职业下的所有干员组都已选中；OperBox 未匹配的组标记缺失后跳过
             if (exit) {
                 break;
             }
@@ -633,7 +641,11 @@ bool asst::BattleFormationTask::select_opers_in_cur_page(const std::vector<OperG
             if (m_operbox_assist_enabled) {
                 if (auto it = m_operbox_assigned.find(group->name);
                     it != m_operbox_assigned.end() && it->second == res.text) {
-                    oper = &(*std::ranges::find_if(group->opers, is_selectable));
+                    auto sel = std::ranges::find_if(group->opers, is_selectable);
+                    if (sel == group->opers.end()) {
+                        return false;
+                    }
+                    oper = &(*sel);
                     return true;
                 }
                 return false;
@@ -1171,11 +1183,11 @@ bool asst::BattleFormationTask::do_operbox_precheck()
         return true;
     }
 
-    auto can_match = [](const OperGroup& group, const OperBoxInfo& info) {
+    auto can_match = [](const OperGroup& group, const OperBoxInfo& info) { // 目前只考虑忽略干员练度情况
         if (!info.own || info.id.empty()) {
             return false;
         }
-        auto it = std::ranges::find_if(group.second, [&](const battle::OperUsage& op) {
+        auto it = std::ranges::find_if(group.opers, [&](const battle::OperUsage& op) {
             if (BattleData.get_id(op.name) != info.id) { // ! 用的是干员的 id 而不是 name，干员识别的 name 可能不是中文
                 return false;
             }
@@ -1184,7 +1196,7 @@ bool asst::BattleFormationTask::do_operbox_precheck()
             }
             return info.elite >= op.requirements.elite;
         });
-        return it != group.second.end();
+        return it != group.opers.end();
     };
 
     // 使用二分图最大权匹配算法，尝试将干员组与可用干员进行匹配
@@ -1201,10 +1213,10 @@ bool asst::BattleFormationTask::do_operbox_precheck()
     std::unordered_map<std::string, std::string> assigned;
     json::array matched_groups;
     for (const auto& [left, right] : result.matched) {
-        assigned[flat_groups[left].first] = oper_data[right].name;
-        Log.info("  Matched group:", flat_groups[left].first, "with oper:", oper_data[right].name);
+        assigned[flat_groups[left].name] = oper_data[right].name;
+        Log.info("  Matched group:", flat_groups[left].name, "with oper:", oper_data[right].name);
         matched_groups.emplace_back(
-            std::unordered_map<std::string, std::string> { { "group_name", flat_groups[left].first },
+            std::unordered_map<std::string, std::string> { { "group_name", flat_groups[left].name },
                                                            { "oper_name", oper_data[right].name } });
     }
     if (!matched_groups.empty()) {
@@ -1222,7 +1234,7 @@ bool asst::BattleFormationTask::do_operbox_precheck()
 
     // 只有一个未匹配的干员组
     if (result.unmatched_left.size() == 1) {
-        m_operbox_unmatched_group = flat_groups[result.unmatched_left[0]].first;
+        m_operbox_unmatched_group = flat_groups[result.unmatched_left[0]].name;
         if (m_support_unit_usage == SupportUnitUsage::None) {
             json::value info = basic_info_with_what("BattleFormationOperbox1Unmatched");
             info["details"]["group_name"] = m_operbox_unmatched_group;
@@ -1235,8 +1247,11 @@ bool asst::BattleFormationTask::do_operbox_precheck()
         // 不知道这么写效率够不够，应该是常数很小的O(n^4)，可能跟O(n^3)的差不多
         std::unordered_set<std::string> candidate_ids;
         for (const auto& group : flat_groups) {
-            for (const auto& op : group.second) {
-                candidate_ids.insert(BattleData.get_id(op.name));
+            for (const auto& op : group.opers) {
+                auto id = BattleData.get_id(op.name);
+                if (!id.empty()) {
+                    candidate_ids.insert(id);
+                }
             }
         }
 
@@ -1254,11 +1269,11 @@ bool asst::BattleFormationTask::do_operbox_precheck()
                 std::unordered_map<std::string, std::string> new_assigned;
                 for (const auto& [left, right] : retry.matched) {
                     if (right == fake_idx) {
-                        Log.info("OperBox precheck: borrow", borrow_id, "for", flat_groups[left].first);
-                        m_operbox_unmatched_group = flat_groups[left].first;
+                        Log.info("OperBox precheck: borrow", borrow_id, "for", flat_groups[left].name);
+                        m_operbox_unmatched_group = flat_groups[left].name;
                     }
                     else {
-                        new_assigned[flat_groups[left].first] = cur_data[right].name;
+                        new_assigned[flat_groups[left].name] = cur_data[right].name;
                     }
                 }
                 m_operbox_assigned = std::move(new_assigned);
@@ -1279,8 +1294,8 @@ bool asst::BattleFormationTask::do_operbox_precheck()
     json::array unmatched_groups;
     Log.info("OperBox precheck:", result.unmatched_left.size(), "slots unmatched, aborting formation");
     for (size_t idx : result.unmatched_left) {
-        Log.info("  Unmatched slot:", flat_groups[idx].first);
-        unmatched_groups.emplace_back(flat_groups[idx].first);
+        Log.info("  Unmatched slot:", flat_groups[idx].name);
+        unmatched_groups.emplace_back(flat_groups[idx].name);
     }
     {
         json::value info = basic_info();

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -62,6 +62,9 @@ bool asst::BattleFormationTask::_run()
     if (!parse_formation()) {
         return false;
     }
+    if (!do_operbox_precheck()) {
+        return false;
+    }
     if (compare_formation()) { // 与上一个作业的编队进行对比，相同则跳过
         Log.info(__FUNCTION__, "| Formation is the same as last time, skip");
         for (auto& [name, _, __, opers] : m_formation | std::views::values | std::views::join) {
@@ -82,9 +85,6 @@ bool asst::BattleFormationTask::_run()
             }
         }
         return true; // 编队未变更，跳过
-    }
-    if (!do_operbox_precheck()) {
-        return false;
     }
 
     if (m_select_formation_index > 0 && !select_formation(m_select_formation_index, img)) {
@@ -235,17 +235,6 @@ void asst::BattleFormationTask::formation_with_last_opers()
     for (auto it = last_formation.begin(); !need_exit() && it != last_formation.end();) {
         const battle::OperNameTag& oper_tag = it->first;
         const std::string& group_name = it->second;
-
-        if (is_operbox_for_assignment()) {
-            // compare_formation 后剩下的是完全相同的干员组, 但是可能预匹配结果不同
-            auto pre_assigned_it = m_operbox_assigned.find(group_name);
-            if (pre_assigned_it == m_operbox_assigned.end() ||
-                pre_assigned_it->second != BattleData.get_id(oper_tag.role, oper_tag.name)) {
-                ++it;
-                continue; // 该干员不是这次预匹配的干员, 跳过
-            }
-        }
-
         const auto& oper_in_page_it = std::ranges::find_if(opers_result, [&](const QuickFormationOper& op) {
             return !op.is_selected && op.role == oper_tag.role && op.text == oper_tag.name;
         }); // 编队页中的干员
@@ -301,18 +290,8 @@ bool asst::BattleFormationTask::add_formation(battle::Role role, const std::vect
     while (!need_exit()) {
         if (select_opers_in_cur_page(oper_group)) {
             has_error = false;
-            bool exit = std::ranges::all_of(oper_group, [&](OperGroup* group) {
-                if (is_operbox_for_assignment() && group->name == m_operbox_unmatched_group) {
-                    // Mark as missing so the existing support-unit filling logic can build required_opers.
-                    for (auto& oper : group->opers) {
-                        if (oper.status == battle::OperStatus::Unchecked) {
-                            oper.status = battle::OperStatus::Missing;
-                        }
-                    }
-                    return true;
-                }
-                return !has_oper_unchecked(group->opers);
-            }); // 该职业下的所有干员组都已选中；OperBox 未匹配的组标记缺失后跳过
+            bool exit =
+                std::ranges::all_of(oper_group, [&](OperGroup* group) { return !has_oper_unchecked(group->opers); });
             if (exit) {
                 break;
             }
@@ -649,18 +628,6 @@ bool asst::BattleFormationTask::select_opers_in_cur_page(const std::vector<OperG
             level_last = oper_cache_it->second.level;
         }
         const auto& iter = std::ranges::find_if(groups, [&](OperGroup* group) {
-            if (is_operbox_for_assignment()) {
-                if (auto it = m_operbox_assigned.find(group->name);
-                    it != m_operbox_assigned.end() && it->second == BattleData.get_id(res.role, res.text)) {
-                    auto sel = std::ranges::find_if(group->opers, is_selectable);
-                    if (sel == group->opers.end()) {
-                        return false;
-                    }
-                    oper = &(*sel);
-                    return true;
-                }
-                return false;
-            }
             if (!has_oper_unchecked(group->opers)) { // 干员组没有干员已选中且存在可用干员
                 return false;
             }
@@ -1141,28 +1108,26 @@ bool asst::BattleFormationTask::do_operbox_precheck()
 {
     LogTraceFunction;
 
-    m_operbox_assigned.clear();
-    m_operbox_unmatched_group.clear();
     if (!is_operbox_for_assignment()) {
         return true;
     }
     const auto& oper_data = *m_operbox_data;
 
-    std::vector<OperGroup> flat_groups;
-    for (const auto& [role, oper_groups] : m_formation) {
-        for (const auto& group : oper_groups) {
-            flat_groups.emplace_back(group);
+    std::vector<OperGroup*> flat_groups;
+    for (auto& [role, oper_groups] : m_formation) {
+        for (auto& group : oper_groups) {
+            flat_groups.emplace_back(&group);
         }
     }
     if (flat_groups.empty()) {
         return true;
     }
 
-    auto can_match = [](const OperGroup& group, const OperBoxInfo& info) { // 目前只考虑忽略干员练度情况
+    auto can_match = [](OperGroup* group, const OperBoxInfo& info) { // 目前只考虑忽略干员练度情况
         if (!info.own || info.id.empty()) {
             return false;
         }
-        auto it = std::ranges::find_if(group.opers, [&](const battle::OperUsage& op) {
+        auto it = std::ranges::find_if(group->opers, [&](const battle::OperUsage& op) {
             // !!! 要用干员的 id 而不是 name，干员识别的 name 可能不是中文
             if (BattleData.get_id(op.role, op.name) != info.id) {
                 return false;
@@ -1172,11 +1137,11 @@ bool asst::BattleFormationTask::do_operbox_precheck()
             }
             return info.elite >= op.requirements.elite;
         });
-        return it != group.opers.end();
+        return it != group->opers.end();
     };
 
     // 使用二分图最大权匹配算法，尝试将干员组与可用干员进行匹配
-    auto result = algorithm::bipartite::bipartite_max_match<OperGroup, OperBoxInfo>(flat_groups, oper_data, can_match);
+    auto result = algorithm::bipartite::bipartite_max_match<OperGroup*, OperBoxInfo>(flat_groups, oper_data, can_match);
 
     LogInfo << __FUNCTION__ << "| matched" << result.matched.size() << "groups, unmatched"
             << result.unmatched_left.size() << "groups";
@@ -1185,17 +1150,17 @@ bool asst::BattleFormationTask::do_operbox_precheck()
     std::unordered_map<std::string, std::string> assigned;
     json::array matched_groups;
     for (const auto& [left, right] : result.matched) {
-        assigned[flat_groups[left].name] = oper_data[right].id;
+        assigned[flat_groups[left]->name] = oper_data[right].id;
         std::string oper_name = BattleData.find_oper_by_id(oper_data[right].id)->name;
-        auto req_it = std::ranges::find_if(flat_groups[left].opers, [&](const battle::OperUsage& op) {
+        auto req_it = std::ranges::find_if(flat_groups[left]->opers, [&](const battle::OperUsage& op) {
             return BattleData.get_id(op.role, op.name) == oper_data[right].id;
         });
-        LogInfo << __FUNCTION__ << "| Matched group:" << flat_groups[left].name << "with oper:" << oper_name
+        LogInfo << __FUNCTION__ << "| Matched group:" << flat_groups[left]->name << "with oper:" << oper_name
                 << ". Usage elite:" << req_it->requirements.elite << ", level:" << req_it->requirements.level
                 << ", skill:" << req_it->skill << ". Operbox elite:" << oper_data[right].elite
                 << ", level:" << oper_data[right].level;
         matched_groups.emplace_back(
-            std::unordered_map<std::string, std::string> { { "group_name", flat_groups[left].name },
+            std::unordered_map<std::string, std::string> { { "group_name", flat_groups[left]->name },
                                                            { "oper_name", oper_name } });
     }
     if (!matched_groups.empty()) {
@@ -1206,17 +1171,22 @@ bool asst::BattleFormationTask::do_operbox_precheck()
 
     // 没有未匹配的干员组
     if (result.unmatched_left.empty()) {
-        m_operbox_assigned = std::move(assigned);
-        m_operbox_unmatched_group.clear();
+        for (const auto& [left, right] : result.matched) {
+            auto req_it = std::ranges::find_if(flat_groups[left]->opers, [&](const battle::OperUsage& op) {
+                return BattleData.get_id(op.role, op.name) == oper_data[right].id;
+            });
+            flat_groups[left]->opers = { *req_it }; // 只保留匹配的干员
+        }
         return true;
     }
 
     // 只有一个未匹配的干员组
+    std::string unmatched_group_name;
     if (result.unmatched_left.size() == 1) {
-        m_operbox_unmatched_group = flat_groups[result.unmatched_left[0]].name;
+        unmatched_group_name = flat_groups[result.unmatched_left[0]]->name;
         if (m_support_unit_usage == SupportUnitUsage::None) {
             json::value info = basic_info_with_what("BattleFormationOperbox1Unmatched");
-            info["details"]["group_name"] = m_operbox_unmatched_group;
+            info["details"]["group_name"] = unmatched_group_name;
             callback(AsstMsg::SubTaskExtraInfo, info);
             return false;
         }
@@ -1226,7 +1196,7 @@ bool asst::BattleFormationTask::do_operbox_precheck()
         // 不知道这么写效率够不够，应该是常数很小的O(n^4)，可能跟O(n^3)的差不多
         std::unordered_set<std::string> candidate_ids;
         for (const auto& group : flat_groups) {
-            for (const auto& op : group.opers) {
+            for (const auto& op : group->opers) {
                 auto id = BattleData.get_id(op.role, op.name);
                 if (!id.empty()) {
                     candidate_ids.insert(id);
@@ -1250,60 +1220,63 @@ bool asst::BattleFormationTask::do_operbox_precheck()
             cur_data.insert(cur_data.begin() + insert_pos, std::move(fake_oper));
 
             auto retry =
-                algorithm::bipartite::bipartite_max_match<OperGroup, OperBoxInfo>(flat_groups, cur_data, can_match);
+                algorithm::bipartite::bipartite_max_match<OperGroup*, OperBoxInfo>(flat_groups, cur_data, can_match);
 
-            if (retry.unmatched_left.empty()) {
-                std::unordered_map<std::string, std::string> new_assigned;
-                for (const auto& [left, right] : retry.matched) {
-                    if (cur_data[right].id == borrow_id) {
-                        LogInfo << __FUNCTION__ << "| borrow" << BattleData.find_oper_by_id(borrow_id)->name << "for"
-                                << flat_groups[left].name;
-                        m_operbox_unmatched_group = flat_groups[left].name;
-                    }
-                    else {
-                        new_assigned[flat_groups[left].name] = cur_data[right].id;
-                    }
-                }
-                if (assigned != new_assigned) {
-                    LogInfo << __FUNCTION__ << "| assigned changed after borrow, update:";
-                    json::value info = basic_info_with_what("BattleFormationOperboxMatched");
-                    json::array assigned_groups;
-                    for (const auto& [group_name, oper_id] : new_assigned) {
-                        std::string oper_name = BattleData.find_oper_by_id(oper_id)->name;
-                        assigned_groups.emplace_back(
-                            std::unordered_map<std::string, std::string> { { "group_name", group_name },
-                                                                           { "oper_name", oper_name } });
-                    }
-                    for (const auto& group : flat_groups) {
-                        if (new_assigned.find(group.name) != new_assigned.end()) {
-                            const auto& oper_id = new_assigned[group.name];
-                            auto oper_it = std::ranges::find_if(oper_data, [&](const OperBoxInfo& op) {
-                                return op.id == oper_id;
-                            });
-                            auto req_it = std::ranges::find_if(group.opers, [&](const battle::OperUsage& op) {
-                                return BattleData.get_id(op.role, op.name) == oper_id;
-                            });
-                            LogInfo << __FUNCTION__ << "| Matched group:" << group.name << "with oper:" << oper_it->name
-                                    << ". Usage elite:" << req_it->requirements.elite
-                                    << ", level:" << req_it->requirements.level << ", skill:" << req_it->skill
-                                    << ". Operbox elite:" << oper_it->elite << ", level:" << oper_it->level;
-                        }
-                    }
-                    info["details"]["matched_groups"] = std::move(assigned_groups);
-                    callback(AsstMsg::SubTaskExtraInfo, info);
-                }
-                m_operbox_assigned = std::move(new_assigned);
-                json::value info = basic_info_with_what("BattleFormationOperbox1Unmatched");
-                info["details"]["group_name"] = m_operbox_unmatched_group;
-                info["details"]["may_borrow_oper"] = BattleData.find_oper_by_id(borrow_id)->name;
-                callback(AsstMsg::SubTaskExtraInfo, info);
-                return true;
+            if (!retry.unmatched_left.empty()) {
+                return false;
             }
-            return false;
+            std::unordered_map<std::string, std::string> new_assigned;
+            for (const auto& [left, right] : retry.matched) {
+                if (cur_data[right].id == borrow_id) {
+                    LogInfo << __FUNCTION__ << "| borrow" << BattleData.find_oper_by_id(borrow_id)->name << "for"
+                            << flat_groups[left]->name;
+                    unmatched_group_name = flat_groups[left]->name;
+                    for (auto& oper : flat_groups[left]->opers) {
+                        oper.status = battle::OperStatus::Unavailable;
+                    }
+                }
+                else {
+                    new_assigned[flat_groups[left]->name] = cur_data[right].id;
+                    auto req_it = std::ranges::find_if(flat_groups[left]->opers, [&](const battle::OperUsage& op) {
+                        return BattleData.get_id(op.role, op.name) == cur_data[right].id;
+                    });
+                    flat_groups[left]->opers = { *req_it }; // 只保留匹配的干员
+                }
+            }
+            if (assigned != new_assigned) {
+                LogInfo << __FUNCTION__ << "| assigned groups changed after borrow, update:";
+                json::value info = basic_info_with_what("BattleFormationOperboxMatched");
+                json::array assigned_groups;
+                for (const auto& group : flat_groups) {
+                    if (new_assigned.find(group->name) == new_assigned.end()) {
+                        continue;
+                    }
+                    const auto& oper_id = new_assigned[group->name];
+                    auto oper_it =
+                        std::ranges::find_if(oper_data, [&](const OperBoxInfo& op) { return op.id == oper_id; });
+                    auto req_it = std::ranges::find_if(group->opers, [&](const battle::OperUsage& op) {
+                        return BattleData.get_id(op.role, op.name) == oper_id;
+                    });
+                    LogInfo << __FUNCTION__ << "| Matched group:" << group->name << "with oper:" << oper_it->name
+                            << ". Usage elite:" << req_it->requirements.elite
+                            << ", level:" << req_it->requirements.level << ", skill:" << req_it->skill
+                            << ". Operbox elite:" << oper_it->elite << ", level:" << oper_it->level;
+                    assigned_groups.emplace_back(
+                        std::unordered_map<std::string, std::string> { { "group_name", group->name },
+                                                                       { "oper_name", oper_it->name } });
+                }
+                info["details"]["matched_groups"] = std::move(assigned_groups);
+                callback(AsstMsg::SubTaskExtraInfo, info);
+            }
+            json::value info = basic_info_with_what("BattleFormationOperbox1Unmatched");
+            info["details"]["group_name"] = unmatched_group_name;
+            info["details"]["may_borrow_oper"] = BattleData.find_oper_by_id(borrow_id)->name;
+            callback(AsstMsg::SubTaskExtraInfo, info);
+            return true;
         };
 
         auto& unmatched_group = flat_groups[result.unmatched_left[0]];
-        for (const auto& op : unmatched_group.opers) {
+        for (const auto& op : unmatched_group->opers) {
             if (need_exit()) {
                 break;
             }
@@ -1324,7 +1297,7 @@ bool asst::BattleFormationTask::do_operbox_precheck()
             }
         }
         json::value info = basic_info_with_what("BattleFormationOperbox1Unmatched");
-        info["details"]["group_name"] = m_operbox_unmatched_group;
+        info["details"]["group_name"] = unmatched_group_name;
         callback(AsstMsg::SubTaskExtraInfo, info);
         return false;
     }
@@ -1333,8 +1306,8 @@ bool asst::BattleFormationTask::do_operbox_precheck()
     json::array unmatched_groups;
     LogInfo << __FUNCTION__ << "|" << result.unmatched_left.size() << "slots unmatched, aborting formation";
     for (size_t idx : result.unmatched_left) {
-        LogInfo << __FUNCTION__ << "| Unmatched slot:" << flat_groups[idx].name;
-        unmatched_groups.emplace_back(flat_groups[idx].name);
+        LogInfo << __FUNCTION__ << "| Unmatched slot:" << flat_groups[idx]->name;
+        unmatched_groups.emplace_back(flat_groups[idx]->name);
     }
     {
         json::value info = basic_info();

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -1173,6 +1173,36 @@ bool asst::BattleFormationTask::do_operbox_precheck()
         return false;
     }
 
+    std::sort(oper_data.begin(), oper_data.end(), [](const OperBoxInfo& a, const OperBoxInfo& b) {
+        if (a.elite != b.elite) {
+            return a.elite > b.elite;
+        }
+        if (a.level != b.level) {
+            return a.level > b.level;
+        }
+        if (a.rarity != b.rarity) {
+            return a.rarity > b.rarity;
+        }
+        auto get_id_num = [](const std::string& id) {
+            auto first_underscore = id.find('_');
+            if (first_underscore == std::string::npos) {
+                return 0;
+            }
+            auto second_underscore = id.find('_', first_underscore + 1);
+            if (second_underscore == std::string::npos) {
+                return 0;
+            }
+            std::string num_str = id.substr(first_underscore + 1, second_underscore - first_underscore - 1);
+            try {
+                return std::stoi(num_str);
+            }
+            catch (...) {
+                return 0;
+            }
+        };
+        return get_id_num(a.id) > get_id_num(b.id);
+    });
+
     std::vector<OperGroup> flat_groups;
     for (const auto& [role, oper_groups] : m_formation) {
         for (const auto& group : oper_groups) {

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -11,6 +11,7 @@
 #include "Controller/Controller.h"
 #include "MaaUtils/ImageIo.h"
 #include "Task/ProcessTask.h"
+#include "Utils/BipartiteMatch.hpp"
 #include "Utils/Logger.hpp"
 #include "Vision/Matcher.h"
 #include "Vision/Miscellaneous/OperNameAnalyzer.h"
@@ -61,7 +62,10 @@ bool asst::BattleFormationTask::_run()
     if (!parse_formation()) {
         return false;
     }
-    else if (compare_formation()) { // 与上一个作业的编队进行对比，相同则跳过
+    if (!do_operbox_precheck()) {
+        return false;
+    }
+    if (compare_formation()) { // 与上一个作业的编队进行对比，相同则跳过
         Log.info(__FUNCTION__, "| Formation is the same as last time, skip");
         for (auto& [name, _, __, opers] : m_formation | std::views::values | std::views::join) {
             const auto& pair_it =
@@ -287,8 +291,10 @@ bool asst::BattleFormationTask::add_formation(battle::Role role, const std::vect
     while (!need_exit()) {
         if (select_opers_in_cur_page(oper_group)) {
             has_error = false;
-            bool exit =
-                std::ranges::all_of(oper_group, [&](OperGroup* group) { return !has_oper_unchecked(group->opers); });
+            bool exit = std::ranges::all_of(oper_group, [&](OperGroup* group) {
+                return !has_oper_unchecked(group->opers) ||
+                       (m_operbox_assist_enabled && group->name == m_operbox_unmatched_group);
+            }); // 该职业下的所有干员组都已选中, 或者是operbox未匹配的组, 直接退出
             if (exit) {
                 break;
             }
@@ -597,6 +603,9 @@ bool asst::BattleFormationTask::select_opers_in_cur_page(const std::vector<OperG
     bool ret = true;
     for (const auto& res :
          opers_result | std::views::filter([](const QuickFormationOper& op) { return !op.is_selected; })) {
+        auto is_selectable = [&](const battle::OperUsage& op) {
+            return op.name == res.text && op.status != battle::OperStatus::Unavailable;
+        };
         auto oper_cache_it = m_opers.find({ res.role, res.text });
         if (oper_cache_it == m_opers.end()) {
             auto [_elite, _level] = m_quick_formation_ui.analyze_oper_level(image, res.flag_rect);
@@ -621,12 +630,18 @@ bool asst::BattleFormationTask::select_opers_in_cur_page(const std::vector<OperG
             level_last = oper_cache_it->second.level;
         }
         const auto& iter = std::ranges::find_if(groups, [&](OperGroup* group) {
+            if (m_operbox_assist_enabled) {
+                if (auto it = m_operbox_assigned.find(group->name);
+                    it != m_operbox_assigned.end() && it->second == res.text) {
+                    oper = &(*std::ranges::find_if(group->opers, is_selectable));
+                    return true;
+                }
+                return false;
+            }
             if (!has_oper_unchecked(group->opers)) { // 干员组没有干员已选中且存在可用干员
                 return false;
             }
-            auto it = std::ranges::find_if(group->opers, [&](const battle::OperUsage& op) {
-                return op.name == res.text && op.status != battle::OperStatus::Unavailable;
-            });
+            auto it = std::ranges::find_if(group->opers, is_selectable);
             if (it != group->opers.cend()) {
                 oper = &(*it);
                 return true; // 找到干员
@@ -1129,4 +1144,73 @@ std::vector<asst::OperBoxInfo> asst::BattleFormationTask::parse_operbox_data(con
     }
 
     return result;
+}
+
+bool asst::BattleFormationTask::do_operbox_precheck()
+{
+    LogTraceFunction;
+
+    if (!m_operbox_assist_enabled || m_operbox_data_path.empty()) {
+        return true;
+    }
+
+    auto oper_data = parse_operbox_data(m_operbox_data_path);
+    if (oper_data.empty()) {
+        Log.error("OperBox data is empty, cannot perform precheck");
+        return false;
+    }
+
+    std::vector<OperGroup> flat_groups;
+    for (const auto& [role, oper_groups] : m_formation) {
+        for (const auto& group : oper_groups) {
+            flat_groups.emplace_back(group);
+        }
+    }
+
+    if (flat_groups.empty()) {
+        return true;
+    }
+
+    auto result = algorithm::bipartite::bipartite_max_match<OperGroup, OperBoxInfo>(
+        flat_groups,
+        oper_data,
+        [](const OperGroup& group, const OperBoxInfo& info) {
+            if (!info.own || info.name.empty()) {
+                return false;
+            }
+            auto it = std::ranges::find_if(group.second, [&](const battle::OperUsage& op) {
+                if (op.name != info.name) {
+                    return false;
+                }
+                if (op.requirements.elite <= 0 && op.requirements.level <= 0) {
+                    return true;
+                }
+                return info.elite >= op.requirements.elite;
+            });
+            return it != group.second.end();
+        });
+
+    std::unordered_map<std::string, std::string> assigned;
+    for (const auto& [left, right] : result.matched) {
+        assigned[flat_groups[left].first] = oper_data[right].name;
+    }
+
+    if (result.unmatched_left.empty()) {
+        m_operbox_assigned = std::move(assigned);
+        m_operbox_unmatched_group.clear();
+        return true;
+    }
+
+    if (result.unmatched_left.size() == 1) {
+        m_operbox_assigned = std::move(assigned);
+        m_operbox_unmatched_group = flat_groups[result.unmatched_left[0]].first;
+        Log.info("OperBox precheck: 1 slot unmatched, will use support unit");
+        return true;
+    }
+
+    Log.info("OperBox precheck:", result.unmatched_left.size(), "slots unmatched, aborting formation");
+    for (size_t idx : result.unmatched_left) {
+        Log.info("  Unmatched slot:", flat_groups[idx].first);
+    }
+    return false;
 }

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -1242,8 +1242,8 @@ bool asst::BattleFormationTask::do_operbox_precheck()
             return false;
         }
 
-        // 枚举作业中所有候选的未拥有干员，尝试借助战
-        // 不能改图结构，因为可能你有一个精1的干员，但作业1个组要求精1的干员，另1个要求精2的同名干员，借战的干员可能是精2的，网络流做不了
+        // 枚举作业中所有干员，尝试借助战
+        // 不能改图结构，因为可能你有一个精1的干员，但作业1个组要求精1的干员，另1个要求精2的同名干员，借助战的干员可能是精2的，网络流做不了
         // 不知道这么写效率够不够，应该是常数很小的O(n^4)，可能跟O(n^3)的差不多
         std::unordered_set<std::string> candidate_ids;
         for (const auto& group : flat_groups) {

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -1136,35 +1136,6 @@ std::optional<std::string> asst::BattleFormationTask::add_support_unit_from_supp
     return std::nullopt;
 }
 
-std::vector<asst::OperBoxInfo> asst::BattleFormationTask::parse_operbox_data(const std::string& path)
-{
-    LogTraceFunction;
-
-    std::vector<OperBoxInfo> result;
-    auto json_opt = json::open(path, true, true);
-    if (!json_opt) {
-        Log.error("Failed to open OperBox data file:", path);
-        return result;
-    }
-
-    auto& json_obj = json_opt.value();
-    auto own_opers = json_obj.get("own_opers", json::array());
-
-    for (auto& item : own_opers) {
-        OperBoxInfo info;
-        info.id = item.get("id", std::string());
-        info.name = item.get("name", std::string());
-        info.elite = item.get("elite", 0);
-        info.level = item.get("level", 0);
-        info.potential = item.get("potential", 0);
-        info.rarity = item.get("rarity", 0);
-        info.own = item.get("own", false);
-        result.emplace_back(std::move(info));
-    }
-
-    return result;
-}
-
 bool asst::BattleFormationTask::do_operbox_precheck()
 {
     LogTraceFunction;
@@ -1174,16 +1145,7 @@ bool asst::BattleFormationTask::do_operbox_precheck()
     if (!is_operbox_for_assignment()) {
         return true;
     }
-
-    auto oper_data = parse_operbox_data(m_operbox_data_path);
-    if (oper_data.empty()) {
-        Log.error("OperBox data is empty, cannot perform precheck");
-        json::value info = basic_info_with_what("BattleFormationOperboxDataParseFailed");
-        callback(AsstMsg::SubTaskExtraInfo, info);
-        return false;
-    }
-
-    std::sort(oper_data.begin(), oper_data.end(), OperBoxInfo::SortCmp {});
+    const auto& oper_data = *m_operbox_data;
 
     std::vector<OperGroup> flat_groups;
     for (const auto& [role, oper_groups] : m_formation) {

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -1187,7 +1187,13 @@ bool asst::BattleFormationTask::do_operbox_precheck()
     for (const auto& [left, right] : result.matched) {
         assigned[flat_groups[left].name] = oper_data[right].id;
         std::string oper_name = BattleData.find_oper_by_id(oper_data[right].id)->name;
-        LogInfo << __FUNCTION__ << "| Matched group:" << flat_groups[left].name << "with oper:" << oper_name;
+        auto req_it = std::ranges::find_if(flat_groups[left].opers, [&](const battle::OperUsage& op) {
+            return BattleData.get_id(op.role, op.name) == oper_data[right].id;
+        });
+        LogInfo << __FUNCTION__ << "| Matched group:" << flat_groups[left].name << "with oper:" << oper_name
+                << ". Usage elite:" << req_it->requirements.elite << ", level:" << req_it->requirements.level
+                << ", skill:" << req_it->skill << ". Operbox elite:" << oper_data[right].elite
+                << ", level:" << oper_data[right].level;
         matched_groups.emplace_back(
             std::unordered_map<std::string, std::string> { { "group_name", flat_groups[left].name },
                                                            { "oper_name", oper_name } });
@@ -1250,7 +1256,8 @@ bool asst::BattleFormationTask::do_operbox_precheck()
                 std::unordered_map<std::string, std::string> new_assigned;
                 for (const auto& [left, right] : retry.matched) {
                     if (cur_data[right].id == borrow_id) {
-                        LogInfo << __FUNCTION__ << "| borrow" << borrow_id << "for" << flat_groups[left].name;
+                        LogInfo << __FUNCTION__ << "| borrow" << BattleData.find_oper_by_id(borrow_id)->name << "for"
+                                << flat_groups[left].name;
                         m_operbox_unmatched_group = flat_groups[left].name;
                     }
                     else {
@@ -1263,10 +1270,24 @@ bool asst::BattleFormationTask::do_operbox_precheck()
                     json::array assigned_groups;
                     for (const auto& [group_name, oper_id] : new_assigned) {
                         std::string oper_name = BattleData.find_oper_by_id(oper_id)->name;
-                        LogInfo << __FUNCTION__ << "| Matched group:" << group_name << "with oper:" << oper_name;
                         assigned_groups.emplace_back(
                             std::unordered_map<std::string, std::string> { { "group_name", group_name },
                                                                            { "oper_name", oper_name } });
+                    }
+                    for (const auto& group : flat_groups) {
+                        if (new_assigned.find(group.name) != new_assigned.end()) {
+                            const auto& oper_id = new_assigned[group.name];
+                            auto oper_it = std::ranges::find_if(oper_data, [&](const OperBoxInfo& op) {
+                                return op.id == oper_id;
+                            });
+                            auto req_it = std::ranges::find_if(group.opers, [&](const battle::OperUsage& op) {
+                                return BattleData.get_id(op.role, op.name) == oper_id;
+                            });
+                            LogInfo << __FUNCTION__ << "| Matched group:" << group.name << "with oper:" << oper_it->name
+                                    << ". Usage elite:" << req_it->requirements.elite
+                                    << ", level:" << req_it->requirements.level << ", skill:" << req_it->skill
+                                    << ". Operbox elite:" << oper_it->elite << ", level:" << oper_it->level;
+                        }
                     }
                     info["details"]["matched_groups"] = std::move(assigned_groups);
                     callback(AsstMsg::SubTaskExtraInfo, info);

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -240,7 +240,7 @@ void asst::BattleFormationTask::formation_with_last_opers()
             // compare_formation 后剩下的是完全相同的干员组, 但是可能预匹配结果不同
             auto pre_assigned_it = m_operbox_assigned.find(group_name);
             if (pre_assigned_it == m_operbox_assigned.end() ||
-                pre_assigned_it->second != BattleData.get_id(oper_name)) {
+                pre_assigned_it->second != BattleData.get_id(oper_tag.role, oper_tag.name)) {
                 ++it;
                 continue; // 该干员不是这次预匹配的干员, 跳过
             }
@@ -622,7 +622,8 @@ bool asst::BattleFormationTask::select_opers_in_cur_page(const std::vector<OperG
     for (const auto& res :
          opers_result | std::views::filter([](const QuickFormationOper& op) { return !op.is_selected; })) {
         auto is_selectable = [&](const battle::OperUsage& op) {
-            return op.name == res.text && op.status != battle::OperStatus::Unavailable;
+            return (op.role == battle::Role::Unknown || op.role == res.role) && op.name == res.text &&
+                   op.status != battle::OperStatus::Unavailable;
         };
         auto oper_cache_it = m_opers.find({ res.role, res.text });
         if (oper_cache_it == m_opers.end()) {
@@ -650,7 +651,7 @@ bool asst::BattleFormationTask::select_opers_in_cur_page(const std::vector<OperG
         const auto& iter = std::ranges::find_if(groups, [&](OperGroup* group) {
             if (is_operbox_for_assignment()) {
                 if (auto it = m_operbox_assigned.find(group->name);
-                    it != m_operbox_assigned.end() && it->second == BattleData.get_id(res.text)) {
+                    it != m_operbox_assigned.end() && it->second == BattleData.get_id(res.role, res.text)) {
                     auto sel = std::ranges::find_if(group->opers, is_selectable);
                     if (sel == group->opers.end()) {
                         return false;
@@ -1162,7 +1163,8 @@ bool asst::BattleFormationTask::do_operbox_precheck()
             return false;
         }
         auto it = std::ranges::find_if(group.opers, [&](const battle::OperUsage& op) {
-            if (BattleData.get_id(op.name) != info.id) { // ! 用的是干员的 id 而不是 name，干员识别的 name 可能不是中文
+            // !!! 要用干员的 id 而不是 name，干员识别的 name 可能不是中文
+            if (BattleData.get_id(op.role, op.name) != info.id) {
                 return false;
             }
             if (op.requirements.elite <= 0 && op.requirements.level <= 0) {
@@ -1224,7 +1226,7 @@ bool asst::BattleFormationTask::do_operbox_precheck()
         std::unordered_set<std::string> candidate_ids;
         for (const auto& group : flat_groups) {
             for (const auto& op : group.opers) {
-                auto id = BattleData.get_id(op.name);
+                auto id = BattleData.get_id(op.role, op.name);
                 if (!id.empty()) {
                     candidate_ids.insert(id);
                 }
@@ -1289,7 +1291,7 @@ bool asst::BattleFormationTask::do_operbox_precheck()
             if (need_exit()) {
                 break;
             }
-            auto borrow_id = BattleData.get_id(op.name);
+            auto borrow_id = BattleData.get_id(op.role, op.name);
             if (borrow_id.empty() || !candidate_ids.erase(borrow_id)) {
                 continue;
             }

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -1186,12 +1186,11 @@ bool asst::BattleFormationTask::do_operbox_precheck()
         "groups");
 
     // 匹配的干员组
-    const auto& all_chars = BattleData.get_all_chars();
     std::unordered_map<std::string, std::string> assigned;
     json::array matched_groups;
     for (const auto& [left, right] : result.matched) {
         assigned[flat_groups[left].name] = oper_data[right].id;
-        std::string oper_name = all_chars.at(oper_data[right].id)->name;
+        std::string oper_name = BattleData.find_oper_by_id(oper_data[right].id)->name;
         Log.info("  Matched group:", flat_groups[left].name, "with oper:", oper_name);
         matched_groups.emplace_back(
             std::unordered_map<std::string, std::string> { { "group_name", flat_groups[left].name },
@@ -1238,8 +1237,9 @@ bool asst::BattleFormationTask::do_operbox_precheck()
             std::erase_if(cur_data, [&](const OperBoxInfo& o) { return o.id == borrow_id; });
             OperBoxInfo fake_oper {};
             fake_oper.id = borrow_id;
-            fake_oper.name = all_chars.at(borrow_id)->name;
-            fake_oper.rarity = all_chars.at(borrow_id)->rarity;
+            auto oper_ptr = BattleData.find_oper_by_id(borrow_id);
+            fake_oper.name = oper_ptr->name;
+            fake_oper.rarity = oper_ptr->rarity;
             fake_oper.elite = (fake_oper.rarity >= 3) + (fake_oper.rarity >= 4); // magic: 满练
             fake_oper.level = 30 + (fake_oper.elite * 25) + (fake_oper.rarity > 3) * 10 * (fake_oper.rarity - 5);
             fake_oper.potential = 6;
@@ -1266,7 +1266,7 @@ bool asst::BattleFormationTask::do_operbox_precheck()
                     json::value info = basic_info_with_what("BattleFormationOperboxMatched");
                     json::array assigned_groups;
                     for (const auto& [group_name, oper_id] : new_assigned) {
-                        std::string oper_name = all_chars.at(oper_id)->name;
+                        std::string oper_name = BattleData.find_oper_by_id(oper_id)->name;
                         Log.info("  Matched group:", group_name, "with oper:", oper_name);
                         assigned_groups.emplace_back(
                             std::unordered_map<std::string, std::string> { { "group_name", group_name },
@@ -1278,7 +1278,7 @@ bool asst::BattleFormationTask::do_operbox_precheck()
                 m_operbox_assigned = std::move(new_assigned);
                 json::value info = basic_info_with_what("BattleFormationOperbox1Unmatched");
                 info["details"]["group_name"] = m_operbox_unmatched_group;
-                info["details"]["may_borrow_oper"] = all_chars.at(borrow_id)->name;
+                info["details"]["may_borrow_oper"] = BattleData.find_oper_by_id(borrow_id)->name;
                 callback(AsstMsg::SubTaskExtraInfo, info);
                 return true;
             }

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -62,9 +62,6 @@ bool asst::BattleFormationTask::_run()
     if (!parse_formation()) {
         return false;
     }
-    if (!do_operbox_precheck()) {
-        return false;
-    }
     if (compare_formation()) { // 与上一个作业的编队进行对比，相同则跳过
         Log.info(__FUNCTION__, "| Formation is the same as last time, skip");
         for (auto& [name, _, __, opers] : m_formation | std::views::values | std::views::join) {
@@ -85,6 +82,9 @@ bool asst::BattleFormationTask::_run()
             }
         }
         return true; // 编队未变更，跳过
+    }
+    if (!do_operbox_precheck()) {
+        return false;
     }
 
     if (m_select_formation_index > 0 && !select_formation(m_select_formation_index, img)) {
@@ -1257,11 +1257,10 @@ bool asst::BattleFormationTask::do_operbox_precheck()
             }
         }
 
-        for (const auto& borrow_id : candidate_ids) {
+        const auto& all_chars = BattleData.get_all_chars();
+        auto try_borrow = [&](const std::string& borrow_id) -> bool {
             auto cur_data = oper_data;
             std::erase_if(cur_data, [&](const OperBoxInfo& o) { return o.id == borrow_id; });
-            auto fake_idx = cur_data.size();
-            const auto& all_chars = BattleData.get_all_chars();
             OperBoxInfo fake_oper {};
             fake_oper.id = borrow_id;
             fake_oper.name = all_chars.at(borrow_id)->name;
@@ -1279,7 +1278,7 @@ bool asst::BattleFormationTask::do_operbox_precheck()
             if (retry.unmatched_left.empty()) {
                 std::unordered_map<std::string, std::string> new_assigned;
                 for (const auto& [left, right] : retry.matched) {
-                    if (right == fake_idx) {
+                    if (cur_data[right].id == borrow_id) {
                         Log.info("OperBox precheck: borrow", borrow_id, "for", flat_groups[left].name);
                         m_operbox_unmatched_group = flat_groups[left].name;
                     }
@@ -1292,6 +1291,23 @@ bool asst::BattleFormationTask::do_operbox_precheck()
                 info["details"]["group_name"] = m_operbox_unmatched_group;
                 info["details"]["may_borrow_oper"] = all_chars.at(borrow_id)->name;
                 callback(AsstMsg::SubTaskExtraInfo, info);
+                return true;
+            }
+            return false;
+        };
+
+        auto& unmatched_group = flat_groups[result.unmatched_left[0]];
+        for (const auto& op : unmatched_group.opers) {
+            auto borrow_id = BattleData.get_id(op.name);
+            if (borrow_id.empty() || !candidate_ids.erase(borrow_id)) {
+                continue;
+            }
+            if (try_borrow(borrow_id)) {
+                return true;
+            }
+        }
+        for (const auto& borrow_id : candidate_ids) {
+            if (try_borrow(borrow_id)) {
                 return true;
             }
         }

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -1183,6 +1183,9 @@ bool asst::BattleFormationTask::do_operbox_precheck()
         if (a.rarity != b.rarity) {
             return a.rarity > b.rarity;
         }
+        if (a.potential != b.potential) {
+            return a.potential > b.potential;
+        }
         auto get_id_num = [](const std::string& id) {
             auto first_underscore = id.find('_');
             if (first_underscore == std::string::npos) {
@@ -1289,8 +1292,16 @@ bool asst::BattleFormationTask::do_operbox_precheck()
             auto cur_data = oper_data;
             std::erase_if(cur_data, [&](const OperBoxInfo& o) { return o.id == borrow_id; });
             auto fake_idx = cur_data.size();
-            cur_data.push_back(
-                { .id = borrow_id, .elite = 2, .own = true }); // 借助战干员，精英化等级设为2，保证能匹配上
+            const auto& all_chars = BattleData.get_all_chars();
+            OperBoxInfo fake_oper {};
+            fake_oper.id = borrow_id;
+            fake_oper.name = all_chars.at(borrow_id)->name;
+            fake_oper.rarity = all_chars.at(borrow_id)->rarity;
+            fake_oper.elite = fake_oper.rarity / 4 + (fake_oper.rarity > 2); // magic: 满练
+            fake_oper.level = 30 + (fake_oper.elite * 25) + (fake_oper.rarity > 3) * 10 * (fake_oper.rarity - 5);
+            fake_oper.potential = 6;
+            fake_oper.own = true;
+            cur_data.push_back(std::move(fake_oper));
 
             auto retry =
                 algorithm::bipartite::bipartite_max_match<OperGroup, OperBoxInfo>(flat_groups, cur_data, can_match);
@@ -1309,7 +1320,7 @@ bool asst::BattleFormationTask::do_operbox_precheck()
                 m_operbox_assigned = std::move(new_assigned);
                 json::value info = basic_info_with_what("BattleFormationOperbox1Unmatched");
                 info["details"]["group_name"] = m_operbox_unmatched_group;
-                info["details"]["may_borrow_oper"] = BattleData.get_all_chars().at(borrow_id)->name;
+                info["details"]["may_borrow_oper"] = all_chars.at(borrow_id)->name;
                 callback(AsstMsg::SubTaskExtraInfo, info);
                 return true;
             }

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -1147,13 +1147,17 @@ bool asst::BattleFormationTask::do_operbox_precheck()
 {
     LogTraceFunction;
 
-    if (!m_operbox_assist_enabled || m_operbox_data_path.empty()) {
+    m_operbox_assigned.clear();
+    m_operbox_unmatched_group.clear();
+    if (!m_operbox_assist_enabled) {
         return true;
     }
 
     auto oper_data = parse_operbox_data(m_operbox_data_path);
     if (oper_data.empty()) {
         Log.error("OperBox data is empty, cannot perform precheck");
+        json::value info = basic_info_with_what("BattleFormationOperboxDataParseFailed");
+        callback(AsstMsg::SubTaskExtraInfo, info);
         return false;
     }
 
@@ -1163,37 +1167,21 @@ bool asst::BattleFormationTask::do_operbox_precheck()
             flat_groups.emplace_back(group);
         }
     }
-
-    Log.info("OperBox precheck: total", flat_groups.size(), "groups, total", oper_data.size(), "opers");
-    auto join_names = [](const auto& container, auto to_name) {
-        std::string result;
-        bool first = true;
-        for (const auto& item : container) {
-            if (!first) {
-                result += ",";
-            }
-            first = false;
-            result += to_name(item);
-        }
-        return result;
-    };
-
-    Log.info("OperBox precheck: groups:", join_names(flat_groups, [](const OperGroup& g) { return g.first; }));
-    Log.info("OperBox precheck: opers:", join_names(oper_data, [](const OperBoxInfo& o) { return o.name; }));
-
     if (flat_groups.empty()) {
         return true;
     }
 
+    // 使用二分图最大权匹配算法，尝试将干员组与可用干员进行匹配
     auto result = algorithm::bipartite::bipartite_max_match<OperGroup, OperBoxInfo>(
         flat_groups,
         oper_data,
         [](const OperGroup& group, const OperBoxInfo& info) {
-            if (!info.own || info.name.empty()) {
+            if (!info.own || info.id.empty()) {
                 return false;
             }
             auto it = std::ranges::find_if(group.second, [&](const battle::OperUsage& op) {
-                if (op.name != info.name) {
+                if (BattleData.get_id(op.name) !=
+                    info.id) { // ! 用的是干员的 id 而不是 name，干员识别的 name 可能不是中文
                     return false;
                 }
                 if (op.requirements.elite <= 0 && op.requirements.level <= 0) {
@@ -1210,53 +1198,57 @@ bool asst::BattleFormationTask::do_operbox_precheck()
         "groups, unmatched",
         result.unmatched_left.size(),
         "groups");
-    auto join_view = [](auto&& rng, const std::string& sep) {
-        std::string out;
-        bool first = true;
-        for (auto&& e : rng) {
-            if (!first) {
-                out += sep;
-            }
-            first = false;
-            out += e;
-        }
-        return out;
-    };
 
-    Log.info(
-        "OperBox precheck: matched:",
-        join_view(
-            result.matched | std::views::transform([&](const auto& pair) {
-                return flat_groups[pair.first].first + "->" + oper_data[pair.second].name;
-            }),
-            ","));
-    Log.info(
-        "OperBox precheck: unmatched:",
-        join_view(
-            result.unmatched_left | std::views::transform([&](size_t idx) { return flat_groups[idx].first; }),
-            ","));
-
+    // 匹配的干员组
     std::unordered_map<std::string, std::string> assigned;
+    json::array matched_groups;
     for (const auto& [left, right] : result.matched) {
         assigned[flat_groups[left].first] = oper_data[right].name;
+        Log.info("  Matched group:", flat_groups[left].first, "with oper:", oper_data[right].name);
+        matched_groups.emplace_back(
+            std::unordered_map<std::string, std::string> { { "group_name", flat_groups[left].first },
+                                                           { "oper_name", oper_data[right].name } });
+    }
+    if (!matched_groups.empty()) {
+        json::value info = basic_info_with_what("BattleFormationOperboxMatched");
+        info["details"]["matched_groups"] = std::move(matched_groups);
+        callback(AsstMsg::SubTaskExtraInfo, info);
     }
 
+    // 没有未匹配的干员组
     if (result.unmatched_left.empty()) {
         m_operbox_assigned = std::move(assigned);
         m_operbox_unmatched_group.clear();
         return true;
     }
 
+    // 只有一个未匹配的干员组
     if (result.unmatched_left.size() == 1) {
         m_operbox_assigned = std::move(assigned);
         m_operbox_unmatched_group = flat_groups[result.unmatched_left[0]].first;
-        Log.info("OperBox precheck: 1 slot unmatched, will use support unit");
+        Log.info("OperBox precheck: ", m_operbox_unmatched_group, " unmatched, need support unit");
+        json::value info = basic_info_with_what("BattleFormationOperbox1Unmatched");
+        info["details"]["group_name"] = m_operbox_unmatched_group;
+        callback(AsstMsg::SubTaskExtraInfo, info);
+        if (m_support_unit_usage == SupportUnitUsage::None) {
+            return false; // 如果不允许使用助战干员，则直接返回失败
+        }
         return true;
     }
 
+    // 多个未匹配的干员组
+    json::array unmatched_groups;
     Log.info("OperBox precheck:", result.unmatched_left.size(), "slots unmatched, aborting formation");
     for (size_t idx : result.unmatched_left) {
         Log.info("  Unmatched slot:", flat_groups[idx].first);
+        unmatched_groups.emplace_back(flat_groups[idx].first);
+    }
+    {
+        json::value info = basic_info();
+        info["why"] = "OperboxMultipleUnmatched";
+        info["details"] = json::object { { "unmatched_groups", std::move(unmatched_groups) },
+                                         { "matched_groups", std::move(matched_groups) } };
+        callback(AsstMsg::SubTaskError, info);
     }
     return false;
 }

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -1125,13 +1125,10 @@ std::vector<asst::OperBoxInfo> asst::BattleFormationTask::parse_operbox_data(con
         return result;
     }
 
-    auto& own_opers = json_opt->get("own_opers");
-    if (!own_opers.is_array()) {
-        Log.error("Missing own_opers array in OperBox data");
-        return result;
-    }
+    auto& json_obj = json_opt.value();
+    auto own_opers = json_obj.get("own_opers", json::array());
 
-    for (auto& item : own_opers.as_array()) {
+    for (auto& item : own_opers) {
         OperBoxInfo info;
         info.id = item.get("id", std::string());
         info.name = item.get("name", std::string());
@@ -1167,6 +1164,23 @@ bool asst::BattleFormationTask::do_operbox_precheck()
         }
     }
 
+    Log.info("OperBox precheck: total", flat_groups.size(), "groups, total", oper_data.size(), "opers");
+    auto join_names = [](const auto& container, auto to_name) {
+        std::string result;
+        bool first = true;
+        for (const auto& item : container) {
+            if (!first) {
+                result += ",";
+            }
+            first = false;
+            result += to_name(item);
+        }
+        return result;
+    };
+
+    Log.info("OperBox precheck: groups:", join_names(flat_groups, [](const OperGroup& g) { return g.first; }));
+    Log.info("OperBox precheck: opers:", join_names(oper_data, [](const OperBoxInfo& o) { return o.name; }));
+
     if (flat_groups.empty()) {
         return true;
     }
@@ -1189,6 +1203,38 @@ bool asst::BattleFormationTask::do_operbox_precheck()
             });
             return it != group.second.end();
         });
+
+    Log.info(
+        "OperBox precheck: matched",
+        result.matched.size(),
+        "groups, unmatched",
+        result.unmatched_left.size(),
+        "groups");
+    auto join_view = [](auto&& rng, const std::string& sep) {
+        std::string out;
+        bool first = true;
+        for (auto&& e : rng) {
+            if (!first) {
+                out += sep;
+            }
+            first = false;
+            out += e;
+        }
+        return out;
+    };
+
+    Log.info(
+        "OperBox precheck: matched:",
+        join_view(
+            result.matched | std::views::transform([&](const auto& pair) {
+                return flat_groups[pair.first].first + "->" + oper_data[pair.second].name;
+            }),
+            ","));
+    Log.info(
+        "OperBox precheck: unmatched:",
+        join_view(
+            result.unmatched_left | std::views::transform([&](size_t idx) { return flat_groups[idx].first; }),
+            ","));
 
     std::unordered_map<std::string, std::string> assigned;
     for (const auto& [left, right] : result.matched) {

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -236,7 +236,7 @@ void asst::BattleFormationTask::formation_with_last_opers()
         const battle::OperNameTag& oper_tag = it->first;
         const std::string& group_name = it->second;
 
-        if (m_operbox_assist_enabled) {
+        if (is_operbox_for_assignment()) {
             // compare_formation 后剩下的是完全相同的干员组, 但是可能预匹配结果不同
             auto pre_assigned_it = m_operbox_assigned.find(group_name);
             if (pre_assigned_it == m_operbox_assigned.end() ||
@@ -302,7 +302,7 @@ bool asst::BattleFormationTask::add_formation(battle::Role role, const std::vect
         if (select_opers_in_cur_page(oper_group)) {
             has_error = false;
             bool exit = std::ranges::all_of(oper_group, [&](OperGroup* group) {
-                if (m_operbox_assist_enabled && group->name == m_operbox_unmatched_group) {
+                if (is_operbox_for_assignment() && group->name == m_operbox_unmatched_group) {
                     // Mark as missing so the existing support-unit filling logic can build required_opers.
                     for (auto& oper : group->opers) {
                         if (oper.status == battle::OperStatus::Unchecked) {
@@ -648,7 +648,7 @@ bool asst::BattleFormationTask::select_opers_in_cur_page(const std::vector<OperG
             level_last = oper_cache_it->second.level;
         }
         const auto& iter = std::ranges::find_if(groups, [&](OperGroup* group) {
-            if (m_operbox_assist_enabled) {
+            if (is_operbox_for_assignment()) {
                 if (auto it = m_operbox_assigned.find(group->name);
                     it != m_operbox_assigned.end() && it->second == BattleData.get_id(res.text)) {
                     auto sel = std::ranges::find_if(group->opers, is_selectable);
@@ -1171,7 +1171,7 @@ bool asst::BattleFormationTask::do_operbox_precheck()
 
     m_operbox_assigned.clear();
     m_operbox_unmatched_group.clear();
-    if (!m_operbox_assist_enabled) {
+    if (!is_operbox_for_assignment()) {
         return true;
     }
 

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.h
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.h
@@ -89,9 +89,7 @@ public:
 
     bool set_specific_support_unit(const std::string& name = ""); // 设置指定助战干员
 
-    void set_operbox_assist_enabled(bool value) { m_operbox_assist_enabled = value; }
-
-    void set_operbox_assist_path(std::string path) { m_operbox_data_path = std::move(path); }
+    void set_operbox_data(std::optional<std::vector<OperBoxInfo>> data) { m_operbox_data = std::move(data); }
 
 protected:
     using OperGroup = battle::copilot::OperUsageGroup;
@@ -178,14 +176,12 @@ protected:
     // ————————————————————————————————
     // 干员识别辅助编队相关
     // ————————————————————————————————
-    bool m_operbox_assist_enabled = false;
-    std::string m_operbox_data_path;
+    std::optional<std::vector<OperBoxInfo>> m_operbox_data;
     std::unordered_map<std::string, std::string> m_operbox_assigned; // 组名 - 干员id
     std::string m_operbox_unmatched_group;
 
-    bool is_operbox_for_assignment() const { return m_operbox_assist_enabled && m_ignore_requirements; }
+    bool is_operbox_for_assignment() const { return m_operbox_data.has_value() && m_ignore_requirements; }
 
-    std::vector<OperBoxInfo> parse_operbox_data(const std::string& path);
     bool do_operbox_precheck();
 
 private:

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.h
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.h
@@ -180,7 +180,7 @@ protected:
     // ————————————————————————————————
     bool m_operbox_assist_enabled = false;
     std::string m_operbox_data_path;
-    std::unordered_map<std::string, std::string> m_operbox_assigned;
+    std::unordered_map<std::string, std::string> m_operbox_assigned; // 组名 - 干员id
     std::string m_operbox_unmatched_group;
 
     std::vector<OperBoxInfo> parse_operbox_data(const std::string& path);

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.h
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.h
@@ -180,9 +180,11 @@ protected:
     // ————————————————————————————————
     bool m_operbox_assist_enabled = false;
     std::string m_operbox_data_path;
-    std::optional<std::unordered_map<size_t, size_t>> m_operbox_matching;
+    std::unordered_map<std::string, std::string> m_operbox_assigned;
+    std::string m_operbox_unmatched_group;
 
     std::vector<OperBoxInfo> parse_operbox_data(const std::string& path);
+    bool do_operbox_precheck();
 
 private:
     static constexpr battle::Role Roles[] = { battle::Role::Caster,  battle::Role::Medic,   battle::Role::Pioneer,

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.h
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.h
@@ -177,8 +177,6 @@ protected:
     // 干员识别辅助编队相关
     // ————————————————————————————————
     std::optional<std::vector<OperBoxInfo>> m_operbox_data;
-    std::unordered_map<std::string, std::string> m_operbox_assigned; // 组名 - 干员id
-    std::string m_operbox_unmatched_group;
 
     bool is_operbox_for_assignment() const { return m_operbox_data.has_value() && m_ignore_requirements; }
 

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.h
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.h
@@ -183,6 +183,8 @@ protected:
     std::unordered_map<std::string, std::string> m_operbox_assigned; // 组名 - 干员id
     std::string m_operbox_unmatched_group;
 
+    bool is_operbox_for_assignment() const { return m_operbox_assist_enabled && m_ignore_requirements; }
+
     std::vector<OperBoxInfo> parse_operbox_data(const std::string& path);
     bool do_operbox_precheck();
 

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.h
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.h
@@ -89,7 +89,10 @@ public:
 
     bool set_specific_support_unit(const std::string& name = ""); // 设置指定助战干员
 
-    void set_operbox_data(std::optional<std::vector<OperBoxInfo>> data) { m_operbox_data = std::move(data); }
+    void set_assigned_groups(std::optional<battle::copilot::OperUsageGroups> groups)
+    {
+        m_assigned_groups = std::move(groups);
+    }
 
 protected:
     using OperGroup = battle::copilot::OperUsageGroup;
@@ -176,11 +179,7 @@ protected:
     // ————————————————————————————————
     // 干员识别辅助编队相关
     // ————————————————————————————————
-    std::optional<std::vector<OperBoxInfo>> m_operbox_data;
-
-    bool is_operbox_for_assignment() const { return m_operbox_data.has_value() && m_ignore_requirements; }
-
-    bool do_operbox_precheck();
+    std::optional<battle::copilot::OperUsageGroups> m_assigned_groups;
 
 private:
     static constexpr battle::Role Roles[] = { battle::Role::Caster,  battle::Role::Medic,   battle::Role::Pioneer,

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.h
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.h
@@ -7,6 +7,7 @@
 #include "Task/AbstractTask.h"
 #include "Ui/BattleQuickFormation.h"
 #include "Ui/SupportList.h"
+#include "Vision/Miscellaneous/OperBoxImageAnalyzer.h"
 #include "Vision/TemplDetOCRer.h"
 
 namespace asst
@@ -87,6 +88,10 @@ public:
     }
 
     bool set_specific_support_unit(const std::string& name = ""); // 设置指定助战干员
+
+    void set_operbox_assist_enabled(bool value) { m_operbox_assist_enabled = value; }
+
+    void set_operbox_assist_path(std::string path) { m_operbox_data_path = std::move(path); }
 
 protected:
     using OperGroup = battle::copilot::OperUsageGroup;
@@ -169,6 +174,15 @@ protected:
     bool m_used_support_unit = false; // 是否已经招募助战干员
     // ———————— 以下变量为指定助战干员设置，仅当 m_support_unit_usage == SupportUnitUsage::Specific 时有效 ————————
     battle::RequiredOper m_specific_support_unit;
+
+    // ————————————————————————————————
+    // 干员识别辅助编队相关
+    // ————————————————————————————————
+    bool m_operbox_assist_enabled = false;
+    std::string m_operbox_data_path;
+    std::optional<std::unordered_map<size_t, size_t>> m_operbox_matching;
+
+    std::vector<OperBoxInfo> parse_operbox_data(const std::string& path);
 
 private:
     static constexpr battle::Role Roles[] = { battle::Role::Caster,  battle::Role::Medic,   battle::Role::Pioneer,

--- a/src/MaaCore/Task/Miscellaneous/MultiCopilotTaskPlugin.cpp
+++ b/src/MaaCore/Task/Miscellaneous/MultiCopilotTaskPlugin.cpp
@@ -6,6 +6,7 @@
 #include "Config/Miscellaneous/CopilotConfig.h"
 #include "Config/TaskData.h"
 #include "Controller/Controller.h"
+#include "Task/Miscellaneous/BattleFormationTask.h"
 #include "Task/Miscellaneous/BattleProcessTask.h"
 #include "Task/ProcessTask.h"
 #include "Task/StageNavigationHelper.h"
@@ -31,6 +32,13 @@ bool asst::MultiCopilotTaskPlugin::_run()
         return false;
     }
     file_name = utils::path_to_utf8_string(config.copilot_file);
+
+    if (config.assigned_groups) {
+        m_formation_task_ptr->set_assigned_groups(*config.assigned_groups);
+    }
+    else {
+        m_formation_task_ptr->set_assigned_groups(std::nullopt);
+    }
 
     const auto& stage_name = Copilot.get_stage_name();
     if (!m_battle_task_ptr->set_stage_name(stage_name)) {

--- a/src/MaaCore/Task/Miscellaneous/MultiCopilotTaskPlugin.h
+++ b/src/MaaCore/Task/Miscellaneous/MultiCopilotTaskPlugin.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "Common/AsstBattleDef.h"
 #include "Task/AbstractTask.h"
 
 #include <optional>
@@ -8,6 +9,7 @@
 
 namespace asst
 {
+class BattleFormationTask;
 class BattleProcessTask;
 
 class MultiCopilotTaskPlugin : public AbstractTask
@@ -19,6 +21,7 @@ public:
         std::string nav_name;               // 关卡名
         bool is_raid = false;               // 是否是突袭
         int id;
+        std::shared_ptr<battle::copilot::OperUsageGroups> assigned_groups;
     };
 
 public:
@@ -28,6 +31,8 @@ public:
     void set_multi_copilot_config(std::vector<MultiCopilotConfig> config) { m_copilot_configs = std::move(config); }
 
     void set_battle_task_ptr(const std::shared_ptr<BattleProcessTask>& ptr) { m_battle_task_ptr = ptr; }
+
+    void set_formation_task_ptr(const std::shared_ptr<BattleFormationTask>& ptr) { m_formation_task_ptr = ptr; }
 
 private:
     virtual bool _run() override;
@@ -43,6 +48,7 @@ private:
     std::vector<MultiCopilotConfig> m_copilot_configs;
     int m_index_current = 0; // 当前执行的索引
     std::shared_ptr<BattleProcessTask> m_battle_task_ptr = nullptr;
+    std::shared_ptr<BattleFormationTask> m_formation_task_ptr = nullptr;
     int m_max_retry = 20;
 };
 }

--- a/src/MaaCore/Task/Miscellaneous/OperBoxRecognitionTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/OperBoxRecognitionTask.cpp
@@ -26,6 +26,7 @@ bool asst::OperBoxRecognitionTask::swipe_and_analyze()
     std::string pre_pre_last_oper;
     std::string pre_last_oper;
     m_own_opers.clear();
+    m_own_opers_names.clear();
 
     while (!need_exit()) {
         OperBoxImageAnalyzer analyzer(ctrler()->get_image());
@@ -35,7 +36,8 @@ bool asst::OperBoxRecognitionTask::swipe_and_analyze()
         if (!analyzer.analyze()) {
             break;
         }
-        const auto& opers_result = analyzer.get_result();
+        auto opers_result = analyzer.get_result();
+        sort_by_vertical_(opers_result);
 
         const std::string& last_oper = opers_result.back().name;
         if (last_oper == pre_last_oper && pre_last_oper == pre_pre_last_oper) {
@@ -45,7 +47,9 @@ bool asst::OperBoxRecognitionTask::swipe_and_analyze()
         pre_last_oper = last_oper;
 
         for (const auto& box_info : opers_result) {
-            m_own_opers.emplace(box_info.name, box_info);
+            if (m_own_opers_names.emplace(box_info.name).second) {
+                m_own_opers.emplace_back(box_info);
+            }
         }
         callback_analyze_result(false);
         future.wait();
@@ -74,7 +78,7 @@ void asst::OperBoxRecognitionTask::callback_analyze_result(bool done)
                                  return pair.second->role != battle::Role::Drone;
                              })) {
         const auto& props = chars.second;
-        bool own = m_own_opers.contains(props->name);
+        bool own = m_own_opers_names.contains(props->name);
         all_opers.emplace_back(
             json::object {
                 { "id", props ? props->id : "" },
@@ -87,7 +91,7 @@ void asst::OperBoxRecognitionTask::callback_analyze_result(bool done)
                 { "own", own }, // 在m_own_opers中重复
             });
     }
-    for (const auto& [name, box_info] : m_own_opers) {
+    for (const auto& box_info : m_own_opers) {
         own_opers.emplace_back(
             json::object {
                 { "id", box_info.id },

--- a/src/MaaCore/Task/Miscellaneous/OperBoxRecognitionTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/OperBoxRecognitionTask.cpp
@@ -26,7 +26,6 @@ bool asst::OperBoxRecognitionTask::swipe_and_analyze()
     std::string pre_pre_last_oper;
     std::string pre_last_oper;
     m_own_opers.clear();
-    m_own_opers_names.clear();
 
     while (!need_exit()) {
         OperBoxImageAnalyzer analyzer(ctrler()->get_image());
@@ -36,8 +35,7 @@ bool asst::OperBoxRecognitionTask::swipe_and_analyze()
         if (!analyzer.analyze()) {
             break;
         }
-        auto opers_result = analyzer.get_result();
-        sort_by_vertical_(opers_result);
+        const auto& opers_result = analyzer.get_result();
 
         const std::string& last_oper = opers_result.back().name;
         if (last_oper == pre_last_oper && pre_last_oper == pre_pre_last_oper) {
@@ -47,9 +45,7 @@ bool asst::OperBoxRecognitionTask::swipe_and_analyze()
         pre_last_oper = last_oper;
 
         for (const auto& box_info : opers_result) {
-            if (m_own_opers_names.emplace(box_info.name).second) {
-                m_own_opers.emplace_back(box_info);
-            }
+            m_own_opers.emplace(box_info.name, box_info);
         }
         callback_analyze_result(false);
         future.wait();
@@ -78,7 +74,7 @@ void asst::OperBoxRecognitionTask::callback_analyze_result(bool done)
                                  return pair.second->role != battle::Role::Drone;
                              })) {
         const auto& props = chars.second;
-        bool own = m_own_opers_names.contains(props->name);
+        bool own = m_own_opers.contains(props->name);
         all_opers.emplace_back(
             json::object {
                 { "id", props ? props->id : "" },
@@ -91,7 +87,7 @@ void asst::OperBoxRecognitionTask::callback_analyze_result(bool done)
                 { "own", own }, // 在m_own_opers中重复
             });
     }
-    for (const auto& box_info : m_own_opers) {
+    for (const auto& [name, box_info] : m_own_opers) {
         own_opers.emplace_back(
             json::object {
                 { "id", box_info.id },

--- a/src/MaaCore/Task/Miscellaneous/OperBoxRecognitionTask.h
+++ b/src/MaaCore/Task/Miscellaneous/OperBoxRecognitionTask.h
@@ -17,6 +17,7 @@ protected:
     void callback_analyze_result(bool done);
     bool swipe_and_analyze();
 
-    std::unordered_map<std::string, OperBoxInfo> m_own_opers;
+    std::vector<OperBoxInfo> m_own_opers;
+    std::unordered_set<std::string> m_own_opers_names;
 };
 }

--- a/src/MaaCore/Task/Miscellaneous/OperBoxRecognitionTask.h
+++ b/src/MaaCore/Task/Miscellaneous/OperBoxRecognitionTask.h
@@ -17,7 +17,6 @@ protected:
     void callback_analyze_result(bool done);
     bool swipe_and_analyze();
 
-    std::vector<OperBoxInfo> m_own_opers;
-    std::unordered_set<std::string> m_own_opers_names;
+    std::unordered_map<std::string, OperBoxInfo> m_own_opers;
 };
 }

--- a/src/MaaCore/Utils/BipartiteMatch.hpp
+++ b/src/MaaCore/Utils/BipartiteMatch.hpp
@@ -34,8 +34,8 @@ inline flow::FlowGraph
     }
     for (size_t i = 0; i < left_count; ++i) {
         for (size_t j : adjacency[i]) {
-            // magic: 第一项优先满足左边前面的。第二项是反四边形不等式，让前面的组尽可能匹配前面的干员
-            int64_t cost = (i + 1) * 10000 - (i + 1) * (j + 1);
+            // magic: 第一项优先满足选强的干员。第二项是反四边形不等式，让前面的组尽可能匹配前面的干员
+            int64_t cost = (j + 1) * 10000 - (i + 1) * (j + 1);
             fg.add_edge(static_cast<int>(i + 1), static_cast<int>(left_count + j + 1), 1, cost);
         }
     }

--- a/src/MaaCore/Utils/BipartiteMatch.hpp
+++ b/src/MaaCore/Utils/BipartiteMatch.hpp
@@ -6,7 +6,7 @@
 
 #include "Utils/MinCostFlow.hpp"
 
-namespace asst::algorithm
+namespace asst::algorithm::bipartite
 {
 struct BipartiteMatchResult
 {
@@ -17,14 +17,12 @@ struct BipartiteMatchResult
     [[nodiscard]] bool all_matched() const noexcept { return unmatched_left.empty(); }
 };
 
-inline BipartiteMatchResult
-    bipartite_max_match(const std::vector<std::vector<size_t>>& adjacency, size_t left_count, size_t right_count)
+inline flow::FlowGraph
+    build_flow_graph(const std::vector<std::vector<size_t>>& adjacency, size_t left_count, size_t right_count)
 {
-    using flow::FlowGraph;
-
     int src = 0;
     int sink = static_cast<int>(left_count + right_count + 1);
-    FlowGraph fg { .src = src, .sink = sink };
+    flow::FlowGraph fg { .src = src, .sink = sink };
     fg.graph.resize(sink + 1);
 
     for (size_t i = 0; i < left_count; ++i) {
@@ -39,7 +37,13 @@ inline BipartiteMatchResult
             fg.add_edge(static_cast<int>(i + 1), static_cast<int>(left_count + j + 1), 1, cost);
         }
     }
+    return fg;
+}
 
+inline BipartiteMatchResult
+    bipartite_max_match(const std::vector<std::vector<size_t>>& adjacency, size_t left_count, size_t right_count)
+{
+    auto fg = bipartite::build_flow_graph(adjacency, left_count, right_count);
     flow::min_cost_max_flow(fg);
 
     BipartiteMatchResult result;
@@ -76,4 +80,4 @@ BipartiteMatchResult bipartite_max_match(
     }
     return bipartite_max_match(adjacency, left.size(), right.size());
 }
-} // namespace asst::algorithm
+} // namespace asst::algorithm::bipartite

--- a/src/MaaCore/Utils/BipartiteMatch.hpp
+++ b/src/MaaCore/Utils/BipartiteMatch.hpp
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 #include <functional>
+#include <utility>
 #include <vector>
 
 #include "Utils/MinCostFlow.hpp"

--- a/src/MaaCore/Utils/BipartiteMatch.hpp
+++ b/src/MaaCore/Utils/BipartiteMatch.hpp
@@ -34,7 +34,7 @@ inline flow::FlowGraph
     }
     for (size_t i = 0; i < left_count; ++i) {
         for (size_t j : adjacency[i]) {
-            int64_t cost = static_cast<int64_t>(i) * static_cast<int64_t>(right_count) + static_cast<int64_t>(j);
+            int64_t cost = (i + 1) * (j + 1);
             fg.add_edge(static_cast<int>(i + 1), static_cast<int>(left_count + j + 1), 1, cost);
         }
     }

--- a/src/MaaCore/Utils/BipartiteMatch.hpp
+++ b/src/MaaCore/Utils/BipartiteMatch.hpp
@@ -50,7 +50,7 @@ inline BipartiteMatchResult
     for (size_t i = 0; i < left_count; ++i) {
         bool matched = false;
         for (auto& e : fg.graph[i + 1]) {
-            if (e.cap == 0) {
+            if (e.cap == 0 && e.to > static_cast<int>(left_count)) {
                 result.matched.emplace_back(i, e.to - static_cast<int>(left_count) - 1);
                 ++result.match_count;
                 matched = true;

--- a/src/MaaCore/Utils/BipartiteMatch.hpp
+++ b/src/MaaCore/Utils/BipartiteMatch.hpp
@@ -34,8 +34,9 @@ inline flow::FlowGraph
     }
     for (size_t i = 0; i < left_count; ++i) {
         for (size_t j : adjacency[i]) {
-            // magic: 第一项优先满足选强的干员。第二项是反四边形不等式，让前面的组尽可能匹配前面的干员
-            int64_t cost = (j + 1) * 10000 - (i + 1) * (j + 1);
+            // 明日方舟 7 年了，一共 425 个干员，不知道能不能等到有 1024 个干员的那一天
+            // 目前的位数需求是 21 (保全派驻) * log2(425) = 21 * 9 = 189 < 256
+            flow::Int256 cost = flow::Int256(static_cast<int64_t>(j)) << (10 * (left_count - i - 1));
             fg.add_edge(static_cast<int>(i + 1), static_cast<int>(left_count + j + 1), 1, cost);
         }
     }

--- a/src/MaaCore/Utils/BipartiteMatch.hpp
+++ b/src/MaaCore/Utils/BipartiteMatch.hpp
@@ -34,7 +34,8 @@ inline flow::FlowGraph
     }
     for (size_t i = 0; i < left_count; ++i) {
         for (size_t j : adjacency[i]) {
-            int64_t cost = (i + 1) * (j + 1);
+            // magic: 第一项优先满足左边前面的。第二项是反四边形不等式，让前面的组尽可能匹配前面的干员
+            int64_t cost = (i + 1) * 10000 - (i + 1) * (j + 1);
             fg.add_edge(static_cast<int>(i + 1), static_cast<int>(left_count + j + 1), 1, cost);
         }
     }

--- a/src/MaaCore/Utils/BipartiteMatch.hpp
+++ b/src/MaaCore/Utils/BipartiteMatch.hpp
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <cstdint>
+#include <functional>
+#include <vector>
+
+#include "Utils/MinCostFlow.hpp"
+
+namespace asst::algorithm
+{
+struct BipartiteMatchResult
+{
+    size_t match_count = 0;
+    std::vector<std::pair<size_t, size_t>> matched;
+    std::vector<size_t> unmatched_left;
+
+    [[nodiscard]] bool all_matched() const noexcept { return unmatched_left.empty(); }
+};
+
+inline BipartiteMatchResult
+    bipartite_max_match(const std::vector<std::vector<size_t>>& adjacency, size_t left_count, size_t right_count)
+{
+    using flow::FlowGraph;
+
+    int src = 0;
+    int sink = static_cast<int>(left_count + right_count + 1);
+    FlowGraph fg { .src = src, .sink = sink };
+    fg.graph.resize(sink + 1);
+
+    for (size_t i = 0; i < left_count; ++i) {
+        fg.add_edge(src, static_cast<int>(i + 1), 1, 0);
+    }
+    for (size_t j = 0; j < right_count; ++j) {
+        fg.add_edge(static_cast<int>(left_count + j + 1), sink, 1, 0);
+    }
+    for (size_t i = 0; i < left_count; ++i) {
+        for (size_t j : adjacency[i]) {
+            int64_t cost = static_cast<int64_t>(i) * static_cast<int64_t>(right_count) + static_cast<int64_t>(j);
+            fg.add_edge(static_cast<int>(i + 1), static_cast<int>(left_count + j + 1), 1, cost);
+        }
+    }
+
+    flow::min_cost_max_flow(fg);
+
+    BipartiteMatchResult result;
+    for (size_t i = 0; i < left_count; ++i) {
+        bool matched = false;
+        for (auto& e : fg.graph[i + 1]) {
+            if (e.cap == 0) {
+                result.matched.emplace_back(i, e.to - static_cast<int>(left_count) - 1);
+                ++result.match_count;
+                matched = true;
+                break;
+            }
+        }
+        if (!matched) {
+            result.unmatched_left.push_back(i);
+        }
+    }
+    return result;
+}
+
+template <typename A, typename B>
+BipartiteMatchResult bipartite_max_match(
+    const std::vector<A>& left,
+    const std::vector<B>& right,
+    std::function<bool(const A&, const B&)> can_match)
+{
+    std::vector<std::vector<size_t>> adjacency(left.size());
+    for (size_t i = 0; i < left.size(); ++i) {
+        for (size_t j = 0; j < right.size(); ++j) {
+            if (can_match(left[i], right[j])) {
+                adjacency[i].push_back(j);
+            }
+        }
+    }
+    return bipartite_max_match(adjacency, left.size(), right.size());
+}
+} // namespace asst::algorithm

--- a/src/MaaCore/Utils/MinCostFlow.hpp
+++ b/src/MaaCore/Utils/MinCostFlow.hpp
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <limits>
 #include <queue>
+#include <utility>
 #include <vector>
 
 namespace asst::algorithm::flow

--- a/src/MaaCore/Utils/MinCostFlow.hpp
+++ b/src/MaaCore/Utils/MinCostFlow.hpp
@@ -1,0 +1,153 @@
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+#include <queue>
+#include <vector>
+
+namespace asst::algorithm::flow
+{
+static constexpr int64_t kInfCost = std::numeric_limits<int64_t>::max() / 2;
+
+struct FlowEdge
+{
+    int to = 0;
+    int rev = 0;
+    int64_t cap = 0;
+    int64_t cost = 0;
+};
+
+struct FlowGraph
+{
+    std::vector<std::vector<FlowEdge>> graph;
+    int src = 0;
+    int sink = 0;
+
+    void add_edge(int from, int to, int64_t cap, int64_t cost)
+    {
+        graph[from].push_back({ to, static_cast<int>(graph[to].size()), cap, cost });
+        graph[to].push_back({ from, static_cast<int>(graph[from].size()) - 1, 0, -cost });
+    }
+};
+
+inline bool dijkstra(const FlowGraph& fg, const std::vector<int64_t>& potential, std::vector<int64_t>& dist)
+{
+    int n = static_cast<int>(fg.graph.size());
+    std::ranges::fill(dist, kInfCost);
+    dist[fg.src] = 0;
+
+    using State = std::pair<int64_t, int>;
+    std::priority_queue<State, std::vector<State>, std::greater<>> pq;
+    pq.emplace(0, fg.src);
+
+    while (!pq.empty()) {
+        auto [d, v] = pq.top();
+        pq.pop();
+        if (dist[v] < d) {
+            continue;
+        }
+        for (auto& e : fg.graph[v]) {
+            if (e.cap <= 0) {
+                continue;
+            }
+            int64_t nd = d + e.cost + potential[v] - potential[e.to];
+            if (dist[e.to] > nd) {
+                dist[e.to] = nd;
+                pq.emplace(nd, e.to);
+            }
+        }
+    }
+    return dist[fg.sink] < kInfCost;
+}
+
+inline bool build_level_graph(const FlowGraph& fg, const std::vector<int64_t>& potential, std::vector<int>& level)
+{
+    std::ranges::fill(level, -1);
+    level[fg.src] = 0;
+    std::queue<int> q;
+    q.push(fg.src);
+
+    while (!q.empty()) {
+        int v = q.front();
+        q.pop();
+        for (auto& e : fg.graph[v]) {
+            if (e.cap <= 0) {
+                continue;
+            }
+            if (e.cost + potential[v] - potential[e.to] != 0) {
+                continue;
+            }
+            if (level[e.to] >= 0) {
+                continue;
+            }
+            level[e.to] = level[v] + 1;
+            q.push(e.to);
+        }
+    }
+    return level[fg.sink] >= 0;
+}
+
+inline int64_t dinic_dfs(
+    FlowGraph& fg,
+    int v,
+    const std::vector<int>& level,
+    const std::vector<int64_t>& potential,
+    std::vector<int>& iter,
+    int64_t f)
+{
+    if (v == fg.sink) {
+        return f;
+    }
+    int64_t total = 0;
+    for (int& i = iter[v]; i < static_cast<int>(fg.graph[v].size()); ++i) {
+        auto& e = fg.graph[v][i];
+        if (e.cap <= 0 || e.cost + potential[v] - potential[e.to] != 0) {
+            continue;
+        }
+        if (level[e.to] != level[v] + 1) {
+            continue;
+        }
+        int64_t pushed = dinic_dfs(fg, e.to, level, potential, iter, std::min(f, e.cap));
+        if (pushed == 0) {
+            continue;
+        }
+        e.cap -= pushed;
+        fg.graph[e.to][e.rev].cap += pushed;
+        total += pushed;
+        f -= pushed;
+        if (f == 0) {
+            break;
+        }
+    }
+    return total;
+}
+
+inline void min_cost_max_flow(FlowGraph& fg)
+{
+    int n = static_cast<int>(fg.graph.size());
+    std::vector<int64_t> potential(n, 0);
+    std::vector<int64_t> dist(n);
+    std::vector<int> level(n), iter(n);
+
+    while (true) {
+        if (!dijkstra(fg, potential, dist)) {
+            break;
+        }
+        for (int v = 0; v < n; ++v) {
+            if (dist[v] < kInfCost) {
+                potential[v] += dist[v];
+            }
+        }
+        while (build_level_graph(fg, potential, level)) {
+            std::ranges::fill(iter, 0);
+            while (true) {
+                int64_t pushed = dinic_dfs(fg, fg.src, level, potential, iter, kInfCost);
+                if (pushed == 0) {
+                    break;
+                }
+            }
+        }
+    }
+}
+} // namespace asst::algorithm::flow

--- a/src/MaaCore/Utils/MinCostFlow.hpp
+++ b/src/MaaCore/Utils/MinCostFlow.hpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <functional>
 #include <limits>
 #include <queue>
 #include <utility>

--- a/src/MaaCore/Utils/MinCostFlow.hpp
+++ b/src/MaaCore/Utils/MinCostFlow.hpp
@@ -33,7 +33,6 @@ struct FlowGraph
 
 inline bool dijkstra(const FlowGraph& fg, const std::vector<int64_t>& potential, std::vector<int64_t>& dist)
 {
-    int n = static_cast<int>(fg.graph.size());
     std::ranges::fill(dist, kInfCost);
     dist[fg.src] = 0;
 

--- a/src/MaaCore/Utils/MinCostFlow.hpp
+++ b/src/MaaCore/Utils/MinCostFlow.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <algorithm>
+#include <array>
+#include <compare>
 #include <cstdint>
 #include <functional>
 #include <limits>
@@ -10,14 +12,126 @@
 
 namespace asst::algorithm::flow
 {
-static constexpr int64_t kInfCost = std::numeric_limits<int64_t>::max() / 2;
+// 固定 256-bit 有符号整数，4 x uint64_t 小端压位（base 2^64），2-补码表示。
+// 仅实现费用流算法所需的加减/移位/比较，等要复用的时候再移到独立的 Int256.hpp
+class Int256
+{
+    std::array<uint64_t, 4> limbs {};
+
+    constexpr Int256(uint64_t a, uint64_t b, uint64_t c, uint64_t d) :
+        limbs { a, b, c, d }
+    {
+    }
+
+public:
+    constexpr Int256() = default;
+
+    constexpr Int256(int64_t value)
+    {
+        const uint64_t v = static_cast<uint64_t>(value);
+        limbs[0] = v;
+        limbs[1] = limbs[2] = limbs[3] = (value < 0) ? UINT64_MAX : 0;
+    }
+
+    static constexpr Int256 max_value() { return Int256(UINT64_MAX, UINT64_MAX, UINT64_MAX, INT64_MAX); }
+
+    constexpr Int256& operator+=(const Int256& rhs)
+    {
+        uint64_t carry = 0;
+        for (int q = 0; q < 4; ++q) {
+            const uint64_t a = limbs[q];
+            const uint64_t b = rhs.limbs[q];
+            const uint64_t sum = a + b;
+            limbs[q] = sum + carry;
+            carry = (sum < a) || (carry != 0 && sum == UINT64_MAX);
+        }
+        return *this;
+    }
+
+    constexpr Int256& operator-=(const Int256& rhs) { return *this += -rhs; }
+
+    constexpr Int256 operator-() const
+    {
+        Int256 result;
+        uint64_t carry = 1;
+        for (int q = 0; q < 4; ++q) {
+            const uint64_t inv = ~limbs[q];
+            result.limbs[q] = inv + carry;
+            carry = carry && inv == UINT64_MAX;
+        }
+        return result;
+    }
+
+    constexpr Int256 operator+(const Int256& rhs) const
+    {
+        Int256 result = *this;
+        result += rhs;
+        return result;
+    }
+
+    constexpr Int256 operator-(const Int256& rhs) const
+    {
+        Int256 result = *this;
+        result -= rhs;
+        return result;
+    }
+
+    constexpr Int256& operator<<=(uint64_t shift)
+    {
+        if (shift >= 256) {
+            limbs = {};
+            return *this;
+        }
+        const uint64_t whole = shift / 64;
+        const uint64_t part = shift % 64;
+        for (int q = 3; q >= 0; --q) {
+            uint64_t value = 0;
+            const int src = q - static_cast<int>(whole);
+            if (src >= 0) {
+                value = limbs[src] << part;
+                if (part != 0 && src - 1 >= 0) {
+                    value |= limbs[src - 1] >> (64 - part);
+                }
+            }
+            limbs[q] = value;
+        }
+        return *this;
+    }
+
+    constexpr Int256 operator<<(uint64_t shift) const
+    {
+        Int256 result = *this;
+        result <<= shift;
+        return result;
+    }
+
+    friend constexpr bool operator==(const Int256& lhs, const Int256& rhs) { return lhs.limbs == rhs.limbs; }
+
+    friend constexpr std::strong_ordering operator<=>(const Int256& lhs, const Int256& rhs)
+    {
+        const bool lhs_negative = (lhs.limbs[3] >> 63) != 0;
+        const bool rhs_negative = (rhs.limbs[3] >> 63) != 0;
+        if (lhs_negative != rhs_negative) {
+            return lhs_negative ? std::strong_ordering::less : std::strong_ordering::greater;
+        }
+        for (int q = 3; q >= 0; --q) {
+            if (lhs.limbs[q] != rhs.limbs[q]) {
+                return lhs.limbs[q] < rhs.limbs[q] ? std::strong_ordering::less : std::strong_ordering::greater;
+            }
+        }
+        return std::strong_ordering::equal;
+    }
+};
+
+static constexpr Int256 kInfCost = Int256::max_value();
+static constexpr int64_t kInfCap = std::numeric_limits<int64_t>::max() / 2;
 
 struct FlowEdge
 {
     int to = 0;
     int rev = 0;
     int64_t cap = 0;
-    int64_t cost = 0;
+    Int256 cost = 0;
 };
 
 struct FlowGraph
@@ -26,19 +140,19 @@ struct FlowGraph
     int src = 0;
     int sink = 0;
 
-    void add_edge(int from, int to, int64_t cap, int64_t cost)
+    void add_edge(int from, int to, int64_t cap, Int256 cost)
     {
         graph[from].push_back({ to, static_cast<int>(graph[to].size()), cap, cost });
         graph[to].push_back({ from, static_cast<int>(graph[from].size()) - 1, 0, -cost });
     }
 };
 
-inline bool dijkstra(const FlowGraph& fg, const std::vector<int64_t>& potential, std::vector<int64_t>& dist)
+inline bool dijkstra(const FlowGraph& fg, const std::vector<Int256>& potential, std::vector<Int256>& dist)
 {
     std::ranges::fill(dist, kInfCost);
     dist[fg.src] = 0;
 
-    using State = std::pair<int64_t, int>;
+    using State = std::pair<Int256, int>;
     std::priority_queue<State, std::vector<State>, std::greater<>> pq;
     pq.emplace(0, fg.src);
 
@@ -52,7 +166,7 @@ inline bool dijkstra(const FlowGraph& fg, const std::vector<int64_t>& potential,
             if (e.cap <= 0) {
                 continue;
             }
-            int64_t nd = d + e.cost + potential[v] - potential[e.to];
+            Int256 nd = d + e.cost + potential[v] - potential[e.to];
             if (dist[e.to] > nd) {
                 dist[e.to] = nd;
                 pq.emplace(nd, e.to);
@@ -62,7 +176,7 @@ inline bool dijkstra(const FlowGraph& fg, const std::vector<int64_t>& potential,
     return dist[fg.sink] < kInfCost;
 }
 
-inline bool build_level_graph(const FlowGraph& fg, const std::vector<int64_t>& potential, std::vector<int>& level)
+inline bool build_level_graph(const FlowGraph& fg, const std::vector<Int256>& potential, std::vector<int>& level)
 {
     std::ranges::fill(level, -1);
     level[fg.src] = 0;
@@ -76,7 +190,7 @@ inline bool build_level_graph(const FlowGraph& fg, const std::vector<int64_t>& p
             if (e.cap <= 0) {
                 continue;
             }
-            if (e.cost + potential[v] - potential[e.to] != 0) {
+            if (e.cost + potential[v] != potential[e.to]) {
                 continue;
             }
             if (level[e.to] >= 0) {
@@ -93,7 +207,7 @@ inline int64_t dinic_dfs(
     FlowGraph& fg,
     int v,
     const std::vector<int>& level,
-    const std::vector<int64_t>& potential,
+    const std::vector<Int256>& potential,
     std::vector<int>& iter,
     int64_t f)
 {
@@ -103,7 +217,7 @@ inline int64_t dinic_dfs(
     int64_t total = 0;
     for (int& i = iter[v]; i < static_cast<int>(fg.graph[v].size()); ++i) {
         auto& e = fg.graph[v][i];
-        if (e.cap <= 0 || e.cost + potential[v] - potential[e.to] != 0) {
+        if (e.cap <= 0 || e.cost + potential[v] != potential[e.to]) {
             continue;
         }
         if (level[e.to] != level[v] + 1) {
@@ -127,8 +241,8 @@ inline int64_t dinic_dfs(
 inline void min_cost_max_flow(FlowGraph& fg)
 {
     int n = static_cast<int>(fg.graph.size());
-    std::vector<int64_t> potential(n, 0);
-    std::vector<int64_t> dist(n);
+    std::vector<Int256> potential(n, 0);
+    std::vector<Int256> dist(n);
     std::vector<int> level(n), iter(n);
 
     while (true) {
@@ -143,7 +257,7 @@ inline void min_cost_max_flow(FlowGraph& fg)
         while (build_level_graph(fg, potential, level)) {
             std::ranges::fill(iter, 0);
             while (true) {
-                int64_t pushed = dinic_dfs(fg, fg.src, level, potential, iter, kInfCost);
+                int64_t pushed = dinic_dfs(fg, fg.src, level, potential, iter, kInfCap);
                 if (pushed == 0) {
                     break;
                 }

--- a/src/MaaCore/Vision/Miscellaneous/OperBoxImageAnalyzer.h
+++ b/src/MaaCore/Vision/Miscellaneous/OperBoxImageAnalyzer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Config/Miscellaneous/BattleDataConfig.h"
 #include "Vision/VisionHelper.h"
 
 namespace asst
@@ -15,6 +16,29 @@ struct OperBoxInfo
 
     Rect rect;
     bool own = false;
+
+    struct SortCmp
+    {
+        bool operator()(const OperBoxInfo& lhs, const OperBoxInfo& rhs) const
+        {
+            if (lhs.elite != rhs.elite) {
+                return lhs.elite > rhs.elite;
+            }
+            if (lhs.level != rhs.level) {
+                return lhs.level > rhs.level;
+            }
+            if (lhs.rarity != rhs.rarity) {
+                return lhs.rarity > rhs.rarity;
+            }
+            const auto& all_chars = BattleData.get_all_chars();
+            const auto& lhs_iter = all_chars.at(lhs.id);
+            const auto& rhs_iter = all_chars.at(rhs.id);
+            if (lhs_iter->role != rhs_iter->role) {
+                return lhs_iter->role < rhs_iter->role;
+            }
+            return lhs_iter->sort_index < rhs_iter->sort_index;
+        }
+    };
 };
 
 class OperBoxImageAnalyzer final : public VisionHelper

--- a/src/MaaCore/Vision/Miscellaneous/OperBoxImageAnalyzer.h
+++ b/src/MaaCore/Vision/Miscellaneous/OperBoxImageAnalyzer.h
@@ -30,13 +30,12 @@ struct OperBoxInfo
             if (lhs.rarity != rhs.rarity) {
                 return lhs.rarity > rhs.rarity;
             }
-            const auto& all_chars = BattleData.get_all_chars();
-            const auto& lhs_iter = all_chars.at(lhs.id);
-            const auto& rhs_iter = all_chars.at(rhs.id);
-            if (lhs_iter->role != rhs_iter->role) {
-                return lhs_iter->role < rhs_iter->role;
+            auto lhs_oper_props = BattleData.find_oper_by_id(lhs.id);
+            auto rhs_oper_props = BattleData.find_oper_by_id(rhs.id);
+            if (lhs_oper_props->role != rhs_oper_props->role) {
+                return lhs_oper_props->role < rhs_oper_props->role;
             }
-            return lhs_iter->sort_index < rhs_iter->sort_index;
+            return lhs_oper_props->sort_index < rhs_oper_props->sort_index;
         }
     };
 };

--- a/src/MaaWpfGui/Configuration/Single/Settings/Copilot.cs
+++ b/src/MaaWpfGui/Configuration/Single/Settings/Copilot.cs
@@ -13,11 +13,9 @@
 
 #nullable enable
 using System.Collections.Generic;
-using System.IO;
 using MaaWpfGui.ViewModels.Items;
 using PropertyChanged;
 using static MaaWpfGui.Configuration.Factory.ConfigFactory;
-using static MaaWpfGui.Helper.PathsHelper;
 using static MaaWpfGui.Models.AsstTasks.AsstCopilotTask;
 using static MaaWpfGui.ViewModels.UI.CopilotViewModel;
 
@@ -45,6 +43,4 @@ public partial class Copilot
     public int SelectFormation { get; set; } = 1;
 
     public int LoopTimes { get; set; } = 1;
-
-    public string CopilotOperBoxDataPath { get; set; } = Path.Combine(DataDir, "OperBoxData.json");
 }

--- a/src/MaaWpfGui/Configuration/Single/Settings/Copilot.cs
+++ b/src/MaaWpfGui/Configuration/Single/Settings/Copilot.cs
@@ -13,9 +13,11 @@
 
 #nullable enable
 using System.Collections.Generic;
+using System.IO;
 using MaaWpfGui.ViewModels.Items;
 using PropertyChanged;
 using static MaaWpfGui.Configuration.Factory.ConfigFactory;
+using static MaaWpfGui.Helper.PathsHelper;
 using static MaaWpfGui.Models.AsstTasks.AsstCopilotTask;
 using static MaaWpfGui.ViewModels.UI.CopilotViewModel;
 
@@ -43,4 +45,6 @@ public partial class Copilot
     public int SelectFormation { get; set; } = 1;
 
     public int LoopTimes { get; set; } = 1;
+
+    public string CopilotOperBoxDataPath { get; set; } = Path.Combine(DataDir, "OperBoxData.json");
 }

--- a/src/MaaWpfGui/Constants/ConfigurationKeys.cs
+++ b/src/MaaWpfGui/Constants/ConfigurationKeys.cs
@@ -230,7 +230,6 @@ public static class ConfigurationKeys
     public const string CopilotSelectFormation = "Copilot.SelectFormation"; // √
     public const string CopilotSupportUnitUsage = "Copilot.SupportUnitUsage"; // √
     public const string CopilotLoopTimes = "Copilot.LoopTimes"; // √
-    public const string CopilotOperBoxDataPath = "Copilot.OperBoxDataPath";
     public const string CopilotTaskList = "Copilot.CopilotTaskList"; // √
     public const string UpdateProxy = "VersionUpdate.Proxy"; // √
     public const string ProxyType = "VersionUpdate.ProxyType"; // √

--- a/src/MaaWpfGui/Constants/ConfigurationKeys.cs
+++ b/src/MaaWpfGui/Constants/ConfigurationKeys.cs
@@ -230,6 +230,7 @@ public static class ConfigurationKeys
     public const string CopilotSelectFormation = "Copilot.SelectFormation"; // √
     public const string CopilotSupportUnitUsage = "Copilot.SupportUnitUsage"; // √
     public const string CopilotLoopTimes = "Copilot.LoopTimes"; // √
+    public const string CopilotOperBoxDataPath = "Copilot.OperBoxDataPath";
     public const string CopilotTaskList = "Copilot.CopilotTaskList"; // √
     public const string UpdateProxy = "VersionUpdate.Proxy"; // √
     public const string ProxyType = "VersionUpdate.ProxyType"; // √

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -1624,6 +1624,10 @@ public class AsstProxy
                         var operName = details["details"]?["name"]?.ToString();
                         Instances.CopilotViewModel.AddLog(LocalizationHelper.GetStringFormat("CopilotUserAdditionalNameInvalid", operName ?? string.Empty), UiLogColor.Error);
                     }
+                    if (what == "OperboxDataParseFailed")
+                    {
+                        Instances.CopilotViewModel.AddLog(LocalizationHelper.GetString("CopilotOperboxDataParseFailed"), UiLogColor.Error);
+                    }
                     break;
                 }
         }
@@ -2239,13 +2243,6 @@ public class AsstProxy
                     }
 
                     Instances.CopilotViewModel.AddLog(LocalizationHelper.GetStringFormat("BattleFormationOperUnavailable", oper_name ?? string.Empty, type), isError ? UiLogColor.Error : UiLogColor.Warning);
-                    break;
-                }
-
-            case "BattleFormationOperboxDataParseFailed":
-                {
-                    Instances.CopilotViewModel.AddLog(
-                        LocalizationHelper.GetString("BattleFormationOperboxDataParseFailed"), UiLogColor.Error);
                     break;
                 }
 

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -2267,8 +2267,9 @@ public class AsstProxy
             case "BattleFormationOperbox1Unmatched":
                 {
                     var groupName = subTaskDetails!["group_name"]?.ToString() ?? "Unknown Group";
+                    var operName = DataHelper.GetLocalizedCharacterName(subTaskDetails["may_borrow_oper"]?.ToString()) ?? String.Empty;
                     Instances.CopilotViewModel.AddLog(
-                        LocalizationHelper.GetStringFormat("BattleFormationOperbox1Unmatched", groupName), UiLogColor.Warning);
+                        LocalizationHelper.GetStringFormat("BattleFormationOperbox1Unmatched", groupName, operName), operName == string.Empty ? UiLogColor.Error : UiLogColor.Warning);
                     break;
                 }
 

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -1604,16 +1604,6 @@ public class AsstProxy
                             AchievementTrackerHelper.Instance.Unlock(AchievementIds.Irreplaceable);
                         }
                     }
-                    if (why == "OperboxMultipleUnmatched")
-                    {
-                        var unmatched = details["details"]?["unmatched_groups"]?.ToObject<List<string>>() ?? [];
-                        var sb = new StringBuilder();
-                        sb.AppendLine(LocalizationHelper.GetString("OperboxMultipleUnmatched"));
-                        foreach (var g in unmatched) {
-                            sb.AppendLine($"{g}");
-                        }
-                        Instances.CopilotViewModel.AddLog(sb.ToString().TrimEnd(), UiLogColor.Error);
-                    }
                     break;
                 }
             case "CopilotTask":
@@ -1627,6 +1617,16 @@ public class AsstProxy
                     if (what == "OperboxDataParseFailed")
                     {
                         Instances.CopilotViewModel.AddLog(LocalizationHelper.GetString("CopilotOperboxDataParseFailed"), UiLogColor.Error);
+                    }
+                    if (what == "OperboxMultipleUnmatched")
+                    {
+                        var unmatched = details["details"]?["unmatched_groups"]?.ToObject<List<string>>() ?? [];
+                        var sb = new StringBuilder();
+                        sb.AppendLine(LocalizationHelper.GetString("OperboxMultipleUnmatched"));
+                        foreach (var g in unmatched) {
+                            sb.AppendLine($"{g}");
+                        }
+                        Instances.CopilotViewModel.AddLog(sb.ToString().TrimEnd(), UiLogColor.Error);
                     }
                     break;
                 }

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -1604,6 +1604,16 @@ public class AsstProxy
                             AchievementTrackerHelper.Instance.Unlock(AchievementIds.Irreplaceable);
                         }
                     }
+                    if (why == "OperboxMultipleUnmatched")
+                    {
+                        var unmatched = details["details"]?["unmatched_groups"]?.ToObject<List<string>>() ?? [];
+                        var sb = new StringBuilder();
+                        sb.AppendLine(LocalizationHelper.GetString("OperboxMultipleUnmatched"));
+                        foreach (var g in unmatched) {
+                            sb.AppendLine($"{g}");
+                        }
+                        Instances.CopilotViewModel.AddLog(sb.ToString().TrimEnd(), UiLogColor.Error);
+                    }
                     break;
                 }
             case "CopilotTask":
@@ -2229,6 +2239,36 @@ public class AsstProxy
                     }
 
                     Instances.CopilotViewModel.AddLog(LocalizationHelper.GetStringFormat("BattleFormationOperUnavailable", oper_name ?? string.Empty, type), isError ? UiLogColor.Error : UiLogColor.Warning);
+                    break;
+                }
+
+            case "BattleFormationOperboxDataParseFailed":
+                {
+                    Instances.CopilotViewModel.AddLog(
+                        LocalizationHelper.GetString("BattleFormationOperboxDataParseFailed"), UiLogColor.Error);
+                    break;
+                }
+
+            case "BattleFormationOperboxMatched":
+                {
+                    var matchedGroups = subTaskDetails!["matched_groups"]?.ToObject<List<JObject>>() ?? [];
+                    var sb = new StringBuilder();
+                    sb.AppendLine(LocalizationHelper.GetString("BattleFormationOperboxMatched"));
+                    foreach (var group in matchedGroups)
+                    {
+                        var gn = group["group_name"]?.ToString() ?? string.Empty;
+                        var on = DataHelper.GetLocalizedCharacterName(group["oper_name"]?.ToString());
+                        sb.AppendLine($"{gn} => {on}");
+                    }
+                    Instances.CopilotViewModel.AddLog(sb.ToString().TrimEnd(), UiLogColor.Info);
+                    break;
+                }
+
+            case "BattleFormationOperbox1Unmatched":
+                {
+                    var groupName = subTaskDetails!["group_name"]?.ToString() ?? "Unknown Group";
+                    Instances.CopilotViewModel.AddLog(
+                        LocalizationHelper.GetStringFormat("BattleFormationOperbox1Unmatched", groupName), UiLogColor.Warning);
                     break;
                 }
 

--- a/src/MaaWpfGui/Models/AsstTasks/AsstCopilotTask.cs
+++ b/src/MaaWpfGui/Models/AsstTasks/AsstCopilotTask.cs
@@ -68,6 +68,16 @@ public class AsstCopilotTask : AsstBaseTask
     public bool UseSanityPotion { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether 依据干员识别结果辅助编队
+    /// </summary>
+    public bool OperBoxAssist { get; set; }
+
+    /// <summary>
+    /// Gets or sets 干员识别数据文件路径
+    /// </summary>
+    public string OperBoxDataPath { get; set; } = string.Empty;
+
+    /// <summary>
     /// Gets or sets 自定干员列表
     /// </summary>
     public List<UserAdditional>? UserAdditionals { get; set; }
@@ -113,6 +123,12 @@ public class AsstCopilotTask : AsstBaseTask
         if (UserAdditionals?.Count > 0)
         {
             taskParams["user_additional"] = JArray.FromObject(UserAdditionals);
+        }
+
+        if (OperBoxAssist)
+        {
+            taskParams["operbox_assist"] = true;
+            taskParams["operbox_data_path"] = OperBoxDataPath;
         }
 
         return (TaskType, taskParams);

--- a/src/MaaWpfGui/Models/AsstTasks/AsstCopilotTask.cs
+++ b/src/MaaWpfGui/Models/AsstTasks/AsstCopilotTask.cs
@@ -68,11 +68,6 @@ public class AsstCopilotTask : AsstBaseTask
     public bool UseSanityPotion { get; set; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether 依据干员识别结果辅助编队
-    /// </summary>
-    public bool OperBoxAssist { get; set; }
-
-    /// <summary>
     /// Gets or sets 干员识别数据文件路径
     /// </summary>
     public string OperBoxDataPath { get; set; } = string.Empty;
@@ -96,6 +91,7 @@ public class AsstCopilotTask : AsstBaseTask
             ["ignore_requirements"] = IgnoreRequirements,
             ["loop_times"] = LoopTimes,
             ["use_sanity_potion"] = UseSanityPotion,
+            ["operbox_data_path"] = OperBoxDataPath,
         };
 
         if (!string.IsNullOrEmpty(FileName) && MultiTasks.Count > 0)
@@ -123,12 +119,6 @@ public class AsstCopilotTask : AsstBaseTask
         if (UserAdditionals?.Count > 0)
         {
             taskParams["user_additional"] = JArray.FromObject(UserAdditionals);
-        }
-
-        if (OperBoxAssist)
-        {
-            taskParams["operbox_assist"] = true;
-            taskParams["operbox_data_path"] = OperBoxDataPath;
         }
 
         return (TaskType, taskParams);

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -1650,7 +1650,7 @@ Right-click to clear inactive jobs</system:String>
     <system:String x:Key="BattleFormationOperUnavailable.SkillLevel">Skill level too low</system:String>
     <system:String x:Key="BattleFormationOperUnavailable.Module">Required module not unlocked</system:String>
     <system:String x:Key="BattleFormationOperboxDataParseFailed">{key=OperBoxRecognition} data parse failed</system:String>
-    <system:String x:Key="BattleFormationOperbox1Unmatched" xml:space="preserve">{key=Operator} (group) {0} has no matching {key=Operator}</system:String>
+    <system:String x:Key="BattleFormationOperbox1Unmatched" xml:space="preserve">{key=Operator} (group) {0} has no matching {key=Operator}, may need to borrow {key=Operator} {1}</system:String>
     <system:String x:Key="BattleFormationOperboxMatched">Pre-matched {key=Operator} (groups):</system:String>
     <system:String x:Key="CopilotUserAdditionalNameInvalid">Additional custom {key=Operator} name invalid: {0}, please check spelling</system:String>
     <system:String x:Key="CurrentSteps">Step: {0} {1}</system:String>

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -1204,6 +1204,7 @@ Only level rewards can be farmed; to get the Engraved Medal, all ｢Key Objectiv
     <system:String x:Key="Copilot.IgnoreRequirements.Tip" xml:space="preserve">Some jobs require specific skill levels, Modules or other prerequisites.
 Enabling this will skip these checks, but may cause the job to fail.
 Operators' Elite level CANNOT be ignored. If any requirements are ignored, the operation will no longer be automatically rated after the battle.</system:String>
+    <system:String x:Key="Copilot.UseOperBoxAssist">Assist formation with OperBox data</system:String>
     <system:String x:Key="AddUserAdditional">Add custom {key=Operator}s</system:String>
     <system:String x:Key="AddUserAdditionalTip">Use ｢;｣ as the separator, ｢,｣ to separate the {key=Operator} name and Skills, for example: W, 3; Ash, 2</system:String>
     <system:String x:Key="UserAdditional.OperatorName">{key=Operator} Name</system:String>
@@ -1373,6 +1374,7 @@ Right-click to clear inactive jobs</system:String>
     <system:String x:Key="ReportSkippedForPcClient">The PC client cursor can obscure drop items and counts. This report was skipped to avoid polluting the data pool with inaccurate data</system:String>
     <system:String x:Key="TheEx">No bonus stage, stopped</system:String>
     <system:String x:Key="MissingOperators">None of the {key=Operator}s in the following groups are owned (only one is needed per group):\n{0}｢Favourite｣ marks may affect {key=Operator} recognition; if the {key=Operator}s above are owned, remove the mark and retry. If not, use ｢{key=SupportUnitUsage}｣ when only one group is missing, or use another job when two or more are missing.</system:String>
+    <system:String x:Key="OperboxMultipleUnmatched">Multiple {key=Operator} (groups) unmatched:</system:String>
     <system:String x:Key="RecruitSupportOperator">Add support unit: {0}</system:String>
     <system:String x:Key="StageQueue">Stage Queue:&#160;</system:String>
     <system:String x:Key="UnableToAgent">Unable to use PRTS</system:String>
@@ -1647,6 +1649,9 @@ Right-click to clear inactive jobs</system:String>
     <system:String x:Key="BattleFormationOperUnavailable.Level">Level too low</system:String>
     <system:String x:Key="BattleFormationOperUnavailable.SkillLevel">Skill level too low</system:String>
     <system:String x:Key="BattleFormationOperUnavailable.Module">Required module not unlocked</system:String>
+    <system:String x:Key="BattleFormationOperboxDataParseFailed">{key=OperBoxRecognition} data parse failed</system:String>
+    <system:String x:Key="BattleFormationOperbox1Unmatched" xml:space="preserve">{key=Operator} (group) {0} has no matching {key=Operator}</system:String>
+    <system:String x:Key="BattleFormationOperboxMatched">Pre-matched {key=Operator} (groups):</system:String>
     <system:String x:Key="CopilotUserAdditionalNameInvalid">Additional custom {key=Operator} name invalid: {0}, please check spelling</system:String>
     <system:String x:Key="CurrentSteps">Step: {0} {1}</system:String>
     <system:String x:Key="ElapsedTime">Elapsed time: {0}ms</system:String>

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -1649,10 +1649,10 @@ Right-click to clear inactive jobs</system:String>
     <system:String x:Key="BattleFormationOperUnavailable.Level">Level too low</system:String>
     <system:String x:Key="BattleFormationOperUnavailable.SkillLevel">Skill level too low</system:String>
     <system:String x:Key="BattleFormationOperUnavailable.Module">Required module not unlocked</system:String>
-    <system:String x:Key="BattleFormationOperboxDataParseFailed">{key=OperBoxRecognition} data parse failed</system:String>
     <system:String x:Key="BattleFormationOperbox1Unmatched" xml:space="preserve">{key=Operator} (group) {0} has no matching {key=Operator}, may need to borrow {key=Operator} {1}</system:String>
     <system:String x:Key="BattleFormationOperboxMatched">Pre-matched {key=Operator} (groups):</system:String>
     <system:String x:Key="CopilotUserAdditionalNameInvalid">Additional custom {key=Operator} name invalid: {0}, please check spelling</system:String>
+    <system:String x:Key="CopilotOperboxDataParseFailed">{key=OperBoxRecognition} data parse failed</system:String>
     <system:String x:Key="CurrentSteps">Step: {0} {1}</system:String>
     <system:String x:Key="ElapsedTime">Elapsed time: {0}ms</system:String>
     <system:String x:Key="Deploy">Deploy</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -1651,10 +1651,10 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="BattleFormationOperUnavailable.Level">レベル不足</system:String>
     <system:String x:Key="BattleFormationOperUnavailable.SkillLevel">スキルレベルが低すぎる</system:String>
     <system:String x:Key="BattleFormationOperUnavailable.Module">必要なモジュールが未解除</system:String>
-    <system:String x:Key="BattleFormationOperboxDataParseFailed">{key=OperBoxRecognition}データ解析失敗</system:String>
     <system:String x:Key="BattleFormationOperbox1Unmatched" xml:space="preserve">{key=Operator}（グループ） {0} に一致する{key=Operator}なし、{key=Operator}{1}を借りる必要があるかもしれません</system:String>
     <system:String x:Key="BattleFormationOperboxMatched">事前マッチした{key=Operator}（グループ）：</system:String>
     <system:String x:Key="CopilotUserAdditionalNameInvalid">追加のカスタム{key=Operator}名が無効です: {0}、スペルを確認してください</system:String>
+    <system:String x:Key="CopilotOperboxDataParseFailed">{key=OperBoxRecognition}データ解析失敗</system:String>
     <system:String x:Key="CurrentSteps">現在の手順: {0} {1}</system:String>
     <system:String x:Key="ElapsedTime">経過時間: {0}ms</system:String>
     <system:String x:Key="Deploy">配置</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -1652,7 +1652,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="BattleFormationOperUnavailable.SkillLevel">スキルレベルが低すぎる</system:String>
     <system:String x:Key="BattleFormationOperUnavailable.Module">必要なモジュールが未解除</system:String>
     <system:String x:Key="BattleFormationOperboxDataParseFailed">{key=OperBoxRecognition}データ解析失敗</system:String>
-    <system:String x:Key="BattleFormationOperbox1Unmatched" xml:space="preserve">{key=Operator}（グループ） {0} に一致する{key=Operator}なし</system:String>
+    <system:String x:Key="BattleFormationOperbox1Unmatched" xml:space="preserve">{key=Operator}（グループ） {0} に一致する{key=Operator}なし、{key=Operator}{1}を借りる必要があるかもしれません</system:String>
     <system:String x:Key="BattleFormationOperboxMatched">事前マッチした{key=Operator}（グループ）：</system:String>
     <system:String x:Key="CopilotUserAdditionalNameInvalid">追加のカスタム{key=Operator}名が無効です: {0}、スペルを確認してください</system:String>
     <system:String x:Key="CurrentSteps">現在の手順: {0} {1}</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -1206,6 +1206,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="Copilot.IgnoreRequirements.Tip" xml:space="preserve">一部の攻略は特定のモジュールなどを前提条件とします
 この項目を選択するとこれらのチェックをスキップしますが、タスクが正常に動作しなくなる可能性があります。
 オペレーターのエリートレベルはスキップできません。いずれかの条件をスキップした場合、戦闘後にオペレーションは自動的に評価されなくなります。</system:String>
+    <system:String x:Key="Copilot.UseOperBoxAssist">オペレーター認識データで編隊を支援</system:String>
     <system:String x:Key="AddUserAdditional">カスタム{key=Operator}追加</system:String>
     <system:String x:Key="AddUserAdditionalTip">｢;｣ はセパレータ、 ｢,｣ で{key=Operator}の名前とスキルを区切ります。例: Surtr, 3; Eyjafjalla, 1</system:String>
     <system:String x:Key="UserAdditional.OperatorName">{key=Operator}名</system:String>
@@ -1375,6 +1376,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="ReportSkippedForPcClient">PC クライアントではカーソルがドロップ品や個数の認識を遮る場合があります。誤ったデータでデータプールを汚染しないよう、今回のレポートは自動的にスキップしました</system:String>
     <system:String x:Key="TheEx">ステージ報酬がないため停止します</system:String>
     <system:String x:Key="MissingOperators">以下の{key=Operator}グループの{key=Operator}を所有していません（各グループ1体で足ります）：\n{0}｢戦術要員｣ マークは{key=Operator}の認識に影響する可能性があります。上記の{key=Operator}を所有している場合はマークを解除して再試行してください。所有していない場合は、不足グループが1つなら ｢{key=SupportUnitUsage}｣ で補えますが、2つ以上の場合は他の作業ファイルを使用してください。</system:String>
+    <system:String x:Key="OperboxMultipleUnmatched">複数の{key=Operator}（グループ）が不一致：</system:String>
     <system:String x:Key="RecruitSupportOperator">サポートユニットを追加：{0}</system:String>
     <system:String x:Key="StageQueue">ステージキュー:</system:String>
     <system:String x:Key="UnableToAgent">自動指揮利用不可</system:String>
@@ -1649,6 +1651,9 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="BattleFormationOperUnavailable.Level">レベル不足</system:String>
     <system:String x:Key="BattleFormationOperUnavailable.SkillLevel">スキルレベルが低すぎる</system:String>
     <system:String x:Key="BattleFormationOperUnavailable.Module">必要なモジュールが未解除</system:String>
+    <system:String x:Key="BattleFormationOperboxDataParseFailed">{key=OperBoxRecognition}データ解析失敗</system:String>
+    <system:String x:Key="BattleFormationOperbox1Unmatched" xml:space="preserve">{key=Operator}（グループ） {0} に一致する{key=Operator}なし</system:String>
+    <system:String x:Key="BattleFormationOperboxMatched">事前マッチした{key=Operator}（グループ）：</system:String>
     <system:String x:Key="CopilotUserAdditionalNameInvalid">追加のカスタム{key=Operator}名が無効です: {0}、スペルを確認してください</system:String>
     <system:String x:Key="CurrentSteps">現在の手順: {0} {1}</system:String>
     <system:String x:Key="ElapsedTime">経過時間: {0}ms</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -1653,7 +1653,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="BattleFormationOperUnavailable.SkillLevel">스킬 레벨이 너무 낮음</system:String>
     <system:String x:Key="BattleFormationOperUnavailable.Module">필요한 모듈이 잠금 해제되지 않음</system:String>
     <system:String x:Key="BattleFormationOperboxDataParseFailed">{key=OperBoxRecognition} 데이터 분석 실패</system:String>
-    <system:String x:Key="BattleFormationOperbox1Unmatched" xml:space="preserve">{key=Operator}(그룹) {0}에 일치하는 {key=Operator} 없음</system:String>
+    <system:String x:Key="BattleFormationOperbox1Unmatched" xml:space="preserve">{key=Operator}(그룹) {0}에 일치하는 {key=Operator} 없음，{key=Operator}{1}을(를) 빌려야 할 수 있습니다</system:String>
     <system:String x:Key="BattleFormationOperboxMatched">사전 매칭된 {key=Operator}(그룹):</system:String>
     <system:String x:Key="CopilotUserAdditionalNameInvalid">추가된 커스텀 {key=Operator} 이름이 유효하지 않음: {0}, 철자를 확인하세요</system:String>
     <system:String x:Key="CurrentSteps">현재 단계: {0} {1}</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -1652,10 +1652,10 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="BattleFormationOperUnavailable.Level">레벨이 너무 낮음</system:String>
     <system:String x:Key="BattleFormationOperUnavailable.SkillLevel">스킬 레벨이 너무 낮음</system:String>
     <system:String x:Key="BattleFormationOperUnavailable.Module">필요한 모듈이 잠금 해제되지 않음</system:String>
-    <system:String x:Key="BattleFormationOperboxDataParseFailed">{key=OperBoxRecognition} 데이터 분석 실패</system:String>
     <system:String x:Key="BattleFormationOperbox1Unmatched" xml:space="preserve">{key=Operator}(그룹) {0}에 일치하는 {key=Operator} 없음，{key=Operator}{1}을(를) 빌려야 할 수 있습니다</system:String>
     <system:String x:Key="BattleFormationOperboxMatched">사전 매칭된 {key=Operator}(그룹):</system:String>
     <system:String x:Key="CopilotUserAdditionalNameInvalid">추가된 커스텀 {key=Operator} 이름이 유효하지 않음: {0}, 철자를 확인하세요</system:String>
+    <system:String x:Key="CopilotOperboxDataParseFailed">{key=OperBoxRecognition} 데이터 분석 실패</system:String>
     <system:String x:Key="CurrentSteps">현재 단계: {0} {1}</system:String>
     <system:String x:Key="ElapsedTime">경과 시간: {0}ms</system:String>
     <system:String x:Key="Deploy">배치</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -1652,7 +1652,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="BattleFormationOperUnavailable.Level">레벨이 너무 낮음</system:String>
     <system:String x:Key="BattleFormationOperUnavailable.SkillLevel">스킬 레벨이 너무 낮음</system:String>
     <system:String x:Key="BattleFormationOperUnavailable.Module">필요한 모듈이 잠금 해제되지 않음</system:String>
-    <system:String x:Key="BattleFormationOperbox1Unmatched" xml:space="preserve">{key=Operator}(그룹) {0}에 일치하는 {key=Operator} 없음，{key=Operator}{1}을(를) 빌려야 할 수 있습니다</system:String>
+    <system:String x:Key="BattleFormationOperbox1Unmatched" xml:space="preserve">{key=Operator}(그룹) {0}에 일치하는 {key=Operator} 없음, {key=Operator}{1}을(를) 빌려야 할 수 있습니다</system:String>
     <system:String x:Key="BattleFormationOperboxMatched">사전 매칭된 {key=Operator}(그룹):</system:String>
     <system:String x:Key="CopilotUserAdditionalNameInvalid">추가된 커스텀 {key=Operator} 이름이 유효하지 않음: {0}, 철자를 확인하세요</system:String>
     <system:String x:Key="CopilotOperboxDataParseFailed">{key=OperBoxRecognition} 데이터 분석 실패</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -1207,6 +1207,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="Copilot.IgnoreRequirements.Tip" xml:space="preserve">일부 작업은 특정 스킬 레벨, 모듈 또는 기타 요구 사항이 필요합니다.
 이 옵션을 활성화하면 해당 검사를 건너뛰지만, 작업이 정상적으로 동작하지 않을 수 있습니다.
 오퍼레이터의 정예화 등급은 무시할 수 없습니다. 요구 사항을 하나라도 무시할 경우, 전투 종료 후 자동으로 '좋아요'를 남기지 않습니다.</system:String>
+    <system:String x:Key="Copilot.UseOperBoxAssist">오퍼레이터 인식 데이터로 편성 지원</system:String>
     <system:String x:Key="AddUserAdditional">커스텀 {key=Operator} 추가</system:String>
     <system:String x:Key="AddUserAdditionalTip">｢;｣ 로 {key=Operator}를 구분하고, ｢,｣ 로 스킬을 구분합니다. 예시: W, 3; Ash, 2</system:String>
     <system:String x:Key="UserAdditional.OperatorName">{key=Operator} 이름</system:String>
@@ -1376,6 +1377,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="ReportSkippedForPcClient">PC 클라이언트에서는 커서가 드롭 아이템과 수량 인식을 가릴 수 있습니다. 잘못된 데이터가 데이터 풀을 오염시키지 않도록 이번 보고는 자동으로 건너뜁니다</system:String>
     <system:String x:Key="TheEx">EX 스테이지가 없어 중단되었습니다</system:String>
     <system:String x:Key="MissingOperators">다음 {key=Operator} 그룹의 {key=Operator}를 보유하고 있지 않습니다(그룹당 1명이면 충분합니다):\n{0}｢선호｣ 표시는 {key=Operator} 인식에 영향을 줄 수 있습니다. 위의 {key=Operator}를 보유하고 있다면 표시를 해제한 후 다시 시도하세요. 보유하지 않은 경우 부족한 그룹이 1개뿐이라면 ｢{key=SupportUnitUsage}｣로 대체할 수 있고, 2개 이상이라면 다른 작업 파일을 사용해 주세요.</system:String>
+    <system:String x:Key="OperboxMultipleUnmatched">여러 {key=Operator}(그룹)이 일치하지 않음:</system:String>
     <system:String x:Key="RecruitSupportOperator">지원 유닛 추가: {0}</system:String>
     <system:String x:Key="StageQueue">스테이지 대기열:</system:String>
     <system:String x:Key="UnableToAgent">대리 지휘를 사용할 수 없습니다</system:String>
@@ -1650,6 +1652,9 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="BattleFormationOperUnavailable.Level">레벨이 너무 낮음</system:String>
     <system:String x:Key="BattleFormationOperUnavailable.SkillLevel">스킬 레벨이 너무 낮음</system:String>
     <system:String x:Key="BattleFormationOperUnavailable.Module">필요한 모듈이 잠금 해제되지 않음</system:String>
+    <system:String x:Key="BattleFormationOperboxDataParseFailed">{key=OperBoxRecognition} 데이터 분석 실패</system:String>
+    <system:String x:Key="BattleFormationOperbox1Unmatched" xml:space="preserve">{key=Operator}(그룹) {0}에 일치하는 {key=Operator} 없음</system:String>
+    <system:String x:Key="BattleFormationOperboxMatched">사전 매칭된 {key=Operator}(그룹):</system:String>
     <system:String x:Key="CopilotUserAdditionalNameInvalid">추가된 커스텀 {key=Operator} 이름이 유효하지 않음: {0}, 철자를 확인하세요</system:String>
     <system:String x:Key="CurrentSteps">현재 단계: {0} {1}</system:String>
     <system:String x:Key="ElapsedTime">경과 시간: {0}ms</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -1650,7 +1650,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="BattleFormationOperUnavailable.SkillLevel">技能等级不足</system:String>
     <system:String x:Key="BattleFormationOperUnavailable.Module">所需模组未解锁</system:String>
     <system:String x:Key="BattleFormationOperboxDataParseFailed">{key=OperBoxRecognition}数据解析失败</system:String>
-    <system:String x:Key="BattleFormationOperbox1Unmatched" xml:space="preserve">{key=Operator}（组） {0} 没有匹配的{key=Operator}，可能需要借助战 {1}</system:String>
+    <system:String x:Key="BattleFormationOperbox1Unmatched" xml:space="preserve">{key=Operator}（组） {0} 没有匹配的{key=Operator}，可能需要借助战{key=Operator}{1}</system:String>
     <system:String x:Key="BattleFormationOperboxMatched">预匹配的{key=Operator}（组）：</system:String>
     <system:String x:Key="CopilotUserAdditionalNameInvalid">追加自定{key=Operator}名称无效: {0}，请检查拼写</system:String>
     <system:String x:Key="CurrentSteps">当前步骤: {0} {1}</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -1649,10 +1649,10 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="BattleFormationOperUnavailable.Level">等级不足</system:String>
     <system:String x:Key="BattleFormationOperUnavailable.SkillLevel">技能等级不足</system:String>
     <system:String x:Key="BattleFormationOperUnavailable.Module">所需模组未解锁</system:String>
-    <system:String x:Key="BattleFormationOperboxDataParseFailed">{key=OperBoxRecognition}数据解析失败</system:String>
     <system:String x:Key="BattleFormationOperbox1Unmatched" xml:space="preserve">{key=Operator}（组） {0} 没有匹配的{key=Operator}，可能需要借助战{key=Operator}{1}</system:String>
     <system:String x:Key="BattleFormationOperboxMatched">预匹配的{key=Operator}（组）：</system:String>
     <system:String x:Key="CopilotUserAdditionalNameInvalid">追加自定{key=Operator}名称无效: {0}，请检查拼写</system:String>
+    <system:String x:Key="CopilotOperboxDataParseFailed">{key=OperBoxRecognition}数据解析失败</system:String>
     <system:String x:Key="CurrentSteps">当前步骤: {0} {1}</system:String>
     <system:String x:Key="ElapsedTime">当前计时器: {0}ms</system:String>
     <system:String x:Key="Deploy">部署</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -1204,6 +1204,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="Copilot.IgnoreRequirements.Tip" xml:space="preserve">某些作业需要特定技能等级、模组等作为前置条件
 勾选此项将跳过这些检查，但可能导致作业无法正常运行
 干员精英化等级无法被跳过，如果跳过了任何需求，则战斗完成后不再进行自动点赞</system:String>
+    <system:String x:Key="Copilot.UseOperBoxAssist">依据干员识别结果辅助编队</system:String>
     <system:String x:Key="AddUserAdditional">追加自定{key=Operator}</system:String>
     <system:String x:Key="AddUserAdditionalTip">以英文 ｢;｣ 为分隔符，英文 ｢,｣ 分隔{key=Operator}名与技能，例: 史尔特尔,3;艾雅法拉,1</system:String>
     <system:String x:Key="UserAdditional.OperatorName">{key=Operator}名</system:String>
@@ -1373,6 +1374,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="ReportSkippedForPcClient">PC 端鼠标为独立渲染，可能遮挡掉落物及数量识别。为避免错误数据污染数据池，已自动跳过本次上报</system:String>
     <system:String x:Key="TheEx">无奖励关卡，已停止</system:String>
     <system:String x:Key="MissingOperators">以下{key=Operator}组内的{key=Operator}均未拥有（每组只需其一）：\n{0}｢特别关注｣ 可能影响{key=Operator}识别，上述{key=Operator}若已拥有，请移除后重试；若未拥有，仅缺一组时可使用 ｢{key=SupportUnitUsage}｣，缺两组以上请更换作业。</system:String>
+    <system:String x:Key="OperboxMultipleUnmatched">多个{key=Operator}（组）不匹配：</system:String>
     <system:String x:Key="RecruitSupportOperator">编入助战{key=Operator}：{0}</system:String>
     <system:String x:Key="StageQueue">关卡队列:</system:String>
     <system:String x:Key="UnableToAgent">无法使用代理指挥</system:String>
@@ -1647,6 +1649,9 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="BattleFormationOperUnavailable.Level">等级不足</system:String>
     <system:String x:Key="BattleFormationOperUnavailable.SkillLevel">技能等级不足</system:String>
     <system:String x:Key="BattleFormationOperUnavailable.Module">所需模组未解锁</system:String>
+    <system:String x:Key="BattleFormationOperboxDataParseFailed">{key=OperBoxRecognition}数据解析失败</system:String>
+    <system:String x:Key="BattleFormationOperbox1Unmatched" xml:space="preserve">{key=Operator}（组） {0} 没有匹配的{key=Operator}</system:String>
+    <system:String x:Key="BattleFormationOperboxMatched">预匹配的{key=Operator}（组）：</system:String>
     <system:String x:Key="CopilotUserAdditionalNameInvalid">追加自定{key=Operator}名称无效: {0}，请检查拼写</system:String>
     <system:String x:Key="CurrentSteps">当前步骤: {0} {1}</system:String>
     <system:String x:Key="ElapsedTime">当前计时器: {0}ms</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -1650,7 +1650,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="BattleFormationOperUnavailable.SkillLevel">技能等级不足</system:String>
     <system:String x:Key="BattleFormationOperUnavailable.Module">所需模组未解锁</system:String>
     <system:String x:Key="BattleFormationOperboxDataParseFailed">{key=OperBoxRecognition}数据解析失败</system:String>
-    <system:String x:Key="BattleFormationOperbox1Unmatched" xml:space="preserve">{key=Operator}（组） {0} 没有匹配的{key=Operator}</system:String>
+    <system:String x:Key="BattleFormationOperbox1Unmatched" xml:space="preserve">{key=Operator}（组） {0} 没有匹配的{key=Operator}，可能需要借助战 {1}</system:String>
     <system:String x:Key="BattleFormationOperboxMatched">预匹配的{key=Operator}（组）：</system:String>
     <system:String x:Key="CopilotUserAdditionalNameInvalid">追加自定{key=Operator}名称无效: {0}，请检查拼写</system:String>
     <system:String x:Key="CurrentSteps">当前步骤: {0} {1}</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -1650,10 +1650,10 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="BattleFormationOperUnavailable.Level">等級不足</system:String>
     <system:String x:Key="BattleFormationOperUnavailable.SkillLevel">技能等級不足</system:String>
     <system:String x:Key="BattleFormationOperUnavailable.Module">所需模組未解鎖</system:String>
-    <system:String x:Key="BattleFormationOperboxDataParseFailed">{key=OperBoxRecognition}資料解析失敗</system:String>
     <system:String x:Key="BattleFormationOperbox1Unmatched" xml:space="preserve">{key=Operator}（組） {0} 沒有匹配的{key=Operator}，可能需要借助戰{key=Operator}{1}</system:String>
     <system:String x:Key="BattleFormationOperboxMatched">預匹配的{key=Operator}（組）：</system:String>
     <system:String x:Key="CopilotUserAdditionalNameInvalid">追加自定義{key=Operator}名稱無效：{0}，請檢查拼寫</system:String>
+    <system:String x:Key="CopilotOperboxDataParseFailed">{key=OperBoxRecognition}資料解析失敗</system:String>
     <system:String x:Key="CurrentSteps">目前步驟：{0} {1}</system:String>
     <system:String x:Key="ElapsedTime">經過時間：{0}ms</system:String>
     <system:String x:Key="Deploy">部署</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -1651,7 +1651,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="BattleFormationOperUnavailable.SkillLevel">技能等級不足</system:String>
     <system:String x:Key="BattleFormationOperUnavailable.Module">所需模組未解鎖</system:String>
     <system:String x:Key="BattleFormationOperboxDataParseFailed">{key=OperBoxRecognition}資料解析失敗</system:String>
-    <system:String x:Key="BattleFormationOperbox1Unmatched" xml:space="preserve">{key=Operator}（組） {0} 沒有匹配的{key=Operator}</system:String>
+    <system:String x:Key="BattleFormationOperbox1Unmatched" xml:space="preserve">{key=Operator}（組） {0} 沒有匹配的{key=Operator}，可能需要借助戰{key=Operator}{1}</system:String>
     <system:String x:Key="BattleFormationOperboxMatched">預匹配的{key=Operator}（組）：</system:String>
     <system:String x:Key="CopilotUserAdditionalNameInvalid">追加自定義{key=Operator}名稱無效：{0}，請檢查拼寫</system:String>
     <system:String x:Key="CurrentSteps">目前步驟：{0} {1}</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -426,7 +426,7 @@
 📄 更新說明：
     • {key=UpdateCheckNow}：包含介面與功能更新。介面改動、新功能需透過 {key=UpdateCheckNow} 取得
     • {key=ResourceUpdate}：包含自動作戰新關卡、掉落辨識圖示、公招幹員標籤等素材資料
-    • 導航熱更新：自動觸發，用於更新主介面提示與活動關卡入口。成功後右上角會顯示 ｢{key=ApiUpdateSuccess}｣ 
+    • 導航熱更新：自動觸發，用於更新主介面提示與活動關卡入口。成功後右上角會顯示 ｢{key=ApiUpdateSuccess}｣
 </system:String>
     <system:String x:Key="GlobalSource">全域來源</system:String>
     <system:String x:Key="ForceGithubGlobalSource">強制使用 GitHub</system:String>
@@ -1105,7 +1105,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="MiniGame@SPA">衛戍協議：盟約</system:String>
     <system:String x:Key="MiniGame@SPATip" xml:space="preserve">在活動主介面（有 ｢獨立模擬｣ 處）開始任務。
 在有存檔時需要先手動放棄
-最高只測試過 ｢險境模擬｣ 
+最高只測試過 ｢險境模擬｣
 如果已通關更高難度導致看不到 ｢險境模擬｣ 或 ｢標準模擬｣ ，需手動選擇一次 ｢險境模擬｣ 難度
 手動通關 ｢標準模擬｣ 可以更快刷分。
 只能刷等級獎勵，拿蝕刻章得打完所有的 ｢關鍵目標｣ 。</system:String>
@@ -1205,6 +1205,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="Copilot.IgnoreRequirements.Tip" xml:space="preserve">部分作業需要特定技能等級、模組等作為前置條件。
 勾選此項將跳過這些檢查，但可能導致作業無法正常執行。
 幹員精英化等級無法跳過；若跳過任何需求，戰鬥完成後將不再為作業自動點贊。</system:String>
+    <system:String x:Key="Copilot.UseOperBoxAssist">依據幹員識別結果輔助編隊</system:String>
     <system:String x:Key="AddUserAdditional">追加自定義{key=Operator}</system:String>
     <system:String x:Key="AddUserAdditionalTip">使用 ｢;｣ 作為分隔符，用 ｢,｣ 分隔{key=Operator}姓名和技能，例如：史爾特爾,3;艾雅法拉,1</system:String>
     <system:String x:Key="UserAdditional.OperatorName">{key=Operator}名稱</system:String>
@@ -1374,6 +1375,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="ReportSkippedForPcClient">PC 端滑鼠為獨立渲染，可能遮擋掉落物及數量辨識。為避免錯誤資料污染資料池，已自動跳過本次上報</system:String>
     <system:String x:Key="TheEx">無獎勵關卡，已停止</system:String>
     <system:String x:Key="MissingOperators">以下{key=Operator}組內的{key=Operator}均未擁有（每組只需其一）：\n{0}｢特別關注｣ 可能影響{key=Operator}辨識，上述{key=Operator}若已擁有，請移除後重試；若未擁有，僅缺一組時可使用 ｢{key=SupportUnitUsage}｣，缺兩組以上請更換作業。</system:String>
+    <system:String x:Key="OperboxMultipleUnmatched">多個{key=Operator}（組）不匹配：</system:String>
     <system:String x:Key="RecruitSupportOperator">編入助戰{key=Operator}：{0}</system:String>
     <system:String x:Key="StageQueue">關卡佇列：</system:String>
     <system:String x:Key="UnableToAgent">無法使用代理指揮</system:String>
@@ -1648,6 +1650,9 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="BattleFormationOperUnavailable.Level">等級不足</system:String>
     <system:String x:Key="BattleFormationOperUnavailable.SkillLevel">技能等級不足</system:String>
     <system:String x:Key="BattleFormationOperUnavailable.Module">所需模組未解鎖</system:String>
+    <system:String x:Key="BattleFormationOperboxDataParseFailed">{key=OperBoxRecognition}資料解析失敗</system:String>
+    <system:String x:Key="BattleFormationOperbox1Unmatched" xml:space="preserve">{key=Operator}（組） {0} 沒有匹配的{key=Operator}</system:String>
+    <system:String x:Key="BattleFormationOperboxMatched">預匹配的{key=Operator}（組）：</system:String>
     <system:String x:Key="CopilotUserAdditionalNameInvalid">追加自定義{key=Operator}名稱無效：{0}，請檢查拼寫</system:String>
     <system:String x:Key="CurrentSteps">目前步驟：{0} {1}</system:String>
     <system:String x:Key="ElapsedTime">經過時間：{0}ms</system:String>

--- a/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
@@ -497,6 +497,17 @@ public partial class CopilotViewModel : Screen
         }
     }
 
+    [PropertyDependsOn(nameof(EnableOperBoxAssist))]
+    [PropertyDependsOn(nameof(OperBoxLastSyncTimeText))]
+    [PropertyDependsOn(nameof(IgnoreRequirements))]
+    [PropertyDependsOn(nameof(Form))]
+    [PropertyDependsOn(nameof(CopilotTabIndex))]
+    public bool EffectiveOperBoxAssist => EnableOperBoxAssist
+        && !string.IsNullOrEmpty(OperBoxLastSyncTimeText)
+        && IgnoreRequirements
+        && Form
+        && (CopilotTabIndex == 0 || CopilotTabIndex == 3);
+
     /// <summary>
     /// Gets or sets a value indicating whether 真正有干员被忽略了要求
     /// </summary>
@@ -2078,7 +2089,7 @@ public partial class CopilotViewModel : Screen
                 UserAdditionals = AddUserAdditional ? [.. userAdditional] : [],
                 UseSanityPotion = UseSanityPotion,
                 FormationIndex = UseFormation ? FormationIndex : 0,
-                OperBoxDataPath = EnableOperBoxAssist ? OperBoxDataJsonPath : string.Empty,
+                OperBoxDataPath = EffectiveOperBoxAssist ? OperBoxDataJsonPath : string.Empty,
             };
 
             // 能用列表的是主线/ss/故事集/悖论，都是 Copilot 类型
@@ -2134,7 +2145,7 @@ public partial class CopilotViewModel : Screen
                 LoopTimes = Loop ? LoopTimes : 1,
                 UseSanityPotion = false,
                 FormationIndex = UseFormation ? FormationIndex : 0,
-                OperBoxDataPath = EnableOperBoxAssist ? OperBoxDataJsonPath : string.Empty,
+                OperBoxDataPath = EffectiveOperBoxAssist ? OperBoxDataJsonPath : string.Empty,
             };
 
             // 单作业需要区分 Copilot / SSSCopilot

--- a/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
@@ -2101,7 +2101,7 @@ public partial class CopilotViewModel : Screen
                 UserAdditionals = AddUserAdditional ? [.. userAdditional] : [],
                 UseSanityPotion = UseSanityPotion,
                 FormationIndex = UseFormation ? FormationIndex : 0,
-                OperBoxAssist = EnableOperBoxAssist && IgnoreRequirements,
+                OperBoxAssist = EnableOperBoxAssist,
                 OperBoxDataPath = OperBoxDataPath,
             };
 
@@ -2158,7 +2158,7 @@ public partial class CopilotViewModel : Screen
                 LoopTimes = Loop ? LoopTimes : 1,
                 UseSanityPotion = false,
                 FormationIndex = UseFormation ? FormationIndex : 0,
-                OperBoxAssist = EnableOperBoxAssist && IgnoreRequirements,
+                OperBoxAssist = EnableOperBoxAssist,
                 OperBoxDataPath = OperBoxDataPath,
             };
 

--- a/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
@@ -77,6 +77,7 @@ public partial class CopilotViewModel : Screen
     // VideoRecognition 已不支持：仅保留 json 作业
     private static readonly string[] _supportExt = [".json"];
     private static readonly string CopilotJsonDir = Path.Combine(ConfigDir, "copilot");
+    private static readonly string OperBoxDataJsonPath = Path.Combine(DataDir, $"{JsonDataKey.OperBoxData}.json");
     private const string StageNameRegex = @"(?:[a-z]{0,3})(?:\d{0,2})-(?:(?:A|B|C|D|EX|S|TR|MO)-?)?(?:\d{1,2})";
     private const string InvalidStageNameChars = @"[:',\.\(\)\|\[\]\?，。【】｛｝；：]"; // 无效字符
 
@@ -469,23 +470,8 @@ public partial class CopilotViewModel : Screen
     /// </summary>
     public bool IgnoreRequirements { get => field; set => SetAndNotify(ref field, value); }
 
-    public bool EnableOperBoxAssist { get => field; set => SetAndNotify(ref field, value); }
+    public bool EnableOperBoxAssist { get; set => SetAndNotify(ref field, value); }
 
-    public string OperBoxDataPath
-    {
-        get; set {
-            SetAndNotify(ref field, value);
-            ConfigFactory.CurrentConfig.Copilot.CopilotOperBoxDataPath = value;
-        }
-    } = ConfigFactory.CurrentConfig.Copilot.CopilotOperBoxDataPath;
-
-    [PropertyDependsOn(nameof(OperBoxDataPath))]
-    public string OperBoxDisplayPath =>
-        !string.IsNullOrEmpty(OperBoxDataPath) && OperBoxDataPath.StartsWith(BaseDir, StringComparison.OrdinalIgnoreCase)
-            ? Path.GetRelativePath(BaseDir, OperBoxDataPath)
-            : OperBoxDataPath;
-
-    [PropertyDependsOn(nameof(OperBoxDataPath))]
     [PropertyDependsOn(nameof(EnableOperBoxAssist))]
     public string OperBoxLastSyncTimeText
     {
@@ -495,8 +481,8 @@ public partial class CopilotViewModel : Screen
                 return string.Empty;
             }
             try {
-                if (!string.IsNullOrEmpty(OperBoxDataPath) && File.Exists(OperBoxDataPath)) {
-                    var json = JObject.Parse(File.ReadAllText(OperBoxDataPath));
+                if (!string.IsNullOrEmpty(OperBoxDataJsonPath) && File.Exists(OperBoxDataJsonPath)) {
+                    var json = JObject.Parse(File.ReadAllText(OperBoxDataJsonPath));
                     var syncTime = json["syncTime"]?.Value<string>();
                     if (!string.IsNullOrEmpty(syncTime) && DateTimeOffset.TryParse(syncTime, out var dto)) {
                         return Extensions.DateTimeExtension.ToLocalTimeString(dto);
@@ -505,7 +491,7 @@ public partial class CopilotViewModel : Screen
                 }
             }
             catch (Exception ex) {
-                _logger.Warning(ex, "Failed to read OperBox syncTime from {Path}", OperBoxDataPath);
+                _logger.Warning(ex, "Failed to read OperBox syncTime from {Path}", OperBoxDataJsonPath);
             }
             return string.Empty;
         }
@@ -881,19 +867,6 @@ public partial class CopilotViewModel : Screen
         if (dialog.ShowDialog() == true)
         {
             Filename = dialog.FileName;
-        }
-    }
-
-    [UsedImplicitly]
-    public void SelectOperBoxFile()
-    {
-        var dialog = new OpenFileDialog {
-            Filter = "JSON|*.json",
-        };
-
-        if (dialog.ShowDialog() == true)
-        {
-            OperBoxDataPath = dialog.FileName;
         }
     }
 
@@ -2105,8 +2078,7 @@ public partial class CopilotViewModel : Screen
                 UserAdditionals = AddUserAdditional ? [.. userAdditional] : [],
                 UseSanityPotion = UseSanityPotion,
                 FormationIndex = UseFormation ? FormationIndex : 0,
-                OperBoxAssist = EnableOperBoxAssist,
-                OperBoxDataPath = OperBoxDataPath,
+                OperBoxDataPath = EnableOperBoxAssist ? OperBoxDataJsonPath : string.Empty,
             };
 
             // 能用列表的是主线/ss/故事集/悖论，都是 Copilot 类型
@@ -2162,8 +2134,7 @@ public partial class CopilotViewModel : Screen
                 LoopTimes = Loop ? LoopTimes : 1,
                 UseSanityPotion = false,
                 FormationIndex = UseFormation ? FormationIndex : 0,
-                OperBoxAssist = EnableOperBoxAssist,
-                OperBoxDataPath = OperBoxDataPath,
+                OperBoxDataPath = EnableOperBoxAssist ? OperBoxDataJsonPath : string.Empty,
             };
 
             // 单作业需要区分 Copilot / SSSCopilot

--- a/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
@@ -492,10 +492,14 @@ public partial class CopilotViewModel : Screen
                 if (!string.IsNullOrEmpty(_operBoxDataPath) && File.Exists(_operBoxDataPath)) {
                     var json = JObject.Parse(File.ReadAllText(_operBoxDataPath));
                     var syncTime = json["syncTime"]?.Value<string>();
+                    if (!string.IsNullOrEmpty(syncTime) && DateTimeOffset.TryParse(syncTime, out var dto)) {
+                        return Extensions.DateTimeExtension.ToLocalTimeString(dto);
+                    }
                     return syncTime ?? string.Empty;
                 }
             }
-            catch {
+            catch (Exception ex) {
+                _logger.Warning(ex, "Failed to read OperBox syncTime from {Path}", _operBoxDataPath);
             }
             return string.Empty;
         }

--- a/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
@@ -490,6 +490,10 @@ public partial class CopilotViewModel : Screen
     public string OperBoxLastSyncTimeText
     {
         get {
+            if (!EnableOperBoxAssist)
+            {
+                return string.Empty;
+            }
             try {
                 if (!string.IsNullOrEmpty(OperBoxDataPath) && File.Exists(OperBoxDataPath)) {
                     var json = JObject.Parse(File.ReadAllText(OperBoxDataPath));

--- a/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
@@ -152,6 +152,12 @@ public partial class CopilotViewModel : Screen
         };
     }
 
+    protected override void OnActivate()
+    {
+        base.OnActivate();
+        NotifyOfPropertyChange(nameof(OperBoxLastSyncTimeText));
+    }
+
     #region UI绑定及操作
 
     #region Log
@@ -465,32 +471,28 @@ public partial class CopilotViewModel : Screen
 
     public bool EnableOperBoxAssist { get => field; set => SetAndNotify(ref field, value); }
 
-    private string _operBoxDataPath = ConfigurationHelper.GetValue(
-        ConfigurationKeys.CopilotOperBoxDataPath,
-        Path.Combine(DataDir, "OperBoxData.json")).Trim();
-
     public string OperBoxDataPath
     {
-        get => _operBoxDataPath;
-        set {
-            SetAndNotify(ref _operBoxDataPath, value);
-            ConfigurationHelper.SetValue(ConfigurationKeys.CopilotOperBoxDataPath, value);
+        get; set {
+            SetAndNotify(ref field, value);
+            ConfigFactory.CurrentConfig.Copilot.CopilotOperBoxDataPath = value;
         }
-    }
+    } = ConfigFactory.CurrentConfig.Copilot.CopilotOperBoxDataPath;
 
     [PropertyDependsOn(nameof(OperBoxDataPath))]
     public string OperBoxDisplayPath =>
-        !string.IsNullOrEmpty(_operBoxDataPath) && _operBoxDataPath.StartsWith(BaseDir, StringComparison.OrdinalIgnoreCase)
-            ? Path.GetRelativePath(BaseDir, _operBoxDataPath)
-            : _operBoxDataPath;
+        !string.IsNullOrEmpty(OperBoxDataPath) && OperBoxDataPath.StartsWith(BaseDir, StringComparison.OrdinalIgnoreCase)
+            ? Path.GetRelativePath(BaseDir, OperBoxDataPath)
+            : OperBoxDataPath;
 
     [PropertyDependsOn(nameof(OperBoxDataPath))]
+    [PropertyDependsOn(nameof(EnableOperBoxAssist))]
     public string OperBoxLastSyncTimeText
     {
         get {
             try {
-                if (!string.IsNullOrEmpty(_operBoxDataPath) && File.Exists(_operBoxDataPath)) {
-                    var json = JObject.Parse(File.ReadAllText(_operBoxDataPath));
+                if (!string.IsNullOrEmpty(OperBoxDataPath) && File.Exists(OperBoxDataPath)) {
+                    var json = JObject.Parse(File.ReadAllText(OperBoxDataPath));
                     var syncTime = json["syncTime"]?.Value<string>();
                     if (!string.IsNullOrEmpty(syncTime) && DateTimeOffset.TryParse(syncTime, out var dto)) {
                         return Extensions.DateTimeExtension.ToLocalTimeString(dto);
@@ -499,7 +501,7 @@ public partial class CopilotViewModel : Screen
                 }
             }
             catch (Exception ex) {
-                _logger.Warning(ex, "Failed to read OperBox syncTime from {Path}", _operBoxDataPath);
+                _logger.Warning(ex, "Failed to read OperBox syncTime from {Path}", OperBoxDataPath);
             }
             return string.Empty;
         }

--- a/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
@@ -463,6 +463,44 @@ public partial class CopilotViewModel : Screen
     /// </summary>
     public bool IgnoreRequirements { get => field; set => SetAndNotify(ref field, value); }
 
+    public bool EnableOperBoxAssist { get => field; set => SetAndNotify(ref field, value); }
+
+    private string _operBoxDataPath = ConfigurationHelper.GetValue(
+        ConfigurationKeys.CopilotOperBoxDataPath,
+        Path.Combine(DataDir, "OperBoxData.json")).Trim();
+
+    public string OperBoxDataPath
+    {
+        get => _operBoxDataPath;
+        set {
+            SetAndNotify(ref _operBoxDataPath, value);
+            ConfigurationHelper.SetValue(ConfigurationKeys.CopilotOperBoxDataPath, value);
+        }
+    }
+
+    [PropertyDependsOn(nameof(OperBoxDataPath))]
+    public string OperBoxDisplayPath =>
+        !string.IsNullOrEmpty(_operBoxDataPath) && _operBoxDataPath.StartsWith(BaseDir, StringComparison.OrdinalIgnoreCase)
+            ? Path.GetRelativePath(BaseDir, _operBoxDataPath)
+            : _operBoxDataPath;
+
+    [PropertyDependsOn(nameof(OperBoxDataPath))]
+    public string OperBoxLastSyncTimeText
+    {
+        get {
+            try {
+                if (!string.IsNullOrEmpty(_operBoxDataPath) && File.Exists(_operBoxDataPath)) {
+                    var json = JObject.Parse(File.ReadAllText(_operBoxDataPath));
+                    var syncTime = json["syncTime"]?.Value<string>();
+                    return syncTime ?? string.Empty;
+                }
+            }
+            catch {
+            }
+            return string.Empty;
+        }
+    }
+
     /// <summary>
     /// Gets or sets a value indicating whether 真正有干员被忽略了要求
     /// </summary>
@@ -833,6 +871,19 @@ public partial class CopilotViewModel : Screen
         if (dialog.ShowDialog() == true)
         {
             Filename = dialog.FileName;
+        }
+    }
+
+    [UsedImplicitly]
+    public void SelectOperBoxFile()
+    {
+        var dialog = new OpenFileDialog {
+            Filter = "JSON|*.json",
+        };
+
+        if (dialog.ShowDialog() == true)
+        {
+            OperBoxDataPath = dialog.FileName;
         }
     }
 
@@ -2044,6 +2095,8 @@ public partial class CopilotViewModel : Screen
                 UserAdditionals = AddUserAdditional ? [.. userAdditional] : [],
                 UseSanityPotion = UseSanityPotion,
                 FormationIndex = UseFormation ? FormationIndex : 0,
+                OperBoxAssist = EnableOperBoxAssist && IgnoreRequirements,
+                OperBoxDataPath = OperBoxDataPath,
             };
 
             // 能用列表的是主线/ss/故事集/悖论，都是 Copilot 类型
@@ -2099,6 +2152,8 @@ public partial class CopilotViewModel : Screen
                 LoopTimes = Loop ? LoopTimes : 1,
                 UseSanityPotion = false,
                 FormationIndex = UseFormation ? FormationIndex : 0,
+                OperBoxAssist = EnableOperBoxAssist && IgnoreRequirements,
+                OperBoxDataPath = OperBoxDataPath,
             };
 
             // 单作业需要区分 Copilot / SSSCopilot

--- a/src/MaaWpfGui/Views/UI/CopilotView.xaml
+++ b/src/MaaWpfGui/Views/UI/CopilotView.xaml
@@ -492,6 +492,36 @@
 
                         </WrapPanel>
 
+                        <!--  UseOperBoxAssist  -->
+                        <WrapPanel
+                            Orientation="Vertical"
+                            Visibility="{c:Binding 'IgnoreRequirements and Form and (CopilotTabIndex == 0 or CopilotTabIndex == 3)'}">
+                            <CheckBox
+                                Margin="2.5,5"
+                                Content="{DynamicResource Copilot.UseOperBoxAssist}" IsChecked="{Binding EnableOperBoxAssist}" />
+                            <StackPanel Visibility="{c:Binding EnableOperBoxAssist}" Margin="24,0,0,0">
+                                <StackPanel Orientation="Horizontal">
+                                    <TextBox
+                                        Width="150"
+                                        Height="28"
+                                        Text="{Binding OperBoxDisplayPath, Mode=OneWay}"
+                                        IsEnabled="{c:Binding Idle}"
+                                        IsReadOnly="True" />
+                                    <Button
+                                        Height="28"
+                                        MinWidth="28"
+                                        Padding="0,5"
+                                        Command="{s:Action SelectOperBoxFile}"
+                                        IsEnabled="{c:Binding Idle}"
+                                        hc:IconElement.Geometry="{StaticResource FolderOpen20Regular}" />
+                                </StackPanel>
+                                <TextBlock
+                                    Margin="0,2,0,0"
+                                    Foreground="Gray"
+                                    Text="{Binding OperBoxLastSyncTimeText}" />
+                            </StackPanel>
+                        </WrapPanel>
+
                         <!--  UseCopilotList  -->
                         <StackPanel
                             Margin="2.5,5"

--- a/src/MaaWpfGui/Views/UI/CopilotView.xaml
+++ b/src/MaaWpfGui/Views/UI/CopilotView.xaml
@@ -499,27 +499,14 @@
                             <CheckBox
                                 Margin="2.5,5"
                                 Content="{DynamicResource Copilot.UseOperBoxAssist}" IsChecked="{Binding EnableOperBoxAssist}" />
-                            <StackPanel Visibility="{c:Binding EnableOperBoxAssist}" Margin="24,0,0,0">
-                                <StackPanel Orientation="Horizontal">
-                                    <TextBox
-                                        Width="150"
-                                        Height="28"
-                                        Text="{Binding OperBoxDisplayPath, Mode=OneWay}"
-                                        IsEnabled="{c:Binding Idle}"
-                                        IsReadOnly="True" />
-                                    <Button
-                                        Height="28"
-                                        MinWidth="28"
-                                        Padding="0,5"
-                                        Command="{s:Action SelectOperBoxFile}"
-                                        IsEnabled="{c:Binding Idle}"
-                                        hc:IconElement.Geometry="{StaticResource FolderOpen20Regular}" />
-                                </StackPanel>
-                                <TextBlock
-                                    Margin="0,2,0,0"
-                                    Foreground="Gray"
-                                    Text="{Binding OperBoxLastSyncTimeText}" />
-                            </StackPanel>
+                            <TextBlock
+                                Visibility="{c:Binding EnableOperBoxAssist}"
+                                Margin="0,2,0,0"
+                                Foreground="Gray">
+                                <Run Text="{DynamicResource LastSyncTime}" />
+                                <Run Text=": " />
+                                <Run Text="{Binding OperBoxLastSyncTimeText, Mode=OneWay}" />
+                            </TextBlock>
                         </WrapPanel>
 
                         <!--  UseCopilotList  -->


### PR DESCRIPTION
用二分图最大权匹配来保证最优性和完备性。带权匹配确保靠前的编队组优先分配靠前干员。可以保证在匹配的组数最多的情况下，匹配尽量最优，靠前的干员组优先匹配强干员。
应该能保证在1s内匹配完全。

## Sourcery 总结

使用已识别的干员清单，在战斗前以最优方式预先分配助战编队。

新功能：
- 添加可选的 OperBox 辅助编队功能，使用已识别的自有干员数据来指导助战队伍分配。
- 在助战 UI 中提供 OperBox 辅助控制、同步信息和任务配置。

错误修复：
- 确保编队选择遵循预先分配的干员，并在启用借用支援干员时正确处理未匹配分组。

增强功能：
- 使用最大基数、优先级感知的二分图匹配对编队进行预检查，并在恰好有一个分组无法匹配时提供支援干员建议。
- 为无效的 OperBox 数据、成功分配以及未匹配的编队分组添加结构化用户通知和日志记录。
- 引入可复用的最小费用流和二分图匹配工具，并在编队分配过程中保留干员优先级元数据。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

将已识别的 OperBox 干员数据整合到协战编队选择中，以预先分配最佳可用干员，并指导支援单位的处理。

新功能：
- 使用已识别的自有干员数据，为协战战斗添加可选的 OperBox 辅助编队功能。
- 在协战 UI 中公开 OperBox 辅助控制、同步详情和任务配置。

错误修复：
- 确保战斗编队选择遵循预先分配的干员，并在启用支援单位借用时正确处理未匹配的编队组。

增强功能：
- 使用考虑优先级的最大基数匹配来预先分配编队组，并在恰好有一个编队组无法匹配时提供支援干员指导。
- 为无效的 OperBox 数据、成功分配和未匹配的编队组添加结构化通知和日志记录。
- 引入可复用的最小费用流和二分图匹配工具，同时在分配过程中保留干员优先级元数据。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

将识别出的 OperBox 数据集成到 Copilot 编队选择中，以预先分配可用的最佳自有干员，并指导支援单位的处理方式。

新功能：
- 添加可选的 OperBox 辅助编队分配功能，使用识别出的自有干员数据。
- 在 Copilot UI 中提供 OperBox 辅助控制、同步详情和配置。

错误修复：
- 确保编队选择遵循预先分配的干员，并在启用支援单位借用时正确处理未匹配的编队组。

增强功能：
- 使用支持优先级的最大基数匹配对编队进行预检查，并在仅剩一个编队组未匹配时提供支援干员指引。
- 为 OperBox 解析、分配和未匹配编队组添加结构化通知和日志记录。
- 引入可复用的最小费用流和二分图匹配工具，用于按优先级分配编队。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

将识别出的 OperBox 数据集成到 Copilot 编队选择中，以预先分配可用的最佳自有干员，并指导支援干员的处理方式。

新功能：
- 添加可选的 OperBox 辅助编队分配功能，使用识别出的自有干员数据，并在 Copilot UI 中提供相关控制项、同步状态和配置。

Bug 修复：
- 确保战斗编队选择遵循预先分配的干员，并在借用支援干员时正确处理未匹配的组。

增强功能：
- 使用考虑优先级的最大基数匹配来预检查编队，在分配过程中保留干员优先级，并在恰好有一个组无法匹配时推荐一名支援干员。
- 为无效的 OperBox 数据、成功分配以及未匹配的编队组添加结构化通知和日志记录。
- 引入可复用的最小费用流和二分图匹配工具。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

将已识别的 OperBox 数据集成到 Copilot 编队选择中，以优化自有干员的预分配，并指导支援单位的处理。

新功能：
- 添加由 OperBox 辅助的可选编队分配功能，使用已识别的自有干员数据，并在 Copilot UI 中提供相关控制项、同步状态和配置。

错误修复：
- 确保战斗编队选择遵循预分配的干员，并在借用支援单位时正确处理未匹配的分组。

改进：
- 使用支持优先级的最大基数匹配对编队进行预检查，并在恰好有一个分组无法匹配时提供支援干员指引。
- 为无效的 OperBox 数据、成功分配以及未匹配的编队分组添加结构化的用户通知和日志。
- 引入可复用的最小费用流和二分图匹配工具，同时在分配过程中保留干员优先级元数据。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

将 OperBox 识别数据集成到 Copilot 编队选择中，以便在战斗前预检查并最优分配自有干员。

新功能：
- 添加基于 OperBox 识别的自有干员数据进行编队分配的可选功能，并在 Copilot UI 中提供相关控制项和同步状态。

错误修复：
- 确保战斗编队选择遵循预分配的干员，并在借用支援干员时正确处理未匹配的编队组。

改进：
- 使用支持优先级的最大基数匹配来预分配编队组，保留干员优先级，并在恰好剩余一个未匹配编队组时建议一名支援干员。
- 为无效数据、分配成功和未匹配编队组添加结构化通知和日志。
- 引入可复用的最小费用流和二分图匹配工具，用于编队分配。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Integrate OperBox recognition data into Copilot formation selection to precheck and optimally assign owned operators before battle.

New Features:
- Add optional OperBox-assisted formation assignment using recognized owned-operator data and expose its controls and synchronization status in the Copilot UI.

Bug Fixes:
- Ensure battle formation selection follows preassigned operators and correctly handles the unmatched group when borrowing a support operator.

Enhancements:
- Use priority-aware maximum-cardinality matching to preassign formation groups, preserve operator priority, and suggest a support operator when exactly one group remains unmatched.
- Add structured notifications and logs for invalid data, successful assignments, and unmatched groups.
- Introduce reusable minimum-cost-flow and bipartite-matching utilities for formation assignment.

</details>

</details>

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>



</details>

## Sourcery 总结

将识别到的干员仓库（operator-box）数据整合进协助作战编队流程，用于预检查并最优分配已有干员，同时围绕该辅助模式增加新的 UI 控件、配置项和日志记录。

新功能：
- 新增可选的 OperBox 辅助编队模式，从 JSON 中读取识别到的已拥有干员数据，用于引导自动队伍分配。
- 引入基于最小费用最大流的二分图匹配算法，以最优方式将编队分组映射到可用干员，优先考虑更强的单位及较前的编队分组。
- 在协助作战 UI 中暴露 OperBox 辅助开关、数据路径选择、相对路径显示以及最后同步时间文本，并通过任务序列化将这些设置传递到核心编队任务中。

缺陷修复：
- 确保在编队中选择干员时能够遵从 OperBox 预分配的干员，并在启用辅助时，通过将其干员标记为缺失来正确跳过那个唯一无法匹配的编队分组。

改进与增强：
- 在编队对比与选择前执行一次基于 OperBox 的预检查，当数据无效或有多个分组匹配失败时中止编队；当恰好只有一个分组未匹配时，给出支援干员借用建议。
- 为 OperBox 数据解析失败、匹配成功的分组、单个未匹配分组（可选的借用建议）以及多个未匹配分组等情况增加结构化日志和面向用户的通知。
- 扩展战斗数据以支持角色重排和排序索引，从而在 OperBox 匹配中保持干员优先级的一致性，并新增通用的最小费用最大流工具以便复用。

<details>
<summary>Original summary in English</summary>



</details>



<details>
<summary>Original summary in English</summary>



</details>

<details>
<summary>Original summary in English</summary>



<details>
<summary>Original summary in English</summary>



</details>

</details>

<details>
<summary>Original summary in English</summary>



<details>
<summary>Original summary in English</summary>



</details>

<details>
<summary>Original summary in English</summary>



<details>
<summary>Original summary in English</summary>



</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>



<details>
<summary>Original summary in English</summary>



</details>

<details>
<summary>Original summary in English</summary>



<details>
<summary>Original summary in English</summary>



</details>

</details>

<details>
<summary>Original summary in English</summary>



<details>
<summary>Original summary in English</summary>



</details>

<details>
<summary>Original summary in English</summary>



<details>
<summary>Original summary in English</summary>



</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>



<details>
<summary>Original summary in English</summary>



</details>

<details>
<summary>Original summary in English</summary>



<details>
<summary>Original summary in English</summary>



</details>

</details>

<details>
<summary>Original summary in English</summary>



<details>
<summary>Original summary in English</summary>



</details>

<details>
<summary>Original summary in English</summary>



<details>
<summary>Original summary in English</summary>



</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>



<details>
<summary>Original summary in English</summary>



</details>

<details>
<summary>Original summary in English</summary>



<details>
<summary>Original summary in English</summary>



</details>

</details>

<details>
<summary>Original summary in English</summary>



<details>
<summary>Original summary in English</summary>



</details>

<details>
<summary>Original summary in English</summary>



<details>
<summary>Original summary in English</summary>



</details>

</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>



<details>
<summary>Original summary in English</summary>



</details>

<details>
<summary>Original summary in English</summary>



<details>
<summary>Original summary in English</summary>



</details>

</details>

<details>
<summary>Original summary in English</summary>



<details>
<summary>Original summary in English</summary>



</details>

<details>
<summary>Original summary in English</summary>



<details>
<summary>Original summary in English</summary>



</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>



<details>
<summary>Original summary in English</summary>



</details>

<details>
<summary>Original summary in English</summary>



<details>
<summary>Original summary in English</summary>



</details>

</details>

<details>
<summary>Original summary in English</summary>



<details>
<summary>Original summary in English</summary>



</details>

<details>
<summary>Original summary in English</summary>



<details>
<summary>Original summary in English</summary>



</details>

</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>



<details>
<summary>Original summary in English</summary>



</details>

<details>
<summary>Original summary in English</summary>



<details>
<summary>Original summary in English</summary>



</details>

</details>

<details>
<summary>Original summary in English</summary>



<details>
<summary>Original summary in English</summary>



</details>

<details>
<summary>Original summary in English</summary>



<details>
<summary>Original summary in English</summary>



</details>

</details>

</details>

<details>
<summary>Original summary in English</summary>



<details>
<summary>Original summary in English</summary>



</details>

<details>
<summary>Original summary in English</summary>



<details>
<summary>Original summary in English</summary>



</details>

</details>

<details>
<summary>Original summary in English</summary>



<details>
<summary>Original summary in English</summary>



</details>

<details>
<summary>Original summary in English</summary>



<details>
<summary>Original summary in English</summary>



</details>

</details>

</details>

</details>

</details>

</details>