### PR TITLE
feat: 支持 MuMu 模拟器触控

### DIFF
--- a/src/MaaCore/Assistant.cpp
+++ b/src/MaaCore/Assistant.cpp
@@ -137,6 +137,12 @@ bool asst::Assistant::set_instance_option(InstanceOptionKey key, const std::stri
             m_ctrler->set_touch_mode(TouchMode::MaaFwAdb);
             return true;
         }
+#if ASST_WITH_EMULATOR_EXTRAS
+        else if (constexpr std::string_view MumuExtras = "MumuExtras"; value == MumuExtras) {
+            m_ctrler->set_touch_mode(TouchMode::MumuExtras);
+            return true;
+        }
+#endif
 #ifdef __ANDROID__
         else if (constexpr std::string_view Android = "Android"; value == Android) {
             m_ctrler->set_touch_mode(TouchMode::Android);

--- a/src/MaaCore/Common/AsstTypes.h
+++ b/src/MaaCore/Common/AsstTypes.h
@@ -42,7 +42,7 @@ enum class InstanceOptionKey
 {
     Invalid = 0,
     /* Deprecated */         // MinitouchEnabled = 1,
-    TouchMode = 2,           // 触控模式设置， "minitouch" | "maatouch" | "adb"
+    TouchMode = 2,           // 触控模式设置， "minitouch" | "maatouch" | "adb" | "MaaFwAdb" | "MumuExtras"
     DeploymentWithPause = 3, // 自动战斗、肉鸽、保全 是否使用 暂停下干员， "0" | "1"
     AdbLiteEnabled = 4,      // 是否使用 AdbLite， "0" | "1"
     KillAdbOnExit = 5,       // 退出时是否杀掉 Adb 进程， "0" | "1"
@@ -58,6 +58,7 @@ enum class TouchMode
     MacPlayTools = 3,
     MaaFwAdb = 4,
     Android = 5,
+    MumuExtras = 6, // MuMu external renderer IPC，不可用时自动降级为 Maatouch
 };
 
 #ifdef _WIN32

--- a/src/MaaCore/Controller/AdbController.cpp
+++ b/src/MaaCore/Controller/AdbController.cpp
@@ -281,9 +281,11 @@ void asst::AdbController::init_mumu_extras(const AdbCfg& adb_cfg, const std::str
     set_mumu_package(adb_cfg.extras.get("client_type", ""));
 
     std::filesystem::path mumu_path = utils::path(adb_cfg.extras.get("path", ""));
+    // 触控需要额外探测 MuMuManager 版本，只截图的用户不该付这份开销
+    bool enable_input = adb_cfg.extras.get("touch", false);
 
     if (adb_cfg.extras.contains("index")) { // MuMu index is provided directly
-        m_mumu_extras.init(mumu_path, adb_cfg.extras.get("index", 0));
+        m_mumu_extras.init(mumu_path, adb_cfg.extras.get("index", 0), enable_input);
     }
     else {
         auto mumu_index = get_mumu_index(address);
@@ -291,7 +293,7 @@ void asst::AdbController::init_mumu_extras(const AdbCfg& adb_cfg, const std::str
             LogError << "Failed to parse MuMu index from address, skip MumuExtras init" << VAR(address);
             return;
         }
-        m_mumu_extras.init(mumu_path, mumu_index.value());
+        m_mumu_extras.init(mumu_path, mumu_index.value(), enable_input);
     }
 #endif
 }

--- a/src/MaaCore/Controller/Controller.cpp
+++ b/src/MaaCore/Controller/Controller.cpp
@@ -24,6 +24,9 @@
 #include "MaatouchController.h"
 #include "MinitouchController.h"
 #include "PlayToolsController.h"
+#if ASST_WITH_EMULATOR_EXTRAS
+#include "MumuController.h"
+#endif
 #ifdef _WIN32
 #include "Win32Controller.h"
 #endif
@@ -62,6 +65,10 @@ std::shared_ptr<asst::ControllerAPI>
             return std::make_shared<PlayToolsController>(m_callback, m_inst, platform_type);
         case ControllerType::MaaFwAdb:
             return std::make_shared<MaaFwAdbController>(m_callback, m_inst, platform_type);
+#if ASST_WITH_EMULATOR_EXTRAS
+        case ControllerType::Mumu:
+            return std::make_shared<MumuController>(m_callback, m_inst, platform_type);
+#endif
 #ifdef __ANDROID__
         case ControllerType::MaaFwAndroidNative:
             Log.debug("Use Android");
@@ -380,6 +387,11 @@ void asst::Controller::set_touch_mode(const TouchMode& mode) noexcept
     case TouchMode::MaaFwAdb:
         m_controller_type = ControllerType::MaaFwAdb;
         break;
+#if ASST_WITH_EMULATOR_EXTRAS
+    case TouchMode::MumuExtras:
+        m_controller_type = ControllerType::Mumu;
+        break;
+#endif
 #ifdef __ANDROID__
     case TouchMode::Android:
         m_controller_type = ControllerType::MaaFwAndroidNative;

--- a/src/MaaCore/Controller/ControllerAPI.h
+++ b/src/MaaCore/Controller/ControllerAPI.h
@@ -19,6 +19,9 @@ enum class ControllerType
     Win32,
 #endif
     MaaFwAdb,
+#if ASST_WITH_EMULATOR_EXTRAS
+    Mumu,
+#endif
 #ifdef __ANDROID__
     MaaFwAndroidNative,
 #endif

--- a/src/MaaCore/Controller/MaaFwAdbController.cpp
+++ b/src/MaaCore/Controller/MaaFwAdbController.cpp
@@ -91,7 +91,11 @@ bool MaaFwAdbController::connect(const std::string& adb_path, const std::string&
         adb_path.c_str(),
         address.c_str(),
         MaaAdbScreencapMethod::Default,
-        MaaAdbInputMethod::AdbShell | MaaAdbInputMethod::EmulatorExtras,
+        // 不要加 EmulatorExtras：MaaFramework 的 MuMuPlayerExtras::click/swipe 是空实现，
+        // 它靠 get_features() 返回 UseMouseDownAndUpInsteadOfClick 让上层改走 touch_down/up，
+        // 而这里的 click()/swipe() 直接透传给 ControlUnit，从不读 features，会全部失败。
+        // MuMu 触控走 MumuController（TouchMode::MumuExtras）。
+        MaaAdbInputMethod::AdbShell,
         config == "AVD" ? "{\"extras\":{\"avd\":{\"enable\":true}}}" : "{}",
         // MaaAgentBinary目录
         utils::path_to_utf8_string(ResDir.get()).c_str());

--- a/src/MaaCore/Controller/MumuController.cpp
+++ b/src/MaaCore/Controller/MumuController.cpp
@@ -1,0 +1,268 @@
+#include "MumuController.h"
+
+#if ASST_WITH_EMULATOR_EXTRAS
+
+#include <algorithm>
+#include <chrono>
+#include <thread>
+
+#include "Config/GeneralConfig.h"
+#include "SwipeHelper.hpp"
+#include "Utils/Logger.hpp"
+
+namespace asst
+{
+bool MumuController::connect(const std::string& adb_path, const std::string& address, const std::string& config)
+{
+    LogTraceFunction;
+
+    m_mumu_input_ready = false;
+    release_minitouch();
+
+#ifdef ASST_DEBUG
+    if (config == "DEBUG") {
+        m_inited = true;
+        return true;
+    }
+#endif
+
+    // 这里不能直接调 MaatouchController::connect()：它在 maatouch 探测失败时会抛出
+    // TouchModeNotAvailable 并返回 false，而此时 MuMu 触控可能是好的。
+    // 所以自己接管探测顺序：先 adb 连接（顺带 init_mumu_extras），再优先试 MuMu。
+    if (!AdbController::connect(adb_path, address, config)) {
+        return false;
+    }
+
+    if (m_mumu_extras.input_available()) {
+        // ControlScaleProxy 会把坐标缩放到 get_screen_res() 的尺寸，而 nemu 期望的是
+        // display 自身的坐标系。两者不一致时点击会全部偏掉，宁可降级也不要乱点。
+        auto [mumu_width, mumu_height] = m_mumu_extras.get_display_size();
+        if (mumu_width == m_width && mumu_height == m_height) {
+            m_mumu_input_ready = true;
+            LogInfo << "MuMu extras input is ready" << VAR(m_width) << VAR(m_height);
+            return true;
+        }
+        LogWarn << "MuMu display size mismatches adb screen size" << VAR(mumu_width) << VAR(mumu_height) << VAR(m_width)
+                << VAR(m_height);
+    }
+
+    LogInfo << "MuMu extras input is not available, fallback to maatouch";
+
+    m_minitouch_available = probe_minitouch();
+    if (!m_minitouch_available) {
+        json::value info = json::object {
+            { "uuid", m_uuid },
+            { "details",
+              json::object {
+                  { "adb", adb_path },
+                  { "address", address },
+                  { "config", config },
+              } },
+            { "what", "TouchModeNotAvailable" },
+            { "why", "" },
+        };
+        callback(AsstMsg::ConnectionInfo, info);
+        return false;
+    }
+
+    return true;
+}
+
+bool MumuController::click(const Point& p)
+{
+    if (!use_mumu_input()) {
+        return MaatouchController::click(p);
+    }
+
+    if (p.x < 0 || p.x >= m_width || p.y < 0 || p.y >= m_height) {
+        Log.error("click point out of range");
+    }
+
+    Log.trace("mumu click:", p);
+
+    // 无条件抬手，避免 down 出错后手指卡在屏幕上
+    bool down = m_mumu_extras.touch_down(0, p.x, p.y);
+    return m_mumu_extras.touch_up(0) && down;
+}
+
+bool MumuController::swipe(
+    const Point& p1,
+    const Point& p2,
+    int duration,
+    bool extra_swipe,
+    double slope_in,
+    double slope_out,
+    bool with_pause)
+{
+    if (!use_mumu_input()) {
+        return MaatouchController::swipe(p1, p2, duration, extra_swipe, slope_in, slope_out, with_pause);
+    }
+
+    int x1 = p1.x, y1 = p1.y;
+    int x2 = p2.x, y2 = p2.y;
+
+    // 起点不能在屏幕外，但是终点可以
+    if (x1 < 0 || x1 >= m_width || y1 < 0 || y1 >= m_height) {
+        Log.warn("swipe point1 is out of range", x1, y1);
+        x1 = std::clamp(x1, 0, m_width - 1);
+        y1 = std::clamp(y1, 0, m_height - 1);
+    }
+
+    Log.trace("mumu swipe", p1, p2, duration, extra_swipe, slope_in, slope_out);
+
+    if (!m_mumu_extras.touch_down(0, x1, y1)) {
+        return false;
+    }
+
+    const auto& opt = Config.get_options();
+    constexpr int TimeInterval = Minitoucher::DefaultSwipeDelay;
+
+    auto move_func = [this](int x, int y) {
+        // nemu 的调用是同步的，没有 minitouch 那样的 commit/wait 协议，
+        // 这里自己按 TimeInterval 节流，否则滑动会瞬间走完
+        bool ret = m_mumu_extras.touch_move(0, x, y);
+        std::this_thread::sleep_for(std::chrono::milliseconds(TimeInterval));
+        return ret;
+    };
+
+    auto bounds_check = [this](int x, int y) { return x >= 0 && x < m_width && y >= 0 && y < m_height; };
+
+    bool need_pause = with_pause && use_swipe_with_pause();
+
+    auto pause_check = [&opt](int cur_x, int cur_y, int start_x, int start_y) {
+        return std::sqrt(std::pow(cur_x - start_x, 2) + std::pow(cur_y - start_y, 2)) >
+               opt.swipe_with_pause_required_distance;
+    };
+
+    // nemu 直接发按键，不用像 minitouch 那样异步起一个 adb press_esc
+    auto pause_action = [this]() {
+        constexpr int EscKeyCode = 111;
+        m_mumu_extras.key_down(EscKeyCode);
+        m_mumu_extras.key_up(EscKeyCode);
+    };
+
+    auto mumu_move = [&](int _x1, int _y1, int _x2, int _y2, int _duration) -> bool {
+        if (need_pause) {
+            return interpolate_swipe_with_pause(
+                _x1,
+                _y1,
+                _x2,
+                _y2,
+                _duration,
+                TimeInterval,
+                slope_in,
+                slope_out,
+                move_func,
+                bounds_check,
+                pause_check,
+                [&]() {
+                    need_pause = false;
+                    pause_action();
+                });
+        }
+        else {
+            return interpolate_swipe(
+                _x1,
+                _y1,
+                _x2,
+                _y2,
+                _duration,
+                TimeInterval,
+                slope_in,
+                slope_out,
+                move_func,
+                bounds_check);
+        }
+    };
+
+    // 中途失败也必须抬手，否则手指会一直按在屏幕上，后续操作全部失效
+    bool moved = mumu_move(x1, y1, x2, y2, duration ? duration : opt.minitouch_swipe_default_duration);
+
+    if (moved && extra_swipe && opt.minitouch_extra_swipe_duration > 0) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(opt.minitouch_swipe_extra_end_delay));
+        moved = mumu_move(x2, y2, x2, y2 - opt.minitouch_extra_swipe_dist, opt.minitouch_extra_swipe_duration);
+    }
+
+    return m_mumu_extras.touch_up(0) && moved;
+}
+
+bool MumuController::inject_input_event(const InputEvent& event)
+{
+    if (!use_mumu_input()) {
+        return MaatouchController::inject_input_event(event);
+    }
+
+    switch (event.type) {
+    case InputEvent::Type::TOUCH_DOWN:
+        return m_mumu_extras.touch_down(event.pointerId, event.point.x, event.point.y);
+    case InputEvent::Type::TOUCH_MOVE:
+        return m_mumu_extras.touch_move(event.pointerId, event.point.x, event.point.y);
+    case InputEvent::Type::TOUCH_UP:
+        return m_mumu_extras.touch_up(event.pointerId);
+    case InputEvent::Type::KEY_DOWN:
+        return m_mumu_extras.key_down(event.keycode);
+    case InputEvent::Type::KEY_UP:
+        return m_mumu_extras.key_up(event.keycode);
+    case InputEvent::Type::WAIT_MS:
+        std::this_thread::sleep_for(std::chrono::milliseconds(event.milisec));
+        return true;
+    // nemu 每次调用即时生效，没有 minitouch 的批量提交语义
+    case InputEvent::Type::TOUCH_RESET:
+    case InputEvent::Type::COMMIT:
+        return true;
+    case InputEvent::Type::UNKNOWN:
+    default:
+        Log.error("unknown input event type");
+        return false;
+    }
+}
+
+bool MumuController::input(const std::string& text)
+{
+    if (!use_mumu_input()) {
+        return MaatouchController::input(text);
+    }
+
+    return m_mumu_extras.input_text(text);
+}
+
+bool MumuController::press_esc()
+{
+    if (!use_mumu_input()) {
+        return MaatouchController::press_esc();
+    }
+
+    constexpr int EscKeyCode = 111;
+    return m_mumu_extras.key_down(EscKeyCode) && m_mumu_extras.key_up(EscKeyCode);
+}
+
+ControlFeat::Feat MumuController::support_features() const noexcept
+{
+    if (!use_mumu_input()) {
+        return MaatouchController::support_features();
+    }
+
+    // nemu 的坐标就是 display 原生坐标，不像 minitouch 要按 max_x/max_y 换算，
+    // 暂停也是同步下发的按键，两个特性都能完整支持
+    return ControlFeat::PRECISE_SWIPE | ControlFeat::SWIPE_WITH_PAUSE;
+}
+
+std::optional<std::string> MumuController::reconnect(const std::string& cmd, int64_t timeout, bool recv_by_socket)
+{
+    if (!use_mumu_input()) {
+        return MaatouchController::reconnect(cmd, timeout, recv_by_socket);
+    }
+
+    // 走 MuMu 触控时没有探测过 maatouch，跳过基类的 maatouch 重新拉起，
+    // 否则会拿着空命令去起交互式 shell。nemu 的连接由 MumuExtras 自己维护。
+    return AdbController::reconnect(cmd, timeout, recv_by_socket);
+}
+
+void MumuController::clear_info() noexcept
+{
+    MaatouchController::clear_info();
+    m_mumu_input_ready = false;
+}
+} // namespace asst
+
+#endif

