### PR TITLE
feat: 自动战斗支持指定职业以区分同名干员

### DIFF
--- a/src/MaaCore/Common/AsstBattleDef.h
+++ b/src/MaaCore/Common/AsstBattleDef.h
@@ -74,6 +74,12 @@ struct OperUsage                                  // 干员用法
         return std::tie(role, name, skill, skill_usage, skill_times, requirements) <=>
                std::tie(other.role, other.name, other.skill, other.skill_usage, other.skill_times, other.requirements);
     }
+
+    bool operator==(const OperUsage& other) const
+    {
+        return std::tie(role, name, skill, skill_usage, skill_times, requirements) ==
+               std::tie(other.role, other.name, other.skill, other.skill_usage, other.skill_times, other.requirements);
+    }
 };
 
 enum class DeployDirection

--- a/src/MaaCore/Common/AsstBattleDef.h
+++ b/src/MaaCore/Common/AsstBattleDef.h
@@ -10,6 +10,20 @@
 
 namespace asst::battle
 {
+enum class Role
+{
+    Unknown,
+    Pioneer, // 先锋
+    Warrior, // 近卫
+    Tank,    // 重装
+    Sniper,  // 狙击
+    Caster,  // 术士
+    Medic,   // 医疗
+    Support, // 辅助
+    Special, // 特种
+    Drone    // 无人机
+};
+
 // 统一变量名：
 // loc, location, 表示格子坐标，例如 [1, 1], [5, 5]
 // pos, position, 表示像素坐标，例如 [1280, 720], [500, 300]
@@ -48,8 +62,9 @@ enum class OperStatus
     // Unknown,     // 未知状态
 };
 
-struct OperUsage // 干员用法
+struct OperUsage                                  // 干员用法
 {
+    battle::Role role = battle::Role::Unknown;    // 干员职业
     std::string name;
     int skill = 0;                                // 技能序号，取值范围 [0, 3]，0时使用默认技能 或 上次编队时使用的技能
     SkillUsage skill_usage = SkillUsage::NotUse;
@@ -62,6 +77,8 @@ struct OperUsage // 干员用法
         return name == other.name && skill == other.skill && skill_usage == other.skill_usage &&
                skill_times == other.skill_times && requirements == other.requirements;
     }
+
+    auto operator<=>(const OperUsage&) const = default;
 };
 
 enum class DeployDirection
@@ -71,20 +88,6 @@ enum class DeployDirection
     Left = 2,
     Up = 3,
     None = 4 // 没有方向，通常是无人机之类的
-};
-
-enum class Role
-{
-    Unknown,
-    Pioneer, // 先锋
-    Warrior, // 近卫
-    Tank,    // 重装
-    Sniper,  // 狙击
-    Caster,  // 术士
-    Medic,   // 医疗
-    Support, // 辅助
-    Special, // 特种
-    Drone    // 无人机
 };
 
 inline static Role get_role_type(const std::string& role_name)
@@ -418,7 +421,8 @@ struct Action
     int cost_changes = 0;
     int cooling = 0;
     ActionType type = ActionType::Deploy;
-    std::string name; // 目标名，若 type >= SwitchSpeed, name 为空
+    battle::Role role = battle::Role::Unknown; // 目标职业
+    std::string name;                          // 目标名，若 type >= SwitchSpeed, name 为空
     Point location;
     DeployDirection direction = DeployDirection::Right;
     SkillUsage modify_usage = SkillUsage::NotUse;
@@ -606,3 +610,30 @@ inline std::string enum_to_string(const battle::OperModule module)
     return "Unknown";
 }
 } // namespace asst
+
+namespace asst::battle
+{
+struct OperNameTag
+{
+    Role role = Role::Unknown; // 干员职业
+    std::string name;          // 干员名
+
+    auto operator<=>(const OperNameTag&) const = default;
+
+    std::string to_string() const { return "(" + enum_to_string(role) + ", " + name + ")"; }
+
+    explicit operator std::string() const { return to_string(); }
+};
+}
+
+namespace std
+{
+template <>
+struct hash<asst::battle::OperNameTag>
+{
+    std::size_t operator()(const asst::battle::OperNameTag& k) const noexcept
+    {
+        return std::hash<std::string> {}(k.name) ^ (std::hash<int> {}(static_cast<int>(k.role)) << 1);
+    }
+};
+}

--- a/src/MaaCore/Common/AsstBattleDef.h
+++ b/src/MaaCore/Common/AsstBattleDef.h
@@ -46,10 +46,7 @@ struct OperatorRequirements
     int module = -1;      // 模组编号 -1: 不切换模组 / 无要求, 0: 不使用模组, 1: 模组χ, 2: 模组γ, 3: 模组α, 4: 模组Δ
                           // int potentiality = -1; // 潜能要求
 
-    bool operator==(const OperatorRequirements& req) const
-    {
-        return elite == req.elite && level == req.level && skill_level == req.skill_level && module == req.module;
-    }
+    auto operator<=>(const OperatorRequirements&) const = default;
 };
 
 // 干员编队状态
@@ -72,13 +69,11 @@ struct OperUsage                                  // 干员用法
     battle::OperatorRequirements requirements {}; // 练度需求
     OperStatus status = OperStatus::Unchecked;    // 编队状态, 可能有其他更好的位置存储
 
-    bool operator==(const OperUsage& other) const
+    auto operator<=>(const OperUsage& other) const
     {
-        return name == other.name && skill == other.skill && skill_usage == other.skill_usage &&
-               skill_times == other.skill_times && requirements == other.requirements;
+        return std::tie(role, name, skill, skill_usage, skill_times, requirements) <=>
+               std::tie(other.role, other.name, other.skill, other.skill_usage, other.skill_times, other.requirements);
     }
-
-    auto operator<=>(const OperUsage&) const = default;
 };
 
 enum class DeployDirection

--- a/src/MaaCore/Config/Miscellaneous/BattleDataConfig.h
+++ b/src/MaaCore/Config/Miscellaneous/BattleDataConfig.h
@@ -90,6 +90,23 @@ public:
         return battle::Role::Unknown;
     }
 
