### PR TITLE
feat: 新增「更新后立即重启时不自动运行」选项，启动自动运行前增加倒计时确认

### DIFF
--- a/src/MaaUpdater/main.cpp
+++ b/src/MaaUpdater/main.cpp
@@ -9,7 +9,12 @@
 //                   [--mutex-name <name>] [--show-console] [--no-progress-ui]
 //
 // Plan file format (UTF-8 JSON):
-//   { "packageType": "full|ota", "removeList": ["rel/path", ...], "moveList": ["rel/path", ...] }
+//   {
+//     "packageType": "full|ota",
+//     "removeList": ["rel/path", ...],
+//     "moveList": ["rel/path", ...],
+//     "relaunchArgs": ["--skip-startup-auto-run", ...]   // optional, forwarded to MAA.exe
+//   }
 
 #include <windows.h>
 #include <commctrl.h>
@@ -1394,6 +1399,8 @@ struct PendingUpdatePlan
     std::wstring packageType;
     std::vector<std::wstring> removeList;
     std::vector<std::wstring> moveList;
+    // Optional args forwarded to MAA.exe on relaunch (e.g. --skip-startup-auto-run).
+    std::vector<std::wstring> relaunchArgs;
 };
 
 static bool LoadPendingUpdatePlan(
@@ -1427,7 +1434,47 @@ static bool LoadPendingUpdatePlan(
     outPlan.packageType = ParseJsonStringProperty(planJson, "packageType");
     outPlan.removeList = ParseJsonStringArray(planJson, "removeList");
     outPlan.moveList = ParseJsonStringArray(planJson, "moveList");
+    outPlan.relaunchArgs = ParseJsonStringArray(planJson, "relaunchArgs");
     return true;
+}
+
+// Build a CreateProcess command line: "exe" [quoted args...]
+static std::wstring BuildRelaunchCommandLine(
+    const std::wstring& executable,
+    const std::vector<std::wstring>& args)
+{
+    auto needsQuotes = [](const std::wstring& value) {
+        return value.find_first_of(L" \t\"") != std::wstring::npos;
+    };
+    auto appendQuoted = [&](std::wstring& dest, const std::wstring& value) {
+        if (!needsQuotes(value)) {
+            dest += value;
+            return;
+        }
+
+        dest.push_back(L'"');
+        for (wchar_t ch : value) {
+            if (ch == L'"') {
+                dest += L"\\\"";
+            } else {
+                dest.push_back(ch);
+            }
+        }
+        dest.push_back(L'"');
+    };
+
+    std::wstring cmdLine;
+    appendQuoted(cmdLine, executable);
+    for (const std::wstring& arg : args) {
+        if (arg.empty()) {
+            continue;
+        }
+
+        cmdLine.push_back(L' ');
+        appendQuoted(cmdLine, arg);
+    }
+
+    return cmdLine;
 }
 
 static void PrintPlanEntries(const std::wstring& title, const std::vector<std::wstring>& entries)
@@ -1465,6 +1512,7 @@ static int RunPlanParserTest(const std::wstring& initialPlanFile)
         L" | Package type: " + (plan.packageType.empty() ? std::wstring(L"<empty>") : plan.packageType), true);
     PrintPlanEntries(L"待删除文件列表 | Files to remove", plan.removeList);
     PrintPlanEntries(L"待安装文件列表 | Files to install", plan.moveList);
+    PrintPlanEntries(L"重启参数 | Relaunch args", plan.relaunchArgs);
     return 0;
 }
 
@@ -1829,6 +1877,8 @@ int wmain(int argc, wchar_t* argv[])
     bool success = false;
     std::wstring failureReason;
     HANDLE hUpdateMutex = nullptr;
+    // Copied from plan for CreateProcess after a successful update.
+    std::vector<std::wstring> relaunchArgs;
 
     // ------------------------------------------------------------------
     // Wait for parent process to exit
@@ -1898,6 +1948,8 @@ int wmain(int argc, wchar_t* argv[])
             break;
         }
 
+        relaunchArgs = plan.relaunchArgs;
+
         bool isFullPackage = EqualsIgnoreCase(plan.packageType, L"full");
         const std::vector<std::wstring>& removeList = plan.removeList;
         const std::vector<std::wstring>& moveList = plan.moveList;
@@ -1907,7 +1959,7 @@ int wmain(int argc, wchar_t* argv[])
             L"正在分析更新内容... | Analyzing update contents...",
             L"更新计划读取完成 | Update plan loaded");
 
-        WriteLog((L"Plan loaded, package type: " + plan.packageType + L", remove entries: " + std::to_wstring(removeList.size()) + L", install entries: " + std::to_wstring(moveList.size())).c_str());
+        WriteLog((L"Plan loaded, package type: " + plan.packageType + L", remove entries: " + std::to_wstring(removeList.size()) + L", install entries: " + std::to_wstring(moveList.size()) + L", relaunch args: " + std::to_wstring(relaunchArgs.size())).c_str());
         WriteLogEntries(L"Files to remove", removeList);
         WriteLogEntries(L"Files to install", moveList);
 
