### PR TITLE
fix: 修正代理倍率参数校验合法上限为 10

### DIFF
--- a/src/MaaCore/Task/Interface/FightTask.cpp
+++ b/src/MaaCore/Task/Interface/FightTask.cpp
@@ -91,7 +91,7 @@ bool asst::FightTask::set_params(const json::value& params)
     const int series = params.get("series", 1);
 
     m_fight_times_prt->set_fight_times(times);
-    if (series < -1 || series > 6) {
+    if (series < -1 || series > 10) {
         Log.error("Invalid series");
         return false;
     }


### PR DESCRIPTION
ui已支持手动选择大于6倍的代理倍率，但相关校验的限制最大值仍为6，对该问题进行了修正。

## Summary by Sourcery

Bug Fixes:
- 在战斗任务验证中，将系列/代理倍增参数的允许上限从 6 提高到 10，以与 UI 行为保持一致。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Increase the allowed upper limit for the series/proxy multiplier parameter from 6 to 10 in fight task validation to align with UI behavior.

</details>