### PR TITLE
rft: 库存保持任务 UI 重构，新增临期药支持，新增预设列表

### DIFF
--- a/src/MaaWpfGui/Configuration/Single/MaaTask/DepotMaintainTask.cs
+++ b/src/MaaWpfGui/Configuration/Single/MaaTask/DepotMaintainTask.cs
@@ -42,6 +42,24 @@ public class DepotMaintainTask : BaseTask
     /// </summary>
     public bool UseAutoSeries { get; set; }
 
+    /// <summary>
+    /// Gets or sets a value indicating whether 启用「使用药剂」勾选框。
+    /// 默认开启；关闭后各 Plan 不显示药剂行，序列化时强制传 0。
+    /// </summary>
+    public bool UseMedicine { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether 启用「使用源石」勾选框。
+    /// 默认开启；关闭后各 Plan 不显示源石行，序列化时强制传 0。
+    /// </summary>
+    public bool UseStone { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether 使用 48 小时内过期的理智药。
+    /// 默认关闭；开启后所有 Plan 均使用临期药（固定 2 天阈值）。
+    /// </summary>
+    public bool UseExpiringMedicine { get; set; }
+
     public List<Plan> PlanList { get; set; } = [];
 
     public record class Plan(string Stage = "", string DropId = "", int DropCount = 0, bool UseMedicine = false, int MedicineCount = 0, bool UseStone = false, int StoneCount = 0, [property: JsonIgnore] int TaskId = 0);

--- a/src/MaaWpfGui/Configuration/Single/MaaTask/DepotMaintainTask.cs
+++ b/src/MaaWpfGui/Configuration/Single/MaaTask/DepotMaintainTask.cs
@@ -22,6 +22,11 @@ public class DepotMaintainTask : BaseTask
 {
     public DepotMaintainTask() => TaskType = TaskType.DepotMaintain;
 
+    /// <summary>
+    /// 临期药阈值（天）：仅使用 N 天内将过期的理智药。
+    /// </summary>
+    public const int ExpiringMedicineDays = 2;
+
     public bool UpdateDepot { get; set; } = true;
 
     public bool IsStageManually { get; set; }

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -883,6 +883,12 @@ Do not adjust the proxy multiplier setting in the game</system:String>
     <system:String x:Key="DepotPlanUpdateDepotFailed">Failed to update inventory data.</system:String>
     <system:String x:Key="DepotUseAutoSeries">Auto Series</system:String>
     <system:String x:Key="DepotUseAutoSeriesTip" xml:space="preserve">When unchecked, runs at 1×; when checked, runs at the highest series multiplier allowed by current sanity, so drops from a single run may exceed the target inventory limit.</system:String>
+    <system:String x:Key="DepotEnableUseMedicine">Enable "{key=UseSanityPotion}" checkbox</system:String>
+    <system:String x:Key="DepotEnableUseStone">Enable "{key=UseOriginitePrime}" checkbox</system:String>
+    <system:String x:Key="DepotUseExpiringMedicine">Use expiring sanity potions (within 48 hours)</system:String>
+    <system:String x:Key="DepotGroupTaskBehavior">Task Behavior</system:String>
+    <system:String x:Key="DepotGroupStageAndBattle">Stage &amp; Battle</system:String>
+    <system:String x:Key="DepotGroupSanityRecovery">Sanity Recovery</system:String>
     <system:String x:Key="LessThanOneDay">Less than 1 day</system:String>
     <system:String x:Key="1-7">1-7</system:String>
     <system:String x:Key="CE-6">CE-6</system:String>

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -869,7 +869,11 @@ Do not adjust the proxy multiplier setting in the game</system:String>
     <!--  DepotMaintain  -->
     <system:String x:Key="DepotUpdateBeforeStart">Update inventory before starting</system:String>
     <system:String x:Key="AddPlan">Add</system:String>
+    <system:String x:Key="DepotPreset">Preset</system:String>
+    <system:String x:Key="DepotPresetChip1">Chips (All Classes)</system:String>
+    <system:String x:Key="DepotPresetChip2">Chip Packs (All Classes)</system:String>
     <system:String x:Key="CollapseAll">Collapse</system:String>
+    <system:String x:Key="ClearPlans">Clear</system:String>
     <system:String x:Key="DepotPlanInvalidDropItem">Plan {0}: no drop item specified.</system:String>
     <system:String x:Key="DepotPlanZeroDropCount">Plan {0}: target inventory is 0.</system:String>
     <system:String x:Key="DepotPlanNoStage">Plan {0}: stage not specified or is "Current/Last".</system:String>

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -872,6 +872,9 @@ Do not adjust the proxy multiplier setting in the game</system:String>
     <system:String x:Key="DepotPreset">Preset</system:String>
     <system:String x:Key="DepotPresetChip1">Chips (All Classes)</system:String>
     <system:String x:Key="DepotPresetChip2">Chip Packs (All Classes)</system:String>
+    <system:String x:Key="DepotPresetLmd">LMD</system:String>
+    <system:String x:Key="DepotPresetCertificate">Purchase Certificates</system:String>
+    <system:String x:Key="DepotPresetSkillSummary">Skill Summary - III</system:String>
     <system:String x:Key="CollapseAll">Collapse</system:String>
     <system:String x:Key="ClearPlans">Clear</system:String>
     <system:String x:Key="DepotPlanInvalidDropItem">Plan {0}: no drop item specified.</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -873,6 +873,9 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="DepotPreset">プリセット</system:String>
     <system:String x:Key="DepotPresetChip1">低級チップ（全職業）</system:String>
     <system:String x:Key="DepotPresetChip2">上級チップ組（全職業）</system:String>
+    <system:String x:Key="DepotPresetLmd">龍門幣</system:String>
+    <system:String x:Key="DepotPresetCertificate">購買資格証（赤チケ）</system:String>
+    <system:String x:Key="DepotPresetSkillSummary">アーツ学・Ⅲ</system:String>
     <system:String x:Key="CollapseAll">折りたたむ</system:String>
     <system:String x:Key="ClearPlans">クリア</system:String>
     <system:String x:Key="DepotPlanInvalidDropItem">プラン {0}：ドロップアイテム未指定。</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -884,6 +884,12 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="DepotPlanUpdateDepotFailed">在庫データの更新に失敗しました。</system:String>
     <system:String x:Key="DepotUseAutoSeries">AUTO 代理倍率</system:String>
     <system:String x:Key="DepotUseAutoSeriesTip" xml:space="preserve">未チェック時は 1 倍で代理；チェック後は現在の理性で可能な最大倍率で代理し、1回の周回で目標在庫上限を超える場合があります。</system:String>
+    <system:String x:Key="DepotEnableUseMedicine">「{key=UseSanityPotion}」チェックボックスを有効化</system:String>
+    <system:String x:Key="DepotEnableUseStone">「{key=UseOriginitePrime}」チェックボックスを有効化</system:String>
+    <system:String x:Key="DepotUseExpiringMedicine">48 時間以内に期限切れの理性薬を使用</system:String>
+    <system:String x:Key="DepotGroupTaskBehavior">タスク動作</system:String>
+    <system:String x:Key="DepotGroupStageAndBattle">ステージと戦闘</system:String>
+    <system:String x:Key="DepotGroupSanityRecovery">理性回復</system:String>
     <system:String x:Key="LessThanOneDay">1日以内</system:String>
     <system:String x:Key="1-7">1-7</system:String>
     <system:String x:Key="CE-6">龍門幣-6(CE-6)</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -870,7 +870,11 @@ C:\\leidian\\LDPlayer9
     <!--  在庫維持  -->
     <system:String x:Key="DepotUpdateBeforeStart">タスク開始前に在庫データを更新</system:String>
     <system:String x:Key="AddPlan">追加</system:String>
+    <system:String x:Key="DepotPreset">プリセット</system:String>
+    <system:String x:Key="DepotPresetChip1">低級チップ（全職業）</system:String>
+    <system:String x:Key="DepotPresetChip2">上級チップ組（全職業）</system:String>
     <system:String x:Key="CollapseAll">折りたたむ</system:String>
+    <system:String x:Key="ClearPlans">クリア</system:String>
     <system:String x:Key="DepotPlanInvalidDropItem">プラン {0}：ドロップアイテム未指定。</system:String>
     <system:String x:Key="DepotPlanZeroDropCount">プラン {0}：目標在庫が 0。</system:String>
     <system:String x:Key="DepotPlanNoStage">プラン {0}：ステージ未指定または ｢現在/前回｣。</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -871,7 +871,11 @@ C:\\leidian\\LDPlayer9
     <!--  재고 유지  -->
     <system:String x:Key="DepotUpdateBeforeStart">작업 시작 전 재고 데이터 업데이트</system:String>
     <system:String x:Key="AddPlan">추가</system:String>
+    <system:String x:Key="DepotPreset">프리셋</system:String>
+    <system:String x:Key="DepotPresetChip1">저급 칩 (전 직업)</system:String>
+    <system:String x:Key="DepotPresetChip2">고급 칩 세트 (전 직업)</system:String>
     <system:String x:Key="CollapseAll">접기</system:String>
+    <system:String x:Key="ClearPlans">전체 삭제</system:String>
     <system:String x:Key="DepotPlanInvalidDropItem">계획 {0}: 드롭 아이템 미지정.</system:String>
     <system:String x:Key="DepotPlanZeroDropCount">계획 {0}: 목표 재고가 0.</system:String>
     <system:String x:Key="DepotPlanNoStage">계획 {0}: 스테이지 미지정 또는 \"현재/이전\".</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -885,6 +885,12 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="DepotPlanUpdateDepotFailed">재고 데이터 업데이트에 실패했습니다.</system:String>
     <system:String x:Key="DepotUseAutoSeries">AUTO 대리 배수</system:String>
     <system:String x:Key="DepotUseAutoSeriesTip" xml:space="preserve">체크 해제 시 1배로 대리; 체크 시 현재 이성으로 가능한 최대 배수로 대리 작전하며, 1회 진행 시 목표 재고 상한을 초과할 수 있습니다.</system:String>
+    <system:String x:Key="DepotEnableUseMedicine">「{key=UseSanityPotion}」 체크박스 활성화</system:String>
+    <system:String x:Key="DepotEnableUseStone">「{key=UseOriginitePrime}」 체크박스 활성화</system:String>
+    <system:String x:Key="DepotUseExpiringMedicine">48시간 이내 만료되는 이성 포션 사용</system:String>
+    <system:String x:Key="DepotGroupTaskBehavior">작업 동작</system:String>
+    <system:String x:Key="DepotGroupStageAndBattle">스테이지 및 전투</system:String>
+    <system:String x:Key="DepotGroupSanityRecovery">이성 회복</system:String>
     <system:String x:Key="LessThanOneDay">1일 미만</system:String>
     <system:String x:Key="1-7">1-7</system:String>
     <system:String x:Key="CE-6">CE-6 (용문폐)</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -874,6 +874,9 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="DepotPreset">프리셋</system:String>
     <system:String x:Key="DepotPresetChip1">저급 칩 (전 직업)</system:String>
     <system:String x:Key="DepotPresetChip2">고급 칩 세트 (전 직업)</system:String>
+    <system:String x:Key="DepotPresetLmd">용문폐</system:String>
+    <system:String x:Key="DepotPresetCertificate">구매 증명서 (레드 티켓)</system:String>
+    <system:String x:Key="DepotPresetSkillSummary">스킬 개론 - 3</system:String>
     <system:String x:Key="CollapseAll">접기</system:String>
     <system:String x:Key="ClearPlans">전체 삭제</system:String>
     <system:String x:Key="DepotPlanInvalidDropItem">계획 {0}: 드롭 아이템 미지정.</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -884,6 +884,12 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="DepotPlanUpdateDepotFailed">更新库存数据失败。</system:String>
     <system:String x:Key="DepotUseAutoSeries">AUTO 代理倍率</system:String>
     <system:String x:Key="DepotUseAutoSeriesTip" xml:space="preserve">未勾选时按单倍代理；勾选后按当前理智可刷的最大倍率代理，单次刷取可能超过目标库存上限。</system:String>
+    <system:String x:Key="DepotEnableUseMedicine">启用「{key=UseSanityPotion}」勾选框</system:String>
+    <system:String x:Key="DepotEnableUseStone">启用「{key=UseOriginitePrime}」勾选框</system:String>
+    <system:String x:Key="DepotUseExpiringMedicine">使用 48 小时内过期的理智药</system:String>
+    <system:String x:Key="DepotGroupTaskBehavior">任务行为</system:String>
+    <system:String x:Key="DepotGroupStageAndBattle">关卡与战斗</system:String>
+    <system:String x:Key="DepotGroupSanityRecovery">理智恢复</system:String>
     <system:String x:Key="LessThanOneDay">不到 1 天</system:String>
     <system:String x:Key="1-7">1-7</system:String>
     <system:String x:Key="CE-6">龙门币-6/5</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -873,6 +873,9 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="DepotPreset">预设</system:String>
     <system:String x:Key="DepotPresetChip1">低级芯片（全职业）</system:String>
     <system:String x:Key="DepotPresetChip2">高级芯片组（全职业）</system:String>
+    <system:String x:Key="DepotPresetLmd">龙门币</system:String>
+    <system:String x:Key="DepotPresetCertificate">采购凭证（红票）</system:String>
+    <system:String x:Key="DepotPresetSkillSummary">技巧概要·卷3</system:String>
     <system:String x:Key="CollapseAll">折叠</system:String>
     <system:String x:Key="ClearPlans">清空</system:String>
     <system:String x:Key="DepotPlanInvalidDropItem">计划 {0}：未指定掉落物。</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -870,7 +870,11 @@ C:\\leidian\\LDPlayer9
     <!--  库存保持  -->
     <system:String x:Key="DepotUpdateBeforeStart">任务开始前更新库存数据</system:String>
     <system:String x:Key="AddPlan">添加</system:String>
+    <system:String x:Key="DepotPreset">预设</system:String>
+    <system:String x:Key="DepotPresetChip1">低级芯片（全职业）</system:String>
+    <system:String x:Key="DepotPresetChip2">高级芯片组（全职业）</system:String>
     <system:String x:Key="CollapseAll">折叠</system:String>
+    <system:String x:Key="ClearPlans">清空</system:String>
     <system:String x:Key="DepotPlanInvalidDropItem">计划 {0}：未指定掉落物。</system:String>
     <system:String x:Key="DepotPlanZeroDropCount">计划 {0}：目标库存为 0。</system:String>
     <system:String x:Key="DepotPlanNoStage">计划 {0}：关卡未指定或为 ｢当前/上次｣。</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -884,6 +884,12 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="DepotPlanUpdateDepotFailed">更新庫存資料失敗。</system:String>
     <system:String x:Key="DepotUseAutoSeries">AUTO 代理倍率</system:String>
     <system:String x:Key="DepotUseAutoSeriesTip" xml:space="preserve">未勾選時按單倍代理；勾選後按目前理智可刷的最大倍率代理，單次刷取可能超過目標庫存上限。</system:String>
+    <system:String x:Key="DepotEnableUseMedicine">啟用「{key=UseSanityPotion}」勾選框</system:String>
+    <system:String x:Key="DepotEnableUseStone">啟用「{key=UseOriginitePrime}」勾選框</system:String>
+    <system:String x:Key="DepotUseExpiringMedicine">使用 48 小時內過期的理智藥</system:String>
+    <system:String x:Key="DepotGroupTaskBehavior">任務行為</system:String>
+    <system:String x:Key="DepotGroupStageAndBattle">關卡與戰鬥</system:String>
+    <system:String x:Key="DepotGroupSanityRecovery">理智恢復</system:String>
     <system:String x:Key="LessThanOneDay">不到 1 天</system:String>
     <system:String x:Key="1-7">1-7</system:String>
     <system:String x:Key="CE-6">龍門幣-6/5</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -870,7 +870,11 @@ C:\\leidian\\LDPlayer9
     <!--  庫存保持  -->
     <system:String x:Key="DepotUpdateBeforeStart">任務開始前更新庫存資料</system:String>
     <system:String x:Key="AddPlan">新增</system:String>
+    <system:String x:Key="DepotPreset">預設</system:String>
+    <system:String x:Key="DepotPresetChip1">低級晶片（全職業）</system:String>
+    <system:String x:Key="DepotPresetChip2">高級晶片組（全職業）</system:String>
     <system:String x:Key="CollapseAll">折疊</system:String>
+    <system:String x:Key="ClearPlans">清空</system:String>
     <system:String x:Key="DepotPlanInvalidDropItem">計劃 {0}：未指定掉落物。</system:String>
     <system:String x:Key="DepotPlanZeroDropCount">計劃 {0}：目標庫存為 0。</system:String>
     <system:String x:Key="DepotPlanNoStage">計劃 {0}：關卡未指定或為 ｢當前/上次｣。</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -873,6 +873,9 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="DepotPreset">預設</system:String>
     <system:String x:Key="DepotPresetChip1">低級晶片（全職業）</system:String>
     <system:String x:Key="DepotPresetChip2">高級晶片組（全職業）</system:String>
+    <system:String x:Key="DepotPresetLmd">龍門幣</system:String>
+    <system:String x:Key="DepotPresetCertificate">採購憑證（紅票）</system:String>
+    <system:String x:Key="DepotPresetSkillSummary">技巧概要·卷3</system:String>
     <system:String x:Key="CollapseAll">折疊</system:String>
     <system:String x:Key="ClearPlans">清空</system:String>
     <system:String x:Key="DepotPlanInvalidDropItem">計劃 {0}：未指定掉落物。</system:String>

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
@@ -114,7 +114,7 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
                 Stage = stage,
                 Medicine = task.UseMedicine && plan.UseMedicine ? plan.MedicineCount : 0,
                 Stone = task.UseStone && plan.UseStone ? plan.StoneCount : 0,
-                MedicineExpireDays = task.UseExpiringMedicine ? 2 : 0,
+                MedicineExpireDays = task.UseExpiringMedicine ? DepotMaintainTask.ExpiringMedicineDays : 0,
                 Series = task.UseAutoSeries ? 0 : 1,
                 MaxTimes = int.MaxValue,
                 ReportToPenguin = SettingsViewModel.GameSettings.EnablePenguin,
@@ -221,7 +221,17 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
             plan.PropertyChanged -= PlanItem_PropertyChanged;
         }
 
-        PlanList.Clear();
+        // 挂起 CollectionChanged，避免 Clear() 触发 Reset 事件导致 SavePlan/PlanInfo 重复执行
+        PlanList.CollectionChanged -= PlanList_CollectionChanged;
+        try
+        {
+            PlanList.Clear();
+        }
+        finally
+        {
+            PlanList.CollectionChanged += PlanList_CollectionChanged;
+        }
+
         SavePlan();
         NotifyOfPropertyChange(nameof(PlanInfo));
     }
@@ -654,7 +664,7 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
                     MaxTimes = need > 0 ? int.MaxValue : 0,
                     Medicine = depot.UseMedicine && plan.UseMedicine ? plan.MedicineCount : 0,
                     Stone = depot.UseStone && plan.UseStone ? plan.StoneCount : 0,
-                    MedicineExpireDays = depot.UseExpiringMedicine ? 2 : 0,
+                    MedicineExpireDays = depot.UseExpiringMedicine ? DepotMaintainTask.ExpiringMedicineDays : 0,
                     Series = depot.UseAutoSeries ? 0 : 1,
                     ReportToPenguin = SettingsViewModel.GameSettings.EnablePenguin,
                     ReportToYituliu = SettingsViewModel.GameSettings.EnableYituliu,

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
@@ -227,29 +227,34 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
     }
 
     /// <summary>