--- a/src/MaaCore/Controller/MumuController.h
+++ b/src/MaaCore/Controller/MumuController.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#if ASST_WITH_EMULATOR_EXTRAS
+
+#include "MaatouchController.h"
+
+namespace asst
+{
+// 通过 MuMu 的 external renderer IPC 直接下发触控，绕开 adb。
+// 继承 MaatouchController 是为了拿到现成的降级链：MuMu 触控不可用时（模拟器版本过低、
+// dll 缺少 input 符号、非 MuMu 连接配置等）所有操作自动落回 maatouch。
+class MumuController : public MaatouchController
+{
+public:
+    MumuController(const AsstCallback& callback, Assistant* inst, PlatformType type) :
+        MaatouchController(callback, inst, type)
+    {
+    }
+
+    MumuController(const MumuController&) = delete;
+    MumuController(MumuController&&) = delete;
+    virtual ~MumuController() override = default;
+
+    virtual bool connect(const std::string& adb_path, const std::string& address, const std::string& config) override;
+
+    virtual bool click(const Point& p) override;
+
+    virtual bool swipe(
+        const Point& p1,
+        const Point& p2,
+        int duration = 0,
+        bool extra_swipe = false,
+        double slope_in = 1,
+        double slope_out = 1,
+        bool with_pause = false) override;
+
+    virtual bool inject_input_event(const InputEvent& event) override;
+
+    virtual bool input(const std::string& text) override;
+
+    virtual bool press_esc() override;
+
+    virtual ControlFeat::Feat support_features() const noexcept override;
+
+    MumuController& operator=(const MumuController&) = delete;
+    MumuController& operator=(MumuController&&) = delete;
+
+protected:
+    virtual std::optional<std::string> reconnect(const std::string& cmd, int64_t timeout, bool recv_by_socket) override;
+
+    virtual void clear_info() noexcept override;
+
+private:
+    // MuMu 触控是否就绪。未就绪时全部操作降级到 MaatouchController
+    bool use_mumu_input() const noexcept { return m_mumu_input_ready; }
+
+    bool m_mumu_input_ready = false;
+};
+} // namespace asst
+
+#endif

--- a/src/MaaCore/Controller/MumuExtras.cpp
+++ b/src/MaaCore/Controller/MumuExtras.cpp
@@ -2,8 +2,12 @@
 
 #if ASST_WITH_EMULATOR_EXTRAS
 
+#include <unordered_map>
+
 #include "MaaUtils/NoWarningCV.hpp"
 #include "Utils/Logger.hpp"
+#include "Utils/Platform.hpp"
+#include "Utils/StringMisc.hpp"
 
 namespace asst
 {
@@ -12,9 +16,9 @@ MumuExtras::~MumuExtras()
     uninit();
 }
 
-bool MumuExtras::init(const std::filesystem::path& mumu_path, int mumu_inst_index)
+bool MumuExtras::init(const std::filesystem::path& mumu_path, int mumu_inst_index, bool enable_input)
 {
-    bool same = mumu_path == mumu_path_ && mumu_inst_index == mumu_inst_index_;
+    bool same = mumu_path == mumu_path_ && mumu_inst_index == mumu_inst_index_ && enable_input == input_enabled_;
 
     if (same && inited_) {
         return true;
@@ -22,6 +26,9 @@ bool MumuExtras::init(const std::filesystem::path& mumu_path, int mumu_inst_inde
 
     mumu_path_ = mumu_path;
     mumu_inst_index_ = mumu_inst_index;
+    input_enabled_ = enable_input;
+    // 换了模拟器路径或开关，之前的版本探测结果不作数了
+    input_version_checked_ = false;
 
     inited_ = load_mumu_library() && connect_mumu() && init_screencap();
 
@@ -36,18 +43,24 @@ void MumuExtras::set_package_name(const std::string& package_name)
     else {
         package_name_ = package_name;
     }
+
+    // 换了包名，之前缓存的 display id 就不作数了
+    invalidate_display_id();
 }
 
 bool MumuExtras::reload()
 {
+    invalidate_display_id();
     inited_ = load_mumu_library() && connect_mumu() && init_screencap();
-    LogInfo << "Reload MumuExtras: " << VAR(inited_);
+    LogInfo << "Reload MumuExtras: " << VAR(inited_) << VAR(input_available_);
     return inited_;
 }
 
 void MumuExtras::uninit()
 {
     inited_ = false;
+    input_available_ = false;
+    invalidate_display_id();
     disconnect_mumu();
 }
 
@@ -97,6 +110,105 @@ std::optional<cv::Mat> MumuExtras::screencap()
     cv::flip(bgr, dst, 0);
 
     return dst;
+}
+
+bool MumuExtras::touch_down(int contact, int x, int y)
+{
+    if (!input_event_finger_touch_down_func_) {
+        LogError << "input_event_finger_touch_down_func_ is null";
+        return false;
+    }
+
+    int display_id = get_display_id();
+
+    // contact 从 0 开始，mumu 的 finger_id 从 1 开始
+    int ret = input_event_finger_touch_down_func_(mumu_handle_, display_id, contact + 1, x, y);
+    if (ret) {
+        LogError << "Failed to touch_down" << VAR(ret) << VAR(contact) << VAR(x) << VAR(y) << VAR(display_id);
+        return false;
+    }
+
+    return true;
+}
+
+bool MumuExtras::touch_move(int contact, int x, int y)
+{
+    // mumu 没有单独的 move，重复 touch_down 即可
+    return touch_down(contact, x, y);
+}
+
+bool MumuExtras::touch_up(int contact)
+{
+    if (!input_event_finger_touch_up_func_) {
+        LogError << "input_event_finger_touch_up_func_ is null";
+        return false;
+    }
+
+    int display_id = get_display_id();
+
+    int ret = input_event_finger_touch_up_func_(mumu_handle_, display_id, contact + 1);
+    if (ret) {
+        LogError << "Failed to touch_up" << VAR(ret) << VAR(contact) << VAR(display_id);
+        return false;
+    }
+
+    return true;
+}
+
+bool MumuExtras::key_down(int android_keycode)
+{
+    if (!input_event_key_down_func_) {
+        LogError << "input_event_key_down_func_ is null";
+        return false;
+    }
+
+    int display_id = get_display_id();
+    int key_code = android_keycode_to_linux_key_code(android_keycode);
+
+    int ret = input_event_key_down_func_(mumu_handle_, display_id, key_code);
+    if (ret) {
+        LogError << "Failed to key_down" << VAR(ret) << VAR(android_keycode) << VAR(key_code) << VAR(display_id);
+        return false;
+    }
+
+    return true;
+}
+
+bool MumuExtras::key_up(int android_keycode)
+{
+    if (!input_event_key_up_func_) {
+        LogError << "input_event_key_up_func_ is null";
+        return false;
+    }
+
+    int display_id = get_display_id();
+    int key_code = android_keycode_to_linux_key_code(android_keycode);
+
+    int ret = input_event_key_up_func_(mumu_handle_, display_id, key_code);
+    if (ret) {
+        LogError << "Failed to key_up" << VAR(ret) << VAR(android_keycode) << VAR(key_code) << VAR(display_id);
+        return false;
+    }
+
+    return true;
+}
+
+bool MumuExtras::input_text(const std::string& text)
+{
+    if (!input_text_func_) {
+        LogError << "input_text_func_ is null";
+        return false;
+    }
+
+    LogInfo << VAR(text) << VAR(text.size());
+
+    int ret = input_text_func_(mumu_handle_, static_cast<int>(text.size()), text.c_str());
+    if (ret) {
+        LogError << "Failed to input_text" << VAR(ret);
+        return false;
+    }
+
+    return true;
 }
 
 bool MumuExtras::load_mumu_library()
@@ -151,36 +263,122 @@ bool MumuExtras::load_mumu_library()
         return false;
     }
 
