### PR TITLE
feat: 在自动战斗多作业模式下添加漏怪重新开始战斗的行为

### DIFF
--- a/docs/en-us/protocol/integration.md
+++ b/docs/en-us/protocol/integration.md
@@ -751,6 +751,12 @@ Each object contains:
   ::: field name="use_sanity_potion" type="boolean" optional default="false"  
   Whether to use sanity potions when sanity is insufficient.  
   :::  
+  ::: field name="auto_restart" type="boolean" optional default="false"  
+  In Multi-Job mode, restart the current stage when an enemy leak is detected during battle or the battle fails. A leaked battle is abandoned before settlement.  
+  :::  
+  ::: field name="auto_restart_times" type="number" optional default="3"  
+  Maximum number of automatic restarts allowed for each job, from 1 to 999. Effective only when `auto_restart` is `true`.  
+  :::  
   ::: field name="formation" type="boolean" optional default="false"  
   Whether to enable auto formation.  
   :::  

--- a/docs/ja-jp/protocol/integration.md
+++ b/docs/ja-jp/protocol/integration.md
@@ -751,6 +751,12 @@ Sarkaz テーマ、Investment モード、「破棘成金分隊」または「�
   ::: field name="use_sanity_potion" type="boolean" optional default="false"  
   理智が不足した場合に理智薬を使用するかどうか。  
   :::  
+  ::: field name="auto_restart" type="boolean" optional default="false"  
+  マルチジョブモードで、戦闘中に敵を通した場合、または戦闘に失敗した場合に現在のステージを再開するかどうか。敵を通した場合はリザルト前に戦闘を中止します。  
+  :::  
+  ::: field name="auto_restart_times" type="number" optional default="3"  
+  各ジョブで許可する自動再開の最大回数（1～999）。`auto_restart` が `true` の場合のみ有効。  
+  :::  
   ::: field name="formation" type="boolean" optional default="false"  
   自動編成を行うかどうか。  
   :::  

--- a/docs/ko-kr/protocol/integration.md
+++ b/docs/ko-kr/protocol/integration.md
@@ -740,6 +740,12 @@ Sarkaz 테마, Investment 모드, "연금술 분대" 또는 "지원 분대"일 �
   ::: field name="use_sanity_potion" type="boolean" optional default="false"  
   이성 부족 시 이성 회복제 사용 허용 여부  
   :::  
+  ::: field name="auto_restart" type="boolean" optional default="false"  
+  다중 작업 모드에서 전투 중 적을 놓치거나 전투에 실패하면 현재 스테이지를 다시 시작할지 여부. 적을 놓친 경우 정산 전에 전투를 포기합니다.  
+  :::  
+  ::: field name="auto_restart_times" type="number" optional default="3"  
+  각 작업에서 허용할 자동 재시작 최대 횟수(1~999). `auto_restart`가 `true`일 때만 유효  
+  :::  
   ::: field name="formation" type="boolean" optional default="false"  
   자동 편성 수행 여부  
   :::  

--- a/docs/zh-cn/protocol/integration.md
+++ b/docs/zh-cn/protocol/integration.md
@@ -751,6 +751,12 @@ Tag 等级（大于等于 3）和对应的希望招募时限，单位为分钟�
   ::: field name="use_sanity_potion" type="boolean" optional default="false"  
   是否允许在剩余理智不足时使用理智药。  
   :::  
+  ::: field name="auto_restart" type="boolean" optional default="false"  
+  多作业模式下，是否在战斗中检测到漏怪或战斗失败时重开当前关卡。漏怪时会在结算前退出战斗。  
+  :::  
+  ::: field name="auto_restart_times" type="number" optional default="3"  
+  每个作业允许自动重开的最大次数，可设置为 1 至 999。仅在 `auto_restart` 为 `true` 时有效。  
+  :::  
   ::: field name="formation" type="boolean" optional default="false"  
   是否进行自动编队。  
   :::  

--- a/docs/zh-tw/protocol/integration.md
+++ b/docs/zh-tw/protocol/integration.md
@@ -751,6 +751,12 @@ Tag 等級（大於等於 3）對應的期望招募時限（單位：分鐘）�
   ::: field name="use_sanity_potion" type="boolean" optional default="false"  
   是否允許在理智不足時自動使用理智藥。  
   :::  
+  ::: field name="auto_restart" type="boolean" optional default="false"  
+  多作業模式下，是否在戰鬥中偵測到漏怪或戰鬥失敗時重開目前關卡。漏怪時會在結算前退出戰鬥。  
+  :::  
+  ::: field name="auto_restart_times" type="number" optional default="3"  
+  每個作業允許自動重開的最大次數，可設定為 1 至 999。僅在 `auto_restart` 為 `true` 時有效。  
+  :::  
   ::: field name="formation" type="boolean" optional default="false"  
   是否執行自動編隊。  
   :::  

--- a/src/MaaCore/Task/Interface/CopilotTask.cpp
+++ b/src/MaaCore/Task/Interface/CopilotTask.cpp
@@ -1,7 +1,11 @@
 #include "CopilotTask.h"
 
+#include <algorithm>
+#include <limits>
+
 #include "Arknights-Tile-Pos/TileCalc2.hpp"
 
+#include "Config/GeneralConfig.h"
 #include "Config/Miscellaneous/BattleDataConfig.h"
 #include "Config/Miscellaneous/CopilotConfig.h"
 #include "Config/TaskData.h"
@@ -51,6 +55,21 @@ asst::CopilotTask::CopilotTask(const AsstCallback& callback, Assistant* inst) :
 
     m_stop_task_ptr->set_enable(false);
     m_subtasks.emplace_back(m_stop_task_ptr);
+    m_subtasks_per_run = m_subtasks.size();
+}
+
+bool asst::CopilotTask::run()
+{
+    if (!m_auto_restart || !m_multi_copilot_plugin_ptr->get_enable()) {
+        return InterfaceTask::run();
+    }
+
+    if (run_with_auto_restart()) {
+        return true;
+    }
+
+    save_img(utils::path("debug") / utils::path("interface"));
+    return false;
 }
 
 bool asst::CopilotTask::set_params(const json::value& params)
