### PR TITLE
fix: 连接配置设置为pc端时关闭自动检测连接

### DIFF
--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/ConnectSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/ConnectSettingsUserControlModel.cs
@@ -103,6 +103,11 @@ public class ConnectSettingsUserControlModel : PropertyChangedBase
             }
 
             ConfigFactory.CurrentConfig.Gui.ConnectSettings.AutoDetect = value;
+            if (!value)
+            {
+                AlwaysAutoDetectConnection = false;
+            }
+
             if (value)
             {
                 Instances.AsstProxy.Connected = false;

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/ConnectSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/ConnectSettingsUserControlModel.cs
@@ -230,6 +230,11 @@ public class ConnectSettingsUserControlModel : PropertyChangedBase
             Instances.AsstProxy.Connected = false;
             SetAndNotify(ref field, value);
             ConfigFactory.CurrentConfig.Gui.ConnectSettings.Config = value;
+            if (value == ConnectConfig.PC)
+            {
+                AutoDetectConnection = false;
+            }
+
             Instances.SettingsViewModel.UpdateWindowTitle(); // 每次修改客户端时更新WindowTitle
 
             // 切换连接配置时，若不再使用 MuMu 截图增强，需移除 MuMu 触控选项


### PR DESCRIPTION
修复连接配置为pc端且开启自动检测连接时无法修改截图方式、鼠标输入等

## Summary by Sourcery

在涉及 PC 配置和自动检测时，确保连接设置行为正确。

错误修复：
- 防止在切换到 PC 连接配置时，自动检测连接仍保持启用状态，从而恢复修改截图和输入选项的能力。
- 在关闭自动检测时重置“始终自动检测”标志，以保持连接状态的一致性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure connection settings behave correctly when configured for PC and auto-detect is involved.

Bug Fixes:
- Prevent auto-detect connection from remaining enabled when switching to PC connection configuration, restoring ability to change screenshot and input options.
- Reset the always-auto-detect flag when auto-detect is turned off to keep connection state consistent.

</details>