### PR TITLE
fix: 修复 Win32IO 竞争条件导致的 am start 误判失败

### DIFF
--- a/src/MaaCore/Controller/Platform/Win32IO.cpp
+++ b/src/MaaCore/Controller/Platform/Win32IO.cpp
@@ -224,6 +224,11 @@ std::optional<int> asst::Win32IO::call_command(
                 if (process_running) {
                     TerminateProcess(process_info.hProcess, 0);
                 }
+                // 取消挂起的 pipe 读并同步等待取消完成，避免内核在 OVERLAPPED/缓冲区失效后写入
+                if (!pipe_eof && CancelIoEx(pipe_parent_read, &pipeov)) {
+                    DWORD cancelled_len = 0;
+                    GetOverlappedResult(pipe_parent_read, &pipeov, &cancelled_len, TRUE);
+                }
                 // 处理超时后返回 std::nullopt
                 CloseHandle(pipe_parent_read);
                 CloseHandle(pipeov.hEvent);
@@ -354,7 +359,11 @@ std::optional<int> asst::Win32IO::call_command(
     GetExitCodeProcess(process_info.hProcess, &exit_ret);
     CloseHandle(process_info.hProcess);
     CloseHandle(process_info.hThread);
-    CancelIoEx(pipe_parent_read, &pipeov);
+    // 取消挂起的 pipe 读并同步等待取消完成，避免内核在 OVERLAPPED/缓冲区失效后写入
+    if (!pipe_eof && CancelIoEx(pipe_parent_read, &pipeov)) {
+        DWORD cancelled_len = 0;
+        GetOverlappedResult(pipe_parent_read, &pipeov, &cancelled_len, TRUE);
+    }
     CloseHandle(pipe_parent_read);
     CloseHandle(pipeov.hEvent);
     return static_cast<int>(exit_ret);

--- a/src/MaaCore/Controller/Platform/Win32IO.cpp
+++ b/src/MaaCore/Controller/Platform/Win32IO.cpp
@@ -255,12 +255,21 @@ std::optional<int> asst::Win32IO::call_command(
             // pipe read
             DWORD len = 0;
             if (GetOverlappedResult(pipe_parent_read, &pipeov, &len, FALSE)) {
-                pipe_data.insert(pipe_data.end(), pipe_buffer.get(), pipe_buffer.get() + len);
-                arm_pipe_read();
+                if (len == 0) {
+                    pipe_eof = true;
+                }
+                else {
+                    pipe_data.insert(pipe_data.end(), pipe_buffer.get(), pipe_buffer.get() + len);
+                    arm_pipe_read();
+                }
             }
             else {
                 DWORD err = GetLastError();
-                if (err == ERROR_HANDLE_EOF || err == ERROR_BROKEN_PIPE) {
+                if (err == ERROR_HANDLE_EOF || err == ERROR_BROKEN_PIPE || err == ERROR_OPERATION_ABORTED) {
+                    pipe_eof = true;
+                }
+                else {
+                    Log.error(__FUNCTION__, "GetOverlappedResult failed", err);
                     pipe_eof = true;
                 }
             }
@@ -345,6 +354,7 @@ std::optional<int> asst::Win32IO::call_command(
     GetExitCodeProcess(process_info.hProcess, &exit_ret);
     CloseHandle(process_info.hProcess);
     CloseHandle(process_info.hThread);
+    CancelIoEx(pipe_parent_read, &pipeov);
     CloseHandle(pipe_parent_read);
     CloseHandle(pipeov.hEvent);
     return static_cast<int>(exit_ret);

--- a/src/MaaCore/Controller/Platform/Win32IO.cpp
+++ b/src/MaaCore/Controller/Platform/Win32IO.cpp
@@ -235,10 +235,16 @@ std::optional<int> asst::Win32IO::call_command(
                 CloseHandle(process_info.hProcess);
                 CloseHandle(process_info.hThread);
                 if (recv_by_socket) {
-                    CloseHandle(sockov.hEvent);
+                    if (accept_pending) {
+                        CancelIoEx(reinterpret_cast<HANDLE>(m_server_sock), &sockov);
+                    }
+                    else if (!socket_eof) {
+                        CancelIoEx(reinterpret_cast<HANDLE>(client_socket), &sockov);
+                    }
                     if (client_socket != INVALID_SOCKET) {
                         closesocket(client_socket);
                     }
+                    CloseHandle(sockov.hEvent);
                 }
                 return std::nullopt;
                 // break;

--- a/src/MaaCore/Controller/Platform/Win32IO.cpp
+++ b/src/MaaCore/Controller/Platform/Win32IO.cpp
@@ -116,7 +116,24 @@ std::optional<int> asst::Win32IO::call_command(
     bool socket_eof = false;
 
     OVERLAPPED pipeov { .hEvent = CreateEventW(nullptr, TRUE, FALSE, nullptr) };
-    (void)ReadFile(pipe_parent_read, pipe_buffer.get(), (DWORD)pipe_buffer.size(), nullptr, &pipeov);
+    // 与 PlatformWin32.cpp 的 arm_pipe_read 保持一致：ReadFile 可能同步完成或同步失败，
+    // 必须正确处理三种情况，否则 (void) 忽略返回值后 event 可能永远不会 signal。
+    auto arm_pipe_read = [&]() {
+        if (pipe_eof) {
+            return;
+        }
+        if (ReadFile(pipe_parent_read, pipe_buffer.get(), (DWORD)pipe_buffer.size(), nullptr, &pipeov)) {
+            // 同步完成：手动置位 event，走统一的 GetOverlappedResult 路径
+            SetEvent(pipeov.hEvent);
+            return;
+        }
+        DWORD err = GetLastError();
+        if (err != ERROR_IO_PENDING) {
+            // 典型场景：子进程已退出且写端关闭，ReadFile 同步返回 ERROR_BROKEN_PIPE
+            pipe_eof = true;
+        }
+    };
+    arm_pipe_read();
 
     OVERLAPPED sockov {};
     SOCKET client_socket = INVALID_SOCKET;
@@ -165,8 +182,16 @@ std::optional<int> asst::Win32IO::call_command(
         auto elapsed = steady_clock::now() - start_time;
         // TODO: 这里目前是隔 5000ms 判断一次，应该可以加一个 wait_handle 来判断外部中断（need_exit）
         auto wait_time = (std::min)(timeout - duration_cast<milliseconds>(elapsed).count(), 5LL * 1000);
-        if (wait_time < 0 || !process_running) {
+        if (wait_time < 0) {
             wait_time = 0;
+        }
+        // 子进程退出后不能再无限等 pipe：若末次 ReadFile 同步失败且 event 未置位，会卡死。
+        // 给一个短 drain 窗口把残余输出收完即可（对齐 PlatformWin32.cpp 的 kPostExitDrainMs）。
+        if (!process_running) {
+            constexpr int64_t kPostExitDrainMs = 1000;
+            if (wait_time > kPostExitDrainMs) {
+                wait_time = kPostExitDrainMs;
+            }
         }
         auto wait_result =
             WaitForMultipleObjectsEx((DWORD)wait_handles.size(), wait_handles.data(), FALSE, (DWORD)wait_time, TRUE);
@@ -175,6 +200,10 @@ std::optional<int> asst::Win32IO::call_command(
             signaled_object = wait_handles[(size_t)wait_result - WAIT_OBJECT_0];
         }
         else if (wait_result == WAIT_TIMEOUT) {
+            // 进程已退出后的 drain 超时：pipe 数据应已收完（或无法再收），正常返回 exit code
+            if (!process_running) {
+                break;
+            }
             if (wait_time == 0) {
                 std::vector<std::string> handle_string {};
                 for (auto handle : wait_handles) {
@@ -227,7 +256,7 @@ std::optional<int> asst::Win32IO::call_command(
             DWORD len = 0;
             if (GetOverlappedResult(pipe_parent_read, &pipeov, &len, FALSE)) {
                 pipe_data.insert(pipe_data.end(), pipe_buffer.get(), pipe_buffer.get() + len);
-                (void)ReadFile(pipe_parent_read, pipe_buffer.get(), (DWORD)pipe_buffer.size(), nullptr, &pipeov);
+                arm_pipe_read();
             }
             else {
                 DWORD err = GetLastError();


### PR DESCRIPTION
fix #17542

## Summary by Sourcery

修复 Win32IO 命令执行逻辑，以正确处理重叠管道读取和进程退出后的剩余数据清空，避免在启动进程时出现死锁以及错误地将情况判定为失败。

Bug 修复：
- 确保在 Win32 管道上的重叠 `ReadFile` 能正确处理同步完成、挂起 I/O 以及管道断开等情况，从而保证事件总能被触发或能够检测到 EOF。
- 在子进程退出后限制等待时间，并在清空输出超时时中断，防止在进程输出已清空的情况下调用一直无限期挂起。

增强：
- 使 Win32IO 管道读取与进程退出后的剩余数据清空行为与 `PlatformWin32.cpp` 保持一致，从而在各平台间实现更一致的进程 I/O 处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix Win32IO command execution to correctly handle overlapped pipe reads and post-exit drainage to avoid deadlocks and misdetecting failures when starting processes.

Bug Fixes:
- Ensure overlapped ReadFile on the Win32 pipe properly handles synchronous completion, pending I/O, and broken pipe cases so the event is always signaled or EOF is detected.
- Limit wait time after the child process exits and break on drain timeout so the call does not hang indefinitely once process output is drained.

Enhancements:
- Align Win32IO pipe read and post-exit drain behavior with PlatformWin32.cpp for more consistent process I/O handling across platforms.

</details>