@@ -73,6 +92,18 @@ bool asst::CopilotTask::set_params(const json::value& params)
     auto support_unit_usage = static_cast<SupportUnitUsage>(
         params.get("support_unit_usage", static_cast<int>(SupportUnitUsage::None))); // 助战干员使用模式
     std::string support_unit_name = params.get("support_unit_name", std::string());
+
+    constexpr int DefaultAutoRestartTimes = 3; // 未传入参数时的默认重开次数
+    constexpr int MinAutoRestartTimes = 1;     // 每个作业允许重开的次数下限
+    constexpr int MaxAutoRestartTimes = 999;   // 与界面控件保持一致的重开次数上限
+
+    const int normalized_auto_restart_times = std::clamp(
+        params.get("auto_restart_times", DefaultAutoRestartTimes),
+        MinAutoRestartTimes,
+        MaxAutoRestartTimes);                                                  // 将外部参数限制在界面允许的范围内
+
+    m_auto_restart = params.get("auto_restart", false);                        // 是否启用自动重开
+    m_auto_restart_times = static_cast<size_t>(normalized_auto_restart_times); // 每个作业最大重开次数
 
     auto filename_opt = params.find<std::string>("filename");
     auto multi_tasks_opt = params.find<json::array>("copilot_list"); // 多任务列表
@@ -114,6 +145,11 @@ bool asst::CopilotTask::set_params(const json::value& params)
         }
 
         size_t count = configs_cvt.size();
+        if (count == 0) {
+            Log.error("CopilotTask set_params failed, copilot_list is empty");
+            return false;
+        }
+        m_run_count = count;
         // 追加任务
         m_subtasks.reserve(m_subtasks.size() * count);
         // 保存原始大小
@@ -164,8 +200,12 @@ bool asst::CopilotTask::set_params(const json::value& params)
     }
 
     m_battle_task_ptr->set_formation_task_ptr(m_formation_task_ptr->get_opers_in_formation());
+    const bool enable_auto_restart = m_auto_restart && m_multi_copilot_plugin_ptr->get_enable();
+    m_battle_task_ptr->set_abort_on_leak(enable_auto_restart);
 
+    // 单作业循环次数沿用原有逻辑，与多作业模式下的自动重开次数无关。
     size_t loop_times = params.get("loop_times", 1);
+    m_stop_task_ptr->set_enable(false); // 清除上一次 set_params 留下的结算任务启用状态
     if (m_multi_copilot_plugin_ptr->get_enable()) {
         // 如果没三星就中止
         // 悖论模拟不需要强制三星，因为练度等关系有概率不过，反正不消耗理智，走单独的退出逻辑
@@ -179,19 +219,185 @@ bool asst::CopilotTask::set_params(const json::value& params)
         m_stop_task_ptr->set_tasks({ "Copilot@WaitUntilEndOfAction" }); // 带三星检查
         m_stop_task_ptr->set_enable(true);
     }
