### PR TITLE
fix: 使用 LUID 解析 GPU OCR 设备

### DIFF
--- a/src/MaaCore/Assistant.cpp
+++ b/src/MaaCore/Assistant.cpp
@@ -53,9 +53,13 @@ bool ::AsstExtAPI::set_static_option(StaticOptionKey key, const std::string& val
             return false;
         }
 
+        if (!OnnxSessions::get_instance().use_gpu(*selector)) {
+            return false;
+        }
+
         WordOcr::get_instance().use_gpu(*selector);
         CharOcr::get_instance().use_gpu(*selector);
-        return OnnxSessions::get_instance().use_gpu(*selector);
+        return true;
     } break;
     default:
         Log.error(__FUNCTION__, "| unknown key:", static_cast<int>(key));

--- a/src/MaaCore/Assistant.cpp
+++ b/src/MaaCore/Assistant.cpp
@@ -5,6 +5,7 @@
 #include <ranges>
 
 #include "Config/GeneralConfig.h"
+#include "Config/GpuDeviceSelector.h"
 #include "Config/Miscellaneous/OcrPack.h"
 #include "Config/OnnxSessions.h"
 #include "Config/ResourceLoader.h"
@@ -46,11 +47,15 @@ bool ::AsstExtAPI::set_static_option(StaticOptionKey key, const std::string& val
         return true;
     } break;
     case StaticOptionKey::GpuOCR: {
-        int device_id = std::stoi(value);
-        WordOcr::get_instance().use_gpu(device_id);
-        CharOcr::get_instance().use_gpu(device_id);
-        OnnxSessions::get_instance().use_gpu(device_id);
-        return true;
+        const auto selector = GpuDeviceSelector::parse(value);
+        if (!selector) {
+            Log.error(__FUNCTION__, "| invalid GPU selector:", value);
+            return false;
+        }
+
+        WordOcr::get_instance().use_gpu(*selector);
+        CharOcr::get_instance().use_gpu(*selector);
+        return OnnxSessions::get_instance().use_gpu(*selector);
     } break;
     default:
         Log.error(__FUNCTION__, "| unknown key:", static_cast<int>(key));

--- a/src/MaaCore/CMakeLists.txt
+++ b/src/MaaCore/CMakeLists.txt
@@ -47,7 +47,7 @@ else()
 endif()
 
 if(WIN32)
-    target_link_libraries(MaaCore ws2_32)
+    target_link_libraries(MaaCore ws2_32 dxgi)
 endif()
 
 if(LINUX)

--- a/src/MaaCore/Common/AsstTypes.h
+++ b/src/MaaCore/Common/AsstTypes.h
@@ -34,8 +34,8 @@ enum class StaticOptionKey
 {
     Invalid = 0,
     CpuOCR = 1, // use CPU to OCR, no value. It does not support switching after the resource is loaded.
-    GpuOCR = 2, // use GPU to OCR, value is gpu_id int to string. It does not support switching after the resource
-                // is loaded.
+    GpuOCR = 2, // use GPU to OCR. value is a device id integer, or "luid:<hex>" on Windows. It does not support
+                // switching after the resource is loaded.
 };
 
 enum class InstanceOptionKey

