### PR TITLE
Release v6.16.3

### DIFF
--- a/.agents/skills/maa-issue-log-analysis/SKILL.md
+++ b/.agents/skills/maa-issue-log-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: maa-issue-log-analysis
-description: 分析 MaaAssistantArknights 上游仓库公开 Issue（`https://github.com/MaaAssistantArknights/MaaAssistantArknights/issues/...` 或 `#1234`）。自动抓取 issue 正文和评论中的 `report_*.zip` 附件，优先读取 `debug/asst.log`、`debug/gui.log`、`config/gui.new.json`、`cache/resource/tasks.json`，并在有后续分卷时补看 `debug/interface/*.png`、`debug/drops/*.png`、`debug/infrast/**`、`debug/dumps/*` 等现场证据；结合 MAA Core/WPF/资源任务代码与文档判断根因、给出修复方案，供用户让你分析 MAA issue、日志包、ADB 连接失败、关卡导航、识别失败、任务出错、闪退时使用。
+description: 分析 MaaAssistantArknights 上游仓库公开 Issue（`https://github.com/MaaAssistantArknights/MaaAssistantArknights/issues/...` 或 `#1234`）。自动抓取 issue 正文和评论中的 `report_*.zip` 附件，优先读取 `debug/asst.log`、`debug/gui.log`、`config/gui.new.json`、`cache/resource/tasks.json`，并在有后续分卷时补看 `debug/interface/*.png`、`debug/drops/*.png`、`debug/infrast/**`、`debug/dumps/*` 等现场证据；结合 MAA Core/WPF/资源任务代码与文档判断根因、给出修复方案，供用户让你分析 MAA issue、日志包、ADB 连接失败、关卡导航、识别失败、任务出错、闪退时使用。内置的「诉求评估」方法论（三道筛：合理性 / 必要性 / 优先级）可脱离日志单独引用，用于评估 B 站评论、群聊反馈、纯文字 feature request 等无日志场景中的用户诉求。
 ---
 
 # MAA Issue Log Analysis
@@ -10,6 +10,7 @@ description: 分析 MaaAssistantArknights 上游仓库公开 Issue（`https://gi
 - 开始分析前，先读取同目录的 `KNOWLEDGE.md`，先用其中的通用误判规则校正自己的分析路径，再读 issue 和日志。
 - 如果 issue 涉及会客室、线索、快捷按钮、批量按钮、自动领取/赠送/放置这类“会先改变界面状态再继续执行”的流程，必须先套用 `KNOWLEDGE.md` 中的 `Stateful UI Automation Checks` 与 `Reception Clue Analysis`。
 - 如果用户没有贴出日志、报告包、报错文本、截图或导出诊断等有效证据，不要进入严肃分析；改用 `maa-cyber-fortune-master/SKILL.md` 引导补证据（详见 Scope 和 Workflow Step 2）。
+- 本 skill 内置「诉求评估」方法论（Workflow Step 9 的三道筛：合理性 / 必要性 / 优先级）。即使没有日志、报告包、截图——例如面对 B 站评论、群聊反馈、纯文字 feature request——只要用户提出了明确的诉求，就可以单独引用这套框架做判断，不需要走完整 Workflow 或输出模板。
 
 ## Scope
 

--- a/.agents/skills/maa-issue-log-analysis/SKILL.md
+++ b/.agents/skills/maa-issue-log-analysis/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: maa-issue-log-analysis
-description: 分析 MaaAssistantArknights 上游仓库公开 Issue（`https://github.com/MaaAssistantArknights/MaaAssistantArknights/issues/...` 或 `#1234`）。自动抓取 issue 正文和评论中的 `report_*.zip` 附件，优先读取 `debug/asst.log`、`debug/gui.log`、`config/gui.json` / `config/gui.new.json`、`cache/resource/tasks.json`，并在有后续分卷时补看 `debug/interface/*.png`、`debug/drops/*.png`、`debug/infrast/**`、`debug/dumps/*` 等现场证据；结合 MAA Core/WPF/资源任务代码与文档判断根因、给出修复方案，供用户让你分析 MAA issue、日志包、ADB 连接失败、关卡导航、识别失败、任务出错、闪退时使用。
+description: 分析 MaaAssistantArknights 上游仓库公开 Issue（`https://github.com/MaaAssistantArknights/MaaAssistantArknights/issues/...` 或 `#1234`）。自动抓取 issue 正文和评论中的 `report_*.zip` 附件，优先读取 `debug/asst.log`、`debug/gui.log`、`config/gui.new.json`、`cache/resource/tasks.json`，并在有后续分卷时补看 `debug/interface/*.png`、`debug/drops/*.png`、`debug/infrast/**`、`debug/dumps/*` 等现场证据；结合 MAA Core/WPF/资源任务代码与文档判断根因、给出修复方案，供用户让你分析 MAA issue、日志包、ADB 连接失败、关卡导航、识别失败、任务出错、闪退时使用。
 ---
 
 # MAA Issue Log Analysis
@@ -9,16 +9,16 @@ description: 分析 MaaAssistantArknights 上游仓库公开 Issue（`https://gi
 
 - 开始分析前，先读取同目录的 `KNOWLEDGE.md`，先用其中的通用误判规则校正自己的分析路径，再读 issue 和日志。
 - 如果 issue 涉及会客室、线索、快捷按钮、批量按钮、自动领取/赠送/放置这类“会先改变界面状态再继续执行”的流程，必须先套用 `KNOWLEDGE.md` 中的 `Stateful UI Automation Checks` 与 `Reception Clue Analysis`。
-- 如果用户没有贴出日志、报告包、报错文本、截图或导出诊断等有效证据，不要直接进入严肃日志分析；先转用同目录技能 `maa-cyber-fortune-master/SKILL.md` 生成一段短小的玄学回复，把对话自然引导到“补日志 / 截图 / 报错 / 诊断信息”。
+- 如果用户没有贴出日志、报告包、报错文本、截图或导出诊断等有效证据，不要进入严肃分析；改用 `maa-cyber-fortune-master/SKILL.md` 引导补证据（详见 Scope 和 Workflow Step 2）。
 
 ## Scope
 
 - 仅用于上游公开仓库 `https://github.com/MaaAssistantArknights/MaaAssistantArknights`。
 - 输入可以是完整 issue URL，或 `#1234` 形式的 issue 编号。
 - 只分析公开 issue 中可直接访问的附件。
-- 如果没有可下载的 `report_*.zip`，先判断用户是否至少提供了其他有效证据（报错文本、截图、导出诊断、清晰复现步骤）。
-- 如果连这些也没有，优先转用 `maa-cyber-fortune-master/SKILL.md`，不要直接输出严肃分析模板。
-- 如果没有 `report_*.zip` 但仍有其他有效证据，再明确说明证据不足，并尽量基于 issue 文本、截图、代码和文档给出初步判断。
+- 如果没有可下载的 `report_*.zip`，看用户是否提供了其他有效证据（报错文本、截图、导出诊断、清晰复现步骤）。
+    - 有其他证据 → 基于现有证据给出初步判断，明确说明证据不足。
+    - 无其他证据 → 转用 `maa-cyber-fortune-master/SKILL.md`，不要输出严肃分析模板。
 - 如果评论里有机器人提示“日志没有上传成功”，不要直接放弃；正文里的附件链接仍可能可下载。
 
 ## Workflow
@@ -71,14 +71,14 @@ description: 分析 MaaAssistantArknights 上游仓库公开 Issue（`https://gi
  - 再用 `asst.log` 还原底层行为。
  - 关卡或任务问题时，优先用 `gui.log` 中的 `Start Task Chain`、`GetFightStage`、`任务出错` 锁定时间窗，再回到 `asst.log` 里的 `taskid`、`SubTaskError`、`TaskChainError`。
  - 连接问题时，优先把 `gui.log` 中的重试流程和 `asst.log` 中的 `adb devices`、`adb connect`、`ConnectionInfo` 串起来。
-- 如果 `ConnectConfig` 是 `PC`，改走 `AttachWindow` / `Win32Controller` 这条线：
-- 先在 `gui.log` 确认 `AttachWindow: Found window`
-- 再在 `asst.log` 里看 `Win32Controller::screencap`、`Win32Controller::click`
-- 不要再按 ADB 端口或 `ConnectionInfo.ConnectFailed` 的思路分析
-- 如果问题属于状态型 UI 自动化（例如会客室线索、批量按钮、快捷按钮、先拆后放一类流程），时间线里必须单独标出：
-- 自动化在什么时刻先修改了用户原状态
-- 后续进入下一步或恢复终态由哪个条件控制
-- 条件不满足时流程是停止、跳过，还是按设计停在别的状态
+ - 如果 `ConnectConfig` 是 `PC`，改走 `AttachWindow` / `Win32Controller` 这条线：
+     - 先在 `gui.log` 确认 `AttachWindow: Found window`
+     - 再在 `asst.log` 里看 `Win32Controller::screencap`、`Win32Controller::click`
+     - 不要再按 ADB 端口或 `ConnectionInfo.ConnectFailed` 的思路分析
+ - 如果问题属于状态型 UI 自动化（例如会客室线索、批量按钮、快捷按钮、先拆后放一类流程），时间线里必须单独标出：
+     - 自动化在什么时刻先修改了用户原状态
+     - 后续进入下一步或恢复终态由哪个条件控制
+     - 条件不满足时流程是停止、跳过，还是按设计停在别的状态
 
 7. 区分 issue 当时环境和当前分支。
 
@@ -123,26 +123,23 @@ description: 分析 MaaAssistantArknights 上游仓库公开 Issue（`https://gi
  - 程序重启前的上下文
  - 更早一次复现
 
