### PR TITLE
rft: 库存Item拆分

### DIFF
--- a/src/MaaWpfGui/ViewModels/Items/DepotPlanItemViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/Items/DepotPlanItemViewModel.cs
@@ -19,9 +19,23 @@ using MaaWpfGui.Helper;
 using MaaWpfGui.ViewModels.UserControl.TaskQueue;
 using Stylet;
 
+[assembly: PropertyChanged.FilterType("MaaWpfGui.ViewModels.Items.DepotPlanItemViewModel")]
+
 namespace MaaWpfGui.ViewModels.Items;
 
-public class DepotPlanItemViewModel(string stage, string dropId, string? dropName = null, int dropCount = 0, bool useMedicine = false, int medicineCount = 0, bool useStone = false, int stoneCount = 0, int taskId = 0) : PropertyChangedBase
+/// <summary>
+/// 库存维持ItemModel
+/// </summary>
+/// <param name="stage">关卡名</param>
+/// <param name="dropId">掉落物id</param>
+/// <param name="dropName">掉落物名称</param>
+/// <param name="dropCount">掉落物数量</param>
+/// <param name="useMedicine">是否使用理智药</param>
+/// <param name="medicineCount">理智药数量</param>
+/// <param name="useStone">是否碎石</param>
+/// <param name="stoneCount">碎石数量</param>
+/// <param name="taskId">任务AsstId</param>
+public partial class DepotPlanItemViewModel(string stage, string dropId, string? dropName = null, int dropCount = 0, bool useMedicine = false, int medicineCount = 0, bool useStone = false, int stoneCount = 0, int taskId = 0) : PropertyChangedBase
 {
     public DepotPlanItemViewModel()
         : this(string.Empty, string.Empty, null, 0, false, 0, false, 0, 0)
@@ -30,13 +44,7 @@ public class DepotPlanItemViewModel(string stage, string dropId, string? dropNam
 
     public bool IsExpanded { get; set => SetAndNotify(ref field, value); }
 
-    public int Index
-    {
-        get; set {
-            field = value;
-            NotifyOfPropertyChange(nameof(Title));
-        }
-    }
+    public int Index { get; set; }
 
     public string Title => $"{Index + 1}: {DepotMaintainTaskUserControlModel.Instance.StageListSource.FirstOrDefault(i => i.Value == Stage)?.Display ?? Stage} - {DropName} x{DropCount.FormatNumber(false)}";
 
@@ -45,55 +53,19 @@ public class DepotPlanItemViewModel(string stage, string dropId, string? dropNam
     /// </summary>
     public void RefreshTitle() => NotifyOfPropertyChange(nameof(Title));
 
-    public string Stage
-    {
-        get; set {
-            if (!SetAndNotify(ref field, value))
-            {
-                return;
-            }
-            NotifyOfPropertyChange(nameof(Title));
-        }
-    } = stage;
+    public string Stage { get; set => SetAndNotify(ref field, value); } = stage;
 
     /// <summary>
     /// Gets or sets 指定掉落材料 ID。
     /// </summary>
-    public string DropId
-    {
-        get; set {
-            if (!SetAndNotify(ref field, value))
-            {
-                return;
-            }
-            NotifyOfPropertyChange(nameof(Title));
-        }
-    } = dropId;
+    public string DropId { get; set => SetAndNotify(ref field, value); } = dropId;
 
     /// <summary>
     /// Gets or sets 指定掉落材料名称。
     /// </summary>
-    public string DropName
-    {
-        get; set {
-            if (!SetAndNotify(ref field, value))
-            {
-                return;
-            }
-            NotifyOfPropertyChange(nameof(Title));
-        }
-    } = dropName ?? LocalizationHelper.GetString("NotSelected");
+    public string DropName { get; set => SetAndNotify(ref field, value); } = dropName ?? LocalizationHelper.GetString("NotSelected");
 
-    public int DropCount
-    {
-        get; set {
-            if (!SetAndNotify(ref field, value))
-            {
-                return;
-            }
-            NotifyOfPropertyChange(nameof(Title));
-        }
-    } = dropCount;
+    public int DropCount { get; set => SetAndNotify(ref field, value); } = dropCount;
 
     public bool UseMedicine { get; set => SetAndNotify(ref field, value); } = useMedicine;
 

--- a/src/MaaWpfGui/ViewModels/Items/DepotPlanItemViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/Items/DepotPlanItemViewModel.cs
@@ -1,0 +1,123 @@
+// <copyright file="DepotPlanItemViewModel.cs" company="MaaAssistantArknights">
+// Part of the MaaWpfGui project, maintained by the MaaAssistantArknights team (Maa Team)
+// Copyright (C) 2021-2025 MaaAssistantArknights Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License v3.0 only as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY
+// </copyright>
+
+#nullable enable
+using System.Linq;
+using JetBrains.Annotations;
+using MaaWpfGui.Extensions;
+using MaaWpfGui.Helper;
+using MaaWpfGui.ViewModels.UserControl.TaskQueue;
+using Stylet;
+
+namespace MaaWpfGui.ViewModels.Items;
+
+public class DepotPlanItemViewModel(string stage, string dropId, string? dropName = null, int dropCount = 0, bool useMedicine = false, int medicineCount = 0, bool useStone = false, int stoneCount = 0, int taskId = 0) : PropertyChangedBase
+{
+    public DepotPlanItemViewModel()
+        : this(string.Empty, string.Empty, null, 0, false, 0, false, 0, 0)
+    {
+    }
+
+    public bool IsExpanded { get; set => SetAndNotify(ref field, value); }
+
+    public int Index
+    {
+        get; set {
+            field = value;
+            NotifyOfPropertyChange(nameof(Title));
+        }
+    }
+
+    public string Title => $"{Index + 1}: {DepotMaintainTaskUserControlModel.Instance.StageListSource.FirstOrDefault(i => i.Value == Stage)?.Display ?? Stage} - {DropName} x{DropCount.FormatNumber(false)}";
+
+    /// <summary>
+    /// 增删 plan 或语言切换后刷新 Title 显示（序号/关卡名/材料名）。
+    /// </summary>
+    public void RefreshTitle() => NotifyOfPropertyChange(nameof(Title));
+
+    public string Stage
+    {
+        get; set {
+            if (!SetAndNotify(ref field, value))
+            {
+                return;
+            }
+            NotifyOfPropertyChange(nameof(Title));
+        }
+    } = stage;
+
+    /// <summary>
+    /// Gets or sets 指定掉落材料 ID。
+    /// </summary>
+    public string DropId
+    {
+        get; set {
+            if (!SetAndNotify(ref field, value))
+            {
+                return;
+            }
+            NotifyOfPropertyChange(nameof(Title));
+        }
+    } = dropId;
+
+    /// <summary>
+    /// Gets or sets 指定掉落材料名称。
+    /// </summary>
+    public string DropName
+    {
+        get; set {
+            if (!SetAndNotify(ref field, value))
+            {
+                return;
+            }
+            NotifyOfPropertyChange(nameof(Title));
+        }
+    } = dropName ?? LocalizationHelper.GetString("NotSelected");
+
+    public int DropCount
+    {
+        get; set {
+            if (!SetAndNotify(ref field, value))
+            {
+                return;
+            }
+            NotifyOfPropertyChange(nameof(Title));
+        }
+    } = dropCount;
+
+    public bool UseMedicine { get; set => SetAndNotify(ref field, value); } = useMedicine;
+
+    public int MedicineCount { get; set => SetAndNotify(ref field, value); } = medicineCount;
+
+    public bool UseStone { get; set => SetAndNotify(ref field, value); } = useStone;
+
+    public int StoneCount { get; set => SetAndNotify(ref field, value); } = stoneCount;
+
+    public int TaskId { get; set; } = taskId;
+
+    // UI 绑定的方法
+    [UsedImplicitly]
+    public void DropsListDropDownClosed()
+    {
+        if (FightSettingsUserControlModel.Instance.DropsList.FirstOrDefault(i => i.Display == DropName) is { } item)
+        {
+            DropId = item.Value;
+        }
+        else
+        {
+            DropId = string.Empty;
+            DropName = LocalizationHelper.GetString("NotSelected");
+            NotifyOfPropertyChange(nameof(DropName));
+        }
+    }
+}

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
@@ -31,6 +31,7 @@ using MaaWpfGui.Models;
 using MaaWpfGui.Models.AsstTasks;
 using MaaWpfGui.Services;
 using MaaWpfGui.Utilities;
+using MaaWpfGui.ViewModels.Items;
 using MaaWpfGui.Utilities.ValueType;
 using MaaWpfGui.ViewModels.UI;
 using MaaWpfGui.ViewModels.UserControl.Settings;
@@ -196,14 +197,11 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
         set => SetTaskConfig<DepotMaintainTask>(t => t.UseExpiringMedicine == value, t => t.UseExpiringMedicine = value);
     }
 
-    public ObservableCollection<Plan> PlanList { get; private set => SetAndNotify(ref field, value); } = [];
+    public ObservableCollection<DepotPlanItemViewModel> PlanList { get; private set => SetAndNotify(ref field, value); } = [];
 
-    public void AddPlan()
-    {
-        PlanList.Add(new Plan());
-    }
+    public void AddPlan() => PlanList.Add(new());
 
-    public void RemovePlan(Plan plan)
+    public void RemovePlan(DepotPlanItemViewModel plan)
     {
         PlanList.Remove(plan);
     }
@@ -374,17 +372,6 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
         return item?.Count >= 0 ? item.Count.ToString() : "--";
     }
 
-    private void SavePlan()
-    {
-        if (IsRefreshingUI)
-        {
-            return;
-        }
-
-        var list = PlanList.Select(i => new DepotMaintainTask.Plan(i.Stage, i.DropId, i.DropCount, i.UseMedicine, i.MedicineCount, i.UseStone, i.StoneCount, i.TaskId));
-        SetTaskConfig<DepotMaintainTask>(t => t.PlanList.SequenceEqual(list), t => t.PlanList = [.. list]);
-    }
-
     /// <summary>
     /// 更新关卡列表。
     /// 使用手动输入时，只更新关卡列表，不更新关卡选择
@@ -442,87 +429,6 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
         }
     }
 