-    else if (loop_times > 1) {
-        m_stop_task_ptr->set_tasks({ "ClickCornerUntilStartButton" });
-        m_stop_task_ptr->set_enable(true);
-
-        // 追加
-        m_subtasks.reserve(m_subtasks.size() * loop_times);
-        size_t original_size = m_subtasks.size();
-        for (size_t i = 1; i < loop_times; ++i) {
-            m_subtasks.insert(m_subtasks.end(), m_subtasks.begin(), m_subtasks.begin() + original_size);
+    else {
+        if (loop_times > 1) {
+            m_stop_task_ptr->set_tasks({ "ClickCornerUntilStartButton" });
+            m_stop_task_ptr->set_enable(true);
         }
-        m_has_subtasks_duplicate = true;
+
+        if (loop_times > 1) {
+            // 每轮循环都追加一组完整子任务。
+            m_subtasks.reserve(m_subtasks.size() * loop_times);
+            size_t original_size = m_subtasks.size();
+            for (size_t i = 1; i < loop_times; ++i) {
+                m_subtasks.insert(m_subtasks.end(), m_subtasks.begin(), m_subtasks.begin() + original_size);
+            }
+            m_has_subtasks_duplicate = true;
+        }
+    }
+
+    if (enable_auto_restart) {
+        // ProcessTask 会在多次尝试间复用并保留执行计数；下方状态机已经按作业限制重开次数，
+        // 因此流程节点不能再使用一个跨作业累计的失败上限。
+        m_stop_task_ptr->set_times_limit("Copilot@FightMissionFailed", std::numeric_limits<int>::max());
     }
     return true;
+}
+
+bool asst::CopilotTask::run_with_auto_restart()
+{
+    if (!m_enable) {
+        Log.info("task disabled, pass", basic_info().to_string());
+        return true;
+    }
+    m_running = true;
+    notify_auto_restart(AutoRestartState::Enabled, 0);
+
+    for (size_t run_index = 0; run_index < m_run_count; ++run_index) {
+        size_t restart_times = 0;
+        while (!need_exit()) {
+            const auto result = run_stage_attempt(run_index);
+            if (result == StageAttemptResult::Success) {
+                if (restart_times > 0) {
+                    notify_auto_restart(AutoRestartState::Recovered, run_index, restart_times);
+                }
+                break;
+            }
+            if (result == StageAttemptResult::Error) {
+                return false;
+            }
+            if (restart_times >= m_auto_restart_times) {
+                notify_auto_restart(AutoRestartState::LimitReached, run_index, restart_times, result);
+                return false;
+            }
+
+            ++restart_times;
+            notify_auto_restart(AutoRestartState::Restarting, run_index, restart_times, result);
+
+            if (result == StageAttemptResult::RetryAfterFailure) {
+                // 战斗失败后仍停留在失败结算界面；漏怪分支已主动放弃并返回关卡页，
+                // 因此只有明确失败时才需要执行返回关卡页的恢复流程。
+                if (!ProcessTask(*this, { "Copilot@ClickCornerUntilStartButton" }).set_retry_times(20).run()) {
+                    return false;
+                }
+            }
+
+            // 多作业每次加载配置时会先推进游标；重试前回退一次，确保仍加载并导航到当前作业。
+            if (m_multi_copilot_plugin_ptr->get_enable() && !m_multi_copilot_plugin_ptr->retry_current_config()) {
+                Log.error("Failed to rewind multi-copilot config for auto restart");
+                return false;
+            }
+        }
+        if (need_exit()) {
+            return false;
+        }
+    }
+    return true;
+}
+
+asst::CopilotTask::StageAttemptResult asst::CopilotTask::run_stage_attempt(size_t run_index)
+{
+    // m_subtasks 中的重复分组共享任务对象；每次尝试只运行当前作业分组，避免重试时跳入下一项作业。
+    const size_t begin = run_index * m_subtasks_per_run;
+    const size_t end = begin + m_subtasks_per_run;
+    if (end > m_subtasks.size()) {
+        Log.error("Invalid multi-copilot subtask range", begin, end, m_subtasks.size());
+        return StageAttemptResult::Error;
+    }
+
+    const int task_delay = Config.get_options().task_delay;
+    const int failed_times_before = m_stop_task_ptr->get_exec_times("Copilot@FightMissionFailed");
+
+    for (size_t index = begin; index < end; ++index) {
+        if (need_exit()) {
+            return StageAttemptResult::Error;
+        }
+
+        const auto& task_ptr = m_subtasks.at(index);
+        if (!task_ptr->get_enable()) {
+            continue;
+        }
+
+        Log.trace(
+            __FUNCTION__,
+            "| run subtask",
+            index - begin + 1,
+            "/",
+            m_subtasks_per_run,
+            task_ptr->basic_info().to_string());
+        task_ptr->set_task_id(m_task_id);
+
+        const bool succeeded = task_ptr->run();
+        // 即使流程图之后正常结束，也可能已经命中过失败节点，因此必须独立检查计数，不能只依赖返回值。
+        if (task_ptr == m_stop_task_ptr &&
+            m_stop_task_ptr->get_exec_times("Copilot@FightMissionFailed") > failed_times_before) {
+            return StageAttemptResult::RetryAfterFailure;
+        }
+        if (!succeeded) {
+            if (task_ptr == m_battle_task_ptr && m_battle_task_ptr->has_leaked()) {
+                return StageAttemptResult::RetryAfterLeak;
+            }
+            if (!task_ptr->get_ignore_error()) {
+                return StageAttemptResult::Error;
+            }
+        }
+
+        if (index + 1 != end) {
+            sleep(task_delay);
+        }
+    }
+    return StageAttemptResult::Success;
+}
+
+void asst::CopilotTask::notify_auto_restart(
+    AutoRestartState state,
+    size_t run_index,
+    size_t restart_times,
+    StageAttemptResult reason)
+{
+    const std::string state_name = [state]() {
+        switch (state) {
+        case AutoRestartState::Enabled:
+            return "Enabled";
+        case AutoRestartState::Restarting:
+            return "Restarting";
+        case AutoRestartState::Recovered:
+            return "Recovered";
+        case AutoRestartState::LimitReached:
+            return "LimitReached";
+        }
+        return "Unknown";
+    }();
+    const std::string reason_name = reason == StageAttemptResult::RetryAfterLeak      ? "EnemyLeak"
+                                    : reason == StageAttemptResult::RetryAfterFailure ? "BattleFailed"
+                                                                                      : "None";
+
+    // 核心状态保存在 debug/asst.log；同一状态还会通过回调由 WPF 写入 debug/gui.log，
+    // 便于从底层日志和用户可见日志两条路径审查每次状态变化。
+    const auto log_level = state == AutoRestartState::LimitReached ? Logger::level::error
+                           : state == AutoRestartState::Restarting ? Logger::level::warn
+                                                                   : Logger::level::info;
+    Log.log(
+        log_level,
+        "Copilot auto-restart state",
+        state_name,
+        "run",
+        run_index + 1,
+        "/",
+        m_run_count,
+        "restart",
+        restart_times,
+        "/",
+        m_auto_restart_times,
+        "reason",
+        reason_name);
+
+    auto info = basic_info_with_what("CopilotAutoRestart");
+    info["details"] = json::object {
+        { "state", state_name },   { "times", restart_times },     { "max_times", m_auto_restart_times },
+        { "reason", reason_name }, { "run_index", run_index + 1 }, { "run_count", m_run_count },
+    };
+    callback(AsstMsg::SubTaskExtraInfo, info);
 }
 
 std::optional<std::filesystem::path> asst::CopilotTask::parse_copilot_filename(const std::string& name)

--- a/src/MaaCore/Task/Interface/CopilotTask.h
+++ b/src/MaaCore/Task/Interface/CopilotTask.h
@@ -32,12 +32,37 @@ public:
     CopilotTask(const AsstCallback& callback, Assistant* inst);
     virtual ~CopilotTask() override = default;
 
+    virtual bool run() override;
     virtual bool set_params(const json::value& params) override;
 
     std::string get_stage_name() const { return m_stage_name; }
 
 private:
+    // 自动重开以多作业列表中的一项为单位维护状态，重试不会影响前后作业的计数。
+    enum class StageAttemptResult
+    {
+        Success,
+        RetryAfterLeak,
+        RetryAfterFailure,
+        Error,
+    };
+
+    enum class AutoRestartState
+    {
+        Enabled,
+        Restarting,
+        Recovered,
+        LimitReached,
+    };
+
     std::optional<std::filesystem::path> parse_copilot_filename(const std::string& name);
+    bool run_with_auto_restart();
+    StageAttemptResult run_stage_attempt(size_t run_index);
+    void notify_auto_restart(
+        AutoRestartState state,
+        size_t run_index,
+        size_t restart_times = 0,
+        StageAttemptResult reason = StageAttemptResult::Success);
 
     std::shared_ptr<MultiCopilotTaskPlugin> m_multi_copilot_plugin_ptr = nullptr;
     std::shared_ptr<ProcessTask> m_medicine_task_ptr = nullptr;
@@ -46,5 +71,9 @@ private:
     std::shared_ptr<ProcessTask> m_stop_task_ptr = nullptr;
     std::string m_stage_name;
     bool m_has_subtasks_duplicate = false;
+    bool m_auto_restart = false;
+    size_t m_auto_restart_times = 3;
+    size_t m_run_count = 0;
+    size_t m_subtasks_per_run = 0;
 };
 }