@@ -2123,7 +2175,9 @@ int wmain(int argc, wchar_t* argv[])
         STARTUPINFOW si {};
         si.cb = sizeof(si);
         PROCESS_INFORMATION pi {};
-        std::wstring cmdLine = L"\"" + relaunchExecutable + L"\"";
+        // Forward plan.relaunchArgs to the next MAA process (e.g. --skip-startup-auto-run).
+        std::wstring cmdLine = BuildRelaunchCommandLine(relaunchExecutable, relaunchArgs);
+        WriteLog((L"Relaunch command line: " + cmdLine).c_str());
         if (CreateProcessW(
                 relaunchExecutable.c_str(),
                 cmdLine.data(),

--- a/src/MaaWpfGui/Configuration/Single/Settings/StartUpSettings.cs
+++ b/src/MaaWpfGui/Configuration/Single/Settings/StartUpSettings.cs
@@ -22,6 +22,13 @@ public class StartUpSettings : INotifyPropertyChanged
 
     public bool RunDirectly { get; set; }
 
+    /// <summary>
+    /// 更新后「立即重启」时是否跳过「启动后直接运行 / 启动模拟器」。
+    /// 默认开启：｢自动安装更新包｣ 或更新提示中选择立即重启时，在该重启链写入 <c>--skip-startup-auto-run</c>。
+    /// 选择「稍后」再手动启动不属于该链，仍按正常启动流程执行。
+    /// </summary>
+    public bool SkipStartupAutoRunAfterUpdate { get; set; } = true;
+
     public bool StartEmulator { get; set; }
 
     public bool RestartEmulatorWhenAdbFailed { get; set; }

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -640,7 +640,36 @@ public class AsstProxy
         // ReSharper disable once AsyncVoidLambda
         Execute.OnUIThread(
             async () => {
-                if (SettingsViewModel.StartSettings.RunDirectly)
+                bool runDirectly = SettingsViewModel.StartSettings.RunDirectly;
+                bool openEmulator = SettingsViewModel.StartSettings.OpenEmulatorAfterLaunch;
+
+                // 更新重启链写入的 --skip-startup-auto-run：跳过启动后自动开任务/模拟器
+                if (Bootstrapper.ShouldSkipStartupAutoRun)
+                {
+                    _logger.Information("Skip startup auto-run due to {Arg}", Bootstrapper.SkipStartupAutoRunArg);
+                    return;
+                }
+
+                // 会自动开任务或模拟器时，先给 10 秒反悔倒计时（不强制拉起主窗口）
+                if (runDirectly || openEmulator)
+                {
+                    string tipKey = (runDirectly, openEmulator) switch {
+                        (true, true) => "StartupAutoRunCountdownTaskAndEmulator",
+                        (true, false) => "StartupAutoRunCountdownTaskOnly",
+                        _ => "StartupAutoRunCountdownEmulatorOnly",
+                    };
+
+                    if (await Instances.TaskQueueViewModel.ConfirmStartupAutoRunAsync(
+                            LocalizationHelper.GetString("StartupAutoRunCountdownTitle"),
+                            LocalizationHelper.GetString(tipKey),
+                            seconds: 10))
+                    {
+                        _logger.Information("Startup auto-run canceled by user during countdown");
+                        return;
+                    }
+                }
+
+                if (runDirectly)
                 {
                     // 如果是直接运行模式，就先让按钮显示为运行
                     _runningState.SetIdle(false);
@@ -656,7 +685,7 @@ public class AsstProxy
                 }
 
                 // ReSharper disable once InvertIf
-                if (SettingsViewModel.StartSettings.RunDirectly)
+                if (runDirectly)
                 {
                     // 重置按钮状态，不影响LinkStart判断
                     _runningState.SetIdle(true);

--- a/src/MaaWpfGui/Main/Bootstrapper.cs
+++ b/src/MaaWpfGui/Main/Bootstrapper.cs
@@ -495,6 +495,13 @@ public class Bootstrapper : Bootstrapper<RootViewModel>
 
         _logger.Information("===================================");
 
+        // 尽早解析 skip 参数：pending 更新早退重启需要原样转发
+        _skipStartupAutoRun = args.Any(arg => string.Equals(arg, SkipStartupAutoRunArg, StringComparison.OrdinalIgnoreCase));
+        if (_skipStartupAutoRun)
+        {
+            _logger.Information("Startup auto-run will be skipped due to {Arg}", SkipStartupAutoRunArg);
+        }
+
         ConfigurationHelper.Load();
         LocalizationHelper.Load();
         if (PendingUpdateApplier.TryConsumeDelegatedUpdateSuccess())
@@ -996,25 +1003,66 @@ public class Bootstrapper : Bootstrapper<RootViewModel>
         _mutex?.Dispose();
     }
 
+    /// <summary>
+    /// 更新后「立即重启」链写入的启动参数：本次进程跳过「启动后直接运行 / 启动模拟器」。
+    /// 选择「稍后」再手动启动不会带此参数。
+    /// </summary>
+    public const string SkipStartupAutoRunArg = "--skip-startup-auto-run";
+
     private static bool _isRestartingWithoutArgs;
     private static ProcessStartInfo _restartStartInfo;
+    private static bool _skipStartupAutoRun;
+
+    /// <summary>
+    /// Gets a value indicating whether the current process should skip startup auto-run
+    /// (tasks / emulator launch after MAA start).
+    /// </summary>
+    public static bool ShouldSkipStartupAutoRun => _skipStartupAutoRun;
 
     /// <summary>
     /// 在完整 GUI 尚未初始化前，应用待处理更新后立即重启。
+    /// 若当前进程已带 <see cref="SkipStartupAutoRunArg"/>，则原样转发给下一进程。
     /// </summary>
     private static void RestartAfterPendingUpdateEarly()
     {
         _logger.Information("Pending update package applied, restarting application");
         if (Environment.ProcessPath is not null)
         {
-            Process.Start(new ProcessStartInfo {
+            var startInfo = new ProcessStartInfo {
                 FileName = Environment.ProcessPath,
                 WorkingDirectory = AppDomain.CurrentDomain.BaseDirectory,
-                UseShellExecute = true,
-            });
+                UseShellExecute = false,
+            };
+            foreach (string arg in GetForwardableRestartArgs())
+            {
+                startInfo.ArgumentList.Add(arg);
+            }
+
+            Process.Start(startInfo);
         }
 
         Environment.Exit(0);
+    }
+
+    /// <summary>
+    /// 获取需要转发给下一进程的启动参数（当前仅转发 skip-startup-auto-run）。
+    /// </summary>
+    /// <returns>需要转发的参数数组；无需转发时为空数组。</returns>
+    public static string[] GetForwardableRestartArgs()
+    {
+        return ShouldSkipStartupAutoRun ? [SkipStartupAutoRunArg] : [];
+    }
+
+    /// <summary>
+    /// 若启动设置允许，返回「更新后立即重启」链应写入的参数；否则返回空。
+    /// 仅用于自动安装或更新提示中选择立即重启；「稍后」手动启动不调用此方法。
+    /// </summary>
+    /// <returns>应写入的参数数组；选项关闭时为空数组。</returns>
+    public static string[] GetUpdateRestartArgsIfEnabled()
+    {
+        return ConfigFactory.CurrentConfig.Gui.StartUpSettings.SkipStartupAutoRunAfterUpdate
+            ? [SkipStartupAutoRunArg]
+            : [];
     }
 
     private static void ShowPendingUpdateRecoveryDialog()
@@ -1042,6 +1090,34 @@ public class Bootstrapper : Bootstrapper<RootViewModel>
         _isRestartingWithoutArgs = true;
         _logger.Information("Shutdown and restart without Args, call by `{Caller}`", caller);
         Execute.OnUIThread(Application.Current.Shutdown);
+    }
+
+    /// <summary>
+    /// 重启，并带上指定启动参数。
+    /// </summary>
+    /// <param name="args">传给下一进程的参数，例如 <c>--skip-startup-auto-run</c>。</param>
+    public static void ShutdownAndRestartWithArgs(params string[] args)
+    {
+        if (Environment.ProcessPath is null)
+        {
+            ShutdownAndRestartWithoutArgs();
+            return;
+        }
+
+        var startInfo = new ProcessStartInfo {
+            FileName = Environment.ProcessPath,
+            WorkingDirectory = AppDomain.CurrentDomain.BaseDirectory,
+            UseShellExecute = false,
+        };
+        if (args is not null)
+        {
+            foreach (string arg in args.Where(static a => !string.IsNullOrWhiteSpace(a)))
+            {
+                startInfo.ArgumentList.Add(arg);
+            }
+        }
+
+        ShutdownAndRestartWith(startInfo);
     }
 
     /// <summary>
@@ -1089,7 +1165,12 @@ public class Bootstrapper : Bootstrapper<RootViewModel>
 
     private static bool _isWaitingToRestart;
 
-    public static async Task RestartAfterIdleAsync()
+    /// <summary>
+    /// 等待空闲后重启。可选带上启动参数（如更新链的 <see cref="SkipStartupAutoRunArg"/>）。
+    /// </summary>
+    /// <param name="args">传给下一进程的参数；为空则无参重启。</param>
+    /// <returns>表示异步等待的任务。</returns>
+    public static async Task RestartAfterIdleAsync(params string[] args)
     {
         if (_isWaitingToRestart)
         {
@@ -1099,7 +1180,14 @@ public class Bootstrapper : Bootstrapper<RootViewModel>
         _isWaitingToRestart = true;
 
         await RunningState.Instance.UntilIdleAsync(60000);
-        ShutdownAndRestartWithoutArgs();
+        if (args is { Length: > 0 })
+        {
+            ShutdownAndRestartWithArgs(args);
+        }
+        else
+        {
+            ShutdownAndRestartWithoutArgs();
+        }
     }
 
     /// <inheritdoc/>

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -497,6 +497,13 @@ If you are concerned about leftover entries, please disable this option before d
         Administrator mode does not support startup on boot. It is not recommended to run MAA with administrator privileges for an extended period.\nIf necessary, please go to Control Panel &gt; Windows Tools &gt; Task Scheduler to create a custom task. When setting the trigger, make sure to check ｢Run with highest privileges｣
     </system:String>
     <system:String x:Key="RunTaskAfterLaunch">Auto Run task after launched</system:String>
+    <system:String x:Key="SkipStartupAutoRunAfterUpdate">Do not auto-run when restarting immediately for update</system:String>
+    <system:String x:Key="SkipStartupAutoRunAfterUpdateTip" xml:space="preserve">Only applies when ｢{key=AutoInstallUpdatePackage}｣ is on, or when you choose to restart immediately in the update prompt.
+If you choose ｢{key=ManualRestart}｣ and start MAA manually later, ｢{key=RunTaskAfterLaunch}｣ / ｢{key=OpenEmulatorAfterLaunch}｣ still run as usual.</system:String>
+    <system:String x:Key="StartupAutoRunCountdownTitle">Auto-start pending</system:String>
+    <system:String x:Key="StartupAutoRunCountdownTaskOnly">About to auto-run tasks. Cancel?</system:String>
+    <system:String x:Key="StartupAutoRunCountdownEmulatorOnly">About to start the emulator automatically. Cancel?</system:String>
+    <system:String x:Key="StartupAutoRunCountdownTaskAndEmulator">About to auto-run tasks and start the emulator. Cancel?</system:String>
     <system:String x:Key="MinimizeAfterLaunch">Auto Minimize after launched</system:String>
     <system:String x:Key="ClientType">Client Type</system:String>
     <system:String x:Key="StartGameLaunchClient">Launch Client on Start</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -497,6 +497,13 @@ MAA は非インストール型のアプリケーションであり、レジス�
         管理者権限での起動は、起動時の自動実行をサポートしていません。MAAを長時間管理者権限で実行することはお勧めしません。\n必要な場合は、 ｢コントロールパネル &gt; Windowsツール &gt; タスクスケジューラ｣ に移動してカスタムタスクを作成してください。トリガーを設定する際に、 ｢最も高い特権で実行｣ を必ず選択してください。
     </system:String>
     <system:String x:Key="RunTaskAfterLaunch">アプリの起動時に自動的に実行</system:String>
+    <system:String x:Key="SkipStartupAutoRunAfterUpdate">更新のため直ちに再起動する時は自動実行しない</system:String>
+    <system:String x:Key="SkipStartupAutoRunAfterUpdateTip" xml:space="preserve">｢{key=AutoInstallUpdatePackage}｣ が有効な場合、または更新確認で直ちに再起動を選んだ場合のみ適用されます。
+｢{key=ManualRestart}｣ を選んで後から手動起動した場合は、｢{key=RunTaskAfterLaunch}｣ / ｢{key=OpenEmulatorAfterLaunch}｣ は通常どおり実行されます。</system:String>
+    <system:String x:Key="StartupAutoRunCountdownTitle">自動起動の準備中</system:String>
+    <system:String x:Key="StartupAutoRunCountdownTaskOnly">まもなくタスクを自動実行します。キャンセルしますか？</system:String>
+    <system:String x:Key="StartupAutoRunCountdownEmulatorOnly">まもなくエミュレータを自動起動します。キャンセルしますか？</system:String>
+    <system:String x:Key="StartupAutoRunCountdownTaskAndEmulator">まもなくタスクを自動実行し、エミュレータを起動します。キャンセルしますか？</system:String>
     <system:String x:Key="MinimizeAfterLaunch">アプリの起動時に自動的に最小化</system:String>
     <system:String x:Key="ClientType">クライアントバージョン</system:String>
     <system:String x:Key="StartGameLaunchClient">起動時にクライアントを開始する</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -497,6 +497,13 @@ MAA는 비설치형 응용 프로그램으로, 삭제 시 레지스트리 항목
         관리자 권한으로 실행 시 부팅 시 자동 실행이 지원되지 않습니다. MAA를 관리자 권한으로 장시간 실행하는 것은 권장하지 않습니다.\n필요할 경우 제어판 &gt; Windows 도구 &gt; 작업 스케줄러에서 커스텀 작업을 생성하세요. 트리거를 설정할 때 ｢가장 높은 권한으로 실행｣을 반드시 선택하세요.
     </system:String>
     <system:String x:Key="RunTaskAfterLaunch">MAA 실행 후 작업 자동 시작</system:String>
+    <system:String x:Key="SkipStartupAutoRunAfterUpdate">업데이트 후 즉시 재시작할 때 자동 실행 안 함</system:String>
+    <system:String x:Key="SkipStartupAutoRunAfterUpdateTip" xml:space="preserve">｢{key=AutoInstallUpdatePackage}｣ 이 켜져 있거나, 업데이트 안내에서 즉시 재시작을 선택한 경우에만 적용됩니다.
+｢{key=ManualRestart}｣ 를 선택한 뒤 나중에 수동으로 MAA를 실행하면 ｢{key=RunTaskAfterLaunch}｣ / ｢{key=OpenEmulatorAfterLaunch}｣ 는 평소처럼 동작합니다.</system:String>
+    <system:String x:Key="StartupAutoRunCountdownTitle">자동 시작 예정</system:String>
+    <system:String x:Key="StartupAutoRunCountdownTaskOnly">곧 작업을 자동 실행합니다. 취소할까요?</system:String>
+    <system:String x:Key="StartupAutoRunCountdownEmulatorOnly">곧 에뮬레이터를 자동 실행합니다. 취소할까요?</system:String>
+    <system:String x:Key="StartupAutoRunCountdownTaskAndEmulator">곧 작업을 자동 실행하고 에뮬레이터를 시작합니다. 취소할까요?</system:String>
     <system:String x:Key="MinimizeAfterLaunch">MAA 실행 후 최소화</system:String>
     <system:String x:Key="ClientType">클라이언트 종류</system:String>
     <system:String x:Key="StartGameLaunchClient">시작 시 클라이언트 실행</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -497,6 +497,13 @@ D:\
         管理员权限启动不支持开机自启。不建议长期以管理员权限运行 MAA。\n如确有需要，请前往 控制面板 > Windows 工具 > 任务计划程序 创建自定义任务。设置触发器时，请确保勾选 ｢使用最高权限运行｣。
     </system:String>
     <system:String x:Key="RunTaskAfterLaunch">启动 MAA 后直接运行</system:String>
+    <system:String x:Key="SkipStartupAutoRunAfterUpdate">更新后立即重启时不自动运行</system:String>
+    <system:String x:Key="SkipStartupAutoRunAfterUpdateTip" xml:space="preserve">仅在 ｢{key=AutoInstallUpdatePackage}｣ 或更新提示中选择立即重启时生效。
+若选择 ｢{key=ManualRestart}｣ 再手动启动 MAA，仍会按 ｢{key=RunTaskAfterLaunch}｣ / ｢{key=OpenEmulatorAfterLaunch}｣ 正常执行。</system:String>
+    <system:String x:Key="StartupAutoRunCountdownTitle">即将自动启动</system:String>
+    <system:String x:Key="StartupAutoRunCountdownTaskOnly">即将自动运行任务，是否取消？</system:String>
+    <system:String x:Key="StartupAutoRunCountdownEmulatorOnly">即将自动启动模拟器，是否取消？</system:String>
+    <system:String x:Key="StartupAutoRunCountdownTaskAndEmulator">即将自动运行任务并启动模拟器，是否取消？</system:String>
     <system:String x:Key="MinimizeAfterLaunch">启动 MAA 后直接最小化</system:String>
     <system:String x:Key="ClientType">客户端类型</system:String>
     <system:String x:Key="StartGameLaunchClient">是否启动客户端</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -497,6 +497,13 @@ D:\
         ｢以系統管理員身分執行｣ 不支援開機自動啟動。不建議長期以系統管理員身分執行 MAA。\n如有需要，請前往 控制台 &gt; 系統管理工具 &gt; 工作排程器 建立工作。設定安全性選項時，請確保已勾選 ｢以最高權限執行｣。
     </system:String>
     <system:String x:Key="RunTaskAfterLaunch">啟動 MAA 後直接執行</system:String>
+    <system:String x:Key="SkipStartupAutoRunAfterUpdate">更新後立即重啟時不自動執行</system:String>
+    <system:String x:Key="SkipStartupAutoRunAfterUpdateTip" xml:space="preserve">僅在 ｢{key=AutoInstallUpdatePackage}｣ 或更新提示中選擇立即重啟時生效。
+若選擇 ｢{key=ManualRestart}｣ 再手動啟動 MAA，仍會依 ｢{key=RunTaskAfterLaunch}｣ / ｢{key=OpenEmulatorAfterLaunch}｣ 正常執行。</system:String>
+    <system:String x:Key="StartupAutoRunCountdownTitle">即將自動啟動</system:String>
+    <system:String x:Key="StartupAutoRunCountdownTaskOnly">即將自動執行任務，是否取消？</system:String>
+    <system:String x:Key="StartupAutoRunCountdownEmulatorOnly">即將自動啟動模擬器，是否取消？</system:String>
+    <system:String x:Key="StartupAutoRunCountdownTaskAndEmulator">即將自動執行任務並啟動模擬器，是否取消？</system:String>
     <system:String x:Key="MinimizeAfterLaunch">啟動 MAA 後直接最小化</system:String>
     <system:String x:Key="ClientType">用戶端類型</system:String>
     <system:String x:Key="StartGameLaunchClient">是否啟動用戶端</system:String>

--- a/src/MaaWpfGui/Services/PendingUpdateApplier.cs
+++ b/src/MaaWpfGui/Services/PendingUpdateApplier.cs
@@ -450,7 +450,9 @@ internal static partial class PendingUpdateApplier
         string updaterExecutablePath = PrepareDelegatedUpdaterExecutable(context);
         string relaunchExecutablePath = Path.Combine(context.RootDir, "MAA.exe");
 
-        File.WriteAllText(planPath, CreatePendingUpdatePlan(packageType, removeEntries, moveEntries));
+        // 将当前进程需要转发的启动参数写入 plan，供 Updater 原样传给下次 MAA.exe
+        string[] relaunchArgs = Bootstrapper.GetForwardableRestartArgs();
+        File.WriteAllText(planPath, CreatePendingUpdatePlan(packageType, removeEntries, moveEntries, relaunchArgs));
 
         var startInfo = new ProcessStartInfo {
             FileName = updaterExecutablePath,
@@ -512,13 +514,25 @@ internal static partial class PendingUpdateApplier
         return string.Equals(Path.GetFileName(ex.FileName), "MAA.Updater.exe", StringComparison.OrdinalIgnoreCase);
     }
 
-    private static string CreatePendingUpdatePlan(string packageType, IReadOnlyList<string> removeEntries, IReadOnlyList<string> moveEntries)
+    private static string CreatePendingUpdatePlan(
+        string packageType,
+        IReadOnlyList<string> removeEntries,
+        IReadOnlyList<string> moveEntries,
+        IReadOnlyList<string>? relaunchArgs = null)
     {
-        return new JObject {
+        var plan = new JObject {
             ["packageType"] = packageType,
             ["removeList"] = JArray.FromObject(removeEntries),
             ["moveList"] = JArray.FromObject(moveEntries),
-        }.ToString();
+        };
+
+        // relaunchArgs：Updater 成功后传给 MAA.exe 的启动参数（如 --skip-startup-auto-run）
+        if (relaunchArgs is { Count: > 0 })
+        {
+            plan["relaunchArgs"] = JArray.FromObject(relaunchArgs);
+        }
+
+        return plan.ToString();
     }
 
     private static string[] GetFullPackageRemoveEntries(PendingUpdateContext context)

--- a/src/MaaWpfGui/ViewModels/Dialogs/VersionUpdateDialogViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/Dialogs/VersionUpdateDialogViewModel.cs
@@ -744,6 +744,10 @@ public class VersionUpdateDialogViewModel : Screen
 
     private async Task AskToRestartCore(string description, string title)
     {
+        // 自动安装，或用户点「立即更新/确定」：按启动设置决定是否写入 --skip-startup-auto-run。
+        // 选「稍后」不会走到这里，之后手动启动是正常流程，不会带 skip 参数。
+        string[] updateRestartArgs = Bootstrapper.GetUpdateRestartArgsIfEnabled();
+
         if (SettingsViewModel.VersionUpdateSettings.AutoInstallUpdatePackage)
         {
             if (FakeUpdateHelper.HasPendingFakeUpdate)
@@ -753,7 +757,7 @@ public class VersionUpdateDialogViewModel : Screen
                 return;
             }
 
-            await Bootstrapper.RestartAfterIdleAsync();
+            await Bootstrapper.RestartAfterIdleAsync(updateRestartArgs);
             return;
         }
 
@@ -774,7 +778,14 @@ public class VersionUpdateDialogViewModel : Screen
                 return;
             }
 
-            Bootstrapper.ShutdownAndRestartWithoutArgs();
+            if (updateRestartArgs.Length > 0)
+            {
+                Bootstrapper.ShutdownAndRestartWithArgs(updateRestartArgs);
+            }
+            else
+            {
+                Bootstrapper.ShutdownAndRestartWithoutArgs();
+            }
         }
     }
 

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -985,6 +985,24 @@ public class TaskQueueViewModel : Screen
         AchievementTrackerHelper.Instance.AddProgressToGroup(AchievementIds.ScheduleMasterGroup);
     }
 