+    // 输入是可选能力，缺失时只影响触控，不能连累截图。
+    // 版本探测要起子进程，reload() 时不该重复付这份开销，所以结果缓存下来。
+    if (!input_version_checked_) {
+        input_version_ok_ = input_enabled_ && check_input_version();
+        input_version_checked_ = true;
+    }
+    input_available_ = input_enabled_ && input_version_ok_ && load_input_functions();
+    LogInfo << "MuMu extras input" << VAR(input_enabled_) << VAR(input_available_);
+
+    return true;
+}
+
+bool MumuExtras::load_input_functions()
+{
     input_text_func_ = get_function<decltype(nemu_input_text)>(kInputTextFuncName);
     if (!input_text_func_) {
-        LogError << "Failed to get function" << VAR(kInputTextFuncName);
+        LogWarn << "Failed to get function" << VAR(kInputTextFuncName);
         return false;
     }
 
-    input_event_touch_down_func_ = get_function<decltype(nemu_input_event_touch_down)>(kInputEventTouchDownFuncName);
-    if (!input_event_touch_down_func_) {
-        LogError << "Failed to get function" << VAR(kInputEventTouchDownFuncName);
+    input_event_finger_touch_down_func_ =
+        get_function<decltype(nemu_input_event_finger_touch_down)>(kInputEventFingerTouchDownFuncName);
+    if (!input_event_finger_touch_down_func_) {
+        LogWarn << "Failed to get function" << VAR(kInputEventFingerTouchDownFuncName);
         return false;
     }
 
-    input_event_touch_up_func_ = get_function<decltype(nemu_input_event_touch_up)>(kInputEventTouchUpFuncName);
-    if (!input_event_touch_up_func_) {
-        LogError << "Failed to get function" << VAR(kInputEventTouchUpFuncName);
+    input_event_finger_touch_up_func_ =
+        get_function<decltype(nemu_input_event_finger_touch_up)>(kInputEventFingerTouchUpFuncName);
+    if (!input_event_finger_touch_up_func_) {
+        LogWarn << "Failed to get function" << VAR(kInputEventFingerTouchUpFuncName);
         return false;
     }
 
     input_event_key_down_func_ = get_function<decltype(nemu_input_event_key_down)>(kInputEventKeyDownFuncName);
     if (!input_event_key_down_func_) {
-        LogError << "Failed to get function" << VAR(kInputEventKeyDownFuncName);
+        LogWarn << "Failed to get function" << VAR(kInputEventKeyDownFuncName);
         return false;
     }
 
     input_event_key_up_func_ = get_function<decltype(nemu_input_event_key_up)>(kInputEventKeyUpFuncName);
     if (!input_event_key_up_func_) {
-        LogError << "Failed to get function" << VAR(kInputEventKeyUpFuncName);
+        LogWarn << "Failed to get function" << VAR(kInputEventKeyUpFuncName);
         return false;
     }
 
+    return true;
+}
+
+bool MumuExtras::check_input_version() const
+{
+    // MuMuManager.exe 与 adb 同目录，按版本从新到旧排列
+    static const std::vector<std::filesystem::path> kCandidateRelativePaths = {
+        "nx_main/MuMuManager.exe", // MuMu v5+
+        "shell/MuMuManager.exe",   // MuMu v4 及更早
+    };
+
+    std::filesystem::path mgr_path;
+    for (const auto& rel_path : kCandidateRelativePaths) {
+        auto full_path = mumu_path_ / rel_path;
+        if (std::filesystem::exists(full_path)) {
+            mgr_path = full_path;
+            break;
+        }
+    }
+
+    if (mgr_path.empty()) {
+        LogWarn << "MuMuManager not found, disable extras input" << VAR(mumu_path_);
+        return false;
+    }
+
+    std::string cmd = "\"" + utils::path_to_utf8_string(mgr_path) + "\" version";
+    std::string output = utils::call_command(cmd);
+    LogDebug << VAR(cmd) << VAR(output);
+
+    // { "version": "6.3.2.0" }
+    auto jopt = json::parse(output);
+    if (!jopt || !jopt->is_object()) {
+        LogWarn << "Parse MuMuManager version failed" << VAR(output);
+        return false;
+    }
+
+    std::string version = jopt->get("version", "");
+    if (version.empty()) {
+        LogWarn << "MuMuManager version field is empty" << VAR(output);
+        return false;
+    }
+
+    // 低于 6.3.2.0 的 external renderer 输入行为异常，只启用截图
+    static constexpr int kMinVersion[] = { 6, 3, 2, 0 };
+    std::string_view remain = version;
+    for (int expected : kMinVersion) {
+        std::string_view part = remain;
+        if (auto pos = remain.find('.'); pos != std::string_view::npos) {
+            part = remain.substr(0, pos);
+            remain = remain.substr(pos + 1);
+        }
+        else {
+            remain = {};
+        }
+
+        // 版本号位数不足时按 0 补齐，如 "6.4" 视作 6.4.0.0
+        int value = 0;
+        if (!part.empty() && !utils::chars_to_number<int, true>(part, value)) {
+            LogWarn << "Invalid MuMuManager version" << VAR(version);
+            return false;
+        }
+
+        if (value != expected) {
+            bool supported = value > expected;
+            LogInfo << "MuMuManager version" << VAR(version) << VAR(supported);
+            return supported;
+        }
+    }
+
+    LogInfo << "MuMuManager version" << VAR(version) << ", supported";
     return true;
 }
 
@@ -241,6 +439,12 @@ void MumuExtras::disconnect_mumu()
 
 int MumuExtras::get_display_id()
 {
+    // swipe 的 move 每几毫秒一次，每次都问一遍 dll 太贵了
+    int cached = display_id_cache_.load(std::memory_order_relaxed);
+    if (cached != kInvalidDisplayId) {
+        return cached;
+    }
+
     if (!get_display_id_func_) {
         LogError << "get_display_id_func_ is null, please update your MuMu Player";
         return 0;
@@ -252,7 +456,124 @@ int MumuExtras::get_display_id()
         return 0;
     }
 
+    display_id_cache_.store(id, std::memory_order_relaxed);
     return id;
+}
+
+int MumuExtras::android_keycode_to_linux_key_code(int key)
+{
+    // https://developer.android.com/reference/android/view/KeyEvent
+    // https://github.com/torvalds/linux/blob/master/include/uapi/linux/input-event-codes.h
+    static const std::unordered_map<int, int> kMap = {
+        // Letters
+        { 29, 30 }, // KEYCODE_A -> KEY_A
+        { 30, 48 }, // KEYCODE_B -> KEY_B
+        { 31, 46 }, // KEYCODE_C -> KEY_C
+        { 32, 32 }, // KEYCODE_D -> KEY_D
+        { 33, 18 }, // KEYCODE_E -> KEY_E
+        { 34, 33 }, // KEYCODE_F -> KEY_F
+        { 35, 34 }, // KEYCODE_G -> KEY_G
+        { 36, 35 }, // KEYCODE_H -> KEY_H
+        { 37, 23 }, // KEYCODE_I -> KEY_I
+        { 38, 36 }, // KEYCODE_J -> KEY_J
+        { 39, 37 }, // KEYCODE_K -> KEY_K
+        { 40, 38 }, // KEYCODE_L -> KEY_L
+        { 41, 50 }, // KEYCODE_M -> KEY_M
+        { 42, 49 }, // KEYCODE_N -> KEY_N
+        { 43, 24 }, // KEYCODE_O -> KEY_O
+        { 44, 25 }, // KEYCODE_P -> KEY_P
+        { 45, 16 }, // KEYCODE_Q -> KEY_Q
+        { 46, 19 }, // KEYCODE_R -> KEY_R
+        { 47, 31 }, // KEYCODE_S -> KEY_S
+        { 48, 20 }, // KEYCODE_T -> KEY_T
+        { 49, 22 }, // KEYCODE_U -> KEY_U
+        { 50, 47 }, // KEYCODE_V -> KEY_V
+        { 51, 17 }, // KEYCODE_W -> KEY_W
+        { 52, 45 }, // KEYCODE_X -> KEY_X
+        { 53, 21 }, // KEYCODE_Y -> KEY_Y
+        { 54, 44 }, // KEYCODE_Z -> KEY_Z
+
+        // Numbers (top row)
+        { 7, 11 },  // KEYCODE_0 -> KEY_0
+        { 8, 2 },   // KEYCODE_1 -> KEY_1
+        { 9, 3 },   // KEYCODE_2 -> KEY_2
+        { 10, 4 },  // KEYCODE_3 -> KEY_3
+        { 11, 5 },  // KEYCODE_4 -> KEY_4
+        { 12, 6 },  // KEYCODE_5 -> KEY_5
+        { 13, 7 },  // KEYCODE_6 -> KEY_6
+        { 14, 8 },  // KEYCODE_7 -> KEY_7
+        { 15, 9 },  // KEYCODE_8 -> KEY_8
+        { 16, 10 }, // KEYCODE_9 -> KEY_9
+
+        // Function keys
+        { 131, 59 }, // KEYCODE_F1 -> KEY_F1
+        { 132, 60 }, // KEYCODE_F2 -> KEY_F2
+        { 133, 61 }, // KEYCODE_F3 -> KEY_F3
+        { 134, 62 }, // KEYCODE_F4 -> KEY_F4
+        { 135, 63 }, // KEYCODE_F5 -> KEY_F5
+        { 136, 64 }, // KEYCODE_F6 -> KEY_F6
+        { 137, 65 }, // KEYCODE_F7 -> KEY_F7
+        { 138, 66 }, // KEYCODE_F8 -> KEY_F8
+        { 139, 67 }, // KEYCODE_F9 -> KEY_F9
+        { 140, 68 }, // KEYCODE_F10 -> KEY_F10
+        { 141, 87 }, // KEYCODE_F11 -> KEY_F11
+        { 142, 88 }, // KEYCODE_F12 -> KEY_F12
+
+        // Navigation
+        { 19, 103 }, // KEYCODE_DPAD_UP -> KEY_UP
+        { 20, 108 }, // KEYCODE_DPAD_DOWN -> KEY_DOWN
+        { 21, 105 }, // KEYCODE_DPAD_LEFT -> KEY_LEFT
+        { 22, 106 }, // KEYCODE_DPAD_RIGHT -> KEY_RIGHT
+        { 23, 28 },  // KEYCODE_DPAD_CENTER -> KEY_ENTER
+
+        // Space, Enter, Backspace, Tab, Escape
+        { 62, 57 }, // KEYCODE_SPACE -> KEY_SPACE
+        { 66, 28 }, // KEYCODE_ENTER -> KEY_ENTER
+        { 67, 14 }, // KEYCODE_DEL -> KEY_BACKSPACE
+        { 61, 15 }, // KEYCODE_TAB -> KEY_TAB
+        { 111, 1 }, // KEYCODE_ESCAPE -> KEY_ESC
+
+        // Shift, Ctrl, Alt, CapsLock, Meta
+        { 59, 42 },   // KEYCODE_SHIFT_LEFT -> KEY_LEFTSHIFT
+        { 60, 54 },   // KEYCODE_SHIFT_RIGHT -> KEY_RIGHTSHIFT
+        { 113, 29 },  // KEYCODE_CTRL_LEFT -> KEY_LEFTCTRL
+        { 114, 97 },  // KEYCODE_CTRL_RIGHT -> KEY_RIGHTCTRL
+        { 57, 56 },   // KEYCODE_ALT_LEFT -> KEY_LEFTALT
+        { 58, 100 },  // KEYCODE_ALT_RIGHT -> KEY_RIGHTALT
+        { 115, 58 },  // KEYCODE_CAPS_LOCK -> KEY_CAPSLOCK
+        { 117, 125 }, // KEYCODE_META_LEFT -> KEY_LEFTMETA
+        { 118, 126 }, // KEYCODE_META_RIGHT -> KEY_RIGHTMETA
+
+        // Symbols
+        { 76, 127 },  // KEYCODE_SLASH -> KEY_COMPOSE
+        { 122, 102 }, // KEYCODE_MOVE_HOME -> KEY_HOME
+        { 123, 107 }, // KEYCODE_MOVE_END -> KEY_END
+        { 124, 104 }, // KEYCODE_INSERT -> KEY_PAGEUP
+        { 92, 109 },  // KEYCODE_PAGE_UP -> KEY_PAGEDOWN
+        { 112, 111 }, // KEYCODE_FORWARD_DEL -> KEY_DELETE
+
+        // Misc
+        { 4, 158 },   // KEYCODE_BACK -> KEY_BACK
+        { 3, 102 },   // KEYCODE_HOME -> KEY_HOME
+        { 82, 139 },  // KEYCODE_MENU -> KEY_MENU
+        { 84, 114 },  // KEYCODE_SEARCH -> KEY_SEARCH
+        { 85, 164 },  // KEYCODE_MEDIA_PLAY_PAUSE -> KEY_PLAYPAUSE
+        { 86, 128 },  // KEYCODE_MEDIA_STOP -> KEY_STOPCD
+        { 87, 163 },  // KEYCODE_MEDIA_NEXT -> KEY_NEXTSONG
+        { 88, 165 },  // KEYCODE_MEDIA_PREVIOUS -> KEY_PREVIOUSSONG
+        { 89, 168 },  // KEYCODE_MEDIA_REWIND -> KEY_REWIND
+        { 90, 208 },  // KEYCODE_MEDIA_FAST_FORWARD -> KEY_FASTFORWARD
+        { 24, 115 },  // KEYCODE_VOLUME_UP -> KEY_VOLUMEUP
+        { 25, 114 },  // KEYCODE_VOLUME_DOWN -> KEY_VOLUMEDOWN
+        { 164, 113 }, // KEYCODE_VOLUME_MUTE -> KEY_MUTE
+    };
+
+    auto it = kMap.find(key);
+    if (it == kMap.end()) {
+        LogWarn << "unknown android key" << VAR(key);
+        return key;
+    }
+    return it->second;
 }
 } // namespace asst
 

--- a/src/MaaCore/Controller/MumuExtras.cpp
+++ b/src/MaaCore/Controller/MumuExtras.cpp
@@ -51,6 +51,15 @@ void MumuExtras::set_package_name(const std::string& package_name)
 bool MumuExtras::reload()
 {
     invalidate_display_id();
+
+    // LibraryHolder::load_library 对已加载的库只是 ++ref_count_，
+    // 不先释放的话每次 reload 都会多留一份引用，dll 永远不会被卸载
+    if (library_loaded_) {
+        disconnect_mumu();
+        unload_library();
+        library_loaded_ = false;
+    }
+
     inited_ = load_mumu_library() && connect_mumu() && init_screencap();
     LogInfo << "Reload MumuExtras: " << VAR(inited_) << VAR(input_available_);
     return inited_;
@@ -71,10 +80,15 @@ std::optional<cv::Mat> MumuExtras::screencap()
         return std::nullopt;
     }
 
-    int display_id = get_display_id();
+    auto display_id = get_display_id();
+    if (!display_id) {
+        LogError << "Failed to get display id";
+        return std::nullopt;
+    }
+
     int ret = capture_display_func_(
         mumu_handle_,
-        display_id,
+        *display_id,
         static_cast<int>(display_buffer_.size()),
         &display_width_,
         &display_height_,
@@ -84,21 +98,25 @@ std::optional<cv::Mat> MumuExtras::screencap()
         // Try reloading once before giving up.
         if (!reload()) {
             LogError << "Failed to capture display and failed to reload. " << VAR(ret) << VAR(mumu_handle_)
-                     << VAR(display_id) << VAR(display_buffer_.size()) << VAR(display_width_) << VAR(display_height_);
+                     << VAR(*display_id) << VAR(display_buffer_.size()) << VAR(display_width_) << VAR(display_height_);
             return std::nullopt;
         }
         // Reload 之后 display_id 可能变化，重新获取后再重试一次 capture。
         display_id = get_display_id();
+        if (!display_id) {
+            LogError << "Failed to get display id after reload";
+            return std::nullopt;
+        }
         ret = capture_display_func_(
             mumu_handle_,
-            display_id,
+            *display_id,
             static_cast<int>(display_buffer_.size()),
             &display_width_,
             &display_height_,
             display_buffer_.data());
         if (ret) {
             LogError << "Failed to capture display even after reload. " << VAR(ret) << VAR(mumu_handle_)
-                     << VAR(display_id) << VAR(display_buffer_.size()) << VAR(display_width_) << VAR(display_height_);
+                     << VAR(*display_id) << VAR(display_buffer_.size()) << VAR(display_width_) << VAR(display_height_);
             return std::nullopt;
         }
     }
@@ -119,12 +137,16 @@ bool MumuExtras::touch_down(int contact, int x, int y)
         return false;
     }
 