--- a/src/MaaCore/Task/Miscellaneous/BattleProcessTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleProcessTask.cpp
@@ -52,13 +52,16 @@ bool asst::BattleProcessTask::_run()
     for (size_t i = 0; i < action_size && !need_exit() && m_in_battle; ++i) {
         const auto& action = get_combat_data().actions.at(i);
         do_action(action, i);
+        if (m_has_leaked) {
+            break;
+        }
     }
 
-    if (need_to_wait_until_end()) {
+    if (need_to_wait_until_end() && !m_has_leaked) {
         wait_until_end();
     }
 
-    return true;
+    return !m_has_leaked;
 }
 
 void asst::BattleProcessTask::clear()
@@ -67,6 +70,41 @@ void asst::BattleProcessTask::clear()
 
     m_oper_in_group.clear();
     m_in_bullet_time = false;
+    m_has_leaked = false;
+}
+
+bool asst::BattleProcessTask::do_strategic_action(const cv::Mat& reusable)
+{
+    // 等待作业时机或条件期间会反复执行策略动作，在此识别可避免因下一条脚本动作较晚而漏掉漏怪事件。
+    if (m_abort_on_leak && check_and_abandon_on_leak(reusable)) {
+        return true;
+    }
+    return BattleHelper::do_strategic_action(reusable);
+}
+
+bool asst::BattleProcessTask::check_and_abandon_on_leak(const cv::Mat& image)
+{
+    if (m_has_leaked) {
+        return true;
+    }
+
+    BattlefieldMatcher analyzer(image);
+    if (!analyzer.leak_flag_analyze()) {
+        return false;
+    }
+
+    // 放弃战斗成功前不能把本次尝试标记为可重开，否则下一次尝试可能在上一场战斗尚未退出时启动。
+    Log.warn("Enemy leak detected, abandoning the battle before settlement");
+
+    if (check_pause_button(image)) {
+        pause();
+    }
+    if (!abandon()) {
+        Log.error("Failed to abandon the battle after detecting an enemy leak");
+        return false;
+    }
+    m_has_leaked = true;
+    return true;
 }
 
 bool asst::BattleProcessTask::set_stage_name(const std::string& stage_name)