+    /// <summary>
+    /// 启动后自动运行前的倒计时确认。超时返回 <see langword="false"/>（继续自动开），
+    /// 用户点取消返回 <see langword="true"/>（本次不自动开）。
+    /// 不强制显示主窗口（与关机倒计时不同）。
+    /// </summary>
+    /// <param name="content">主文案</param>
+    /// <param name="tipContent">提示文案</param>
+    /// <param name="seconds">倒计时秒数</param>
+    /// <returns>是否被用户取消</returns>
+    public Task<bool> ConfirmStartupAutoRunAsync(string content, string tipContent, int seconds = 10)
+    {
+        return TimerCanceledAsync(
+            content,
+            tipContent,
+            LocalizationHelper.GetString("Cancel"),
+            seconds);
+    }
+
     private static async Task<bool> TimerCanceledAsync(string content = "", string tipContent = "", string buttonContent = "", int seconds = 10)
     {
         if (Application.Current.Dispatcher.CheckAccess())

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/StartSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/StartSettingsUserControlModel.cs
@@ -89,6 +89,18 @@ public class StartSettingsUserControlModel : PropertyChangedBase
     } = ConfigFactory.CurrentConfig.Gui.StartUpSettings.RunDirectly;
 
     /// <summary>
+    /// Gets or sets a value indicating whether to skip startup auto-run when restarting immediately for an update
+    /// (auto-install or choosing restart now). Choosing “later” then starting MAA manually is a normal launch.
+    /// </summary>
+    public bool SkipStartupAutoRunAfterUpdate
+    {
+        get; set {
+            SetAndNotify(ref field, value);
+            ConfigFactory.CurrentConfig.Gui.StartUpSettings.SkipStartupAutoRunAfterUpdate = value;
+        }
+    } = ConfigFactory.CurrentConfig.Gui.StartUpSettings.SkipStartupAutoRunAfterUpdate;
+
+    /// <summary>
     /// Gets or sets a value indicating whether to minimize directly.
     /// </summary>
     public bool MinimizeDirectly