-    /// 芯片预设列表，低级芯片（PR-X-1）和高级芯片组（PR-X-2）各一组。
+    /// 预设列表。
     /// </summary>
     public static LocalizedObservableList<string> PresetList { get; } = new(
         ("Chip1", "DepotPresetChip1"),
-        ("Chip2", "DepotPresetChip2"));
+        ("Chip2", "DepotPresetChip2"),
+        ("CE6", "DepotPresetLmd"),
+        ("AP5", "DepotPresetCertificate"),
+        ("CA5", "DepotPresetSkillSummary"));
 
     /// <summary>
-    /// 芯片预设数据：关卡 → [(掉落物 itemId, 掉落物名称), ...]。
+    /// 预设数据：关卡 → [(掉落物 itemId, 掉落物名称), ...]。
     /// </summary>
-    private static readonly Dictionary<string, (string Stage, string[] Drops)[]> PresetData = new()
-    {
+    private static readonly Dictionary<string, (string Stage, string[] Drops, int DefaultCount)[]> PresetData = new() {
         ["Chip1"] = [
-            ("PR-A-1", ["3261", "3231"]),  // 医疗芯片、重装芯片
-            ("PR-B-1", ["3251", "3241"]),  // 术师芯片、狙击芯片
-            ("PR-C-1", ["3211", "3271"]),  // 先锋芯片、辅助芯片
-            ("PR-D-1", ["3221", "3281"]),  // 近卫芯片、特种芯片
+            ("PR-A-1", ["3261", "3231"], 20),  // 医疗芯片、重装芯片
+            ("PR-B-1", ["3251", "3241"], 20),  // 术师芯片、狙击芯片
+            ("PR-C-1", ["3211", "3271"], 20),  // 先锋芯片、辅助芯片
+            ("PR-D-1", ["3221", "3281"], 20),  // 近卫芯片、特种芯片
         ],
         ["Chip2"] = [
-            ("PR-A-2", ["3262", "3232"]),  // 医疗芯片组、重装芯片组
-            ("PR-B-2", ["3252", "3242"]),  // 术师芯片组、狙击芯片组
-            ("PR-C-2", ["3212", "3272"]),  // 先锋芯片组、辅助芯片组
-            ("PR-D-2", ["3222", "3282"]),  // 近卫芯片组、特种芯片组
+            ("PR-A-2", ["3262", "3232"], 20),  // 医疗芯片组、重装芯片组
+            ("PR-B-2", ["3252", "3242"], 20),  // 术师芯片组、狙击芯片组
+            ("PR-C-2", ["3212", "3272"], 20),  // 先锋芯片组、辅助芯片组
+            ("PR-D-2", ["3222", "3282"], 20),  // 近卫芯片组、特种芯片组
         ],
+        ["CE6"] = [("CE-6", ["4001"], 2000000)],    // 龙门币
+        ["AP5"] = [("AP-5", ["4006"], 5000)],       // 采购凭证（红票）
+        ["CA5"] = [("CA-5", ["3303"], 200)],        // 技巧概要·卷3
     };
 
     public void AddPresetPlan(string presetValue)
@@ -263,12 +268,12 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
         PlanList.CollectionChanged -= PlanList_CollectionChanged;
         try
         {
-            foreach (var (stage, drops) in stages)
+            foreach (var (stage, drops, defaultCount) in stages)
             {
                 foreach (var dropId in drops)
                 {
                     var dropName = ItemListHelper.GetItemName(dropId) ?? LocalizationHelper.GetString("NotSelected");
-                    var plan = new Plan(stage, dropId, dropName, 20);
+                    var plan = new Plan(stage, dropId, dropName, defaultCount);
                     plan.PropertyChanged += PlanItem_PropertyChanged;
                     PlanList.Add(plan);
                 }

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
@@ -106,8 +106,9 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
         {
             var fight = new AsstFightTask() {
                 Stage = stage,
-                Medicine = plan.UseMedicine ? plan.MedicineCount : 0,
-                Stone = plan.UseStone ? plan.StoneCount : 0,
+                Medicine = task.UseMedicine && plan.UseMedicine ? plan.MedicineCount : 0,
+                Stone = task.UseStone && plan.UseStone ? plan.StoneCount : 0,
+                MedicineExpireDays = task.UseExpiringMedicine ? 2 : 0,
                 Series = task.UseAutoSeries ? 0 : 1,
                 MaxTimes = int.MaxValue,
                 ReportToPenguin = SettingsViewModel.GameSettings.EnablePenguin,
@@ -157,6 +158,36 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
     {
         get => GetTaskConfig<DepotMaintainTask>().UseAutoSeries;
         set => SetTaskConfig<DepotMaintainTask>(t => t.UseAutoSeries == value, t => t.UseAutoSeries = value);
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether 启用「使用药剂」勾选框。
+    /// 默认开启；关闭后各 Plan 不显示药剂行，序列化时强制传 0。
+    /// </summary>
+    public bool UseMedicine
+    {
+        get => GetTaskConfig<DepotMaintainTask>().UseMedicine;
+        set => SetTaskConfig<DepotMaintainTask>(t => t.UseMedicine == value, t => t.UseMedicine = value);
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether 启用「使用源石」勾选框。
+    /// 默认开启；关闭后各 Plan 不显示源石行，序列化时强制传 0。
+    /// </summary>
+    public bool UseStone
+    {
+        get => GetTaskConfig<DepotMaintainTask>().UseStone;
+        set => SetTaskConfig<DepotMaintainTask>(t => t.UseStone == value, t => t.UseStone = value);
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether 使用 48 小时内过期的理智药。
+    /// 默认关闭；开启后所有 Plan 均使用临期药（固定 2 天阈值）。
+    /// </summary>
+    public bool UseExpiringMedicine
+    {
+        get => GetTaskConfig<DepotMaintainTask>().UseExpiringMedicine;
+        set => SetTaskConfig<DepotMaintainTask>(t => t.UseExpiringMedicine == value, t => t.UseExpiringMedicine = value);
     }
 
     public ObservableCollection<Plan> PlanList { get; private set => SetAndNotify(ref field, value); } = [];
@@ -516,8 +547,9 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
                     Stage = stage,
                     Drops = new() { { plan.DropId, need } },
                     MaxTimes = need > 0 ? int.MaxValue : 0,
-                    Medicine = plan.UseMedicine ? plan.MedicineCount : 0,
-                    Stone = plan.UseStone ? plan.StoneCount : 0,
+                    Medicine = depot.UseMedicine && plan.UseMedicine ? plan.MedicineCount : 0,
+                    Stone = depot.UseStone && plan.UseStone ? plan.StoneCount : 0,
+                    MedicineExpireDays = depot.UseExpiringMedicine ? 2 : 0,
                     Series = depot.UseAutoSeries ? 0 : 1,
                     ReportToPenguin = SettingsViewModel.GameSettings.EnablePenguin,
                     ReportToYituliu = SettingsViewModel.GameSettings.EnableYituliu,

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
@@ -18,6 +18,8 @@ using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
 using JetBrains.Annotations;
 using MaaWpfGui.Configuration.Factory;
 using MaaWpfGui.Configuration.Single.MaaTask;
@@ -29,6 +31,7 @@ using MaaWpfGui.Models;
 using MaaWpfGui.Models.AsstTasks;
 using MaaWpfGui.Services;
 using MaaWpfGui.Utilities;
+using MaaWpfGui.Utilities.ValueType;
 using MaaWpfGui.ViewModels.UI;
 using MaaWpfGui.ViewModels.UserControl.Settings;
 using ObservableCollections;
@@ -68,6 +71,9 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
 
     public void OnLanguageChanged()
     {
+        // 刷新预设列表的本地化显示
+        PresetList.RefreshLocalization();
+
         // DropsList 已由 RebuildDropsList 原地更新 Display（不增删项），ComboBox SelectedValue 不会丢失
         // 只需刷新各 plan 的 DropName
         foreach (var plan in PlanList)
@@ -200,6 +206,100 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
     public void RemovePlan(Plan plan)
     {
         PlanList.Remove(plan);
+    }
+
+    public void ClearPlans()
+    {
+        if (PlanList.Count == 0)
+        {
+            return;
+        }
+
+        // 先取消所有 PropertyChanged 订阅，避免 Clear 逐条触发
+        foreach (var plan in PlanList)
+        {
+            plan.PropertyChanged -= PlanItem_PropertyChanged;
+        }
+
+        PlanList.Clear();
+        SavePlan();
+        NotifyOfPropertyChange(nameof(PlanInfo));
+    }
+
+    /// <summary>
+    /// 芯片预设列表，低级芯片（PR-X-1）和高级芯片组（PR-X-2）各一组。
+    /// </summary>
+    public static LocalizedObservableList<string> PresetList { get; } = new(
+        ("Chip1", "DepotPresetChip1"),
+        ("Chip2", "DepotPresetChip2"));
+
+    /// <summary>
+    /// 芯片预设数据：关卡 → [(掉落物 itemId, 掉落物名称), ...]。
+    /// </summary>
+    private static readonly Dictionary<string, (string Stage, string[] Drops)[]> PresetData = new()
+    {
+        ["Chip1"] = [
+            ("PR-A-1", ["3261", "3231"]),  // 医疗芯片、重装芯片
+            ("PR-B-1", ["3251", "3241"]),  // 术师芯片、狙击芯片
+            ("PR-C-1", ["3211", "3271"]),  // 先锋芯片、辅助芯片
+            ("PR-D-1", ["3221", "3281"]),  // 近卫芯片、特种芯片
+        ],
+        ["Chip2"] = [
+            ("PR-A-2", ["3262", "3232"]),  // 医疗芯片组、重装芯片组
+            ("PR-B-2", ["3252", "3242"]),  // 术师芯片组、狙击芯片组
+            ("PR-C-2", ["3212", "3272"]),  // 先锋芯片组、辅助芯片组
+            ("PR-D-2", ["3222", "3282"]),  // 近卫芯片组、特种芯片组
+        ],
+    };
+
+    public void AddPresetPlan(string presetValue)
+    {
+        if (!PresetData.TryGetValue(presetValue, out var stages))
+        {
+            return;
+        }
+
+        // 批量添加时挂起 CollectionChanged，避免逐条触发 SavePlan/RefreshTitle 导致卡顿
+        PlanList.CollectionChanged -= PlanList_CollectionChanged;
+        try
+        {
+            foreach (var (stage, drops) in stages)
+            {
+                foreach (var dropId in drops)
+                {
+                    var dropName = ItemListHelper.GetItemName(dropId) ?? LocalizationHelper.GetString("NotSelected");
+                    var plan = new Plan(stage, dropId, dropName, 20);
+                    plan.PropertyChanged += PlanItem_PropertyChanged;
+                    PlanList.Add(plan);
+                }
+            }
+        }
+        finally
+        {
+            PlanList.CollectionChanged += PlanList_CollectionChanged;
+        }
+
+        // 统一触发一次
+        SavePlan();
+        NotifyOfPropertyChange(nameof(PlanInfo));
+        foreach (var plan in PlanList)
+        {
+            plan.RefreshTitle();
+        }
+    }
+
+    /// <summary>
+    /// Menu 的 MenuItem.Click 事件处理，从点击的菜单项 DataContext 提取预设 Value。
+    /// </summary>
+    /// <param name="sender">事件发送者。</param>
+    /// <param name="e">路由事件参数。</param>
+    [UsedImplicitly]
+    public void PresetMenuClick(object sender, RoutedEventArgs e)
+    {
+        if (e.OriginalSource is MenuItem { DataContext: GenericCombinedData<string> item })
+        {
+            AddPresetPlan(item.Value);
+        }
     }
 
     public bool IsStageManually

--- a/src/MaaWpfGui/Views/UserControl/TaskQueue/DepotMaintainTaskUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/TaskQueue/DepotMaintainTaskUserControl.xaml
@@ -24,7 +24,8 @@
                 HorizontalAlignment="Left"
                 d:Text="1: 当前/上次 - 不选择 x0"
                 Text="{Binding PlanInfo}"
-                TextWrapping="Wrap" />
+                TextWrapping="Wrap"
+                Visibility="{c:Binding 'PlanInfo != &quot;&quot;'}" />
             <ListBox
                 Padding="0"
                 VerticalAlignment="Top"
@@ -164,7 +165,6 @@
                                             hc:InfoElement.Placeholder="{DynamicResource DefaultStage}"
                                             IsEnabled="{c:Binding !IsStageItemDragging,
                                                                   Source={x:Static ui_vms:TaskQueueViewModel.FightTask}}"
-                                            Opacity="{c:Binding 'IsOpen ? 1 : 0.5'}"
                                             Text="{Binding Stage, UpdateSourceTrigger=PropertyChanged}"
                                             ToolTip="{DynamicResource IsStageManuallyTip}"
                                             Visibility="{c:Binding IsStageManually,
@@ -272,28 +272,53 @@
                     </DataTemplate>
                 </ListBox.ItemTemplate>
             </ListBox>
-            <StackPanel Orientation="Horizontal">
+            <WrapPanel HorizontalAlignment="Center">
                 <Button
-                    Margin="6"
-                    VerticalAlignment="Bottom"
-                    d:IsHitTestVisible="True"
-                    Command="{s:Action AddPlan}"
-                    Content="{DynamicResource AddPlan}"
-                    IsHitTestVisible="{c:Binding !IsCurrentTaskRunning,
-                                                 Source={x:Static ui_vms:TaskQueueViewModel.TaskSettingVisibilities}}" />
-                <Button
-                    Margin="6"
-                    VerticalAlignment="Bottom"
-                    d:IsHitTestVisible="True"
+                    Margin="0,0,-1,0"
+                    hc:BorderElement.CornerRadius="4,0,0,4"
                     Command="{s:Action CollapseAll}"
                     Content="{DynamicResource CollapseAll}"
                     IsHitTestVisible="{c:Binding !IsCurrentTaskRunning,
                                                  Source={x:Static ui_vms:TaskQueueViewModel.TaskSettingVisibilities}}" />
-            </StackPanel>
+                <Button
+                    Margin="0,0,-1,0"
+                    hc:BorderElement.CornerRadius="0"
+                    Command="{s:Action ClearPlans}"
+                    Content="{DynamicResource ClearPlans}"
+                    IsHitTestVisible="{c:Binding !IsCurrentTaskRunning,
+                                                 Source={x:Static ui_vms:TaskQueueViewModel.TaskSettingVisibilities}}" />
+                <Button
+                    Margin="0,0,-1,0"
+                    hc:BorderElement.CornerRadius="0"
+                    Command="{s:Action AddPlan}"
+                    Content="{DynamicResource AddPlan}"
+                    IsHitTestVisible="{c:Binding !IsCurrentTaskRunning,
+                                                 Source={x:Static ui_vms:TaskQueueViewModel.TaskSettingVisibilities}}" />
+                <hc:SplitButton
+                    hc:BorderElement.CornerRadius="0,4,4,0"
+                    Content="{DynamicResource DepotPreset}"
+                    IsHitTestVisible="{c:Binding !IsCurrentTaskRunning,
+                                                 Source={x:Static ui_vms:TaskQueueViewModel.TaskSettingVisibilities}}">
+                    <hc:SplitButton.DropDownContent>
+                        <Menu ItemsSource="{Binding PresetList, Source={x:Static taskQueue_vms:DepotMaintainTaskUserControlModel.Instance}}" MenuItem.Click="{s:Action PresetMenuClick}">
+                            <Menu.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <StackPanel Orientation="Vertical" />
+                                </ItemsPanelTemplate>
+                            </Menu.ItemsPanel>
+                            <Menu.ItemContainerStyle>
+                                <Style BasedOn="{StaticResource {x:Type MenuItem}}" TargetType="MenuItem">
+                                    <Setter Property="Header" Value="{Binding Display}" />
+                                </Style>
+                            </Menu.ItemContainerStyle>
+                        </Menu>
+                    </hc:SplitButton.DropDownContent>
+                </hc:SplitButton>
+            </WrapPanel>
         </StackPanel>
 
         <!--  高级设置  -->
-        <StackPanel Visibility="{c:Binding EnableAdvancedSettings, Source={x:Static ui_vms:TaskQueueViewModel.TaskSettingVisibilities}}">
+        <StackPanel d:Visibility="Collapsed" Visibility="{c:Binding EnableAdvancedSettings, Source={x:Static ui_vms:TaskQueueViewModel.TaskSettingVisibilities}}">
             <hc:Divider Content="{DynamicResource DepotGroupTaskBehavior}" />
             <CheckBox
                 Margin="0,6,0,0"

--- a/src/MaaWpfGui/Views/UserControl/TaskQueue/DepotMaintainTaskUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/TaskQueue/DepotMaintainTaskUserControl.xaml
@@ -17,288 +17,320 @@
     d:DesignWidth="220"
     s:View.ActionTarget="{Binding}"
     mc:Ignorable="d">
-    <StackPanel Visibility="{c:Binding !EnableAdvancedSettings, Source={x:Static ui_vms:TaskQueueViewModel.TaskSettingVisibilities}}">
-        <CheckBox Content="{DynamicResource DepotUpdateBeforeStart}" IsChecked="{Binding UpdateDepot}" />
-        <CheckBox
-            Margin="0,6,0,0"
-            Content="{DynamicResource DepotSkipDuringActivity}"
-            IsChecked="{Binding SkipDuringActivity}" />
-        <CheckBox
-            Margin="0,6,0,0"
-            Content="{DynamicResource DepotSkipDuringResourceCollection}"
-            IsChecked="{Binding SkipDuringResourceCollection}" />
-        <StackPanel Margin="0,6,0,0" Orientation="Horizontal">
-            <CheckBox Content="{DynamicResource CustomStageCode}" IsChecked="{Binding IsStageManually}" />
-            <controls:TooltipBlock TooltipText="{DynamicResource CustomStageCodeTip}" />
-        </StackPanel>
-        <StackPanel Margin="0,6,0,0" Orientation="Horizontal">
-            <CheckBox
-                Content="{DynamicResource DepotUseAutoSeries}"
-                IsChecked="{Binding UseAutoSeries}" />
-            <controls:TooltipBlock Margin="3,0,0,0" TooltipText="{DynamicResource DepotUseAutoSeriesTip}" />
-        </StackPanel>
-        <controls:TextBlock
-            Margin="0,5,0,0"
-            HorizontalAlignment="Left"
-            d:Text="1: 当前/上次 - 不选择 x0"
-            Text="{Binding PlanInfo}"
-            TextWrapping="Wrap" />
-        <StackPanel Orientation="Horizontal">
-            <Button
-                Margin="6"
-                VerticalAlignment="Bottom"
-                d:IsHitTestVisible="True"
-                Command="{s:Action AddPlan}"
-                Content="{DynamicResource AddPlan}"
+    <Grid>
+        <StackPanel Visibility="{c:Binding !EnableAdvancedSettings, Source={x:Static ui_vms:TaskQueueViewModel.TaskSettingVisibilities}}">
+            <controls:TextBlock
+                Margin="5,0,0,5"
+                HorizontalAlignment="Left"
+                d:Text="1: 当前/上次 - 不选择 x0"
+                Text="{Binding PlanInfo}"
+                TextWrapping="Wrap" />
+            <ListBox
+                Padding="0"
+                VerticalAlignment="Top"
+                HorizontalContentAlignment="Stretch"
+                d:ItemsSource="{d:SampleData ItemCount=2}"
+                dd:DragDrop.DragDropContext="{Binding RelativeSource={RelativeSource Self}}"
+                dd:DragDrop.IsDragSource="True"
+                dd:DragDrop.IsDropTarget="True"
+                BorderThickness="0"
+                ClipToBounds="False"
                 IsHitTestVisible="{c:Binding !IsCurrentTaskRunning,
-                                             Source={x:Static ui_vms:TaskQueueViewModel.TaskSettingVisibilities}}" />
-            <Button
-                Margin="6"
-                VerticalAlignment="Bottom"
-                d:IsHitTestVisible="True"
-                Command="{s:Action CollapseAll}"
-                Content="{DynamicResource CollapseAll}"
-                IsHitTestVisible="{c:Binding !IsCurrentTaskRunning,
-                                             Source={x:Static ui_vms:TaskQueueViewModel.TaskSettingVisibilities}}" />
-        </StackPanel>
-        <ListBox
-            Padding="0"
-            VerticalAlignment="Top"
-            HorizontalContentAlignment="Stretch"
-            d:ItemsSource="{d:SampleData ItemCount=2}"
-            dd:DragDrop.DragDropContext="{Binding RelativeSource={RelativeSource Self}}"
-            dd:DragDrop.IsDragSource="True"
-            dd:DragDrop.IsDropTarget="True"
-            BorderThickness="0"
-            ClipToBounds="False"
-            IsHitTestVisible="{c:Binding !IsCurrentTaskRunning,
-                                         Source={x:Static ui_vms:TaskQueueViewModel.TaskSettingVisibilities}}"
-            ItemsSource="{Binding Path=PlanList}"
-            PreviewMouseWheel="{s:Action RouteMouseWheelToParentExceptScrollable,
-                                         Target={x:Type helper:MouseWheelHelper}}">
-            <ListBox.ItemContainerStyle>
-                <Style BasedOn="{StaticResource NoSelectedHighlightListBoxItemStyle}" TargetType="{x:Type ListBoxItem}">
-                    <Setter Property="HorizontalContentAlignment" Value="Stretch" />
-                    <Setter Property="Padding" Value="0" />
-                    <Setter Property="Margin" Value="1" />
-                </Style>
-            </ListBox.ItemContainerStyle>
-            <ListBox.ItemTemplate>
-                <DataTemplate>
-                    <Expander HorizontalContentAlignment="Stretch" IsExpanded="{Binding IsExpanded}">
-                        <Expander.Header>
-                            <Grid HorizontalAlignment="Stretch" Background="Transparent">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="Auto" />
-                                </Grid.ColumnDefinitions>
-                                <controls:TextBlock
-                                    HorizontalAlignment="Left"
-                                    Text="{Binding Title}"
-                                    TextTrimming="CharacterEllipsis" />
-                                <Button
-                                    Grid.Column="1"
-                                    Width="25"
-                                    Height="25"
-                                    Margin="0,0,-5,0"
-                                    Padding="0"
-                                    hc:IconElement.Geometry="{StaticResource DeleteTaskGeometry}"
-                                    hc:IconElement.Height="15"
-                                    hc:IconElement.Width="15"
-                                    BorderBrush="Transparent"
-                                    BorderThickness="0"
-                                    Command="{s:Action RemovePlan,
-                                                       Target={x:Static taskQueue_vms:DepotMaintainTaskUserControlModel.Instance}}"
-                                    CommandParameter="{Binding}"
-                                    ToolTip="{DynamicResource Delete}">
-                                    <Button.Style>
-                                        <Style BasedOn="{StaticResource {x:Type Button}}" TargetType="Button">
-                                            <Setter Property="Visibility" Value="Collapsed" />
-                                            <Style.Triggers>
-                                                <DataTrigger Binding="{Binding IsMouseOver, RelativeSource={RelativeSource AncestorType={x:Type Grid}}}" Value="True">
-                                                    <Setter Property="Visibility" Value="Visible" />
-                                                </DataTrigger>
-                                            </Style.Triggers>
-                                        </Style>
-                                    </Button.Style>
-                                </Button>
-                            </Grid>
-                        </Expander.Header>
-                        <Border
-                            BorderBrush="{DynamicResource BorderBrush}"
-                            BorderThickness="1,0,1,1"
-                            CornerRadius="0,0,4,4">
-                            <Grid Margin="6">
-                                <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="Auto" MinWidth="100" />
-                                    <ColumnDefinition Width="*" />
-                                </Grid.ColumnDefinitions>
-                                <Grid.RowDefinitions>
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="Auto" />
-                                    <RowDefinition Height="Auto" />
-                                </Grid.RowDefinitions>
-
-                                <!--  关卡选择  -->
-                                <controls:TextBlock
-                                    Grid.Row="0"
-                                    Grid.Column="0"
-                                    Margin="0,0,6,0"
-                                    VerticalAlignment="Center"
-                                    Text="{DynamicResource StageSelect}" />
-                                <Grid
-                                    Grid.Row="0"
-                                    Grid.Column="1"
-                                    Height="30">
-                                    <!--  当 IsStageManually 为 false 时显示 ComboBox  -->
-                                    <ComboBox
-                                        ItemsSource="{Binding StageListSource, Source={x:Static ui_vms:TaskQueueViewModel.DepotMaintainTask}}"
-                                        ScrollViewer.CanContentScroll="False"
-                                        SelectedValue="{Binding Stage}"
-                                        SelectedValuePath="Value"
-                                        Visibility="{c:Binding !IsStageManually,
-                                                               Source={x:Static ui_vms:TaskQueueViewModel.DepotMaintainTask}}">
-
-                                        <ComboBox.ItemContainerStyle>
-                                            <Style BasedOn="{StaticResource ComboBoxItemBaseStyle}" TargetType="ComboBoxItem">
+                                             Source={x:Static ui_vms:TaskQueueViewModel.TaskSettingVisibilities}}"
+                ItemsSource="{Binding Path=PlanList}"
+                PreviewMouseWheel="{s:Action RouteMouseWheelToParentExceptScrollable,
+                                             Target={x:Type helper:MouseWheelHelper}}">
+                <ListBox.ItemContainerStyle>
+                    <Style BasedOn="{StaticResource NoSelectedHighlightListBoxItemStyle}" TargetType="{x:Type ListBoxItem}">
+                        <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                        <Setter Property="Padding" Value="0" />
+                        <Setter Property="Margin" Value="1" />
+                    </Style>
+                </ListBox.ItemContainerStyle>
+                <ListBox.ItemTemplate>
+                    <DataTemplate>
+                        <Expander HorizontalContentAlignment="Stretch" IsExpanded="{Binding IsExpanded}">
+                            <Expander.Header>
+                                <Grid HorizontalAlignment="Stretch" Background="Transparent">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
+                                    <controls:TextBlock
+                                        HorizontalAlignment="Left"
+                                        Text="{Binding Title}"
+                                        TextTrimming="CharacterEllipsis" />
+                                    <Button
+                                        Grid.Column="1"
+                                        Width="25"
+                                        Height="25"
+                                        Margin="0,0,-5,0"
+                                        Padding="0"
+                                        hc:IconElement.Geometry="{StaticResource DeleteTaskGeometry}"
+                                        hc:IconElement.Height="15"
+                                        hc:IconElement.Width="15"
+                                        BorderBrush="Transparent"
+                                        BorderThickness="0"
+                                        Command="{s:Action RemovePlan,
+                                                           Target={x:Static taskQueue_vms:DepotMaintainTaskUserControlModel.Instance}}"
+                                        CommandParameter="{Binding}"
+                                        ToolTip="{DynamicResource Delete}">
+                                        <Button.Style>
+                                            <Style BasedOn="{StaticResource {x:Type Button}}" TargetType="Button">
+                                                <Setter Property="Visibility" Value="Collapsed" />
                                                 <Style.Triggers>