-    int display_id = get_display_id();
+    auto display_id = get_display_id();
+    if (!display_id) {
+        LogError << "Failed to get display id, skip touch_down" << VAR(contact) << VAR(x) << VAR(y);
+        return false;
+    }
 
     // contact 从 0 开始，mumu 的 finger_id 从 1 开始
-    int ret = input_event_finger_touch_down_func_(mumu_handle_, display_id, contact + 1, x, y);
+    int ret = input_event_finger_touch_down_func_(mumu_handle_, *display_id, contact + 1, x, y);
     if (ret) {
-        LogError << "Failed to touch_down" << VAR(ret) << VAR(contact) << VAR(x) << VAR(y) << VAR(display_id);
+        LogError << "Failed to touch_down" << VAR(ret) << VAR(contact) << VAR(x) << VAR(y) << VAR(*display_id);
         return false;
     }
 
@@ -144,11 +166,15 @@ bool MumuExtras::touch_up(int contact)
         return false;
     }
 
-    int display_id = get_display_id();
+    auto display_id = get_display_id();
+    if (!display_id) {
+        LogError << "Failed to get display id, skip touch_up" << VAR(contact);
+        return false;
+    }
 
-    int ret = input_event_finger_touch_up_func_(mumu_handle_, display_id, contact + 1);
+    int ret = input_event_finger_touch_up_func_(mumu_handle_, *display_id, contact + 1);
     if (ret) {
-        LogError << "Failed to touch_up" << VAR(ret) << VAR(contact) << VAR(display_id);
+        LogError << "Failed to touch_up" << VAR(ret) << VAR(contact) << VAR(*display_id);
         return false;
     }
 
@@ -162,12 +188,17 @@ bool MumuExtras::key_down(int android_keycode)
         return false;
     }
 
-    int display_id = get_display_id();
+    auto display_id = get_display_id();
+    if (!display_id) {
+        LogError << "Failed to get display id, skip key_down" << VAR(android_keycode);
+        return false;
+    }
+
     int key_code = android_keycode_to_linux_key_code(android_keycode);
 
-    int ret = input_event_key_down_func_(mumu_handle_, display_id, key_code);
+    int ret = input_event_key_down_func_(mumu_handle_, *display_id, key_code);
     if (ret) {
-        LogError << "Failed to key_down" << VAR(ret) << VAR(android_keycode) << VAR(key_code) << VAR(display_id);
+        LogError << "Failed to key_down" << VAR(ret) << VAR(android_keycode) << VAR(key_code) << VAR(*display_id);
         return false;
     }
 
@@ -181,12 +212,17 @@ bool MumuExtras::key_up(int android_keycode)
         return false;
     }
 
-    int display_id = get_display_id();
+    auto display_id = get_display_id();
+    if (!display_id) {
+        LogError << "Failed to get display id, skip key_up" << VAR(android_keycode);
+        return false;
+    }
+
     int key_code = android_keycode_to_linux_key_code(android_keycode);
 
-    int ret = input_event_key_up_func_(mumu_handle_, display_id, key_code);
+    int ret = input_event_key_up_func_(mumu_handle_, *display_id, key_code);
     if (ret) {
-        LogError << "Failed to key_up" << VAR(ret) << VAR(android_keycode) << VAR(key_code) << VAR(display_id);
+        LogError << "Failed to key_up" << VAR(ret) << VAR(android_keycode) << VAR(key_code) << VAR(*display_id);
         return false;
     }
 
@@ -226,6 +262,7 @@ bool MumuExtras::load_mumu_library()
         if (load_library(lib_path)) {
             LogInfo << "Successfully loaded MuMu external renderer library from: " << lib_path;
             loaded = true;
+            library_loaded_ = true;
             break;
         }
     }
@@ -411,14 +448,18 @@ bool MumuExtras::init_screencap()
         return false;
     }
 
-    int display_id = get_display_id();
-    LogInfo << "Get display id" << VAR(display_id);
+    auto display_id = get_display_id();
+    if (!display_id) {
+        LogError << "Failed to get display id";
+        return false;
+    }
+    LogInfo << "Get display id" << VAR(*display_id);
 
-    int ret = capture_display_func_(mumu_handle_, display_id, 0, &display_width_, &display_height_, nullptr);
+    int ret = capture_display_func_(mumu_handle_, *display_id, 0, &display_width_, &display_height_, nullptr);
 
     // mumu 的文档给错了，这里 0 才是成功
     if (ret) {
-        LogError << "Failed to capture display" << VAR(ret) << VAR(mumu_handle_) << VAR(display_id);
+        LogError << "Failed to capture display" << VAR(ret) << VAR(mumu_handle_) << VAR(*display_id);
         return false;
     }
 