--- a/src/MaaWpfGui/Views/UserControl/Settings/StartSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/Settings/StartSettingsUserControl.xaml
@@ -61,11 +61,18 @@
                 Block.TextAlignment="Center"
                 Content="{DynamicResource OpenEmulatorAfterLaunch}"
                 IsChecked="{Binding OpenEmulatorAfterLaunch}" />
-            <Grid>
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition />
-                    <ColumnDefinition Width="Auto" />
-                </Grid.ColumnDefinitions>
+            <StackPanel Orientation="Horizontal">
+                <CheckBox
+                    Grid.Column="0"
+                    Margin="10,10,0,10"
+                    HorizontalAlignment="Left"
+                    VerticalAlignment="Top"
+                    Block.TextAlignment="Center"
+                    Content="{DynamicResource SkipStartupAutoRunAfterUpdate}"
+                    IsChecked="{Binding SkipStartupAutoRunAfterUpdate}" />
+                <controls:TooltipBlock Grid.Column="1" TooltipText="{DynamicResource SkipStartupAutoRunAfterUpdateTip}" />
+            </StackPanel>
+            <StackPanel Orientation="Horizontal">
                 <CheckBox
                     Grid.Column="0"
                     Margin="10,10,0,10"
@@ -73,17 +80,17 @@
                     <controls:TextBlock Text="{DynamicResource RetryOnDisconnected}" TextWrapping="Wrap" />
                 </CheckBox>
                 <controls:TooltipBlock Grid.Column="1" TooltipText="{DynamicResource RetryOnDisconnectedTip}" />