-                                                    <DataTrigger Binding="{Binding IsVisible}" Value="False">
-                                                        <Setter Property="Visibility" Value="Collapsed" />
+                                                    <DataTrigger Binding="{Binding IsMouseOver, RelativeSource={RelativeSource AncestorType={x:Type Grid}}}" Value="True">
+                                                        <Setter Property="Visibility" Value="Visible" />
                                                     </DataTrigger>
                                                 </Style.Triggers>
                                             </Style>
-                                        </ComboBox.ItemContainerStyle>
-                                        <ComboBox.ItemTemplate>
-                                            <DataTemplate>
-                                                <TextBlock Text="{Binding Display}">
-                                                    <TextBlock.Style>
-                                                        <Style TargetType="TextBlock">
-                                                            <Style.Triggers>
-                                                                <DataTrigger Binding="{Binding IsOutdated}" Value="True">
-                                                                    <Setter Property="TextDecorations" Value="Strikethrough" />
-                                                                    <Setter Property="Foreground" Value="{DynamicResource ErrorLogBrush}" />
-                                                                </DataTrigger>
-                                                                <DataTrigger Binding="{Binding IsOpen}" Value="False">
-                                                                    <Setter Property="Opacity" Value="0.5" />
-                                                                </DataTrigger>
-                                                                <DataTrigger Binding="{Binding IsOpen}" Value="True">
-                                                                    <Setter Property="Opacity" Value="1" />
-                                                                </DataTrigger>
-                                                            </Style.Triggers>
-                                                        </Style>
-                                                    </TextBlock.Style>
-                                                </TextBlock>
-                                            </DataTemplate>
-                                        </ComboBox.ItemTemplate>
-                                    </ComboBox>
-
-                                    <!--  当 IsStageManually 为 true 时显示 TextBox  -->
-                                    <TextBox
-                                        Height="30"
-                                        hc:InfoElement.Placeholder="{DynamicResource DefaultStage}"
-                                        IsEnabled="{c:Binding !IsStageItemDragging,
-                                                              Source={x:Static ui_vms:TaskQueueViewModel.FightTask}}"
-                                        Opacity="{c:Binding 'IsOpen ? 1 : 0.5'}"
-                                        Text="{Binding Stage, UpdateSourceTrigger=PropertyChanged}"
-                                        ToolTip="{DynamicResource IsStageManuallyTip}"
-                                        Visibility="{c:Binding IsStageManually,
-                                                               Source={x:Static ui_vms:TaskQueueViewModel.DepotMaintainTask}}" />
+                                        </Button.Style>
+                                    </Button>
                                 </Grid>
