### PR TITLE
Release v6.15.0-beta.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,7 @@
 
 #### MuMu 模拟器触控增强
 
-新增 MuMu 外置渲染器触控模式（实验性）：在启用截图增强的基础上可勾选「同时用于触控」，通过 MuMu IPC 直连输入并支持后台保活稳定运行；低版本或失败时自动回退至既有触控通路。需 MuMuManager 6.3.2 及以上。
-
-#### 配置迁移至 gui.new.json
-
-GUI 配置正式迁移至 `gui.new.json`，后续版本将不再使用 `gui.json`；配合 WPF 配置体系全量迁移至强类型 JSON，统一管理外部通知、性能、远程控制等设置，提升配置可靠性与可维护性。
+新增 MuMu 触控增强模式（实验性）：在启用截图增强的基础上可在触控模式中直接选择「MuMu 触控增强」，通过 MuMu IPC 直连输入并支持后台保活稳定运行；连接后自动检测触控是否实际生效，不支持时停止任务并提示用户。需 MuMu 模拟器 6.3.2 及以上。
 
 <details>
 <summary><b>English</b></summary>
@@ -31,11 +27,7 @@ Added a Depot Maintain task that supports multiple plans within a single task, f
 
 #### MuMu Emulator Touch Enhancement
 
-Added experimental MuMu external-renderer touch mode: with screenshot extras enabled, you can also enable touch via MuMu IPC for stable background keep-alive operation, with automatic fallback to existing touch paths on older versions or failure. Requires MuMuManager 6.3.2 or later.
-
-#### Configuration Migration to gui.new.json
-
-GUI configuration has been migrated to `gui.new.json`; future versions will no longer use `gui.json`. Combined with the full WPF configuration migration to strongly typed JSON (covering external notification, performance, remote control, and more), this improves reliability and maintainability.
+Added experimental MuMu touch enhancement mode: with screenshot extras enabled, you can directly select "MuMu Touch" in the touch mode dropdown for stable background keep-alive operation via MuMu IPC, with automatic detection of touch availability that stops the task and notifies the user if unsupported. Requires MuMu emulator 6.3.2 or later.
 
 </details>
 
@@ -48,7 +40,7 @@ GUI configuration has been migrated to `gui.new.json`; future versions will no l
 
 ### 新增 | New
 