@@ -197,6 +235,10 @@ bool asst::BattleProcessTask::do_action(const battle::copilot::Action& action, s
 {
     LogTraceFunction;
 
+    if (m_abort_on_leak && check_and_abandon_on_leak(ctrler()->get_image())) {
+        return false;
+    }
+
     notify_action(action);
 
     thread_local auto prev_frame_time = std::chrono::steady_clock::time_point {};
@@ -217,6 +259,9 @@ bool asst::BattleProcessTask::do_action(const battle::copilot::Action& action, s
 
     if (action.pre_delay > 0) {
         sleep_and_do_strategy(action.pre_delay);
+        if (m_has_leaked) {
+            return false;
+        }
         if (action.type == ActionType::Deploy) {
             update_deployment(); // 等待之后画面可能会变化, 更新下干员信息, 但若为非部署动作, 则无需更新
         }

--- a/src/MaaCore/Task/Miscellaneous/BattleProcessTask.h
+++ b/src/MaaCore/Task/Miscellaneous/BattleProcessTask.h
@@ -16,6 +16,13 @@ public:
 
     virtual bool set_stage_name(const std::string& stage_name) override;
     void set_wait_until_end(bool wait_until_end);
+
+    // 启用后，一旦识别到战斗中的红色漏怪标记，就在结算前退出战斗。
+    void set_abort_on_leak(bool abort_on_leak) noexcept { m_abort_on_leak = abort_on_leak; }
+
+    // CopilotTask 根据本次尝试的漏怪状态，判断是否可以重开同一作业。
+    bool has_leaked() const noexcept { return m_has_leaked; }
+
     void set_formation_task_ptr(std::shared_ptr<std::unordered_map<std::string, std::string>> value);
 
 protected:
@@ -24,6 +31,7 @@ protected:
     virtual AbstractTask& this_task() override { return *this; }
 
     virtual void clear() override;
+    virtual bool do_strategic_action(const cv::Mat& reusable = cv::Mat()) override;
 
     virtual bool
         do_derived_action([[maybe_unused]] const battle::copilot::Action& action, [[maybe_unused]] size_t index)
@@ -44,11 +52,16 @@ protected:
     bool enter_bullet_time(const std::string& name, const Point& location);
     void sleep_and_do_strategy(unsigned millisecond);
 
+    // 只有识别到漏怪且放弃战斗流程成功完成后才返回 true。
+    bool check_and_abandon_on_leak(const cv::Mat& image);
+
     battle::copilot::CombatData m_combat_data;
     std::unordered_map</*group*/ std::string, /*oper*/ std::string> m_oper_in_group;
 
     bool m_in_bullet_time = false;
     bool m_need_to_wait_until_end = false;
+    bool m_abort_on_leak = false;
+    bool m_has_leaked = false;
     std::shared_ptr<std::unordered_map<std::string, std::string>> m_formation_ptr = nullptr;
 };
 }

--- a/src/MaaCore/Task/Miscellaneous/MultiCopilotTaskPlugin.cpp
+++ b/src/MaaCore/Task/Miscellaneous/MultiCopilotTaskPlugin.cpp
@@ -17,7 +17,7 @@
 bool asst::MultiCopilotTaskPlugin::_run()
 {
     LogTraceFunction;
-    if (m_copilot_configs.size() < (size_t)m_index_current) {
+    if (m_copilot_configs.size() <= static_cast<size_t>(m_index_current)) {
         LogError << __FUNCTION__ << "configs size:" << m_copilot_configs.size() << ", current index:" << m_index_current
                  << ", out of range";
         return false;
@@ -226,4 +226,3 @@ bool asst::MultiCopilotTaskPlugin::confirm_stage_name(const cv::Mat& image, cons
     LogError << __FUNCTION__ << "confirm stage name failed after retrying 3 times, stage name:" << stage_name;
     return false;
 }
-

--- a/src/MaaCore/Task/Miscellaneous/MultiCopilotTaskPlugin.h
+++ b/src/MaaCore/Task/Miscellaneous/MultiCopilotTaskPlugin.h
@@ -29,6 +29,16 @@ public:
 
     void set_battle_task_ptr(const std::shared_ptr<BattleProcessTask>& ptr) { m_battle_task_ptr = ptr; }
 
+    // _run() 会在作业开始前推进游标；重试同一作业时仅回退一次。
+    bool retry_current_config() noexcept
+    {
+        if (m_index_current == 0) {
+            return false;
+        }
+        --m_index_current;
+        return true;
+    }
+
 private:
     virtual bool _run() override;
     bool navigate_to_stage(const std::string& stage_name);

--- a/src/MaaCore/Task/ProcessTask.h
+++ b/src/MaaCore/Task/ProcessTask.h
@@ -39,6 +39,13 @@ public:
 
     const std::string& get_last_task_name() const noexcept { return m_last_task_name; }
 
+    // 提供只读执行次数，使组合任务能区分“明确命中失败节点”和其他流程停止原因。
+    int get_exec_times(const std::string& task_name) const noexcept
+    {
+        const auto iter = m_exec_times.find(task_name);
+        return iter == m_exec_times.cend() ? 0 : iter->second;
+    }
+
     const auto& get_last_hit() const noexcept { return m_last_hit_detail; }
 
 protected:

--- a/src/MaaCore/Vision/Battle/BattlefieldMatcher.cpp
+++ b/src/MaaCore/Vision/Battle/BattlefieldMatcher.cpp
@@ -260,6 +260,12 @@ bool BattlefieldMatcher::hp_flag_analyze() const
     }
 
     // 漏怪的时候，那个图标会变成红色的，所以多识别一次
+    return leak_flag_analyze();
+}
+
+bool BattlefieldMatcher::leak_flag_analyze() const
+{
+    Matcher flag_analyzer(m_image);
     flag_analyzer.set_task_info("BattleHpFlag2");
     return flag_analyzer.analyze().has_value();
 }

--- a/src/MaaCore/Vision/Battle/BattlefieldMatcher.h
+++ b/src/MaaCore/Vision/Battle/BattlefieldMatcher.h
@@ -56,6 +56,9 @@ public:
     void set_image_prev(const cv::Mat& image);
     ResultOpt analyze() const;
 
+    // 匹配敌人进入保护目标后出现的红色战场生命值标记（漏怪标记）。
+    bool leak_flag_analyze() const;
+
 protected:
     bool hp_flag_analyze() const;
     bool kills_flag_analyze() const;

--- a/src/MaaWpfGui/Configuration/Single/Settings/Copilot.cs
+++ b/src/MaaWpfGui/Configuration/Single/Settings/Copilot.cs
@@ -43,4 +43,8 @@ public partial class Copilot
     public int SelectFormation { get; set; } = 1;
 
     public int LoopTimes { get; set; } = 1;
+
+    public bool AutoRestart { get; set; } = false;
+
+    public int AutoRestartTimes { get; set; } = 3;
 }

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -1894,6 +1894,60 @@ public class AsstProxy
         string what = details["what"]?.ToString() ?? string.Empty;
         switch (what)
         {
+            case "CopilotAutoRestart":
+                {
+                    // AddLog 会同时在作业面板显示状态变化，并将其持久化到 debug/gui.log。
+                    var state = subTaskDetails?["state"]?.ToString() ?? string.Empty;
+                    var restartTimes = subTaskDetails?["times"]?.ToString() ?? "?";
+                    var maxRestartTimes = subTaskDetails?["max_times"]?.ToString() ?? "?";
+                    var runIndex = subTaskDetails?["run_index"]?.ToString() ?? "?";
+                    var runCount = subTaskDetails?["run_count"]?.ToString() ?? "?";
+                    var reasonKey = subTaskDetails?["reason"]?.ToString() == "EnemyLeak"
+                        ? "CopilotAutoRestartReasonEnemyLeak"
+                        : "CopilotAutoRestartReasonBattleFailed";
+
+                    switch (state)
+                    {
+                        case "Enabled":
+                            Instances.CopilotViewModel.AddLog(
+                                LocalizationHelper.GetStringFormat("CopilotAutoRestartEnabledLog", runCount, maxRestartTimes),
+                                UiLogColor.Info);
+                            break;
+
+                        case "Restarting":
+                            Instances.CopilotViewModel.AddLog(
+                                LocalizationHelper.GetStringFormat(
+                                    "CopilotAutoRestartLog",
+                                    runIndex,
+                                    runCount,
+                                    LocalizationHelper.GetString(reasonKey),
+                                    restartTimes,
+                                    maxRestartTimes),
+                                UiLogColor.Warning);
+                            break;
+
+                        case "Recovered":
+                            Instances.CopilotViewModel.AddLog(
+                                LocalizationHelper.GetStringFormat("CopilotAutoRestartRecoveredLog", runIndex, runCount),
+                                UiLogColor.Info);
+                            break;
+
+                        case "LimitReached":
+                            Instances.CopilotViewModel.AddLog(
+                                LocalizationHelper.GetStringFormat(
+                                    "CopilotAutoRestartLimitLog",
+                                    runIndex,
+                                    runCount,
+                                    LocalizationHelper.GetString(reasonKey),
+                                    restartTimes,
+                                    maxRestartTimes),
+                                UiLogColor.Error);
+                            break;
+                    }
+
+                    break;
+                }
+
             case "StageDrops":
                 {
                     string allDrops = string.Empty;

--- a/src/MaaWpfGui/Models/AsstTasks/AsstCopilotTask.cs
+++ b/src/MaaWpfGui/Models/AsstTasks/AsstCopilotTask.cs
@@ -68,6 +68,16 @@ public class AsstCopilotTask : AsstBaseTask
     public bool UseSanityPotion { get; set; }
 
     /// <summary>
+    /// 获取或设置是否在多作业模式下，漏怪或战斗失败后重开当前作业。
+    /// </summary>
+    public bool AutoRestart { get; set; }
+
+    /// <summary>
+    /// 获取或设置多作业模式下每个作业允许的最大自动重开次数。
+    /// </summary>
+    public int AutoRestartTimes { get; set; } = 3;
+
+    /// <summary>
     /// Gets or sets 自定干员列表
     /// </summary>
     public List<UserAdditional>? UserAdditionals { get; set; }
@@ -87,6 +97,8 @@ public class AsstCopilotTask : AsstBaseTask
             ["ignore_requirements"] = IgnoreRequirements,
             ["loop_times"] = LoopTimes,
             ["use_sanity_potion"] = UseSanityPotion,
+            ["auto_restart"] = AutoRestart,
+            ["auto_restart_times"] = AutoRestartTimes,
         };
 
         if (!string.IsNullOrEmpty(FileName) && MultiTasks.Count > 0)

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -1138,6 +1138,15 @@ Operators' Elite level CANNOT be ignored. If any requirements are ignored, the o
     <system:String x:Key="LoopTimes">Loop Times</system:String>
     <system:String x:Key="CopilotList">Job List</system:String>
     <system:String x:Key="UseCopilotList">Multi-Job mode</system:String>
+    <system:String x:Key="AutoRestart">Auto Restart</system:String>
+    <system:String x:Key="AutoRestartTimes">Max Restarts</system:String>
+    <system:String x:Key="AutoRestartTip" xml:space="preserve">A leaked battle is abandoned before settlement to avoid a non-3-star result.&#10;Max restarts can be set from 1 to 999 per job.</system:String>
+    <system:String x:Key="CopilotAutoRestartEnabledLog">Auto Restart enabled for {0} job(s), with up to {1} restarts per job.</system:String>
+    <system:String x:Key="CopilotAutoRestartReasonEnemyLeak">an enemy leak</system:String>
+    <system:String x:Key="CopilotAutoRestartReasonBattleFailed">a battle failure</system:String>
+    <system:String x:Key="CopilotAutoRestartLog">Job {0}/{1}: detected {2}. Restarting the current stage ({3}/{4}).</system:String>
+    <system:String x:Key="CopilotAutoRestartRecoveredLog">Job {0}/{1}: Auto Restart succeeded and execution resumed.</system:String>
+    <system:String x:Key="CopilotAutoRestartLimitLog">Job {0}/{1}: stopped because repeated {2} reached the Auto Restart limit ({3}/{4}).</system:String>
     <system:String x:Key="UseCopilotListTip" xml:space="preserve">Only supported in the following modes:
   1. {key=MainStage}: Navigate within the same chapter
   2. {key=SideStory}: Navigate within the current page (cannot jump between Normal/EX/S)

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -1139,6 +1139,15 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="LoopTimes">ループ回数</system:String>
     <system:String x:Key="CopilotList">ジョブリスト</system:String>
     <system:String x:Key="UseCopilotList">マルチジョブモード</system:String>
+    <system:String x:Key="AutoRestart">自動再開</system:String>
+    <system:String x:Key="AutoRestartTimes">最大再開回数</system:String>
+    <system:String x:Key="AutoRestartTip" xml:space="preserve">敵を通した場合は、非★3の結果を避けるためリザルト前に戦闘を中止します。&#10;最大再開回数は1～999回に設定できます。</system:String>
+    <system:String x:Key="CopilotAutoRestartEnabledLog">自動再開を有効にしました。全 {0} ジョブで、それぞれ最大 {1} 回再開します。</system:String>
+    <system:String x:Key="CopilotAutoRestartReasonEnemyLeak">敵の通過</system:String>
+    <system:String x:Key="CopilotAutoRestartReasonBattleFailed">戦闘失敗</system:String>
+    <system:String x:Key="CopilotAutoRestartLog">ジョブ {0}/{1}：{2}を検出しました。現在のステージを自動再開します（{3}/{4}）。</system:String>
+    <system:String x:Key="CopilotAutoRestartRecoveredLog">ジョブ {0}/{1}：自動再開に成功し、実行を続行します。</system:String>
+    <system:String x:Key="CopilotAutoRestartLimitLog">ジョブ {0}/{1}：{2}が続き、自動再開の上限（{3}/{4}）に達したため停止しました。</system:String>
     <system:String x:Key="UseCopilotListTip" xml:space="preserve">以下のモードのみ対応:
   1. {key=MainStage}: 同じ章内でのナビゲーション
   2. {key=SideStory}: 現在のページ内でのナビゲーション（Normal/EX/S 間の移動は不可）

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -1140,6 +1140,15 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="LoopTimes">반복 횟수</system:String>
     <system:String x:Key="CopilotList">작업 목록</system:String>
     <system:String x:Key="UseCopilotList">다중 작업 모드</system:String>
+    <system:String x:Key="AutoRestart">자동 재시작</system:String>
+    <system:String x:Key="AutoRestartTimes">최대 재시작 횟수</system:String>
+    <system:String x:Key="AutoRestartTip" xml:space="preserve">적을 놓친 경우 3성 미만 결과를 피하도록 정산 전에 전투를 포기합니다.&#10;작업별 최대 재시작 횟수는 1~999회로 설정할 수 있습니다.</system:String>
+    <system:String x:Key="CopilotAutoRestartEnabledLog">자동 재시작을 활성화했습니다. 총 {0}개 작업에서 각각 최대 {1}회 재시작합니다.</system:String>
+    <system:String x:Key="CopilotAutoRestartReasonEnemyLeak">적 통과</system:String>
+    <system:String x:Key="CopilotAutoRestartReasonBattleFailed">전투 실패</system:String>
+    <system:String x:Key="CopilotAutoRestartLog">작업 {0}/{1}: {2} 감지. 현재 스테이지를 자동으로 다시 시작합니다 ({3}/{4}).</system:String>
+    <system:String x:Key="CopilotAutoRestartRecoveredLog">작업 {0}/{1}: 자동 재시작에 성공하여 실행을 계속합니다.</system:String>
+    <system:String x:Key="CopilotAutoRestartLimitLog">작업 {0}/{1}: {2}이 계속되어 자동 재시작 한도({3}/{4})에 도달했으므로 중지했습니다.</system:String>
     <system:String x:Key="UseCopilotListTip" xml:space="preserve">다음 모드에서만 지원됩니다:
   1. {key=MainStage}: 동일 챕터 내에서 이동
   2. {key=SideStory}: 현재 페이지 내에서 이동 (일반/EX/S 간 이동 불가)

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -1139,6 +1139,15 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="LoopTimes">循环次数</system:String>
     <system:String x:Key="CopilotList">作业列表</system:String>
     <system:String x:Key="UseCopilotList">多作业模式</system:String>
+    <system:String x:Key="AutoRestart">自动重开</system:String>
+    <system:String x:Key="AutoRestartTimes">最大重开次数</system:String>
+    <system:String x:Key="AutoRestartTip" xml:space="preserve">漏怪后会在结算前退出，避免以非三星结果结算。&#10;最大重开次数可设置为 1 至 999。</system:String>
+    <system:String x:Key="CopilotAutoRestartEnabledLog">自动重开已启用：共 {0} 个作业，每个作业最多重开 {1} 次</system:String>
+    <system:String x:Key="CopilotAutoRestartReasonEnemyLeak">漏怪</system:String>
+    <system:String x:Key="CopilotAutoRestartReasonBattleFailed">战斗失败</system:String>
+    <system:String x:Key="CopilotAutoRestartLog">作业 {0}/{1}：检测到{2}，正在自动重开当前关卡（{3}/{4}）</system:String>
+    <system:String x:Key="CopilotAutoRestartRecoveredLog">作业 {0}/{1}：自动重开成功，已恢复运行</system:String>
+    <system:String x:Key="CopilotAutoRestartLimitLog">作业 {0}/{1}：因持续{2}达到自动重开上限（{3}/{4}），已停止当前任务</system:String>
     <system:String x:Key="UseCopilotListTip" xml:space="preserve">仅支持以下模式:
   1. {key=MainStage}: 同一章节内导航
   2. {key=SideStory}: 当前页面内导航（普通/EX/S 不能互跳）

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -1138,6 +1138,15 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="UserAdditional.Add">新增</system:String>
     <system:String x:Key="CopilotList">作業列表</system:String>
     <system:String x:Key="UseCopilotList">多作業模式</system:String>
+    <system:String x:Key="AutoRestart">自動重開</system:String>
+    <system:String x:Key="AutoRestartTimes">最大重開次數</system:String>
+    <system:String x:Key="AutoRestartTip" xml:space="preserve">漏怪後會在結算前退出，避免以非三星結果結算。&#10;最大重開次數可設定為 1 至 999。</system:String>
+    <system:String x:Key="CopilotAutoRestartEnabledLog">自動重開已啟用：共 {0} 個作業，每個作業最多重開 {1} 次</system:String>
+    <system:String x:Key="CopilotAutoRestartReasonEnemyLeak">漏怪</system:String>
+    <system:String x:Key="CopilotAutoRestartReasonBattleFailed">戰鬥失敗</system:String>
+    <system:String x:Key="CopilotAutoRestartLog">作業 {0}/{1}：偵測到{2}，正在自動重開目前關卡（{3}/{4}）</system:String>
+    <system:String x:Key="CopilotAutoRestartRecoveredLog">作業 {0}/{1}：自動重開成功，已恢復執行</system:String>
+    <system:String x:Key="CopilotAutoRestartLimitLog">作業 {0}/{1}：因持續{2}達到自動重開上限（{3}/{4}），已停止目前任務</system:String>
     <system:String x:Key="UseCopilotListTip" xml:space="preserve">僅支援以下模式：
   1. {key=MainStage}：同一章節內導航
   2. {key=SideStory}：目前頁面內導航（普通/EX/S 不能互跳）

--- a/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
@@ -761,6 +761,26 @@ public partial class CopilotViewModel : Screen
         }
     } = ConfigFactory.CurrentConfig.Copilot.LoopTimes;
 
+    public bool AutoRestart
+    {
+        get; set {
+            SetAndNotify(ref field, value);
+            ConfigFactory.CurrentConfig.Copilot.AutoRestart = value;
+        }
+    } = ConfigFactory.CurrentConfig.Copilot.AutoRestart;
+
+    private const int MinAutoRestartTimes = 1;
+    private const int MaxAutoRestartTimes = 999;
+
+    public int AutoRestartTimes
+    {
+        get; set {
+            value = Math.Clamp(value, MinAutoRestartTimes, MaxAutoRestartTimes);
+            SetAndNotify(ref field, value);
+            ConfigFactory.CurrentConfig.Copilot.AutoRestartTimes = value;
+        }
+    } = Math.Clamp(ConfigFactory.CurrentConfig.Copilot.AutoRestartTimes, MinAutoRestartTimes, MaxAutoRestartTimes);
+
     private const string CopilotUiUrl = MaaUrls.PrtsPlus;
 
     private string _copilotUrl = CopilotUiUrl;
@@ -2019,6 +2039,8 @@ public partial class CopilotViewModel : Screen
                 UserAdditionals = AddUserAdditional ? [.. userAdditional] : [],
                 UseSanityPotion = UseSanityPotion,
                 FormationIndex = UseFormation ? FormationIndex : 0,
+                AutoRestart = AutoRestart,
+                AutoRestartTimes = AutoRestartTimes,
             };
 
             // 能用列表的是主线/ss/故事集/悖论，都是 Copilot 类型