--- a/src/MaaCore/Config/GpuDeviceSelector.cpp
+++ b/src/MaaCore/Config/GpuDeviceSelector.cpp
@@ -1,0 +1,66 @@
+#include "GpuDeviceSelector.h"
+
+#include <format>
+
+#include "MaaUtils/Encoding.h"
+#include "Utils/Logger.hpp"
+
+#ifdef _WIN32
+#include <dxgi.h>
+#include <wrl/client.h>
+
+#endif
+
+std::optional<int> asst::GpuDeviceSelector::resolve_device_id() const
+{
+    if (!m_adapter_luid) {
+        return m_device_id;
+    }
+
+#ifdef _WIN32
+    Microsoft::WRL::ComPtr<IDXGIFactory1> factory;
+    const auto factory_hr = CreateDXGIFactory1(IID_PPV_ARGS(factory.GetAddressOf()));
+    if (FAILED(factory_hr)) {
+        Log.error(__FUNCTION__, "CreateDXGIFactory1 failed", std::format("0x{:08X}", factory_hr));
+        return std::nullopt;
+    }
+
+    for (UINT index = 0;; ++index) {
+        Microsoft::WRL::ComPtr<IDXGIAdapter> adapter;
+        const auto enum_hr = factory->EnumAdapters(index, adapter.GetAddressOf());
+        if (enum_hr == DXGI_ERROR_NOT_FOUND) {
+            break;
+        }
+        if (FAILED(enum_hr)) {
+            Log.error(__FUNCTION__, "EnumAdapters failed", index, std::format("0x{:08X}", enum_hr));
+            return std::nullopt;
+        }
+
+        DXGI_ADAPTER_DESC desc {};
+        if (FAILED(adapter->GetDesc(&desc))) {
+            continue;
+        }
+
+        const auto adapter_luid = (static_cast<uint64_t>(static_cast<uint32_t>(desc.AdapterLuid.HighPart)) << 32) |
+                                  static_cast<uint64_t>(desc.AdapterLuid.LowPart);
+        if (adapter_luid != *m_adapter_luid) {
+            continue;
+        }
+
+        Log.info(
+            __FUNCTION__,
+            "resolved adapter LUID",
+            std::format("{:016X}", adapter_luid),
+            "to device id",
+            index,
+            MAA_NS::from_u16(std::wstring_view(desc.Description)));
+        return static_cast<int>(index);
+    }
+
+    Log.error(__FUNCTION__, "adapter LUID not found", std::format("{:016X}", *m_adapter_luid));
+#else
+    Log.error(__FUNCTION__, "adapter LUID selectors are only supported on Windows");
+#endif
+
+    return std::nullopt;
+}

--- a/src/MaaCore/Config/GpuDeviceSelector.h
+++ b/src/MaaCore/Config/GpuDeviceSelector.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <charconv>
+#include <cstdint>
+#include <optional>
+#include <string_view>
+
+namespace asst
+{
+class GpuDeviceSelector
+{
+public:
+    static constexpr std::string_view LuidPrefix = "luid:";
+
+    static std::optional<GpuDeviceSelector> parse(std::string_view value)
+    {
+        GpuDeviceSelector result;
+
+        if (value.starts_with(LuidPrefix)) {
+            const auto luid_value = value.substr(LuidPrefix.size());
+            if (luid_value.empty() || luid_value.size() > 16) {
+                return std::nullopt;
+            }
+
+            uint64_t adapter_luid = 0;
+            const auto [ptr, ec] =
+                std::from_chars(luid_value.data(), luid_value.data() + luid_value.size(), adapter_luid, 16);
+            if (ec != std::errc {} || ptr != luid_value.data() + luid_value.size()) {
+                return std::nullopt;
+            }
+
+            result.m_adapter_luid = adapter_luid;
+            return result;
+        }
+
+        int device_id = 0;
+        const auto [ptr, ec] = std::from_chars(value.data(), value.data() + value.size(), device_id);
+        if (value.empty() || ec != std::errc {} || ptr != value.data() + value.size() || device_id < 0) {
+            return std::nullopt;
+        }
+
+        result.m_device_id = device_id;
+        return result;
+    }
+
+    [[nodiscard]] bool uses_adapter_luid() const noexcept { return m_adapter_luid.has_value(); }
+
+    [[nodiscard]] std::optional<uint64_t> adapter_luid() const noexcept { return m_adapter_luid; }
+
+    [[nodiscard]] int device_id() const noexcept { return m_device_id; }
+
+    [[nodiscard]] std::optional<int> resolve_device_id() const;
+
+    bool operator==(const GpuDeviceSelector&) const = default;
+
+private:
+    int m_device_id = 0;
+    std::optional<uint64_t> m_adapter_luid;
+};
+} // namespace asst

--- a/src/MaaCore/Config/GpuDeviceSelector.h
+++ b/src/MaaCore/Config/GpuDeviceSelector.h
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <optional>
 #include <string_view>
