### PR TITLE
fix: 更新阿米娅角色数据的sortIndex和subProfessionId

### DIFF
--- a/tools/ResourceUpdater/main.cpp
+++ b/tools/ResourceUpdater/main.cpp
@@ -980,10 +980,8 @@ bool update_battle_chars_info(const fs::path& official_dir, const fs::path& over
     Amiya_data["rangeId"] = json::array { "1-1", "1-1", "1-1" };
     Amiya_data["rarity"] = 5;
     Amiya_data["position"] = "MELEE";
-    if (auto amiya2_opt = chars_json[0].first.find<json::object>("char_1001_amiya2")) {
-        Amiya_data["sortIndex"] = amiya2_opt->get("sortIndex", -1);
-        Amiya_data["subProfessionId"] = amiya2_opt->get("subProfessionId", std::string());
-    }
+    Amiya_data["sortIndex"] = 0;
+    Amiya_data["subProfessionId"] = "artsfghter";
     chars.emplace("char_1001_amiya2", std::move(Amiya_data));
 
     json::value Amiya_data3;
@@ -996,10 +994,8 @@ bool update_battle_chars_info(const fs::path& official_dir, const fs::path& over
     Amiya_data3["rangeId"] = json::array { "3-1", "3-3", "3-3" };
     Amiya_data3["rarity"] = 5;
     Amiya_data3["position"] = "RANGED";
-    if (auto amiya3_opt = chars_json[0].first.find<json::object>("char_1037_amiya3")) {
-        Amiya_data3["sortIndex"] = amiya3_opt->get("sortIndex", -1);
-        Amiya_data3["subProfessionId"] = amiya3_opt->get("subProfessionId", std::string());
-    }
+    Amiya_data3["sortIndex"] = 0;
+    Amiya_data3["subProfessionId"] = "incantationmedic";
     chars.emplace("char_1037_amiya3", std::move(Amiya_data3));
 
     const auto& out_file = output_dir / "battle_data.json";


### PR DESCRIPTION
原来的character_table.json里面就没这两项
参照char_patch_table.json里面的数据
不过为什么character_table.json里面阿米娅的sortIndex是16，char_patch_table.json里面是0

## Summary by Sourcery

Bug Fixes:
- 确保阿米娅的第二和第三战斗形态在生成的 `battle_data.json` 中具有正确的 `sortIndex` 和 `subProfessionId` 值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure Amiya’s second and third battle forms have correct sortIndex and subProfessionId values in generated battle_data.json.

</details>
- 通过硬编码 `sortIndex` 和 `subProfessionId`，而不是依赖 `character_table.json` 中缺失的值，修正阿米娅第二、第三形态的战斗数据。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- 确保阿米娅的第二和第三战斗形态在生成的 `battle_data.json` 中具有正确的 `sortIndex` 和 `subProfessionId` 值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure Amiya’s second and third battle forms have correct sortIndex and subProfessionId values in generated battle_data.json.

</details>

</details>