--- a/src/MaaWpfGui/Views/UI/CopilotView.xaml
+++ b/src/MaaWpfGui/Views/UI/CopilotView.xaml
@@ -501,6 +501,46 @@
                             <controls:TooltipBlock TooltipText="{DynamicResource UseCopilotListTip}" />
                         </StackPanel>
 
+                        <!--  自动重开及每个作业允许的最大重开次数  -->
+                        <StackPanel
+                            Orientation="Horizontal"
+                            Visibility="{c:Binding 'UseCopilotList and CopilotTabIndex == 0'}">
+                            <CheckBox
+                                x:Name="AutoRestartCheckBox"
+                                Margin="2.5,5"
+                                IsChecked="{Binding AutoRestart}">
+                                <StackPanel Orientation="Horizontal">
+                                    <TextBlock
+                                        VerticalAlignment="Center"
+                                        FontFamily="{Binding ElementName=AutoRestartCheckBox, Path=FontFamily}"
+                                        FontSize="{Binding ElementName=AutoRestartCheckBox, Path=FontSize}"
+                                        FontStretch="{Binding ElementName=AutoRestartCheckBox, Path=FontStretch}"
+                                        FontStyle="{Binding ElementName=AutoRestartCheckBox, Path=FontStyle}"
+                                        FontWeight="{Binding ElementName=AutoRestartCheckBox, Path=FontWeight}"
+                                        Text="{DynamicResource AutoRestart}" />
+                                    <TextBlock
+                                        Margin="12,0,4,0"
+                                        VerticalAlignment="Center"
+                                        FontFamily="{Binding ElementName=AutoRestartCheckBox, Path=FontFamily}"
+                                        FontSize="{Binding ElementName=AutoRestartCheckBox, Path=FontSize}"
+                                        FontStretch="{Binding ElementName=AutoRestartCheckBox, Path=FontStretch}"
+                                        FontStyle="{Binding ElementName=AutoRestartCheckBox, Path=FontStyle}"
+                                        FontWeight="{Binding ElementName=AutoRestartCheckBox, Path=FontWeight}"
+                                        Text="{DynamicResource AutoRestartTimes}" />
+                                </StackPanel>
+                            </CheckBox>
+                            <hc:NumericUpDown
+                                Width="55"
+                                Height="20"
+                                VerticalAlignment="Center"
+                                InputMethod.IsInputMethodEnabled="False"
+                                IsEnabled="{Binding AutoRestart}"
+                                Maximum="999"
+                                Minimum="1"
+                                Value="{Binding AutoRestartTimes}" />
+                            <controls:TooltipBlock TooltipText="{DynamicResource AutoRestartTip}" />
+                        </StackPanel>
+
                         <!--  UseSanityPotion  -->
                         <CheckBox
                             Margin="2.5,5"