+                            </Expander.Header>
+                            <Border
+                                BorderBrush="{DynamicResource BorderBrush}"
+                                BorderThickness="1,0,1,1"
+                                CornerRadius="0,0,4,4">
+                                <Grid Margin="6">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" MinWidth="100" />
+                                        <ColumnDefinition Width="*" />
+                                    </Grid.ColumnDefinitions>
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                        <RowDefinition Height="Auto" />
+                                    </Grid.RowDefinitions>
 
-                                <!--  指定材料  -->
-                                <controls:TextBlock
-                                    Grid.Row="1"
-                                    Grid.Column="0"
-                                    Margin="0,6,6,0"
-                                    VerticalAlignment="Center"
-                                    Text="{DynamicResource AssignedMaterial}" />
-                                <ComboBox
-                                    Grid.Row="1"
-                                    Grid.Column="1"
-                                    Height="30"
-                                    Margin="0,6,0,0"
-                                    HorizontalContentAlignment="Stretch"
-                                    VerticalContentAlignment="Center"
-                                    s:View.ActionTarget="{Binding}"
-                                    DisplayMemberPath="Display"
-                                    DropDownClosed="{s:Action DropsListDropDownClosed}"
-                                    IsEditable="True"
-                                    IsTextSearchEnabled="False"
-                                    ItemsSource="{Binding DropsList, Source={x:Static ui_vms:TaskQueueViewModel.FightTask}}"
-                                    Loaded="{s:Action MakeComboBoxSearchable,
-                                                      Target={x:Type ui_vms:SettingsViewModel}}"
-                                    SelectedValue="{Binding DropId}"
-                                    SelectedValuePath="Value"
-                                    Text="{Binding DropName}" />
+                                    <!--  关卡选择  -->
+                                    <controls:TextBlock
+                                        Grid.Row="0"
+                                        Grid.Column="0"
+                                        Margin="0,0,6,0"
+                                        VerticalAlignment="Center"
+                                        Text="{DynamicResource StageSelect}" />
+                                    <Grid
+                                        Grid.Row="0"
+                                        Grid.Column="1"
+                                        Height="30">
+                                        <!--  当 IsStageManually 为 false 时显示 ComboBox  -->
+                                        <ComboBox
+                                            ItemsSource="{Binding StageListSource, Source={x:Static ui_vms:TaskQueueViewModel.DepotMaintainTask}}"
+                                            ScrollViewer.CanContentScroll="False"
+                                            SelectedValue="{Binding Stage}"
+                                            SelectedValuePath="Value"
+                                            Visibility="{c:Binding !IsStageManually,
+                                                                   Source={x:Static ui_vms:TaskQueueViewModel.DepotMaintainTask}}">
 