-    public class Plan(string stage, string dropId, string? dropName = null, int dropCount = 0, bool useMedicine = false, int medicineCount = 0, bool useStone = false, int stoneCount = 0, int taskId = 0) : PropertyChangedBase
-    {
-        public Plan()
-            : this(string.Empty, string.Empty, null, 0, false, 0, false, 0, 0)
-        {
-        }
-
-        public bool IsExpanded { get; set => SetAndNotify(ref field, value); }
-
-        public string Title => $"{Instance.PlanList.IndexOf(this) + 1}: {Instance.StageListSource.FirstOrDefault(i => i.Value == Stage)?.Display ?? Stage} - {DropName} x{DropCount.FormatNumber(false)}";
-
-        /// <summary>
-        /// 增删 plan 或语言切换后刷新 Title 显示（序号/关卡名/材料名）。
-        /// </summary>
-        public void RefreshTitle() => NotifyOfPropertyChange(nameof(Title));
-
-        public string Stage
-        {
-            get; set {
-                SetAndNotify(ref field, value);
-                NotifyOfPropertyChange(nameof(Title));
-            }
-        } = stage;
-
-        /// <summary>
-        /// Gets or sets 指定掉落材料 ID。
-        /// </summary>
-        public string DropId
-        {
-            get; set {
-                SetAndNotify(ref field, value);
-                NotifyOfPropertyChange(nameof(Title));
-            }
-        } = dropId;
-
-        /// <summary>
-        /// Gets or sets 指定掉落材料名称。
-        /// </summary>
-        public string DropName
-        {
-            get; set {
-                SetAndNotify(ref field, value);
-                NotifyOfPropertyChange(nameof(Title));
-            }
-        } = dropName ?? LocalizationHelper.GetString("NotSelected");
-
-        public int DropCount
-        {
-            get; set {
-                SetAndNotify(ref field, value);
-                NotifyOfPropertyChange(nameof(Title));
-            }
-        } = dropCount;
-
-        public bool UseMedicine { get; set => SetAndNotify(ref field, value); } = useMedicine;
-
-        public int MedicineCount { get; set => SetAndNotify(ref field, value); } = medicineCount;
-
-        public bool UseStone { get; set => SetAndNotify(ref field, value); } = useStone;
-
-        public int StoneCount { get; set => SetAndNotify(ref field, value); } = stoneCount;
-
-        public int TaskId { get; set; } = taskId;
-
-        // UI 绑定的方法
-        [UsedImplicitly]
-        public void DropsListDropDownClosed()
-        {
-            if (FightSettingsUserControlModel.Instance.DropsList.FirstOrDefault(i => i.Display == DropName) is { } item)
-            {
-                DropId = item.Value;
-            }
-            else
-            {
-                DropId = string.Empty;
-                DropName = LocalizationHelper.GetString("NotSelected");
-                NotifyOfPropertyChange(nameof(DropName));
-            }
-        }
-    }
-
     public override void RefreshUI(BaseTask baseTask)
     {
         if (baseTask is not DepotMaintainTask task)
@@ -531,7 +437,7 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
         }
 
         using var refresh = new UiRefreshingScope();