-* 支持 MuMu 模拟器触控增强（实验性，需 MuMuManager 6.3.2+；在截图增强下可勾选同时用于触控，支持后台保活，失败时自动回退） ([#17425](https://github.com/MaaAssistantArknights/MaaAssistantArknights/pull/17425)) @MistEO
+* 新增 MuMu 触控增强模式（实验性）：在截图增强启用时可在触控模式下直接选择「MuMu 触控增强」，通过 MuMu IPC 直连输入并支持后台保活稳定运行 ([#17425](https://github.com/MaaAssistantArknights/MaaAssistantArknights/pull/17425)) @MistEO @ABA2396
 * 库存保持任务支持使用 AUTO 代理倍率，并在游戏更新后倍战锁定期间同步禁用该选项 @ABA2396
 * 任务队列支持按住 Ctrl 点击清空以移除全部任务 @status102
 
@@ -56,6 +48,8 @@ GUI configuration has been migrated to `gui.new.json`; future versions will no l
 
 * 增强跨平台 `call_command` 实现（工作目录、超时与管道/进程清理），避免子进程输出读取卡死 @MistEO
 * 完善 MuMu Extras 包名与 display id 解析，缺失客户端类型时回退至有效默认值 @MistEO
+* 优化连接设置页面布局，缩减各控件间距并调整对齐方式 @ABA2396
+* 当 MuMu 后台保活开启但触控增强未实际生效时，直接停止任务并提示用户，避免进入无法操作的后台状态 @ABA2396
 
 ### 修复 | Fix
 

--- a/src/MaaCore/Controller/MumuController.cpp
+++ b/src/MaaCore/Controller/MumuController.cpp
@@ -40,6 +40,15 @@ bool MumuController::connect(const std::string& adb_path, const std::string& add
         if (mumu_width == m_width && mumu_height == m_height) {
             m_mumu_input_ready = true;
             LogInfo << "MuMu extras input is ready" << VAR(m_width) << VAR(m_height);
+
+            // 通知 GUI：MuMu 触控增强已实际生效
+            json::value input_info = json::object {
+                { "uuid", m_uuid },
+                { "what", "MuMuExtrasInputStatus" },
+                { "details", json::object { { "available", true } } },
+            };
+            callback(AsstMsg::ConnectionInfo, input_info);
+
             return true;
         }
         LogWarn << "MuMu display size mismatches adb screen size" << VAR(mumu_width) << VAR(mumu_height) << VAR(m_width)
@@ -47,6 +56,14 @@ bool MumuController::connect(const std::string& adb_path, const std::string& add
     }
 
     LogInfo << "MuMu extras input is not available, fallback to maatouch";
+
+    // 通知 GUI：MuMu 触控增强未生效（版本不支持或路径错误等），已降级
+    json::value input_info = json::object {
+        { "uuid", m_uuid },
+        { "what", "MuMuExtrasInputStatus" },
+        { "details", json::object { { "available", false } } },
+    };
+    callback(AsstMsg::ConnectionInfo, input_info);
 
     m_minitouch_available = probe_minitouch();
     if (!m_minitouch_available) {

--- a/src/MaaWpfGui/Constants/Enums/TouchMode.cs
+++ b/src/MaaWpfGui/Constants/Enums/TouchMode.cs
@@ -17,22 +17,28 @@ namespace MaaWpfGui.Constants.Enums;
 
 public enum TouchMode
 {
+    /// <summary>
+    /// MiniTouch 触控模式，适用于大多数设备，默认。
+    /// </summary>
     MiniTouch,
-    MaaTouch,
-    Adb,
-    MaaFwAdb,
-}
 
-public static class TouchModeExtensions
-{
-    public static string ToCustomString(this TouchMode touchMode)
-    {
-        return touchMode switch {
-            TouchMode.MiniTouch => "minitouch",
-            TouchMode.MaaTouch => "maatouch",
-            TouchMode.Adb => "adb",
-            TouchMode.MaaFwAdb => "MaaFwAdb",
-            _ => throw new ArgumentOutOfRangeException(nameof(touchMode), touchMode, null),
-        };
-    }
+    /// <summary>
+    /// MaaTouch 触控模式，适用于部分设备，雷电模拟器用可能会有拖动问题。
+    /// </summary>
+    MaaTouch,
+
+    /// <summary>
+    /// Adb 触控模式，适用于部分设备，巨几把慢。
+    /// </summary>
+    Adb,
+
+    /// <summary>
+    /// MaaFwAdb 触控模式。
+    /// </summary>
+    MaaFwAdb,
+
+    /// <summary>
+    /// MuMu external renderer IPC 触控，仅截图增强启用时可选。
+    /// </summary>
+    MumuExtras,
 }

--- a/src/MaaWpfGui/Extensions/ApplicationExtensions.cs
+++ b/src/MaaWpfGui/Extensions/ApplicationExtensions.cs
@@ -13,7 +13,7 @@
 
 using System.Windows;
 
-namespace MaaWpfGui.Helper;
+namespace MaaWpfGui.Extensions;
 
 internal static class ApplicationExtensions
 {

--- a/src/MaaWpfGui/Extensions/BitmapImageExtensions.cs
+++ b/src/MaaWpfGui/Extensions/BitmapImageExtensions.cs
@@ -15,7 +15,7 @@ using System.IO;
 using System.Linq;
 using System.Windows.Media.Imaging;
 
-namespace MaaWpfGui.Helper;
+namespace MaaWpfGui.Extensions;
 
 public static class BitmapImageExtensions
 {

--- a/src/MaaWpfGui/Extensions/ClientTypeExtension.cs
+++ b/src/MaaWpfGui/Extensions/ClientTypeExtension.cs
@@ -15,8 +15,9 @@
 using System;
 using System.Collections.Generic;
 using System.Text;
+using MaaWpfGui.Constants.Enums;
 
-namespace MaaWpfGui.Constants.Enums;
+namespace MaaWpfGui.Extensions;
 
 public static class ClientTypeExtension
 {

--- a/src/MaaWpfGui/Extensions/TouchModeExtensions.cs
+++ b/src/MaaWpfGui/Extensions/TouchModeExtensions.cs
@@ -1,0 +1,32 @@
+// <copyright file="TouchModeExtensions.cs" company="MaaAssistantArknights">
+// Part of the MaaWpfGui project, maintained by the MaaAssistantArknights team (Maa Team)
+// Copyright (C) 2021-2025 MaaAssistantArknights Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License v3.0 only as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY
+// </copyright>
+#nullable enable
+using System;
+using MaaWpfGui.Constants.Enums;
+
+namespace MaaWpfGui.Extensions;
+
+public static class TouchModeExtensions
+{
+    public static string ToCustomString(this TouchMode touchMode)
+    {
+        return touchMode switch {
+            TouchMode.MiniTouch => "minitouch",
+            TouchMode.MaaTouch => "maatouch",
+            TouchMode.Adb => "adb",
+            TouchMode.MaaFwAdb => "MaaFwAdb",
+            TouchMode.MumuExtras => "MumuExtras",
+            _ => throw new ArgumentOutOfRangeException(nameof(touchMode), touchMode, null),
+        };
+    }
+}

--- a/src/MaaWpfGui/Helper/DataHelper.cs
+++ b/src/MaaWpfGui/Helper/DataHelper.cs
@@ -19,6 +19,7 @@ using System.IO;
 using System.Linq;
 using MaaWpfGui.Configuration.Factory;
 using MaaWpfGui.Constants.Enums;
+using MaaWpfGui.Extensions;
 using MaaWpfGui.ViewModels.UI;
 using MaaWpfGui.ViewModels.UserControl.Settings;
 using Newtonsoft.Json;

--- a/src/MaaWpfGui/Helper/ItemListHelper.cs
+++ b/src/MaaWpfGui/Helper/ItemListHelper.cs
@@ -22,6 +22,7 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using MaaWpfGui.Configuration.Factory;
 using MaaWpfGui.Constants.Enums;
+using MaaWpfGui.Extensions;
 using MaaWpfGui.Models;
 using Serilog;
 

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -779,6 +779,11 @@ public class AsstProxy
     private string _connectedAddress = string.Empty;
     private string _lastConnectionError = string.Empty;
 
+    /// <summary>
+    /// MuMu 触控增强是否实际生效（由 core 连接后通过 MuMuExtrasInputStatus 回调报告）。
+    /// </summary>
+    private bool _mumuExtrasInputAvailable;
+
     private void ProcConnectInfo(JObject details)
     {
         var what = details["what"]?.ToString() ?? string.Empty;
@@ -790,32 +795,6 @@ public class AsstProxy
                 _connectedAddress = details["details"]!["address"]!.ToString();
                 SettingsViewModel.ConnectSettings.ConnectAddress = _connectedAddress;
                 _lastConnectionError = string.Empty;
-
-                // 检测 MuMu 后台保活是否开启（异步执行，避免阻塞 UI 线程）
-                if (SettingsViewModel.ConnectSettings.ConnectConfig == ConnectConfig.MuMuEmulator12)
-                {
-                    _ = Task.Run(() => {
-                        if (!EmulatorHelper.CheckMuMuKeepAlive())
-                        {
-                            return;
-                        }
-
-                        // 截图增强 + 触控均已开启时，MuMu extras 可在后台保活下稳定工作
-                        var fullExtras = SettingsViewModel.ConnectSettings.ExtraConfig is MuMu12Extra { Enable: true, EnableTouch: true };
-                        if (fullExtras)
-                        {
-                            Instances.TaskQueueViewModel.AddLog(
-                                LocalizationHelper.GetString("MuMuEmulator12FullExtrasReady"),
-                                UiLogColor.Rainbow);
-                        }
-                        else
-                        {
-                            Instances.TaskQueueViewModel.AddLog(
-                                LocalizationHelper.GetString("MuMuEmulator12KeepAliveOn"),
-                                UiLogColor.Info);
-                        }
-                    });
-                }
 
                 break;
 
@@ -841,6 +820,11 @@ public class AsstProxy
                         Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("ResolutionInfoYoStarEN"), UiLogColor.Error);
                     }
                 }
+                break;
+
+            case "MuMuExtrasInputStatus":
+                // core 连接后报告 MuMu 触控增强是否实际生效
+                _mumuExtrasInputAvailable = details["details"]?["available"]?.ToObject<bool>() ?? false;
                 break;
 
             case "ResolutionError":
@@ -928,6 +912,18 @@ public class AsstProxy
                                 break;
                             }
 
+                            // 保活开启但触控未生效 → 后台保活下无法操作，直接停止
+                            if (!_mumuExtrasInputAvailable && EmulatorHelper.CheckMuMuKeepAlive())
+                            {
+                                Instances.TaskQueueViewModel.AddLog(
+                                    LocalizationHelper.GetString("MuMuEmulator12KeepAliveOn"),
+                                    UiLogColor.Error);
+                                Instances.CopilotViewModel.AddLog(
+                                    LocalizationHelper.GetString("MuMuEmulator12KeepAliveOn"),
+                                    UiLogColor.Error, showTime: false);
+                                needToStop = true;
+                            }
+
                             if (method != "MumuExtras")
                             {
                                 Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("MuMuExtrasNotEnabledMessage"), UiLogColor.Error);
@@ -937,6 +933,14 @@ public class AsstProxy
                             else if (timeCost < 100)
                             {
                                 color = UiLogColor.MuMuSpecialScreenshot;
+
+                                // 截图 + 触控均生效，完整增强就绪
+                                if (_mumuExtrasInputAvailable)
+                                {
+                                    Instances.TaskQueueViewModel.AddLog(
+                                        LocalizationHelper.GetString("MuMuEmulator12FullExtrasReady"),
+                                        UiLogColor.Rainbow);
+                                }
                             }
 
                             break;

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -2637,12 +2637,6 @@ public class AsstProxy
         if (ConnectSettingsUserControlModel.Instance.ExtraConfig is MuMu12Extra mumu12)
         {
             AsstSetConnectionExtrasMuMu(mumu12.Config);
-
-            // 勾了「同时用于触控」时 EffectiveTouchMode 会给出 MumuExtras，
-            // 模拟器实际不支持时 core 会自己降级回 maatouch
-            AsstSetInstanceOption(
-                InstanceOptionKey.TouchMode,
-                ConnectSettingsUserControlModel.Instance.EffectiveTouchMode);
         }
         else if (ConnectSettingsUserControlModel.Instance.ExtraConfig is LDPlayerExtra ldPlayer)
         {

--- a/src/MaaWpfGui/Models/AsstTasks/AsstCloseDownTask.cs
+++ b/src/MaaWpfGui/Models/AsstTasks/AsstCloseDownTask.cs
@@ -13,6 +13,7 @@
 
 #nullable enable
 using MaaWpfGui.Constants.Enums;
+using MaaWpfGui.Extensions;
 using MaaWpfGui.Services;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;

--- a/src/MaaWpfGui/Models/AsstTasks/AsstFightTask.cs
+++ b/src/MaaWpfGui/Models/AsstTasks/AsstFightTask.cs
@@ -14,6 +14,7 @@
 #nullable enable
 using System.Collections.Generic;
 using MaaWpfGui.Constants.Enums;
+using MaaWpfGui.Extensions;
 using MaaWpfGui.Services;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;

--- a/src/MaaWpfGui/Models/AsstTasks/AsstStartUpTask.cs
+++ b/src/MaaWpfGui/Models/AsstTasks/AsstStartUpTask.cs
@@ -14,6 +14,7 @@
 #nullable enable
 using System.ComponentModel;
 using MaaWpfGui.Constants.Enums;
+using MaaWpfGui.Extensions;
 using MaaWpfGui.Services;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;

--- a/src/MaaWpfGui/Models/EmulatorConnectionExtra/MuMu12Extra.cs
+++ b/src/MaaWpfGui/Models/EmulatorConnectionExtra/MuMu12Extra.cs
@@ -251,7 +251,16 @@ public class MuMu12Extra() : ExtraConfig, IJsonOnDeserialized
                 return;
             }
 
-            ConnectSettingsUserControlModel.Instance.TouchMode = value ? TouchMode.MumuExtras : TouchMode.MiniTouch;
+            if (value)
+            {
+                ConnectSettingsUserControlModel.Instance.TouchMode = TouchMode.MumuExtras;
+            }
+            else if (ConnectSettingsUserControlModel.Instance.TouchMode == TouchMode.MumuExtras)
+            {
+                // 仅在当前仍处于 MuMu 触控时才回退到默认，
+                // 避免用户主动切换到其他触控模式时被覆盖
+                ConnectSettingsUserControlModel.Instance.TouchMode = TouchMode.MiniTouch;
+            }
         }
     }
 

--- a/src/MaaWpfGui/Models/EmulatorConnectionExtra/MuMu12Extra.cs
+++ b/src/MaaWpfGui/Models/EmulatorConnectionExtra/MuMu12Extra.cs
@@ -19,6 +19,7 @@ using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using System.Windows;
 using MaaWpfGui.Constants.Enums;
+using MaaWpfGui.Extensions;
 using MaaWpfGui.Helper;
 using MaaWpfGui.ViewModels.UI;
 using MaaWpfGui.ViewModels.UserControl.Settings;
@@ -66,6 +67,8 @@ public class MuMu12Extra() : ExtraConfig, IJsonOnDeserialized
                 AutoDetectEmulatorPath();
             }
 
+            // 通知 ConnectSettings 动态增删触控模式下拉项并自动切换
+            ConnectSettingsUserControlModel.Instance.OnMuMuExtrasEnableChanged(value);
             Instances.AsstProxy.Connected = false;
         }
     }
@@ -236,6 +239,7 @@ public class MuMu12Extra() : ExtraConfig, IJsonOnDeserialized
 
     /// <summary>
     /// Gets or sets a value indicating whether MuMu extras is also used for touch input, not just screencap.
+    /// 勾选时自动切换触控模式为 MuMu 触控，取消勾选时回到默认 Minitouch。
     /// </summary>
     [JsonIgnore]
     public bool EnableTouch
@@ -247,9 +251,7 @@ public class MuMu12Extra() : ExtraConfig, IJsonOnDeserialized
                 return;
             }
 
