### PR TITLE
fix: lower iOS office mini threshold

### DIFF
--- a/resource/platform_diff/iOS/resource/tasks.json
+++ b/resource/platform_diff/iOS/resource/tasks.json
@@ -20,6 +20,9 @@
     "InfrastControlMini": {
         "templThreshold": 0.85
     },
+    "InfrastOfficeMini": {
+        "templThreshold": 0.9
+    },
     "InfrastSmileyOnRest": {
         "templThreshold": 0.7
     },


### PR DESCRIPTION
## Summary

- Add an iOS platform-diff override for `InfrastOfficeMini.templThreshold = 0.9`.
- Keep the base resource threshold at `0.95`, so Android / Windows / MuMu behavior is unchanged.

## Why

On PlayCover / PlayTools, the source frame is `3840x2160` and MaaCore normalizes it to `1280x720`. In a controlled Office-only run, the correct `OfficeMini.png` match scored `0.934911`, so the base threshold `0.95` rejected the only valid result and `InfrastOfficeTask` ended with `SubTaskError`.

With only the threshold overridden to `0.9`, the same client and task produced:

```text
OfficeMini.png rect=[1032,367,62,51] score=0.934911
InfrastOfficeTask EnterFacility
InfrastOfficeTask SubTaskCompleted
Infrast TaskChainCompleted
```

This change is intentionally scoped to `platform_diff/iOS`. PR #17048 changes the base threshold globally, while its review discussion asks to keep the PlayTools-specific adjustment in the existing platform-diff directory. The iOS resource already contains similar threshold overrides for `InfrastControlMini` and other downscaled templates.

## Evidence

- Issue and complete reasoning: #17526
- [Minimal sanitized reproduction bundle](https://github.com/user-attachments/files/30636578/maa-ios-office-issue.zip)
- [Original failed recognition frame](https://github.com/user-attachments/assets/7ac8cdcf-cd79-478f-975e-4778934b7e73)
- Related prior PlayCover / YoStarJP fix: #16389 / #16390

## Validation

- `python3 -m json.tool resource/platform_diff/iOS/resource/tasks.json`
- `git diff --check`
- Baseline iOS / PlayTools run at `0.95`: repeated `result is empty`, then `InfrastOfficeTask SubTaskError`
- Controlled iOS / PlayTools run at `0.9`: correct match at `0.934911`, then `SubTaskCompleted` and `TaskChainCompleted`
- The base resource remains unchanged at `0.95`

Closes #17526

## Summary by Sourcery

调整 iOS 特定的模板匹配阈值，用于 Office mini 识别，以解决在 PlayTools/PlayCover 上 Office 任务完成失败的问题，同时保持全局阈值不变。

Bug Fixes:
- 修复 iOS 上 OfficeMini 识别因模板阈值过于严格而失败的问题，该问题会导致 InfrastOfficeTask 在 PlayTools/PlayCover 客户端上报错。

Enhancements:
- 对齐 iOS 平台差异（platform-diff）中 OfficeMini 的阈值设置，使其与其他降采样模板保持一致，以更好地支持归一化后的高分辨率输入帧，同时不影响 Android、Windows 或 MuMu 的行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust iOS-specific template matching thresholds for Office mini recognition to resolve failed Office task completion on PlayTools/PlayCover while keeping global thresholds unchanged.

Bug Fixes:
- Fix iOS OfficeMini recognition failing due to an overly strict template threshold that caused InfrastOfficeTask to error on PlayTools/PlayCover clients.

Enhancements:
- Align iOS platform-diff thresholds for OfficeMini with other downscaled templates to better support normalized high-resolution input frames without affecting Android, Windows, or MuMu behavior.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

调整 iOS 特定的模板匹配阈值，用于 Office mini 识别，以解决在 PlayTools/PlayCover 上 Office 任务完成失败的问题，同时保持全局阈值不变。

Bug Fixes:
- 修复 iOS 上 OfficeMini 识别因模板阈值过于严格而失败的问题，该问题会导致 InfrastOfficeTask 在 PlayTools/PlayCover 客户端上报错。

Enhancements:
- 对齐 iOS 平台差异（platform-diff）中 OfficeMini 的阈值设置，使其与其他降采样模板保持一致，以更好地支持归一化后的高分辨率输入帧，同时不影响 Android、Windows 或 MuMu 的行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Adjust iOS-specific template matching thresholds for Office mini recognition to resolve failed Office task completion on PlayTools/PlayCover while keeping global thresholds unchanged.

Bug Fixes:
- Fix iOS OfficeMini recognition failing due to an overly strict template threshold that caused InfrastOfficeTask to error on PlayTools/PlayCover clients.

Enhancements:
- Align iOS platform-diff thresholds for OfficeMini with other downscaled templates to better support normalized high-resolution input frames without affecting Android, Windows, or MuMu behavior.

</details>

</details>