-                                <!--  目标库存  -->
-                                <controls:TextBlock
-                                    Grid.Row="2"
-                                    Grid.Column="0"
-                                    Margin="0,6,6,0"
-                                    VerticalAlignment="Center"
-                                    Text="{DynamicResource TargetInventory}" />
-                                <hc:NumericUpDown
-                                    Grid.Row="2"
-                                    Grid.Column="1"
-                                    Width="70"
-                                    Height="30"
-                                    Margin="0,6,0,0"
-                                    HorizontalAlignment="Left"
-                                    HorizontalContentAlignment="Center"
-                                    VerticalContentAlignment="Center"
-                                    Maximum="1145141919"
-                                    Minimum="0"
-                                    Value="{Binding DropCount, UpdateSourceTrigger=PropertyChanged}" />
+                                            <ComboBox.ItemContainerStyle>
+                                                <Style BasedOn="{StaticResource ComboBoxItemBaseStyle}" TargetType="ComboBoxItem">
+                                                    <Style.Triggers>
+                                                        <DataTrigger Binding="{Binding IsVisible}" Value="False">
+                                                            <Setter Property="Visibility" Value="Collapsed" />
+                                                        </DataTrigger>
+                                                    </Style.Triggers>
+                                                </Style>
+                                            </ComboBox.ItemContainerStyle>
+                                            <ComboBox.ItemTemplate>
+                                                <DataTemplate>
+                                                    <TextBlock Text="{Binding Display}">
+                                                        <TextBlock.Style>
+                                                            <Style TargetType="TextBlock">
+                                                                <Style.Triggers>
+                                                                    <DataTrigger Binding="{Binding IsOutdated}" Value="True">
+                                                                        <Setter Property="TextDecorations" Value="Strikethrough" />
+                                                                        <Setter Property="Foreground" Value="{DynamicResource ErrorLogBrush}" />
+                                                                    </DataTrigger>
+                                                                    <DataTrigger Binding="{Binding IsOpen}" Value="False">
+                                                                        <Setter Property="Opacity" Value="0.5" />
+                                                                    </DataTrigger>
+                                                                    <DataTrigger Binding="{Binding IsOpen}" Value="True">
+                                                                        <Setter Property="Opacity" Value="1" />
+                                                                    </DataTrigger>
+                                                                </Style.Triggers>
+                                                            </Style>
+                                                        </TextBlock.Style>
+                                                    </TextBlock>
+                                                </DataTemplate>
+                                            </ComboBox.ItemTemplate>
+                                        </ComboBox>
 