+    std::unordered_set<battle::Role> get_roles(const std::string& name) const
+    {
+        std::unordered_set<battle::Role> roles;
+        if (name.empty()) {
+            return roles;
+        }
+        for (const auto& [role, oper_map] : m_chars_by_role) {
+            auto oper_it =
+                std::ranges::find_if(oper_map, [&name](const auto& pair) { return pair.second->name == name; });
+            if (oper_it != oper_map.cend()) {
+                roles.emplace(role);
+                continue;
+            }
+        }
+        return roles;
+    }
+
     int get_rarity(battle::Role role, const std::string& name) const
     {
         if (const auto& oper = find_oper(role, name); oper != nullptr) {

--- a/src/MaaCore/Config/Miscellaneous/CopilotConfig.cpp
+++ b/src/MaaCore/Config/Miscellaneous/CopilotConfig.cpp
@@ -51,6 +51,7 @@ asst::battle::copilot::BasicInfo asst::CopilotConfig::parse_basic_info(const jso
 std::optional<asst::battle::OperUsage> asst::CopilotConfig::parse_oper_usage(const json::value& json)
 {
     OperUsage oper;
+    oper.role = get_role_type(oper_info.get("role", std::string()));
     oper.name = json.at("name").as_string();
     oper.skill = json.get("skill", 0);
     oper.skill_usage = static_cast<battle::SkillUsage>(json.get("skill_usage", 0));
@@ -72,6 +73,7 @@ std::optional<asst::battle::OperUsage> asst::CopilotConfig::parse_oper_usage(con
                  << " cannot use skill index 1, set to 0.";
         oper.skill = 0;
     }
+
 
     int elite_require = oper.skill - 1;
     // 解析练度需求并检查非法设置

--- a/src/MaaCore/Config/Miscellaneous/CopilotConfig.cpp
+++ b/src/MaaCore/Config/Miscellaneous/CopilotConfig.cpp
@@ -245,6 +245,7 @@ std::vector<asst::battle::copilot::Action> asst::CopilotConfig::parse_actions(co
         action.cost_changes = action_info.get("cost_changes", 0);
         action.costs = action_info.get("costs", 0);
         action.cooling = action_info.get("cooling", -1);
+        action.role = get_role_type(action_info.get("role", std::string()));
         action.name = action_info.get("name", std::string());
 
         action.location.x = action_info.get("location", 0, 0);

--- a/src/MaaCore/Config/Miscellaneous/CopilotConfig.cpp
+++ b/src/MaaCore/Config/Miscellaneous/CopilotConfig.cpp
@@ -51,7 +51,7 @@ asst::battle::copilot::BasicInfo asst::CopilotConfig::parse_basic_info(const jso
 std::optional<asst::battle::OperUsage> asst::CopilotConfig::parse_oper_usage(const json::value& json)
 {
     OperUsage oper;
-    oper.role = get_role_type(oper_info.get("role", std::string()));
+    oper.role = get_role_type(json.get("role", std::string()));
     oper.name = json.at("name").as_string();
     oper.skill = json.get("skill", 0);
     oper.skill_usage = static_cast<battle::SkillUsage>(json.get("skill_usage", 0));

--- a/src/MaaCore/Config/Roguelike/RoguelikeRecruitConfig.cpp
+++ b/src/MaaCore/Config/Roguelike/RoguelikeRecruitConfig.cpp
@@ -95,6 +95,36 @@ std::vector<int> asst::RoguelikeRecruitConfig::get_group_ids_of_oper(
     }
 }
 
+std::vector<int> asst::RoguelikeRecruitConfig::get_group_ids_of_oper(
+    const std::string& theme,
+    const battle::OperNameTag& oper_tag) const noexcept
+{
+    auto& opers = m_all_opers.at(theme);
+
+    if (oper_tag.role != battle::Role::Unknown) {
+        const auto& find_iter = std::ranges::find_if(opers, [&](const auto& pair) { return pair.first == oper_tag; });
+        if (find_iter != opers.end()) {
+            return find_iter->second.group_id;
+        }
+    }
+
+    const auto& find_iter =
+        std::ranges::find_if(opers, [&](const auto& pair) { return pair.first.name == oper_tag.name; });
+    if (find_iter != opers.end()) {
+        return find_iter->second.group_id;
+    }
+    else {
+        const auto& role = oper_tag.role != battle::Role::Unknown ? oper_tag.role : BattleData.get_role(oper_tag.name);
+        if (role != battle::Role::Pioneer && role != battle::Role::Tank && role != battle::Role::Warrior &&
+            role != battle::Role::Special) {
+            return { static_cast<int>(m_oper_groups.at(theme).size()) - 2 };
+        }
+        else {
+            return { static_cast<int>(m_oper_groups.at(theme).size()) - 1 };
+        }
+    }
+}
+
 int asst::RoguelikeRecruitConfig::get_group_id_from_name(
     const std::string& theme,
     const std::string& group_name) noexcept

--- a/src/MaaCore/Config/Roguelike/RoguelikeRecruitConfig.cpp
+++ b/src/MaaCore/Config/Roguelike/RoguelikeRecruitConfig.cpp
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <meojson/json.hpp>
+#include <ranges>
 
 #include "Utils/Logger.hpp"
 
@@ -10,15 +11,39 @@ const asst::RoguelikeOperInfo&
     asst::RoguelikeRecruitConfig::get_oper_info(const std::string& theme, const std::string& oper_name) noexcept
 {
     auto& opers = m_all_opers.at(theme);
-    if (opers.contains(oper_name)) {
-        return opers.at(oper_name);
+    const auto& it = std::ranges::find_if(opers, [&](const auto& pair) { return pair.first.name == oper_name; });
+    if (it != opers.end()) {
+        return it->second;
+    }
+
+    const auto& role = BattleData.get_role(oper_name);
+    battle::OperNameTag oper_tag { .role = role, .name = oper_name };
+    RoguelikeOperInfo info;
+    info.role = role;
+    info.name = oper_name;
+    info.group_id = get_group_ids_of_oper(theme, oper_name);
+    opers.emplace(oper_tag, std::move(info));
+    return opers.at(oper_tag);
+}
+
+const asst::RoguelikeOperInfo&
+    asst::RoguelikeRecruitConfig::get_oper_info(const std::string& theme, const battle::OperNameTag& oper_tag) noexcept
+{
+    auto& opers = m_all_opers.at(theme);
+    if (opers.contains(oper_tag)) {
+        return opers.at(oper_tag);
+    }
+    const auto& it = std::ranges::find_if(opers, [&](const auto& pair) { return pair.first.name == oper_tag.name; });
+    if (it != opers.end()) {
+        return it->second;
     }
     else {
         RoguelikeOperInfo info;
-        info.name = oper_name;
-        info.group_id = get_group_ids_of_oper(theme, oper_name);
-        opers.emplace(oper_name, std::move(info));
-        return opers.at(oper_name);
+        info.role = oper_tag.role;
+        info.name = oper_tag.name;
+        info.group_id = get_group_ids_of_oper(theme, oper_tag.name);
+        opers.emplace(oper_tag, std::move(info));
+        return opers.at(oper_tag);
     }
 }
 
@@ -53,7 +78,9 @@ std::vector<int> asst::RoguelikeRecruitConfig::get_group_ids_of_oper(
     const std::string& oper_name) const noexcept
 {
     auto& opers = m_all_opers.at(theme);
-    if (auto find_iter = opers.find(oper_name); find_iter != opers.cend()) {
+
+    const auto& find_iter = std::ranges::find_if(opers, [&](const auto& pair) { return pair.first.name == oper_name; });
+    if (find_iter != opers.end()) {
         return find_iter->second.group_id;
     }
     else {
@@ -118,11 +145,24 @@ bool asst::RoguelikeRecruitConfig::parse(const json::value& json)
         int order_in_group = 0;
         // 遍历"opers"数组
         for (const auto& oper_json : group_json.at("opers").as_array()) {
+            battle::Role role = battle::Role::Unknown;
             std::string name = oper_json.at("name").as_string();
+            if (auto opt = oper_json.find<std::string>("role")) {
+                role = battle::get_role_type(opt.value());
+            }
+            else {
+                const auto& roles = BattleData.get_roles(name);
+                if (roles.size() == 1) {
+                    role = *roles.cbegin();
+                }
+                else if (roles.size() > 1) {
+                    LogWarn << __FUNCTION__ << "oper:" << name << "has multiple roles, but still not specific any";
+                }
+            }
             group_info.opers.emplace(name);
             // 肉鸽干员招募信息
             RoguelikeOperInfo oper_info;
-            auto iter = m_all_opers[theme].find(name);
+            auto iter = m_all_opers[theme].find({ role, name });
             if (iter != m_all_opers[theme].end()) {
                 // 干员已存在时仅做更新
                 oper_info = iter->second;
@@ -181,7 +221,7 @@ bool asst::RoguelikeRecruitConfig::parse(const json::value& json)
                 }
             }
 
-            m_all_opers[theme][name] = std::move(oper_info);
+            m_all_opers[theme][{ role, name }] = std::move(oper_info);
             order_in_group++;
         }
         m_all_groups[theme][group_name] = std::move(group_info);

--- a/src/MaaCore/Config/Roguelike/RoguelikeRecruitConfig.h
+++ b/src/MaaCore/Config/Roguelike/RoguelikeRecruitConfig.h
@@ -77,6 +77,8 @@ public:
     const std::vector<RecruitPriorityOffset> get_team_complete_info(const std::string& theme) const noexcept;
     std::vector<int> get_group_ids_of_oper(const std::string& theme, const std::string& oper_name)
         const noexcept; // renamed from "get_group_id"
+    std::vector<int> get_group_ids_of_oper(const std::string& theme, const battle::OperNameTag& oper_tag)
+        const noexcept; // renamed from "get_group_id"
     const std::vector<std::string> get_group_names(const std::string& theme)
         const noexcept; // 获取该肉鸽内用到的干员组[干员组1,干员组2, ...], renamed from "get_group_info"
     int get_group_id_from_name(

--- a/src/MaaCore/Config/Roguelike/RoguelikeRecruitConfig.h
+++ b/src/MaaCore/Config/Roguelike/RoguelikeRecruitConfig.h
@@ -31,6 +31,7 @@ struct CollectionPriorityOffset
 // 干员信息，战斗相关
 struct RoguelikeOperInfo
 {
+    battle::Role role = battle::Role::Unknown;                         // 干员职业
     std::string name;                                                  // 干员名
     std::vector<int> group_id = {};                                    // 干员组 id,允许一个干员存在于多个干员组
     std::unordered_map<int, int> order_in_group;                       // 干员在干员组内的顺序 干员组 id:干员组内顺序
@@ -71,6 +72,7 @@ public:
     virtual ~RoguelikeRecruitConfig() override = default;
 
     const RoguelikeOperInfo& get_oper_info(const std::string& theme, const std::string& oper_name) noexcept;
+    const RoguelikeOperInfo& get_oper_info(const std::string& theme, const battle::OperNameTag& oper_tag) noexcept;
     const RoguelikeGroupInfo& get_group_info(const std::string& theme, const std::string& group_name) noexcept;
     const std::vector<RecruitPriorityOffset> get_team_complete_info(const std::string& theme) const noexcept;
     std::vector<int> get_group_ids_of_oper(const std::string& theme, const std::string& oper_name)
@@ -93,7 +95,7 @@ protected:
 
     void clear(const std::string& theme);
 
-    std::unordered_map<std::string, std::unordered_map<std::string, RoguelikeOperInfo>>
+    std::unordered_map<std::string, std::unordered_map<battle::OperNameTag, RoguelikeOperInfo>>
         m_all_opers;   // <theme, <oper_name, oper_info>>
     std::unordered_map<std::string, std::unordered_map<std::string, RoguelikeGroupInfo>>
         m_all_groups;  // <theme, <group_name, group_info>>

--- a/src/MaaCore/Task/BattleHelper.cpp
+++ b/src/MaaCore/Task/BattleHelper.cpp
@@ -402,22 +402,76 @@ bool asst::BattleHelper::update_cost(const cv::Mat& image, const cv::Mat& image_
     return true;
 }
 
+asst::battle::OperNameTag asst::BattleHelper::get_oper_tag(battle::Role role, const std::string& name)
+{
+    auto deployed_it = std::ranges::find_if(m_battlefield_opers, [&](const auto& pair) {
+        return (role == battle::Role::Unknown || pair.first.role == role) && pair.first.name == name;
+    });
+    if (deployed_it != m_battlefield_opers.cend()) {
+        return battle::OperNameTag { deployed_it->first.role, deployed_it->first.name };
+    }
+    auto it = std::ranges::find_if(m_cur_deployment_opers, [&](const auto& oper) {
+        return (role == battle::Role::Unknown || oper.role == role) && oper.name == name;
+    });
+    if (it != m_cur_deployment_opers.cend()) {
+        return battle::OperNameTag { it->role, it->name };
+    }
+    return battle::OperNameTag { role, name };
+}
+
+asst::battle::OperNameTag asst::BattleHelper::get_oper_tag(const battle::OperNameTag& tag)
+{
+    return get_oper_tag(tag.role, tag.name);
+}
+
+std::optional<asst::battle::OperNameTag> asst::BattleHelper::get_oper_skill_tag(const battle::OperNameTag& tag)
+{
+    auto it = std::ranges::find_if(m_cur_deployment_opers, [&](const auto& oper) {
+        return (tag.role == battle::Role::Unknown || oper.role == tag.role) && oper.name == tag.name;
+    });
+    if (it != m_cur_deployment_opers.cend()) {
+        return battle::OperNameTag { it->role, it->name };
+    }
+    it = std::ranges::find_if(m_cur_deployment_opers, [&](const auto& oper) { return oper.name == tag.name; });
+    if (it != m_cur_deployment_opers.cend()) {
+        return battle::OperNameTag { it->role, it->name };
+    }
+    LogError << __FUNCTION__ << "No oper" << tag;
+    return std::nullopt;
+}
+
 bool asst::BattleHelper::deploy_oper(const std::string& name, const Point& loc, DeployDirection direction)
+{
+    return deploy_oper(battle::Role::Unknown, name, loc, direction);
+}
+
+bool asst::BattleHelper::deploy_oper(
+    battle::Role role,
+    const std::string& name,
+    const Point& loc,
+    battle::DeployDirection direction)
 {
     LogTraceFunction;
 
     const auto swipe_oper_task_ptr = Task.get("BattleSwipeOper");
     const auto use_oper_task_ptr = Task.get("BattleUseOper");
 
-    auto rect_opt = get_oper_rect_on_deployment(name);
-    if (!rect_opt) {
+    auto it = std::ranges::find_if(m_cur_deployment_opers, [&](const auto& oper) {
+        return (role == battle::Role::Unknown || oper.role == role) && oper.name == name;
+    });
+
+    if (it == m_cur_deployment_opers.cend()) {
+        LogError << "No oper" << enum_to_string(role) << name;
         return false;
     }
-    const Rect& oper_rect = *rect_opt;
+
+    const auto& oper_role = it->role;
+    const auto& oper_name = it->name;
+    const Rect& oper_rect = it->rect;
 
     auto target_iter = m_side_tile_info.find(loc);
     if (target_iter == m_side_tile_info.cend()) {
-        Log.error("No loc", loc);
+        LogError << "No loc" << loc;
         return false;
     }
     Point target_point = target_iter->second.pos;
@@ -486,22 +540,23 @@ bool asst::BattleHelper::deploy_oper(const std::string& name, const Point& loc, 
 
     // for SSS, multiple operator may be deployed at the same location.
     if (m_used_tiles.contains(loc)) {
-        std::string pre_name = m_used_tiles.at(loc);
-        Log.info("remove previous oper", pre_name, loc);
+        const auto& pre_oper = m_used_tiles.at(loc);
+        LogInfo << "remove previous oper" << pre_oper << loc;
         m_used_tiles.erase(loc);
-        m_battlefield_opers.erase(pre_name);
+        m_battlefield_opers.erase(pre_oper);
     }
 
     // 肉鸽中，一个干员可能被部署多次
-    if (m_battlefield_opers.contains(name) && BattleData.get_role(name) != battle::Role::Drone) {
-        Point pre_loc = m_battlefield_opers.at(name);
-        Log.info("remove deploy failed oper", name, pre_loc);
-        m_battlefield_opers.erase(name);
+    battle::OperNameTag oper_tag { oper_role, oper_name };
+    if (m_battlefield_opers.contains(oper_tag) && oper_role != battle::Role::Drone) {
+        Point pre_loc = m_battlefield_opers.at(oper_tag);
+        LogInfo << "remove deploy failed oper" << oper_tag << pre_loc;
+        m_battlefield_opers.erase(oper_tag);
         // 擦除已使用干员,但是不擦除已使用格子
         // m_used_tiles.erase(pre_loc);
     }
 
-    register_deployed_oper(name, loc);
+    register_deployed_oper(oper_role, oper_name, loc);
     m_inst_helper.sleep(200); // 部署完会有 166 ms 的动画
 
     return true;
@@ -509,11 +564,18 @@ bool asst::BattleHelper::deploy_oper(const std::string& name, const Point& loc, 
 
 bool asst::BattleHelper::retreat_oper(const std::string& name)
 {
+    return retreat_oper(battle::Role::Unknown, name);
+}
+
+bool asst::BattleHelper::retreat_oper(battle::Role role, const std::string& name)
+{
     LogTraceFunction;
 
-    auto oper_iter = m_battlefield_opers.find(name);
+    auto oper_iter = std::ranges::find_if(m_battlefield_opers, [&](const auto& pair) {
+        return (role == battle::Role::Unknown || pair.first.role == role) && pair.first.name == name;
+    });
     if (oper_iter == m_battlefield_opers.cend()) {
-        Log.error("No oper", name);
+        LogError << "No oper" << name << "role:" << enum_to_string(role);
         return false;
     }
 
@@ -521,7 +583,7 @@ bool asst::BattleHelper::retreat_oper(const std::string& name)
         return false;
     }
 
-    m_battlefield_opers.erase(name);
+    m_battlefield_opers.erase({ role, name });
     return true;
 }
 
@@ -564,9 +626,16 @@ bool asst::BattleHelper::is_skill_ready(const Point& loc, const cv::Mat& reusabl
 
 bool asst::BattleHelper::is_skill_ready(const std::string& name, const cv::Mat& reusable)
 {
-    auto oper_iter = m_battlefield_opers.find(name);
+    return is_skill_ready(battle::Role::Unknown, name, reusable);
+}
+
+bool asst::BattleHelper::is_skill_ready(battle::Role role, const std::string& name, const cv::Mat& reusable)
+{
+    auto oper_iter = std::ranges::find_if(m_battlefield_opers, [&](const auto& pair) {
+        return (role == battle::Role::Unknown || pair.first.role == role) && pair.first.name == name;
+    });
     if (oper_iter == m_battlefield_opers.cend()) {
-        Log.error("No oper", name);
+        LogError << "No oper" << name << "role:" << enum_to_string(role);
         return false;
     }
     return is_skill_ready(oper_iter->second, reusable);
@@ -574,11 +643,18 @@ bool asst::BattleHelper::is_skill_ready(const std::string& name, const cv::Mat& 
 
 bool asst::BattleHelper::use_skill(const std::string& name, bool keep_waiting)
 {
+    return use_skill(battle::Role::Unknown, name, keep_waiting);
+}
+
+bool asst::BattleHelper::use_skill(battle::Role role, const std::string& name, bool keep_waiting)
+{
     LogTraceFunction;
 
-    auto oper_iter = m_battlefield_opers.find(name);
+    auto oper_iter = std::ranges::find_if(m_battlefield_opers, [&](const auto& pair) {
+        return (role == battle::Role::Unknown || pair.first.role == role) && pair.first.name == name;
+    });
     if (oper_iter == m_battlefield_opers.cend()) {
-        Log.error("No oper", name);
+        LogError << "No oper" << name << "role:" << enum_to_string(role);
         return false;
     }
 
@@ -721,17 +797,21 @@ bool asst::BattleHelper::use_all_ready_skill(const cv::Mat& reusable)
     bool used = false;
     const auto now = std::chrono::steady_clock::now();
     const cv::Mat image = reusable.empty() ? m_inst_helper.ctrler()->get_image() : reusable;
-    for (const auto& [name, loc] : m_battlefield_opers) {
-        auto& usage = m_skill_usage[name];
-        auto& retry = m_skill_error_count[name];
-        auto& times = m_skill_times[name];
-        auto& last_use_time = m_last_use_skill_time[name];
+    for (const auto& [oper_tag, loc] : m_battlefield_opers) {
+        auto skill_opt = get_oper_skill_tag(oper_tag);
+        if (!skill_opt) {
+            continue;
+        }
+        auto& usage = m_skill_usage[*skill_opt];
+        auto& times = m_skill_times[*skill_opt];
+        auto& retry = m_skill_error_count[oper_tag];
+        auto& last_use_time = m_last_use_skill_time[oper_tag];
         if (usage != SkillUsage::Possibly && usage != SkillUsage::Times) {
             continue;
         }
 
         if (auto interval = now - last_use_time; min_frame_interval > interval) {
-            LogInfo << name << "analyze skill too fast, interval time:"
+            LogInfo << oper_tag.name << "analyze skill too fast, interval time:"
                     << std::chrono::duration_cast<std::chrono::milliseconds>(interval).count() << " ms";
             continue;
         }
@@ -740,16 +820,16 @@ bool asst::BattleHelper::use_all_ready_skill(const cv::Mat& reusable)
             continue;
         }
 
-        Log.info("Skill", name, "is ready");
+        LogInfo << "Skill" << oper_tag.name << "is ready";
 
         // 识别到了，但点进去发现没有。一般来说是识别错了
         if (!use_skill(loc, false)) {
-            Log.warn("Skill", name, "is not ready");
+            LogWarn << "Skill" << oper_tag.name << "is not ready";
             static const bool save_infinitely = std::filesystem::exists("DEBUG_skill_ready.txt");
             if (!save_infinitely) {
                 constexpr int MaxRetry = 3;
                 if (++retry >= MaxRetry) {
-                    Log.warn("Do not use skill anymore", name);
+                    LogWarn << "Do not use skill anymore" << oper_tag.name;
                     usage = SkillUsage::NotUse;
                 }
             }
@@ -757,7 +837,7 @@ bool asst::BattleHelper::use_all_ready_skill(const cv::Mat& reusable)
         }
         used = true;
         retry = 0;
-        m_last_use_skill_time[name] = now;
+        m_last_use_skill_time[oper_tag] = now;
 
         if (usage == SkillUsage::Times) {
             times--;
@@ -773,9 +853,20 @@ bool asst::BattleHelper::use_all_ready_skill(const cv::Mat& reusable)
 
 bool asst::BattleHelper::check_and_use_skill(const std::string& name, bool& has_error, const cv::Mat& reusable)
 {
-    auto oper_iter = m_battlefield_opers.find(name);
+    return check_and_use_skill(battle::Role::Unknown, name, has_error, reusable);
+}
+
+bool asst::BattleHelper::check_and_use_skill(
+    battle::Role role,
+    const std::string& name,
+    bool& has_error,
+    const cv::Mat& reusable)
+{
+    auto oper_iter = std::ranges::find_if(m_battlefield_opers, [&](const auto& pair) {
+        return (role == battle::Role::Unknown || pair.first.role == role) && pair.first.name == name;
+    });
     if (oper_iter == m_battlefield_opers.cend()) {
-        Log.error("No oper", name);
+        LogError << "No oper" << name << "role" << enum_to_string(role);
         return false;
     }
     return check_and_use_skill(oper_iter->second, has_error, reusable);
@@ -832,7 +923,19 @@ bool asst::BattleHelper::click_oper_on_deployment(const std::string& name)
 {
     LogTraceFunction;
 
-    auto rect_opt = get_oper_rect_on_deployment(name);
+    auto rect_opt = get_oper_rect_on_deployment(battle::Role::Unknown, name);
+    if (!rect_opt) {
+        return false;
+    }
+
+    return click_oper_on_deployment(*rect_opt);
+}
+
+bool asst::BattleHelper::click_oper_on_deployment(battle::Role role, const std::string& name)
+{
+    LogTraceFunction;
+
+    auto rect_opt = get_oper_rect_on_deployment(role, name);
     if (!rect_opt) {
         return false;
     }
@@ -853,11 +956,18 @@ bool asst::BattleHelper::click_oper_on_deployment(const Rect& rect)
 
 bool asst::BattleHelper::click_oper_on_battlefield(const std::string& name)
 {
+    return click_oper_on_battlefield(battle::Role::Unknown, name);
+}
+
+bool asst::BattleHelper::click_oper_on_battlefield(battle::Role role, const std::string& name)
+{
     LogTraceFunction;
 
-    auto oper_iter = m_battlefield_opers.find(name);
+    auto oper_iter = std::ranges::find_if(m_battlefield_opers, [&](const auto& pair) {
+        return (role == battle::Role::Unknown || pair.first.role == role) && pair.first.name == name;
+    });
     if (oper_iter == m_battlefield_opers.cend()) {
-        Log.error("No oper", name);
+        LogError << "No oper" << name << "role" << enum_to_string(role);
         return false;
     }
     return click_oper_on_battlefield(oper_iter->second);
@@ -1079,13 +1189,14 @@ std::string asst::BattleHelper::analyze_detail_page_oper_name(const cv::Mat& ima
     return std::string();
 }
 
-std::optional<asst::Rect> asst::BattleHelper::get_oper_rect_on_deployment(const std::string& name) const
+std::optional<asst::Rect>
+    asst::BattleHelper::get_oper_rect_on_deployment(battle::Role role, const std::string& name) const
 {
-    LogTraceFunction;
-
-    auto oper_iter = std::ranges::find_if(m_cur_deployment_opers, [&](const auto& oper) { return oper.name == name; });
+    auto oper_iter = std::ranges::find_if(m_cur_deployment_opers, [&](const auto& oper) {
+        return (role == battle::Role::Unknown || oper.role == role) && oper.name == name;
+    });
     if (oper_iter == m_cur_deployment_opers.end()) {
-        Log.error("No oper", name);
+        LogError << "No oper" << name << "with role" << enum_to_string(role);
         return std::nullopt;
     }
 
@@ -1106,11 +1217,11 @@ int asst::BattleHelper::elapsed_time()
     return static_cast<int>(elapsed_ms);
 }
 
-void asst::BattleHelper::register_deployed_oper(const std::string& name, const Point& loc)
+void asst::BattleHelper::register_deployed_oper(battle::Role role, const std::string& name, const Point& loc)
 {
-    m_used_tiles.emplace(loc, name);
-    m_battlefield_opers.emplace(name, loc);
-    m_last_use_skill_time.emplace(name, std::chrono::steady_clock::time_point());
+    m_used_tiles.emplace(loc, battle::OperNameTag { role, name });
+    m_battlefield_opers.emplace(battle::OperNameTag { role, name }, loc);
+    m_last_use_skill_time.emplace(battle::OperNameTag { role, name }, std::chrono::steady_clock::time_point());
 }
 
 void asst::BattleHelper::remove_cooling_from_battlefield(const battle::DeploymentOper& oper)
@@ -1118,7 +1229,10 @@ void asst::BattleHelper::remove_cooling_from_battlefield(const battle::Deploymen
     if (!oper.cooling) {
         return;
     }
-    auto iter = m_battlefield_opers.find(oper.name);
+
+    auto iter = std::ranges::find_if(m_battlefield_opers, [&](const auto& pair) {
+        return pair.first.role == oper.role && pair.first.name == oper.name;
+    });
     if (iter == m_battlefield_opers.end()) {
         return;
     }

--- a/src/MaaCore/Task/BattleHelper.cpp
+++ b/src/MaaCore/Task/BattleHelper.cpp
@@ -583,7 +583,7 @@ bool asst::BattleHelper::retreat_oper(battle::Role role, const std::string& name
         return false;
     }
 
-    m_battlefield_opers.erase({ role, name });
+    m_battlefield_opers.erase(oper_iter);
     return true;
 }
 

--- a/src/MaaCore/Task/BattleHelper.h
+++ b/src/MaaCore/Task/BattleHelper.h
@@ -13,6 +13,7 @@
 #include <concepts>
 #include <filesystem>
 #include <map>
+#include <optional>
 
 namespace asst
 {
@@ -58,12 +59,20 @@ protected:
 
     cv::Mat get_top_view(const cv::Mat& cam_img, bool side = true, bool has_multi_stages = false);
 
+    // 从作业中的可空role干员匹配到实际的干员职业和名称
+    battle::OperNameTag get_oper_tag(battle::Role role, const std::string& name);
+    battle::OperNameTag get_oper_tag(const battle::OperNameTag& tag);
+    std::optional<battle::OperNameTag> get_oper_skill_tag(const battle::OperNameTag& tag);
     bool deploy_oper(const std::string& name, const Point& loc, battle::DeployDirection direction);
+    bool deploy_oper(battle::Role role, const std::string& name, const Point& loc, battle::DeployDirection direction);
     bool retreat_oper(const std::string& name);
+    bool retreat_oper(battle::Role role, const std::string& name);
     bool retreat_oper(const Point& loc, bool manually = true);
     bool is_skill_ready(const Point& loc, const cv::Mat& reusable = cv::Mat());
     bool is_skill_ready(const std::string& name, const cv::Mat& reusable = cv::Mat());
+    bool is_skill_ready(battle::Role role, const std::string& name, const cv::Mat& reusable = cv::Mat());
     bool use_skill(const std::string& name, bool keep_waiting = true);
+    bool use_skill(battle::Role role, const std::string& name, bool keep_waiting = true);
     bool use_skill(const Point& loc, bool keep_waiting = true);
     bool check_pause_button(const cv::Mat& reusable = cv::Mat());
     bool check_skip_plot_button(const cv::Mat& reusable = cv::Mat());
@@ -76,12 +85,19 @@ protected:
     bool wait_until_end(bool weak = true);
     bool use_all_ready_skill(const cv::Mat& reusable = cv::Mat());
     bool check_and_use_skill(const std::string& name, bool& has_error, const cv::Mat& reusable = cv::Mat());
+    bool check_and_use_skill(
+        battle::Role role,
+        const std::string& name,
+        bool& has_error,
+        const cv::Mat& reusable = cv::Mat());
     bool check_and_use_skill(const Point& loc, bool& has_error, const cv::Mat& reusable = cv::Mat());
     void save_map(const cv::Mat& image);
 
     bool click_oper_on_deployment(const std::string& name);
+    bool click_oper_on_deployment(battle::Role role, const std::string& name);
     bool click_oper_on_deployment(const Rect& rect);
     bool click_oper_on_battlefield(const std::string& name);
+    bool click_oper_on_battlefield(battle::Role role, const std::string& name);
     bool click_oper_on_battlefield(const Point& loc);
     bool click_retreat();                       // 这个是不带识别的，直接点
     bool click_skill(bool keep_waiting = true); // 这个是带识别的，转好了才点
@@ -97,12 +113,12 @@ protected:
     bool move_camera(const std::pair<double, double>& delta);
 
     std::string analyze_detail_page_oper_name(const cv::Mat& image, battle::Role role);
-    std::optional<Rect> get_oper_rect_on_deployment(const std::string& name) const;
+    std::optional<Rect> get_oper_rect_on_deployment(battle::Role role, const std::string& name) const;
 
     int elapsed_time();
 
     // 注册已部署干员及位置
-    void register_deployed_oper(const std::string& name, const Point& loc);
+    void register_deployed_oper(battle::Role role, const std::string& name, const Point& loc);
     // 从场上干员和已占用格子中移除冷却中的干员
     void remove_cooling_from_battlefield(const battle::DeploymentOper& oper);
 
@@ -113,10 +129,10 @@ protected:
     Point m_skill_button_pos;
     Point m_retreat_button_pos;
     bool m_has_multi_stages = false;
-    std::unordered_map<std::string, battle::SkillUsage> m_skill_usage;
-    std::unordered_map<std::string, int> m_skill_times;
-    std::unordered_map<std::string, int> m_skill_error_count;
-    std::unordered_map<std::string, std::chrono::steady_clock::time_point> m_last_use_skill_time;
+    std::unordered_map<battle::OperNameTag, battle::SkillUsage> m_skill_usage;
+    std::unordered_map<battle::OperNameTag, int> m_skill_times;
+    std::unordered_map<battle::OperNameTag, int> m_skill_error_count;
+    std::unordered_map<battle::OperNameTag, std::chrono::steady_clock::time_point> m_last_use_skill_time;
     int m_camera_count = 0;
     bool m_in_speedup = false; // 是否处于2倍速
     std::pair<double, double> m_camera_shift = { 0., 0. };
@@ -131,8 +147,8 @@ protected:
 
     std::vector<battle::DeploymentOper> m_cur_deployment_opers;
 
-    std::map<std::string, Point> m_battlefield_opers;
-    std::map<Point, std::string> m_used_tiles;
+    std::map<battle::OperNameTag, Point> m_battlefield_opers;
+    std::map<Point, battle::OperNameTag> m_used_tiles;
 
 private:
     InstHelper m_inst_helper;

--- a/src/MaaCore/Task/Experiment/CombatRecordRecognitionTask.cpp
+++ b/src/MaaCore/Task/Experiment/CombatRecordRecognitionTask.cpp
@@ -149,7 +149,7 @@ bool asst::CombatRecordRecognitionTask::analyze_formation()
     auto& cb_formation = cb_info["details"]["formation"];
     for (const auto& [name, avatar] : m_formation) {
         std::vector<battle::OperUsage> opers;
-        opers.emplace_back(battle::OperUsage { name, 0, battle::SkillUsage::NotUse });
+        opers.emplace_back(battle::OperUsage { battle::Role::Unknown, name, 0, battle::SkillUsage::NotUse });
         json::object oper_json { { "name", name }, { "skill", 0 }, { "skill_usage", 0 } };
         m_copilot_json["opers"].emplace(std::move(oper_json));
 

--- a/src/MaaCore/Task/Interface/DebugTask.cpp
+++ b/src/MaaCore/Task/Interface/DebugTask.cpp
@@ -29,19 +29,6 @@ asst::DebugTask::DebugTask(const AsstCallback& callback, Assistant* inst) :
 
 bool asst::DebugTask::run()
 {
-    struct RoguelikeOperInfo : battle::OperNameTag
-    {
-        std::vector<int> group_id = {};
-    };
-
-    RoguelikeOperInfo tag1 { { .role = battle::Role::Medic, .name = "阿米娅" } };
-    RoguelikeOperInfo tag2 { { .role = battle::Role::Medic, .name = "阿米娅" } };
-    RoguelikeOperInfo tag3 { { .role = battle::Role::Caster, .name = "阿米娅" } };
-
-
-    LogInfo << "tag1 == tag2: " << (tag1 == tag2);
-    LogInfo << "tag1 == tag3: " << (tag1 == tag3);
-
     return true;
 }
 

--- a/src/MaaCore/Task/Interface/DebugTask.cpp
+++ b/src/MaaCore/Task/Interface/DebugTask.cpp
@@ -29,6 +29,19 @@ asst::DebugTask::DebugTask(const AsstCallback& callback, Assistant* inst) :
 
 bool asst::DebugTask::run()
 {
+    struct RoguelikeOperInfo : battle::OperNameTag
+    {
+        std::vector<int> group_id = {};
+    };
+
+    RoguelikeOperInfo tag1 { { .role = battle::Role::Medic, .name = "阿米娅" } };
+    RoguelikeOperInfo tag2 { { .role = battle::Role::Medic, .name = "阿米娅" } };
+    RoguelikeOperInfo tag3 { { .role = battle::Role::Caster, .name = "阿米娅" } };
+
+
+    LogInfo << "tag1 == tag2: " << (tag1 == tag2);
+    LogInfo << "tag1 == tag3: " << (tag1 == tag3);
+
     return true;
 }
 

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -139,9 +139,7 @@ bool asst::BattleFormationTask::_run()
         Log.info(__FUNCTION__, "| Left quick formation scene");
         if (auto opt = add_support_unit(required_opers)) {
             m_used_support_unit = true;
-            m_opers_in_formation->emplace(
-                battle::OperNameTag { required_opers.front().role, required_opers.front().name },
-                missing_group->first);
+            m_opers_in_formation->emplace(*opt, missing_group->first);
         }
         // 再到快速编队页面
         if (!ProcessTask(*this, { "Formation-EnterQuickFormation" }).set_retry_times(3).run()) {
@@ -927,7 +925,7 @@ bool asst::BattleFormationTask::is_formation_valid(cv::Mat& img) const
     return false;
 }
 
-std::optional<std::string> asst::BattleFormationTask::add_support_unit(
+std::optional<asst::battle::OperNameTag> asst::BattleFormationTask::add_support_unit(
     const std::vector<RequiredOper>& required_opers,
     const size_t max_refresh_times,
     const Friendship friendship)
@@ -944,7 +942,7 @@ std::optional<std::string> asst::BattleFormationTask::add_support_unit(
     if (required_opers.empty()) { // 随机模式
         for (size_t refresh_times = 0; refresh_times <= max_refresh_times && !need_exit(); ++refresh_times) {
             if (auto opt = add_support_unit_from_support_list(support_list, required_opers, friendship)) {
-                return opt;
+                return battle::OperNameTag { BattleData.get_role(*opt), *opt };
             }
             if (refresh_times < max_refresh_times) {
                 support_list.refresh_list();
@@ -973,7 +971,7 @@ std::optional<std::string> asst::BattleFormationTask::add_support_unit(
 
             for (size_t refresh_times = 0; refresh_times <= max_refresh_times && !need_exit(); ++refresh_times) {
                 if (auto opt = add_support_unit_from_support_list(support_list, filtered_required_opers, friendship)) {
-                    return opt;
+                    return battle::OperNameTag { role, *opt };
                 }
                 if (refresh_times < max_refresh_times) {
                     support_list.refresh_list();

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -70,8 +70,9 @@ bool asst::BattleFormationTask::_run()
                 continue;
             }
 
-            auto oper_it =
-                std::ranges::find_if(opers, [&](const battle::OperUsage& oper) { return oper.name == pair_it->first; });
+            auto oper_it = std::ranges::find_if(opers, [&](const battle::OperUsage& oper) {
+                return oper.role == pair_it->first.role && oper.name == pair_it->first.name;
+            });
             if (oper_it == opers.end()) {
                 Log.error(__FUNCTION__, "| Cannot find oper ", pair_it->first, " in m_formation");
             }
@@ -138,7 +139,9 @@ bool asst::BattleFormationTask::_run()
         Log.info(__FUNCTION__, "| Left quick formation scene");
         if (auto opt = add_support_unit(required_opers)) {
             m_used_support_unit = true;
-            m_opers_in_formation->emplace(*opt, missing_group->first);
+            m_opers_in_formation->emplace(
+                battle::OperNameTag { required_opers.front().role, required_opers.front().name },
+                missing_group->first);
         }
         // 再到快速编队页面
         if (!ProcessTask(*this, { "Formation-EnterQuickFormation" }).set_retry_times(3).run()) {
@@ -164,7 +167,10 @@ bool asst::BattleFormationTask::_run()
         std::unordered_map<battle::Role, std::vector<OperGroup>> user_formation; // 解析后用户自定编队
         auto limit = 12 + m_used_support_unit - (int)m_opers_in_formation->size();
         for (const auto& [name, skill] : m_user_additional) {
-            if (m_opers_in_formation->contains(name)) {
+            auto has_oper = std::ranges::any_of(
+                *m_opers_in_formation,
+                [&](const std::pair<battle::OperNameTag, std::string>& pair) { return pair.first.name == name; });
+            if (has_oper) {
                 continue;
             }
             if (--limit < 0) {
@@ -209,7 +215,7 @@ void asst::BattleFormationTask::formation_with_last_opers()
     if (m_opers_in_formation->empty()) {
         return;
     }
-    std::unordered_map<std::string, std::string> last_formation; // 上次作业的干员-组映射
+    std::unordered_map<battle::OperNameTag, std::string> last_formation; // 上次作业的干员-组映射
     m_opers_in_formation->swap(last_formation);
 
     // 此时的oper_in_formation是根据上次编队结果复用的, 但是task此时已清空, 重新选一下
@@ -225,14 +231,14 @@ void asst::BattleFormationTask::formation_with_last_opers()
     }
     const int delay = Task.get("BattleQuickFormationOCR")->post_delay;
     for (auto it = last_formation.begin(); !need_exit() && it != last_formation.end();) {
-        const std::string& oper_name = it->first;
+        const battle::OperNameTag& oper_tag = it->first;
         const std::string& group_name = it->second;
 
         const auto& oper_in_page_it = std::ranges::find_if(opers_result, [&](const QuickFormationOper& op) {
-            return !op.is_selected && op.text == oper_name;
+            return !op.is_selected && op.role == oper_tag.role && op.text == oper_tag.name;
         }); // 编队页中的干员
         if (oper_in_page_it == opers_result.end()) [[unlikely]] {
-            Log.warn(__FUNCTION__, "| Oper", oper_name, "was selected last time, but not found in current page");
+            Log.warn(__FUNCTION__, "| Oper", oper_tag.name, "was selected last time, but not found in current page");
             ++it;
             continue; // 该干员找不到, 一页只能放下10个干员, 可能被右侧挡住. 打回到正常编队逻辑
         }
@@ -246,10 +252,11 @@ void asst::BattleFormationTask::formation_with_last_opers()
         }
 
         // 在找到的组中查找具体的干员
-        auto oper_it =
-            std::ranges::find_if(*(group_it->second), [&](battle::OperUsage& op) { return op.name == oper_name; });
+        auto oper_it = std::ranges::find_if(*(group_it->second), [&](battle::OperUsage& op) {
+            return op.name == oper_tag.name && op.role == oper_tag.role;
+        });
         if (oper_it == group_it->second->end()) {
-            LogError << __FUNCTION__ << "| Group" << group_name << ",Oper" << oper_name
+            LogError << __FUNCTION__ << "| Group" << group_name << ",Oper" << oper_tag
                      << "was selected last time, but not found in current pair";
             ++it;
             continue; // 很怪, 按理说不会找不到, 有组相同但是找不到干员
@@ -261,10 +268,10 @@ void asst::BattleFormationTask::formation_with_last_opers()
         oper_it->status = battle::OperStatus::Selected;
         json::value info = basic_info_with_what("BattleFormationSelected");
         auto& details = info["details"];
-        details["selected"] = oper_name;
+        details["selected"] = oper_tag.name;
         details["group_name"] = group_name;
         callback(AsstMsg::SubTaskExtraInfo, info);
-        m_opers_in_formation->emplace(oper_name, group_name);
+        m_opers_in_formation->emplace(oper_tag, group_name);
         it = last_formation.erase(it);
     }
 }
@@ -306,7 +313,7 @@ bool asst::BattleFormationTask::add_formation(battle::Role role, const std::vect
                     }
                     for (auto& oper : group->second) {
                         if (oper.status == battle::OperStatus::Unchecked &&
-                            !m_opers_in_formation->contains(oper.name)) {
+                            !m_opers_in_formation->contains(battle::OperNameTag { role, oper.name })) {
                             oper.status = battle::OperStatus::Missing;
                         }
                     }
@@ -657,10 +664,10 @@ bool asst::BattleFormationTask::select_opers_in_cur_page(const std::vector<OperG
             sleep(delay);
         }
         oper->status = battle::OperStatus::Selected;
-        m_opers_in_formation->emplace(res.text, (*iter)->first);
+        m_opers_in_formation->emplace(battle::OperNameTag { oper->role, oper->name }, (*iter)->first);
         json::value info = basic_info_with_what("BattleFormationSelected");
         auto& details = info["details"];
-        details["selected"] = res.text;
+        details["selected"] = oper->name;
         details["group_name"] = (*iter)->first;
         callback(AsstMsg::SubTaskExtraInfo, info);
         oper = nullptr; // reset oper pointer
@@ -867,7 +874,7 @@ bool asst::BattleFormationTask::compare_formation()
                          << "was selected last time, but no oper was selected";
                 continue; // 旧编队中该干员组有干员被选中，但找不到被选中的干员
             }
-            m_opers_in_formation->emplace(oper_last_it->name, group.first);
+            m_opers_in_formation->emplace(battle::OperNameTag { oper_last_it->role, oper_last_it->name }, group.first);
             last_groups.erase(last_group_it); // 移除已匹配的干员组
         }
     }

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.h
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.h
@@ -53,7 +53,7 @@ public:
     // 设置对指定编队自动编队
     void set_select_formation(int index) { m_select_formation_index = index; }
 
-    std::shared_ptr<std::unordered_map<std::string, std::string>> get_opers_in_formation() const
+    std::shared_ptr<std::unordered_map<battle::OperNameTag, std::string>> get_opers_in_formation() const
     {
         return m_opers_in_formation;
     }
@@ -126,8 +126,8 @@ protected:
     std::unordered_map<battle::Role, std::vector<OperGroup>> m_formation;      // 作业编队
     std::unordered_map<battle::Role, std::vector<OperGroup>> m_formation_last; // 上次的编队
     // 编队中的干员名称-所属组名, 传递给外部使用, 编入的干员需要存入该表
-    std::shared_ptr<std::unordered_map<std::string, std::string>> m_opers_in_formation =
-        std::make_shared<std::unordered_map<std::string, std::string>>();
+    std::shared_ptr<std::unordered_map<battle::OperNameTag, std::string>> m_opers_in_formation =
+        std::make_shared<std::unordered_map<battle::OperNameTag, std::string>>();
     bool m_add_trust = false;                                   // 是否需要追加信赖干员
     bool m_ignore_requirements = false;                         // 是否跳过未满足的干员属性要求
     std::vector<std::pair<std::string, int>> m_user_additional; // 追加干员表，从头往后加

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.h
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.h
@@ -145,7 +145,7 @@ protected:
     using OperModule = battle::OperModule;
     using RequiredOper = battle::RequiredOper;
 
-    std::optional<std::string> add_support_unit(
+    std::optional<battle::OperNameTag> add_support_unit(
         const std::vector<RequiredOper>& required_opers = {},
         size_t max_refresh_times = 5,
         Friendship friendship = Friendship::Stranger);

--- a/src/MaaCore/Task/Miscellaneous/BattleProcessTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleProcessTask.cpp
@@ -356,6 +356,16 @@ bool asst::BattleProcessTask::do_action(const battle::copilot::Action& action, s
 asst::battle::OperNameTag
     asst::BattleProcessTask::get_name_from_group(battle::Role role, const std::string& oper_name_in_action)
 {
+    if (role == battle::Role::Unknown) {
+        // 未指定职业, 先作为组名检查
+        auto it = std::ranges::find_if(m_oper_in_group, [&](const auto& pair) {
+            return pair.first.name == oper_name_in_action;
+        });
+        if (it != m_oper_in_group.end()) {
+            return it->second;
+        }
+    }
+
     auto iter = std::ranges::find_if(m_oper_in_group, [&](const auto& pair) {
         return (role == battle::Role::Unknown || pair.second.role == role) && pair.second.name == oper_name_in_action;
     });

--- a/src/MaaCore/Task/Miscellaneous/BattleProcessTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleProcessTask.cpp
@@ -92,36 +92,38 @@ void asst::BattleProcessTask::set_wait_until_end(bool wait_until_end)
     m_need_to_wait_until_end = wait_until_end;
 }
 
-void
-    asst::BattleProcessTask::set_formation_task_ptr(std::shared_ptr<std::unordered_map<std::string, std::string>> value)
+void asst::BattleProcessTask::set_formation_task_ptr(
+    std::shared_ptr<std::unordered_map<battle::OperNameTag, std::string>> value)
 {
     m_formation_ptr = value;
 }
 
 bool asst::BattleProcessTask::to_group()
 {
-    std::unordered_map<std::string, std::vector<std::string>> groups;
+    std::unordered_map<battle::OperNameTag, std::vector<battle::OperNameTag>> groups;
     // 从编队任务中获取<干员-组名>映射
     if (m_formation_ptr != nullptr) {
-        for (const auto& [group, oper] : *m_formation_ptr) {
-            groups.emplace(oper, std::vector<std::string> { group });
+        for (const auto& [oper, group] : *m_formation_ptr) {
+            groups.emplace(
+                battle::OperNameTag { battle::Role::Unknown, group },
+                std::vector<battle::OperNameTag> { oper });
         }
     }
     // 补充剩余的干员
     for (const auto& [group_name, oper_list] : get_combat_data().groups) {
-        if (groups.contains(group_name)) {
+        if (groups.contains(battle::OperNameTag { battle::Role::Unknown, group_name })) {
             continue;
         }
-        std::vector<std::string> oper_name_list;
+        std::vector<battle::OperNameTag> oper_name_list;
         std::ranges::transform(oper_list, std::back_inserter(oper_name_list), [](const auto& oper) {
-            return oper.name;
+            return battle::OperNameTag { oper.role, oper.name };
         });
-        groups.emplace(group_name, std::move(oper_name_list));
+        groups.emplace(battle::OperNameTag { battle::Role::Unknown, group_name }, std::move(oper_name_list));
     }
 
-    std::unordered_set<std::string> char_set; // 干员集合
+    std::unordered_set<battle::OperNameTag> char_set; // 干员集合
     for (const auto& oper : m_cur_deployment_opers) {
-        char_set.emplace(oper.name);
+        char_set.emplace(battle::OperNameTag { oper.role, oper.name });
     }
 
     auto allocation_result = algorithm::get_char_allocation_for_each_group(groups, char_set);
@@ -151,43 +153,63 @@ bool asst::BattleProcessTask::to_group()
         }
     }
 
-    std::unordered_map<std::string, std::string> ungrouped;
+    std::unordered_map<battle::OperNameTag, battle::OperNameTag> ungrouped;
     const auto& grouped_view = m_oper_in_group | std::views::values;
-    for (const auto& name : char_set) {
-        if (std::ranges::find(grouped_view, name) != grouped_view.end()) {
+    for (const auto& tag : char_set) {
+        if (std::ranges::find(grouped_view, tag) != grouped_view.end()) {
             continue;
         }
-        ungrouped.emplace(name, name);
+        ungrouped.emplace(tag, tag);
     }
     m_oper_in_group.merge(ungrouped);
 
     for (const auto& action : m_combat_data.actions) {
+        battle::Role role = action.role;
         const std::string& action_name = action.name;
-        if (action_name.empty() || m_oper_in_group.contains(action_name)) {
+        if (action_name.empty()) {
             continue;
         }
-        m_oper_in_group.emplace(action_name, action_name);
+        if (role != battle::Role::Unknown) { // 指定了role, 此时name应为干员名
+            auto it = std::ranges::find_if(m_oper_in_group, [&](const auto& pair) {
+                return pair.second.role == role && pair.second.name == action_name;
+            });
+            if (it != m_oper_in_group.end()) {
+                continue;
+            }
+        }
+        else {
+            // 未指定role, 先作为组名检查
+            auto it =
+                std::ranges::find_if(m_oper_in_group, [&](const auto& pair) { return pair.first.name == action_name; });
+            if (it != m_oper_in_group.end()) {
+                continue;
+            }
+        }
+
+        battle::OperNameTag tag { role, action_name };
+        m_oper_in_group.emplace(tag, tag);
     }
 
-    for (const auto& [group_name, oper_name] : m_oper_in_group) {
+    for (const auto& [group_tag, oper_tag] : m_oper_in_group) {
         const auto& group_it = std::ranges::find_if(get_combat_data().groups, [&](const OperUsageGroup& pair) {
-            return pair.first == group_name;
+            return pair.first == group_tag.name;
         });
         if (group_it == get_combat_data().groups.end()) {
-            Log.warn(__FUNCTION__, "Group not found in combat data: ", group_name);
+            LogError << __FUNCTION__ << "Group not found in combat data: " << group_tag.name;
             continue;
         }
         const auto& this_group = group_it->second;
         // there is a build error on macOS
         // https://github.com/MaaAssistantArknights/MaaAssistantArknights/actions/runs/3779762713/jobs/6425284487
-        const std::string& oper_name_for_lambda = oper_name;
-        auto iter =
-            std::ranges::find_if(this_group, [&](const auto& oper) { return oper.name == oper_name_for_lambda; });
+        // const std::string& oper_name_for_lambda = oper_tag;
+        auto iter = std::ranges::find_if(this_group, [&](const auto& oper) {
+            return oper.role == oper_tag.role && oper.name == oper_tag.name;
+        });
         if (iter == this_group.end()) {
             continue;
         }
-        m_skill_usage.emplace(oper_name, iter->skill_usage);
-        m_skill_times.emplace(oper_name, iter->skill_times);
+        m_skill_usage.emplace(oper_tag, iter->skill_usage);
+        m_skill_times.emplace(oper_tag, iter->skill_times);
     }
 
     return true;
@@ -223,19 +245,20 @@ bool asst::BattleProcessTask::do_action(const battle::copilot::Action& action, s
     }
 
     bool ret = false;
-    const std::string& name = get_name_from_group(action.name);
+    const auto& [role, name] = get_name_from_group(action.role, action.name);
     const auto& location = action.location;
 
     switch (action.type) {
     case ActionType::Deploy:
-        ret = deploy_oper(name, location, action.direction);
+        ret = deploy_oper(role, name, location, action.direction);
         if (ret) {
             m_in_bullet_time = false;
         }
         break;
 
     case ActionType::Retreat:
-        ret = m_in_bullet_time ? click_retreat() : (location.empty() ? retreat_oper(name) : retreat_oper(location));
+        ret =
+            m_in_bullet_time ? click_retreat() : (location.empty() ? retreat_oper(role, name) : retreat_oper(location));
         if (ret) {
             m_in_bullet_time = false;
         }
@@ -243,7 +266,7 @@ bool asst::BattleProcessTask::do_action(const battle::copilot::Action& action, s
 
     case ActionType::UseSkill:
         ret = m_in_bullet_time ? click_skill(!action.skip_if_not_ready)
-                               : (location.empty() ? use_skill(name, !action.skip_if_not_ready)
+                               : (location.empty() ? use_skill(role, name, !action.skip_if_not_ready)
                                                    : use_skill(location, !action.skip_if_not_ready));
         if (ret) {
             m_in_bullet_time = false;
@@ -258,37 +281,46 @@ bool asst::BattleProcessTask::do_action(const battle::copilot::Action& action, s
         break;
 
     case ActionType::BulletTime:
-        ret = enter_bullet_time(name, location);
+        ret = enter_bullet_time(role, name, location);
         if (ret) {
             m_in_bullet_time = true;
         }
         break;
 
     case ActionType::SkillUsage: {
-        const auto set_usage = [this](const std::string& name, SkillUsage usage, int times) {
-            m_skill_usage[name] = usage;
+        const auto set_usage = [this](const battle::OperNameTag& tag, SkillUsage usage, int times) {
+            m_skill_usage[tag] = usage;
             if (usage == SkillUsage::Times) {
-                m_skill_times[name] = times;
+                m_skill_times[tag] = times;
             }
         };
-        if (!location.empty()) {
-            std::string drone_name;
-            if (!name.empty()) {
-                LogWarn << "Both name and location are set for SkillUsage action. Skip this step.";
-                break;
+        if (!location.empty() && !name.empty()) {
+            LogError << "Both name and location are set for SkillUsage action. Skip this step.";
+            break;
+        }
+        else if (location.empty()) {
+            auto tag_opt = get_oper_skill_tag({ role, name });
+            if (tag_opt) {
+                set_usage(*tag_opt, action.modify_usage, action.modify_times);
             }
+            else {
+                LogError << __FUNCTION__ << "No oper" << enum_to_string(role) << name << "could not set skill usage";
+            }
+        }
+        else {
+            battle::Role _role;
+            std::string drone_name;
             if (auto it = m_used_tiles.find(location); it == m_used_tiles.end()) {
                 LogInfo << "Tile hasn't used, register for drone" << location;
                 drone_name = std::format("drone_{}_{}", location.x, location.y);
-                register_deployed_oper(drone_name, location);
+                _role = Role::Drone;
+                register_deployed_oper(_role, drone_name, location);
             }
             else {
-                drone_name = it->second;
+                drone_name = it->second.name;
+                _role = it->second.role;
             }
-            set_usage(drone_name, action.modify_usage, action.modify_times);
-        }
-        else {
-            set_usage(name, action.modify_usage, action.modify_times);
+            set_usage({ _role, drone_name }, action.modify_usage, action.modify_times);
         }
         ret = true;
         break;
@@ -321,14 +353,18 @@ bool asst::BattleProcessTask::do_action(const battle::copilot::Action& action, s
     return ret;
 }
 
-const std::string& asst::BattleProcessTask::get_name_from_group(const std::string& action_name)
+asst::battle::OperNameTag
+    asst::BattleProcessTask::get_name_from_group(battle::Role role, const std::string& oper_name_in_action)
 {
-    auto iter = m_oper_in_group.find(action_name);
+    auto iter = std::ranges::find_if(m_oper_in_group, [&](const auto& pair) {
+        return (role == battle::Role::Unknown || pair.second.role == role) && pair.second.name == oper_name_in_action;
+    });
     if (iter != m_oper_in_group.cend()) {
         return iter->second;
     }
-    m_oper_in_group.emplace(action_name, action_name);
-    return m_oper_in_group.at(action_name);
+    battle::OperNameTag tag { role, oper_name_in_action };
+    m_oper_in_group.emplace(tag, tag);
+    return m_oper_in_group.at(tag);
 }
 
 void asst::BattleProcessTask::notify_action(const battle::copilot::Action& action)
@@ -459,14 +495,15 @@ bool asst::BattleProcessTask::wait_condition(const Action& action)
 
     // 部署干员还要额外等待费用够或 CD 转好
     if (action.type == ActionType::Deploy) {
-        const std::string& name = get_name_from_group(action.name);
+        const auto& oper_tag = get_oper_tag(get_name_from_group(action.role, action.name));
         update_image_if_empty();
         while (!need_exit()) {
             if (!update_deployment(false, image)) {
                 return false;
             }
-            if (auto iter =
-                    std::ranges::find_if(m_cur_deployment_opers, [&](const auto& oper) { return oper.name == name; });
+            if (auto iter = std::ranges::find_if(
+                    m_cur_deployment_opers,
+                    [&](const auto& oper) { return oper.role == oper_tag.role && oper.name == oper_tag.name; });
                 iter != m_cur_deployment_opers.end() && iter->available) {
                 break;
             }
@@ -477,13 +514,13 @@ bool asst::BattleProcessTask::wait_condition(const Action& action)
     return true;
 }
 
-bool asst::BattleProcessTask::enter_bullet_time(const std::string& name, const Point& location)
+bool asst::BattleProcessTask::enter_bullet_time(battle::Role role, const std::string& name, const Point& location)
 {
     LogTraceFunction;
 
-    bool ret = location.empty() ? click_oper_on_battlefield(name) : click_oper_on_battlefield(location);
+    bool ret = location.empty() ? click_oper_on_battlefield(role, name) : click_oper_on_battlefield(location);
     if (!ret) {
-        ret = click_oper_on_deployment(name);
+        ret = click_oper_on_deployment(role, name);
     };
 
     return ret;

--- a/src/MaaCore/Task/Miscellaneous/BattleProcessTask.h
+++ b/src/MaaCore/Task/Miscellaneous/BattleProcessTask.h
@@ -16,7 +16,7 @@ public:
 
     virtual bool set_stage_name(const std::string& stage_name) override;
     void set_wait_until_end(bool wait_until_end);
-    void set_formation_task_ptr(std::shared_ptr<std::unordered_map<std::string, std::string>> value);
+    void set_formation_task_ptr(std::shared_ptr<std::unordered_map<battle::OperNameTag, std::string>> value);
 
 protected:
     virtual bool _run() override;
@@ -38,17 +38,18 @@ protected:
     bool to_group();
     bool do_action(const battle::copilot::Action& action, size_t index);
 
-    const std::string& get_name_from_group(const std::string& action_name);
+    // 将作业步骤中的name转换为具体干员名
+    battle::OperNameTag get_name_from_group(battle::Role role, const std::string& oper_name_in_action);
     void notify_action(const battle::copilot::Action& action);
     bool wait_condition(const battle::copilot::Action& action);
-    bool enter_bullet_time(const std::string& name, const Point& location);
+    bool enter_bullet_time(battle::Role role, const std::string& name, const Point& location);
     void sleep_and_do_strategy(unsigned millisecond);
 
     battle::copilot::CombatData m_combat_data;
-    std::unordered_map</*group*/ std::string, /*oper*/ std::string> m_oper_in_group;
+    std::unordered_map</*group*/ battle::OperNameTag, /*oper*/ battle::OperNameTag> m_oper_in_group;
 
     bool m_in_bullet_time = false;
     bool m_need_to_wait_until_end = false;
-    std::shared_ptr<std::unordered_map<std::string, std::string>> m_formation_ptr = nullptr;
+    std::shared_ptr<std::unordered_map<battle::OperNameTag, std::string>> m_formation_ptr = nullptr;
 };
 }

--- a/src/MaaCore/Task/Roguelike/RoguelikeBattleTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeBattleTaskPlugin.cpp
@@ -373,6 +373,7 @@ bool asst::RoguelikeBattleTaskPlugin::do_best_deploy()
             continue;
         }
 
+        const battle::OperNameTag oper_tag { oper.role, oper.name };
         const std::string& oper_name = oper_name_in_config(oper);
         // 获取招募信息
         const auto& recruit_info = RoguelikeRecruit.get_oper_info(m_config->get_theme(), oper_name);
@@ -394,6 +395,7 @@ bool asst::RoguelikeBattleTaskPlugin::do_best_deploy()
                     }
 
                     DeployPlanInfo deploy_plan;
+                    deploy_plan.role = oper.role;
                     deploy_plan.oper_name = oper.name;
                     // deploy_plan.oper_priority = recruit_info.recruit_priority;
                     // deploy_plan.oper_order_in_group = recruit_info.order_in_group.at(group_id);
@@ -429,26 +431,25 @@ bool asst::RoguelikeBattleTaskPlugin::do_best_deploy()
             !m_blacklist_location.contains(deploy_plan.placed) /* 判断该位置是否已被占据 */) {
             if (auto oper_it = std::ranges::find_if(
                     m_cur_deployment_opers,
-                    [&](const auto& oper) { return oper.name == deploy_plan.oper_name; });
+                    [&](const auto& oper) {
+                        return oper.role == deploy_plan.role && oper.name == deploy_plan.oper_name;
+                    });
                 oper_it == m_cur_deployment_opers.end() || !oper_it->available) { // 等费
-                Log.trace(
-                    "    best deploy is",
-                    deploy_plan.oper_name,
-                    "with rank",
-                    deploy_plan.rank,
-                    "but now waiting for cost.");
+                LogTrace << "    best deploy is" << deploy_plan.oper_name << "with rank" << deploy_plan.rank
+                         << "but now waiting for cost.";
                 return true;
             }
-            deploy_oper(deploy_plan.oper_name, deploy_plan.placed, deploy_plan.direction);
+            deploy_oper(deploy_plan.role, deploy_plan.oper_name, deploy_plan.placed, deploy_plan.direction);
+            battle::OperNameTag oper_tag { deploy_plan.role, deploy_plan.oper_name };
             // 防止滑动丢失(有些物体比如鸟笼没有方向),点一下右下角费用那里
             asst::BattleHelper::cancel_oper_selection();
             // 开始计时
             auto deployed_time = std::chrono::steady_clock::now();
-            m_deployed_time.insert_or_assign(deploy_plan.oper_name, deployed_time);
+            m_deployed_time.insert_or_assign(oper_tag, deployed_time);
             // 获取技能用法和使用次数
-            const auto& oper_info = RoguelikeRecruit.get_oper_info(m_config->get_theme(), deploy_plan.oper_name);
-            m_skill_usage[deploy_plan.oper_name] = oper_info.skill_usage;
-            m_skill_times[deploy_plan.oper_name] = oper_info.skill_times;
+            const auto& oper_info = RoguelikeRecruit.get_oper_info(m_config->get_theme(), oper_tag);
+            m_skill_usage[oper_tag] = oper_info.skill_usage;
+            m_skill_times[oper_tag] = oper_info.skill_times;
             Log.trace("    best deploy is", deploy_plan.oper_name, "with rank", deploy_plan.rank);
             return true;
         }
@@ -481,20 +482,20 @@ bool asst::RoguelikeBattleTaskPlugin::do_once(const cv::Mat& image, const cv::Ma
     for (const auto& oper : m_cur_deployment_opers) {
         if (oper.cooling) {
             pre_cooling.emplace(oper.name);
-            m_deployed_time.erase(oper.name);
+            m_deployed_time.erase({ oper.role, oper.name });
         }
     }
 
     auto pre_battlefield = m_battlefield_opers;
-    for (const auto& [name, loc] : pre_battlefield) {
-        const auto& oper_info = RoguelikeRecruit.get_oper_info(m_config->get_theme(), name);
-        auto iter = m_deployed_time.find(name);
+    for (const auto& [oper_tag, loc] : pre_battlefield) {
+        const auto& oper_info = RoguelikeRecruit.get_oper_info(m_config->get_theme(), oper_tag);
+        auto iter = m_deployed_time.find(oper_tag);
         if (iter != m_deployed_time.end() && oper_info.auto_retreat > 0) {
-            if (std::chrono::steady_clock::now() - m_deployed_time.at(name) >=
+            if (std::chrono::steady_clock::now() - m_deployed_time.at(oper_tag) >=
                 oper_info.auto_retreat * std::chrono::seconds(1)) {
                 // 时间到了就撤退
-                asst::BattleHelper::retreat_oper(name);
-                m_deployed_time.erase(name);
+                asst::BattleHelper::retreat_oper(oper_tag.role, oper_tag.name);
+                m_deployed_time.erase(oper_tag);
             }
         }
     }
@@ -517,7 +518,7 @@ bool asst::RoguelikeBattleTaskPlugin::do_once(const cv::Mat& image, const cv::Ma
         ++cur_deployments_count;
         if (oper.cooling) {
             cur_cooling.emplace(oper.name);
-            m_deployed_time.erase(oper.name);
+            m_deployed_time.erase({ oper.role, oper.name });
         }
         if (oper.available) {
             ++cur_available_count;
@@ -585,17 +586,18 @@ bool asst::RoguelikeBattleTaskPlugin::do_once(const cv::Mat& image, const cv::Ma
         }
         const auto& [placed_loc, direction] = *best_loc_opt;
 
-        deploy_oper(best_oper.name, placed_loc, direction);
+        deploy_oper(best_oper.role, best_oper.name, placed_loc, direction);
         postproc_of_deployment_conditions(best_oper, placed_loc, direction);
 
+        battle::OperNameTag oper_tag { best_oper.role, best_oper.name };
         m_first_deploy = false;
         // 开始计时
         auto deployed_time = std::chrono::steady_clock::now();
-        m_deployed_time.insert_or_assign(best_oper.name, deployed_time);
+        m_deployed_time.insert_or_assign(oper_tag, deployed_time);
         // 获取技能用法和使用次数
-        const auto& oper_info = RoguelikeRecruit.get_oper_info(m_config->get_theme(), best_oper.name);
-        m_skill_usage[best_oper.name] = oper_info.skill_usage;
-        m_skill_times[best_oper.name] = oper_info.skill_times;
+        const auto& oper_info = RoguelikeRecruit.get_oper_info(m_config->get_theme(), oper_tag);
+        m_skill_usage[oper_tag] = oper_info.skill_usage;
+        m_skill_times[oper_tag] = oper_info.skill_times;
 
         if (urgent_home_opt) {
             m_urgent_home_index.pop_front();
@@ -680,15 +682,16 @@ void asst::RoguelikeBattleTaskPlugin::check_drone_tiles()
 std::optional<size_t> asst::RoguelikeBattleTaskPlugin::check_urgent(
     const std::unordered_set<std::string>& pre_cooling,
     const std::unordered_set<std::string>& cur_cooling,
-    const std::map<std::string, Point>& pre_battlefield)
+    const std::map<battle::OperNameTag, Point>& pre_battlefield)
 {
     std::vector<size_t> new_urgent;
     for (const auto& name : cur_cooling) {
         if (pre_cooling.find(name) != pre_cooling.cend()) {
             continue;
         }
-        Log.info(name, "retreated");
-        auto pre_loc_iter = pre_battlefield.find(name);
+        LogInfo << name << "retreated";
+        auto pre_loc_iter =
+            std::ranges::find_if(pre_battlefield, [&](const auto& pair) { return pair.first.name == name; });
         if (pre_loc_iter == pre_battlefield.cend()) {
             Log.error("the oper", name, "was not on the battlefield before");
             continue;
@@ -1102,7 +1105,7 @@ asst::RoguelikeBattleTaskPlugin::DirectionAndScore asst::RoguelikeBattleTaskPlug
             case battle::Role::Medic:
                 if (auto iter = m_used_tiles.find(absolute_pos);
                     iter != m_used_tiles.cend() &&
-                    BattleData.get_role(iter->second) != battle::Role::Drone) { // 根据哪个方向上人多决定朝向哪
+                    iter->second.role != battle::Role::Drone) { // 根据哪个方向上人多决定朝向哪
                     score += 10000;
                 }
                 if (auto iter = m_side_tile_info.find(absolute_pos); iter == m_side_tile_info.end()) {

--- a/src/MaaCore/Task/Roguelike/RoguelikeBattleTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeBattleTaskPlugin.cpp
@@ -369,27 +369,28 @@ bool asst::RoguelikeBattleTaskPlugin::do_best_deploy()
     for (const auto& oper : m_cur_deployment_opers) {
         // 干员冷却中
         if (oper.cooling) {
-            Log.debug("operator", oper.name, "is cooling now.");
+            LogDebug << "operator" << oper.name << "is cooling now.";
             continue;
         }
 
-        const battle::OperNameTag oper_tag { oper.role, oper.name };
-        const std::string& oper_name = oper_name_in_config(oper);
+        const battle::OperNameTag oper_tag { oper.role,
+                                             oper_name_in_config(
+                                                 oper) }; // 临时使用阿米娅-WARRIOR/阿米娅-MEDIC来获取招募信息
         // 获取招募信息
-        const auto& recruit_info = RoguelikeRecruit.get_oper_info(m_config->get_theme(), oper_name);
+        const auto& recruit_info = RoguelikeRecruit.get_oper_info(m_config->get_theme(), oper_tag);
         // 获取会用到该干员的干员组[干员组1序号,干员组2序号,...]
-        std::vector<int> group_ids = RoguelikeRecruit.get_group_ids_of_oper(m_config->get_theme(), oper_name);
+        std::vector<int> group_ids = RoguelikeRecruit.get_group_ids_of_oper(m_config->get_theme(), oper_tag);
 
         bool is_in_group = false;
         for (const auto& group_id : group_ids) {
             // 当前干员组名,string类型
             std::string group_name = groups[group_id];
-            Log.debug(m_stage_name, "group_name", group_name);
+            LogDebug << m_stage_name << "group_name" << group_name;
             if (m_deploy_plan.contains(group_name)) {
                 is_in_group = true;
                 for (const auto& info : m_deploy_plan[group_name]) {
                     if (m_kills < info.kill_lower_bound || m_kills > info.kill_upper_bound) {
-                        Log.debug("    deploy info", oper.name, "in group", group_name, "is waiting.");
+                        LogDebug << "    deploy info" << oper.name << "in group" << group_name << "is waiting.";
                         is_success = true; // 如果发现了待命干员，此函数最终返回true
                         continue;
                     }
@@ -406,23 +407,18 @@ bool asst::RoguelikeBattleTaskPlugin::do_best_deploy()
                     deploy_plan.placed = info.location;
                     deploy_plan.direction = info.direction;
                     deploy_plan_list.emplace_back(deploy_plan);
-                    Log.debug(
-                        "    deploy info",
-                        deploy_plan.oper_name,
-                        "is No. ",
-                        deploy_plan.oper_order_in_group + 1,
-                        "in group",
-                        group_name,
-                        ", with deploy command rank",
-                        deploy_plan.rank);
+                    LogDebug << "    deploy info" << deploy_plan.oper_name << "is No. "
+                             << deploy_plan.oper_order_in_group + 1 << "in group" << group_name
+                             << ", with deploy command rank" << deploy_plan.rank;
                 }
             }
             else {
-                Log.debug(m_stage_name, "group_name", group_name, "operator", oper.name, "is not in the deploy plan.");
+                LogDebug << m_stage_name << "group_name" << group_name << "operator" << oper.name
+                         << "is not in the deploy plan.";
             }
         }
         if (!is_in_group) {
-            Log.trace(m_stage_name, "operator", oper.name, "is not in ALL deploy plan.");
+            LogTrace << m_stage_name << "operator" << oper.name << "is not in ALL deploy plan.";
         }
     }
     std::sort(deploy_plan_list.begin(), deploy_plan_list.end());

--- a/src/MaaCore/Task/Roguelike/RoguelikeBattleTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/RoguelikeBattleTaskPlugin.h
@@ -40,6 +40,7 @@ protected:
     struct DeployPlanInfo
     {
         // int oper_priority;                         // 干员招募优先级
+        battle::Role role = battle::Role::Unknown;    // 干员职业
         std::string oper_name;                        // 干员名称
         int oper_order_in_group {};                   // 干员在干员组中排名
         int rank {};                                  // 干员组在部署指令扁平化后的排名
@@ -60,8 +61,7 @@ protected:
     std::optional<size_t> check_urgent(
         const std::unordered_set<std::string>& pre_cooling,
         const std::unordered_set<std::string>& cur_cooling,
-        const std::map<std::string, Point>& pre_battlefield);
-
+        const std::map<battle::OperNameTag, Point>& pre_battlefield);
     std::optional<battle::DeploymentOper> calc_best_oper() const;
 
     struct DeployInfo
@@ -163,7 +163,7 @@ protected:
     std::priority_queue<DroneTile> m_need_clear_tiles;
     std::unordered_map<std::string, std::vector<battle::roguelike::DeployInfoWithRank>> m_deploy_plan;
     std::vector<battle::roguelike::DeployInfoWithRank> m_retreat_plan;
-    std::unordered_map<std::string, std::chrono::steady_clock::time_point> m_deployed_time;
+    std::unordered_map<battle::OperNameTag, std::chrono::steady_clock::time_point> m_deployed_time;
 
     // 缓存干员精英
     std::unordered_map<std::string, int64_t> m_oper_elite;

--- a/src/MaaCore/Task/SSS/SSSBattleProcessTask.cpp
+++ b/src/MaaCore/Task/SSS/SSSBattleProcessTask.cpp
@@ -198,7 +198,7 @@ bool asst::SSSBattleProcessTask::check_and_do_strategy(const cv::Mat& reusable)
         else if (oper.is_usual_location && !m_all_action_opers.contains(oper.name)) {
             tool_men.emplace_back(oper);
             // 工具人的技能一概好了就用
-            m_skill_usage.try_emplace(oper.name, SkillUsage::Possibly);
+            m_skill_usage.try_emplace({ oper.role, oper.name }, SkillUsage::Possibly);
         }
     }
 
@@ -329,7 +329,10 @@ bool asst::SSSBattleProcessTask::check_if_start_over(const battle::copilot::Acti
 
     if (!action.name.empty() &&
         !std::ranges::any_of(m_cur_deployment_opers, [&](const auto& oper) { return oper.name == action.name; }) &&
-        !m_battlefield_opers.contains(action.name)) {
+        !std::ranges::any_of(m_battlefield_opers, [&](const auto& pair) {
+            return (action.role == battle::Role::Unknown || pair.first.role == action.role) &&
+                   pair.first.name == action.name;
+        })) {
         to_abandon = true;
     }
     else if (!action.role_counts.empty()) {

--- a/src/MaaCore/Utils/Algorithm.hpp
+++ b/src/MaaCore/Utils/Algorithm.hpp
@@ -21,9 +21,10 @@ enum class CharAllocationStatus
 struct CharAllocationResult
 {
     CharAllocationStatus status { CharAllocationStatus::NoSolution };
-    std::unordered_map<std::string, std::string> allocation;
+    std::unordered_map<battle::OperNameTag, battle::OperNameTag> allocation;
 
-    [[nodiscard]] static CharAllocationResult success(std::unordered_map<std::string, std::string>&& allocation_value)
+    [[nodiscard]] static CharAllocationResult
+        success(std::unordered_map<battle::OperNameTag, battle::OperNameTag>&& allocation_value)
     {
         return { CharAllocationStatus::Success, std::move(allocation_value) };
     }
@@ -58,11 +59,11 @@ struct CharAllocationResult
  *         其余状态表示求解过程中发生溢出或内部错误。
  */
 [[nodiscard]] inline static CharAllocationResult get_char_allocation_for_each_group(
-    const std::unordered_map<std::string, std::vector<std::string>>& group_list,
-    const std::unordered_set<std::string>& char_set)
+    const std::unordered_map<battle::OperNameTag, std::vector<battle::OperNameTag>>& group_list,
+    const std::unordered_set<battle::OperNameTag>& char_set)
 {
     if (group_list.empty()) {
-        return CharAllocationResult::success(std::unordered_map<std::string, std::string> {});
+        return CharAllocationResult::success(std::unordered_map<battle::OperNameTag, battle::OperNameTag> {});
     }
     if (char_set.empty()) {
         return CharAllocationResult::no_solution();
@@ -315,9 +316,9 @@ struct CharAllocationResult
 
     // 建立结点、组、干员与各自 id 的映射关系
     std::vector<CandidateNode> node_id_mapping;
-    std::vector<std::string> group_id_mapping;
-    std::vector<std::string> char_id_mapping;
-    std::unordered_map<std::string, size_t> char_name_mapping;
+    std::vector<battle::OperNameTag> group_id_mapping;
+    std::vector<battle::OperNameTag> char_id_mapping;
+    std::unordered_map<battle::OperNameTag, size_t> char_name_mapping;
 
     node_id_mapping.reserve(candidate_upper_bound);
     group_id_mapping.reserve(group_list.size());
@@ -329,7 +330,7 @@ struct CharAllocationResult
         group_id_mapping.emplace_back(group_name);
 
         bool has_candidate = false;
-        std::unordered_set<std::string> seen_candidates;
+        std::unordered_set<battle::OperNameTag> seen_candidates;
         seen_candidates.reserve(candidates.size());
 
         for (const auto& candidate_name : candidates) {
@@ -408,7 +409,7 @@ struct CharAllocationResult
         return CharAllocationResult::no_solution();
     }
 
-    std::unordered_map<std::string, std::string> return_value;
+    std::unordered_map<battle::OperNameTag, battle::OperNameTag> return_value;
     return_value.reserve(group_num);
 
     for (size_t i = 0; i < dancing_links_model.answer_stack_size; i++) {

--- a/src/MaaWpfGui/Models/Copilot/CopilotModel.cs
+++ b/src/MaaWpfGui/Models/Copilot/CopilotModel.cs
@@ -16,6 +16,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using MaaWpfGui.Constants;
+using MaaWpfGui.Constants.Enums;
 using MaaWpfGui.Helper;
 using Newtonsoft.Json;
 
@@ -132,7 +133,13 @@ public class CopilotModel : CopilotBase
     public class Oper
     {
         /// <summary>
-        /// Gets or sets 干员名，必选。
+        /// Gets or sets 职业名，可选
+        /// </summary>
+        [JsonProperty("role")]
+        public OperatorRole? Role { get; set; }
+
+        /// <summary>
+        /// Gets or sets 干员名，必选
         /// </summary>
         [JsonProperty("name")]
         public string Name { get; set; } = string.Empty;
@@ -225,6 +232,12 @@ public class CopilotModel : CopilotBase
         /// </summary>
         [JsonProperty("cooling")]
         public int Cooling { get; set; } = -1;
+
+        /// <summary>
+        /// Gets or sets 职业名，可选
+        /// </summary>
+        [JsonProperty("role")]
+        public OperatorRole? Role { get; set; }
 
         /// <summary>
         /// Gets or sets 干员名 或 群组名， type 为 "部署" 时必选，为 "技能" | "撤退" 时可选。


### PR DESCRIPTION
## Summary by Sourcery

为算子添加“角色感知”的标签，用于在自动战斗、Copilot、编队、SSS 和肉鸽流程中区分同名算子，同时在未指定角色时保持现有行为不变。

New Features:
- 支持在 Copilot 动作和算子定义中指定算子角色，以在自动战斗和肉鸽运行过程中对同名算子进行消歧。

Enhancements:
- 引入复合算子标签（角色 + 名字），并在战斗辅助工具、分组/分配逻辑、技能追踪以及肉鸽招募流程中进行传递，使算子状态和技能使用具备角色感知能力。
- 更新战斗编队、SSS 处理以及肉鸽部署逻辑，使用具备角色感知的算子标识和招募数据，同时在未提供角色时保持兼容性。
- 扩展数据模型和配置（战斗、Copilot、肉鸽），以在名字之外存储和解析算子角色。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add role-aware operator tagging to distinguish same-name operators across auto battle, copilot, formation, SSS, and roguelike flows while preserving existing behavior when role is unspecified.

New Features:
- Support specifying operator role in copilot actions and operator definitions to disambiguate same-name operators during automated battles and roguelike runs.

Enhancements:
- Introduce a composite operator tag (role + name) and propagate it through battle helpers, grouping/allocation logic, skill tracking, and roguelike recruitment so operator state and skill usage become role-aware.
- Update battle formation, SSS processing, and roguelike deployment logic to use role-aware operator identification and recruitment data, maintaining compatibility when role is not provided.
- Extend data models and configs (battle, copilot, roguelike) to store and parse operator roles alongside names.

</details>

新功能：
- 在副驾动作和编队中支持指定干员职业，以在自动战斗和肉鸽模式中区分同名干员。

增强项：
- 引入复合干员标签（职业 + 名字），并在战斗辅助、分组/分配算法以及肉鸽招募流程中传递该标签，使干员状态和技能使用能够感知其职业角色。
- 扩展战斗编队、SSS 和调试工具以支持基于职业感知的干员识别，同时在未指定职业时保持现有行为不变。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

为算子添加“角色感知”的标签，用于在自动战斗、Copilot、编队、SSS 和肉鸽流程中区分同名算子，同时在未指定角色时保持现有行为不变。

New Features:
- 支持在 Copilot 动作和算子定义中指定算子角色，以在自动战斗和肉鸽运行过程中对同名算子进行消歧。

Enhancements:
- 引入复合算子标签（角色 + 名字），并在战斗辅助工具、分组/分配逻辑、技能追踪以及肉鸽招募流程中进行传递，使算子状态和技能使用具备角色感知能力。
- 更新战斗编队、SSS 处理以及肉鸽部署逻辑，使用具备角色感知的算子标识和招募数据，同时在未提供角色时保持兼容性。
- 扩展数据模型和配置（战斗、Copilot、肉鸽），以在名字之外存储和解析算子角色。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add role-aware operator tagging to distinguish same-name operators across auto battle, copilot, formation, SSS, and roguelike flows while preserving existing behavior when role is unspecified.

New Features:
- Support specifying operator role in copilot actions and operator definitions to disambiguate same-name operators during automated battles and roguelike runs.

Enhancements:
- Introduce a composite operator tag (role + name) and propagate it through battle helpers, grouping/allocation logic, skill tracking, and roguelike recruitment so operator state and skill usage become role-aware.
- Update battle formation, SSS processing, and roguelike deployment logic to use role-aware operator identification and recruitment data, maintaining compatibility when role is not provided.
- Extend data models and configs (battle, copilot, roguelike) to store and parse operator roles alongside names.

</details>

</details>