-            // 立刻把 TouchMode 同步给 core，取消勾选时会自动还原成用户选的模式
-            ConnectSettingsUserControlModel.Instance.UpdateInstanceSettings();
-            Instances.AsstProxy.Connected = false;
+            ConnectSettingsUserControlModel.Instance.TouchMode = value ? TouchMode.MumuExtras : TouchMode.MiniTouch;
         }
     }
 

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -522,6 +522,7 @@ If you are concerned about leftover entries, please disable this option before d
     <system:String x:Key="MaaTouchMode">MaaTouch (Experimental)</system:String>
     <system:String x:Key="AdbTouchMode">ADB Input (Deprecated)</system:String>
     <system:String x:Key="MaaFwAdbTouchMode">MaaFramework (Experimental)</system:String>
+    <system:String x:Key="MumuExtrasTouchMode">MuMu Touch (Experimental)</system:String>
     <system:String x:Key="TouchModeTip" xml:space="preserve">ADB Input is for physical devices running an older OS version that cannot use Minitouch or MaaTouch. Do not use ADB Input if the other two modes work.&#10;ADB Input swipes tend to drift. To avoid this, swipe speed is set very slow and swipe distances differ from the other two modes. It cannot be used in scenarios requiring precise coordinate control.</system:String>
     <system:String x:Key="AdditionCommand">Additional command arguments</system:String>
     <system:String x:Key="AdditionCommandTip" xml:space="preserve">Additional commands for emulator parameters (e.g. ｢--instance 1｣ for instance 1).&#10;Command formats vary by emulator, typically including instance numbers and window modes, please consult your emulator's documentation.</system:String>
@@ -722,7 +723,7 @@ Note:
     <system:String x:Key="MuMu12Index">Instance Number</system:String>
     <system:String x:Key="MuMu12Display">Display Number</system:String>
     <system:String x:Key="MuMuExtrasNotEnabledMessage">Mumu screenshot enhancement not enabled, please check related settings</system:String>
-    <system:String x:Key="MuMuEmulator12KeepAliveOn">MuMu background keep-alive is on. To run stably in the background, enable both "MuMu screenshot enhancement" and "MuMu touch" in Settings.</system:String>
+    <system:String x:Key="MuMuEmulator12KeepAliveOn">MuMu background keep-alive is on. To run stably in the background, enable both ｢{key=MuMu12ExtrasEnabled}｣ and ｢{key=MuMuExtrasTouchEnabled}｣ in Settings.</system:String>
     <system:String x:Key="MuMuEmulator12FullExtrasReady">Full MuMu enhancement online — screenshot &amp; touch dual-link engaged. Background keep-alive bows to our will!</system:String>
     <system:String x:Key="LdExtrasEnabled">Enable LD's screenshot enhancement mode</system:String>
     <system:String x:Key="LdPlayerEmulatorPathNotFound">LDPlayer emulator path not found.</system:String>

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -723,7 +723,7 @@ Note:
     <system:String x:Key="MuMu12Index">Instance Number</system:String>
     <system:String x:Key="MuMu12Display">Display Number</system:String>
     <system:String x:Key="MuMuExtrasNotEnabledMessage">Mumu screenshot enhancement not enabled, please check related settings</system:String>
-    <system:String x:Key="MuMuEmulator12KeepAliveOn">MuMu background keep-alive is on. To run stably in the background, enable both ｢{key=MuMu12ExtrasEnabled}｣ and ｢{key=MuMuExtrasTouchEnabled}｣ in Settings.</system:String>
+    <system:String x:Key="MuMuEmulator12KeepAliveOn">MuMu background keep-alive is on, but MuMu touch enhancement is not working. Operations are not possible under keep-alive. Please enable ｢{key=MuMuExtrasTouchEnabled}｣ or disable ｢Keep Alive in Background｣ in MuMu settings.</system:String>
     <system:String x:Key="MuMuEmulator12FullExtrasReady">Full MuMu enhancement online — screenshot &amp; touch dual-link engaged. Background keep-alive bows to our will!</system:String>
     <system:String x:Key="LdExtrasEnabled">Enable LD's screenshot enhancement mode</system:String>
     <system:String x:Key="LdPlayerEmulatorPathNotFound">LDPlayer emulator path not found.</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -724,7 +724,7 @@ C:\\Program Files\\Netease\\MuMuPlayer を入力してください。\n
     <system:String x:Key="MuMu12Index">インスタンス番号</system:String>
     <system:String x:Key="MuMu12Display">表示番号</system:String>
     <system:String x:Key="MuMuExtrasNotEnabledMessage">MuMu スクリーンショットの強化 が有効になっていません。関連する設定を確認してください</system:String>
