### PR TITLE
fix: 更新数据只勾选仓库识别时任务跳过

### DIFF
--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/UserDataUpdateSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/UserDataUpdateSettingsUserControlModel.cs
@@ -101,11 +101,10 @@ public class UserDataUpdateSettingsUserControlModel : TaskSettingsViewModel, Use
             }
 
             List<int> ids = [];
-            bool ret = false;
             if (operBoxTriggerDue)
             {
-                ret = Instances.ToolboxViewModel.StartOperBoxRecognitionTask(startImmediately: false);
-                if (!ret)
+                bool operBoxRet = Instances.ToolboxViewModel.StartOperBoxRecognitionTask(startImmediately: false);
+                if (!operBoxRet)
                 {
                     return (false, []);
                 }
@@ -123,18 +122,16 @@ public class UserDataUpdateSettingsUserControlModel : TaskSettingsViewModel, Use
                     Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("DepotPlanUpdateDepotFailed"), UiLogColor.Error);
                     return (false, []);
                 }
-
-                ret = result;
                 Instances.ToolboxViewModel.MarkDepotRecognitionSyncTimeForReset(depotTaskId);
                 ids.Add(depotTaskId);
             }
 
-            if (ret && operBoxTriggerDue && depotTriggerDue)
+            if (operBoxTriggerDue && depotTriggerDue)
             {
                 AchievementTrackerHelper.Instance.Unlock(AchievementIds.DoubleSync);
             }
 
-            return ret ? (true, ids) : (null, []);
+            return ids.Count > 0 ? (true, ids) : (null, []);
         }
 
         private static bool IsTriggerDue(DateTimeOffset? lastSyncTime, UserDataUpdateTriggerInterval triggerInterval)

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/UserDataUpdateSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/UserDataUpdateSettingsUserControlModel.cs
@@ -123,6 +123,8 @@ public class UserDataUpdateSettingsUserControlModel : TaskSettingsViewModel, Use
                     Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("DepotPlanUpdateDepotFailed"), UiLogColor.Error);
                     return (false, []);
                 }
+
+                ret = result;
                 Instances.ToolboxViewModel.MarkDepotRecognitionSyncTimeForReset(depotTaskId);
                 ids.Add(depotTaskId);
             }


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- 修复仅选择仓库识别时用户数据更新任务被跳过的问题，通过将仓库识别结果正确更新到整体结果中来解决。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix user data update tasks skipping when only depot recognition is selected by correctly updating the overall result with depot recognition outcomes.

</details>