-            </Grid>
+            </StackPanel>
         </StackPanel>
 
         <StackPanel Grid.Column="1" VerticalAlignment="Center">
-            <StackPanel>
+            <StackPanel Margin="10">
                 <StackPanel
-                    Margin="10,0"
                     HorizontalAlignment="Center"
                     VerticalAlignment="Center"
                     Orientation="Horizontal">
                     <controls:TextBlock
+                        Margin="0,5"
                         VerticalAlignment="Center"
                         Block.TextAlignment="Center"
                         Text="{DynamicResource EmulatorPath}" />
@@ -99,20 +106,18 @@
                         Command="{s:Action TestEmulatorExec}"
                         Content="{DynamicResource Test}" />
                 </StackPanel>
-                <TextBox Margin="20,5" Text="{Binding EmulatorPath}" />
+                <TextBox Text="{Binding EmulatorPath}" />
             </StackPanel>
-            <StackPanel>
+            <StackPanel Margin="10">
                 <StackPanel
+                    Margin="0,0,0,5"
                     HorizontalAlignment="Center"
                     VerticalAlignment="Center"
                     Orientation="Horizontal">
                     <controls:TextBlock Block.TextAlignment="Center" Text="{DynamicResource AdditionCommand}" />
                     <controls:TooltipBlock TooltipText="{DynamicResource AdditionCommandTip}" />
                 </StackPanel>