-### `config/gui.json`、`config/gui.new.json`、备份文件
+### `config/gui.new.json`、备份文件
 
-- 模块归属：GUI 配置快照。
+- 模块归属：GUI 配置快照（dev-v2 起 `gui.new.json` 为新配置系统主文件；旧 `gui.json` 已废弃，仅作为迁移残留或旧版本回退时可能存在）。
 - 常见文件：
- - `config/gui.json`
- - `config/gui.new.json`
- - `config/gui.json.old`
- - `config/gui.json.bak`
+ - `config/gui.new.json`（主）
+ - `config/gui.new.json.bak`（每次启动自动备份）
+ - `config/gui.json.old`（迁移前的旧配置备份，仅迁移时产生一次）
+ - `config/gui.new.json.err`（解析失败时保存的损坏配置）
 - 最适合看：
  - 实际连接配置
  - 模拟器路径、ADB 地址、是否开启截图增强
  - 任务队列、`StagePlan`
  - 是否真的选择了 `15-13-hard` 之类的硬难度关卡
 - 注意：
- - `gui.new.json` 可能比 `gui.json` 更接近用户当前界面上的任务配置，不能只看一个文件。
-- 如果 `gui.new.json` 与 `gui.log` / `asst.log` 的实际运行状态冲突，继续检查：
-- `gui.new.json.bak`
-- `gui.json.old`
-- `gui.json.bak`
-- 报告导出时用户可能已经改过勾选项，当前文件不一定就是复现时那一份。
+ - `gui.new.json` 与 `gui.log` / `asst.log` 的实际运行状态冲突时，先检查 `gui.new.json.bak`。
+ - 如果 issue 用户版本较旧（迁移前），可能仍使用旧 `gui.json`，此时 `gui.json` 和 `gui.json.old` 才有参考价值。
+ - 报告导出时用户可能已经改过勾选项，当前文件不一定就是复现时那一份。
 
 ### `cache/resource/tasks.json` 和 `cache/resource/tasks/tasks.json`
 