### PR DESCRIPTION
```mermaid
flowchart LR
    A["加载多作业中的当前作业"] --> B["执行自动编队与作业"]
    B --> C{"战斗结果"}
    C -->|"检测到漏怪"| D["暂停并在结算前退出"]
    C -->|"明确战斗失败"| E["从失败界面返回关卡页"]
    C -->|"三星成功"| F["执行下一项作业"]
    C -->|"非三星或其他错误"| G["按原逻辑停止，不重开"]
    D --> H{"是否达到重开上限"}
    E --> H
    H -->|"否"| I["回退作业游标并重跑当前作业"]
    H -->|"是"| G
    I --> A
```

整体思路流程如上图所示。

在 CopilotView.xaml、CopilotViewModel.cs 和 Copilot.cs 中新增仅在多作业模式下显示的“自动重开”及 1～999 次数设置，并保持控件样式、状态和提示文案一致；在 AsstCopilotTask.cs 中将设置传入核心，在 AsstProxy.cs 中记录启用、重开、恢复和达到上限等状态，方便事后审查；在 CopilotTask.* 、BattleProcessTask.* 、MultiCopilotTaskPlugin.* 和 ProcessTask.h 中实现按作业独立计数的重开状态机，使漏怪时在结算前放弃、明确战斗失败时返回关卡并重新执行当前作业，同时不把普通非三星结果当作重开条件；在 BattlefieldMatcher.* 中复用现有 BattleHpFlag2 识别漏怪标记，避免重新设计识别资源；最后同步更新五种语言的界面资源和协议文档，说明参数用途、取值范围及行为，确保 GUI、接口和核心实现保持一致。