-    <system:String x:Key="MuMuEmulator12KeepAliveOn">MuMu のバックグラウンド常駐が有効です。バックグラウンドで安定動作させるには、設定で ｢{key=MuMu12ExtrasEnabled}｣ と ｢{key=MuMuExtrasTouchEnabled}｣ の両方を有効にしてください。</system:String>
+    <system:String x:Key="MuMuEmulator12KeepAliveOn">MuMu のバックグラウンド常駐が有効ですが、MuMu タッチ強化が機能していません。バックグラウンド常駐下では操作できません。｢{key=MuMuExtrasTouchEnabled}｣ を有効にするか、MuMu 設定で ｢バックグラウンド常駐｣ を無効にしてください。</system:String>
     <system:String x:Key="MuMuEmulator12FullExtrasReady">完全 MuMu 強化が起動——スクリーンショットとタッチの双核直結が貫通、バックグラウンド常駐も我らが掌中に！</system:String>
     <system:String x:Key="LdExtrasEnabled">LD のスクリーンショット拡張モードを有効にする</system:String>
     <system:String x:Key="LdPlayerEmulatorPathNotFound">LDPlayer のインストールパスが見つかりません。</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -522,6 +522,7 @@ MAA は非インストール型のアプリケーションであり、レジス�
     <system:String x:Key="MaaTouchMode">MaaTouch (実験機能)</system:String>
     <system:String x:Key="AdbTouchMode">ADB Input (非推奨)</system:String>
     <system:String x:Key="MaaFwAdbTouchMode">MaaFramework (実験機能)</system:String>
+    <system:String x:Key="MumuExtrasTouchMode">MuMu タッチ (実験機能)</system:String>
     <system:String x:Key="TouchModeTip" xml:space="preserve">ADB Input は、OS バージョンが古く Minitouch や MaaTouch を使用できない物理デバイス用です。他の2モードが使える場合は、ADB Input を選択しないでください。&#10;ADB Input のスワイプはズレやすいため、スワイプ速度が非常に遅く設定され、スワイプ距離も他の2モードと異なります。正確な座標制御が必要な場面では使用できません。</system:String>
     <system:String x:Key="AdditionCommand">追加コマンド</system:String>
     <system:String x:Key="AdditionCommandTip" xml:space="preserve">エミュレーター起動パラメータの追加コマンド（例： ｢--instance 1｣ は 1 番インスタンス）。&#10;コマンド形式はエミュレーターにより異なり、通常はインスタンス番号やウィンドウモードなどを含みます。</system:String>
@@ -723,7 +724,7 @@ C:\\Program Files\\Netease\\MuMuPlayer を入力してください。\n
     <system:String x:Key="MuMu12Index">インスタンス番号</system:String>
     <system:String x:Key="MuMu12Display">表示番号</system:String>
     <system:String x:Key="MuMuExtrasNotEnabledMessage">MuMu スクリーンショットの強化 が有効になっていません。関連する設定を確認してください</system:String>
-    <system:String x:Key="MuMuEmulator12KeepAliveOn">MuMu のバックグラウンド常駐が有効です。バックグラウンドで安定動作させるには、設定で「MuMu スクリーンショット強化」と「MuMu タッチ」の両方を有効にしてください。</system:String>
+    <system:String x:Key="MuMuEmulator12KeepAliveOn">MuMu のバックグラウンド常駐が有効です。バックグラウンドで安定動作させるには、設定で ｢{key=MuMu12ExtrasEnabled}｣ と ｢{key=MuMuExtrasTouchEnabled}｣ の両方を有効にしてください。</system:String>
     <system:String x:Key="MuMuEmulator12FullExtrasReady">完全 MuMu 強化が起動——スクリーンショットとタッチの双核直結が貫通、バックグラウンド常駐も我らが掌中に！</system:String>
     <system:String x:Key="LdExtrasEnabled">LD のスクリーンショット拡張モードを有効にする</system:String>
     <system:String x:Key="LdPlayerEmulatorPathNotFound">LDPlayer のインストールパスが見つかりません。</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -724,7 +724,7 @@ C:\\Program Files\\Netease\\MuMuPlayer으로 입력해야 합니다.\n
     <system:String x:Key="MuMu12Index">인스턴스 번호</system:String>
     <system:String x:Key="MuMu12Display">표시 번호</system:String>
     <system:String x:Key="MuMuExtrasNotEnabledMessage">MuMu 스크린샷 강화 기능이 활성화되지 않았습니다. 관련 설정을 확인하세요</system:String>
-    <system:String x:Key="MuMuEmulator12KeepAliveOn">MuMu 백그라운드 유지가 켜져 있습니다. 백그라운드에서 안정적으로 실행하려면 설정에서 ｢{key=MuMu12ExtrasEnabled}｣ 와 ｢{key=MuMuExtrasTouchEnabled}｣ 를 모두 체크하세요.</system:String>
+    <system:String x:Key="MuMuEmulator12KeepAliveOn">MuMu 백그라운드 유지가 켜져 있지만 MuMu 터치 강화가 작동하지 않습니다. 백그라운드 유지 중에는 조작할 수 없습니다. ｢{key=MuMuExtrasTouchEnabled}｣ 를 활성화하거나 MuMu 설정에서 ｢백그라운드 유지｣ 를 비활성화하세요.</system:String>
     <system:String x:Key="MuMuEmulator12FullExtrasReady">완전한 MuMu 강화 가동——스크린샷과 터치 듀얼 링크 개통, 백그라운드 유지마저도 우리 손안에!</system:String>
     <system:String x:Key="LdExtrasEnabled">LD 스크린샷 강화 기능 활성화</system:String>
     <system:String x:Key="LdPlayerEmulatorPathNotFound">LDPlayer 에뮬레이터 경로를 찾을 수 없습니다.</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -522,6 +522,7 @@ MAA는 비설치형 응용 프로그램으로, 삭제 시 레지스트리 항목
     <system:String x:Key="MaaTouchMode">MaaTouch (실험적)</system:String>
     <system:String x:Key="AdbTouchMode">ADB Input (비권장)</system:String>
     <system:String x:Key="MaaFwAdbTouchMode">MaaFramework (실험적)</system:String>
+    <system:String x:Key="MumuExtrasTouchMode">MuMu 터치 (실험적)</system:String>
     <system:String x:Key="TouchModeTip" xml:space="preserve">ADB Input는 OS 버전이 낮아 Minitouch나 MaaTouch를 사용할 수 없는 물리적 기기용입니다. 다른 두 모드를 사용할 수 있다면 ADB Input를 선택하지 마세요.&#10;ADB Input 스와이프는 오프셋이 발생하기 쉬우며, 이 문제를 방지하기 위해 스와이프 속도가 매우 느리게 설정되고 스와이프 거리도 다른 두 모드와 다릅니다. 정확한 좌표 제어가 필요한 상황에서는 사용할 수 없습니다.</system:String>
     <system:String x:Key="AdditionCommand">추가 변수</system:String>
     <system:String x:Key="AdditionCommandTip" xml:space="preserve">에뮬레이터 실행 매개변수 추가 명령 (예: ｢--instance 1｣ 은 1 번 인스턴스).&#10;명령 형식은 에뮬레이터마다 다르며 일반적으로 인스턴스 번호나 창 모드 등을 포함합니다.</system:String>
@@ -723,7 +724,7 @@ C:\\Program Files\\Netease\\MuMuPlayer으로 입력해야 합니다.\n
     <system:String x:Key="MuMu12Index">인스턴스 번호</system:String>
     <system:String x:Key="MuMu12Display">표시 번호</system:String>
     <system:String x:Key="MuMuExtrasNotEnabledMessage">MuMu 스크린샷 강화 기능이 활성화되지 않았습니다. 관련 설정을 확인하세요</system:String>