@@ -432,12 +473,14 @@ void MumuExtras::disconnect_mumu()
 {
     LogInfo << VAR(mumu_handle_);
 
-    if (mumu_handle_ != 0) {
+    if (mumu_handle_ != 0 && disconnect_func_) {
         disconnect_func_(mumu_handle_);
+        // 清零，避免 reload 路径下拿旧 handle 重复 disconnect
+        mumu_handle_ = 0;
     }
 }
 
-int MumuExtras::get_display_id()
+std::optional<int> MumuExtras::get_display_id()
 {
     // swipe 的 move 每几毫秒一次，每次都问一遍 dll 太贵了
     int cached = display_id_cache_.load(std::memory_order_relaxed);
@@ -446,14 +489,15 @@ int MumuExtras::get_display_id()
     }
 
     if (!get_display_id_func_) {
-        LogError << "get_display_id_func_ is null, please update your MuMu Player";
+        // 旧版本 mumu 没这个函数，此时只有 display 0，按 0 处理
+        LogWarn << "get_display_id_func_ is null, fallback to 0, please update your MuMu Player";
         return 0;
     }
 
     int id = get_display_id_func_(mumu_handle_, package_name_.c_str(), 0);
     if (id < 0) {
         LogWarn << "Failed to get display id" << VAR(id) << VAR(package_name_);
-        return 0;
+        return std::nullopt;
     }
 
     display_id_cache_.store(id, std::memory_order_relaxed);

--- a/src/MaaCore/Controller/MumuExtras.cpp
+++ b/src/MaaCore/Controller/MumuExtras.cpp
@@ -188,17 +188,20 @@ bool MumuExtras::key_down(int android_keycode)
         return false;
     }
 
+    auto key_code = android_keycode_to_linux_key_code(android_keycode);
+    if (!key_code) {
+        return false;
+    }
+
     auto display_id = get_display_id();
     if (!display_id) {
         LogError << "Failed to get display id, skip key_down" << VAR(android_keycode);
         return false;
     }
 
-    int key_code = android_keycode_to_linux_key_code(android_keycode);
-
-    int ret = input_event_key_down_func_(mumu_handle_, *display_id, key_code);
+    int ret = input_event_key_down_func_(mumu_handle_, *display_id, *key_code);
     if (ret) {
-        LogError << "Failed to key_down" << VAR(ret) << VAR(android_keycode) << VAR(key_code) << VAR(*display_id);
+        LogError << "Failed to key_down" << VAR(ret) << VAR(android_keycode) << VAR(*key_code) << VAR(*display_id);
         return false;
     }
 
@@ -212,17 +215,20 @@ bool MumuExtras::key_up(int android_keycode)
         return false;
     }
 
+    auto key_code = android_keycode_to_linux_key_code(android_keycode);
+    if (!key_code) {
+        return false;
+    }
+
     auto display_id = get_display_id();
     if (!display_id) {
         LogError << "Failed to get display id, skip key_up" << VAR(android_keycode);
         return false;
     }
 
-    int key_code = android_keycode_to_linux_key_code(android_keycode);
-
-    int ret = input_event_key_up_func_(mumu_handle_, *display_id, key_code);
+    int ret = input_event_key_up_func_(mumu_handle_, *display_id, *key_code);
     if (ret) {
-        LogError << "Failed to key_up" << VAR(ret) << VAR(android_keycode) << VAR(key_code) << VAR(*display_id);
+        LogError << "Failed to key_up" << VAR(ret) << VAR(android_keycode) << VAR(*key_code) << VAR(*display_id);
         return false;
     }
 
@@ -236,7 +242,8 @@ bool MumuExtras::input_text(const std::string& text)
         return false;
     }
 
-    LogInfo << VAR(text) << VAR(text.size());
+    // 只记长度：输入内容可能含账号密码等敏感信息，不该进日志
+    LogDebug << VAR(text.size());
 
     int ret = input_text_func_(mumu_handle_, static_cast<int>(text.size()), text.c_str());
     if (ret) {
@@ -504,7 +511,7 @@ std::optional<int> MumuExtras::get_display_id()
     return id;
 }
 
-int MumuExtras::android_keycode_to_linux_key_code(int key)
+std::optional<int> MumuExtras::android_keycode_to_linux_key_code(int key)
 {
     // https://developer.android.com/reference/android/view/KeyEvent
     // https://github.com/torvalds/linux/blob/master/include/uapi/linux/input-event-codes.h
@@ -589,20 +596,21 @@ int MumuExtras::android_keycode_to_linux_key_code(int key)
         { 118, 126 }, // KEYCODE_META_RIGHT -> KEY_RIGHTMETA
 
         // Symbols
-        { 76, 127 },  // KEYCODE_SLASH -> KEY_COMPOSE
+        { 76, 53 },   // KEYCODE_SLASH -> KEY_SLASH
         { 122, 102 }, // KEYCODE_MOVE_HOME -> KEY_HOME
         { 123, 107 }, // KEYCODE_MOVE_END -> KEY_END
-        { 124, 104 }, // KEYCODE_INSERT -> KEY_PAGEUP
-        { 92, 109 },  // KEYCODE_PAGE_UP -> KEY_PAGEDOWN
+        { 124, 110 }, // KEYCODE_INSERT -> KEY_INSERT
+        { 92, 104 },  // KEYCODE_PAGE_UP -> KEY_PAGEUP
+        { 93, 109 },  // KEYCODE_PAGE_DOWN -> KEY_PAGEDOWN
         { 112, 111 }, // KEYCODE_FORWARD_DEL -> KEY_DELETE
 
         // Misc
         { 4, 158 },   // KEYCODE_BACK -> KEY_BACK
         { 3, 102 },   // KEYCODE_HOME -> KEY_HOME
         { 82, 139 },  // KEYCODE_MENU -> KEY_MENU
-        { 84, 114 },  // KEYCODE_SEARCH -> KEY_SEARCH
+        { 84, 217 },  // KEYCODE_SEARCH -> KEY_SEARCH
         { 85, 164 },  // KEYCODE_MEDIA_PLAY_PAUSE -> KEY_PLAYPAUSE
-        { 86, 128 },  // KEYCODE_MEDIA_STOP -> KEY_STOPCD
+        { 86, 166 },  // KEYCODE_MEDIA_STOP -> KEY_STOPCD
         { 87, 163 },  // KEYCODE_MEDIA_NEXT -> KEY_NEXTSONG
         { 88, 165 },  // KEYCODE_MEDIA_PREVIOUS -> KEY_PREVIOUSSONG
         { 89, 168 },  // KEYCODE_MEDIA_REWIND -> KEY_REWIND
@@ -614,8 +622,9 @@ int MumuExtras::android_keycode_to_linux_key_code(int key)
 
     auto it = kMap.find(key);
     if (it == kMap.end()) {
-        LogWarn << "unknown android key" << VAR(key);
-        return key;
+        // 两套编码互不相干，原样透传几乎必然按错键，不如不按
+        LogError << "unknown android key, no linux keycode mapping" << VAR(key);
+        return std::nullopt;
     }
     return it->second;
 }

--- a/src/MaaCore/Controller/MumuExtras.h
+++ b/src/MaaCore/Controller/MumuExtras.h
@@ -2,6 +2,7 @@
 
 #if ASST_WITH_EMULATOR_EXTRAS
 
+#include <atomic>
 #include <filesystem>
 #include <optional>
 #include <string>
@@ -22,19 +23,43 @@ public:
 
     bool inited() const { return inited_; }
 
-    bool init(const std::filesystem::path& mumu_path, int mumu_inst_index);
+    // 触控是否可用：需要 dll 导出了 input 相关符号，且 MuMuManager 版本达标
+    bool input_available() const { return inited_ && input_available_; }
+
+    // enable_input 为 false 时只初始化截图，跳过 input 符号解析和 MuMuManager 版本探测
+    bool init(const std::filesystem::path& mumu_path, int mumu_inst_index, bool enable_input);
     void set_package_name(const std::string& package_name);
     bool reload();
     void uninit();
 
     std::optional<cv::Mat> screencap();
 
+    std::pair<int, int> get_display_size() const { return { display_width_, display_height_ }; }
+
+    // contact 为 0 起始，内部转换为 mumu 的 1 起始 finger_id
+    bool touch_down(int contact, int x, int y);
+    bool touch_move(int contact, int x, int y);
+    bool touch_up(int contact);
+
+    // keycode 为 Android KeyEvent 值，内部转换为 Linux input-event-code
+    bool key_down(int android_keycode);
+    bool key_up(int android_keycode);
+
+    bool input_text(const std::string& text);
+
 private:
     bool load_mumu_library();
+    bool load_input_functions();
     bool connect_mumu();
     bool init_screencap();
     void disconnect_mumu();
     int get_display_id();
+    void invalidate_display_id() { display_id_cache_ = kInvalidDisplayId; }
+
+    // MuMuManager.exe version >= 6.3.2.0 才支持 external renderer 输入，低版本行为异常
+    bool check_input_version() const;
+
+    static int android_keycode_to_linux_key_code(int key);
 
 private:
     std::filesystem::path mumu_path_;
@@ -48,7 +73,16 @@ private:
     int display_height_ = 0;
     std::vector<unsigned char> display_buffer_;
 
+    // swipe 的 move 每几毫秒一次，不缓存 display_id 会把 dll 调用打满
+    static constexpr int kInvalidDisplayId = -1;
+    std::atomic<int> display_id_cache_ = kInvalidDisplayId;
+
     bool inited_ = false;
+    bool input_enabled_ = false;   // 上层是否请求了触控
+    bool input_available_ = false; // 触控是否真的可用（符号齐全 + 版本达标）
+    // 版本探测要起子进程，reload() 时不重复执行
+    bool input_version_checked_ = false;
+    bool input_version_ok_ = false;
 
 private:
     inline static const std::string kConnectFuncName = "nemu_connect";
@@ -56,8 +90,8 @@ private:
     inline static const std::string kGetDisplayIdFuncName = "nemu_get_display_id";
     inline static const std::string kCaptureDisplayFuncName = "nemu_capture_display";
     inline static const std::string kInputTextFuncName = "nemu_input_text";
-    inline static const std::string kInputEventTouchDownFuncName = "nemu_input_event_touch_down";
-    inline static const std::string kInputEventTouchUpFuncName = "nemu_input_event_touch_up";
+    inline static const std::string kInputEventFingerTouchDownFuncName = "nemu_input_event_finger_touch_down";
+    inline static const std::string kInputEventFingerTouchUpFuncName = "nemu_input_event_finger_touch_up";
     inline static const std::string kInputEventKeyDownFuncName = "nemu_input_event_key_down";
     inline static const std::string kInputEventKeyUpFuncName = "nemu_input_event_key_up";
 
@@ -67,8 +101,8 @@ private:
     std::function<decltype(nemu_get_display_id)> get_display_id_func_;
     std::function<decltype(nemu_capture_display)> capture_display_func_;
     std::function<decltype(nemu_input_text)> input_text_func_;
-    std::function<decltype(nemu_input_event_touch_down)> input_event_touch_down_func_;
-    std::function<decltype(nemu_input_event_touch_up)> input_event_touch_up_func_;
+    std::function<decltype(nemu_input_event_finger_touch_down)> input_event_finger_touch_down_func_;
+    std::function<decltype(nemu_input_event_finger_touch_up)> input_event_finger_touch_up_func_;
     std::function<decltype(nemu_input_event_key_down)> input_event_key_down_func_;
     std::function<decltype(nemu_input_event_key_up)> input_event_key_up_func_;
 };

--- a/src/MaaCore/Controller/MumuExtras.h
+++ b/src/MaaCore/Controller/MumuExtras.h
@@ -53,7 +53,8 @@ private:
     bool connect_mumu();
     bool init_screencap();
     void disconnect_mumu();