+#include <system_error>
 
 namespace asst
 {
@@ -17,6 +18,9 @@ public:
         GpuDeviceSelector result;
 
         if (value.starts_with(LuidPrefix)) {
+#ifndef _WIN32
+            return std::nullopt;
+#else
             const auto luid_value = value.substr(LuidPrefix.size());
             if (luid_value.empty() || luid_value.size() > 16) {
                 return std::nullopt;
@@ -31,6 +35,7 @@ public:
 
             result.m_adapter_luid = adapter_luid;
             return result;
+#endif
         }
 
         int device_id = 0;

--- a/src/MaaCore/Config/Miscellaneous/OcrPack.cpp
+++ b/src/MaaCore/Config/Miscellaneous/OcrPack.cpp
@@ -41,7 +41,7 @@ OcrPack::OcrPack() :
 OcrPack::~OcrPack()
 {
     LogTraceFunction;
-    if (m_gpu_id) {
+    if (m_gpu_active) {
         // FIXME: leak fastdeploy objects to avoid crash (double free?)
         (void)m_impl->det.release();
         (void)m_impl->rec.release();
@@ -195,11 +195,17 @@ bool OcrPack::check_and_load()
     rec_option.UseOrtBackend();
 
 #ifdef _WIN32
-    if (m_gpu_id) {
-        det_option.UseDirectML(*m_gpu_id);
-        rec_option.UseDirectML(*m_gpu_id);
+    const auto device_id = m_gpu_selector ? m_gpu_selector->resolve_device_id() : std::nullopt;
+    if (device_id) {
+        m_gpu_active = true;
+        det_option.UseDirectML(*device_id);
+        rec_option.UseDirectML(*device_id);
     }
     else {
+        m_gpu_active = false;
+        if (m_gpu_selector) {
+            Log.error("Failed to resolve configured GPU; falling back to FastDeploy CPU mode");
+        }
         // CPU 模式下限制线程数，避免过高的 CPU 占用
         det_option.SetCpuThreadNum(cpu_threads);
         rec_option.SetCpuThreadNum(cpu_threads);

--- a/src/MaaCore/Config/Miscellaneous/OcrPack.h
+++ b/src/MaaCore/Config/Miscellaneous/OcrPack.h
@@ -2,9 +2,11 @@
 
 #include "Common/AsstTypes.h"
 #include "Config/AbstractResource.h"
+#include "Config/GpuDeviceSelector.h"
 
 #include <memory>
 #include <optional>
+#include <utility>
 #include <vector>
 
 namespace cv
@@ -25,9 +27,13 @@ public:
 
     virtual bool load(const std::filesystem::path& path) override;
 
-    void use_cpu() { m_gpu_id = std::nullopt; }
+    void use_cpu()
+    {
+        m_gpu_selector = std::nullopt;
+        m_gpu_active = false;
+    }
 
-    void use_gpu(int gpu_id) { m_gpu_id = gpu_id; }
+    void use_gpu(GpuDeviceSelector selector) { m_gpu_selector = std::move(selector); }
 
     ResultsVec recognize(const cv::Mat& image, bool without_det = false, const std::optional<Rect>& base_roi = {});
 
@@ -38,7 +44,8 @@ protected:
 
     struct Impl;
     std::unique_ptr<Impl> m_impl;
-    std::optional<int> m_gpu_id = std::nullopt;
+    std::optional<GpuDeviceSelector> m_gpu_selector = std::nullopt;
+    bool m_gpu_active = false;
 };
 
 class WordOcr final : public MAA_NS::SingletonHolder<WordOcr>, public OcrPack

--- a/src/MaaCore/Config/OnnxSessions.cpp
+++ b/src/MaaCore/Config/OnnxSessions.cpp
@@ -36,6 +36,11 @@ bool asst::OnnxSessions::load(const std::filesystem::path& path)
 Ort::Session& asst::OnnxSessions::get(const std::string& name)
 {
     if (m_sessions.find(name) == m_sessions.end()) {
+        if (gpu_enabled && !gpu_options_initialized && !initialize_gpu_options()) {
+            Log.error(__FUNCTION__, "Failed to initialize configured GPU; falling back to CPU mode");
+            use_cpu();
+        }
+
         Log.info(__FUNCTION__, "lazy load", name);
         Ort::Session session(m_env, m_model_paths.at(name).c_str(), m_options);
         m_sessions.emplace(name, std::move(session));
@@ -71,18 +76,39 @@ bool asst::OnnxSessions::use_cpu()
 
     Log.info("CPU OCR enabled with", cpu_threads, "threads");
 
+    m_gpu_selector = std::nullopt;
     gpu_enabled = false;
+    gpu_options_initialized = false;
     return true;
 }
 
-bool asst::OnnxSessions::use_gpu(int device_id)
+bool asst::OnnxSessions::use_gpu(GpuDeviceSelector selector)
 {
     if (gpu_enabled) {
-        return true;
+        return m_gpu_selector == selector;
     }
     if (m_sessions.size() != 0) {
         return false;
     }
+
+    m_options = Ort::SessionOptions();
+    m_gpu_selector = std::move(selector);
+    gpu_enabled = true;
+    gpu_options_initialized = false;
+    return true;
+}
+
+bool asst::OnnxSessions::initialize_gpu_options()
+{
+    if (!m_gpu_selector) {
+        return false;
+    }
+
+    const auto device_id = m_gpu_selector->resolve_device_id();
+    if (!device_id) {
+        return false;
+    }
+
     auto all_providers = Ort::GetAvailableProviders();
     bool support_cuda = false;
     bool support_dml = false;
@@ -99,18 +125,20 @@ bool asst::OnnxSessions::use_gpu(int device_id)
         }
     }
 
-    bool any_gpu = support_cuda || support_dml || support_coreml;
+    bool provider_configured = false;
 
     if (support_cuda) {
         OrtCUDAProviderOptions cuda_options;
-        cuda_options.device_id = device_id;
+        cuda_options.device_id = *device_id;
         m_options.AppendExecutionProvider_CUDA(cuda_options);
+        provider_configured = true;
     }
 #ifdef WITH_DML
     else if (support_dml) {
-        if (!Ort::Status(OrtSessionOptionsAppendExecutionProvider_DML(m_options, device_id)).IsOK()) {
+        if (!Ort::Status(OrtSessionOptionsAppendExecutionProvider_DML(m_options, *device_id)).IsOK()) {
             return false;
         }
+        provider_configured = true;
     }
 #endif
 #ifdef WITH_COREML
@@ -118,14 +146,15 @@ bool asst::OnnxSessions::use_gpu(int device_id)
         if (!Ort::Status(OrtSessionOptionsAppendExecutionProvider_CoreML((OrtSessionOptions*)m_options, 0)).IsOK()) {
             return false;
         }
+        provider_configured = true;
     }
 #endif
-    if (!any_gpu) {
+    if (!provider_configured) {
         Log.error(__FUNCTION__, "No GPU execution provider available");
         return false;
     }
 
-    gpu_enabled = true;
+    gpu_options_initialized = true;
     return true;
 }
 

--- a/src/MaaCore/Config/OnnxSessions.cpp
+++ b/src/MaaCore/Config/OnnxSessions.cpp
@@ -48,14 +48,11 @@ Ort::Session& asst::OnnxSessions::get(const std::string& name)
     return m_sessions.at(name);
 }
 
-bool asst::OnnxSessions::use_cpu()
+int asst::OnnxSessions::reset_session_options()
 {
-    if (m_sessions.size() != 0) {
-        return false;
-    }
     m_options = Ort::SessionOptions();
 
-    int logical = std::max(1u, std::thread::hardware_concurrency());
+    const int logical = std::max(1u, std::thread::hardware_concurrency());
     int cpu_threads;
     if (logical <= 2) {
         cpu_threads = 1;
@@ -74,6 +71,16 @@ bool asst::OnnxSessions::use_cpu()
     m_options.SetExecutionMode(ExecutionMode::ORT_SEQUENTIAL);
     m_options.SetIntraOpNumThreads(cpu_threads);
 
+    return cpu_threads;
+}
+
+bool asst::OnnxSessions::use_cpu()
+{
+    if (m_sessions.size() != 0) {
+        return false;
+    }
+
+    const auto cpu_threads = reset_session_options();
     Log.info("CPU OCR enabled with", cpu_threads, "threads");
 
     m_gpu_selector = std::nullopt;
@@ -85,13 +92,19 @@ bool asst::OnnxSessions::use_cpu()
 bool asst::OnnxSessions::use_gpu(GpuDeviceSelector selector)
 {
     if (gpu_enabled) {
-        return m_gpu_selector == selector;
+        if (m_gpu_selector == selector) {
+            return true;
+        }
+
+        Log.error(__FUNCTION__, "GPU OCR is already configured with a different device selector");
+        return false;
     }
     if (m_sessions.size() != 0) {
+        Log.error(__FUNCTION__, "GPU OCR cannot be configured after ONNX sessions have been created");
         return false;
     }
 
-    m_options = Ort::SessionOptions();
+    reset_session_options();
     m_gpu_selector = std::move(selector);
     gpu_enabled = true;
     gpu_options_initialized = false;
@@ -128,7 +141,7 @@ bool asst::OnnxSessions::initialize_gpu_options()
     bool provider_configured = false;
 
     if (support_cuda) {
-        OrtCUDAProviderOptions cuda_options;
+        OrtCUDAProviderOptions cuda_options {};
         cuda_options.device_id = *device_id;
         m_options.AppendExecutionProvider_CUDA(cuda_options);
         provider_configured = true;

--- a/src/MaaCore/Config/OnnxSessions.h
+++ b/src/MaaCore/Config/OnnxSessions.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include "AbstractResource.h"
+#include "GpuDeviceSelector.h"
 
+#include <optional>
 #include <unordered_map>
 
 #if __has_include(<onnxruntime_cxx_api.h>)
@@ -22,13 +24,17 @@ public:
 
     Ort::Session& get(const std::string& name);
     bool use_cpu();
-    bool use_gpu(int device_id);
+    bool use_gpu(GpuDeviceSelector selector);
 
 private:
+    bool initialize_gpu_options();
+
     Ort::Env m_env;
     Ort::SessionOptions m_options;
     std::unordered_map<std::string, Ort::Session> m_sessions;
     std::unordered_map<std::string, std::filesystem::path> m_model_paths;
+    std::optional<GpuDeviceSelector> m_gpu_selector;
     bool gpu_enabled = false;
+    bool gpu_options_initialized = false;
 };
 }

--- a/src/MaaCore/Config/OnnxSessions.h
+++ b/src/MaaCore/Config/OnnxSessions.h
@@ -27,6 +27,7 @@ public:
     bool use_gpu(GpuDeviceSelector selector);
 
 private:
+    int reset_session_options();
     bool initialize_gpu_options();
 
     Ort::Env m_env;

--- a/src/MaaWpfGui/Helper/GpuOption.cs
+++ b/src/MaaWpfGui/Helper/GpuOption.cs
@@ -15,6 +15,7 @@
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Runtime.InteropServices;
 using MaaWpfGui.Configuration.Factory;
@@ -495,6 +496,8 @@ public abstract class GpuOption
         public abstract uint Index { get; }
 
         public abstract GpuDriverInformation GpuInfo { get; }
+
+        public virtual string DeviceSelector => Index.ToString(CultureInfo.InvariantCulture);
     }
 
     public class SystemDefaultOption(GpuDriverInformation info) : EnableOption
@@ -532,6 +535,9 @@ public abstract class GpuOption
         }
 
         public override uint Index => _index;
+
+        public override string DeviceSelector =>
+            $"luid:{unchecked((ulong)_description.AdapterLuid.AsLong()).ToString("X16", CultureInfo.InvariantCulture)}";
 
         public string InstancePath => _instancePath;
 

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -615,7 +615,7 @@ public class AsstProxy
                 }
             }
 
-            AsstSetStaticOption(AsstStaticOptionKey.GpuOCR, x.Index.ToString());
+            AsstSetStaticOption(AsstStaticOptionKey.GpuOCR, x.DeviceSelector);
         }
 
         bool loaded = LoadResource();


### PR DESCRIPTION
## 问题

修复 #17461 中 GPU 加速 OCR 偶发绑定到错误显卡的问题。

WPF 目前使用 `IDXGIFactory6::EnumAdapterByGpuPreference` 枚举并保存用户选择的 GPU，但 MaaCore 最终只接收该枚举结果中的数组下标。DirectML/FastDeploy 和 ONNX Runtime 在稍后初始化执行提供程序时，会根据各自当时看到的适配器顺序解释这个下标。两边的枚举顺序或初始化时机不一致时，同一个数字可能指向另一块显卡。

这解释了现场中“空闲 MAA 仍持续占用非预期 GPU、内存长期不释放”的组合现象：任务实际在错误适配器上创建并保留了推理资源，而不是 WPF 所选显卡的身份被稳定传递到了推理层。

## 修复

- WPF 对明确选择的 GPU 传递 DXGI adapter LUID，不再传递界面枚举下标。
- MaaCore 在 FastDeploy 和 ONNX Runtime 首次真正初始化 GPU 前，使用新的 DXGI factory 将 LUID 解析为当前适配器下标。
- 日志记录 LUID、最终下标和适配器名称，便于后续确认实际绑定结果。
- LUID 无法解析或执行提供程序不可用时回退 CPU，避免静默绑定其他 GPU。
- 保留数字设备 ID 输入，供“系统默认”、非 WPF 客户端和非 Windows 平台继续使用。

## 验证

- `clang-format 21.1.8 --dry-run --Werror`：通过。
- `git diff --check`：通过。
- MaaCore Release（Visual Studio 2022，等价手动 CMake 配置）：编译通过。
- `dotnet build src/MaaWpfGui/MaaWpfGui.csproj -c Release`：0 errors。

## 未覆盖

该问题无法稳定复现，因此尚未完成真实双显卡环境中的故障重放。修复后的日志已经包含最终解析出的适配器身份，可用于合并前后的现场核对。

Fixes #17461

## Summary by Sourcery

引入 GPU 设备选择器抽象，用于稳定 GPU OCR 设备绑定，并在 Windows 上优先使用 DXGI 适配器 LUID 而不是 UI 索引；当无法解析 GPU 或 GPU 提供程序不可用时，安全地回退到 CPU。

New Features:
- 添加 `GpuDeviceSelector` 抽象，用于以数字设备 ID 或 DXGI 适配器 LUID 表示 GPU 选择，并在运行时将其解析为设备索引。
- 允许 WPF GUI 使用基于 DXGI 适配器 LUID 的选择器传递 GPU 选择，而不再仅依赖枚举索引。

Bug Fixes:
- 确保仅在将配置的 GPU 选择器解析为有效设备索引后才配置 ONNX Runtime GPU 提供程序，防止 OCR 绑定到错误的 GPU。
- 当配置的 GPU 无法解析或不存在兼容的 GPU 执行提供程序时回退到 CPU OCR，避免静默绑定到非预期的 GPU。
- 通过跟踪 GPU 是否实际被激活，避免在 OCR 包销毁时泄露 FastDeploy 的 GPU 状态。

Enhancements:
- 通过 `GpuDeviceSelector` 抽象，在 MaaCore OCR 组件与 ONNX Runtime 之间集中管理 GPU 选择逻辑。
- 通过在解析 DXGI 适配器时记录适配器 LUID、解析出的设备索引以及适配器名称，改进 GPU 选择相关的诊断信息。
- 将 ONNX Runtime GPU 提供程序的初始化延迟到第一次会话加载时，以匹配已解析的 GPU 配置。

Build:
- 在 Windows 上将 MaaCore 链接到 `dxgi`，以启用基于 DXGI 的适配器解析。

Documentation:
- 澄清 `CpuOCR` 和 `GpuOCR` 静态选项的语义，并文档化新的 Windows GPU 选择器格式 `"luid:<hex>"`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a GPU device selector abstraction to stabilize GPU OCR device binding and prefer DXGI adapter LUIDs over UI indices on Windows, with safe CPU fallback when GPU resolution or providers are unavailable.

New Features:
- Add a GpuDeviceSelector abstraction to represent GPU choices by numeric device ID or DXGI adapter LUID and resolve them to runtime device indices.
- Allow the WPF GUI to pass GPU selections using DXGI adapter LUID-based selectors instead of relying solely on enumeration indices.

Bug Fixes:
- Ensure ONNX Runtime GPU providers are configured only after resolving the configured GPU selector to a valid device index, preventing OCR from binding to the wrong GPU.
- Fallback to CPU OCR when the configured GPU cannot be resolved or no compatible GPU execution provider is available, avoiding silent binding to unintended GPUs.
- Avoid leaking FastDeploy GPU state on OCR pack destruction by tracking whether GPU was actually activated.

Enhancements:
- Centralize GPU selection handling between MaaCore OCR components and ONNX Runtime via the GpuDeviceSelector abstraction.
- Improve GPU selection diagnostics by logging adapter LUID, resolved device index, and adapter name when resolving DXGI adapters.
- Delay ONNX Runtime GPU provider initialization until the first session load to match the resolved GPU configuration.

Build:
- Link MaaCore against dxgi on Windows to enable DXGI-based adapter resolution.

Documentation:
- Clarify the semantics of CpuOCR and GpuOCR static options and document the new Windows GPU selector format "luid:<hex>".

</details>

新功能：
- 引入 `GpuDeviceSelector` 抽象，在 Windows 上同时支持基于数字设备 ID 和基于 DXGI 适配器 LUID 的选择方式。
- 允许 WPF GUI 通过 DXGI 适配器 LUID 传递 GPU 选择器，而不是仅依赖枚举索引。

错误修复：
- 通过在初始化执行提供程序之前，将适配器 LUID 解析为当前设备索引，防止 GPU 加速 OCR 偶尔绑定到错误的 GPU。
- 当配置的 GPU 无法解析或没有可用的兼容执行提供程序时，确保 OCR 回退到 CPU 模式，避免静默绑定到非预期的 GPU。

增强：
- 使用新的选择器抽象，在 MaaCore OCR 组件和 ONNX Runtime 会话之间集中管理 GPU 选择逻辑。
- 改进与 GPU 选择相关的日志记录，记录适配器 LUID、解析后的设备 ID 以及适配器名称，以便诊断绑定行为。

构建：
- 在 Windows 上将 MaaCore 链接到 `dxgi`，以支持基于 DXGI 的适配器解析。

文档：
- 澄清 `CpuOCR` 和 `GpuOCR` 静态选项的语义，并文档化用于在 Windows 上进行 GPU 选择的新格式 `"luid:<hex>"`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

引入 GPU 设备选择器抽象，用于稳定 GPU OCR 设备绑定，并在 Windows 上优先使用 DXGI 适配器 LUID 而不是 UI 索引；当无法解析 GPU 或 GPU 提供程序不可用时，安全地回退到 CPU。

New Features:
- 添加 `GpuDeviceSelector` 抽象，用于以数字设备 ID 或 DXGI 适配器 LUID 表示 GPU 选择，并在运行时将其解析为设备索引。
- 允许 WPF GUI 使用基于 DXGI 适配器 LUID 的选择器传递 GPU 选择，而不再仅依赖枚举索引。

Bug Fixes:
- 确保仅在将配置的 GPU 选择器解析为有效设备索引后才配置 ONNX Runtime GPU 提供程序，防止 OCR 绑定到错误的 GPU。
- 当配置的 GPU 无法解析或不存在兼容的 GPU 执行提供程序时回退到 CPU OCR，避免静默绑定到非预期的 GPU。
- 通过跟踪 GPU 是否实际被激活，避免在 OCR 包销毁时泄露 FastDeploy 的 GPU 状态。

Enhancements:
- 通过 `GpuDeviceSelector` 抽象，在 MaaCore OCR 组件与 ONNX Runtime 之间集中管理 GPU 选择逻辑。
- 通过在解析 DXGI 适配器时记录适配器 LUID、解析出的设备索引以及适配器名称，改进 GPU 选择相关的诊断信息。
- 将 ONNX Runtime GPU 提供程序的初始化延迟到第一次会话加载时，以匹配已解析的 GPU 配置。

Build:
- 在 Windows 上将 MaaCore 链接到 `dxgi`，以启用基于 DXGI 的适配器解析。

Documentation:
- 澄清 `CpuOCR` 和 `GpuOCR` 静态选项的语义，并文档化新的 Windows GPU 选择器格式 `"luid:<hex>"`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Introduce a GPU device selector abstraction to stabilize GPU OCR device binding and prefer DXGI adapter LUIDs over UI indices on Windows, with safe CPU fallback when GPU resolution or providers are unavailable.

New Features:
- Add a GpuDeviceSelector abstraction to represent GPU choices by numeric device ID or DXGI adapter LUID and resolve them to runtime device indices.
- Allow the WPF GUI to pass GPU selections using DXGI adapter LUID-based selectors instead of relying solely on enumeration indices.

Bug Fixes:
- Ensure ONNX Runtime GPU providers are configured only after resolving the configured GPU selector to a valid device index, preventing OCR from binding to the wrong GPU.
- Fallback to CPU OCR when the configured GPU cannot be resolved or no compatible GPU execution provider is available, avoiding silent binding to unintended GPUs.
- Avoid leaking FastDeploy GPU state on OCR pack destruction by tracking whether GPU was actually activated.

Enhancements:
- Centralize GPU selection handling between MaaCore OCR components and ONNX Runtime via the GpuDeviceSelector abstraction.
- Improve GPU selection diagnostics by logging adapter LUID, resolved device index, and adapter name when resolving DXGI adapters.
- Delay ONNX Runtime GPU provider initialization until the first session load to match the resolved GPU configuration.

Build:
- Link MaaCore against dxgi on Windows to enable DXGI-based adapter resolution.

Documentation:
- Clarify the semantics of CpuOCR and GpuOCR static options and document the new Windows GPU selector format "luid:<hex>".

</details>

</details>