-                <TextBox
-                    Margin="20,5"
-                    IsEnabled="{Binding EmulatorPath.Length}"
-                    Text="{Binding EmulatorAddCommand}" />
+                <TextBox IsEnabled="{Binding EmulatorPath.Length}" Text="{Binding EmulatorAddCommand}" />
             </StackPanel>
             <StackPanel
                 Margin="10"

--- a/src/MaaWpfGui/Views/UserControl/Settings/StartSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/Settings/StartSettingsUserControl.xaml
@@ -25,7 +25,6 @@
         </Grid.ColumnDefinitions>
         <StackPanel
             Grid.Column="0"
-            Margin="10"
             HorizontalAlignment="Center"
             VerticalAlignment="Center"
             Orientation="Vertical">
@@ -33,7 +32,6 @@
             <StackPanel Margin="10" Orientation="Horizontal">
                 <CheckBox
                     HorizontalAlignment="Left"
-                    VerticalAlignment="Top"
                     Block.TextAlignment="Center"
                     Content="{DynamicResource LaunchOnSystemStartup}"
                     IsChecked="{Binding StartSelf}" />
@@ -42,7 +40,6 @@
             <CheckBox
                 Margin="10"
                 HorizontalAlignment="Left"
-                VerticalAlignment="Top"
                 Block.TextAlignment="Center"
                 Content="{DynamicResource MinimizeAfterLaunch}"
                 IsChecked="{Binding MinimizeDirectly}" />
