### PR TITLE
fix: 修复冒烟测试因 OpenCV 升级后库依赖错误

### DIFF
--- a/.github/workflows/smoke-testing.yml
+++ b/.github/workflows/smoke-testing.yml
@@ -51,7 +51,7 @@ jobs:
         id: cache_key
         continue-on-error: true
         run: |
-          echo "key=Smoke-testing-${{ hashFiles('src/Cpp/**', 'src/MaaCore/**', '3rdparty/include/**', 'include/**', 'cmake/**', 'CMakeLists.txt', 'tools/maadeps-download.py', 'tools/linux-toolchain-download.py') }}" >> $GITHUB_OUTPUT
+          echo "key=Smoke-testing-v2-${{ hashFiles('src/Cpp/**', 'src/MaaCore/**', '3rdparty/include/**', 'include/**', 'cmake/**', 'CMakeLists.txt', 'tools/maadeps-download.py', 'tools/linux-toolchain-download.py') }}" >> $GITHUB_OUTPUT
 
       - name: Restore cache for Smoke Test
         if: ${{ steps.cache_key.outputs.key != '' }}
@@ -64,8 +64,8 @@ jobs:
             ./install/libfastdeploy_ppocr.dylib
             ./install/libMaaCore.dylib
             ./install/libMaaUtils.dylib
-            ./install/libonnxruntime.1.19.2.dylib
-            ./install/libopencv_world4.4.11.0.dylib
+            ./install/libonnxruntime*.dylib
+            ./install/libopencv_world4*.dylib
             ./install/smoke_test
 
       - name: Fetch submodules
@@ -115,8 +115,8 @@ jobs:
             ./install/libfastdeploy_ppocr.dylib
             ./install/libMaaCore.dylib
             ./install/libMaaUtils.dylib
-            ./install/libonnxruntime.1.19.2.dylib
-            ./install/libopencv_world4.4.11.0.dylib
+            ./install/libonnxruntime*.dylib
+            ./install/libopencv_world4*.dylib
             ./install/smoke_test
 
       - name: Upload logs


### PR DESCRIPTION
## 问题

冒烟测试（macOS）失败，5 个客户端全部报错：

```
dyld: Library not loaded: @rpath/libopencv_world4.4.12.0.dylib
  Referenced from: .../install/smoke_test
  Reason: tried: '.../install/libopencv_world4.4.12.0.dylib' (no such file)
```

## 根因

MaaDeps v2.14.1 将 OpenCV 从 **4.4.11.0 升级到 4.4.12.0**，但 `smoke-testing.yml` 在 cache restore/save 路径硬编码了旧文件名 `libopencv_world4.4.11.0.dylib`：

1. 全量构建后 `install/` 实际产物是 `4.4.12.0`，但 save 步骤按硬编码的 `4.4.11.0` 路径存缓存 → 该文件不存在 → **漏存了 `smoke_test` 实际依赖的 dylib**，缓存被写脏。
2. 之后运行 cache-hit 恢复这条不一致的缓存 → `smoke_test` 找不到 `libopencv_world4.4.12.0.dylib` → `Abort trap: 6`。

## 修复

- **cache key 加 `v2` 前缀**：驱逐已被污染的脏缓存条目（GitHub cache 条目不可变，不改 key 会持续命中脏条目）。
- **restore/save 路径改用通配符** `libopencv_world4*.dylib` / `libonnxruntime*.dylib`：避免今后 MaaDeps 升级 OpenCV / onnxruntime 小版本时再次写脏缓存（与 `ci.yml` 中 `libopencv_world4*.dylib` 的现有写法一致）。

合并后首次运行将为 cache-miss 走一次全量构建，重建出含 `4.4.12.0` dylib 的正确缓存，之后恢复正常 cache-hit。

## Summary by Sourcery

更新冒烟测试的缓存配置，以避免与 OpenCV 版本相关的 dylib 不匹配，并重置受污染的缓存条目。

CI:
- 在冒烟测试缓存键前添加新的版本标识符，以使之前损坏的缓存条目失效。
- 在冒烟测试的缓存恢复/保存步骤中，对 OpenCV 和 onnxruntime 的 dylib 路径使用通配符模式，以保持与未来依赖版本升级的兼容性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Update smoke test cache configuration to avoid OpenCV version-related dylib mismatches and reset polluted cache entries.

CI:
- Prefix the smoke test cache key with a new version identifier to invalidate previously corrupted cache entries.
- Use wildcard patterns for OpenCV and onnxruntime dylib paths in smoke test cache restore/save steps to remain compatible with future dependency version bumps.

</details>