### PR TITLE
fix: YostarJP TA SS OCR to VB

### DIFF
--- a/resource/global/YoStarJP/resource/tasks/Stages/TA.json
+++ b/resource/global/YoStarJP/resource/tasks/Stages/TA.json
@@ -1,7 +1,13 @@
 {
+    "TA-Open": {
+        "baseTask": "SS-Open",
+        "postDelay": 3000,
+        "template": ["StageSideStory.png", "StageActivity.png"],
+        "next": ["TAChapterToTA"]
+    },
     "TA-OpenOcr": {
         "ocrReplace": [["辞.*行", "辞歳行"]],
-        "text": ["辞歳行", "ステージ開放中", "望春拾遺", "望春", "拾遺", "待筆新編", "新編"]
+        "text": ["辞歳行", "望春拾遺", "望春", "拾遺", "待筆新編", "新編"]
     },
     "TAChapterToTA": {
         "text": ["霜秋写録", "霜秋", "秋写", "写録"]


### PR DESCRIPTION
怎么又把"ステージ開放中"放进去了

## Summary by Sourcery

Bug Fixes:
- 修正阶段任务的 OCR 配置，移除对「ステージ開放中」的非预期处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Correct stage task OCR configuration to remove unintended "ステージ開放中" handling.

</details>