-    <system:String x:Key="MuMuEmulator12KeepAliveOn">MuMu 백그라운드 유지가 켜져 있습니다. 백그라운드에서 안정적으로 실행하려면 설정에서 "MuMu 스크린샷 강화"와 "MuMu 터치"를 모두 체크하세요.</system:String>
+    <system:String x:Key="MuMuEmulator12KeepAliveOn">MuMu 백그라운드 유지가 켜져 있습니다. 백그라운드에서 안정적으로 실행하려면 설정에서 ｢{key=MuMu12ExtrasEnabled}｣ 와 ｢{key=MuMuExtrasTouchEnabled}｣ 를 모두 체크하세요.</system:String>
     <system:String x:Key="MuMuEmulator12FullExtrasReady">완전한 MuMu 강화 가동——스크린샷과 터치 듀얼 링크 개통, 백그라운드 유지마저도 우리 손안에!</system:String>
     <system:String x:Key="LdExtrasEnabled">LD 스크린샷 강화 기능 활성화</system:String>
     <system:String x:Key="LdPlayerEmulatorPathNotFound">LDPlayer 에뮬레이터 경로를 찾을 수 없습니다.</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -522,6 +522,7 @@ D:\
     <system:String x:Key="MaaTouchMode">MaaTouch（实验功能）</system:String>
     <system:String x:Key="AdbTouchMode">ADB Input（不推荐使用）</system:String>
     <system:String x:Key="MaaFwAdbTouchMode">MaaFramework（实验功能）</system:String>
+    <system:String x:Key="MumuExtrasTouchMode">MuMu 触控增强（实验功能）</system:String>
     <system:String x:Key="TouchModeTip" xml:space="preserve">ADB Input 用于兼容系统版本过低、无法运行 Minitouch 或 MaaTouch 的实体机设备。能用前两种模式时，不要选择 ADB Input。&#10;ADB Input 的滑动容易拖飞，为避免此问题，滑动速度会设置得非常慢，且滑动距离与前两种模式不同；在需要精确控制坐标的场景下无法使用。</system:String>
     <system:String x:Key="AdditionCommand">附加命令</system:String>
     <system:String x:Key="AdditionCommandTip" xml:space="preserve">附加命令用于指定模拟器启动参数（如 ｢--instance 1｣ 表示启动 1 号实例）。&#10;不同模拟器的命令格式不同，通常包括实例编号、窗口模式等参数，请参考您使用的模拟器文档</system:String>
@@ -723,7 +724,7 @@ C:\\Program Files\\Netease\\MuMuPlayer。\n
     <system:String x:Key="MuMu12Index">实例编号</system:String>
     <system:String x:Key="MuMu12Display">屏幕编号</system:String>
     <system:String x:Key="MuMuExtrasNotEnabledMessage">Mumu 截图增强未生效，请检查相关设置</system:String>
-    <system:String x:Key="MuMuEmulator12KeepAliveOn">检测到 MuMu 开启了后台保活。若要在后台稳定运行，请到设置中同时勾选「MuMu 截图增强」与「MuMu 触控」。</system:String>
+    <system:String x:Key="MuMuEmulator12KeepAliveOn">检测到 MuMu 开启了后台保活。若要在后台稳定运行，请到设置中勾选 ｢{key=MuMu12ExtrasEnabled}｣ 与 ｢{key=MuMuExtrasTouchEnabled}｣。</system:String>
     <system:String x:Key="MuMuEmulator12FullExtrasReady">完整 MuMu 增强已就位——截图与触控双核直连贯通，后台保活亦为我所用！</system:String>
     <system:String x:Key="LdExtrasEnabled">启用 LD 截图增强模式</system:String>
     <system:String x:Key="LdPlayerEmulatorPathNotFound">未找到 LDPlayer 模拟器路径。</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -724,7 +724,7 @@ C:\\Program Files\\Netease\\MuMuPlayer。\n
     <system:String x:Key="MuMu12Index">实例编号</system:String>
     <system:String x:Key="MuMu12Display">屏幕编号</system:String>
     <system:String x:Key="MuMuExtrasNotEnabledMessage">Mumu 截图增强未生效，请检查相关设置</system:String>
-    <system:String x:Key="MuMuEmulator12KeepAliveOn">检测到 MuMu 开启了后台保活。若要在后台稳定运行，请到设置中勾选 ｢{key=MuMu12ExtrasEnabled}｣ 与 ｢{key=MuMuExtrasTouchEnabled}｣。</system:String>
+    <system:String x:Key="MuMuEmulator12KeepAliveOn">检测到 MuMu 开启了后台保活，但 MuMu 触控增强未生效，在后台保活下无法操作。请勾选 ｢{key=MuMuExtrasTouchEnabled}｣ 或在 MuMu 设置中关闭 ｢后台保活｣（或 ｢应用保活｣ ｢后台挂机时保活运行｣ 等）。</system:String>
     <system:String x:Key="MuMuEmulator12FullExtrasReady">完整 MuMu 增强已就位——截图与触控双核直连贯通，后台保活亦为我所用！</system:String>
     <system:String x:Key="LdExtrasEnabled">启用 LD 截图增强模式</system:String>
     <system:String x:Key="LdPlayerEmulatorPathNotFound">未找到 LDPlayer 模拟器路径。</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -724,7 +724,7 @@ C:\\Program Files\\Netease\\MuMuPlayer\n
     <system:String x:Key="MuMu12Index">實例編號</system:String>
     <system:String x:Key="MuMu12Display">螢幕編號</system:String>
     <system:String x:Key="MuMuExtrasNotEnabledMessage">Mumu 截圖增強未生效，請檢查相關設定</system:String>
-    <system:String x:Key="MuMuEmulator12KeepAliveOn">偵測到 MuMu 開啟了背景保活。若要在背景穩定運行，請到設定中同時勾選 ｢{key=MuMu12ExtrasEnabled}｣ 與 ｢{key=MuMuExtrasTouchEnabled}｣。</system:String>
+    <system:String x:Key="MuMuEmulator12KeepAliveOn">偵測到 MuMu 開啟了背景保活，但 MuMu 觸控增強未生效，在背景保活下無法操作。請勾選 ｢{key=MuMuExtrasTouchEnabled}｣ 或在 MuMu 設定中關閉 ｢背景保活｣（或 ｢應用保活｣ ｢背景掛機時保活運行｣ 等）。</system:String>
     <system:String x:Key="MuMuEmulator12FullExtrasReady">完整 MuMu 增強已就位——截圖與觸控雙核直連貫通，背景保活亦為我所用！</system:String>
     <system:String x:Key="LdExtrasEnabled">啟用 LD 截圖增強模式</system:String>
     <system:String x:Key="LdPlayerEmulatorPathNotFound">找不到 LDPlayer 模擬器路徑。</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -522,6 +522,7 @@ D:\
     <system:String x:Key="MaaTouchMode">MaaTouch（實驗功能）</system:String>
     <system:String x:Key="AdbTouchMode">ADB Input（不推薦使用）</system:String>
     <system:String x:Key="MaaFwAdbTouchMode">MaaFramework（實驗功能）</system:String>
+    <system:String x:Key="MumuExtrasTouchMode">MuMu 觸控增強（實驗功能）</system:String>
     <system:String x:Key="TouchModeTip" xml:space="preserve">ADB Input 用於相容系統版本過低、無法運行 Minitouch 或 MaaTouch 的實體機裝置。能用前兩種模式時，不要選擇 ADB Input。&#10;ADB Input 的滑動容易拖飛，為避免此問題，滑動速度會設定得非常慢，且滑動距離與前兩種模式不同；在需要精確控制座標的場景下無法使用。</system:String>
     <system:String x:Key="AdditionCommand">附加命令</system:String>
     <system:String x:Key="AdditionCommandTip" xml:space="preserve">附加命令用於指定模擬器啟動參數（如 ｢--instance 1｣ 表示啟動 1 號實例）。&#10;不同模擬器的命令格式不同，通常包括實例編號、視窗模式等參數，請參考您使用的模擬器說明文件。</system:String>