-                                <!--  使用药剂  -->
-                                <CheckBox
-                                    Grid.Row="3"
-                                    Grid.Column="0"
-                                    Margin="0,6,0,0"
-                                    VerticalAlignment="Center"
-                                    Content="{DynamicResource UseSanityPotion}"
-                                    IsChecked="{Binding UseMedicine}" />
-                                <hc:NumericUpDown
-                                    Grid.Row="3"
-                                    Grid.Column="1"
-                                    Width="70"
-                                    Height="30"
-                                    Margin="0,6,0,0"
-                                    HorizontalAlignment="Left"
-                                    HorizontalContentAlignment="Center"
-                                    VerticalContentAlignment="Center"
-                                    Maximum="999"
-                                    Minimum="0"
-                                    Value="{Binding MedicineCount, UpdateSourceTrigger=PropertyChanged}" />
+                                        <!--  当 IsStageManually 为 true 时显示 TextBox  -->
+                                        <TextBox
+                                            Height="30"
+                                            hc:InfoElement.Placeholder="{DynamicResource DefaultStage}"
+                                            IsEnabled="{c:Binding !IsStageItemDragging,
+                                                                  Source={x:Static ui_vms:TaskQueueViewModel.FightTask}}"
+                                            Opacity="{c:Binding 'IsOpen ? 1 : 0.5'}"
+                                            Text="{Binding Stage, UpdateSourceTrigger=PropertyChanged}"
+                                            ToolTip="{DynamicResource IsStageManuallyTip}"
+                                            Visibility="{c:Binding IsStageManually,
+                                                                   Source={x:Static ui_vms:TaskQueueViewModel.DepotMaintainTask}}" />
+                                    </Grid>
 
