### PR TITLE
feat: 额外检查因技能选择、技能等级、模组而导致的精英化等级需求

### DIFF
--- a/src/MaaCore/Config/Miscellaneous/CopilotConfig.cpp
+++ b/src/MaaCore/Config/Miscellaneous/CopilotConfig.cpp
@@ -43,6 +43,49 @@ asst::battle::copilot::BasicInfo asst::CopilotConfig::parse_basic_info(const jso
     return info;
 }
 
+asst::battle::OperUsage asst::CopilotConfig::parse_oper_usage(const json::value& json)
+{
+    OperUsage oper;
+    oper.name = json.at("name").as_string();
+    oper.skill = json.get("skill", 0);
+    oper.skill_usage = static_cast<battle::SkillUsage>(json.get("skill_usage", 0));
+    oper.skill_times = json.get("skill_times", 1);                       // 使用技能的次数，默认为 1，兼容曾经的作业
+
+    int rarity = BattleDataConfig::get_instance().get_rarity(oper.name); // 兼容古早旧作业中非法的技能选择
+    if (oper.skill == 3 && rarity < 6) {
+        LogError << __FUNCTION__ << "| Oper " << oper.name << " with rarity " << rarity
+                 << " cannot use skill index 3, set to 0.";
+        oper.skill = 0;
+    }
+    else if (oper.skill == 2 && rarity < 4) {
+        LogError << __FUNCTION__ << "| Oper " << oper.name << " with rarity " << rarity
+                 << " cannot use skill index 2, set to 0.";
+        oper.skill = 0;
+    }
+    else if (oper.skill == 1 && rarity < 3) {
+        LogError << __FUNCTION__ << "| Oper " << oper.name << " with rarity " << rarity
+                 << " cannot use skill index 1, set to 0.";
+        oper.skill = 0;
+    }
+
+    // 解析练度需求
+    if (auto req_opt = json.find("requirements")) {
+        oper.requirements.elite = req_opt->get("elite", 0);
+        oper.requirements.level = req_opt->get("level", 0);
+        oper.requirements.skill_level = req_opt->get("skill_level", 0);
+        oper.requirements.module = req_opt->get("module", -1);
+        // oper.requirements.potentiality = req_opt->get("potentiality", 0);
+    }
+
+    if (int elite = oper.skill - 1; elite > oper.requirements.elite) {
+        LogError << __FUNCTION__ << "| Oper " << oper.name << " use skill " << oper.skill << " requires elite " << elite
+                 << ", but current requirement is " << oper.requirements.elite << ". Adjusting elite requirement.";
+        oper.requirements.elite = elite;
+    }
+
+    return oper;
+}
+
 asst::battle::copilot::OperUsageGroups asst::CopilotConfig::parse_groups(const json::value& json)
 {
     LogTraceFunction;
@@ -51,38 +94,7 @@ asst::battle::copilot::OperUsageGroups asst::CopilotConfig::parse_groups(const j
 
     if (auto opt = json.find<json::array>("opers")) {
         for (const auto& oper_info : opt.value()) {
-            OperUsage oper;
-            oper.name = oper_info.at("name").as_string();
-            oper.skill = oper_info.get("skill", 0);
-            oper.skill_usage = static_cast<battle::SkillUsage>(oper_info.get("skill_usage", 0));
-            oper.skill_times = oper_info.get("skill_times", 1); // 使用技能的次数，默认为 1，兼容曾经的作业
-
-            int rarity = BattleDataConfig::get_instance().get_rarity(oper.name); // 兼容古早旧作业中非法的技能选择
-            if (oper.skill == 3 && rarity < 6) {
-                LogError << __FUNCTION__ << "| Oper " << oper.name << " with rarity " << rarity
-                         << " cannot use skill index 3, set to 0.";
-                oper.skill = 0;
-            }
-            else if (oper.skill == 2 && rarity < 4) {
-                LogError << __FUNCTION__ << "| Oper " << oper.name << " with rarity " << rarity
-                         << " cannot use skill index 2, set to 0.";
-                oper.skill = 0;
-            }
-            else if (oper.skill == 1 && rarity < 3) {
-                LogError << __FUNCTION__ << "| Oper " << oper.name << " with rarity " << rarity
-                         << " cannot use skill index 1, set to 0.";
-                oper.skill = 0;
-            }
-
-            // 解析练度需求
-            if (auto req_opt = oper_info.find("requirements")) {
-                oper.requirements.elite = req_opt->get("elite", 0);
-                oper.requirements.level = req_opt->get("level", 0);
-                oper.requirements.skill_level = req_opt->get("skill_level", 0);
-                oper.requirements.module = req_opt->get("module", -1);
-                // oper.requirements.potentiality = req_opt->get("potentiality", 0);
-            }
-
+            OperUsage oper = parse_oper_usage(oper_info);
             // 单个干员的，干员名直接作为组名
             std::string group_name = oper.name;
             groups.emplace_back(OperUsageGroup { std::move(group_name), std::vector { std::move(oper) } });
@@ -94,39 +106,7 @@ asst::battle::copilot::OperUsageGroups asst::CopilotConfig::parse_groups(const j
             std::string group_name = group_info.at("name").as_string();
             std::vector<OperUsage> oper_vec;
             for (const auto& oper_info : group_info.at("opers").as_array()) {
-                OperUsage oper;
-                oper.name = oper_info.at("name").as_string();
-                oper.skill = oper_info.get("skill", 0);
-                oper.skill_usage = static_cast<battle::SkillUsage>(oper_info.get("skill_usage", 0));
-                oper.skill_times = oper_info.get("skill_times", 1); // 使用技能的次数，默认为 1，兼容曾经的作业
-
-                int rarity = BattleDataConfig::get_instance().get_rarity(oper.name); // 兼容古早旧作业中非法的技能选择
-                if (oper.skill == 3 && rarity < 6) {
-                    LogError << __FUNCTION__ << "| Oper " << oper.name << " with rarity " << rarity
-                             << " cannot use skill index 3, set to 0.";
-                    oper.skill = 0;
-                }
-                else if (oper.skill == 2 && rarity < 4) {
-                    LogError << __FUNCTION__ << "| Oper " << oper.name << " with rarity " << rarity
-                             << " cannot use skill index 2, set to 0.";
-                    oper.skill = 0;
-                }
-                else if (oper.skill == 1 && rarity < 3) {
-                    LogError << __FUNCTION__ << "| Oper " << oper.name << " with rarity " << rarity
-                             << " cannot use skill index 1, set to 0.";
-                    oper.skill = 0;
-                }
-
-                // 解析练度需求
-                if (auto req_opt = oper_info.find("requirements")) {
-                    oper.requirements.elite = req_opt->get("elite", 0);
-                    oper.requirements.level = req_opt->get("level", 0);
-                    oper.requirements.skill_level = req_opt->get("skill_level", 0);
-                    oper.requirements.module = req_opt->get("module", -1);
-                    // oper.requirements.potentiality = req_opt->get("potentiality", 0);
-                }
-
-                oper_vec.emplace_back(std::move(oper));
+                oper_vec.emplace_back(parse_oper_usage(oper_info));
             }
             groups.emplace_back(OperUsageGroup { std::move(group_name), std::move(oper_vec) });
         }

--- a/src/MaaCore/Config/Miscellaneous/CopilotConfig.cpp
+++ b/src/MaaCore/Config/Miscellaneous/CopilotConfig.cpp
@@ -110,8 +110,8 @@ std::optional<asst::battle::OperUsage> asst::CopilotConfig::parse_oper_usage(con
             oper.requirements.elite = std::max(*elite_opt, elite_require);
         }
         else if (elite_require > 0) {
-            LogWarn << __FUNCTION__ << "| Oper" << oper.name << "has skill" << oper.skill
-                    << ", but no requirements specified, set elite requirement to" << oper.requirements.elite;
+            LogWarn << __FUNCTION__ << "| Oper" << oper.name << "has higher elite requirement" << elite_require
+                    << ", but no elite specified, set elite requirement to" << oper.requirements.elite;
             oper.requirements.elite = std::max(elite_require, 0); // 默认精英化要求为技能序号 - 1
         }
     }

--- a/src/MaaCore/Config/Miscellaneous/CopilotConfig.cpp
+++ b/src/MaaCore/Config/Miscellaneous/CopilotConfig.cpp
@@ -70,16 +70,36 @@ asst::battle::OperUsage asst::CopilotConfig::parse_oper_usage(const json::value&
 
     // 解析练度需求
     if (auto req_opt = json.find("requirements")) {
-        oper.requirements.elite = req_opt->get("elite", 0);
-        oper.requirements.level = req_opt->get("level", 0);
-        oper.requirements.skill_level = req_opt->get("skill_level", 0);
+        oper.requirements.elite = req_opt->get("elite", -1);
+        oper.requirements.level = req_opt->get("level", -1);
+        oper.requirements.skill_level = req_opt->get("skill_level", -1);
         oper.requirements.module = req_opt->get("module", -1);
-        // oper.requirements.potentiality = req_opt->get("potentiality", 0);
+        // oper.requirements.potentiality = req_opt->get("potentiality", -1);
+    }
+
+    // 下面 2 个改 elite 的 if 顺序不要换
+    if ((oper.requirements.skill_level > 7 || oper.requirements.module > 0) && oper.requirements.elite < 2) {
+        auto log = oper.requirements.elite == -1 ? LogWarn : LogError;
+        auto msg = std::string("| Oper ") + oper.name + " has skill_level " +
+                   std::to_string(oper.requirements.skill_level) + " or module " +
+                   std::to_string(oper.requirements.module) + ", which requires elite 2, but current requirement is " +
+                   std::to_string(oper.requirements.elite) + ". Adjusting elite requirement.";
+        log << __FUNCTION__ << msg;
+        if (oper.requirements.elite != -1) {
+            throw std::invalid_argument(msg);
+        }
+        oper.requirements.elite = 2;
     }
 
     if (int elite = oper.skill - 1; elite > oper.requirements.elite) {
-        LogError << __FUNCTION__ << "| Oper " << oper.name << " use skill " << oper.skill << " requires elite " << elite
-                 << ", but current requirement is " << oper.requirements.elite << ". Adjusting elite requirement.";
+        auto log = oper.requirements.elite == -1 ? LogWarn : LogError;
+        auto log_msg = std::string("| Oper ") + oper.name + " use skill " + std::to_string(oper.skill) +
+                       " requires elite " + std::to_string(elite) + ", but current requirement is " +
+                       std::to_string(oper.requirements.elite) + ". Adjusting elite requirement.";
+        log << __FUNCTION__ << log_msg;
+        if (oper.requirements.elite != -1) {
+            throw std::invalid_argument(log_msg);
+        }
         oper.requirements.elite = elite;
     }
 

--- a/src/MaaCore/Config/Miscellaneous/CopilotConfig.cpp
+++ b/src/MaaCore/Config/Miscellaneous/CopilotConfig.cpp
@@ -73,20 +73,48 @@ std::optional<asst::battle::OperUsage> asst::CopilotConfig::parse_oper_usage(con
         oper.skill = 0;
     }
 
-    // 解析练度需求
+    // 解析练度需求并检查非法设置
     if (auto req_opt = json.find("requirements")) {
         oper.requirements.level = req_opt->get("level", 0);
-        oper.requirements.skill_level = req_opt->get("skill_level", 0);
-        oper.requirements.module = req_opt->get("module", -1);
         // oper.requirements.potentiality = req_opt->get("potentiality", 0);
 
+        int elite_require = oper.skill - 1;
+        if (auto skill_level_opt = req_opt->find<int>("skill_level"); !skill_level_opt) {
+            oper.requirements.skill_level = 0;
+        }
+        else {
+            oper.requirements.skill_level = *skill_level_opt;
+            if (*skill_level_opt > 7) {
+                elite_require = std::max(2, elite_require); // 技能专精要求精二
+            }
+            else if (*skill_level_opt > 4) {
+                elite_require = std::max(1, elite_require);
+            }
+        }
+        if (auto module_opt = req_opt->find<int>("module"); module_opt) {
+            oper.requirements.module = *module_opt;
+            if (*module_opt > 0) {
+                elite_require = std::max(2, elite_require); // 模组要求精2
+            }
+        }
+        else {
+            oper.requirements.module = -1;
+        }
         if (auto elite_opt = req_opt->find<int>("elite"); elite_opt) {
-            oper.requirements.elite = *elite_opt;
-            if (int elite_require = oper.skill - 1; elite_require > oper.requirements.elite) {
-                LogError << __FUNCTION__ << "| Oper " << oper.name << " use skill " << oper.skill << " requires elite "
-                         << elite_require << ", but current requirement is lower:" << oper.requirements.elite;
+            if (elite_require > *elite_opt) {
+                LogError << __FUNCTION__ << "| Oper" << oper.name << "has higher elite requirement:" << elite_require
+                         << ", but elite requirement is set to" << *elite_opt;
                 return std::nullopt;
             }
+
+            oper.requirements.elite = std::max(*elite_opt, elite_require);
+        }
+    }
+    else {
+        if (oper.skill - 1 > 0) {
+            LogWarn << __FUNCTION__ << "| Oper" << oper.name << "has skill" << oper.skill
+                    << ", but no requirements specified, set elite requirement to" << oper.requirements.elite;
+            oper.requirements.elite = std::max(oper.skill - 1, 0); // 默认精英化要求为技能序号 - 1
         }
     }
 

--- a/src/MaaCore/Config/Miscellaneous/CopilotConfig.cpp
+++ b/src/MaaCore/Config/Miscellaneous/CopilotConfig.cpp
@@ -73,12 +73,12 @@ std::optional<asst::battle::OperUsage> asst::CopilotConfig::parse_oper_usage(con
         oper.skill = 0;
     }
 
+    int elite_require = oper.skill - 1;
     // 解析练度需求并检查非法设置
     if (auto req_opt = json.find("requirements")) {
         oper.requirements.level = req_opt->get("level", 0);
         // oper.requirements.potentiality = req_opt->get("potentiality", 0);
 
-        int elite_require = oper.skill - 1;
         if (auto skill_level_opt = req_opt->find<int>("skill_level"); !skill_level_opt) {
             oper.requirements.skill_level = 0;
         }
@@ -109,9 +109,14 @@ std::optional<asst::battle::OperUsage> asst::CopilotConfig::parse_oper_usage(con
 
             oper.requirements.elite = std::max(*elite_opt, elite_require);
         }
+        else if (elite_require > 0) {
+            LogWarn << __FUNCTION__ << "| Oper" << oper.name << "has skill" << oper.skill
+                    << ", but no requirements specified, set elite requirement to" << oper.requirements.elite;
+            oper.requirements.elite = std::max(oper.skill - 1, 0); // 默认精英化要求为技能序号 - 1
+        }
     }
     else {
-        if (oper.skill - 1 > 0) {
+        if (elite_require > 0) {
             LogWarn << __FUNCTION__ << "| Oper" << oper.name << "has skill" << oper.skill
                     << ", but no requirements specified, set elite requirement to" << oper.requirements.elite;
             oper.requirements.elite = std::max(oper.skill - 1, 0); // 默认精英化要求为技能序号 - 1

--- a/src/MaaCore/Config/Miscellaneous/CopilotConfig.cpp
+++ b/src/MaaCore/Config/Miscellaneous/CopilotConfig.cpp
@@ -21,7 +21,12 @@ bool asst::CopilotConfig::parse(const json::value& json)
     clear();
 
     m_data.info = parse_basic_info(json);
-    m_data.groups = parse_groups(json);
+    if (auto groups = parse_groups(json)) {
+        m_data.groups = *groups;
+    }
+    else {
+        return false;
+    }
     m_data.actions = parse_actions(json);
 
     return true;
@@ -43,7 +48,7 @@ asst::battle::copilot::BasicInfo asst::CopilotConfig::parse_basic_info(const jso
     return info;
 }
 
-asst::battle::OperUsage asst::CopilotConfig::parse_oper_usage(const json::value& json)
+std::optional<asst::battle::OperUsage> asst::CopilotConfig::parse_oper_usage(const json::value& json)
 {
     OperUsage oper;
     oper.name = json.at("name").as_string();
@@ -70,23 +75,25 @@ asst::battle::OperUsage asst::CopilotConfig::parse_oper_usage(const json::value&
 
     // 解析练度需求
     if (auto req_opt = json.find("requirements")) {
-        oper.requirements.elite = req_opt->get("elite", 0);
         oper.requirements.level = req_opt->get("level", 0);
         oper.requirements.skill_level = req_opt->get("skill_level", 0);
         oper.requirements.module = req_opt->get("module", -1);
         // oper.requirements.potentiality = req_opt->get("potentiality", 0);
-    }
 
-    if (int elite = oper.skill - 1; elite > oper.requirements.elite) {
-        LogError << __FUNCTION__ << "| Oper " << oper.name << " use skill " << oper.skill << " requires elite " << elite
-                 << ", but current requirement is " << oper.requirements.elite << ". Adjusting elite requirement.";
-        oper.requirements.elite = elite;
+        if (auto elite_opt = req_opt->find<int>("elite"); elite_opt) {
+            oper.requirements.elite = *elite_opt;
+            if (int elite_require = oper.skill - 1; elite_require > oper.requirements.elite) {
+                LogError << __FUNCTION__ << "| Oper " << oper.name << " use skill " << oper.skill << " requires elite "
+                         << elite_require << ", but current requirement is lower:" << oper.requirements.elite;
+                return std::nullopt;
+            }
+        }
     }
 
     return oper;
 }
 
-asst::battle::copilot::OperUsageGroups asst::CopilotConfig::parse_groups(const json::value& json)
+std::optional<asst::battle::copilot::OperUsageGroups> asst::CopilotConfig::parse_groups(const json::value& json)
 {
     LogTraceFunction;
 
@@ -94,10 +101,14 @@ asst::battle::copilot::OperUsageGroups asst::CopilotConfig::parse_groups(const j
 
     if (auto opt = json.find<json::array>("opers")) {
         for (const auto& oper_info : opt.value()) {
-            OperUsage oper = parse_oper_usage(oper_info);
+            auto oper = parse_oper_usage(oper_info);
+            if (!oper) {
+                LogError << __FUNCTION__ << "| Failed to parse oper" << oper_info;
+                return std::nullopt;
+            }
             // 单个干员的，干员名直接作为组名
-            std::string group_name = oper.name;
-            groups.emplace_back(OperUsageGroup { std::move(group_name), std::vector { std::move(oper) } });
+            std::string group_name = oper->name;
+            groups.emplace_back(OperUsageGroup { std::move(group_name), std::vector { std::move(*oper) } });
         }
     }
 
@@ -106,7 +117,12 @@ asst::battle::copilot::OperUsageGroups asst::CopilotConfig::parse_groups(const j
             std::string group_name = group_info.at("name").as_string();
             std::vector<OperUsage> oper_vec;
             for (const auto& oper_info : group_info.at("opers").as_array()) {
-                oper_vec.emplace_back(parse_oper_usage(oper_info));
+                auto oper = parse_oper_usage(oper_info);
+                if (!oper) {
+                    LogError << __FUNCTION__ << "| Failed to parse oper" << oper_info;
+                    return std::nullopt;
+                }
+                oper_vec.emplace_back(std::move(*oper));
             }
             groups.emplace_back(OperUsageGroup { std::move(group_name), std::move(oper_vec) });
         }

--- a/src/MaaCore/Config/Miscellaneous/CopilotConfig.cpp
+++ b/src/MaaCore/Config/Miscellaneous/CopilotConfig.cpp
@@ -97,29 +97,12 @@ std::optional<asst::battle::OperUsage> asst::CopilotConfig::parse_oper_usage(con
                 elite_require = std::max(2, elite_require); // 模组要求精2
             }
         }
-        else {
-            oper.requirements.module = -1;
-        }
         if (auto elite_opt = req_opt->find<int>("elite"); elite_opt) {
             if (elite_require > *elite_opt) {
                 LogError << __FUNCTION__ << "| Oper" << oper.name << "has higher elite requirement:" << elite_require
                          << ", but elite requirement is set to" << *elite_opt;
                 return std::nullopt;
             }
-
-            oper.requirements.elite = std::max(*elite_opt, elite_require);
-        }
-        else if (elite_require > 0) {
-            LogWarn << __FUNCTION__ << "| Oper" << oper.name << "has higher elite requirement" << elite_require
-                    << ", but no elite specified, set elite requirement to" << oper.requirements.elite;
-            oper.requirements.elite = std::max(elite_require, 0); // 默认精英化要求为技能序号 - 1
-        }
-    }
-    else {
-        if (elite_require > 0) {
-            LogWarn << __FUNCTION__ << "| Oper" << oper.name << "has skill" << oper.skill
-                    << ", but no requirements specified, set elite requirement to" << oper.requirements.elite;
-            oper.requirements.elite = std::max(elite_require, 0); // 默认精英化要求为技能序号 - 1
         }
     }
 

--- a/src/MaaCore/Config/Miscellaneous/CopilotConfig.cpp
+++ b/src/MaaCore/Config/Miscellaneous/CopilotConfig.cpp
@@ -112,14 +112,14 @@ std::optional<asst::battle::OperUsage> asst::CopilotConfig::parse_oper_usage(con
         else if (elite_require > 0) {
             LogWarn << __FUNCTION__ << "| Oper" << oper.name << "has skill" << oper.skill
                     << ", but no requirements specified, set elite requirement to" << oper.requirements.elite;
-            oper.requirements.elite = std::max(oper.skill - 1, 0); // 默认精英化要求为技能序号 - 1
+            oper.requirements.elite = std::max(elite_require, 0); // 默认精英化要求为技能序号 - 1
         }
     }
     else {
         if (elite_require > 0) {
             LogWarn << __FUNCTION__ << "| Oper" << oper.name << "has skill" << oper.skill
                     << ", but no requirements specified, set elite requirement to" << oper.requirements.elite;
-            oper.requirements.elite = std::max(oper.skill - 1, 0); // 默认精英化要求为技能序号 - 1
+            oper.requirements.elite = std::max(elite_require, 0); // 默认精英化要求为技能序号 - 1
         }
     }
 

--- a/src/MaaCore/Config/Miscellaneous/CopilotConfig.cpp
+++ b/src/MaaCore/Config/Miscellaneous/CopilotConfig.cpp
@@ -70,36 +70,16 @@ asst::battle::OperUsage asst::CopilotConfig::parse_oper_usage(const json::value&
 
     // 解析练度需求
     if (auto req_opt = json.find("requirements")) {
-        oper.requirements.elite = req_opt->get("elite", -1);
-        oper.requirements.level = req_opt->get("level", -1);
-        oper.requirements.skill_level = req_opt->get("skill_level", -1);
+        oper.requirements.elite = req_opt->get("elite", 0);
+        oper.requirements.level = req_opt->get("level", 0);
+        oper.requirements.skill_level = req_opt->get("skill_level", 0);
         oper.requirements.module = req_opt->get("module", -1);
-        // oper.requirements.potentiality = req_opt->get("potentiality", -1);
-    }
-
-    // 下面 2 个改 elite 的 if 顺序不要换
-    if ((oper.requirements.skill_level > 7 || oper.requirements.module > 0) && oper.requirements.elite < 2) {
-        auto log = oper.requirements.elite == -1 ? LogWarn : LogError;
-        auto msg = std::string("| Oper ") + oper.name + " has skill_level " +
-                   std::to_string(oper.requirements.skill_level) + " or module " +
-                   std::to_string(oper.requirements.module) + ", which requires elite 2, but current requirement is " +
-                   std::to_string(oper.requirements.elite) + ". Adjusting elite requirement.";
-        log << __FUNCTION__ << msg;
-        if (oper.requirements.elite != -1) {
-            throw std::invalid_argument(msg);
-        }
-        oper.requirements.elite = 2;
+        // oper.requirements.potentiality = req_opt->get("potentiality", 0);
     }
 
     if (int elite = oper.skill - 1; elite > oper.requirements.elite) {
-        auto log = oper.requirements.elite == -1 ? LogWarn : LogError;
-        auto log_msg = std::string("| Oper ") + oper.name + " use skill " + std::to_string(oper.skill) +
-                       " requires elite " + std::to_string(elite) + ", but current requirement is " +
-                       std::to_string(oper.requirements.elite) + ". Adjusting elite requirement.";
-        log << __FUNCTION__ << log_msg;
-        if (oper.requirements.elite != -1) {
-            throw std::invalid_argument(log_msg);
-        }
+        LogError << __FUNCTION__ << "| Oper " << oper.name << " use skill " << oper.skill << " requires elite " << elite
+                 << ", but current requirement is " << oper.requirements.elite << ". Adjusting elite requirement.";
         oper.requirements.elite = elite;
     }
 

--- a/src/MaaCore/Config/Miscellaneous/CopilotConfig.h
+++ b/src/MaaCore/Config/Miscellaneous/CopilotConfig.h
@@ -8,8 +8,8 @@ class CopilotConfig : public MAA_NS::SingletonHolder<CopilotConfig>, public Abst
 {
 public:
     static battle::copilot::BasicInfo parse_basic_info(const json::value& json);
-    static battle::OperUsage parse_oper_usage(const json::value& json);
-    static battle::copilot::OperUsageGroups parse_groups(const json::value& json);
+    static std::optional<asst::battle::OperUsage> parse_oper_usage(const json::value& json);
+    static std::optional<asst::battle::copilot::OperUsageGroups> parse_groups(const json::value& json);
     static std::vector<battle::copilot::Action> parse_actions(const json::value& json);
     static battle::RoleCounts parse_role_counts(const json::value& json);
     static battle::DeployDirection string_to_direction(const std::string& str);

--- a/src/MaaCore/Config/Miscellaneous/CopilotConfig.h
+++ b/src/MaaCore/Config/Miscellaneous/CopilotConfig.h
@@ -8,6 +8,7 @@ class CopilotConfig : public MAA_NS::SingletonHolder<CopilotConfig>, public Abst
 {
 public:
     static battle::copilot::BasicInfo parse_basic_info(const json::value& json);
+    static battle::OperUsage parse_oper_usage(const json::value& json);
     static battle::copilot::OperUsageGroups parse_groups(const json::value& json);
     static std::vector<battle::copilot::Action> parse_actions(const json::value& json);
     static battle::RoleCounts parse_role_counts(const json::value& json);

--- a/src/MaaCore/Config/Miscellaneous/SSSCopilotConfig.cpp
+++ b/src/MaaCore/Config/Miscellaneous/SSSCopilotConfig.cpp
@@ -22,7 +22,12 @@ bool asst::SSSCopilotConfig::parse(const json::value& json)
     clear();
 
     m_data.info = CopilotConfig::parse_basic_info(json);
-    m_data.groups = CopilotConfig::parse_groups(json);
+    if (auto groups = CopilotConfig::parse_groups(json)) {
+        m_data.groups = *groups;
+    }
+    else {
+        return false;
+    }
 
     m_data.buff = json.get("buff", std::string());
     m_data.strategy = json.get("strategy", std::string());

--- a/src/MaaCore/Task/Interface/CopilotTask.cpp
+++ b/src/MaaCore/Task/Interface/CopilotTask.cpp
@@ -85,9 +85,6 @@ bool asst::CopilotTask::set_params(const json::value& params)
         m_multi_copilot_plugin_ptr->set_enable(false);
         m_battle_task_ptr->set_wait_until_end(false);
         auto copilot_opt = parse_copilot_filename(*filename_opt);
-        if (!copilot_opt) {
-            return false;
-        }
         m_stage_name = Copilot.get_stage_name();
         if (!m_battle_task_ptr->set_stage_name(m_stage_name)) {
             Log.error("Not support stage");

--- a/src/MaaCore/Task/Interface/CopilotTask.cpp
+++ b/src/MaaCore/Task/Interface/CopilotTask.cpp
@@ -85,6 +85,9 @@ bool asst::CopilotTask::set_params(const json::value& params)
         m_multi_copilot_plugin_ptr->set_enable(false);
         m_battle_task_ptr->set_wait_until_end(false);
         auto copilot_opt = parse_copilot_filename(*filename_opt);
+        if (!copilot_opt) {
+            return false;
+        }
         m_stage_name = Copilot.get_stage_name();
         if (!m_battle_task_ptr->set_stage_name(m_stage_name)) {
             Log.error("Not support stage");

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -674,7 +674,7 @@ bool asst::BattleFormationTask::check_oper_level(
     const battle::OperUsage& oper,
     bool ignore)
 {
-    if (oper.requirements.elite <= 0 && oper.requirements.level <= 0) {
+    if (oper.requirements.elite == 0 && oper.requirements.level == 0) {
         return true; // 无等级要求
     }
     auto [_elite, _level] = m_quick_formation_ui.analyze_oper_level(image, flag);
@@ -729,7 +729,7 @@ bool asst::BattleFormationTask::check_and_select_skill(const battle::OperUsage& 
         return true;
     }*/
 
-    auto result = m_quick_formation_ui.find_oper_skill(oper.skill, oper.requirements.skill_level <= 0);
+    auto result = m_quick_formation_ui.find_oper_skill(oper.skill, oper.requirements.skill_level == 0);
     if (!result) {
         LogError << __FUNCTION__ << "| Skill" << oper.skill << "not found in quick detection";
         return false;

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -674,7 +674,7 @@ bool asst::BattleFormationTask::check_oper_level(
     const battle::OperUsage& oper,
     bool ignore)
 {
-    if (oper.requirements.elite == 0 && oper.requirements.level == 0) {
+    if (oper.requirements.elite <= 0 && oper.requirements.level <= 0) {
         return true; // 无等级要求
     }
     auto [_elite, _level] = m_quick_formation_ui.analyze_oper_level(image, flag);
@@ -729,7 +729,7 @@ bool asst::BattleFormationTask::check_and_select_skill(const battle::OperUsage& 
         return true;
     }*/
 
-    auto result = m_quick_formation_ui.find_oper_skill(oper.skill, oper.requirements.skill_level == 0);
+    auto result = m_quick_formation_ui.find_oper_skill(oper.skill, oper.requirements.skill_level <= 0);
     if (!result) {
         LogError << __FUNCTION__ << "| Skill" << oper.skill << "not found in quick detection";
         return false;

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -674,7 +674,7 @@ bool asst::BattleFormationTask::check_oper_level(
     const battle::OperUsage& oper,
     bool ignore)
 {
-    if (oper.requirements.elite == 0 && oper.requirements.level == 0) {
+    if (oper.requirements.elite <= 0 && oper.requirements.level <= 0) {
         return true; // 无等级要求
     }
     auto [_elite, _level] = m_quick_formation_ui.analyze_oper_level(image, flag);

--- a/src/MaaWpfGui/Models/Copilot/CopilotModel.cs
+++ b/src/MaaWpfGui/Models/Copilot/CopilotModel.cs
@@ -103,11 +103,11 @@ public class CopilotModel : CopilotBase
 
     private static string PrintSkillLevel(Oper oper)
     {
-        if (oper.Requirements is not { } req || req.SkillLevel <= 0 || req.SkillLevel > 10)
+        if (oper.Requirements is not { } req || req.SkillLevel is not int skillLevel || skillLevel <= 0 || skillLevel > 10)
         {
             return string.Empty;
         }
-        return $" [Lv.{req.SkillLevel}]";
+        return $" [Lv.{skillLevel}]";
     }
 
     private static string GetModuleInfo(Requirements? req)

--- a/src/MaaWpfGui/Models/Copilot/CopilotModel.cs
+++ b/src/MaaWpfGui/Models/Copilot/CopilotModel.cs
@@ -14,7 +14,6 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Linq;
 using MaaWpfGui.Constants;
 using MaaWpfGui.Helper;
@@ -95,7 +94,7 @@ public class CopilotModel : CopilotBase
 
     private static string PrintLevelInfo(Oper oper)
     {
-        if (oper.Requirements is not { } req || (req.Elite <= 0 && req.Level <= 0))
+        if (oper.Requirements is not { } req || (req.Elite == 0 && req.Level <= 0))
         {
             return string.Empty;
         }
@@ -165,7 +164,7 @@ public class CopilotModel : CopilotBase
         /// <summary>
         /// Gets or sets 练度要求。保留接口，暂未实现。可选，默认为空
         /// </summary>
-        [JsonProperty("requirements", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonProperty("requirements")]
         public Requirements? Requirements { get; set; }
     }
 
@@ -298,47 +297,41 @@ public class CopilotModel : CopilotBase
     public class Requirements
     {
         /// <summary>
-        /// Gets or sets 精英化等级。可选，默认为 -1, 不要求精英化等级。
+        /// Gets or sets 精英化等级。可选，默认为 0, 不要求精英化等级。
         /// </summary>
-        [DefaultValue(-1)]
-        [JsonProperty("elite", DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public int Elite { get; set; } = -1;
+        [JsonProperty("elite")]
+        public int Elite { get; set; }
 
         /// <summary>
-        /// Gets or sets 干员等级。可选，默认为 -1。
+        /// Gets or sets 干员等级。可选，默认为 0。
         /// </summary>
-        [DefaultValue(-1)]
-        [JsonProperty("level", DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public int Level { get; set; } = -1;
+        [JsonProperty("level")]
+        public int Level { get; set; }
 
         /// <summary>
-        /// Gets or sets 技能等级。可选，默认为 -1。
+        /// Gets or sets 技能等级。可选，默认为 0。
         /// </summary>
-        [DefaultValue(-1)]
-        [JsonProperty("skill_level", DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public int SkillLevel { get; set; } = -1;
+        [JsonProperty("skill_level")]
+        public int SkillLevel { get; set; }
 
         /// <summary>
         /// Gets or sets 模组编号。可选，默认为 -1。
         /// </summary>
-        [DefaultValue(-1)]
-        [JsonProperty("module", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        [JsonProperty("module")]
         public int Module { get; set; } = -1;
         /*
         /// <summary>
         /// Gets or sets 模组编号。可选，默认为 -1。
         /// </summary>
-        [DefaultValue(-1)]
         [JsonProperty("module_level")]
-        public int ModuleLevel { get; set; } = -1;
+        public int ModuleLevel { get; set; } = 0;
         */
 
         /// <summary>
-        /// Gets or sets 潜能要求。可选，默认为 -1。
+        /// Gets or sets 潜能要求。可选，默认为 0。
         /// </summary>
-        [DefaultValue(-1)]
-        [JsonProperty("potentiality", DefaultValueHandling = DefaultValueHandling.Ignore)]
-        public int Potentiality { get; set; } = -1;
+        [JsonProperty("potentiality")]
+        public int Potentiality { get; set; }
     }
 
     [Flags]

--- a/src/MaaWpfGui/Models/Copilot/CopilotModel.cs
+++ b/src/MaaWpfGui/Models/Copilot/CopilotModel.cs
@@ -14,6 +14,7 @@
 #nullable enable
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using MaaWpfGui.Constants;
 using MaaWpfGui.Helper;
@@ -94,7 +95,7 @@ public class CopilotModel : CopilotBase
 
     private static string PrintLevelInfo(Oper oper)
     {
-        if (oper.Requirements is not { } req || (req.Elite == 0 && req.Level <= 0))
+        if (oper.Requirements is not { } req || (req.Elite <= 0 && req.Level <= 0))
         {
             return string.Empty;
         }
@@ -164,7 +165,7 @@ public class CopilotModel : CopilotBase
         /// <summary>
         /// Gets or sets 练度要求。保留接口，暂未实现。可选，默认为空
         /// </summary>
-        [JsonProperty("requirements")]
+        [JsonProperty("requirements", NullValueHandling = NullValueHandling.Ignore)]
         public Requirements? Requirements { get; set; }
     }
 
@@ -297,41 +298,47 @@ public class CopilotModel : CopilotBase
     public class Requirements
     {
         /// <summary>
-        /// Gets or sets 精英化等级。可选，默认为 0, 不要求精英化等级。
+        /// Gets or sets 精英化等级。可选，默认为 -1, 不要求精英化等级。
         /// </summary>
-        [JsonProperty("elite")]
-        public int Elite { get; set; }
+        [DefaultValue(-1)]
+        [JsonProperty("elite", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public int Elite { get; set; } = -1;
 
         /// <summary>
-        /// Gets or sets 干员等级。可选，默认为 0。
+        /// Gets or sets 干员等级。可选，默认为 -1。
         /// </summary>
-        [JsonProperty("level")]
-        public int Level { get; set; }
+        [DefaultValue(-1)]
+        [JsonProperty("level", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public int Level { get; set; } = -1;
 
         /// <summary>
-        /// Gets or sets 技能等级。可选，默认为 0。
+        /// Gets or sets 技能等级。可选，默认为 -1。
         /// </summary>
-        [JsonProperty("skill_level")]
-        public int SkillLevel { get; set; }
+        [DefaultValue(-1)]
+        [JsonProperty("skill_level", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public int SkillLevel { get; set; } = -1;
 
         /// <summary>
         /// Gets or sets 模组编号。可选，默认为 -1。
         /// </summary>
-        [JsonProperty("module")]
+        [DefaultValue(-1)]
+        [JsonProperty("module", DefaultValueHandling = DefaultValueHandling.Ignore)]
         public int Module { get; set; } = -1;
         /*
         /// <summary>
         /// Gets or sets 模组编号。可选，默认为 -1。
         /// </summary>
+        [DefaultValue(-1)]
         [JsonProperty("module_level")]
-        public int ModuleLevel { get; set; } = 0;
+        public int ModuleLevel { get; set; } = -1;
         */
 
         /// <summary>
-        /// Gets or sets 潜能要求。可选，默认为 0。
+        /// Gets or sets 潜能要求。可选，默认为 -1。
         /// </summary>
-        [JsonProperty("potentiality")]
-        public int Potentiality { get; set; }
+        [DefaultValue(-1)]
+        [JsonProperty("potentiality", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public int Potentiality { get; set; } = -1;
     }
 
     [Flags]

--- a/src/MaaWpfGui/Models/Copilot/CopilotModel.cs
+++ b/src/MaaWpfGui/Models/Copilot/CopilotModel.cs
@@ -124,7 +124,7 @@ public class CopilotModel : CopilotBase
         // 模组编号 -1: 不切换模组 / 无要求, 0: 不使用模组, 1: 模组χ, 2: 模组γ, 3: 模组α, 4: 模组Δ
         return req.Module switch {
             0 => $"{LocalizationHelper.GetString("CopilotWithoutModule")}",
-            1 or 2 or 3 or 4 => $"{LocalizationHelper.GetString("CopilotModule")} {moduleName[req.Module]}",
+            1 or 2 or 3 or 4 => $"{LocalizationHelper.GetString("CopilotModule")} {moduleName[req.Module ?? 0]}",
             _ => string.Empty,
         };
     }
@@ -300,7 +300,7 @@ public class CopilotModel : CopilotBase
         /// Gets or sets 精英化等级。可选，默认为 0, 不要求精英化等级。
         /// </summary>
         [JsonProperty("elite")]
-        public int Elite { get; set; }
+        public int? Elite { get; set; }
 
         /// <summary>
         /// Gets or sets 干员等级。可选，默认为 0。
@@ -312,13 +312,13 @@ public class CopilotModel : CopilotBase
         /// Gets or sets 技能等级。可选，默认为 0。
         /// </summary>
         [JsonProperty("skill_level")]
-        public int SkillLevel { get; set; }
+        public int? SkillLevel { get; set; }
 
         /// <summary>
         /// Gets or sets 模组编号。可选，默认为 -1。
         /// </summary>
         [JsonProperty("module")]
-        public int Module { get; set; } = -1;
+        public int? Module { get; set; }
         /*
         /// <summary>
         /// Gets or sets 模组编号。可选，默认为 -1。

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -1390,7 +1390,9 @@ Right-click to clear inactive jobs</system:String>
     <system:String x:Key="DrawCard">Deploy Operator</system:String>
     <system:String x:Key="CheckIfStartOver">Check If Restart</system:String>
     <system:String x:Key="UnsupportedLevel">Unsupported stage, please check the stage name or go to ｢{key=Settings} - {key=UpdateSettings} - {key=ResourceUpdate}｣ and try updating the resource version!</system:String>
-    <system:String x:Key="UnsupportedSkill">{0} does not support Skill {1}, so the Skill will no longer be selected.</system:String>
+    <system:String x:Key="Copilot.UnsupportedSkill">{0} does not support Skill {1}, so the Skill will no longer be selected.</system:String>
+    <system:String x:Key="Copilot.EliteEmpty">{0} No Elite Level requirement was set, but the requirement for other attributes is Elite {1}; this has been auto-filled.</system:String>
+    <system:String x:Key="Copilot.EliteAjust">{0} Was set to require Elite {1}, but the requirement for other attributes is Elite {2}; this has been auto-adjusted.</system:String>
     <system:String x:Key="RecruitTagsDetected" xml:space="preserve">Identification results:&#160;</system:String>
     <system:String x:Key="ConnectFailed">Connection Failed</system:String>
     <system:String x:Key="TryToReconnectByAdb">Attempting to reconnect</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -1391,7 +1391,9 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="DrawCard">オペレーター配分</system:String>
     <system:String x:Key="CheckIfStartOver">再開確認</system:String>
     <system:String x:Key="UnsupportedLevel">サポートされていないステージです。ステージ名を確認するか、 ｢{key=Settings} - {key=UpdateSettings} - {key=ResourceUpdate}｣ に移動してリソースバージョンを更新してみてください！</system:String>
-    <system:String x:Key="UnsupportedSkill">{0} のスキル {1} はサポートされないので、スキルを選択されなくなります。</system:String>
+    <system:String x:Key="Copilot.UnsupportedSkill">{0} のスキル {1} はサポートされないので、スキルを選択されなくなります。</system:String>
+    <system:String x:Key="Copilot.EliteEmpty">{0} エリートレベルの要件は設定されていませんでしたが、他の属性の要件はエリート{1}です。これは自動入力されました。</system:String>
+    <system:String x:Key="Copilot.EliteAjust">{0} エリート{1}の要件が設定されていましたが、他の属性の要件はエリート{2}です。これは自動調整されました。</system:String>
     <system:String x:Key="RecruitTagsDetected" xml:space="preserve">認識結果: </system:String>
     <system:String x:Key="ConnectFailed">接続失敗</system:String>
     <system:String x:Key="TryToReconnectByAdb">再接続を試みています</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -1392,7 +1392,9 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="DrawCard">오퍼레이터 배치</system:String>
     <system:String x:Key="CheckIfStartOver">재시작 여부 확인</system:String>
     <system:String x:Key="UnsupportedLevel">지원되지 않는 스테이지입니다. 스테이지 이름을 확인하거나 ｢{key=Settings} - {key=UpdateSettings} - {key=ResourceUpdate}｣ 로 이동하여 리소스 버전을 업데이트해 보세요!</system:String>
-    <system:String x:Key="UnsupportedSkill">{0}은 {1} 스킬을 지원하지 않으므로, 스킬이 선택되지 않음</system:String>
+    <system:String x:Key="Copilot.UnsupportedSkill">{0}은 {1} 스킬을 지원하지 않으므로, 스킬이 선택되지 않음</system:String>
+    <system:String x:Key="Copilot.EliteEmpty">{0} 엘리트 레벨 요구 사항이 설정되지 않았지만, 다른 속성에 대한 요구 사항은 엘리트 {1}입니다. 이 값은 자동으로 채워졌습니다.</system:String>
+    <system:String x:Key="Copilot.EliteAjust">{0} 엘리트 {1}을 요구하도록 설정되었지만, 다른 속성에 대한 요구 사항은 엘리트 {2}입니다. 이 값은 자동으로 조정되었습니다.</system:String>
     <system:String x:Key="RecruitTagsDetected" xml:space="preserve">인식 결과: </system:String>
     <system:String x:Key="ConnectFailed">연결 실패</system:String>
     <system:String x:Key="TryToReconnectByAdb">재접속을 시도하고 있습니다</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -1391,7 +1391,9 @@ C:\\leidian\\LDPlayer9。\n
     <system:String x:Key="DrawCard">调配干员</system:String>
     <system:String x:Key="CheckIfStartOver">检查是否重开</system:String>
     <system:String x:Key="UnsupportedLevel">不支持的关卡，请检查关卡名或前往 ｢{key=Settings} - {key=UpdateSettings} - {key=ResourceUpdate}｣ 尝试更新资源版本！</system:String>
-    <system:String x:Key="UnsupportedSkill">{0} 不支持技能 {1}, 不再选择技能</system:String>
+    <system:String x:Key="Copilot.UnsupportedSkill">{0} 不支持技能 {1}, 不再选择技能</system:String>
+    <system:String x:Key="Copilot.EliteEmpty">{0} 未设置精英等级要求, 但其他属性要求 精{1}, 已自动补全</system:String>
+    <system:String x:Key="Copilot.EliteAjust">{0} 设置为要求 精{1}, 但是其他属性要求 精{2}, 已自动调整</system:String>
     <system:String x:Key="RecruitTagsDetected" xml:space="preserve">识别结果: </system:String>
     <system:String x:Key="ConnectFailed">连接失败</system:String>
     <system:String x:Key="TryToReconnectByAdb">正在尝试重连</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -1391,7 +1391,9 @@ C:\\leidian\\LDPlayer9\n
     <system:String x:Key="DrawCard">調配幹員</system:String>
     <system:String x:Key="CheckIfStartOver">檢查是否重開</system:String>
     <system:String x:Key="UnsupportedLevel">不支援的關卡，請檢查關卡名稱或前往 ｢{key=Settings} - {key=UpdateSettings} - {key=ResourceUpdate}｣ 嘗試更新資源版本！</system:String>
-    <system:String x:Key="UnsupportedSkill">{0} 不支援技能 {1}, 不再選擇技能</system:String>
+    <system:String x:Key="Copilot.UnsupportedSkill">{0} 不支援技能 {1}, 不再選擇技能</system:String>
+    <system:String x:Key="Copilot.EliteEmpty">{0} 未設定精英等級要求, 但其他屬性要求 精{1}, 已自動補全</system:String>
+    <system:String x:Key="Copilot.EliteAjust">{0} 設定為要求 精{1}, 但是其他屬性需求 精{2}, 已自動調整</system:String>
     <system:String x:Key="RecruitTagsDetected" xml:space="preserve">辨識結果：</system:String>
     <system:String x:Key="ConnectFailed">連線失敗</system:String>
     <system:String x:Key="TryToReconnectByAdb">正在嘗試重連</system:String>

--- a/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
@@ -1158,24 +1158,44 @@ public partial class CopilotViewModel : Screen
             }
         }
 
+        bool is_corrected = false;
         var list = copilot.Opers.Concat(copilot.Groups.SelectMany(g => g.Opers)).ToList();
         foreach (var oper in list)
         {
             int rarity = DataHelper.GetCharacterByNameOrAlias(oper.Name)?.Rarity ?? -1;
-            if (oper.Skill == 3 && rarity < 6)
+            switch (oper.Skill)
             {
-                AddLog(LocalizationHelper.GetStringFormat("UnsupportedSkill", DataHelper.GetLocalizedCharacterName(oper.Name) ?? oper.Name, oper.Skill), UiLogColor.Warning, showTime: false);
-                oper.Skill = 0;
+                case 3 when rarity < 6:
+                case 2 when rarity < 4:
+                case 1 when rarity < 3:
+                    AddLog(LocalizationHelper.GetStringFormat("Copilot.UnsupportedSkill", DataHelper.GetLocalizedCharacterName(oper.Name) ?? oper.Name, oper.Skill), UiLogColor.Warning, showTime: false);
+                    is_corrected = true;
+                    oper.Skill = 0;
+                    break;
             }
-            else if (oper.Skill == 2 && rarity < 4)
+            int skillElite = oper.Skill - 1;
+            int skilLevelElite = oper.Requirements?.SkillLevel switch {
+                <= 4 => 0,
+                <= 7 => 1,
+                <= 10 => 2,
+                _ => 0,
+            };
+            int moduleElite = oper.Requirements?.Module > 0 ? 2 : 0;
+            int eliteReq = Math.Max(skillElite, Math.Max(skilLevelElite, moduleElite));
+            if (eliteReq > 0)
             {
-                AddLog(LocalizationHelper.GetStringFormat("UnsupportedSkill", DataHelper.GetLocalizedCharacterName(oper.Name) ?? oper.Name, oper.Skill), UiLogColor.Warning, showTime: false);
-                oper.Skill = 0;
-            }
-            else if (oper.Skill == 1 && rarity < 3)
-            {
-                AddLog(LocalizationHelper.GetStringFormat("UnsupportedSkill", DataHelper.GetLocalizedCharacterName(oper.Name) ?? oper.Name, oper.Skill), UiLogColor.Warning, showTime: false);
-                oper.Skill = 0;
+                if (oper.Requirements is null || oper.Requirements.Elite is null)
+                {
+                    oper.Requirements ??= new();
+                    oper.Requirements.Elite = eliteReq;
+                    AddLog(LocalizationHelper.GetStringFormat("Copilot.EliteEmpty", DataHelper.GetLocalizedCharacterName(oper.Name) ?? oper.Name, eliteReq), UiLogColor.Info, showTime: false);
+                }
+                else if (oper.Requirements.Elite < eliteReq)
+                {
+                    AddLog(LocalizationHelper.GetStringFormat("Copilot.EliteAjust", DataHelper.GetLocalizedCharacterName(oper.Name) ?? oper.Name, oper.Requirements.Elite, eliteReq), UiLogColor.Warning, showTime: false);
+                    oper.Requirements.Elite = eliteReq;
+                    is_corrected = true;
+                }
             }
         }
         if (printInfo)
@@ -1219,10 +1239,10 @@ public partial class CopilotViewModel : Screen
             switch (copilot.Difficulty)
             {
                 case CopilotModel.DifficultyFlags.None:
-                    await AddCopilotTaskToList(copilot, CopilotModel.DifficultyFlags.Normal, navigateName, copilotId);
+                    await AddCopilotTaskToList(copilot, CopilotModel.DifficultyFlags.Normal, navigateName, is_corrected ? default : copilotId);
                     break;
                 default:
-                    await AddCopilotTaskToList(copilot, copilot.Difficulty, navigateName, copilotId);
+                    await AddCopilotTaskToList(copilot, copilot.Difficulty, navigateName, is_corrected ? default : copilotId);
                     break;
             }
         }

--- a/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
@@ -1230,7 +1230,8 @@ public partial class CopilotViewModel : Screen
         {
             try
             {
-                await File.WriteAllTextAsync(TempCopilotFile, JsonConvert.SerializeObject(copilot, Formatting.Indented));
+                var json = JsonConvert.SerializeObject(copilot, Formatting.Indented, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore, });
+                await File.WriteAllTextAsync(TempCopilotFile, json);
             }
             catch
             {


### PR DESCRIPTION
## 由 Sourcery 提供的总结

将 copilot 干员解析重构为共享的辅助函数，并确保精英等级需求能从所选技能中推断出来。

功能改进：
- 引入可复用的 `parse_oper_usage` 辅助函数，用于在 copilot 配置中解析干员用法，并将其应用到单个和分组的干员定义中。
- 根据所选技能索引自动调整干员精英要求，以与技能选择约束保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor copilot operator parsing to a shared helper and ensure elite level requirements are inferred from selected skills.

Enhancements:
- Introduce a reusable parse_oper_usage helper for operator usage parsing in copilot configuration and apply it to both single and grouped operator definitions.
- Automatically adjust operator elite requirements based on the selected skill index to maintain consistency with skill selection constraints.

</details>