@@ -226,36 +223,36 @@ description: 分析 MaaAssistantArknights 上游仓库公开 Issue（`https://gi
  - `adb.exe devices` 里有没有 `offline`
  - `adb.exe connect` 是否报 `10061`
  - `ConnectionInfo.what` / `why`
- - `config/gui.json` 中的：
- - `ConnectConfig`
- - `Connect.Address`
- - `Connect.AllowADBRestart`
- - `Connect.AllowADBHardRestart`
- - `Connect.MuMu12Extras.Enabled`
+ - `config/gui.new.json` 中的：
+     - `ConnectConfig`
+     - `Connect.Address`
+     - `Connect.AllowADBRestart`
+     - `Connect.AllowADBHardRestart`
+     - `Connect.MuMu12Extras.Enabled`
  - 默认 MuMu 12 端口列表是否和日志中的轮询顺序一致
 
 5. 对 PC / AttachWindow 问题，重点看：
 
- - `config/gui.json` 中 `Connect.ConnectConfig == "PC"`
+ - `config/gui.new.json` 中 `Connect.ConnectConfig == "PC"`
  - `gui.log` 中：
- - `连接 PC 端（实验性功能，稳定性无法保证）`
- - `AttachWindow: Found window`
- - `handle: ..., hwnd: ..., screencapMethod: ..., mouseMethod: ..., keyboardMethod: ...`
+     - `连接 PC 端（实验性功能，稳定性无法保证）`
+     - `AttachWindow: Found window`
+     - `handle: ..., hwnd: ..., screencapMethod: ..., mouseMethod: ..., keyboardMethod: ...`
  - `asst.log` 中：
- - `Win32Controller::screencap`
- - `Win32Controller::click`
+     - `Win32Controller::screencap`
+     - `Win32Controller::click`
  - 点击后的下一次识别结果是否真的改变
  - 如果点击日志存在，但后续截图和 OCR 状态完全没变，要优先判断为“输入未生效”，而不是“流程已正确前进”
 
 6. 对关卡导航 / 磨难切换问题，重点看：
 
- - `config/gui.new.json` / `gui.json` 中的 `StagePlan`
+ - `config/gui.new.json` 中的 `StagePlan`
  - `gui.log` 中的 `GetFightStage`
  - `asst.log` 中的：
- - `Episode15`
- - `ChapterDifficultyHard`
- - `EnterChapterDifficultyHard`
- - `SubTaskError`
+     - `Episode15`
+     - `ChapterDifficultyHard`
+     - `EnterChapterDifficultyHard`
+     - `SubTaskError`
  - `debug/interface/*.png`
  - `resource/tasks/tasks.json` 与 `cache/resource/tasks*.json`
 
@@ -269,6 +266,20 @@ description: 分析 MaaAssistantArknights 上游仓库公开 Issue（`https://gi
  - 先判断日志中的状态变化是否符合游戏规则、资源任务定义和当前实现。
  - 如果流程与设计一致，不要把用户不喜欢的中间状态直接归为 bug。
  - 只有当日志、资源任务和代码彼此冲突，或流程没有达到设计要求的终态时，再归类为实现缺陷。
+
+9. 对用户诉求做合理性 / 必要性 / 优先级判断，不要默认认同。
+
+ - issue 用户通常会带一个隐含或明确的期望："应该支持 X""应该改成 Y"。分析完根因后，对这个期望本身单独评估，不要因为它写在 issue 里就当成既定需求。
+ - 判断前先搜索仓库中是否有相关 / 重复 issue：用 GitHub Issue Search 按关键词、标题或描述搜同类诉求。如果有类似 issue，先看维护者的回复和最终状态（已关闭 / 已实现 / 已拒绝 / Won't fix / 标签），再结合本次日志和代码做独立判断。不要直接复述旧 issue 的结论，但维护者对同类诉求的一贯态度是重要参考。
+ - 三道筛：
+     1. **合理性**：该诉求是否符合 MAA 的设计目标和定位？是否与已有功能、文档说明或已知约束冲突？如果它实质上是在要求 MAA 做它本来就不打算做的事（例如多开、多账号、PC 实验性功能全量维护、违背游戏机制的操作），直接标记为超出范围或不合理。
+     2. **必要性**：这个诉求对应的是真实缺陷，还是只是个人偏好 / 边缘场景 / 可以用现有功能绕过的？如果不实现也不会影响正确性和核心流程，必要性低。
+     3. **优先级**：相对其他 issue，这个诉求影响面有多大？是高频路径还是极少数用户的偶发场景？维护成本和收益是否匹配？只发生在单一环境、单一版本、且已有替代方案的，优先级低。
+ - 判断后的措辞要诚实，不要为了迎合用户而模糊结论：
+     - 不合理 → 写明“该诉求与 MAA 当前设计/定位不符”，给出理由，不要留“可以考虑”这种暧昧余地。
+     - 不必要 → 写明“当前已有替代方案 / 不影响正确性”，不建议为此投入。
+     - 低优先级 → 写明影响面和成本，标为“可延后”，不要和真正的缺陷并列。
+ - 只有当诉求通过三筛（合理、必要、有影响面）时，才在“修复方案”里给出具体实现建议。
 
 ## Common Patterns
 
@@ -286,7 +297,7 @@ description: 分析 MaaAssistantArknights 上游仓库公开 Issue（`https://gi
     - 先确认用户版本，必要时切到对应 tag（例如 `git checkout vXXX`）核对旧逻辑。
     - 不要用当前分支否定旧日志；旧版本问题可能真实存在。
     - 如果主线已修复，再看修复 commit 是否已进入 tag / release：已发版建议升级，未发版建议等待 release。
-- `gui.new.json`、`gui.json` 和实际日志不一致时，不要急着判“用户配置写错了”；先看 `gui.new.json.bak` 和 `gui.json.old`，尤其是用户复现后又改回开关的场景。
+- `gui.new.json` 和实际日志不一致时，不要急着判"用户配置写错了"；先看 `gui.new.json.bak`，尤其是用户复现后又改回开关的场景。
 - 在 `ConnectConfig=PC` 的 issue 里，`Win32Controller::click` 正常返回不代表点击真的生效；要看点击后的下一帧中，按钮状态、数量 OCR、场景识别有没有变化。
 - `gui.log` 中"已使用即将过期的理智药"这类高层提示，不一定等价于底层逐药 OCR 结论；如果 `asst.log` 明确识别到 `3天`、`NotExpiring` 等相反证据，应优先相信 `asst.log`。注意过期天数阈值现为可配置参数 `medicine_expire_days`，不再是固定 48 小时。
 
@@ -366,7 +377,7 @@ description: 分析 MaaAssistantArknights 上游仓库公开 Issue（`https://gi
 
 如果 issue 像 `#16014` 一样是 MuMu ADB 连接随机失败，并且同时出现：
 
-- `config/gui.json` 里 `ConnectConfig` 是 `MuMuEmulator12`
+- `config/gui.new.json` 里 `ConnectConfig` 是 `MuMuEmulator12`
 - 地址是 `127.0.0.1:16384`
 - `gui.log` 在复现时段从 `16384` 轮询到 `16576`
 - `asst.log` 里 `adb devices` 返回 `127.0.0.1:16384 offline`
@@ -444,7 +455,7 @@ description: 分析 MaaAssistantArknights 上游仓库公开 Issue（`https://gi
 
 - `debug/gui.log`：
 - `debug/asst.log`：
-- `config/gui.json` / `config/gui.new.json`：
+- `config/gui.new.json`：
 - `cache/resource` / `cache/gui`：
 - `debug/interface` / `debug/drops`：
 - 代码依据：如需指向具体实现，直接附远端 GitHub 行号链接
@@ -455,6 +466,14 @@ description: 分析 MaaAssistantArknights 上游仓库公开 Issue（`https://gi
 
 - 直接结论：
 - 证据链：
+
+## 诉求评估
+
+- 用户诉求（一句话）：
+- 合理性：合理 / 不合理（写明与哪个设计目标、文档说明或已知约束冲突）
+- 必要性：必要 / 不必要（写明是否已有替代方案、是否仅个人偏好）
+- 优先级：高 / 中 / 低 / 可延后（写明影响面和维护成本）
+- 结论：采纳 / 部分采纳 / 不采纳（不采纳时给出一句话理由）
 
 ## 给用户的建议
 
@@ -503,15 +522,15 @@ Translate the complete conclusion directly into English and paste it here. Note 
 
 ## Reminders
 
-- 如果用户没有贴出日志、报告包、截图、报错文本或导出诊断，不要硬套本 skill 的完整分析模板；优先改用 `maa-cyber-fortune-master/SKILL.md`，先把气氛接住，再把话题引回补证据。
-- 如果是“无有效证据”分支，赛博算卦段落应该放在最开头，并直接结束在“请补证据”；不要再追加长篇的 Issue 摘要、猜测性根因、修复方案或英文翻译。
+- 无有效证据时不要套完整模板，改用赛博算卦并直接收束到"请补证据"（详见 Output Format 分流规则）。
 - 不要只看 `gui.log` 下结论。
 - 不要把 issue 评论或机器人提示当成唯一证据。
 - 不要把当前分支资源直接当成 issue 当时的真实环境；先看报告包里的 `cache/resource`。
 - 日志和截图冲突时，优先相信现场图，再回头解释 OCR / 模板为何误判。
 - 如果问题本身没有在当前日志中复现，要明确写“证据未复现”，不要硬凑结论。
-- 如果 issue 版本很旧，要明确区分“当时的根因”和“当前分支是否已修复”。
-- 如果用户日志与当前代码不一致，先按用户版本 tag 复核；若确认已修，再看修复是否已进入 tag / release：已发版建议升级，未发版建议等待 release。
-- 如果回答里出现任务名、设置项、按钮名、提示文案，优先使用 `src/MaaWpfGui/Res/Localizations/zh-cn.xaml` 的中文文案；必要时才在括号里补原始 key / `taskChain` / 枚举名。
-- 如果回答里引用了具体代码行，直接给远端 GitHub `blob` 行号链接，用尖括号包裹，不要给本地路径加行号。
+- 如果 issue 版本很旧或用户日志与当前代码不一致，先按用户版本 tag 复核，再判断是否已修复（详见 Common Patterns）。
+- 回答中出现任务名、设置项、按钮名、提示文案时，优先使用 `zh-cn.xaml` 的中文文案（详见 Localized Copy）。
+- 引用具体代码行时给远端 GitHub `blob` 行号链接，不给本地路径加行号（详见 Linking Code Evidence）。
 - 如果证据表明问题已在新版本修复，明确建议用户升级；如果怀疑安装包、资源文件或配置损坏，明确建议重新下载或重建；如果判断为真实代码缺陷且暂无 workaround，明确建议等待开发者修复。
+- 对用户诉求做独立评估，不要因为有 issue 就默认认同；判断前先搜同类 issue 看维护者一贯态度；不合理、不必要或低优先级的诉求要诚实写明理由，只有通过三筛的才给修复方案。
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## v6.16.2
+## v6.16.3
 
 ### Highlights
 
@@ -44,6 +44,23 @@ Refactored the depot maintain task UI with global medicine/originium toggles and
 以下是详细内容：
 
 <details open>
+<summary><b>v6.16.3 (2026-08-03)</b></summary>
+
+### 改进 | Improved
+
+* 重构库存保持计划项为独立 ViewModel，按索引同步任务配置 ([#17468](https://github.com/MaaAssistantArknights/MaaAssistantArknights/pull/17468)) @status102
+* 优化库存保持预设按钮：左侧区域可点击展开下拉，并统一 SplitButton 背景样式 @ABA2396
+* 更新进度窗口不再强制置顶，仅在开始更新时前置一次，避免打断全屏游戏或其他操作 ([#17525](https://github.com/MaaAssistantArknights/MaaAssistantArknights/issues/17525)) @ABA2396
+* 统一配置与启动设置下拉列表中的删除按钮样式 @ABA2396
+
+### 修复 | Fix
+
+* 修复刷理智选择代理倍率后未关闭次数列表的问题 @status102
+* 修复 iOS/PlayCover 基建办公室入口模板阈值过高导致识别失败的问题 ([#17527](https://github.com/MaaAssistantArknights/MaaAssistantArknights/pull/17527)) @Rememorio
+
+</details>
+
+<details>
 <summary><b>v6.16.2 (2026-08-02)</b></summary>
 
 ### 新增 | New

--- a/resource/platform_diff/iOS/resource/tasks.json
+++ b/resource/platform_diff/iOS/resource/tasks.json
@@ -20,6 +20,9 @@
     "InfrastControlMini": {
         "templThreshold": 0.85
     },
+    "InfrastOfficeMini": {
+        "templThreshold": 0.9
+    },
     "InfrastSmileyOnRest": {
         "templThreshold": 0.7
     },

--- a/src/MaaCore/Task/Fight/FightTimesTaskPlugin.cpp
+++ b/src/MaaCore/Task/Fight/FightTimesTaskPlugin.cpp
@@ -374,6 +374,7 @@ bool asst::FightTimesTaskPlugin::select_series_new(int times)
             if (item.times == times) {
                 ctrler()->click(item.rect);
                 sleep(Config.get_options().task_delay);
+                close_series_list();
                 return true;
             }
         }

--- a/src/MaaUpdater/main.cpp
+++ b/src/MaaUpdater/main.cpp
@@ -385,7 +385,7 @@ static bool InitializeProgressUi()
     int originY = (GetSystemMetrics(SM_CYSCREEN) - PROGRESS_WINDOW_HEIGHT) / 2;
 
     HWND window = CreateWindowExW(
-        WS_EX_TOPMOST | WS_EX_APPWINDOW | WS_EX_DLGMODALFRAME,
+        WS_EX_APPWINDOW | WS_EX_DLGMODALFRAME,
         PROGRESS_WINDOW_CLASS_NAME,
         L"MAA 正在更新 | MAA Updating",
         WS_CAPTION,
@@ -400,6 +400,9 @@ static bool InitializeProgressUi()
     if (window == nullptr) {
         return false;
     }
+
+    // 弹出时带到前台一次，不强制永久置顶，避免打断全屏游戏或其他操作
+    SetForegroundWindow(window);
 
     HWND statusLabel = CreateWindowExW(
         0,

--- a/src/MaaWpfGui/Configuration/Factory/ConfigFactory.cs
+++ b/src/MaaWpfGui/Configuration/Factory/ConfigFactory.cs
@@ -176,32 +176,6 @@ public static class ConfigFactory
                 parsed.Configurations.Add(parsed.Current, new SpecificConfig());
             }
 
-            if (ParseJsonFile(ConfigurationHelper.ConfigFile) is JsonObject oldConfigJson && oldConfigJson["Configurations"] is JsonObject configurationsObj)
-            {
-                var configNames = configurationsObj.Select(i => i.Key);
-                foreach (var name in parsed.Configurations.Select(i => i.Key).Except(configNames))
-                {
-                    _brokenConfigs.Add(name);
-                    ConfigurationHelper.AddConfiguration(name, parsed.Current); // old config补全
-                    _logger.Information("Config {ConfigName} does not exist in old configuration, add into old configuration copy from {Current}", name, parsed.Current);
-                }
-
-                foreach (var name in configNames)
-                {
-                    if (!parsed.Configurations.ContainsKey(name))
-                    {
-                        _brokenConfigs.Add(name);
-                        parsed.Configurations.Add(name, parsed.CurrentConfig); // new config补全
-                        _logger.Information("Config {ConfigName} exists in old configuration but not in new config, copy from {Current}", name, parsed.Current);
-                    }
-                }
-                if (oldConfigJson["Current"]?.GetValue<string>() is string oldCurrent && parsed.Current != oldCurrent)
-                {
-                    _logger.Warning("Current configuration in old configuration is {OldCurrent}, but in new config is {NewCurrent}, switching to old current", oldCurrent, parsed.Current);
-                    ConfigurationHelper.SwitchConfiguration(parsed.Current); // 检查 Current 一致性
-                }
-            }
-
             return parsed;
 
             void SpecificConfigBind(string name, SpecificConfig config)

--- a/src/MaaWpfGui/Helper/ConfigConverter.cs
+++ b/src/MaaWpfGui/Helper/ConfigConverter.cs
@@ -102,7 +102,11 @@ public class ConfigConverter
         var currentConfigName = ConfigurationHelper.GetCurrentConfiguration();
         foreach (var configName in ConfigurationHelper.GetConfigurationList())
         {
-            ConfigurationHelper.SwitchConfiguration(configName);
+            if (!ConfigurationHelper.SwitchConfiguration(configName))
+            {
+                _logger.Error("配置迁移失败，无法切换到old配置: {ConfigName}", configName);
+                continue;
+            }
             if (ConfigFactory.Root.Configurations.ContainsKey(configName))
             {
             }
@@ -541,7 +545,11 @@ public class ConfigConverter
         var currentConfigName = ConfigurationHelper.GetCurrentConfiguration();
         foreach (var configName in ConfigurationHelper.GetConfigurationList())
         {
-            ConfigurationHelper.SwitchConfiguration(configName);
+            if (!ConfigurationHelper.SwitchConfiguration(configName))
+            {
+                _logger.Error("配置迁移失败，无法切换到old配置: {ConfigName}", configName);
+                continue;
+            }
             if (!ConfigFactory.SwitchConfig(configName))
             {
                 _logger.Error("配置迁移失败，无法切换到配置: {ConfigName}", configName);

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -1321,7 +1321,7 @@ public class AsstProxy
                     var allTaskCompleteMessage = LocalizationHelper.GetString("AllTaskCompleteContent");
                     var sanityReport = string.Empty;
 
-                    var configurationPreset = ConfigurationHelper.GetCurrentConfiguration();
+                    var configurationPreset = ConfigFactory.Root.Current;
 
                     allTaskCompleteMessage = allTaskCompleteMessage
                         .Replace("{DateTime}", dateTimeNow.ToString("yyyy-MM-dd HH:mm:ss"))

--- a/src/MaaWpfGui/Main/Bootstrapper.cs
+++ b/src/MaaWpfGui/Main/Bootstrapper.cs
@@ -1287,7 +1287,6 @@ public class Bootstrapper : Bootstrapper<RootViewModel>
     private static bool UpdateConfiguration(string desiredConfig)
     {
         // 配置名可能就包在引号中，需要转义符，如 \"a\"
-        string currentConfig = ConfigurationHelper.GetCurrentConfiguration();
-        return currentConfig != desiredConfig && ConfigurationHelper.SwitchConfiguration(desiredConfig) && ConfigFactory.SwitchConfig(desiredConfig);
+        return ConfigFactory.Root.Current != desiredConfig && ConfigFactory.SwitchConfig(desiredConfig);
     }
 }

--- a/src/MaaWpfGui/Res/Style.xaml
+++ b/src/MaaWpfGui/Res/Style.xaml
@@ -7,6 +7,7 @@
 
         <!--  按钮与交互控件  -->
         <ResourceDictionary Source="Styles/Button.xaml" />
+        <ResourceDictionary Source="Styles/SplitButton.xaml" />
         <ResourceDictionary Source="Styles/CheckBox.xaml" />
         <ResourceDictionary Source="Styles/CheckComboBox.xaml" />
         <ResourceDictionary Source="Styles/ComboBox.xaml" />

--- a/src/MaaWpfGui/Res/Styles/SplitButton.xaml
+++ b/src/MaaWpfGui/Res/Styles/SplitButton.xaml
@@ -1,0 +1,12 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:hc="https://handyorg.github.io/handycontrol">
+
+    <Style
+        x:Key="MaaSplitButtonDefaultStyle"
+        BasedOn="{StaticResource SplitButtonBaseStyle}"
+        TargetType="{x:Type hc:SplitButton}">
+        <Setter Property="Background" Value="{DynamicResource RegionBrushOpacity25}" />
+    </Style>
+
+    <Style BasedOn="{StaticResource MaaSplitButtonDefaultStyle}" TargetType="{x:Type hc:SplitButton}" />
+
+</ResourceDictionary>

--- a/src/MaaWpfGui/ViewModels/Items/DepotPlanItemViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/Items/DepotPlanItemViewModel.cs
@@ -1,0 +1,95 @@
+// <copyright file="DepotPlanItemViewModel.cs" company="MaaAssistantArknights">
+// Part of the MaaWpfGui project, maintained by the MaaAssistantArknights team (Maa Team)
+// Copyright (C) 2021-2025 MaaAssistantArknights Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License v3.0 only as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY
+// </copyright>
+
+#nullable enable
+using System.Linq;
+using JetBrains.Annotations;
+using MaaWpfGui.Extensions;
+using MaaWpfGui.Helper;
+using MaaWpfGui.ViewModels.UserControl.TaskQueue;
+using Stylet;
+
+[assembly: PropertyChanged.FilterType("MaaWpfGui.ViewModels.Items.DepotPlanItemViewModel")]
+
+namespace MaaWpfGui.ViewModels.Items;
+
+/// <summary>
+/// 库存维持ItemModel
+/// </summary>
+/// <param name="stage">关卡名</param>
+/// <param name="dropId">掉落物id</param>
+/// <param name="dropName">掉落物名称</param>
+/// <param name="dropCount">掉落物数量</param>
+/// <param name="useMedicine">是否使用理智药</param>
+/// <param name="medicineCount">理智药数量</param>
+/// <param name="useStone">是否碎石</param>
+/// <param name="stoneCount">碎石数量</param>
+/// <param name="taskId">任务AsstId</param>
+public partial class DepotPlanItemViewModel(string stage, string dropId, string? dropName = null, int dropCount = 0, bool useMedicine = false, int medicineCount = 0, bool useStone = false, int stoneCount = 0, int taskId = 0) : PropertyChangedBase
+{
+    public DepotPlanItemViewModel()
+        : this(string.Empty, string.Empty, null, 0, false, 0, false, 0, 0)
+    {
+    }
+
+    public bool IsExpanded { get; set => SetAndNotify(ref field, value); }
+
+    public int Index { get; set; }
+
+    public string Title => $"{Index + 1}: {DepotMaintainTaskUserControlModel.Instance.StageListSource.FirstOrDefault(i => i.Value == Stage)?.Display ?? Stage} - {DropName} x{DropCount.FormatNumber(false)}";
+
+    /// <summary>
+    /// 增删 plan 或语言切换后刷新 Title 显示（序号/关卡名/材料名）。
+    /// </summary>
+    public void RefreshTitle() => NotifyOfPropertyChange(nameof(Title));
+
+    public string Stage { get; set => SetAndNotify(ref field, value); } = stage;
+
+    /// <summary>
+    /// Gets or sets 指定掉落材料 ID。
+    /// </summary>
+    public string DropId { get; set => SetAndNotify(ref field, value); } = dropId;
+
+    /// <summary>
+    /// Gets or sets 指定掉落材料名称。
+    /// </summary>
+    public string DropName { get; set => SetAndNotify(ref field, value); } = dropName ?? LocalizationHelper.GetString("NotSelected");
+
+    public int DropCount { get; set => SetAndNotify(ref field, value); } = dropCount;
+
+    public bool UseMedicine { get; set => SetAndNotify(ref field, value); } = useMedicine;
+
+    public int MedicineCount { get; set => SetAndNotify(ref field, value); } = medicineCount;
+
+    public bool UseStone { get; set => SetAndNotify(ref field, value); } = useStone;
+
+    public int StoneCount { get; set => SetAndNotify(ref field, value); } = stoneCount;
+
+    public int TaskId { get; set; } = taskId;
+
+    // UI 绑定的方法
+    [UsedImplicitly]
+    public void DropsListDropDownClosed()
+    {
+        if (FightSettingsUserControlModel.Instance.DropsList.FirstOrDefault(i => i.Display == DropName) is { } item)
+        {
+            DropId = item.Value;
+        }
+        else
+        {
+            DropId = string.Empty;
+            DropName = LocalizationHelper.GetString("NotSelected");
+            NotifyOfPropertyChange(nameof(DropName));
+        }
+    }
+}

--- a/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
@@ -525,14 +525,12 @@ public class SettingsViewModel : Screen
             }
 
             var previousConfiguration = _currentConfiguration;
-            bool ret = ConfigurationHelper.SwitchConfiguration(value);
-            ret &= ConfigFactory.SwitchConfig(value);
+            bool ret = ConfigFactory.SwitchConfig(value);
 
             if (!ret)
             {
                 if (!string.IsNullOrEmpty(previousConfiguration))
                 {
-                    ConfigurationHelper.SwitchConfiguration(previousConfiguration);
                     ConfigFactory.SwitchConfig(previousConfiguration);
                 }
 

--- a/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
@@ -561,11 +561,9 @@ public class SettingsViewModel : Screen
             NewConfigurationName = DateTime.Now.ToString("yy/MM/dd HH:mm:ss");
         }
 
-        bool existsInHelper = ConfigurationHelper.ConfigurationExists(NewConfigurationName);
         bool existsInFactory = ConfigFactory.ConfigurationExists(NewConfigurationName);
 
-        // 两边都已存在，提示并返回
-        if (existsInHelper && existsInFactory)
+        if (existsInFactory)
         {
             Growl.Info(new GrowlInfo {
                 IsCustom = true,
@@ -576,33 +574,8 @@ public class SettingsViewModel : Screen
             return;
         }
 
-        // 至少有一侧存在（两边都存在的情况已在上方 return），清理残余配置以便重新添加
-        if (existsInHelper)
+        if (!ConfigFactory.AddConfiguration(NewConfigurationName, CurrentConfiguration))
         {
-            ConfigurationHelper.DeleteConfiguration(NewConfigurationName);
-        }
-        if (existsInFactory)
-        {
-            ConfigFactory.DeleteConfiguration(NewConfigurationName);
-        }
-
-        // 两边都不存在，执行添加
-        bool helperAdded = ConfigurationHelper.AddConfiguration(NewConfigurationName, CurrentConfiguration);
-        bool factoryAdded = ConfigFactory.AddConfiguration(NewConfigurationName, CurrentConfiguration);
-
-        if (!helperAdded || !factoryAdded)
-        {
-            // 任一侧添加失败，回滚另一侧
-            if (helperAdded)
-            {
-                ConfigurationHelper.DeleteConfiguration(NewConfigurationName);
-            }
-
-            if (factoryAdded)
-            {
-                ConfigFactory.DeleteConfiguration(NewConfigurationName);
-            }
-
             Growl.Info(new GrowlInfo {
                 IsCustom = true,
                 Message = LocalizationHelper.GetStringFormat("ConfigExists", NewConfigurationName),
@@ -629,7 +602,7 @@ public class SettingsViewModel : Screen
     [UsedImplicitly]
     public void DeleteConfiguration(CombinedData delete)
     {
-        if (ConfigurationHelper.DeleteConfiguration(delete.Display) && ConfigFactory.DeleteConfiguration(delete.Display))
+        if (ConfigFactory.DeleteConfiguration(delete.Display))
         {
             ConfigurationList.Remove(delete);
             if (ConfigurationList.Count <= 1)

--- a/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
@@ -302,9 +302,9 @@ public class SettingsViewModel : Screen
     private void InitConfiguration()
     {
         var configurations = new ObservableCollection<CombinedData>();
-        foreach (var conf in ConfigurationHelper.GetConfigurationList())
+        foreach (var conf in ConfigFactory.Root.Configurations)
         {
-            configurations.Add(new CombinedData { Display = conf, Value = conf });
+            configurations.Add(new CombinedData { Display = conf.Key, Value = conf.Key });
         }
 
         ConfigurationList = configurations;

--- a/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
@@ -513,7 +513,7 @@ public class SettingsViewModel : Screen
 
     public ObservableCollection<CombinedData> ConfigurationList { get; set; } = [];
 
-    private string? _currentConfiguration = ConfigurationHelper.GetCurrentConfiguration();
+    private string? _currentConfiguration = ConfigFactory.Root.Current;
 
     public string? CurrentConfiguration
     {

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
@@ -443,8 +443,16 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
             if (e.PropertyName is not nameof(DepotPlanItemViewModel.IsExpanded) and not nameof(DepotPlanItemViewModel.Title) and not nameof(DepotPlanItemViewModel.Index) && sender is DepotPlanItemViewModel plan)
             {
                 var list = GetTaskConfig<DepotMaintainTask>().PlanList.ToList();
-                list[plan.Index] = new DepotMaintainTask.Plan(plan.Stage, plan.DropId, plan.DropCount, plan.UseMedicine, plan.MedicineCount, plan.UseStone, plan.StoneCount, plan.TaskId);
-                SetTaskConfig<DepotMaintainTask>(t => t.PlanList.SequenceEqual(list), t => t.PlanList = list);
+                if (plan.Index < 0 || plan.Index >= list.Count)
+                {
+                    _logger.Warning("PlanItem_PropertyChanged: index {Index} out of range (Count={Count}), skip and resync", plan.Index, list.Count);
+                    SyncPlanListToTaskConfig();
+                }
+                else
+                {
+                    list[plan.Index] = new DepotMaintainTask.Plan(plan.Stage, plan.DropId, plan.DropCount, plan.UseMedicine, plan.MedicineCount, plan.UseStone, plan.StoneCount, plan.TaskId);
+                    SetTaskConfig<DepotMaintainTask>(t => t.PlanList.SequenceEqual(list), t => t.PlanList = list);
+                }
             }
         }
         if (e.PropertyName is nameof(DepotPlanItemViewModel.Title))

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
@@ -412,14 +412,18 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
 
         using var refresh = new UiRefreshingScope();
         var list = new List<DepotPlanItemViewModel>();
+        int index = 0;
         foreach (var plan in task.PlanList)
         {
             // 根据 DropId 从掉落列表恢复 DropName，避免初始化显示为"不选择"
             var dropName = FightSettingsUserControlModel.Instance.DropsList.FirstOrDefault(i => i.Value == plan.DropId)?.Display ?? LocalizationHelper.GetString("NotSelected");
 
-            var uiPlan = new DepotPlanItemViewModel(plan.Stage, plan.DropId, dropName, plan.DropCount, plan.UseMedicine, plan.MedicineCount, plan.UseStone, plan.StoneCount, plan.TaskId);
+            var uiPlan = new DepotPlanItemViewModel(plan.Stage, plan.DropId, dropName, plan.DropCount, plan.UseMedicine, plan.MedicineCount, plan.UseStone, plan.StoneCount, plan.TaskId) {
+                Index = index,
+            };
             list.Add(uiPlan);
             uiPlan.PropertyChanged += PlanItem_PropertyChanged;
+            ++index;
         }
         foreach (var plan in PlanList)
         {

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
@@ -227,25 +227,7 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
             return;
         }
 
-        // 先取消所有 PropertyChanged 订阅，避免 Clear 逐条触发
-        foreach (var plan in PlanList)
-        {
-            plan.PropertyChanged -= PlanItem_PropertyChanged;
-        }
-
-        // 挂起 CollectionChanged，避免 Clear() 触发 Reset 事件导致 SavePlan/PlanInfo 重复执行
-        PlanList.CollectionChanged -= PlanList_CollectionChanged;
-        try
-        {
-            PlanList.Clear();
-        }
-        finally
-        {
-            PlanList.CollectionChanged += PlanList_CollectionChanged;
-        }
-
-        SavePlan();
-        NotifyOfPropertyChange(nameof(PlanInfo));
+        PlanList.Clear();
     }
 
     /// <summary>
@@ -286,7 +268,7 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
             return;
         }
 
-        // 批量添加时挂起 CollectionChanged，避免逐条触发 SavePlan/RefreshTitle 导致卡顿
+        // 批量添加时挂起 CollectionChanged，避免逐条触发 SyncPlanListToTaskConfig/RefreshTitle 导致卡顿
         PlanList.CollectionChanged -= PlanList_CollectionChanged;
         try
         {
@@ -295,7 +277,7 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
                 foreach (var dropId in drops)
                 {
                     var dropName = ItemListHelper.GetItemName(dropId) ?? LocalizationHelper.GetString("NotSelected");
-                    var plan = new Plan(stage, dropId, dropName, defaultCount);
+                    var plan = new DepotPlanItemViewModel(stage, dropId, dropName, defaultCount);
                     plan.PropertyChanged += PlanItem_PropertyChanged;
                     PlanList.Add(plan);
                 }
@@ -307,7 +289,7 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
         }
 
         // 统一触发一次
-        SavePlan();
+        SyncPlanListToTaskConfig();
         NotifyOfPropertyChange(nameof(PlanInfo));
         foreach (var plan in PlanList)
         {
@@ -447,7 +429,7 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
             // 根据 DropId 从掉落列表恢复 DropName，避免初始化显示为"不选择"
             var dropName = FightSettingsUserControlModel.Instance.DropsList.FirstOrDefault(i => i.Value == plan.DropId)?.Display ?? LocalizationHelper.GetString("NotSelected");
 
-            var uiPlan = new Plan(plan.Stage, plan.DropId, dropName, plan.DropCount, plan.UseMedicine, plan.MedicineCount, plan.UseStone, plan.StoneCount, plan.TaskId);
+            var uiPlan = new DepotPlanItemViewModel(plan.Stage, plan.DropId, dropName, plan.DropCount, plan.UseMedicine, plan.MedicineCount, plan.UseStone, plan.StoneCount, plan.TaskId);
             list.Add(uiPlan);
             uiPlan.PropertyChanged += PlanItem_PropertyChanged;
         }
@@ -498,6 +480,17 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
         {
             plan.Index = index;
         }
+
+        SyncPlanListToTaskConfig();
+    }
+
+    /// <summary>
+    /// 将 <see cref="PlanList"/> 同步回 <see cref="DepotMaintainTask.PlanList"/>。
+    /// 供 <see cref="PlanList_CollectionChanged"/>、<see cref="ClearPlans"/>、<see cref="AddPresetPlan"/>
+    /// 等挂起 CollectionChanged 的批量操作复用，替代已删除的 SavePlan。
+    /// </summary>
+    private void SyncPlanListToTaskConfig()
+    {
         var list = PlanList.Select(plan => new DepotMaintainTask.Plan(plan.Stage, plan.DropId, plan.DropCount, plan.UseMedicine, plan.MedicineCount, plan.UseStone, plan.StoneCount, plan.TaskId)).ToList();
         SetTaskConfig<DepotMaintainTask>(t => t.PlanList.SequenceEqual(list), t => t.PlanList = list);
     }

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
@@ -18,7 +18,6 @@ using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
-using System.Windows.Documents;
 using System.Windows;
 using System.Windows.Controls;
 using JetBrains.Annotations;
@@ -32,8 +31,8 @@ using MaaWpfGui.Models;
 using MaaWpfGui.Models.AsstTasks;
 using MaaWpfGui.Services;
 using MaaWpfGui.Utilities;
-using MaaWpfGui.ViewModels.Items;
 using MaaWpfGui.Utilities.ValueType;
+using MaaWpfGui.ViewModels.Items;
 using MaaWpfGui.ViewModels.UI;
 using MaaWpfGui.ViewModels.UserControl.Settings;
 using ObservableCollections;
@@ -268,33 +267,22 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
             return;
         }
 
-        // 批量添加时挂起 CollectionChanged，避免逐条触发 SyncPlanListToTaskConfig/RefreshTitle 导致卡顿
-        PlanList.CollectionChanged -= PlanList_CollectionChanged;
-        try
+        var list = PlanList.ToList();
+        foreach (var (stage, drops, defaultCount) in stages)
         {
-            foreach (var (stage, drops, defaultCount) in stages)
+            foreach (var dropId in drops)
             {
-                foreach (var dropId in drops)
-                {
-                    var dropName = ItemListHelper.GetItemName(dropId) ?? LocalizationHelper.GetString("NotSelected");
-                    var plan = new DepotPlanItemViewModel(stage, dropId, dropName, defaultCount);
-                    plan.PropertyChanged += PlanItem_PropertyChanged;
-                    PlanList.Add(plan);
-                }
+                var dropName = ItemListHelper.GetItemName(dropId) ?? LocalizationHelper.GetString("NotSelected");
+                var plan = new DepotPlanItemViewModel(stage, dropId, dropName, defaultCount);
+                plan.PropertyChanged += PlanItem_PropertyChanged;
+                list.Add(plan);
             }
         }
-        finally
-        {
-            PlanList.CollectionChanged += PlanList_CollectionChanged;
-        }
 
-        // 统一触发一次
+        PlanList = new(list);
+        PlanList.CollectionChanged += PlanList_CollectionChanged;
         SyncPlanListToTaskConfig();
         NotifyOfPropertyChange(nameof(PlanInfo));
-        foreach (var plan in PlanList)
-        {
-            plan.RefreshTitle();
-        }
     }
 
     /// <summary>

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
@@ -18,6 +18,7 @@ using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Windows.Documents;
 using System.Windows;
 using System.Windows.Controls;
 using JetBrains.Annotations;
@@ -31,6 +32,7 @@ using MaaWpfGui.Models;
 using MaaWpfGui.Models.AsstTasks;
 using MaaWpfGui.Services;
 using MaaWpfGui.Utilities;
+using MaaWpfGui.ViewModels.Items;
 using MaaWpfGui.Utilities.ValueType;
 using MaaWpfGui.ViewModels.UI;
 using MaaWpfGui.ViewModels.UserControl.Settings;
@@ -196,14 +198,14 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
         set => SetTaskConfig<DepotMaintainTask>(t => t.UseExpiringMedicine == value, t => t.UseExpiringMedicine = value);
     }
 
-    public ObservableCollection<Plan> PlanList { get; private set => SetAndNotify(ref field, value); } = [];
+    public ObservableCollection<DepotPlanItemViewModel> PlanList { get; private set => SetAndNotify(ref field, value); } = [];
 
     public void AddPlan()
     {
-        PlanList.Add(new Plan());
+        PlanList.Add(new() { Index = PlanList.Count, });
     }
 
-    public void RemovePlan(Plan plan)
+    public void RemovePlan(DepotPlanItemViewModel plan)
     {
         PlanList.Remove(plan);
     }
@@ -374,17 +376,6 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
         return item?.Count >= 0 ? item.Count.ToString() : "--";
     }
 
-    private void SavePlan()
-    {
-        if (IsRefreshingUI)
-        {
-            return;
-        }
-
-        var list = PlanList.Select(i => new DepotMaintainTask.Plan(i.Stage, i.DropId, i.DropCount, i.UseMedicine, i.MedicineCount, i.UseStone, i.StoneCount, i.TaskId));
-        SetTaskConfig<DepotMaintainTask>(t => t.PlanList.SequenceEqual(list), t => t.PlanList = [.. list]);
-    }
-
     /// <summary>
     /// 更新关卡列表。
     /// 使用手动输入时，只更新关卡列表，不更新关卡选择
@@ -442,87 +433,6 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
         }
     }
 
-    public class Plan(string stage, string dropId, string? dropName = null, int dropCount = 0, bool useMedicine = false, int medicineCount = 0, bool useStone = false, int stoneCount = 0, int taskId = 0) : PropertyChangedBase
-    {
-        public Plan()
-            : this(string.Empty, string.Empty, null, 0, false, 0, false, 0, 0)
-        {
-        }
-
-        public bool IsExpanded { get; set => SetAndNotify(ref field, value); }
-
-        public string Title => $"{Instance.PlanList.IndexOf(this) + 1}: {Instance.StageListSource.FirstOrDefault(i => i.Value == Stage)?.Display ?? Stage} - {DropName} x{DropCount.FormatNumber(false)}";
-
-        /// <summary>
-        /// 增删 plan 或语言切换后刷新 Title 显示（序号/关卡名/材料名）。
-        /// </summary>
-        public void RefreshTitle() => NotifyOfPropertyChange(nameof(Title));
-
-        public string Stage
-        {
-            get; set {
-                SetAndNotify(ref field, value);
-                NotifyOfPropertyChange(nameof(Title));
-            }
-        } = stage;
-
-        /// <summary>
-        /// Gets or sets 指定掉落材料 ID。
-        /// </summary>
-        public string DropId
-        {
-            get; set {
-                SetAndNotify(ref field, value);
-                NotifyOfPropertyChange(nameof(Title));
-            }
-        } = dropId;
-
-        /// <summary>
-        /// Gets or sets 指定掉落材料名称。
-        /// </summary>
-        public string DropName
-        {
-            get; set {
-                SetAndNotify(ref field, value);
-                NotifyOfPropertyChange(nameof(Title));
-            }
-        } = dropName ?? LocalizationHelper.GetString("NotSelected");
-
-        public int DropCount
-        {
-            get; set {
-                SetAndNotify(ref field, value);
-                NotifyOfPropertyChange(nameof(Title));
-            }
-        } = dropCount;
-
-        public bool UseMedicine { get; set => SetAndNotify(ref field, value); } = useMedicine;
-
-        public int MedicineCount { get; set => SetAndNotify(ref field, value); } = medicineCount;
-
-        public bool UseStone { get; set => SetAndNotify(ref field, value); } = useStone;
-
-        public int StoneCount { get; set => SetAndNotify(ref field, value); } = stoneCount;
-
-        public int TaskId { get; set; } = taskId;
-
-        // UI 绑定的方法
-        [UsedImplicitly]
-        public void DropsListDropDownClosed()
-        {
-            if (FightSettingsUserControlModel.Instance.DropsList.FirstOrDefault(i => i.Display == DropName) is { } item)
-            {
-                DropId = item.Value;
-            }
-            else
-            {
-                DropId = string.Empty;
-                DropName = LocalizationHelper.GetString("NotSelected");
-                NotifyOfPropertyChange(nameof(DropName));
-            }
-        }
-    }
-
     public override void RefreshUI(BaseTask baseTask)
     {
         if (baseTask is not DepotMaintainTask task)
@@ -531,7 +441,7 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
         }
 
         using var refresh = new UiRefreshingScope();
-        var list = new List<Plan>();
+        var list = new List<DepotPlanItemViewModel>();
         foreach (var plan in task.PlanList)
         {
             // 根据 DropId 从掉落列表恢复 DropName，避免初始化显示为"不选择"
@@ -554,8 +464,16 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
 
     private void PlanItem_PropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
-        SavePlan();
-        if (e.PropertyName is nameof(Plan.Stage) or nameof(Plan.DropId) or nameof(Plan.DropName) or nameof(Plan.DropCount))
+        if (!IsRefreshingUI)
+        {
+            if (e.PropertyName is not nameof(DepotPlanItemViewModel.IsExpanded) and not nameof(DepotPlanItemViewModel.Title) and not nameof(DepotPlanItemViewModel.Index) && sender is DepotPlanItemViewModel plan)
+            {
+                var list = GetTaskConfig<DepotMaintainTask>().PlanList.ToList();
+                list[plan.Index] = new DepotMaintainTask.Plan(plan.Stage, plan.DropId, plan.DropCount, plan.UseMedicine, plan.MedicineCount, plan.UseStone, plan.StoneCount, plan.TaskId);
+                SetTaskConfig<DepotMaintainTask>(t => t.PlanList.SequenceEqual(list), t => t.PlanList = list);
+            }
+        }
+        if (e.PropertyName is nameof(DepotPlanItemViewModel.Title))
         {
             NotifyOfPropertyChange(nameof(PlanInfo));
         }
@@ -563,24 +481,25 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
 
     private void PlanList_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
-        SavePlan();
         NotifyOfPropertyChange(nameof(PlanInfo));
-        foreach (var plan in PlanList)
-        {
-            plan.RefreshTitle();
-        }
         if (e.Action is NotifyCollectionChangedAction.Remove or NotifyCollectionChangedAction.Replace)
         {
-            e.OldItems?.OfType<Plan>().ToList().ForEach(plan => {
+            e.OldItems?.OfType<DepotPlanItemViewModel>().ToList().ForEach(plan => {
                 plan.PropertyChanged -= PlanItem_PropertyChanged;
             });
         }
         if (e.Action is NotifyCollectionChangedAction.Add or NotifyCollectionChangedAction.Replace)
         {
-            e.NewItems?.OfType<Plan>().ToList().ForEach(plan => {
+            e.NewItems?.OfType<DepotPlanItemViewModel>().ToList().ForEach(plan => {
                 plan.PropertyChanged += PlanItem_PropertyChanged;
             });
         }
+        foreach (var (plan, index) in PlanList.Select((plan, index) => (plan, index)))
+        {
+            plan.Index = index;
+        }
+        var list = PlanList.Select(plan => new DepotMaintainTask.Plan(plan.Stage, plan.DropId, plan.DropCount, plan.UseMedicine, plan.MedicineCount, plan.UseStone, plan.StoneCount, plan.TaskId)).ToList();
+        SetTaskConfig<DepotMaintainTask>(t => t.PlanList.SequenceEqual(list), t => t.PlanList = list);
     }
 
     public override (bool? IsSuccess, IEnumerable<int> TaskId) SerializeTask(BaseTask? baseTask, int? taskId = null) => (this as ISerialize).Serialize(baseTask, taskId);

--- a/src/MaaWpfGui/Views/UserControl/Settings/ConfigurationMgrUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/Settings/ConfigurationMgrUserControl.xaml
@@ -44,10 +44,15 @@
                             Text="{Binding}" />
                         <Button
                             Grid.Column="1"
+                            Width="25"
+                            Height="25"
+                            Padding="0"
                             HorizontalAlignment="Right"
+                            hc:IconElement.Geometry="{StaticResource DeleteTaskGeometry}"
+                            hc:IconElement.Height="15"
+                            hc:IconElement.Width="15"
                             Command="{s:Action DeleteConfiguration}"
                             CommandParameter="{Binding}"
-                            Content="×"
                             FontWeight="Bold"
                             Visibility="{c:Binding 'DataContext.ConfigurationList.Count > 1',
                                                    RelativeSource={RelativeSource AncestorType={x:Type UserControl}}}" />

--- a/src/MaaWpfGui/Views/UserControl/TaskQueue/DepotMaintainTaskUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/TaskQueue/DepotMaintainTaskUserControl.xaml
@@ -255,6 +255,7 @@
                                                  Source={x:Static ui_vms:TaskQueueViewModel.TaskSettingVisibilities}}" />
                 <hc:SplitButton
                     hc:BorderElement.CornerRadius="0,4,4,0"
+                    Click="PresetSplitButton_Click"
                     Content="{DynamicResource DepotPreset}"
                     IsHitTestVisible="{c:Binding !IsCurrentTaskRunning,
                                                  Source={x:Static ui_vms:TaskQueueViewModel.TaskSettingVisibilities}}">

--- a/src/MaaWpfGui/Views/UserControl/TaskQueue/DepotMaintainTaskUserControl.xaml.cs
+++ b/src/MaaWpfGui/Views/UserControl/TaskQueue/DepotMaintainTaskUserControl.xaml.cs
@@ -52,4 +52,15 @@ public partial class DepotMaintainTaskUserControl : System.Windows.Controls.User
             window.PreviewMouseLeftButtonUp -= Window_PreviewMouseLeftButtonUp;
         }
     }
+
+    /// <summary>
+    /// SplitButton 左半边点击时也展开下拉，避免用户只能点右侧箭头。
+    /// </summary>
+    private void PresetSplitButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (sender is HandyControl.Controls.SplitButton splitButton)
+        {
+            splitButton.IsDropDownOpen = true;
+        }
+    }
 }

--- a/src/MaaWpfGui/Views/UserControl/TaskQueue/StartUpTaskUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/TaskQueue/StartUpTaskUserControl.xaml
@@ -166,8 +166,8 @@
                                         Text="{Binding}" />
                                     <Button
                                         Grid.Column="1"
-                                        Width="30"
-                                        Height="30"
+                                        Width="25"
+                                        Height="25"
                                         Padding="0"
                                         HorizontalAlignment="Right"
                                         hc:IconElement.Geometry="{StaticResource DeleteTaskGeometry}"


### PR DESCRIPTION
## Summary by Sourcery

通过引入专用的计划项视图模型并改进与任务配置的同步机制，优化仓库维护规划 UI；简化配置预设管理，完全依赖新的配置系统；同时调整更新器和战斗逻辑行为，以提升用户体验并提高正确性。

New Features:
- 引入 `DepotPlanItemViewModel` 来表示仓库维护计划，支持索引和标题处理，使 UI 项与任务配置模型解耦。

Bug Fixes:
- 确保仓库维护计划列表的变更能够正确同步回 `DepotMaintainTask.PlanList`，并移除冗余的 `SavePlan` 逻辑，避免出现陈旧或不一致的配置。
- 修复配置预设切换与管理问题，通过移除对旧版 `ConfigurationHelper` 的耦合，改为依赖 `ConfigFactory` 作为唯一可信来源，防止出现部分更新或失败的配置变更。
- 调整战斗系列选择逻辑，在点击目标条目后关闭系列列表，避免面板意外保持打开状态。
- 修改更新器进度窗口，使其不再始终置顶，但依然会将自身前置一次，避免干扰全屏应用。
- 让仓库维护预设的 `SplitButton` 在点击主按钮区域时也能展开下拉菜单，避免用户点击左侧时产生困惑。

Enhancements:
- 改进仓库维护预设计划的创建逻辑，批量生成视图模型并重新同步索引，简化计划标题与变更追踪。
- 强化旧配置转换的日志记录与鲁棒性，在切换旧配置失败时进行处理，而不是中止整个迁移流程。
- 明确 Maa 问题日志分析技能文档中关于证据要求、配置文件、PC 附加分析以及用户需求评估的说明，并采用结构化的三阶段筛选流程。
- 更新设置与配置管理 UI 绑定，直接使用 `ConfigFactory.Root` 数据来列出和选择配置，减少重复。
- 优化 `Bootstrapper` 和 `AsstProxy`，改为从 `ConfigFactory.Root` 读取当前配置，而非依赖旧版辅助类。
- 新增专用的 `SplitButton` 样式资源，并对任务队列和设置视图的 XAML 进行相关更新，以支持新的行为和样式。

Documentation:
- 扩展 `maa-issue-log-analysis` 技能文档，提供更清晰的工作流程说明、配置文件角色、证据处理规则，以及新增的用户功能请求与优先级评估章节。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine depot maintain planning UI with a dedicated plan item view model and improved synchronization to task configs, simplify configuration preset management to rely solely on the new config system, and tweak updater and fight logic behavior for better UX and correctness.

New Features:
- Introduce DepotPlanItemViewModel to represent depot maintain plans with indexing and title handling, decoupling UI items from task config models.

Bug Fixes:
- Ensure depot maintain plan list changes correctly sync back to DepotMaintainTask.PlanList without redundant SavePlan logic, avoiding stale or inconsistent configurations.
- Fix configuration preset switching and management by removing legacy ConfigurationHelper coupling and relying on ConfigFactory as the single source of truth, preventing partial or failed config changes.
- Adjust fight series selection to close the series list after clicking a target entry, preventing the panel from remaining open unexpectedly.
- Change the updater progress window to no longer stay always-on-top while still bringing it to the foreground once, avoiding interference with full-screen apps.
- Make depot maintain preset SplitButton open its dropdown when the main button area is clicked, preventing confusion when users click the left side.

Enhancements:
- Improve depot maintain preset plan creation to batch-generate view models and resync indices, simplifying plan titles and change tracking.
- Strengthen legacy config conversion logging and resilience by handling failures to switch old configs without aborting the whole migration.
- Clarify Maa issue log analysis skill documentation around evidence requirements, config files, PC attach analysis, and user request evaluation with a structured three-stage filter.
- Update settings and configuration management UI bindings to use ConfigFactory.Root data directly for listing and selecting configurations, reducing duplication.
- Refine Bootstrapper and AsstProxy to read current configuration from ConfigFactory.Root instead of the legacy helper.
- Add dedicated SplitButton style resource and related XAML updates for task queue and settings views to support the new behavior and styling.

Documentation:
- Expand maa-issue-log-analysis skill documentation with clearer workflows, config file roles, evidence handling rules, and a new section on evaluating user feature requests and priorities.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过引入专用的计划项视图模型并改进与任务配置的同步机制，优化仓库维护规划 UI；简化配置预设管理，完全依赖新的配置系统；同时调整更新器和战斗逻辑行为，以提升用户体验并提高正确性。

New Features:
- 引入 `DepotPlanItemViewModel` 来表示仓库维护计划，支持索引和标题处理，使 UI 项与任务配置模型解耦。

Bug Fixes:
- 确保仓库维护计划列表的变更能够正确同步回 `DepotMaintainTask.PlanList`，并移除冗余的 `SavePlan` 逻辑，避免出现陈旧或不一致的配置。
- 修复配置预设切换与管理问题，通过移除对旧版 `ConfigurationHelper` 的耦合，改为依赖 `ConfigFactory` 作为唯一可信来源，防止出现部分更新或失败的配置变更。
- 调整战斗系列选择逻辑，在点击目标条目后关闭系列列表，避免面板意外保持打开状态。
- 修改更新器进度窗口，使其不再始终置顶，但依然会将自身前置一次，避免干扰全屏应用。
- 让仓库维护预设的 `SplitButton` 在点击主按钮区域时也能展开下拉菜单，避免用户点击左侧时产生困惑。

Enhancements:
- 改进仓库维护预设计划的创建逻辑，批量生成视图模型并重新同步索引，简化计划标题与变更追踪。
- 强化旧配置转换的日志记录与鲁棒性，在切换旧配置失败时进行处理，而不是中止整个迁移流程。
- 明确 Maa 问题日志分析技能文档中关于证据要求、配置文件、PC 附加分析以及用户需求评估的说明，并采用结构化的三阶段筛选流程。
- 更新设置与配置管理 UI 绑定，直接使用 `ConfigFactory.Root` 数据来列出和选择配置，减少重复。
- 优化 `Bootstrapper` 和 `AsstProxy`，改为从 `ConfigFactory.Root` 读取当前配置，而非依赖旧版辅助类。
- 新增专用的 `SplitButton` 样式资源，并对任务队列和设置视图的 XAML 进行相关更新，以支持新的行为和样式。

Documentation:
- 扩展 `maa-issue-log-analysis` 技能文档，提供更清晰的工作流程说明、配置文件角色、证据处理规则，以及新增的用户功能请求与优先级评估章节。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refine depot maintain planning UI with a dedicated plan item view model and improved synchronization to task configs, simplify configuration preset management to rely solely on the new config system, and tweak updater and fight logic behavior for better UX and correctness.

New Features:
- Introduce DepotPlanItemViewModel to represent depot maintain plans with indexing and title handling, decoupling UI items from task config models.

Bug Fixes:
- Ensure depot maintain plan list changes correctly sync back to DepotMaintainTask.PlanList without redundant SavePlan logic, avoiding stale or inconsistent configurations.
- Fix configuration preset switching and management by removing legacy ConfigurationHelper coupling and relying on ConfigFactory as the single source of truth, preventing partial or failed config changes.
- Adjust fight series selection to close the series list after clicking a target entry, preventing the panel from remaining open unexpectedly.
- Change the updater progress window to no longer stay always-on-top while still bringing it to the foreground once, avoiding interference with full-screen apps.
- Make depot maintain preset SplitButton open its dropdown when the main button area is clicked, preventing confusion when users click the left side.

Enhancements:
- Improve depot maintain preset plan creation to batch-generate view models and resync indices, simplifying plan titles and change tracking.
- Strengthen legacy config conversion logging and resilience by handling failures to switch old configs without aborting the whole migration.
- Clarify Maa issue log analysis skill documentation around evidence requirements, config files, PC attach analysis, and user request evaluation with a structured three-stage filter.
- Update settings and configuration management UI bindings to use ConfigFactory.Root data directly for listing and selecting configurations, reducing duplication.
- Refine Bootstrapper and AsstProxy to read current configuration from ConfigFactory.Root instead of the legacy helper.
- Add dedicated SplitButton style resource and related XAML updates for task queue and settings views to support the new behavior and styling.

Documentation:
- Expand maa-issue-log-analysis skill documentation with clearer workflows, config file roles, evidence handling rules, and a new section on evaluating user feature requests and priorities.

</details>

</details>