@@ -723,7 +724,7 @@ C:\\Program Files\\Netease\\MuMuPlayer\n
     <system:String x:Key="MuMu12Index">實例編號</system:String>
     <system:String x:Key="MuMu12Display">螢幕編號</system:String>
     <system:String x:Key="MuMuExtrasNotEnabledMessage">Mumu 截圖增強未生效，請檢查相關設定</system:String>
-    <system:String x:Key="MuMuEmulator12KeepAliveOn">偵測到 MuMu 開啟了背景保活。若要在背景穩定運行，請到設定中同時勾選「MuMu 截圖增強」與「MuMu 觸控」。</system:String>
+    <system:String x:Key="MuMuEmulator12KeepAliveOn">偵測到 MuMu 開啟了背景保活。若要在背景穩定運行，請到設定中同時勾選 ｢{key=MuMu12ExtrasEnabled}｣ 與 ｢{key=MuMuExtrasTouchEnabled}｣。</system:String>
     <system:String x:Key="MuMuEmulator12FullExtrasReady">完整 MuMu 增強已就位——截圖與觸控雙核直連貫通，背景保活亦為我所用！</system:String>
     <system:String x:Key="LdExtrasEnabled">啟用 LD 截圖增強模式</system:String>
     <system:String x:Key="LdPlayerEmulatorPathNotFound">找不到 LDPlayer 模擬器路徑。</system:String>

--- a/src/MaaWpfGui/Services/StageManager.cs
+++ b/src/MaaWpfGui/Services/StageManager.cs
@@ -23,6 +23,7 @@ using System.Threading.Tasks;
 using HandyControl.Controls;
 using HandyControl.Data;
 using MaaWpfGui.Constants.Enums;
+using MaaWpfGui.Extensions;
 using MaaWpfGui.Helper;
 using MaaWpfGui.Models;
 using MaaWpfGui.Models.MaaApi;

--- a/src/MaaWpfGui/Styles/Controls/TextBlock.cs
+++ b/src/MaaWpfGui/Styles/Controls/TextBlock.cs
@@ -77,7 +77,6 @@ public class TextBlock : System.Windows.Controls.TextBlock
         }
     }
 
-
     private void TryStartRainbowAnimation()
     {
         if (Foreground is not LinearGradientBrush { Transform: TranslateTransform translate })
@@ -89,7 +88,7 @@ public class TextBlock : System.Windows.Controls.TextBlock
         {
             From = 0,
             To = 4000,
-            Duration = new Duration(System.TimeSpan.FromSeconds(20)),
+            Duration = new Duration(System.TimeSpan.FromSeconds(100)),
             RepeatBehavior = RepeatBehavior.Forever,
         };
         translate.BeginAnimation(TranslateTransform.XProperty, anim);

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/ConnectSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/ConnectSettingsUserControlModel.cs
@@ -26,6 +26,7 @@ using JetBrains.Annotations;
 using MaaWpfGui.Configuration.Factory;
 using MaaWpfGui.Constants;
 using MaaWpfGui.Constants.Enums;
+using MaaWpfGui.Extensions;
 using MaaWpfGui.Helper;
 using MaaWpfGui.Main;
 using MaaWpfGui.Models.EmulatorConnectionExtra;
@@ -56,6 +57,15 @@ public class ConnectSettingsUserControlModel : PropertyChangedBase
     private ConnectSettingsUserControlModel()
     {
         PropertyDependsOnUtility.InitializePropertyDependencies(this);
+
+        // 从配置恢复时，若 MuMu 截图增强已启用，需将 MuMu 触控加入下拉列表
+        if (ExtraConfig is MuMu12Extra { Enable: true })
+        {
+            if (!TouchModeList.Items.Any(item => item.Value == TouchMode.MumuExtras))
+            {
+                TouchModeList.Add(TouchMode.MumuExtras, "MumuExtrasTouchMode");
+            }
+        }
     }
 
     public static ConnectSettingsUserControlModel Instance { get; }
@@ -221,6 +231,10 @@ public class ConnectSettingsUserControlModel : PropertyChangedBase
             SetAndNotify(ref field, value);
             ConfigFactory.CurrentConfig.Gui.ConnectSettings.Config = value;
             Instances.SettingsViewModel.UpdateWindowTitle(); // 每次修改客户端时更新WindowTitle
+
+            // 切换连接配置时，若不再使用 MuMu 截图增强，需移除 MuMu 触控选项
+            var mumuEnabled = ExtraConfig is MuMu12Extra { Enable: true };
+            OnMuMuExtrasEnableChanged(mumuEnabled);
         }
     } = ConfigFactory.CurrentConfig.Gui.ConnectSettings.Config;
 
@@ -668,7 +682,8 @@ public class ConnectSettingsUserControlModel : PropertyChangedBase
     }
 
     /// <summary>