-    int get_display_id();
+    // 0 是合法的 display id，查询失败必须和它区分开，否则会把输入打到错误的 display
+    std::optional<int> get_display_id();
     void invalidate_display_id() { display_id_cache_ = kInvalidDisplayId; }
 
     // MuMuManager.exe version >= 6.3.2.0 才支持 external renderer 输入，低版本行为异常
@@ -76,6 +77,9 @@ private:
     // swipe 的 move 每几毫秒一次，不缓存 display_id 会把 dll 调用打满
     static constexpr int kInvalidDisplayId = -1;
     std::atomic<int> display_id_cache_ = kInvalidDisplayId;
+
+    // 本对象是否持有一份 LibraryHolder 引用，reload 时用来先还再取，避免引用计数泄漏
+    bool library_loaded_ = false;
 
     bool inited_ = false;
     bool input_enabled_ = false;   // 上层是否请求了触控

--- a/src/MaaCore/Controller/MumuExtras.h
+++ b/src/MaaCore/Controller/MumuExtras.h
@@ -60,7 +60,8 @@ private:
     // MuMuManager.exe version >= 6.3.2.0 才支持 external renderer 输入，低版本行为异常
     bool check_input_version() const;
 
-    static int android_keycode_to_linux_key_code(int key);
+    // 无对应映射时返回 nullopt：两套编码互不相干，透传等于按错键
+    static std::optional<int> android_keycode_to_linux_key_code(int key);
 
 private:
     std::filesystem::path mumu_path_;

--- a/src/MaaWpfGui/Constants/ConfigurationKeys.cs
+++ b/src/MaaWpfGui/Constants/ConfigurationKeys.cs
@@ -73,6 +73,7 @@ public static class ConfigurationKeys
     public const string MuMu12ExtrasEnabled = "Connect.MuMu12Extras.Enabled"; // √
     public const string MuMu12EmulatorPath = "Connect.MuMu12EmulatorPath"; // √
     public const string MuMu12Index = "Connect.MuMu12Index"; // √
+    public const string MuMu12TouchEnabled = "Connect.MuMu12Extras.TouchEnabled"; // √
     public const string MuMu12Display = "Connect.MuMu12Display"; // 废弃
     public const string LdPlayerExtrasEnabled = "Connect.LdPlayerExtras.Enabled"; // √
     public const string LdPlayerEmulatorPath = "Connect.LdPlayerEmulatorPath"; // √

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -157,9 +157,6 @@ public class AsstProxy
         return ret;
     }
 
-    /// <summary>Core 侧 MuMu external renderer IPC 输入对应的 TouchMode 取值。</summary>
-    private const string MumuExtrasTouchMode = "MumuExtras";
-
     private static void AsstSetConnectionExtrasMuMu(string extras)
     {
         AsstSetConnectionExtras("MuMuEmulator12", extras);
@@ -2626,13 +2623,11 @@ public class AsstProxy
         {
             AsstSetConnectionExtrasMuMu(mumu12.Config);
 
-            // MuMu 触控是 MuMu Extras 的子选项而非独立触控模式，这里翻译成 core 的 TouchMode。
-            // 模拟器实际不支持时 core 会自己降级回 maatouch。
+            // 勾了「同时用于触控」时 EffectiveTouchMode 会给出 MumuExtras，
+            // 模拟器实际不支持时 core 会自己降级回 maatouch
             AsstSetInstanceOption(
                 InstanceOptionKey.TouchMode,
-                mumu12 is { Enable: true, EnableTouch: true }
-                    ? MumuExtrasTouchMode
-                    : SettingsViewModel.ConnectSettings.TouchMode.ToCustomString());
+                ConnectSettingsUserControlModel.Instance.EffectiveTouchMode);
         }
         else if (ConnectSettingsUserControlModel.Instance.ExtraConfig is LDPlayerExtra ldPlayer)
         {

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -157,6 +157,9 @@ public class AsstProxy
         return ret;
     }
 
+    /// <summary>Core 侧 MuMu external renderer IPC 输入对应的 TouchMode 取值。</summary>
+    private const string MumuExtrasTouchMode = "MumuExtras";
+
     private static void AsstSetConnectionExtrasMuMu(string extras)
     {
         AsstSetConnectionExtras("MuMuEmulator12", extras);
@@ -2622,6 +2625,14 @@ public class AsstProxy
         if (ConnectSettingsUserControlModel.Instance.ExtraConfig is MuMu12Extra mumu12)
         {
             AsstSetConnectionExtrasMuMu(mumu12.Config);
+
+            // MuMu 触控是 MuMu Extras 的子选项而非独立触控模式，这里翻译成 core 的 TouchMode。
+            // 模拟器实际不支持时 core 会自己降级回 maatouch。
+            AsstSetInstanceOption(
+                InstanceOptionKey.TouchMode,
+                mumu12 is { Enable: true, EnableTouch: true }
+                    ? MumuExtrasTouchMode
+                    : SettingsViewModel.ConnectSettings.TouchMode.ToCustomString());
         }
         else if (ConnectSettingsUserControlModel.Instance.ExtraConfig is LDPlayerExtra ldPlayer)
         {

--- a/src/MaaWpfGui/Models/EmulatorConnectionExtra/MuMu12Extra.cs
+++ b/src/MaaWpfGui/Models/EmulatorConnectionExtra/MuMu12Extra.cs
@@ -245,6 +245,8 @@ public class MuMu12Extra() : ExtraConfig, IJsonOnDeserialized
                 return;
             }
 
+            // 立刻把 TouchMode 同步给 core，取消勾选时会自动还原成用户选的模式
+            ConnectSettingsUserControlModel.Instance.UpdateInstanceSettings();
             Instances.AsstProxy.Connected = false;
         }
     }

--- a/src/MaaWpfGui/Models/EmulatorConnectionExtra/MuMu12Extra.cs
+++ b/src/MaaWpfGui/Models/EmulatorConnectionExtra/MuMu12Extra.cs
@@ -30,13 +30,14 @@ public class MuMu12Extra() : ExtraConfig, IJsonOnDeserialized
 {
     private static readonly ILogger _logger = Log.ForContext<MuMu12Extra>();
 
-    public MuMu12Extra(bool isEnabled, string emulatorPath, bool enableBridgeConnection, int instanceIndex)
+    public MuMu12Extra(bool isEnabled, string emulatorPath, bool enableBridgeConnection, int instanceIndex, bool enableTouch = false)
         : this()
     {
         _enable = isEnabled;
         _emulatorPath = emulatorPath;
         _enableBridgeConnection = enableBridgeConnection;
         _instanceIndex = instanceIndex;
+        _enableTouch = enableTouch;
     }
 
     public void OnDeserialized()
@@ -228,6 +229,27 @@ public class MuMu12Extra() : ExtraConfig, IJsonOnDeserialized
     }
 
     [JsonInclude]
+    [JsonPropertyName("EnableTouch")]
+    private bool _enableTouch;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether MuMu extras is also used for touch input, not just screencap.
+    /// </summary>
+    [JsonIgnore]
+    public bool EnableTouch
+    {
+        get => _enableTouch;
+        set {
+            if (!SetAndNotify(ref _enableTouch, value))
+            {
+                return;
+            }
+
+            Instances.AsstProxy.Connected = false;
+        }
+    }
+
+    [JsonInclude]
     [JsonPropertyName("InstanceIndex")]
     private int _instanceIndex;
 
@@ -255,6 +277,7 @@ public class MuMu12Extra() : ExtraConfig, IJsonOnDeserialized
 
             var configObject = new JObject {
                 ["path"] = EmulatorPath,
+                ["touch"] = EnableTouch,
             };
 
             if (EnableBridgeConnection)

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -697,6 +697,7 @@ Only supports Official(CN), Bilibili and Traditional Chinese servers. Third-part
     <system:String x:Key="ConnectionPreset">Connection Preset</system:String>
     <system:String x:Key="ScreenshotTest">Screenshot test</system:String>
     <system:String x:Key="MuMu12ExtrasEnabled">Enable MuMu's screenshot enhancement mode</system:String>
+    <system:String x:Key="MuMuExtrasTouchEnabled">Also use MuMu's input for touch (experimental, requires MuMu 6.3.2+)</system:String>
     <system:String x:Key="MuMuEmulatorPathNotFound">MuMu Emulator path not found.</system:String>
     <system:String x:Key="MuMuExternalRendererMissing" xml:space="preserve">external_renderer_ipc.dll was not found under the selected MuMu installation.\n
 Expected relative path: nx_device/15.0/shell/sdk/external_renderer_ipc.dll or

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -697,6 +697,7 @@ HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Notifications\Settin
     <system:String x:Key="ConnectionPreset">接続構成</system:String>
     <system:String x:Key="ScreenshotTest">スクリーンショットテスト</system:String>
     <system:String x:Key="MuMu12ExtrasEnabled">MuMu のスクリーンショット拡張モードを有効にする</system:String>
+    <system:String x:Key="MuMuExtrasTouchEnabled">タッチ入力にも使用（実験的、MuMu 6.3.2 以上が必要）</system:String>
     <system:String x:Key="MuMuEmulatorPathNotFound">MuMu エミュレータのパスが見つかりません。</system:String>
     <system:String x:Key="MuMuExternalRendererMissing" xml:space="preserve">external_renderer_ipc.dll が選択した MuMu インストール内に見つかりませんでした。\n
 想定される相対パス：

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -697,6 +697,7 @@ HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Notifications\Settin
     <system:String x:Key="ConnectionPreset">연결 프리셋</system:String>
     <system:String x:Key="ScreenshotTest">스크린샷 테스트</system:String>
     <system:String x:Key="MuMu12ExtrasEnabled">MuMu 스크린샷 강화 기능 활성화</system:String>
+    <system:String x:Key="MuMuExtrasTouchEnabled">터치 입력에도 사용 (실험적, MuMu 6.3.2 이상 필요)</system:String>
     <system:String x:Key="MuMuEmulatorPathNotFound">MuMu 에뮬레이터 경로를 찾을 수 없습니다.</system:String>
     <system:String x:Key="MuMuExternalRendererMissing" xml:space="preserve">선택한 MuMu 설치 폴더에서 external_renderer_ipc.dll을 찾을 수 없습니다.\n
 예상 상대 경로:

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -697,6 +697,7 @@ HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Notifications\Settin
     <system:String x:Key="ConnectionPreset">连接配置</system:String>
     <system:String x:Key="ScreenshotTest">截图测试</system:String>
     <system:String x:Key="MuMu12ExtrasEnabled">启用 MuMu 截图增强模式</system:String>
+    <system:String x:Key="MuMuExtrasTouchEnabled">同时用于触控（实验性，需 MuMu 6.3.2 及以上）</system:String>
     <system:String x:Key="MuMuEmulatorPathNotFound">未找到 MuMu 模拟器路径。</system:String>
     <system:String x:Key="MuMuExternalRendererMissing" xml:space="preserve">external_renderer_ipc.dll 未在所选 MuMu 安装目录中找到。\n
 期望的相对路径：

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -697,6 +697,7 @@ HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Notifications\Settin
     <system:String x:Key="ConnectionPreset">連線配置</system:String>
     <system:String x:Key="ScreenshotTest">截圖測試</system:String>
     <system:String x:Key="MuMu12ExtrasEnabled">啟用 MuMu 截圖增強模式</system:String>