@@ -50,33 +47,23 @@
             <CheckBox
                 Margin="10"
                 HorizontalAlignment="Left"
-                VerticalAlignment="Top"
                 Block.TextAlignment="Center"
                 Content="{DynamicResource RunTaskAfterLaunch}"
                 IsChecked="{Binding RunDirectly}" />
             <CheckBox
                 Margin="10"
                 HorizontalAlignment="Left"
-                VerticalAlignment="Top"
                 Block.TextAlignment="Center"
                 Content="{DynamicResource OpenEmulatorAfterLaunch}"
                 IsChecked="{Binding OpenEmulatorAfterLaunch}" />
-            <StackPanel Orientation="Horizontal">
-                <CheckBox
-                    Grid.Column="0"
-                    Margin="10,10,0,10"
-                    HorizontalAlignment="Left"
-                    VerticalAlignment="Top"
-                    Block.TextAlignment="Center"
-                    Content="{DynamicResource SkipStartupAutoRunAfterUpdate}"
-                    IsChecked="{Binding SkipStartupAutoRunAfterUpdate}" />
+            <StackPanel Margin="10" Orientation="Horizontal">
+                <CheckBox MaxWidth="210" IsChecked="{Binding SkipStartupAutoRunAfterUpdate}">
+                    <controls:TextBlock Text="{DynamicResource SkipStartupAutoRunAfterUpdate}" TextWrapping="Wrap" />
+                </CheckBox>
                 <controls:TooltipBlock Grid.Column="1" TooltipText="{DynamicResource SkipStartupAutoRunAfterUpdateTip}" />
             </StackPanel>