-        var list = new List<Plan>();
+        var list = new List<DepotPlanItemViewModel>();
         foreach (var plan in task.PlanList)
         {
             // 根据 DropId 从掉落列表恢复 DropName，避免初始化显示为"不选择"
@@ -554,8 +460,16 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
 
     private void PlanItem_PropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
-        SavePlan();
-        if (e.PropertyName is nameof(Plan.Stage) or nameof(Plan.DropId) or nameof(Plan.DropName) or nameof(Plan.DropCount))
+        if (!IsRefreshingUI)
+        {
+            if (e.PropertyName is not nameof(DepotPlanItemViewModel.IsExpanded) && sender is DepotPlanItemViewModel plan)
+            {
+                var list = GetTaskConfig<DepotMaintainTask>().PlanList.ToList();
+                list[plan.Index] = new DepotMaintainTask.Plan(plan.Stage, plan.DropId, plan.DropCount, plan.UseMedicine, plan.MedicineCount, plan.UseStone, plan.StoneCount, plan.TaskId);
+                SetTaskConfig<DepotMaintainTask>(t => t.PlanList.SequenceEqual(list), t => t.PlanList = list);
+            }
+        }
+        if (e.PropertyName is nameof(DepotPlanItemViewModel.Stage) or nameof(DepotPlanItemViewModel.DropId) or nameof(DepotPlanItemViewModel.DropName) or nameof(DepotPlanItemViewModel.DropCount))
         {
             NotifyOfPropertyChange(nameof(PlanInfo));
         }
@@ -563,23 +477,26 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
 
     private void PlanList_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
-        SavePlan();
         NotifyOfPropertyChange(nameof(PlanInfo));
-        foreach (var plan in PlanList)
-        {
-            plan.RefreshTitle();
-        }
         if (e.Action is NotifyCollectionChangedAction.Remove or NotifyCollectionChangedAction.Replace)
         {
-            e.OldItems?.OfType<Plan>().ToList().ForEach(plan => {
+            e.OldItems?.OfType<DepotPlanItemViewModel>().ToList().ForEach(plan => {
                 plan.PropertyChanged -= PlanItem_PropertyChanged;
             });
         }
         if (e.Action is NotifyCollectionChangedAction.Add or NotifyCollectionChangedAction.Replace)
         {
-            e.NewItems?.OfType<Plan>().ToList().ForEach(plan => {
+            foreach (var plan in PlanList)
+            {
+                plan.RefreshTitle();
+            }
+            e.NewItems?.OfType<DepotPlanItemViewModel>().ToList().ForEach(plan => {
                 plan.PropertyChanged += PlanItem_PropertyChanged;
             });
+        }
+        foreach (var (plan, index) in PlanList.Select((plan, index) => (plan, index)))
+        {
+            plan.Index = index;
         }
     }
 

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
@@ -18,6 +18,7 @@ using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Windows.Documents;
 using System.Windows;
 using System.Windows.Controls;
 using JetBrains.Annotations;
@@ -465,14 +466,14 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
     {
         if (!IsRefreshingUI)
         {
-            if (e.PropertyName is not nameof(DepotPlanItemViewModel.IsExpanded) && sender is DepotPlanItemViewModel plan)
+            if (e.PropertyName is not nameof(DepotPlanItemViewModel.IsExpanded) and not nameof(DepotPlanItemViewModel.Title) and not nameof(DepotPlanItemViewModel.Index) && sender is DepotPlanItemViewModel plan)
             {
                 var list = GetTaskConfig<DepotMaintainTask>().PlanList.ToList();
                 list[plan.Index] = new DepotMaintainTask.Plan(plan.Stage, plan.DropId, plan.DropCount, plan.UseMedicine, plan.MedicineCount, plan.UseStone, plan.StoneCount, plan.TaskId);
                 SetTaskConfig<DepotMaintainTask>(t => t.PlanList.SequenceEqual(list), t => t.PlanList = list);
             }
         }
-        if (e.PropertyName is nameof(DepotPlanItemViewModel.Stage) or nameof(DepotPlanItemViewModel.DropId) or nameof(DepotPlanItemViewModel.DropName) or nameof(DepotPlanItemViewModel.DropCount))
+        if (e.PropertyName is nameof(DepotPlanItemViewModel.Title))
         {
             NotifyOfPropertyChange(nameof(PlanInfo));
         }
@@ -489,10 +490,6 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
         }
         if (e.Action is NotifyCollectionChangedAction.Add or NotifyCollectionChangedAction.Replace)
         {
-            foreach (var plan in PlanList)
-            {
-                plan.RefreshTitle();
-            }
             e.NewItems?.OfType<DepotPlanItemViewModel>().ToList().ForEach(plan => {
                 plan.PropertyChanged += PlanItem_PropertyChanged;
             });
@@ -501,6 +498,8 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
         {
             plan.Index = index;
         }
+        var list = PlanList.Select(plan => new DepotMaintainTask.Plan(plan.Stage, plan.DropId, plan.DropCount, plan.UseMedicine, plan.MedicineCount, plan.UseStone, plan.StoneCount, plan.TaskId)).ToList();
+        SetTaskConfig<DepotMaintainTask>(t => t.PlanList.SequenceEqual(list), t => t.PlanList = list);
     }
 
     public override (bool? IsSuccess, IEnumerable<int> TaskId) SerializeTask(BaseTask? baseTask, int? taskId = null) => (this as ISerialize).Serialize(baseTask, taskId);

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
@@ -199,7 +199,10 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
 
     public ObservableCollection<DepotPlanItemViewModel> PlanList { get; private set => SetAndNotify(ref field, value); } = [];
 
-    public void AddPlan() => PlanList.Add(new());
+    public void AddPlan()
+    {
+        PlanList.Add(new() { Index = PlanList.Count, });
+    }
 
     public void RemovePlan(DepotPlanItemViewModel plan)
     {


### PR DESCRIPTION
## Summary by Sourcery

重构仓库维护任务规划界面，使用专用的库存计划条目 ViewModel，并在计划列表和条目发生变化时保持任务配置同步。

Enhancements:
- 将仓库维护任务界面中的嵌套 Plan 模型替换为可复用的 `DepotPlanItemViewModel` 类。
- 更新计划列表处理逻辑，以跟踪条目索引、刷新标题，并在条目和集合更新时将变更持久化回 `DepotMaintainTask.PlanList`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor depot maintenance task planning UI to use a dedicated item ViewModel for inventory plans and keep task configuration in sync with plan list and item changes.

Enhancements:
- Replace the nested Plan model in depot maintenance task UI with a reusable DepotPlanItemViewModel class.
- Update plan list handling to track item indices, refresh titles, and persist changes back to DepotMaintainTask.PlanList on item and collection updates.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

重构仓库维护任务规划界面，使用专用的库存计划条目 ViewModel，并在计划列表和条目发生变化时保持任务配置同步。

Enhancements:
- 将仓库维护任务界面中的嵌套 Plan 模型替换为可复用的 `DepotPlanItemViewModel` 类。
- 更新计划列表处理逻辑，以跟踪条目索引、刷新标题，并在条目和集合更新时将变更持久化回 `DepotMaintainTask.PlanList`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor depot maintenance task planning UI to use a dedicated item ViewModel for inventory plans and keep task configuration in sync with plan list and item changes.

Enhancements:
- Replace the nested Plan model in depot maintenance task UI with a reusable DepotPlanItemViewModel class.
- Update plan list handling to track item indices, refresh titles, and persist changes back to DepotMaintainTask.PlanList on item and collection updates.

</details>

</details>