### PR TITLE
feat: 为外服提供与游戏版本匹配的 custom_infrast 预设排班配置

### DIFF
--- a/resource/global/YoStarEN/resource/custom_infrast/153_layout_3_times_a_day.json
+++ b/resource/global/YoStarEN/resource/custom_infrast/153_layout_3_times_a_day.json
@@ -1,0 +1,440 @@
+{
+    "author": "uye、lhh",
+    "description": "干员配置要求极高，请留意\\n若缺少干员请自行拷贝文件并修改（请勿直接修改，以免更新后被覆盖）\\n第一个制造站为赤金，其余为记录\\n\\n作业作者：uye、lhh\\n\\n感谢公孙长乐大佬提供数据及方案支持！",
+    "id": 1730652690046966,
+    "title": "153 极限效率，一天三换",
+    "buildingType": 243,
+    "planTimes": "3班",
+    "plans": [
+        {
+            "name": "A+B 16H",
+            "description": "最高效率长班，下次换班请在约16小时后进行",
+            "Fiammetta": {
+                "enable": true,
+                "target": "但书",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "manufacture",
+                "index": 1,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["伺夜", "黑键", "但书"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["苍苔", "砾", "斑点"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["至简", "槐琥", "断罪者"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["野鬃", "远牙", "灰毫"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["淬羽赫默", "多萝西", "迷迭香"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["温蒂", "异客", "掠风"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["承曦格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["Lancet-2"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["爱丽丝", "车尔尼", "塑心", "菲亚梅塔", "闪灵"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["凯尔希", "令", "泡泡", "火神", "杏仁"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["水月", "香草", "杰西卡", "红云", "稀音"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["帕拉斯", "澄闪", "涤火杰西卡", "流明", "见行者"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["森蚺", "焰尾", "薇薇安娜", "琴柳", "夕"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": ["跃跃", "伊内丝"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": ["年"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        },
+        {
+            "name": "A+C 4H",
+            "description": "下次换班请在约4小时后进行",
+            "Fiammetta": {
+                "enable": false,
+                "target": "",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "manufacture",
+                "index": 1,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["推进之王", "摩根", "但书"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["苍苔", "砾", "斑点"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["至简", "槐琥", "断罪者"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["野鬃", "远牙", "灰毫"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["水月", "香草", "杰西卡"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["红云", "稀音", "帕拉斯"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["雷蛇"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["澄闪"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["爱丽丝", "车尔尼", "塑心", "菲亚梅塔", "闪灵"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["黑键", "淬羽赫默", "多萝西", "迷迭香", "温蒂"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["异客", "掠风", "承曦格雷伊", "伊内丝", "絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["森蚺", "琴柳", "夕", "伺夜", "流明"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["戴菲恩", "凯尔希", "焰尾", "薇薇安娜", "涤火杰西卡"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": ["见行者", "跃跃"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["斥罪"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": ["年"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        },
+        {
+            "name": "B+C 4H",
+            "description": "下次换班请在约4小时后进行",
+            "Fiammetta": {
+                "enable": false,
+                "target": "",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "manufacture",
+                "index": 1,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["伺夜", "黑键", "但书"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["泡泡", "火神", "杏仁"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["淬羽赫默", "多萝西", "迷迭香"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["温蒂", "异客", "掠风"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["水月", "香草", "杰西卡"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["红云", "稀音", "帕拉斯"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["承曦格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["Lancet-2"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["澄闪"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["戴菲恩", "焰尾", "薇薇安娜", "推进之王", "摩根"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["苍苔", "砾", "斑点", "至简", "槐琥"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["断罪者", "野鬃", "远牙", "灰毫", "格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["雷蛇", "跃跃", "斥罪", "流明", "闪灵"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["森蚺", "涤火杰西卡", "凯尔希", "琴柳", "令"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": ["见行者", "伊内丝"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": ["年"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        }
+    ],
+    "scheduleType": {
+        "planTimes": 4,
+        "trading": 1,
+        "manufacture": 5,
+        "power": 3,
+        "dormitory": 4
+    }
+}

--- a/resource/global/YoStarEN/resource/custom_infrast/153_layout_4_times_a_day.json
+++ b/resource/global/YoStarEN/resource/custom_infrast/153_layout_4_times_a_day.json
@@ -1,0 +1,585 @@
+{
+    "author": "uye",
+    "description": "干员配置要求极高，请留意\\n若缺少干员请自行拷贝文件并修改（请勿直接修改，以免更新后被覆盖）\\n第一个制造站为赤金，其余为记录\\n\\n作业作者：uye\\n\\n感谢公孙长乐大佬提供数据及方案支持！",
+    "id": 1744463675638466,
+    "title": "153 极限效率，一天四换",
+    "buildingType": 243,
+    "planTimes": "3班",
+    "plans": [
+        {
+            "name": "1",
+            "description": "7h",
+            "description_post": "7小时后换班",
+            "Fiammetta": {
+                "enable": true,
+                "target": "但书",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "trading",
+                "index": 1,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["空弦", "黑键", "但书"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["槐琥", "阿罗玛", "砾"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["温蒂", "异客", "掠风"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["野鬃", "远牙", "灰毫"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["迷迭香", "乌尔比安", "安哲拉"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["幽灵鲨", "斯卡蒂", "至简"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["承曦格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["Lancet-2"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["澄闪"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["菲亚梅塔", "爱丽丝", "车尔尼", "塑心", "年"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["杏仁", "红云", "稀音", "帕拉斯", "多萝西"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["淬羽赫默", "断罪者", "食铁兽", "水月", "香草"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["杰西卡", "格雷伊", "忍冬", "铃兰", "九色鹿"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["薇薇安娜", "焰尾", "森蚺", "琴柳", "歌蕾蒂娅"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": ["伊内丝", "陈"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        },
+        {
+            "name": "2",
+            "description": "5h",
+            "description_post": "5小时后换班",
+            "Fiammetta": {
+                "enable": false,
+                "target": "",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "trading",
+                "index": 1,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["巫恋", "龙舌兰", "但书"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["苍苔", "砾", "引星棘刺"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["温蒂", "异客", "掠风"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["野鬃", "远牙", "灰毫"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["多萝西", "淬羽赫默", "断罪者"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["水月", "香草", "杰西卡"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["承曦格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["Lancet-2"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["雷蛇"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["菲亚梅塔", "夕", "琴柳", "令", "年"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["阿罗玛", "迷迭香", "歌蕾蒂娅", "闪灵", "流明"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["至简", "澄闪", "絮雨", "黑键", "槐琥"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["伊内丝", "陈", "空弦", "杜林", "九色鹿"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["薇薇安娜", "焰尾", "森蚺", "涤火杰西卡", "Mon3tr"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": ["忍冬", "铃兰"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["斥罪"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        },
+        {
+            "name": "3",
+            "description": "7h",
+            "description_post": "7小时后换班",
+            "Fiammetta": {
+                "enable": false,
+                "target": "",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "trading",
+                "index": 1,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["空弦", "黑键", "但书"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["槐琥", "阿罗玛", "砾"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["温蒂", "异客", "掠风"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["野鬃", "远牙", "灰毫"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["迷迭香", "乌尔比安", "安哲拉"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["幽灵鲨", "斯卡蒂", "至简"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["承曦格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["Lancet-2"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["澄闪"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["菲亚梅塔", "爱丽丝", "车尔尼", "塑心", "年"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["巫恋", "龙舌兰", "苍苔", "引星棘刺", "多萝西"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["淬羽赫默", "断罪者", "水月", "香草", "杰西卡"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["雷蛇", "斥罪", "涤火杰西卡", "Mon3tr", "九色鹿"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["薇薇安娜", "焰尾", "森蚺", "琴柳", "歌蕾蒂娅"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": ["伊内丝", "陈"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        },
+        {
+            "name": "4",
+            "description": "5h",
+            "description_post": "5小时后换班",
+            "Fiammetta": {
+                "enable": false,
+                "target": "",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "trading",
+                "index": 1,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["空弦", "黑键", "但书"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["槐琥", "阿罗玛", "杏仁"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["红云", "稀音", "帕拉斯"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["至简", "多萝西", "淬羽赫默"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["迷迭香", "断罪者", "食铁兽"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["水月", "香草", "杰西卡"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["雷蛇"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["澄闪"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["菲亚梅塔", "爱丽丝", "车尔尼", "塑心", "年"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["砾", "温蒂", "异客", "掠风", "野鬃"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["远牙", "灰毫", "歌蕾蒂娅", "流明", "闪灵"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["承曦格雷伊", "森蚺", "焰尾", "薇薇安娜", "九色鹿"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["Mon3tr", "涤火杰西卡", "令", "琴柳", "夕"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": ["伊内丝", "陈"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        }
+    ],
+    "scheduleType": {
+        "planTimes": 4,
+        "trading": 1,
+        "manufacture": 5,
+        "power": 3,
+        "dormitory": 4
+    }
+}

--- a/resource/global/YoStarEN/resource/custom_infrast/243_layout_3_times_a_day.json
+++ b/resource/global/YoStarEN/resource/custom_infrast/243_layout_3_times_a_day.json
@@ -1,0 +1,440 @@
+{
+    "author": "一只摆烂的42&Powered by公孙长乐",
+    "description": "需手动每8或12小时使用菲亚梅塔007巫恋龙舌兰但书\\n干员配置要求极高，请留意\\n若缺少干员/练度不足请自行通过id在一图流基建排班生成器上修改并重新生成导出（请勿直接修改，以免更新后被覆盖）\\n\\n感谢公孙长乐大佬提供数据及方案支持！\\n[20251111 修订] 视频地址: https://www.bilibili.com/video/BV1fhyfBGE59/\\n可自行在一图流排班生成器上自定义班次起止时间",
+    "id": 1762067890282538,
+    "title": "243极限效率，一天三换（需手动菲亚梅塔）",
+    "buildingType": 243,
+    "planTimes": "3班",
+    "plans": [
+        {
+            "name": "16H最高效率长班",
+            "description": "",
+            "Fiammetta": {
+                "enable": false,
+                "target": "巫恋",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "manufacture",
+                "index": 1,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["巫恋", "龙舌兰", "卡夫卡"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["但书", "黑键", "空弦"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["野鬃", "远牙", "灰毫"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["迷迭香", "至简", "断罪者"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["清流", "温蒂", "森蚺"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["槐琥", "阿罗玛", "砾"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["承曦格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["澄闪"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["车尔尼", "爱丽丝", "塑心"],
+                        "sort": true,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["阿米娅", "琴柳", "令", "薇薇安娜", "焰尾"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        },
+        {
+            "name": "4H 次高效替补 2 班",
+            "description": "下次在4小时后换班",
+            "Fiammetta": {
+                "enable": false,
+                "target": "龙舌兰",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "manufacture",
+                "index": 1,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["巫恋", "龙舌兰", "柏喙"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["但书", "空弦", "伺夜"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["野鬃", "远牙", "安哲拉"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["灰毫", "幽灵鲨", "斯卡蒂"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["苍苔", "砾", "引星棘刺"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["槐琥", "阿罗玛", "乌尔比安"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["正义骑士号"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["澄闪"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["雷蛇"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["阿米娅", "八幡海铃", "歌蕾蒂娅", "薇薇安娜", "焰尾"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["斥罪"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        },
+        {
+            "name": "4H 次高效替补 1 班",
+            "description": "下次在4小时后换班",
+            "Fiammetta": {
+                "enable": false,
+                "target": "但书",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "manufacture",
+                "index": 1,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["巫恋", "龙舌兰", "卡夫卡"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["但书", "伺夜", "黑键"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["断罪者", "乌尔比安", "安哲拉"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["幽灵鲨", "斯卡蒂", "至简"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["清流", "温蒂", "森蚺"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["苍苔", "引星棘刺", "迷迭香"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["承曦格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["雷蛇"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["车尔尼", "爱丽丝", "塑心"],
+                        "sort": true,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["诗怀雅", "歌蕾蒂娅", "斩业星熊", "夕", "琴柳"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        }
+    ],
+    "scheduleType": {
+        "planTimes": 3,
+        "trading": 2,
+        "manufacture": 4,
+        "power": 3,
+        "dormitory": 4
+    }
+}

--- a/resource/global/YoStarEN/resource/custom_infrast/243_layout_4_times_a_day.json
+++ b/resource/global/YoStarEN/resource/custom_infrast/243_layout_4_times_a_day.json
@@ -1,0 +1,581 @@
+{
+    "author": "公孙长乐, bodayw",
+    "description": "干员配置要求极高，若缺少干员请自行调整\n默认每八小时使用无人机加速制造作战记录，请按实际需求修改\n首次使用前将令的心情消耗至 12\n请在一图流排班表生成器上导入本文件，修改后下载导出（请勿直接修改本文件，以免 MAA 更新时被覆盖）\n\n[20250806 修订] 视频地址: https://www.bilibili.com/video/BV1EW4RzzE9R/?t=145",
+    "id": 1754476892600274,
+    "title": "243 极限效率，一天四换",
+    "buildingType": 243,
+    "planTimes": "3班",
+    "plans": [
+        {
+            "name": "A+B 高效长班 1",
+            "description_post": "请在八小时后换班",
+            "Fiammetta": {
+                "enable": true,
+                "target": "巫恋",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "manufacture",
+                "index": 3,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["巫恋", "卡夫卡", "龙舌兰"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["空弦", "黑键", "但书"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["清流", "温蒂", "森蚺"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["槐琥", "阿罗玛", "砾"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["野鬃", "远牙", "灰毫"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["迷迭香", "至简", "断罪者"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["承曦格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["缪尔赛思"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["澄闪"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["菲亚梅塔", "雷蛇", "戴菲恩", "推进之王", "摩根"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["歌蕾蒂娅", "乌尔比安", "安哲拉", "幽灵鲨", "斯卡蒂"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["爱丽丝", "车尔尼", "塑心", "伊内丝", "苍苔"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["赫默", "伊芙利特", "塞雷娅", "白面鸮", "梅尔"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["阿米娅", "琴柳", "令", "薇薇安娜", "焰尾"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": ["信仰搅拌机", "见行者"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        },
+        {
+            "name": "A+B 高效长班 2",
+            "description_post": "请在八小时后换班",
+            "Fiammetta": {
+                "enable": true,
+                "target": "龙舌兰",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "manufacture",
+                "index": 3,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["巫恋", "卡夫卡", "龙舌兰"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": true,
+                        "product": "LMD",
+                        "operators": ["空弦", "黑键", "但书"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": true,
+                        "product": "Pure Gold",
+                        "operators": ["清流", "温蒂", "森蚺"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": true,
+                        "product": "Pure Gold",
+                        "operators": ["槐琥", "阿罗玛", "砾"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": true,
+                        "product": "Battle Record",
+                        "operators": ["野鬃", "远牙", "灰毫"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": true,
+                        "product": "Battle Record",
+                        "operators": ["迷迭香", "至简", "断罪者"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": true,
+                        "operators": ["承曦格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": true,
+                        "operators": ["缪尔赛思"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["雷蛇"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["菲亚梅塔", "澄闪", "格雷伊", "柏喙", "斥罪"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["诗怀雅", "斩业星熊", "夕", "引星棘刺", "见行者"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["爱丽丝", "车尔尼", "塑心"],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": true,
+                        "operators": ["赫默", "伊芙利特", "塞雷娅", "白面鸮", "梅尔"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": true,
+                        "operators": ["阿米娅", "琴柳", "令", "薇薇安娜", "焰尾"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": ["信仰搅拌机", "伊内丝"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": true,
+                        "operators": ["絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": true,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        },
+        {
+            "name": "B+C 替补短班 1",
+            "description_post": "请在四小时后换班（三小时后把回满 12 心情的令移出宿舍）",
+            "Fiammetta": {
+                "enable": true,
+                "target": "但书",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "manufacture",
+                "index": 3,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["巫恋", "柏喙", "龙舌兰"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["推进之王", "摩根", "但书"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["苍苔", "砾", "引星棘刺"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["槐琥", "阿罗玛", "乌尔比安"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["野鬃", "远牙", "安哲拉"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["幽灵鲨", "斯卡蒂", "灰毫"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": true,
+                        "operators": ["缪尔赛思"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": true,
+                        "operators": ["雷蛇"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["菲亚梅塔", "令", "卡夫卡", "空弦", "黑键"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["清流", "温蒂", "森蚺", "迷迭香", "至简"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["断罪者", "承曦格雷伊", "信仰搅拌机", "絮雨", "琴柳"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": true,
+                        "operators": ["赫默", "伊芙利特", "塞雷娅", "白面鸮", "梅尔"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["阿米娅", "戴菲恩", "歌蕾蒂娅", "薇薇安娜", "焰尾"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": ["见行者", "伊内丝"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["斥罪"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": true,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        },
+        {
+            "name": "A+C 替补短班 2",
+            "description_post": "请在四小时后换班",
+            "Fiammetta": {
+                "enable": false,
+                "target": "",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "manufacture",
+                "index": 3,
+                "enable": false,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["巫恋", "卡夫卡", "龙舌兰"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["空弦", "黑键", "但书"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["清流", "温蒂", "森蚺"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["苍苔", "引星棘刺", "迷迭香"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["断罪者", "乌尔比安", "安哲拉"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["幽灵鲨", "斯卡蒂", "至简"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["承曦格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["澄闪"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": true,
+                        "operators": ["雷蛇"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["菲亚梅塔", "阿米娅", "薇薇安娜", "焰尾", "砾"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["槐琥", "阿罗玛", "野鬃", "远牙", "灰毫"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["爱丽丝", "车尔尼", "塑心", "缪尔赛思", "见行者"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": true,
+                        "operators": ["赫默", "伊芙利特", "塞雷娅", "白面鸮", "梅尔"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["诗怀雅", "歌蕾蒂娅", "斩业星熊", "夕", "琴柳"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": ["信仰搅拌机", "伊内丝"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": true,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        }
+    ],
+    "scheduleType": {
+        "planTimes": 4,
+        "trading": 2,
+        "manufacture": 4,
+        "power": 3,
+        "dormitory": 4
+    }
+}

--- a/resource/global/YoStarEN/resource/custom_infrast/333_layout_for_Orundum_3_times_a_day.json
+++ b/resource/global/YoStarEN/resource/custom_infrast/333_layout_for_Orundum_3_times_a_day.json
@@ -1,0 +1,442 @@
+{
+    "author": "一只摆烂的42",
+    "description": "长期搓玉333排班协议",
+    "id": 1765973591631819,
+    "title": "333长期搓玉，需要自行将黍进驻专精室协助位。推荐换班时间8-8-8，极限效率12-12-8.5，非8小时换班需要取消使用菲亚梅塔（plans.[0/1/2].Fiammetta.enable = false），并自行每8小时手动使用菲亚梅塔007但书龙舌兰巫恋。修订时间2025-12-17，具体干员配置参考公孙长乐大佬最新视频的333搓玉高级版。对干员要求极高，若缺少干员请自行拷贝文件并修改（请勿直接修改，以免更新后被覆盖）",
+    "planTimes": "3班",
+    "plans": [
+        {
+            "name": "A 组 12 H",
+            "description": "1组",
+            "description_post": "下次换班请在约12小时后进行",
+            "Fiammetta": {
+                "enable": true,
+                "target": "但书",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "trading",
+                "index": "1",
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["巫恋", "卡夫卡", "龙舌兰"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["乌有", "黑键", "但书"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Orundum",
+                        "operators": ["德克萨斯", "拉普兰德", "能天使"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["清流", "温蒂", "森蚺"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["阿罗玛", "槐琥", "迷迭香"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Originium Shard",
+                        "operators": ["泡泡", "火神", "褐果"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["承曦格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["爱丽丝", "车尔尼", "塑心"],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["阿米娅", "重岳", "令", "夕", "琴柳"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": ["年"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        },
+        {
+            "name": "B 组 12H",
+            "description": "2组",
+            "description_post": "下次换班请在约12小时后进行",
+            "Fiammetta": {
+                "enable": true,
+                "target": "龙舌兰",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "trading",
+                "index": "1",
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["巫恋", "卡夫卡", "龙舌兰"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["推进之王", "摩根", "但书"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Orundum",
+                        "operators": ["孑", "琳琅诗怀雅", "银灰"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["清流", "温蒂", "森蚺"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["苍苔", "砾", "引星棘刺"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Originium Shard",
+                        "operators": ["泡泡", "火神", "褐果"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["承曦格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["阿米娅", "灵知", "戴菲恩", "八幡海铃", "斩业星熊"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["斥罪"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        },
+        {
+            "name": "C 组 8.5H",
+            "description": "3组",
+            "description_post": "下次换班请在约8.5小时后进行",
+            "Fiammetta": {
+                "enable": true,
+                "target": "巫恋",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "trading",
+                "index": 1,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["巫恋", "柏喙", "龙舌兰"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["乌有", "黑键", "但书"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Orundum",
+                        "operators": ["德克萨斯", "拉普兰德", "能天使"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["阿罗玛", "槐琥", "迷迭香"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["苍苔", "引星棘刺", "砾"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Originium Shard",
+                        "operators": ["艾雅法拉", "地灵", "炎熔"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["爱丽丝", "车尔尼", "塑心"],
+                        "sort": true,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["诗怀雅", "重岳", "令", "夕", "琴柳"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": ["年"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        }
+    ],
+    "scheduleType": {
+        "planTimes": 3,
+        "trading": 3,
+        "manufacture": 3,
+        "power": 3,
+        "dormitory": 4
+    }
+}

--- a/resource/global/YoStarJP/resource/custom_infrast/153_layout_3_times_a_day.json
+++ b/resource/global/YoStarJP/resource/custom_infrast/153_layout_3_times_a_day.json
@@ -1,0 +1,440 @@
+{
+    "author": "uye、lhh",
+    "description": "干员配置要求极高，请留意\\n若缺少干员请自行拷贝文件并修改（请勿直接修改，以免更新后被覆盖）\\n第一个制造站为赤金，其余为记录\\n\\n作业作者：uye、lhh\\n\\n感谢公孙长乐大佬提供数据及方案支持！",
+    "id": 1730652690046966,
+    "title": "153 极限效率，一天三换",
+    "buildingType": 243,
+    "planTimes": "3班",
+    "plans": [
+        {
+            "name": "A+B 16H",
+            "description": "最高效率长班，下次换班请在约16小时后进行",
+            "Fiammetta": {
+                "enable": true,
+                "target": "但书",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "manufacture",
+                "index": 1,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["伺夜", "黑键", "但书"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["苍苔", "砾", "斑点"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["至简", "槐琥", "断罪者"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["野鬃", "远牙", "灰毫"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["淬羽赫默", "多萝西", "迷迭香"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["温蒂", "异客", "掠风"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["承曦格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["Lancet-2"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["爱丽丝", "车尔尼", "塑心", "菲亚梅塔", "闪灵"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["凯尔希", "令", "泡泡", "火神", "杏仁"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["水月", "香草", "杰西卡", "红云", "稀音"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["帕拉斯", "澄闪", "涤火杰西卡", "流明", "见行者"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["森蚺", "焰尾", "薇薇安娜", "琴柳", "夕"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": ["跃跃", "伊内丝"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": ["年"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        },
+        {
+            "name": "A+C 4H",
+            "description": "下次换班请在约4小时后进行",
+            "Fiammetta": {
+                "enable": false,
+                "target": "",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "manufacture",
+                "index": 1,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["推进之王", "摩根", "但书"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["苍苔", "砾", "斑点"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["至简", "槐琥", "断罪者"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["野鬃", "远牙", "灰毫"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["水月", "香草", "杰西卡"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["红云", "稀音", "帕拉斯"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["雷蛇"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["澄闪"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["爱丽丝", "车尔尼", "塑心", "菲亚梅塔", "闪灵"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["黑键", "淬羽赫默", "多萝西", "迷迭香", "温蒂"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["异客", "掠风", "承曦格雷伊", "伊内丝", "絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["森蚺", "琴柳", "夕", "伺夜", "流明"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["戴菲恩", "凯尔希", "焰尾", "薇薇安娜", "涤火杰西卡"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": ["见行者", "跃跃"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["斥罪"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": ["年"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        },
+        {
+            "name": "B+C 4H",
+            "description": "下次换班请在约4小时后进行",
+            "Fiammetta": {
+                "enable": false,
+                "target": "",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "manufacture",
+                "index": 1,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["伺夜", "黑键", "但书"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["泡泡", "火神", "杏仁"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["淬羽赫默", "多萝西", "迷迭香"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["温蒂", "异客", "掠风"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["水月", "香草", "杰西卡"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["红云", "稀音", "帕拉斯"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["承曦格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["Lancet-2"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["澄闪"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["戴菲恩", "焰尾", "薇薇安娜", "推进之王", "摩根"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["苍苔", "砾", "斑点", "至简", "槐琥"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["断罪者", "野鬃", "远牙", "灰毫", "格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["雷蛇", "跃跃", "斥罪", "流明", "闪灵"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["森蚺", "涤火杰西卡", "凯尔希", "琴柳", "令"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": ["见行者", "伊内丝"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": ["年"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        }
+    ],
+    "scheduleType": {
+        "planTimes": 4,
+        "trading": 1,
+        "manufacture": 5,
+        "power": 3,
+        "dormitory": 4
+    }
+}

--- a/resource/global/YoStarJP/resource/custom_infrast/153_layout_4_times_a_day.json
+++ b/resource/global/YoStarJP/resource/custom_infrast/153_layout_4_times_a_day.json
@@ -1,0 +1,585 @@
+{
+    "author": "uye",
+    "description": "干员配置要求极高，请留意\\n若缺少干员请自行拷贝文件并修改（请勿直接修改，以免更新后被覆盖）\\n第一个制造站为赤金，其余为记录\\n\\n作业作者：uye\\n\\n感谢公孙长乐大佬提供数据及方案支持！",
+    "id": 1744463675638466,
+    "title": "153 极限效率，一天四换",
+    "buildingType": 243,
+    "planTimes": "3班",
+    "plans": [
+        {
+            "name": "1",
+            "description": "7h",
+            "description_post": "7小时后换班",
+            "Fiammetta": {
+                "enable": true,
+                "target": "但书",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "trading",
+                "index": 1,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["空弦", "黑键", "但书"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["槐琥", "阿罗玛", "砾"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["温蒂", "异客", "掠风"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["野鬃", "远牙", "灰毫"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["迷迭香", "乌尔比安", "安哲拉"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["幽灵鲨", "斯卡蒂", "至简"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["承曦格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["Lancet-2"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["澄闪"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["菲亚梅塔", "爱丽丝", "车尔尼", "塑心", "年"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["杏仁", "红云", "稀音", "帕拉斯", "多萝西"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["淬羽赫默", "断罪者", "食铁兽", "水月", "香草"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["杰西卡", "格雷伊", "忍冬", "铃兰", "九色鹿"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["薇薇安娜", "焰尾", "森蚺", "琴柳", "歌蕾蒂娅"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": ["伊内丝", "陈"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        },
+        {
+            "name": "2",
+            "description": "5h",
+            "description_post": "5小时后换班",
+            "Fiammetta": {
+                "enable": false,
+                "target": "",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "trading",
+                "index": 1,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["巫恋", "龙舌兰", "但书"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["苍苔", "砾", "引星棘刺"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["温蒂", "异客", "掠风"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["野鬃", "远牙", "灰毫"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["多萝西", "淬羽赫默", "断罪者"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["水月", "香草", "杰西卡"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["承曦格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["Lancet-2"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["雷蛇"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["菲亚梅塔", "夕", "琴柳", "令", "年"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["阿罗玛", "迷迭香", "歌蕾蒂娅", "闪灵", "流明"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["至简", "澄闪", "絮雨", "黑键", "槐琥"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["伊内丝", "陈", "空弦", "杜林", "九色鹿"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["薇薇安娜", "焰尾", "森蚺", "涤火杰西卡", "Mon3tr"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": ["忍冬", "铃兰"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["斥罪"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        },
+        {
+            "name": "3",
+            "description": "7h",
+            "description_post": "7小时后换班",
+            "Fiammetta": {
+                "enable": false,
+                "target": "",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "trading",
+                "index": 1,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["空弦", "黑键", "但书"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["槐琥", "阿罗玛", "砾"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["温蒂", "异客", "掠风"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["野鬃", "远牙", "灰毫"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["迷迭香", "乌尔比安", "安哲拉"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["幽灵鲨", "斯卡蒂", "至简"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["承曦格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["Lancet-2"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["澄闪"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["菲亚梅塔", "爱丽丝", "车尔尼", "塑心", "年"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["巫恋", "龙舌兰", "苍苔", "引星棘刺", "多萝西"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["淬羽赫默", "断罪者", "水月", "香草", "杰西卡"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["雷蛇", "斥罪", "涤火杰西卡", "Mon3tr", "九色鹿"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["薇薇安娜", "焰尾", "森蚺", "琴柳", "歌蕾蒂娅"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": ["伊内丝", "陈"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        },
+        {
+            "name": "4",
+            "description": "5h",
+            "description_post": "5小时后换班",
+            "Fiammetta": {
+                "enable": false,
+                "target": "",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "trading",
+                "index": 1,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["空弦", "黑键", "但书"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["槐琥", "阿罗玛", "杏仁"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["红云", "稀音", "帕拉斯"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["至简", "多萝西", "淬羽赫默"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["迷迭香", "断罪者", "食铁兽"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["水月", "香草", "杰西卡"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["雷蛇"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["澄闪"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["菲亚梅塔", "爱丽丝", "车尔尼", "塑心", "年"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["砾", "温蒂", "异客", "掠风", "野鬃"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["远牙", "灰毫", "歌蕾蒂娅", "流明", "闪灵"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["承曦格雷伊", "森蚺", "焰尾", "薇薇安娜", "九色鹿"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["Mon3tr", "涤火杰西卡", "令", "琴柳", "夕"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": ["伊内丝", "陈"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        }
+    ],
+    "scheduleType": {
+        "planTimes": 4,
+        "trading": 1,
+        "manufacture": 5,
+        "power": 3,
+        "dormitory": 4
+    }
+}

--- a/resource/global/YoStarJP/resource/custom_infrast/243_layout_3_times_a_day.json
+++ b/resource/global/YoStarJP/resource/custom_infrast/243_layout_3_times_a_day.json
@@ -1,0 +1,440 @@
+{
+    "author": "一只摆烂的42&Powered by公孙长乐",
+    "description": "需手动每8或12小时使用菲亚梅塔007巫恋龙舌兰但书\\n干员配置要求极高，请留意\\n若缺少干员/练度不足请自行通过id在一图流基建排班生成器上修改并重新生成导出（请勿直接修改，以免更新后被覆盖）\\n\\n感谢公孙长乐大佬提供数据及方案支持！\\n[20251111 修订] 视频地址: https://www.bilibili.com/video/BV1fhyfBGE59/\\n可自行在一图流排班生成器上自定义班次起止时间",
+    "id": 1762067890282538,
+    "title": "243极限效率，一天三换（需手动菲亚梅塔）",
+    "buildingType": 243,
+    "planTimes": "3班",
+    "plans": [
+        {
+            "name": "16H最高效率长班",
+            "description": "",
+            "Fiammetta": {
+                "enable": false,
+                "target": "巫恋",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "manufacture",
+                "index": 1,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["巫恋", "龙舌兰", "卡夫卡"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["但书", "黑键", "空弦"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["野鬃", "远牙", "灰毫"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["迷迭香", "至简", "断罪者"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["清流", "温蒂", "森蚺"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["槐琥", "阿罗玛", "砾"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["承曦格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["澄闪"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["车尔尼", "爱丽丝", "塑心"],
+                        "sort": true,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["阿米娅", "琴柳", "令", "薇薇安娜", "焰尾"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        },
+        {
+            "name": "4H 次高效替补 2 班",
+            "description": "下次在4小时后换班",
+            "Fiammetta": {
+                "enable": false,
+                "target": "龙舌兰",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "manufacture",
+                "index": 1,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["巫恋", "龙舌兰", "柏喙"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["但书", "空弦", "伺夜"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["野鬃", "远牙", "安哲拉"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["灰毫", "幽灵鲨", "斯卡蒂"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["苍苔", "砾", "引星棘刺"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["槐琥", "阿罗玛", "乌尔比安"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["正义骑士号"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["澄闪"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["雷蛇"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["阿米娅", "八幡海铃", "歌蕾蒂娅", "薇薇安娜", "焰尾"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["斥罪"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        },
+        {
+            "name": "4H 次高效替补 1 班",
+            "description": "下次在4小时后换班",
+            "Fiammetta": {
+                "enable": false,
+                "target": "但书",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "manufacture",
+                "index": 1,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["巫恋", "龙舌兰", "卡夫卡"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["但书", "伺夜", "黑键"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["断罪者", "乌尔比安", "安哲拉"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["幽灵鲨", "斯卡蒂", "至简"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["清流", "温蒂", "森蚺"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["苍苔", "引星棘刺", "迷迭香"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["承曦格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["雷蛇"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["车尔尼", "爱丽丝", "塑心"],
+                        "sort": true,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["诗怀雅", "歌蕾蒂娅", "斩业星熊", "夕", "琴柳"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        }
+    ],
+    "scheduleType": {
+        "planTimes": 3,
+        "trading": 2,
+        "manufacture": 4,
+        "power": 3,
+        "dormitory": 4
+    }
+}

--- a/resource/global/YoStarJP/resource/custom_infrast/243_layout_4_times_a_day.json
+++ b/resource/global/YoStarJP/resource/custom_infrast/243_layout_4_times_a_day.json
@@ -1,0 +1,581 @@
+{
+    "author": "公孙长乐, bodayw",
+    "description": "干员配置要求极高，若缺少干员请自行调整\n默认每八小时使用无人机加速制造作战记录，请按实际需求修改\n首次使用前将令的心情消耗至 12\n请在一图流排班表生成器上导入本文件，修改后下载导出（请勿直接修改本文件，以免 MAA 更新时被覆盖）\n\n[20250806 修订] 视频地址: https://www.bilibili.com/video/BV1EW4RzzE9R/?t=145",
+    "id": 1754476892600274,
+    "title": "243 极限效率，一天四换",
+    "buildingType": 243,
+    "planTimes": "3班",
+    "plans": [
+        {
+            "name": "A+B 高效长班 1",
+            "description_post": "请在八小时后换班",
+            "Fiammetta": {
+                "enable": true,
+                "target": "巫恋",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "manufacture",
+                "index": 3,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["巫恋", "卡夫卡", "龙舌兰"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["空弦", "黑键", "但书"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["清流", "温蒂", "森蚺"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["槐琥", "阿罗玛", "砾"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["野鬃", "远牙", "灰毫"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["迷迭香", "至简", "断罪者"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["承曦格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["缪尔赛思"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["澄闪"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["菲亚梅塔", "雷蛇", "戴菲恩", "推进之王", "摩根"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["歌蕾蒂娅", "乌尔比安", "安哲拉", "幽灵鲨", "斯卡蒂"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["爱丽丝", "车尔尼", "塑心", "伊内丝", "苍苔"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["赫默", "伊芙利特", "塞雷娅", "白面鸮", "梅尔"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["阿米娅", "琴柳", "令", "薇薇安娜", "焰尾"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": ["信仰搅拌机", "见行者"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        },
+        {
+            "name": "A+B 高效长班 2",
+            "description_post": "请在八小时后换班",
+            "Fiammetta": {
+                "enable": true,
+                "target": "龙舌兰",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "manufacture",
+                "index": 3,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["巫恋", "卡夫卡", "龙舌兰"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": true,
+                        "product": "LMD",
+                        "operators": ["空弦", "黑键", "但书"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": true,
+                        "product": "Pure Gold",
+                        "operators": ["清流", "温蒂", "森蚺"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": true,
+                        "product": "Pure Gold",
+                        "operators": ["槐琥", "阿罗玛", "砾"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": true,
+                        "product": "Battle Record",
+                        "operators": ["野鬃", "远牙", "灰毫"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": true,
+                        "product": "Battle Record",
+                        "operators": ["迷迭香", "至简", "断罪者"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": true,
+                        "operators": ["承曦格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": true,
+                        "operators": ["缪尔赛思"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["雷蛇"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["菲亚梅塔", "澄闪", "格雷伊", "柏喙", "斥罪"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["诗怀雅", "斩业星熊", "夕", "引星棘刺", "见行者"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["爱丽丝", "车尔尼", "塑心"],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": true,
+                        "operators": ["赫默", "伊芙利特", "塞雷娅", "白面鸮", "梅尔"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": true,
+                        "operators": ["阿米娅", "琴柳", "令", "薇薇安娜", "焰尾"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": ["信仰搅拌机", "伊内丝"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": true,
+                        "operators": ["絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": true,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        },
+        {
+            "name": "B+C 替补短班 1",
+            "description_post": "请在四小时后换班（三小时后把回满 12 心情的令移出宿舍）",
+            "Fiammetta": {
+                "enable": true,
+                "target": "但书",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "manufacture",
+                "index": 3,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["巫恋", "柏喙", "龙舌兰"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["推进之王", "摩根", "但书"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["苍苔", "砾", "引星棘刺"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["槐琥", "阿罗玛", "乌尔比安"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["野鬃", "远牙", "安哲拉"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["幽灵鲨", "斯卡蒂", "灰毫"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": true,
+                        "operators": ["缪尔赛思"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": true,
+                        "operators": ["雷蛇"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["菲亚梅塔", "令", "卡夫卡", "空弦", "黑键"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["清流", "温蒂", "森蚺", "迷迭香", "至简"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["断罪者", "承曦格雷伊", "信仰搅拌机", "絮雨", "琴柳"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": true,
+                        "operators": ["赫默", "伊芙利特", "塞雷娅", "白面鸮", "梅尔"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["阿米娅", "戴菲恩", "歌蕾蒂娅", "薇薇安娜", "焰尾"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": ["见行者", "伊内丝"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["斥罪"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": true,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        },
+        {
+            "name": "A+C 替补短班 2",
+            "description_post": "请在四小时后换班",
+            "Fiammetta": {
+                "enable": false,
+                "target": "",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "manufacture",
+                "index": 3,
+                "enable": false,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["巫恋", "卡夫卡", "龙舌兰"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["空弦", "黑键", "但书"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["清流", "温蒂", "森蚺"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["苍苔", "引星棘刺", "迷迭香"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["断罪者", "乌尔比安", "安哲拉"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["幽灵鲨", "斯卡蒂", "至简"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["承曦格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["澄闪"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": true,
+                        "operators": ["雷蛇"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["菲亚梅塔", "阿米娅", "薇薇安娜", "焰尾", "砾"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["槐琥", "阿罗玛", "野鬃", "远牙", "灰毫"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["爱丽丝", "车尔尼", "塑心", "缪尔赛思", "见行者"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": true,
+                        "operators": ["赫默", "伊芙利特", "塞雷娅", "白面鸮", "梅尔"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["诗怀雅", "歌蕾蒂娅", "斩业星熊", "夕", "琴柳"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": ["信仰搅拌机", "伊内丝"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": true,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        }
+    ],
+    "scheduleType": {
+        "planTimes": 4,
+        "trading": 2,
+        "manufacture": 4,
+        "power": 3,
+        "dormitory": 4
+    }
+}

--- a/resource/global/YoStarJP/resource/custom_infrast/333_layout_for_Orundum_3_times_a_day.json
+++ b/resource/global/YoStarJP/resource/custom_infrast/333_layout_for_Orundum_3_times_a_day.json
@@ -1,0 +1,442 @@
+{
+    "author": "一只摆烂的42",
+    "description": "长期搓玉333排班协议",
+    "id": 1765973591631819,
+    "title": "333长期搓玉，需要自行将黍进驻专精室协助位。推荐换班时间8-8-8，极限效率12-12-8.5，非8小时换班需要取消使用菲亚梅塔（plans.[0/1/2].Fiammetta.enable = false），并自行每8小时手动使用菲亚梅塔007但书龙舌兰巫恋。修订时间2025-12-17，具体干员配置参考公孙长乐大佬最新视频的333搓玉高级版。对干员要求极高，若缺少干员请自行拷贝文件并修改（请勿直接修改，以免更新后被覆盖）",
+    "planTimes": "3班",
+    "plans": [
+        {
+            "name": "A 组 12 H",
+            "description": "1组",
+            "description_post": "下次换班请在约12小时后进行",
+            "Fiammetta": {
+                "enable": true,
+                "target": "但书",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "trading",
+                "index": "1",
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["巫恋", "卡夫卡", "龙舌兰"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["乌有", "黑键", "但书"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Orundum",
+                        "operators": ["德克萨斯", "拉普兰德", "能天使"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["清流", "温蒂", "森蚺"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["阿罗玛", "槐琥", "迷迭香"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Originium Shard",
+                        "operators": ["泡泡", "火神", "褐果"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["承曦格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["爱丽丝", "车尔尼", "塑心"],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["阿米娅", "重岳", "令", "夕", "琴柳"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": ["年"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        },
+        {
+            "name": "B 组 12H",
+            "description": "2组",
+            "description_post": "下次换班请在约12小时后进行",
+            "Fiammetta": {
+                "enable": true,
+                "target": "龙舌兰",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "trading",
+                "index": "1",
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["巫恋", "卡夫卡", "龙舌兰"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["推进之王", "摩根", "但书"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Orundum",
+                        "operators": ["孑", "琳琅诗怀雅", "银灰"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["清流", "温蒂", "森蚺"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["苍苔", "砾", "引星棘刺"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Originium Shard",
+                        "operators": ["泡泡", "火神", "褐果"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["承曦格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["阿米娅", "灵知", "戴菲恩", "八幡海铃", "斩业星熊"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["斥罪"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        },
+        {
+            "name": "C 组 8.5H",
+            "description": "3组",
+            "description_post": "下次换班请在约8.5小时后进行",
+            "Fiammetta": {
+                "enable": true,
+                "target": "巫恋",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "trading",
+                "index": 1,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["巫恋", "柏喙", "龙舌兰"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["乌有", "黑键", "但书"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Orundum",
+                        "operators": ["德克萨斯", "拉普兰德", "能天使"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["阿罗玛", "槐琥", "迷迭香"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["苍苔", "引星棘刺", "砾"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Originium Shard",
+                        "operators": ["艾雅法拉", "地灵", "炎熔"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["爱丽丝", "车尔尼", "塑心"],
+                        "sort": true,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["诗怀雅", "重岳", "令", "夕", "琴柳"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": ["年"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        }
+    ],
+    "scheduleType": {
+        "planTimes": 3,
+        "trading": 3,
+        "manufacture": 3,
+        "power": 3,
+        "dormitory": 4
+    }
+}

--- a/resource/global/YoStarKR/resource/custom_infrast/153_layout_3_times_a_day.json
+++ b/resource/global/YoStarKR/resource/custom_infrast/153_layout_3_times_a_day.json
@@ -1,0 +1,440 @@
+{
+    "author": "uye、lhh",
+    "description": "干员配置要求极高，请留意\\n若缺少干员请自行拷贝文件并修改（请勿直接修改，以免更新后被覆盖）\\n第一个制造站为赤金，其余为记录\\n\\n作业作者：uye、lhh\\n\\n感谢公孙长乐大佬提供数据及方案支持！",
+    "id": 1730652690046966,
+    "title": "153 极限效率，一天三换",
+    "buildingType": 243,
+    "planTimes": "3班",
+    "plans": [
+        {
+            "name": "A+B 16H",
+            "description": "最高效率长班，下次换班请在约16小时后进行",
+            "Fiammetta": {
+                "enable": true,
+                "target": "但书",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "manufacture",
+                "index": 1,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["伺夜", "黑键", "但书"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["苍苔", "砾", "斑点"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["至简", "槐琥", "断罪者"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["野鬃", "远牙", "灰毫"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["淬羽赫默", "多萝西", "迷迭香"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["温蒂", "异客", "掠风"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["承曦格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["Lancet-2"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["爱丽丝", "车尔尼", "塑心", "菲亚梅塔", "闪灵"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["凯尔希", "令", "泡泡", "火神", "杏仁"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["水月", "香草", "杰西卡", "红云", "稀音"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["帕拉斯", "澄闪", "涤火杰西卡", "流明", "见行者"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["森蚺", "焰尾", "薇薇安娜", "琴柳", "夕"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": ["跃跃", "伊内丝"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": ["年"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        },
+        {
+            "name": "A+C 4H",
+            "description": "下次换班请在约4小时后进行",
+            "Fiammetta": {
+                "enable": false,
+                "target": "",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "manufacture",
+                "index": 1,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["推进之王", "摩根", "但书"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["苍苔", "砾", "斑点"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["至简", "槐琥", "断罪者"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["野鬃", "远牙", "灰毫"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["水月", "香草", "杰西卡"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["红云", "稀音", "帕拉斯"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["雷蛇"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["澄闪"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["爱丽丝", "车尔尼", "塑心", "菲亚梅塔", "闪灵"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["黑键", "淬羽赫默", "多萝西", "迷迭香", "温蒂"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["异客", "掠风", "承曦格雷伊", "伊内丝", "絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["森蚺", "琴柳", "夕", "伺夜", "流明"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["戴菲恩", "凯尔希", "焰尾", "薇薇安娜", "涤火杰西卡"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": ["见行者", "跃跃"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["斥罪"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": ["年"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        },
+        {
+            "name": "B+C 4H",
+            "description": "下次换班请在约4小时后进行",
+            "Fiammetta": {
+                "enable": false,
+                "target": "",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "manufacture",
+                "index": 1,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["伺夜", "黑键", "但书"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["泡泡", "火神", "杏仁"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["淬羽赫默", "多萝西", "迷迭香"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["温蒂", "异客", "掠风"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["水月", "香草", "杰西卡"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["红云", "稀音", "帕拉斯"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["承曦格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["Lancet-2"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["澄闪"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["戴菲恩", "焰尾", "薇薇安娜", "推进之王", "摩根"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["苍苔", "砾", "斑点", "至简", "槐琥"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["断罪者", "野鬃", "远牙", "灰毫", "格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["雷蛇", "跃跃", "斥罪", "流明", "闪灵"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["森蚺", "涤火杰西卡", "凯尔希", "琴柳", "令"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": ["见行者", "伊内丝"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": ["年"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        }
+    ],
+    "scheduleType": {
+        "planTimes": 4,
+        "trading": 1,
+        "manufacture": 5,
+        "power": 3,
+        "dormitory": 4
+    }
+}

--- a/resource/global/YoStarKR/resource/custom_infrast/153_layout_4_times_a_day.json
+++ b/resource/global/YoStarKR/resource/custom_infrast/153_layout_4_times_a_day.json
@@ -1,0 +1,585 @@
+{
+    "author": "uye",
+    "description": "干员配置要求极高，请留意\\n若缺少干员请自行拷贝文件并修改（请勿直接修改，以免更新后被覆盖）\\n第一个制造站为赤金，其余为记录\\n\\n作业作者：uye\\n\\n感谢公孙长乐大佬提供数据及方案支持！",
+    "id": 1744463675638466,
+    "title": "153 极限效率，一天四换",
+    "buildingType": 243,
+    "planTimes": "3班",
+    "plans": [
+        {
+            "name": "1",
+            "description": "7h",
+            "description_post": "7小时后换班",
+            "Fiammetta": {
+                "enable": true,
+                "target": "但书",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "trading",
+                "index": 1,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["空弦", "黑键", "但书"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["槐琥", "阿罗玛", "砾"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["温蒂", "异客", "掠风"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["野鬃", "远牙", "灰毫"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["迷迭香", "乌尔比安", "安哲拉"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["幽灵鲨", "斯卡蒂", "至简"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["承曦格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["Lancet-2"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["澄闪"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["菲亚梅塔", "爱丽丝", "车尔尼", "塑心", "年"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["杏仁", "红云", "稀音", "帕拉斯", "多萝西"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["淬羽赫默", "断罪者", "食铁兽", "水月", "香草"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["杰西卡", "格雷伊", "忍冬", "铃兰", "九色鹿"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["薇薇安娜", "焰尾", "森蚺", "琴柳", "歌蕾蒂娅"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": ["伊内丝", "陈"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        },
+        {
+            "name": "2",
+            "description": "5h",
+            "description_post": "5小时后换班",
+            "Fiammetta": {
+                "enable": false,
+                "target": "",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "trading",
+                "index": 1,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["巫恋", "龙舌兰", "但书"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["苍苔", "砾", "引星棘刺"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["温蒂", "异客", "掠风"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["野鬃", "远牙", "灰毫"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["多萝西", "淬羽赫默", "断罪者"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["水月", "香草", "杰西卡"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["承曦格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["Lancet-2"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["雷蛇"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["菲亚梅塔", "夕", "琴柳", "令", "年"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["阿罗玛", "迷迭香", "歌蕾蒂娅", "闪灵", "流明"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["至简", "澄闪", "絮雨", "黑键", "槐琥"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["伊内丝", "陈", "空弦", "杜林", "九色鹿"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["薇薇安娜", "焰尾", "森蚺", "涤火杰西卡", "Mon3tr"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": ["忍冬", "铃兰"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["斥罪"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        },
+        {
+            "name": "3",
+            "description": "7h",
+            "description_post": "7小时后换班",
+            "Fiammetta": {
+                "enable": false,
+                "target": "",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "trading",
+                "index": 1,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["空弦", "黑键", "但书"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["槐琥", "阿罗玛", "砾"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["温蒂", "异客", "掠风"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["野鬃", "远牙", "灰毫"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["迷迭香", "乌尔比安", "安哲拉"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["幽灵鲨", "斯卡蒂", "至简"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["承曦格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["Lancet-2"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["澄闪"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["菲亚梅塔", "爱丽丝", "车尔尼", "塑心", "年"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["巫恋", "龙舌兰", "苍苔", "引星棘刺", "多萝西"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["淬羽赫默", "断罪者", "水月", "香草", "杰西卡"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["雷蛇", "斥罪", "涤火杰西卡", "Mon3tr", "九色鹿"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["薇薇安娜", "焰尾", "森蚺", "琴柳", "歌蕾蒂娅"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": ["伊内丝", "陈"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        },
+        {
+            "name": "4",
+            "description": "5h",
+            "description_post": "5小时后换班",
+            "Fiammetta": {
+                "enable": false,
+                "target": "",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "trading",
+                "index": 1,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["空弦", "黑键", "但书"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["槐琥", "阿罗玛", "杏仁"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["红云", "稀音", "帕拉斯"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["至简", "多萝西", "淬羽赫默"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["迷迭香", "断罪者", "食铁兽"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["水月", "香草", "杰西卡"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["雷蛇"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["澄闪"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["菲亚梅塔", "爱丽丝", "车尔尼", "塑心", "年"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["砾", "温蒂", "异客", "掠风", "野鬃"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["远牙", "灰毫", "歌蕾蒂娅", "流明", "闪灵"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["承曦格雷伊", "森蚺", "焰尾", "薇薇安娜", "九色鹿"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["Mon3tr", "涤火杰西卡", "令", "琴柳", "夕"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": ["伊内丝", "陈"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        }
+    ],
+    "scheduleType": {
+        "planTimes": 4,
+        "trading": 1,
+        "manufacture": 5,
+        "power": 3,
+        "dormitory": 4
+    }
+}

--- a/resource/global/YoStarKR/resource/custom_infrast/243_layout_3_times_a_day.json
+++ b/resource/global/YoStarKR/resource/custom_infrast/243_layout_3_times_a_day.json
@@ -1,0 +1,440 @@
+{
+    "author": "一只摆烂的42&Powered by公孙长乐",
+    "description": "需手动每8或12小时使用菲亚梅塔007巫恋龙舌兰但书\\n干员配置要求极高，请留意\\n若缺少干员/练度不足请自行通过id在一图流基建排班生成器上修改并重新生成导出（请勿直接修改，以免更新后被覆盖）\\n\\n感谢公孙长乐大佬提供数据及方案支持！\\n[20251111 修订] 视频地址: https://www.bilibili.com/video/BV1fhyfBGE59/\\n可自行在一图流排班生成器上自定义班次起止时间",
+    "id": 1762067890282538,
+    "title": "243极限效率，一天三换（需手动菲亚梅塔）",
+    "buildingType": 243,
+    "planTimes": "3班",
+    "plans": [
+        {
+            "name": "16H最高效率长班",
+            "description": "",
+            "Fiammetta": {
+                "enable": false,
+                "target": "巫恋",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "manufacture",
+                "index": 1,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["巫恋", "龙舌兰", "卡夫卡"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["但书", "黑键", "空弦"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["野鬃", "远牙", "灰毫"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["迷迭香", "至简", "断罪者"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["清流", "温蒂", "森蚺"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["槐琥", "阿罗玛", "砾"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["承曦格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["澄闪"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["车尔尼", "爱丽丝", "塑心"],
+                        "sort": true,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["阿米娅", "琴柳", "令", "薇薇安娜", "焰尾"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        },
+        {
+            "name": "4H 次高效替补 2 班",
+            "description": "下次在4小时后换班",
+            "Fiammetta": {
+                "enable": false,
+                "target": "龙舌兰",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "manufacture",
+                "index": 1,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["巫恋", "龙舌兰", "柏喙"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["但书", "空弦", "伺夜"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["野鬃", "远牙", "安哲拉"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["灰毫", "幽灵鲨", "斯卡蒂"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["苍苔", "砾", "引星棘刺"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["槐琥", "阿罗玛", "乌尔比安"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["正义骑士号"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["澄闪"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["雷蛇"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["阿米娅", "八幡海铃", "歌蕾蒂娅", "薇薇安娜", "焰尾"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["斥罪"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        },
+        {
+            "name": "4H 次高效替补 1 班",
+            "description": "下次在4小时后换班",
+            "Fiammetta": {
+                "enable": false,
+                "target": "但书",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "manufacture",
+                "index": 1,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["巫恋", "龙舌兰", "卡夫卡"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["但书", "伺夜", "黑键"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["断罪者", "乌尔比安", "安哲拉"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["幽灵鲨", "斯卡蒂", "至简"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["清流", "温蒂", "森蚺"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["苍苔", "引星棘刺", "迷迭香"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["承曦格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["雷蛇"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["车尔尼", "爱丽丝", "塑心"],
+                        "sort": true,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["诗怀雅", "歌蕾蒂娅", "斩业星熊", "夕", "琴柳"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        }
+    ],
+    "scheduleType": {
+        "planTimes": 3,
+        "trading": 2,
+        "manufacture": 4,
+        "power": 3,
+        "dormitory": 4
+    }
+}

--- a/resource/global/YoStarKR/resource/custom_infrast/243_layout_4_times_a_day.json
+++ b/resource/global/YoStarKR/resource/custom_infrast/243_layout_4_times_a_day.json
@@ -1,0 +1,581 @@
+{
+    "author": "公孙长乐, bodayw",
+    "description": "干员配置要求极高，若缺少干员请自行调整\n默认每八小时使用无人机加速制造作战记录，请按实际需求修改\n首次使用前将令的心情消耗至 12\n请在一图流排班表生成器上导入本文件，修改后下载导出（请勿直接修改本文件，以免 MAA 更新时被覆盖）\n\n[20250806 修订] 视频地址: https://www.bilibili.com/video/BV1EW4RzzE9R/?t=145",
+    "id": 1754476892600274,
+    "title": "243 极限效率，一天四换",
+    "buildingType": 243,
+    "planTimes": "3班",
+    "plans": [
+        {
+            "name": "A+B 高效长班 1",
+            "description_post": "请在八小时后换班",
+            "Fiammetta": {
+                "enable": true,
+                "target": "巫恋",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "manufacture",
+                "index": 3,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["巫恋", "卡夫卡", "龙舌兰"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["空弦", "黑键", "但书"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["清流", "温蒂", "森蚺"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["槐琥", "阿罗玛", "砾"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["野鬃", "远牙", "灰毫"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["迷迭香", "至简", "断罪者"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["承曦格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["缪尔赛思"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["澄闪"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["菲亚梅塔", "雷蛇", "戴菲恩", "推进之王", "摩根"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["歌蕾蒂娅", "乌尔比安", "安哲拉", "幽灵鲨", "斯卡蒂"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["爱丽丝", "车尔尼", "塑心", "伊内丝", "苍苔"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["赫默", "伊芙利特", "塞雷娅", "白面鸮", "梅尔"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["阿米娅", "琴柳", "令", "薇薇安娜", "焰尾"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": ["信仰搅拌机", "见行者"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        },
+        {
+            "name": "A+B 高效长班 2",
+            "description_post": "请在八小时后换班",
+            "Fiammetta": {
+                "enable": true,
+                "target": "龙舌兰",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "manufacture",
+                "index": 3,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["巫恋", "卡夫卡", "龙舌兰"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": true,
+                        "product": "LMD",
+                        "operators": ["空弦", "黑键", "但书"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": true,
+                        "product": "Pure Gold",
+                        "operators": ["清流", "温蒂", "森蚺"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": true,
+                        "product": "Pure Gold",
+                        "operators": ["槐琥", "阿罗玛", "砾"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": true,
+                        "product": "Battle Record",
+                        "operators": ["野鬃", "远牙", "灰毫"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": true,
+                        "product": "Battle Record",
+                        "operators": ["迷迭香", "至简", "断罪者"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": true,
+                        "operators": ["承曦格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": true,
+                        "operators": ["缪尔赛思"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["雷蛇"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["菲亚梅塔", "澄闪", "格雷伊", "柏喙", "斥罪"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["诗怀雅", "斩业星熊", "夕", "引星棘刺", "见行者"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["爱丽丝", "车尔尼", "塑心"],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": true,
+                        "operators": ["赫默", "伊芙利特", "塞雷娅", "白面鸮", "梅尔"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": true,
+                        "operators": ["阿米娅", "琴柳", "令", "薇薇安娜", "焰尾"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": ["信仰搅拌机", "伊内丝"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": true,
+                        "operators": ["絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": true,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        },
+        {
+            "name": "B+C 替补短班 1",
+            "description_post": "请在四小时后换班（三小时后把回满 12 心情的令移出宿舍）",
+            "Fiammetta": {
+                "enable": true,
+                "target": "但书",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "manufacture",
+                "index": 3,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["巫恋", "柏喙", "龙舌兰"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["推进之王", "摩根", "但书"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["苍苔", "砾", "引星棘刺"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["槐琥", "阿罗玛", "乌尔比安"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["野鬃", "远牙", "安哲拉"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["幽灵鲨", "斯卡蒂", "灰毫"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": true,
+                        "operators": ["缪尔赛思"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": true,
+                        "operators": ["雷蛇"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["菲亚梅塔", "令", "卡夫卡", "空弦", "黑键"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["清流", "温蒂", "森蚺", "迷迭香", "至简"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["断罪者", "承曦格雷伊", "信仰搅拌机", "絮雨", "琴柳"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": true,
+                        "operators": ["赫默", "伊芙利特", "塞雷娅", "白面鸮", "梅尔"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["阿米娅", "戴菲恩", "歌蕾蒂娅", "薇薇安娜", "焰尾"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": ["见行者", "伊内丝"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["斥罪"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": true,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        },
+        {
+            "name": "A+C 替补短班 2",
+            "description_post": "请在四小时后换班",
+            "Fiammetta": {
+                "enable": false,
+                "target": "",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "manufacture",
+                "index": 3,
+                "enable": false,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["巫恋", "卡夫卡", "龙舌兰"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["空弦", "黑键", "但书"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["清流", "温蒂", "森蚺"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["苍苔", "引星棘刺", "迷迭香"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["断罪者", "乌尔比安", "安哲拉"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["幽灵鲨", "斯卡蒂", "至简"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["承曦格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["澄闪"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": true,
+                        "operators": ["雷蛇"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["菲亚梅塔", "阿米娅", "薇薇安娜", "焰尾", "砾"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["槐琥", "阿罗玛", "野鬃", "远牙", "灰毫"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["爱丽丝", "车尔尼", "塑心", "缪尔赛思", "见行者"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": true,
+                        "operators": ["赫默", "伊芙利特", "塞雷娅", "白面鸮", "梅尔"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["诗怀雅", "歌蕾蒂娅", "斩业星熊", "夕", "琴柳"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": ["信仰搅拌机", "伊内丝"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": true,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        }
+    ],
+    "scheduleType": {
+        "planTimes": 4,
+        "trading": 2,
+        "manufacture": 4,
+        "power": 3,
+        "dormitory": 4
+    }
+}

--- a/resource/global/YoStarKR/resource/custom_infrast/333_layout_for_Orundum_3_times_a_day.json
+++ b/resource/global/YoStarKR/resource/custom_infrast/333_layout_for_Orundum_3_times_a_day.json
@@ -1,0 +1,442 @@
+{
+    "author": "一只摆烂的42",
+    "description": "长期搓玉333排班协议",
+    "id": 1765973591631819,
+    "title": "333长期搓玉，需要自行将黍进驻专精室协助位。推荐换班时间8-8-8，极限效率12-12-8.5，非8小时换班需要取消使用菲亚梅塔（plans.[0/1/2].Fiammetta.enable = false），并自行每8小时手动使用菲亚梅塔007但书龙舌兰巫恋。修订时间2025-12-17，具体干员配置参考公孙长乐大佬最新视频的333搓玉高级版。对干员要求极高，若缺少干员请自行拷贝文件并修改（请勿直接修改，以免更新后被覆盖）",
+    "planTimes": "3班",
+    "plans": [
+        {
+            "name": "A 组 12 H",
+            "description": "1组",
+            "description_post": "下次换班请在约12小时后进行",
+            "Fiammetta": {
+                "enable": true,
+                "target": "但书",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "trading",
+                "index": "1",
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["巫恋", "卡夫卡", "龙舌兰"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["乌有", "黑键", "但书"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Orundum",
+                        "operators": ["德克萨斯", "拉普兰德", "能天使"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["清流", "温蒂", "森蚺"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["阿罗玛", "槐琥", "迷迭香"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Originium Shard",
+                        "operators": ["泡泡", "火神", "褐果"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["承曦格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["爱丽丝", "车尔尼", "塑心"],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["阿米娅", "重岳", "令", "夕", "琴柳"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": ["年"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        },
+        {
+            "name": "B 组 12H",
+            "description": "2组",
+            "description_post": "下次换班请在约12小时后进行",
+            "Fiammetta": {
+                "enable": true,
+                "target": "龙舌兰",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "trading",
+                "index": "1",
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["巫恋", "卡夫卡", "龙舌兰"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["推进之王", "摩根", "但书"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Orundum",
+                        "operators": ["孑", "琳琅诗怀雅", "银灰"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["清流", "温蒂", "森蚺"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["苍苔", "砾", "引星棘刺"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Originium Shard",
+                        "operators": ["泡泡", "火神", "褐果"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["承曦格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["阿米娅", "灵知", "戴菲恩", "八幡海铃", "斩业星熊"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["斥罪"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        },
+        {
+            "name": "C 组 8.5H",
+            "description": "3组",
+            "description_post": "下次换班请在约8.5小时后进行",
+            "Fiammetta": {
+                "enable": true,
+                "target": "巫恋",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "trading",
+                "index": 1,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["巫恋", "柏喙", "龙舌兰"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["乌有", "黑键", "但书"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Orundum",
+                        "operators": ["德克萨斯", "拉普兰德", "能天使"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["阿罗玛", "槐琥", "迷迭香"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["苍苔", "引星棘刺", "砾"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Originium Shard",
+                        "operators": ["艾雅法拉", "地灵", "炎熔"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["爱丽丝", "车尔尼", "塑心"],
+                        "sort": true,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["诗怀雅", "重岳", "令", "夕", "琴柳"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": ["年"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        }
+    ],
+    "scheduleType": {
+        "planTimes": 3,
+        "trading": 3,
+        "manufacture": 3,
+        "power": 3,
+        "dormitory": 4
+    }
+}

--- a/resource/global/txwy/resource/custom_infrast/153_layout_3_times_a_day.json
+++ b/resource/global/txwy/resource/custom_infrast/153_layout_3_times_a_day.json
@@ -1,0 +1,440 @@
+{
+    "author": "uye、lhh",
+    "description": "干员配置要求极高，请留意\\n若缺少干员请自行拷贝文件并修改（请勿直接修改，以免更新后被覆盖）\\n第一个制造站为赤金，其余为记录\\n\\n作业作者：uye、lhh\\n\\n感谢公孙长乐大佬提供数据及方案支持！",
+    "id": 1730652690046966,
+    "title": "153 极限效率，一天三换",
+    "buildingType": 243,
+    "planTimes": "3班",
+    "plans": [
+        {
+            "name": "A+B 16H",
+            "description": "最高效率长班，下次换班请在约16小时后进行",
+            "Fiammetta": {
+                "enable": true,
+                "target": "但书",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "manufacture",
+                "index": 1,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["伺夜", "黑键", "但书"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["苍苔", "砾", "斑点"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["至简", "槐琥", "断罪者"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["野鬃", "远牙", "灰毫"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["淬羽赫默", "多萝西", "迷迭香"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["温蒂", "异客", "掠风"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["承曦格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["Lancet-2"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["爱丽丝", "车尔尼", "塑心", "菲亚梅塔", "闪灵"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["凯尔希", "令", "泡泡", "火神", "杏仁"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["水月", "香草", "杰西卡", "红云", "稀音"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["帕拉斯", "澄闪", "涤火杰西卡", "流明", "见行者"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["森蚺", "焰尾", "薇薇安娜", "琴柳", "夕"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": ["跃跃", "伊内丝"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": ["年"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        },
+        {
+            "name": "A+C 4H",
+            "description": "下次换班请在约4小时后进行",
+            "Fiammetta": {
+                "enable": false,
+                "target": "",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "manufacture",
+                "index": 1,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["推进之王", "摩根", "但书"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["苍苔", "砾", "斑点"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["至简", "槐琥", "断罪者"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["野鬃", "远牙", "灰毫"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["水月", "香草", "杰西卡"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["红云", "稀音", "帕拉斯"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["雷蛇"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["澄闪"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["爱丽丝", "车尔尼", "塑心", "菲亚梅塔", "闪灵"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["黑键", "淬羽赫默", "多萝西", "迷迭香", "温蒂"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["异客", "掠风", "承曦格雷伊", "伊内丝", "絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["森蚺", "琴柳", "夕", "伺夜", "流明"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["戴菲恩", "凯尔希", "焰尾", "薇薇安娜", "涤火杰西卡"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": ["见行者", "跃跃"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["斥罪"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": ["年"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        },
+        {
+            "name": "B+C 4H",
+            "description": "下次换班请在约4小时后进行",
+            "Fiammetta": {
+                "enable": false,
+                "target": "",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "manufacture",
+                "index": 1,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["伺夜", "黑键", "但书"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["泡泡", "火神", "杏仁"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["淬羽赫默", "多萝西", "迷迭香"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["温蒂", "异客", "掠风"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["水月", "香草", "杰西卡"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["红云", "稀音", "帕拉斯"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["承曦格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["Lancet-2"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["澄闪"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["戴菲恩", "焰尾", "薇薇安娜", "推进之王", "摩根"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["苍苔", "砾", "斑点", "至简", "槐琥"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["断罪者", "野鬃", "远牙", "灰毫", "格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["雷蛇", "跃跃", "斥罪", "流明", "闪灵"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["森蚺", "涤火杰西卡", "凯尔希", "琴柳", "令"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": ["见行者", "伊内丝"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": ["年"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        }
+    ],
+    "scheduleType": {
+        "planTimes": 4,
+        "trading": 1,
+        "manufacture": 5,
+        "power": 3,
+        "dormitory": 4
+    }
+}

--- a/resource/global/txwy/resource/custom_infrast/153_layout_4_times_a_day.json
+++ b/resource/global/txwy/resource/custom_infrast/153_layout_4_times_a_day.json
@@ -1,0 +1,585 @@
+{
+    "author": "uye",
+    "description": "干员配置要求极高，请留意\\n若缺少干员请自行拷贝文件并修改（请勿直接修改，以免更新后被覆盖）\\n第一个制造站为赤金，其余为记录\\n\\n作业作者：uye\\n\\n感谢公孙长乐大佬提供数据及方案支持！",
+    "id": 1744463675638466,
+    "title": "153 极限效率，一天四换",
+    "buildingType": 243,
+    "planTimes": "3班",
+    "plans": [
+        {
+            "name": "1",
+            "description": "7h",
+            "description_post": "7小时后换班",
+            "Fiammetta": {
+                "enable": true,
+                "target": "但书",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "trading",
+                "index": 1,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["空弦", "黑键", "但书"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["槐琥", "阿罗玛", "砾"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["温蒂", "异客", "掠风"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["野鬃", "远牙", "灰毫"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["迷迭香", "乌尔比安", "安哲拉"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["幽灵鲨", "斯卡蒂", "至简"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["承曦格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["Lancet-2"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["澄闪"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["菲亚梅塔", "爱丽丝", "车尔尼", "塑心", "年"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["杏仁", "红云", "稀音", "帕拉斯", "多萝西"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["淬羽赫默", "断罪者", "食铁兽", "水月", "香草"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["杰西卡", "格雷伊", "忍冬", "铃兰", "九色鹿"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["薇薇安娜", "焰尾", "森蚺", "琴柳", "歌蕾蒂娅"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": ["伊内丝", "陈"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        },
+        {
+            "name": "2",
+            "description": "5h",
+            "description_post": "5小时后换班",
+            "Fiammetta": {
+                "enable": false,
+                "target": "",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "trading",
+                "index": 1,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["巫恋", "龙舌兰", "但书"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["苍苔", "砾", "引星棘刺"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["温蒂", "异客", "掠风"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["野鬃", "远牙", "灰毫"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["多萝西", "淬羽赫默", "断罪者"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["水月", "香草", "杰西卡"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["承曦格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["Lancet-2"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["雷蛇"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["菲亚梅塔", "夕", "琴柳", "令", "年"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["阿罗玛", "迷迭香", "歌蕾蒂娅", "闪灵", "流明"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["至简", "澄闪", "絮雨", "黑键", "槐琥"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["伊内丝", "陈", "空弦", "杜林", "九色鹿"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["薇薇安娜", "焰尾", "森蚺", "涤火杰西卡", "Mon3tr"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": ["忍冬", "铃兰"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["斥罪"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        },
+        {
+            "name": "3",
+            "description": "7h",
+            "description_post": "7小时后换班",
+            "Fiammetta": {
+                "enable": false,
+                "target": "",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "trading",
+                "index": 1,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["空弦", "黑键", "但书"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["槐琥", "阿罗玛", "砾"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["温蒂", "异客", "掠风"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["野鬃", "远牙", "灰毫"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["迷迭香", "乌尔比安", "安哲拉"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["幽灵鲨", "斯卡蒂", "至简"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["承曦格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["Lancet-2"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["澄闪"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["菲亚梅塔", "爱丽丝", "车尔尼", "塑心", "年"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["巫恋", "龙舌兰", "苍苔", "引星棘刺", "多萝西"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["淬羽赫默", "断罪者", "水月", "香草", "杰西卡"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["雷蛇", "斥罪", "涤火杰西卡", "Mon3tr", "九色鹿"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["薇薇安娜", "焰尾", "森蚺", "琴柳", "歌蕾蒂娅"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": ["伊内丝", "陈"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        },
+        {
+            "name": "4",
+            "description": "5h",
+            "description_post": "5小时后换班",
+            "Fiammetta": {
+                "enable": false,
+                "target": "",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "trading",
+                "index": 1,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["空弦", "黑键", "但书"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["槐琥", "阿罗玛", "杏仁"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["红云", "稀音", "帕拉斯"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["至简", "多萝西", "淬羽赫默"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["迷迭香", "断罪者", "食铁兽"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["水月", "香草", "杰西卡"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["雷蛇"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["澄闪"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["菲亚梅塔", "爱丽丝", "车尔尼", "塑心", "年"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["砾", "温蒂", "异客", "掠风", "野鬃"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["远牙", "灰毫", "歌蕾蒂娅", "流明", "闪灵"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["承曦格雷伊", "森蚺", "焰尾", "薇薇安娜", "九色鹿"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["Mon3tr", "涤火杰西卡", "令", "琴柳", "夕"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": ["伊内丝", "陈"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        }
+    ],
+    "scheduleType": {
+        "planTimes": 4,
+        "trading": 1,
+        "manufacture": 5,
+        "power": 3,
+        "dormitory": 4
+    }
+}

--- a/resource/global/txwy/resource/custom_infrast/243_layout_3_times_a_day.json
+++ b/resource/global/txwy/resource/custom_infrast/243_layout_3_times_a_day.json
@@ -1,0 +1,440 @@
+{
+    "author": "一只摆烂的42&Powered by公孙长乐",
+    "description": "需手动每8或12小时使用菲亚梅塔007巫恋龙舌兰但书\\n干员配置要求极高，请留意\\n若缺少干员/练度不足请自行通过id在一图流基建排班生成器上修改并重新生成导出（请勿直接修改，以免更新后被覆盖）\\n\\n感谢公孙长乐大佬提供数据及方案支持！\\n[20251111 修订] 视频地址: https://www.bilibili.com/video/BV1fhyfBGE59/\\n可自行在一图流排班生成器上自定义班次起止时间",
+    "id": 1762067890282538,
+    "title": "243极限效率，一天三换（需手动菲亚梅塔）",
+    "buildingType": 243,
+    "planTimes": "3班",
+    "plans": [
+        {
+            "name": "16H最高效率长班",
+            "description": "",
+            "Fiammetta": {
+                "enable": false,
+                "target": "巫恋",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "manufacture",
+                "index": 1,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["巫恋", "龙舌兰", "卡夫卡"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["但书", "黑键", "空弦"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["野鬃", "远牙", "灰毫"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["迷迭香", "至简", "断罪者"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["清流", "温蒂", "森蚺"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["槐琥", "阿罗玛", "砾"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["承曦格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["澄闪"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["车尔尼", "爱丽丝", "塑心"],
+                        "sort": true,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["阿米娅", "琴柳", "令", "薇薇安娜", "焰尾"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        },
+        {
+            "name": "4H 次高效替补 2 班",
+            "description": "下次在4小时后换班",
+            "Fiammetta": {
+                "enable": false,
+                "target": "龙舌兰",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "manufacture",
+                "index": 1,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["巫恋", "龙舌兰", "柏喙"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["但书", "空弦", "伺夜"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["野鬃", "远牙", "安哲拉"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["灰毫", "幽灵鲨", "斯卡蒂"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["苍苔", "砾", "引星棘刺"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["槐琥", "阿罗玛", "乌尔比安"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["正义骑士号"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["澄闪"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["雷蛇"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["阿米娅", "八幡海铃", "歌蕾蒂娅", "薇薇安娜", "焰尾"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["斥罪"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        },
+        {
+            "name": "4H 次高效替补 1 班",
+            "description": "下次在4小时后换班",
+            "Fiammetta": {
+                "enable": false,
+                "target": "但书",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "manufacture",
+                "index": 1,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["巫恋", "龙舌兰", "卡夫卡"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["但书", "伺夜", "黑键"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["断罪者", "乌尔比安", "安哲拉"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["幽灵鲨", "斯卡蒂", "至简"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["清流", "温蒂", "森蚺"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["苍苔", "引星棘刺", "迷迭香"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["承曦格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["雷蛇"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["车尔尼", "爱丽丝", "塑心"],
+                        "sort": true,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["诗怀雅", "歌蕾蒂娅", "斩业星熊", "夕", "琴柳"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        }
+    ],
+    "scheduleType": {
+        "planTimes": 3,
+        "trading": 2,
+        "manufacture": 4,
+        "power": 3,
+        "dormitory": 4
+    }
+}

--- a/resource/global/txwy/resource/custom_infrast/243_layout_4_times_a_day.json
+++ b/resource/global/txwy/resource/custom_infrast/243_layout_4_times_a_day.json
@@ -1,0 +1,581 @@
+{
+    "author": "公孙长乐, bodayw",
+    "description": "干员配置要求极高，若缺少干员请自行调整\n默认每八小时使用无人机加速制造作战记录，请按实际需求修改\n首次使用前将令的心情消耗至 12\n请在一图流排班表生成器上导入本文件，修改后下载导出（请勿直接修改本文件，以免 MAA 更新时被覆盖）\n\n[20250806 修订] 视频地址: https://www.bilibili.com/video/BV1EW4RzzE9R/?t=145",
+    "id": 1754476892600274,
+    "title": "243 极限效率，一天四换",
+    "buildingType": 243,
+    "planTimes": "3班",
+    "plans": [
+        {
+            "name": "A+B 高效长班 1",
+            "description_post": "请在八小时后换班",
+            "Fiammetta": {
+                "enable": true,
+                "target": "巫恋",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "manufacture",
+                "index": 3,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["巫恋", "卡夫卡", "龙舌兰"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["空弦", "黑键", "但书"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["清流", "温蒂", "森蚺"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["槐琥", "阿罗玛", "砾"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["野鬃", "远牙", "灰毫"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["迷迭香", "至简", "断罪者"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["承曦格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["缪尔赛思"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["澄闪"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["菲亚梅塔", "雷蛇", "戴菲恩", "推进之王", "摩根"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["歌蕾蒂娅", "乌尔比安", "安哲拉", "幽灵鲨", "斯卡蒂"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["爱丽丝", "车尔尼", "塑心", "伊内丝", "苍苔"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["赫默", "伊芙利特", "塞雷娅", "白面鸮", "梅尔"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["阿米娅", "琴柳", "令", "薇薇安娜", "焰尾"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": ["信仰搅拌机", "见行者"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        },
+        {
+            "name": "A+B 高效长班 2",
+            "description_post": "请在八小时后换班",
+            "Fiammetta": {
+                "enable": true,
+                "target": "龙舌兰",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "manufacture",
+                "index": 3,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["巫恋", "卡夫卡", "龙舌兰"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": true,
+                        "product": "LMD",
+                        "operators": ["空弦", "黑键", "但书"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": true,
+                        "product": "Pure Gold",
+                        "operators": ["清流", "温蒂", "森蚺"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": true,
+                        "product": "Pure Gold",
+                        "operators": ["槐琥", "阿罗玛", "砾"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": true,
+                        "product": "Battle Record",
+                        "operators": ["野鬃", "远牙", "灰毫"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": true,
+                        "product": "Battle Record",
+                        "operators": ["迷迭香", "至简", "断罪者"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": true,
+                        "operators": ["承曦格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": true,
+                        "operators": ["缪尔赛思"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["雷蛇"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["菲亚梅塔", "澄闪", "格雷伊", "柏喙", "斥罪"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["诗怀雅", "斩业星熊", "夕", "引星棘刺", "见行者"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["爱丽丝", "车尔尼", "塑心"],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": true,
+                        "operators": ["赫默", "伊芙利特", "塞雷娅", "白面鸮", "梅尔"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": true,
+                        "operators": ["阿米娅", "琴柳", "令", "薇薇安娜", "焰尾"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": ["信仰搅拌机", "伊内丝"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": true,
+                        "operators": ["絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": true,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        },
+        {
+            "name": "B+C 替补短班 1",
+            "description_post": "请在四小时后换班（三小时后把回满 12 心情的令移出宿舍）",
+            "Fiammetta": {
+                "enable": true,
+                "target": "但书",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "manufacture",
+                "index": 3,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["巫恋", "柏喙", "龙舌兰"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["推进之王", "摩根", "但书"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["苍苔", "砾", "引星棘刺"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["槐琥", "阿罗玛", "乌尔比安"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["野鬃", "远牙", "安哲拉"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["幽灵鲨", "斯卡蒂", "灰毫"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": true,
+                        "operators": ["缪尔赛思"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": true,
+                        "operators": ["雷蛇"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["菲亚梅塔", "令", "卡夫卡", "空弦", "黑键"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["清流", "温蒂", "森蚺", "迷迭香", "至简"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["断罪者", "承曦格雷伊", "信仰搅拌机", "絮雨", "琴柳"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": true,
+                        "operators": ["赫默", "伊芙利特", "塞雷娅", "白面鸮", "梅尔"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["阿米娅", "戴菲恩", "歌蕾蒂娅", "薇薇安娜", "焰尾"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": ["见行者", "伊内丝"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["斥罪"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": true,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        },
+        {
+            "name": "A+C 替补短班 2",
+            "description_post": "请在四小时后换班",
+            "Fiammetta": {
+                "enable": false,
+                "target": "",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "manufacture",
+                "index": 3,
+                "enable": false,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["巫恋", "卡夫卡", "龙舌兰"],
+                        "sort": true,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["空弦", "黑键", "但书"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["清流", "温蒂", "森蚺"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["苍苔", "引星棘刺", "迷迭香"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["断罪者", "乌尔比安", "安哲拉"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Battle Record",
+                        "operators": ["幽灵鲨", "斯卡蒂", "至简"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["承曦格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["澄闪"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": true,
+                        "operators": ["雷蛇"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["菲亚梅塔", "阿米娅", "薇薇安娜", "焰尾", "砾"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["槐琥", "阿罗玛", "野鬃", "远牙", "灰毫"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": ["爱丽丝", "车尔尼", "塑心", "缪尔赛思", "见行者"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": true,
+                        "operators": ["赫默", "伊芙利特", "塞雷娅", "白面鸮", "梅尔"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["诗怀雅", "歌蕾蒂娅", "斩业星熊", "夕", "琴柳"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": ["信仰搅拌机", "伊内丝"],
+                        "sort": true,
+                        "autofill": false
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": true,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        }
+    ],
+    "scheduleType": {
+        "planTimes": 4,
+        "trading": 2,
+        "manufacture": 4,
+        "power": 3,
+        "dormitory": 4
+    }
+}

--- a/resource/global/txwy/resource/custom_infrast/333_layout_for_Orundum_3_times_a_day.json
+++ b/resource/global/txwy/resource/custom_infrast/333_layout_for_Orundum_3_times_a_day.json
@@ -1,0 +1,442 @@
+{
+    "author": "一只摆烂的42",
+    "description": "长期搓玉333排班协议",
+    "id": 1765973591631819,
+    "title": "333长期搓玉，需要自行将黍进驻专精室协助位。推荐换班时间8-8-8，极限效率12-12-8.5，非8小时换班需要取消使用菲亚梅塔（plans.[0/1/2].Fiammetta.enable = false），并自行每8小时手动使用菲亚梅塔007但书龙舌兰巫恋。修订时间2025-12-17，具体干员配置参考公孙长乐大佬最新视频的333搓玉高级版。对干员要求极高，若缺少干员请自行拷贝文件并修改（请勿直接修改，以免更新后被覆盖）",
+    "planTimes": "3班",
+    "plans": [
+        {
+            "name": "A 组 12 H",
+            "description": "1组",
+            "description_post": "下次换班请在约12小时后进行",
+            "Fiammetta": {
+                "enable": true,
+                "target": "但书",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "trading",
+                "index": "1",
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["巫恋", "卡夫卡", "龙舌兰"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["乌有", "黑键", "但书"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Orundum",
+                        "operators": ["德克萨斯", "拉普兰德", "能天使"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["清流", "温蒂", "森蚺"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["阿罗玛", "槐琥", "迷迭香"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Originium Shard",
+                        "operators": ["泡泡", "火神", "褐果"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["承曦格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["爱丽丝", "车尔尼", "塑心"],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["阿米娅", "重岳", "令", "夕", "琴柳"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": ["年"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        },
+        {
+            "name": "B 组 12H",
+            "description": "2组",
+            "description_post": "下次换班请在约12小时后进行",
+            "Fiammetta": {
+                "enable": true,
+                "target": "龙舌兰",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "trading",
+                "index": "1",
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["巫恋", "卡夫卡", "龙舌兰"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["推进之王", "摩根", "但书"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Orundum",
+                        "operators": ["孑", "琳琅诗怀雅", "银灰"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["清流", "温蒂", "森蚺"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["苍苔", "砾", "引星棘刺"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Originium Shard",
+                        "operators": ["泡泡", "火神", "褐果"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": ["承曦格雷伊"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["阿米娅", "灵知", "戴菲恩", "八幡海铃", "斩业星熊"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["斥罪"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        },
+        {
+            "name": "C 组 8.5H",
+            "description": "3组",
+            "description_post": "下次换班请在约8.5小时后进行",
+            "Fiammetta": {
+                "enable": true,
+                "target": "巫恋",
+                "order": "pre"
+            },
+            "drones": {
+                "room": "trading",
+                "index": 1,
+                "enable": true,
+                "order": "pre"
+            },
+            "rooms": {
+                "trading": [
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["巫恋", "柏喙", "龙舌兰"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "LMD",
+                        "operators": ["乌有", "黑键", "但书"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Orundum",
+                        "operators": ["德克萨斯", "拉普兰德", "能天使"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "manufacture": [
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["阿罗玛", "槐琥", "迷迭香"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Pure Gold",
+                        "operators": ["苍苔", "引星棘刺", "砾"],
+                        "sort": false,
+                        "autofill": false
+                    },
+                    {
+                        "skip": false,
+                        "product": "Originium Shard",
+                        "operators": ["艾雅法拉", "地灵", "炎熔"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "power": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "dormitory": [
+                    {
+                        "skip": false,
+                        "operators": ["爱丽丝", "车尔尼", "塑心"],
+                        "sort": true,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    },
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "control": [
+                    {
+                        "skip": false,
+                        "operators": ["诗怀雅", "重岳", "令", "夕", "琴柳"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "meeting": [
+                    {
+                        "skip": false,
+                        "operators": [],
+                        "sort": false,
+                        "autofill": true
+                    }
+                ],
+                "hire": [
+                    {
+                        "skip": false,
+                        "operators": ["絮雨"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ],
+                "processing": [
+                    {
+                        "skip": false,
+                        "operators": ["年"],
+                        "sort": false,
+                        "autofill": false
+                    }
+                ]
+            }
+        }
+    ],
+    "scheduleType": {
+        "planTimes": 3,
+        "trading": 3,
+        "manufacture": 3,
+        "power": 3,
+        "dormitory": 4
+    }
+}


### PR DESCRIPTION
## 背景
`一个外服小伙选上了基建内建配置，于是牛牛推荐了可露希尔与凯尔希·思衡托`
当前 resource/custom_infrast/ 中的预设基建排班配置仅维护国服最新版本，包含外服尚未开放的干员。外服用户使用这些排班方案时可能因干员未实装导致换班异常或无法匹配。

## 方案
利用 MAA 已有的分层资源覆写机制，为各外服提供与其当前游戏版本匹配的 custom_infrast 预设排班方案： 根据各外服当前活动，回溯该活动在国服历史上的对应时间，从最后一次有效 Git Commit 提取。

## 当前版本对应关系
- YoStarEN/JP/KR (辞岁行) -> 国服对应时间 2026-02-10 ~ 2026-03-10
- txwy (雅赛努斯复仇记) -> 国服对应时间 2026-01-09 ~ 2026-01-30 

上述两者皆提取自国服 commit cd7ce30c4 (2025-12-17)。

## 问题

1. 没法自动化更新
2. 其实未来版本(比如矢量突破版本）提出的攻略可能也能用
3. 如果外服排程错位（点名繁中服）可能会坏掉

但毕尽是人工更新，先靠人工检查解决吧

## Summary by Sourcery

新功能：
- 为 YoStarEN、YoStarJP、YoStarKR 和 txwy 服务器在多种调度频率下提供与游戏版本匹配的 `custom_infrast` 预设布局。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Provide game-version-matched custom_infrast preset layouts for YoStarEN, YoStarJP, YoStarKR, and txwy servers across multiple scheduling frequencies.

</details>

## Summary by Sourcery

新功能：
- 为 YoStarEN、YoStarJP、YoStarKR 和 txwy 服务器提供 `custom_infrast` 预设布局，根据当前游戏版本和不同排程频率进行定制。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Provide custom_infrast preset layouts for YoStarEN, YoStarJP, YoStarKR, and txwy servers tailored to their current game version across multiple scheduling frequencies.

</details>