+    <system:String x:Key="MuMuExtrasTouchEnabled">同時用於觸控（實驗性，需 MuMu 6.3.2 以上）</system:String>
     <system:String x:Key="MuMuEmulatorPathNotFound">找不到 MuMu 模擬器路徑。</system:String>
     <system:String x:Key="MuMuExternalRendererMissing" xml:space="preserve">external_renderer_ipc.dll 未在所選 MuMu 安裝目錄中找到。\n
 預期的相對路徑：

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/ConnectSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/ConnectSettingsUserControlModel.cs
@@ -687,9 +687,22 @@ public class ConnectSettingsUserControlModel : PropertyChangedBase
         }
     } = ConfigFactory.CurrentConfig.Gui.ConnectSettings.TouchMode;
 
+    /// <summary>
+    /// Gets the touch mode actually sent to the core.
+    /// MuMu 触控是 MuMu Extras 的子选项而非独立触控模式，勾上后要覆写掉用户选的 TouchMode。
+    /// 这里集中一处，避免改动其他设置时把它冲掉。
+    /// </summary>
+    public string EffectiveTouchMode =>
+        ExtraConfig is MuMu12Extra { Enable: true, EnableTouch: true }
+            ? MumuExtrasTouchMode
+            : TouchMode.ToCustomString();
+
+    /// <summary>Core 侧 MuMu external renderer IPC 输入对应的 TouchMode 取值。</summary>
+    public const string MumuExtrasTouchMode = "MumuExtras";
+
     public void UpdateInstanceSettings()
     {
-        Instances.AsstProxy.AsstSetInstanceOption(InstanceOptionKey.TouchMode, TouchMode.ToCustomString());
+        Instances.AsstProxy.AsstSetInstanceOption(InstanceOptionKey.TouchMode, EffectiveTouchMode);
         Instances.AsstProxy.AsstSetInstanceOption(InstanceOptionKey.DeploymentWithPause, SettingsViewModel.GameSettings.DeploymentWithPause ? "1" : "0");
         Instances.AsstProxy.AsstSetInstanceOption(InstanceOptionKey.AdbLiteEnabled, AdbLiteEnabled ? "1" : "0");
         Instances.AsstProxy.AsstSetInstanceOption(InstanceOptionKey.KillAdbOnExit, KillAdbOnExit ? "1" : "0");

--- a/src/MaaWpfGui/Views/UserControl/Settings/ConnectSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/Settings/ConnectSettingsUserControl.xaml
@@ -186,6 +186,11 @@
                                         hc:TitleElement.Title="{DynamicResource MuMu12EmulatorPath}"
                                         hc:TitleElement.TitlePlacement="Left"
                                         Text="{Binding EmulatorPath}" />
+                                    <CheckBox
+                                        Margin="10"
+                                        HorizontalAlignment="Center"
+                                        Content="{DynamicResource MuMuExtrasTouchEnabled}"
+                                        IsChecked="{Binding EnableTouch}" />
                                     <StackPanel HorizontalAlignment="Center" Orientation="Vertical">
                                         <CheckBox
                                             Margin="10"


### PR DESCRIPTION
## 这是什么

让 MAA 支持用 MuMu 的 external renderer IPC（nemu API）做触控输入，而不只是截图。对标 MaaFramework 的 `b4e126a3`（mumu 6.3.2.0 支持触控）。

## 为什么这么做

MAA 里自家 controller 和 maafw controller 两套并存，MuMu 触控理论上有两条路：

1. **走 maafw 的 `MaaAdbControlUnit`** —— 但它的 ControlUnit 接口只有 `swipe(x1,y1,x2,y2,duration)`，表达不了 MAA 的 `slope_in/slope_out/with_pause/extra_swipe`。肉鸽干员招募、萨米折叠术、自动战斗的暂停下干员全靠这些参数，走这条路会退化。而且发布包里没有 `MaaAdbControlUnit.dll`（只 copy 了 `*Win32ControlUnit*`）。
2. **扩展自家 `MumuExtras`** —— 采用这条。

选 2 的额外理由：`MumuExtras` 在加载 dll 时**其实已经把 input 符号全取出来了**（`nemu_input_event_touch_down/up`、`key_down/up`、`input_text`），取失败还会 `return false`，只是从来没被调用过。当初显然就是照这条路留的口子，这次把它补完。

## 改了什么

### Core

- `MumuExtras` 增加 `touch_down/move/up`、`key_down/up`、`input_text`
  - 绑定从单指 `nemu_input_event_touch_down` 换成多指 `finger_touch_down`（contact 0-based → finger_id 1-based），肉鸽/自动战斗需要多指语义
  - Android KeyEvent → Linux input-event-code 的映射表（MAA 内部 `InputEvent::keycode` 走的是 Android 语义）
- **`get_display_id()` 加缓存**：原来每次都实调 dll。截图每秒几次无所谓，但 swipe 的 move 是每 2ms 一次，不缓存这条路直接废掉
- **input 符号缺失不再连累截图**：原来取不到就 `return false`，会把截图一起废掉；改成单独用 `input_available_` 记录，只有 `capture_display` 是硬性要求
- **版本门槛**：跑 `MuMuManager.exe version`，`>= 6.3.2.0` 才启用触控，低版本静默降级并留 warn。探测要起子进程，结果缓存，`reload()` 不重复执行；只截图的用户完全不付这份开销（靠 `extras.touch` 开关）
- **新增 `MumuController : MaatouchController`**，天然拿到降级链：`Adb → Minitouch → Maatouch → Mumu`
  - `connect()` 没有直接调基类：`MinitouchController::connect` 在 maatouch 探测失败时会抛 `TouchModeNotAvailable` 并返回 false，而那时 MuMu 触控可能是好的。所以自己接管顺序 —— 先 adb 连接（顺带 `init_mumu_extras`），优先试 MuMu，不行再 `probe_minitouch()`
  - swipe 复用 `SwipeHelper.hpp`，`slope/with_pause/extra_swipe` 完整保留；`support_features()` 返回 `PRECISE_SWIPE | SWIPE_WITH_PAUSE`
  - 暂停直接发 nemu 按键，比 minitouch 那个 `std::async(press_esc)` 干净
  - connect 时校验 MuMu display 尺寸与 adb 分辨率一致，不一致则降级（`ControlScaleProxy` 按 `get_screen_res()` 缩放，坐标系对不上会全部点偏）
  - override `reconnect()`：MuMu 模式下没探测过 maatouch，跳过基类重新拉起，否则会拿空命令去起交互式 shell

### GUI（WPF）

「启用 MuMu 截图增强模式」下加子勾选「同时用于触控」，默认关。做成子勾选而不是 TouchMode 下拉第五项，是因为 MuMu 触控本来就依赖 MuMu Extras 的连接，天然只在 MuMuEmulator12 配置下可见，不会出现「选了但配置不匹配」的无效组合。勾上后 extras json 带 `touch` 字段，并把 `TouchMode` 覆写成 `MumuExtras`。

5 个语言的 i18n 都加了。

### 顺带修的隐患

`MaaFwAdbController.cpp` 原本在 input method 里带了 `MaaAdbInputMethod::EmulatorExtras`，但从没传过 mumu 的 extras json（只有 AVD 分支），所以一直没生效 —— 反而躲过一个坑：maafw 的 `MuMuPlayerExtras::click()` 是 `LogError + return false`（靠 `get_features()` 返回 `UseMouseDownAndUpInsteadOfClick` 让上层改走 down/up），而 `MaaFwAdbController::click()` 直接透传给 ControlUnit、**从不读 features**。真要把 json 补上，点击会全线失败。先摘掉并留注释，避免以后有人踩。

## 测试

- MaaCore / MaaWpfGui 均编译 0 错误，新文件无新增警告
- MAAUnified 侧本地化审计 + 连接生命周期 + 配置导入：**127 通过 / 0 失败**
  （另有 4 个 `ToolboxModuleO2FeatureTests` / `TaskQueueG2FeatureTests` 失败，已 `git stash` 到干净树复现，确认改动前就存在）

⚠️ **尚未真机验证**，我这边没有 MuMu 环境。建议合并前实测：
- MuMu 6.3.2+：肉鸽（多指 + 精准滑动）、自动战斗（`with_pause` 下干员）、基建换班（长滑动）
- MuMu < 6.3.2：确认静默降级到 maatouch，日志有明确 warn

## 相关

- MAAUnified（Avalonia GUI）侧的对应改动本 PR 未包含，需另行处理
- 对应 MaaFramework: MaaXYZ/MaaFramework@b4e126a3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

通过在 MumuController 和 WPF MuMu 扩展设置中接入可选且按版本控制的 MuMu 外部渲染器触摸模式，引入基于 MuMu 外部渲染器的触摸输入，同时保留对现有触摸机制的稳健回退，并避免对截图或基于 ADB 的控制造成回归。

New Features:
- 通过 MumuExtras 和专用的 MumuController 触摸模式，新增 MuMu 外部渲染器的直接 IPC 触摸、按键和文本输入支持。
- 在 WPF 连接设置中暴露一个 MuMu 扩展触摸选项，使启用时 MuMu 截图也能驱动触摸输入。

Bug Fixes:
- 防止 MaaFwAdbController 对 MuMu 使用 MaaFramework EmulatorExtras，避免在该模式下出现点击/滑动行为异常。
- 确保在缺少 MuMu 输入符号或 MuMu 版本不受支持时，只禁用触摸输入，而不会破坏截图功能。

Enhancements:
- 缓存 MuMu 显示 ID 和表面显示尺寸，以提升高频滑动操作的性能和坐标精度。
- 通过 MuMuManager.exe 版本检测对 MuMu 扩展输入进行门控，并复用缓存结果，当输入不可用或配置错误时，干净地回退到 maatouch。
- 扩展触摸模式路由和实例选项，以识别由 MumuController 支撑的 MuMuExtras 触摸模式，在 MuMu 输入尚未就绪时自动降级到 maatouch。
- 在 MuMu 扩展输入路径中添加 Android 到 Linux 的按键码映射以及多指针处理，以支持精确滑动、多指手势以及通过按键事件触发暂停。

Documentation:
- 更新 WPF GUI 本地化和设置文案（涵盖所有支持语言），记录 MuMu 截图增强项下新增的 MuMu 触摸输入子选项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce MuMu external renderer-based touch input as an optional, version-gated touch mode wired through MumuController and WPF MuMu extras settings, while preserving robust fallbacks to existing touch mechanisms and avoiding regressions in screenshot or ADB-based control.

New Features:
- Add direct MuMu external renderer IPC touch, key, and text input support via MumuExtras and a dedicated MumuController touch mode.
- Expose a MuMu extras touch option in the WPF connection settings, allowing MuMu screencap to also drive touch input when enabled.

Bug Fixes:
- Prevent MaaFwAdbController from using MaaFramework EmulatorExtras for MuMu, avoiding broken click/swipe behaviour in that mode.
- Ensure missing MuMu input symbols or unsupported MuMu versions only disable touch input rather than breaking screenshot capture.

Enhancements:
- Cache MuMu display IDs and surface display dimensions to improve performance and coordinate accuracy for high-frequency swipe operations.
- Gate MuMu extras input by MuMuManager.exe version detection and reuse cached results, cleanly falling back to maatouch when input is unavailable or misconfigured.
- Extend touch mode routing and instance options to recognise a MuMuExtras touch mode backed by MumuController, with automatic downgrade to maatouch when MuMu input is not ready.
- Add Android-to-Linux keycode mapping and multi-pointer handling in the MuMu extras input path to support precise swipes, multi-finger gestures, and pause via key events.

Documentation:
- Update WPF GUI localization and settings text in all supported languages to document the new MuMu touch input sub-option under MuMu screencap enhancements.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 MumuController 和 WPF MuMu 扩展设置中接入可选且按版本控制的 MuMu 外部渲染器触摸模式，引入基于 MuMu 外部渲染器的触摸输入，同时保留对现有触摸机制的稳健回退，并避免对截图或基于 ADB 的控制造成回归。

New Features:
- 通过 MumuExtras 和专用的 MumuController 触摸模式，新增 MuMu 外部渲染器的直接 IPC 触摸、按键和文本输入支持。
- 在 WPF 连接设置中暴露一个 MuMu 扩展触摸选项，使启用时 MuMu 截图也能驱动触摸输入。

Bug Fixes:
- 防止 MaaFwAdbController 对 MuMu 使用 MaaFramework EmulatorExtras，避免在该模式下出现点击/滑动行为异常。
- 确保在缺少 MuMu 输入符号或 MuMu 版本不受支持时，只禁用触摸输入，而不会破坏截图功能。

Enhancements:
- 缓存 MuMu 显示 ID 和表面显示尺寸，以提升高频滑动操作的性能和坐标精度。
- 通过 MuMuManager.exe 版本检测对 MuMu 扩展输入进行门控，并复用缓存结果，当输入不可用或配置错误时，干净地回退到 maatouch。
- 扩展触摸模式路由和实例选项，以识别由 MumuController 支撑的 MuMuExtras 触摸模式，在 MuMu 输入尚未就绪时自动降级到 maatouch。
- 在 MuMu 扩展输入路径中添加 Android 到 Linux 的按键码映射以及多指针处理，以支持精确滑动、多指手势以及通过按键事件触发暂停。

Documentation:
- 更新 WPF GUI 本地化和设置文案（涵盖所有支持语言），记录 MuMu 截图增强项下新增的 MuMu 触摸输入子选项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce MuMu external renderer-based touch input as an optional, version-gated touch mode wired through MumuController and WPF MuMu extras settings, while preserving robust fallbacks to existing touch mechanisms and avoiding regressions in screenshot or ADB-based control.

New Features:
- Add direct MuMu external renderer IPC touch, key, and text input support via MumuExtras and a dedicated MumuController touch mode.
- Expose a MuMu extras touch option in the WPF connection settings, allowing MuMu screencap to also drive touch input when enabled.

Bug Fixes:
- Prevent MaaFwAdbController from using MaaFramework EmulatorExtras for MuMu, avoiding broken click/swipe behaviour in that mode.
- Ensure missing MuMu input symbols or unsupported MuMu versions only disable touch input rather than breaking screenshot capture.

Enhancements:
- Cache MuMu display IDs and surface display dimensions to improve performance and coordinate accuracy for high-frequency swipe operations.
- Gate MuMu extras input by MuMuManager.exe version detection and reuse cached results, cleanly falling back to maatouch when input is unavailable or misconfigured.
- Extend touch mode routing and instance options to recognise a MuMuExtras touch mode backed by MumuController, with automatic downgrade to maatouch when MuMu input is not ready.
- Add Android-to-Linux keycode mapping and multi-pointer handling in the MuMu extras input path to support precise swipes, multi-finger gestures, and pause via key events.

Documentation:
- Update WPF GUI localization and settings text in all supported languages to document the new MuMu touch input sub-option under MuMu screencap enhancements.

</details>

</details>

新特性：
- 通过专用的 MumuController 增加对 MuMu 外部渲染器 IPC 触摸输入的直接支持，并与现有的触摸模式选择和功能检测进行集成。
- 从核心 MumuExtras 辅助组件中暴露 MuMu 触摸、按键和文本输入能力，并在 WPF GUI 中将其作为一项可选项，与 MuMu 截图增强功能并列呈现。

缺陷修复：
- 阻止 MaaFramework ADB 控制器尝试使用其 MuMu EmulatorExtras 输入路径，避免在该模式下出现损坏的点击/滑动处理。
- 确保当 MuMu 输入符号缺失或 MuMu 版本不受支持时，仅禁用触摸输入，不再导致截图功能失效。

改进与增强：
- 缓存 MuMu 显示 ID 并暴露显示尺寸，以提升高频触摸操作中的滑动性能和坐标精度。
- 将 MuMu extras 输入初始化置于显式触摸配置和 MuMuManager 版本探测之后，并使用缓存结果，在不可用时优雅地回退到 maatouch。
- 扩展实例触摸模式选项和控制器路由，将 MuMuExtras 识别为一种触摸模式，在 MuMu 输入未就绪时自动回退。
- 在 MuMu extras 输入路径中添加 Android 到 Linux 的按键码映射以及多点触控处理，以支持精确滑动、多指针操作以及通过按键事件实现暂停。

文档：
- 更新 WPF GUI 本地化与设置界面，在各支持语言中描述 MuMu 截图增强下新增的 MuMu 触摸输入子选项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 MumuController 和 WPF MuMu 扩展设置中接入可选且按版本控制的 MuMu 外部渲染器触摸模式，引入基于 MuMu 外部渲染器的触摸输入，同时保留对现有触摸机制的稳健回退，并避免对截图或基于 ADB 的控制造成回归。

New Features:
- 通过 MumuExtras 和专用的 MumuController 触摸模式，新增 MuMu 外部渲染器的直接 IPC 触摸、按键和文本输入支持。
- 在 WPF 连接设置中暴露一个 MuMu 扩展触摸选项，使启用时 MuMu 截图也能驱动触摸输入。

Bug Fixes:
- 防止 MaaFwAdbController 对 MuMu 使用 MaaFramework EmulatorExtras，避免在该模式下出现点击/滑动行为异常。
- 确保在缺少 MuMu 输入符号或 MuMu 版本不受支持时，只禁用触摸输入，而不会破坏截图功能。

Enhancements:
- 缓存 MuMu 显示 ID 和表面显示尺寸，以提升高频滑动操作的性能和坐标精度。
- 通过 MuMuManager.exe 版本检测对 MuMu 扩展输入进行门控，并复用缓存结果，当输入不可用或配置错误时，干净地回退到 maatouch。
- 扩展触摸模式路由和实例选项，以识别由 MumuController 支撑的 MuMuExtras 触摸模式，在 MuMu 输入尚未就绪时自动降级到 maatouch。
- 在 MuMu 扩展输入路径中添加 Android 到 Linux 的按键码映射以及多指针处理，以支持精确滑动、多指手势以及通过按键事件触发暂停。

Documentation:
- 更新 WPF GUI 本地化和设置文案（涵盖所有支持语言），记录 MuMu 截图增强项下新增的 MuMu 触摸输入子选项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce MuMu external renderer-based touch input as an optional, version-gated touch mode wired through MumuController and WPF MuMu extras settings, while preserving robust fallbacks to existing touch mechanisms and avoiding regressions in screenshot or ADB-based control.

New Features:
- Add direct MuMu external renderer IPC touch, key, and text input support via MumuExtras and a dedicated MumuController touch mode.
- Expose a MuMu extras touch option in the WPF connection settings, allowing MuMu screencap to also drive touch input when enabled.

Bug Fixes:
- Prevent MaaFwAdbController from using MaaFramework EmulatorExtras for MuMu, avoiding broken click/swipe behaviour in that mode.
- Ensure missing MuMu input symbols or unsupported MuMu versions only disable touch input rather than breaking screenshot capture.

Enhancements:
- Cache MuMu display IDs and surface display dimensions to improve performance and coordinate accuracy for high-frequency swipe operations.
- Gate MuMu extras input by MuMuManager.exe version detection and reuse cached results, cleanly falling back to maatouch when input is unavailable or misconfigured.
- Extend touch mode routing and instance options to recognise a MuMuExtras touch mode backed by MumuController, with automatic downgrade to maatouch when MuMu input is not ready.
- Add Android-to-Linux keycode mapping and multi-pointer handling in the MuMu extras input path to support precise swipes, multi-finger gestures, and pause via key events.

Documentation:
- Update WPF GUI localization and settings text in all supported languages to document the new MuMu touch input sub-option under MuMu screencap enhancements.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过在 MumuController 和 WPF MuMu 扩展设置中接入可选且按版本控制的 MuMu 外部渲染器触摸模式，引入基于 MuMu 外部渲染器的触摸输入，同时保留对现有触摸机制的稳健回退，并避免对截图或基于 ADB 的控制造成回归。

New Features:
- 通过 MumuExtras 和专用的 MumuController 触摸模式，新增 MuMu 外部渲染器的直接 IPC 触摸、按键和文本输入支持。
- 在 WPF 连接设置中暴露一个 MuMu 扩展触摸选项，使启用时 MuMu 截图也能驱动触摸输入。

Bug Fixes:
- 防止 MaaFwAdbController 对 MuMu 使用 MaaFramework EmulatorExtras，避免在该模式下出现点击/滑动行为异常。
- 确保在缺少 MuMu 输入符号或 MuMu 版本不受支持时，只禁用触摸输入，而不会破坏截图功能。

Enhancements:
- 缓存 MuMu 显示 ID 和表面显示尺寸，以提升高频滑动操作的性能和坐标精度。
- 通过 MuMuManager.exe 版本检测对 MuMu 扩展输入进行门控，并复用缓存结果，当输入不可用或配置错误时，干净地回退到 maatouch。
- 扩展触摸模式路由和实例选项，以识别由 MumuController 支撑的 MuMuExtras 触摸模式，在 MuMu 输入尚未就绪时自动降级到 maatouch。
- 在 MuMu 扩展输入路径中添加 Android 到 Linux 的按键码映射以及多指针处理，以支持精确滑动、多指手势以及通过按键事件触发暂停。

Documentation:
- 更新 WPF GUI 本地化和设置文案（涵盖所有支持语言），记录 MuMu 截图增强项下新增的 MuMu 触摸输入子选项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce MuMu external renderer-based touch input as an optional, version-gated touch mode wired through MumuController and WPF MuMu extras settings, while preserving robust fallbacks to existing touch mechanisms and avoiding regressions in screenshot or ADB-based control.

New Features:
- Add direct MuMu external renderer IPC touch, key, and text input support via MumuExtras and a dedicated MumuController touch mode.
- Expose a MuMu extras touch option in the WPF connection settings, allowing MuMu screencap to also drive touch input when enabled.

Bug Fixes:
- Prevent MaaFwAdbController from using MaaFramework EmulatorExtras for MuMu, avoiding broken click/swipe behaviour in that mode.
- Ensure missing MuMu input symbols or unsupported MuMu versions only disable touch input rather than breaking screenshot capture.

Enhancements:
- Cache MuMu display IDs and surface display dimensions to improve performance and coordinate accuracy for high-frequency swipe operations.
- Gate MuMu extras input by MuMuManager.exe version detection and reuse cached results, cleanly falling back to maatouch when input is unavailable or misconfigured.
- Extend touch mode routing and instance options to recognise a MuMuExtras touch mode backed by MumuController, with automatic downgrade to maatouch when MuMu input is not ready.
- Add Android-to-Linux keycode mapping and multi-pointer handling in the MuMu extras input path to support precise swipes, multi-finger gestures, and pause via key events.

Documentation:
- Update WPF GUI localization and settings text in all supported languages to document the new MuMu touch input sub-option under MuMu screencap enhancements.

</details>

</details>

</details>