-                                <!--  使用源石  -->
-                                <CheckBox
-                                    Grid.Row="4"
-                                    Grid.Column="0"
-                                    Margin="0,6,0,0"
-                                    VerticalAlignment="Center"
-                                    Content="{DynamicResource UseOriginitePrime}"
-                                    IsChecked="{Binding UseStone}" />
-                                <hc:NumericUpDown
-                                    Grid.Row="4"
-                                    Grid.Column="1"
-                                    Width="70"
-                                    Height="30"
-                                    Margin="0,6,0,0"
-                                    HorizontalAlignment="Left"
-                                    HorizontalContentAlignment="Center"
-                                    VerticalContentAlignment="Center"
-                                    Maximum="999"
-                                    Minimum="0"
-                                    Value="{Binding StoneCount, UpdateSourceTrigger=PropertyChanged}" />
-                            </Grid>
-                        </Border>
-                    </Expander>
-                </DataTemplate>
-            </ListBox.ItemTemplate>
-        </ListBox>
-    </StackPanel>
+                                    <!--  指定材料  -->
+                                    <controls:TextBlock
+                                        Grid.Row="1"
+                                        Grid.Column="0"
+                                        Margin="0,6,6,0"
+                                        VerticalAlignment="Center"
+                                        Text="{DynamicResource AssignedMaterial}" />
+                                    <ComboBox
+                                        Grid.Row="1"
+                                        Grid.Column="1"
+                                        Height="30"
+                                        Margin="0,6,0,0"
+                                        HorizontalContentAlignment="Stretch"
+                                        VerticalContentAlignment="Center"
+                                        s:View.ActionTarget="{Binding}"
+                                        DisplayMemberPath="Display"
+                                        DropDownClosed="{s:Action DropsListDropDownClosed}"
+                                        IsEditable="True"
+                                        IsTextSearchEnabled="False"
+                                        ItemsSource="{Binding DropsList, Source={x:Static ui_vms:TaskQueueViewModel.FightTask}}"
+                                        Loaded="{s:Action MakeComboBoxSearchable,
+                                                          Target={x:Type ui_vms:SettingsViewModel}}"
+                                        SelectedValue="{Binding DropId}"
+                                        SelectedValuePath="Value"
+                                        Text="{Binding DropName}" />
+
+                                    <!--  目标库存  -->
+                                    <controls:TextBlock
+                                        Grid.Row="2"
+                                        Grid.Column="0"
+                                        Margin="0,6,6,0"
+                                        VerticalAlignment="Center"
+                                        Text="{DynamicResource TargetInventory}" />
+                                    <hc:NumericUpDown
+                                        Grid.Row="2"
+                                        Grid.Column="1"
+                                        Width="70"
+                                        Height="30"
+                                        Margin="0,6,0,0"
+                                        HorizontalAlignment="Left"
+                                        HorizontalContentAlignment="Center"
+                                        VerticalContentAlignment="Center"
+                                        Maximum="1145141919"
+                                        Minimum="0"
+                                        Value="{Binding DropCount, UpdateSourceTrigger=PropertyChanged}" />
+
+                                    <!--  使用药剂  -->
+                                    <CheckBox
+                                        Grid.Row="3"
+                                        Grid.Column="0"
+                                        Margin="0,6,0,0"
+                                        VerticalAlignment="Center"
+                                        Content="{DynamicResource UseSanityPotion}"
+                                        IsChecked="{Binding UseMedicine}"
+                                        Visibility="{c:Binding UseMedicine,
+                                                               Source={x:Static ui_vms:TaskQueueViewModel.DepotMaintainTask}}" />
+                                    <hc:NumericUpDown
+                                        Grid.Row="3"
+                                        Grid.Column="1"
+                                        Width="70"
+                                        Height="30"
+                                        Margin="0,6,0,0"
+                                        HorizontalAlignment="Left"
+                                        HorizontalContentAlignment="Center"
+                                        VerticalContentAlignment="Center"
+                                        Maximum="999"
+                                        Minimum="0"
+                                        Visibility="{c:Binding UseMedicine,
+                                                               Source={x:Static ui_vms:TaskQueueViewModel.DepotMaintainTask}}"
+                                        Value="{Binding MedicineCount, UpdateSourceTrigger=PropertyChanged}" />
+
+                                    <!--  使用源石  -->
+                                    <CheckBox
+                                        Grid.Row="4"
+                                        Grid.Column="0"
+                                        Margin="0,6,0,0"
+                                        VerticalAlignment="Center"
+                                        Content="{DynamicResource UseOriginitePrime}"
+                                        IsChecked="{Binding UseStone}"
+                                        Visibility="{c:Binding UseStone,
+                                                               Source={x:Static ui_vms:TaskQueueViewModel.DepotMaintainTask}}" />
+                                    <hc:NumericUpDown
+                                        Grid.Row="4"
+                                        Grid.Column="1"
+                                        Width="70"
+                                        Height="30"
+                                        Margin="0,6,0,0"
+                                        HorizontalAlignment="Left"
+                                        HorizontalContentAlignment="Center"
+                                        VerticalContentAlignment="Center"
+                                        Maximum="999"
+                                        Minimum="0"
+                                        Visibility="{c:Binding UseStone,
+                                                               Source={x:Static ui_vms:TaskQueueViewModel.DepotMaintainTask}}"
+                                        Value="{Binding StoneCount, UpdateSourceTrigger=PropertyChanged}" />
+                                </Grid>
+                            </Border>
+                        </Expander>
+                    </DataTemplate>
+                </ListBox.ItemTemplate>
+            </ListBox>
+            <StackPanel Orientation="Horizontal">
+                <Button
+                    Margin="6"
+                    VerticalAlignment="Bottom"
+                    d:IsHitTestVisible="True"
+                    Command="{s:Action AddPlan}"
+                    Content="{DynamicResource AddPlan}"
+                    IsHitTestVisible="{c:Binding !IsCurrentTaskRunning,
+                                                 Source={x:Static ui_vms:TaskQueueViewModel.TaskSettingVisibilities}}" />
+                <Button
+                    Margin="6"
+                    VerticalAlignment="Bottom"
+                    d:IsHitTestVisible="True"
+                    Command="{s:Action CollapseAll}"
+                    Content="{DynamicResource CollapseAll}"
+                    IsHitTestVisible="{c:Binding !IsCurrentTaskRunning,
+                                                 Source={x:Static ui_vms:TaskQueueViewModel.TaskSettingVisibilities}}" />
+            </StackPanel>
+        </StackPanel>
+
+        <!--  高级设置  -->
+        <StackPanel Visibility="{c:Binding EnableAdvancedSettings, Source={x:Static ui_vms:TaskQueueViewModel.TaskSettingVisibilities}}">
+            <hc:Divider Content="{DynamicResource DepotGroupTaskBehavior}" />
+            <CheckBox
+                Margin="0,6,0,0"
+                Content="{DynamicResource DepotUpdateBeforeStart}"
+                IsChecked="{Binding UpdateDepot}" />
+            <CheckBox
+                Margin="0,6,0,0"
+                Content="{DynamicResource DepotSkipDuringActivity}"
+                IsChecked="{Binding SkipDuringActivity}" />
+            <CheckBox
+                Margin="0,6,0,0"
+                Content="{DynamicResource DepotSkipDuringResourceCollection}"
+                IsChecked="{Binding SkipDuringResourceCollection}" />
+
+            <hc:Divider Margin="0,12,0,0" Content="{DynamicResource DepotGroupStageAndBattle}" />
+            <StackPanel Margin="0,6,0,0" Orientation="Horizontal">
+                <CheckBox Content="{DynamicResource CustomStageCode}" IsChecked="{Binding IsStageManually}" />
+                <controls:TooltipBlock TooltipText="{DynamicResource CustomStageCodeTip}" />
+            </StackPanel>
+            <StackPanel Margin="0,6,0,0" Orientation="Horizontal">
+                <CheckBox Content="{DynamicResource DepotUseAutoSeries}" IsChecked="{Binding UseAutoSeries}" />
+                <controls:TooltipBlock Margin="3,0,0,0" TooltipText="{DynamicResource DepotUseAutoSeriesTip}" />
+            </StackPanel>
+
+            <hc:Divider Margin="0,12,0,0" Content="{DynamicResource DepotGroupSanityRecovery}" />
+            <CheckBox
+                Margin="0,6,0,0"
+                Content="{DynamicResource DepotEnableUseMedicine}"
+                IsChecked="{Binding UseMedicine}" />
+            <CheckBox
+                Margin="0,6,0,0"
+                Content="{DynamicResource DepotEnableUseStone}"
+                IsChecked="{Binding UseStone}" />
+            <CheckBox
+                Margin="0,6,0,0"
+                Content="{DynamicResource DepotUseExpiringMedicine}"
+                IsChecked="{Binding UseExpiringMedicine}" />
+        </StackPanel>
+    </Grid>
 </UserControl>