-    /// Gets the list of touch modes
+    /// Gets the list of touch modes.
+    /// MuMu 触控选项仅在 MuMu 截图增强启用时动态加入列表。
     /// </summary>
     public LocalizedObservableList<TouchMode> TouchModeList { get; } = new(
         (TouchMode.MiniTouch, "MiniTouchMode"),
@@ -681,29 +696,53 @@ public class ConnectSettingsUserControlModel : PropertyChangedBase
     public TouchMode TouchMode
     {
         get; set {
-            SetAndNotify(ref field, value);
+            if (!SetAndNotify(ref field, value))
+            {
+                return;
+            }
+
             UpdateInstanceSettings();
             ConfigFactory.CurrentConfig.Gui.ConnectSettings.TouchMode = value;
-            SettingsViewModel.AskRestartToApplySettings();
+
+            // 同步 MuMu 触控增强勾选框状态（SetAndNotify 会自动去重，不会循环）
+            if (ExtraConfig is MuMu12Extra mumu)
+            {
+                mumu.EnableTouch = value == TouchMode.MumuExtras;
+            }
+
+            // 触控模式决定控制器子类，Core 侧需重连才能重建控制器实例
+            Instances.AsstProxy.Connected = false;
         }
     } = ConfigFactory.CurrentConfig.Gui.ConnectSettings.TouchMode;
 
     /// <summary>
-    /// Gets the touch mode actually sent to the core.
-    /// MuMu 触控是 MuMu Extras 的子选项而非独立触控模式，勾上后要覆写掉用户选的 TouchMode。
-    /// 这里集中一处，避免改动其他设置时把它冲掉。
+    /// 根据 MuMu 截图增强的开关状态，动态增删触控模式下拉列表中的「MuMu 触控」选项。
+    /// 仅增删下拉项，不自动切换当前触控模式——切换由触控增强勾选框负责。
     /// </summary>
-    public string EffectiveTouchMode =>
-        ExtraConfig is MuMu12Extra { Enable: true, EnableTouch: true }
-            ? MumuExtrasTouchMode
-            : TouchMode.ToCustomString();
-
-    /// <summary>Core 侧 MuMu external renderer IPC 输入对应的 TouchMode 取值。</summary>
-    public const string MumuExtrasTouchMode = "MumuExtras";
+    /// <param name="mumuExtrasEnabled">MuMu 截图增强是否已启用。</param>
+    public void OnMuMuExtrasEnableChanged(bool mumuExtrasEnabled)
+    {
+        Execute.OnUIThread(() =>
+        {
+            var hasMumu = TouchModeList.Items.Any(item => item.Value == TouchMode.MumuExtras);
+            if (mumuExtrasEnabled && !hasMumu)
+            {
+                TouchModeList.Add(TouchMode.MumuExtras, "MumuExtrasTouchMode");
+            }
+            else if (!mumuExtrasEnabled && hasMumu)
+            {
+                TouchModeList.Remove(TouchMode.MumuExtras);
+                if (TouchMode == TouchMode.MumuExtras)
+                {
+                    TouchMode = TouchMode.MiniTouch; // 回到默认
+                }
+            }
+        });
+    }
 
     public void UpdateInstanceSettings()
     {
-        Instances.AsstProxy.AsstSetInstanceOption(InstanceOptionKey.TouchMode, EffectiveTouchMode);
+        Instances.AsstProxy.AsstSetInstanceOption(InstanceOptionKey.TouchMode, TouchMode.ToCustomString());
         Instances.AsstProxy.AsstSetInstanceOption(InstanceOptionKey.DeploymentWithPause, SettingsViewModel.GameSettings.DeploymentWithPause ? "1" : "0");
         Instances.AsstProxy.AsstSetInstanceOption(InstanceOptionKey.AdbLiteEnabled, AdbLiteEnabled ? "1" : "0");
         Instances.AsstProxy.AsstSetInstanceOption(InstanceOptionKey.KillAdbOnExit, KillAdbOnExit ? "1" : "0");

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/RoguelikeSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/RoguelikeSettingsUserControlModel.cs
@@ -21,6 +21,7 @@ using MaaWpfGui.Configuration.Factory;
 using MaaWpfGui.Configuration.Single.MaaTask;
 using MaaWpfGui.Constants;
 using MaaWpfGui.Constants.Enums;
+using MaaWpfGui.Extensions;
 using MaaWpfGui.Helper;
 using MaaWpfGui.Main;
 using MaaWpfGui.Models;

--- a/src/MaaWpfGui/Views/UserControl/Settings/ConnectSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/Settings/ConnectSettingsUserControl.xaml
@@ -28,7 +28,6 @@
             <RowDefinition Height="*" />
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="*" />
         </Grid.RowDefinitions>
         <StackPanel
             Grid.Row="0"
@@ -61,7 +60,7 @@
             <hc:ComboBox
                 Width="300"
                 Height="30"
-                Margin="10"
+                Margin="5"
                 HorizontalAlignment="Center"
                 hc:TitleElement.Title="{DynamicResource ConnectionPreset}"
                 hc:TitleElement.TitlePlacement="Left"
@@ -74,7 +73,7 @@
                 HorizontalAlignment="Center"
                 VerticalAlignment="Center">
                 <TextBlock
-                    Margin="10,0"
+                    Margin="5,0"
                     HorizontalAlignment="Center"
                     d:Visibility="Visible"
                     Foreground="Red"
@@ -86,7 +85,7 @@
             <!--  ADB 连接配置区域  -->
             <StackPanel d:Visibility="Visible" Visibility="{c:Binding 'ConnectConfig != enums:ConnectConfig.PC'}">
                 <StackPanel
-                    Margin="10"
+                    Margin="5"
                     HorizontalAlignment="Center"
                     Orientation="Horizontal">
                     <controls:TooltipBlock Visibility="Hidden" />
@@ -130,7 +129,7 @@
                     <controls:TooltipBlock TooltipText="{DynamicResource ConnectionAddressTip}" />
                 </StackPanel>
                 <StackPanel
-                    Margin="10"
+                    Margin="5"
                     HorizontalAlignment="Center"
                     IsEnabled="{c:Binding !AutoDetectConnection}"
                     Orientation="Horizontal">
@@ -169,7 +168,7 @@
                         <DataTemplate DataType="{x:Type extra:MuMu12Extra}">
                             <StackPanel d:DataContext="{d:DesignInstance {x:Type extra:MuMu12Extra}}">
                                 <CheckBox
-                                    Margin="10"
+                                    Margin="5"
                                     HorizontalAlignment="Center"
                                     Content="{DynamicResource MuMu12ExtrasEnabled}"
                                     IsChecked="{Binding Enable}" />
@@ -179,28 +178,28 @@
                                     Orientation="Vertical"
                                     Visibility="{c:Binding Enable}">
                                     <CheckBox
-                                        Margin="10"
+                                        Margin="5"
                                         HorizontalAlignment="Center"
                                         Content="{DynamicResource MuMuExtrasTouchEnabled}"
                                         IsChecked="{Binding EnableTouch}" />
                                     <hc:TextBox
                                         Width="420"
                                         Height="30"
-                                        Margin="10"
+                                        Margin="5"
                                         hc:InfoElement.Placeholder="Example: C:\Program Files\Netease\MuMuPlayer"
                                         hc:TitleElement.Title="{DynamicResource MuMu12EmulatorPath}"
                                         hc:TitleElement.TitlePlacement="Left"
                                         Text="{Binding EmulatorPath}" />
                                     <StackPanel HorizontalAlignment="Center" Orientation="Vertical">
                                         <CheckBox
-                                            Margin="10"
+                                            Margin="5"
                                             HorizontalAlignment="Center"
                                             VerticalAlignment="Center"
                                             Content="{DynamicResource MuMuBridgeConnection}"
                                             IsChecked="{Binding EnableBridgeConnection}" />
                                         <hc:TextBox
                                             Height="30"
-                                            Margin="10"
+                                            Margin="5"
                                             HorizontalContentAlignment="Center"
                                             d:Visibility="Visible"
                                             hc:TitleElement.Title="{DynamicResource MuMu12Index}"
@@ -214,7 +213,7 @@
                         <DataTemplate DataType="{x:Type extra:LDPlayerExtra}">
                             <StackPanel d:DataContext="{d:DesignInstance {x:Type extra:LDPlayerExtra}}">
                                 <CheckBox
-                                    Margin="10"
+                                    Margin="5"
                                     HorizontalAlignment="Center"
                                     Content="{DynamicResource LdExtrasEnabled}"
                                     IsChecked="{Binding Enable}" />
@@ -222,7 +221,7 @@
                                     <hc:TextBox
                                         Width="420"
                                         Height="30"
-                                        Margin="10"
+                                        Margin="5"
                                         hc:InfoElement.Placeholder="Example: C:\leidian\LDPlayer9"
                                         hc:TitleElement.Title="{DynamicResource LdEmulatorPath}"
                                         hc:TitleElement.TitlePlacement="Left"
@@ -236,7 +235,7 @@
                                         <hc:TextBox
                                             Width="130"
                                             Height="30"
-                                            Margin="10"
+                                            Margin="5"
                                             d:Visibility="Visible"
                                             hc:InfoElement.Placeholder="0"
                                             hc:TitleElement.Title="{DynamicResource LdIndex}"
@@ -250,7 +249,7 @@
                         <DataTemplate DataType="{x:Type extra:Win32Extra}">
                             <StackPanel d:DataContext="{d:DesignInstance {x:Type extra:Win32Extra}}">
                                 <StackPanel
-                                    Margin="10"
+                                    Margin="5"
                                     HorizontalAlignment="Center"
                                     Orientation="Horizontal">
                                     <hc:ComboBox
@@ -265,7 +264,7 @@
                                 </StackPanel>
 
                                 <StackPanel
-                                    Margin="10"
+                                    Margin="5"
                                     HorizontalAlignment="Center"
                                     Orientation="Horizontal">
                                     <hc:ComboBox
@@ -280,7 +279,7 @@
                                 </StackPanel>
 
                                 <StackPanel
-                                    Margin="10"
+                                    Margin="5"
                                     HorizontalAlignment="Center"
                                     Orientation="Horizontal">
                                     <hc:ComboBox
@@ -320,7 +319,7 @@
 
         <controls:TextBlock
             Grid.Row="4"
-            Margin="10"
+            Margin="5"
             HorizontalAlignment="Center"
             Text="{c:Binding ScreencapCost}" />
 
@@ -329,19 +328,21 @@
             HorizontalAlignment="Center"
             d:Visibility="Visible"
             Visibility="{c:Binding 'ConnectConfig != enums:ConnectConfig.PC'}">
-            <StackPanel Orientation="Horizontal">
+            <StackPanel HorizontalAlignment="Left" Orientation="Horizontal">
                 <CheckBox
-                    Margin="20,10,0,10"
+                    Margin="5"
                     Content="{DynamicResource RetryOnDisconnected}"
                     IsChecked="{Binding RetryOnDisconnected}" />
                 <controls:TooltipBlock TooltipText="{DynamicResource RetryOnDisconnectedTip}" />
             </StackPanel>
             <CheckBox
-                Margin="20,10"
+                Margin="5"
+                HorizontalAlignment="Left"
                 Content="{DynamicResource AllowAdbRestart}"
                 IsChecked="{Binding AllowAdbRestart}" />
             <CheckBox
-                Margin="20,10"
+                Margin="5"
+                HorizontalAlignment="Left"
                 Content="{DynamicResource AllowAdbHardRestart}"
                 IsChecked="{Binding AllowAdbHardRestart}" />
         </StackPanel>
@@ -354,7 +355,7 @@
             Visibility="{c:Binding 'ConnectConfig != enums:ConnectConfig.PC'}">
             <hc:ComboBox
                 Height="30"
-                Margin="10,10,0,10"
+                Margin="5,5,0,5"
                 hc:TitleElement.Title="{DynamicResource TouchMode}"
                 hc:TitleElement.TitlePlacement="Left"
                 DisplayMemberPath="Display"
@@ -382,7 +383,7 @@
             </controls:TooltipBlock>
             <Button
                 Height="30"
-                Margin="10,10,0,10"
+                Margin="5,5,0,5"
                 HorizontalAlignment="Left"
                 Command="{s:Action ReplaceAdb}"
                 Content="{DynamicResource ForcedReplaceAdb}" />
@@ -395,24 +396,18 @@
             Visibility="{c:Binding 'ConnectConfig != enums:ConnectConfig.PC'}">
             <StackPanel HorizontalAlignment="Center" Orientation="Horizontal">
                 <CheckBox
-                    Margin="20,10"
+                    Margin="5"
                     HorizontalAlignment="Left"
                     VerticalAlignment="Center"
                     Content="{DynamicResource KillAdbOnExit}"
                     IsChecked="{Binding KillAdbOnExit}" />
                 <CheckBox
-                    Margin="20,10"
+                    Margin="5"
                     HorizontalAlignment="Left"
                     VerticalAlignment="Center"
                     Content="{DynamicResource AdbLiteEnabled}"
                     IsChecked="{Binding AdbLiteEnabled}" />
             </StackPanel>
         </StackPanel>
-
-        <StackPanel
-            Grid.Row="8"
-            HorizontalAlignment="Center"
-            VerticalAlignment="Center"
-            Orientation="Horizontal" />
     </Grid>
 </UserControl>

--- a/src/MaaWpfGui/Views/UserControl/TaskQueue/StartUpTaskUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/TaskQueue/StartUpTaskUserControl.xaml
@@ -62,7 +62,7 @@
                 TextAlignment="Left"
                 TextWrapping="Wrap" />
             <CheckBox
-                Margin="0,10"
+                Margin="0,5"
                 Content="{DynamicResource StartGameLaunchClient}"
                 IsChecked="{Binding StartGame, Source={x:Static settings_vms:GameSettingsUserControlModel.Instance}}" />
             <hc:ComboBox
@@ -79,12 +79,12 @@
 
         <StackPanel s:View.ActionTarget="{Binding DataContext, RelativeSource={RelativeSource Self}}" DataContext="{Binding Source={x:Static settings_vms:ConnectSettingsUserControlModel.Instance}}">
             <StackPanel d:Visibility="Visible" Visibility="{c:Binding 'ConnectConfig != enums:ConnectConfig.PC'}">
-                <StackPanel Margin="0,10" Orientation="Horizontal">
+                <StackPanel Margin="0,5" Orientation="Horizontal">
                     <CheckBox Content="{DynamicResource AutoDetectConnection}" IsChecked="{Binding AutoDetectConnection}" />
                     <controls:TooltipBlock TooltipText="{DynamicResource AutoDetectConnectionTip}" />
                 </StackPanel>
                 <StackPanel
-                    Margin="0,10"
+                    Margin="0,5"
                     Orientation="Horizontal"
                     Visibility="{c:Binding AutoDetectConnection}">
                     <CheckBox
@@ -105,7 +105,7 @@
                 SelectedValuePath="Value" />
 
             <TextBlock
-                Margin="10,0"
+                Margin="5,0"
                 HorizontalAlignment="Center"
                 d:Visibility="Visible"
                 Foreground="Red"
@@ -227,6 +227,7 @@
                                 </StackPanel>
                                 <hc:TextBox
                                     Margin="0,5"
+                                    HorizontalAlignment="Left"
                                     HorizontalContentAlignment="Center"
                                     d:Visibility="Visible"
                                     hc:TitleElement.Title="{DynamicResource MuMu12Index}"

--- a/src/MaaWpfGui/Views/UserControl/TaskQueue/StartUpTaskUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/TaskQueue/StartUpTaskUserControl.xaml
@@ -209,10 +209,9 @@
                                 d:Visibility="Visible"
                                 Orientation="Vertical"
                                 Visibility="{c:Binding Enable}">
-                                <CheckBox
-                                    Margin="0,5"
-                                    Content="{DynamicResource MuMuExtrasTouchEnabled}"
-                                    IsChecked="{Binding EnableTouch}" />
+                                <CheckBox Margin="0,5" IsChecked="{Binding EnableTouch}">
+                                    <TextBlock Text="{DynamicResource MuMuExtrasTouchEnabled}" TextWrapping="Wrap" />
+                                </CheckBox>
                                 <hc:TextBox
                                     Margin="0,5"
                                     hc:InfoElement.Placeholder="Example: C:\Program Files\Netease\MuMuPlayer"


### PR DESCRIPTION
## Summary by Sourcery

改进 MuMu 12 额外触控集成并重构相关扩展。

新功能：
- 添加 MuMu 额外触控作为可选择的触控模式，当启用 MuMu 截图增强功能时可动态启用。
- 从核心向 GUI 报告 MuMu 额外输入的可用性，并在日志中展示完整增强功能是否就绪或存在不兼容情况。

缺陷修复：
- 防止在功能被禁用或不可用时 MuMu 额外触控仍保持选中状态，改为回退到安全的默认模式。
- 确保在启用 MuMu 保持活动（keep-alive）但 MuMu 额外触控实际上不可用的情况下，助手会停止运行，避免进入不可用的后台运行状态。

改进：
- 统一触控模式处理方式，将选定的触控模式直接发送到核心，并将 MuMu 额外触控与对应复选框状态同步。
- 将客户端和应用相关的辅助类重构到共享的扩展命名空间中，并为触控模式添加文档注释。
- 调整彩虹文字动画节奏，使其更慢、更平滑，以获得更好的视觉效果。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve MuMu 12 extras touch integration and refactor related extensions.

New Features:
- Add MuMu extras touch as a selectable touch mode that is dynamically available when MuMu screenshot enhancements are enabled.
- Report MuMu extras input availability from the core to the GUI and surface full enhancement readiness or incompatibility in logs.

Bug Fixes:
- Prevent MuMu extras touch from remaining selected when the feature is disabled or unavailable, falling back to a safe default mode.
- Ensure the assistant stops when MuMu keep-alive is enabled but MuMu extras touch is not effectively available, avoiding unusable background operation states.

Enhancements:
- Unify touch mode handling by sending the selected touch mode directly to the core and synchronizing MuMu extras touch with the corresponding checkbox state.
- Refactor client and application-related helper classes into a shared extensions namespace and add documentation comments for touch modes.
- Adjust rainbow text animation timing for a slower, smoother visual effect.

</details>