## Summary by Sourcery

为多任务自动战斗新增可配置的自动重启行为，当出现漏怪或战斗失败时，可按任务设置重试次数，并同步更新相关的界面、日志以及协议。

New Features:
- 为多任务副驾运行新增自动重启选项，包括开关和按任务设置的最大重启次数，该配置从 GUI 传递到核心任务。
- 通过已有的漏怪标记识别功能检测战斗中的敌人漏怪，并在结算前中止战斗，以便安全地重启当前任务。

Bug Fixes:
- 修复多副驾插件配置索引中的“多算一位”边界检查问题，防止越界访问。

Enhancements:
- 在核心副驾执行流程中跟踪每个任务的自动重启状态和原因，并通过详细的状态回调和 GUI 日志对外暴露，用于审计。
- 调整多任务副驾的执行逻辑，将重试限制在当前任务内，避免跨任务共享失败上限，并区分漏怪与显式失败这两类结果的处理方式。
- 在 GUI 和核心中同时对自动重启配置值进行范围限制，确保其有效，并与既有的单任务循环行为保持兼容。

Documentation:
- 在集成协议中记录新的自动重启参数及其语义，并覆盖所有支持的语言。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable auto-restart behavior for multi-job auto battle when leaks or battle failures occur, with per-job retry limits and associated UI, logging, and protocol updates.

New Features:
- Introduce auto-restart options for multi-job copilot runs, including a toggle and per-job maximum restart count passed through from GUI to core tasks.
- Detect enemy leaks during battle via existing leak flag recognition and abort the battle before settlement to allow safe restart of the current job.

Bug Fixes:
- Fix off-by-one bounds check in multi-copilot plugin config indexing to prevent out-of-range access.

Enhancements:
- Track per-job auto-restart state and reasons in core copilot execution, exposing detailed status callbacks and GUI logs for auditing.
- Adjust multi-job copilot execution to isolate retries to the current job, avoid cross-job failure limits, and handle leak vs explicit failure outcomes distinctly.
- Clamp auto-restart configuration values in both GUI and core to a valid range and ensure compatibility with existing single-job loop behavior.

Documentation:
- Document the new auto-restart parameters and their semantics in the integration protocol across all supported languages.

</details>