### PR DESCRIPTION
## Summary by Sourcery

重构仓库维护任务的 UI，以添加全局消耗品开关，以及用于常见刷图方案的预设关卡配置。

New Features:
- 添加全局开关，用于启用或禁用仓库维护方案中的药品和源石使用。
- 添加选项，可在所有方案中统一使用将在 48 小时内过期的理智药水。
- 引入刷图预设配置（如：芯片、龙门币、凭证、技能书），可通过预设菜单插入。
- 新增一键清除所有现有仓库维护方案的能力。

Enhancements:
- 确保预设列表支持本地化，并在应用语言变更时自动刷新。
- 更新仓库维护任务的序列化逻辑，以遵循新的全局消耗品设置以及即将过期药品的使用行为。
- 调整仓库维护任务视图和本地化资源，以反映新的 UI 布局和控件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor the depot maintain task UI to add global consumable toggles and preset stage configurations for common farming plans.

New Features:
- Add global switches to enable or disable medicine and originium usage for depot maintain plans.
- Add an option to use expiring sanity potions within a fixed 48‑hour threshold across all plans.
- Introduce preset farming configurations (e.g., chip, LMD, certificates, skill summaries) that can be inserted via a preset menu.
- Add the ability to clear all existing depot maintain plans in a single action.

Enhancements:
- Ensure preset lists support localization and refresh when the application language changes.
- Update serialization of depot maintain tasks to honor the new global consumable settings and expiring medicine behavior.
- Revise the depot maintain task view and localization resources to reflect the new UI layout and controls.

</details>