-            <StackPanel Orientation="Horizontal">
-                <CheckBox
-                    Grid.Column="0"
-                    Margin="10,10,0,10"
-                    IsChecked="{Binding RetryOnDisconnected, Source={x:Static ui_vms:SettingsViewModel.ConnectSettings}}">
+            <StackPanel Margin="10" Orientation="Horizontal">
+                <CheckBox MaxWidth="210" IsChecked="{Binding RetryOnDisconnected, Source={x:Static ui_vms:SettingsViewModel.ConnectSettings}}">
                     <controls:TextBlock Text="{DynamicResource RetryOnDisconnected}" TextWrapping="Wrap" />
                 </CheckBox>
                 <controls:TooltipBlock Grid.Column="1" TooltipText="{DynamicResource RetryOnDisconnectedTip}" />


### PR DESCRIPTION
<img width="1596" height="1196" alt="6e090550c7098bd16d5dc06b916125e5" src="https://github.com/user-attachments/assets/d948e4b7-367e-45fd-88a3-cf8f83af7406" />
<img width="1596" height="1196" alt="5ce7c3c8-85f8-4909-9e4a-929a74a628f8" src="https://github.com/user-attachments/assets/517b6ba1-02e5-4f2d-ab84-4250d7702595" />
<img width="1596" height="1196" alt="0e220cfe-658b-4514-9059-1707c9c6bc13" src="https://github.com/user-attachments/assets/6beb0888-ac00-46c2-9cd9-a2e56b296b4d" />
<img width="1086" height="612" alt="image" src="https://github.com/user-attachments/assets/ad1f5d45-ca46-4c48-93f2-03165835b985" />
<img width="1809" height="441" alt="image" src="https://github.com/user-attachments/assets/f44639c8-da55-403a-a914-871b45f2975f" />

## Summary by Sourcery

在立即的更新后重启场景中，新增可配置选项，用于跳过自动任务/模拟器启动，并确保此行为在更新器的二次重启链路中得以传递，同时在任何自动启动动作前引入倒计时确认步骤。

New Features:
- 引入 `--skip-startup-auto-run` 启动参数及对应的配置标记，用于在因更新触发的重启后跳过自动任务/模拟器启动。
- 在应用启动时，在自动启动任务或模拟器之前，增加一个 10 秒倒计时确认对话框。

Enhancements:
- 在待处理更新及更新器重启的链路中转发相关启动参数，确保跨进程保持 skip-auto-run 的行为。
- 扩展重启辅助工具，以支持在空闲时间和立即重启场景中传递自定义启动参数。

Documentation:
- 更新本地化资源和设置界面，在面向用户的 UI 中呈现新的更新后自动运行跳过选项及倒计时提示文案。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a configurable option to skip automatic task/emulator launch after an immediate post‑update restart and ensure this behavior propagates through the updater relaunch chain, while introducing a countdown confirmation before any automatic startup actions.

New Features:
- Introduce the --skip-startup-auto-run launch argument and corresponding configuration flag to skip automatic task/emulator startup after an update-triggered restart.
- Add a 10-second countdown confirmation dialog before automatically starting tasks or the emulator on application launch.

Enhancements:
- Forward relevant startup arguments through the pending update and updater relaunch pipeline so that skip-auto-run behavior is preserved across processes.
- Extend restart helpers to support passing through custom launch arguments for idle-time and immediate restarts.

Documentation:
- Update localization resources and settings UI to surface the new post-update auto-run skip option and countdown messaging to users.

</details>