### PR TITLE
fix: 倒计时/关闭模拟器/完成后脚本等非可打断期间阻止自动更新重启

### DIFF
--- a/src/MaaWpfGui/Services/HotKeys/MaaHotKeyActionHandler.cs
+++ b/src/MaaWpfGui/Services/HotKeys/MaaHotKeyActionHandler.cs
@@ -57,7 +57,7 @@ public class MaaHotKeyActionHandler : IMaaHotKeyActionHandler
             return;
         }
 
-        if (_runningState.GetIdle())
+        if (_runningState.CanInterrupt())
         {
             _ = Instances.TaskQueueViewModel.LinkStart();
 

--- a/src/MaaWpfGui/States/RunningState.cs
+++ b/src/MaaWpfGui/States/RunningState.cs
@@ -223,7 +223,7 @@ public class RunningState
     /// <summary>
     /// 是否空闲（仅反映任务运行状态）。
     /// 仅供 UI 绑定和按钮状态使用。需要判断"是否可以安全执行打断性操作"（如自动更新重启）时，
-    /// 应使用 <see cref="CanInterrupt"/>，它会额外排除倒计时等情况。
+    /// 应使用 <see cref="CanInterrupt"/>，它会额外排除中断锁定（结束后脚本、倒计时等）的情况。
     /// </summary>
     /// <returns>当前是否空闲。</returns>
     public bool GetIdle() => Idle;
@@ -234,51 +234,51 @@ public class RunningState
         Idle = idle;
     }
 
-    // 引用计数：CheckAfterCompleted 外层和 TimerCanceledAsync 内层各自 Enter/Leave，
-    // 只有当计数归零时才真正清除倒计时状态，避免嵌套 try-finally 提前清零的竞态。
-    private int _countingDownDepth;
+    // 引用计数：CheckAfterCompleted 外层和 TimerCanceledAsync 内层各自 Lock/Unlock，
+    // 只有当计数归零时才真正解除锁定，避免嵌套 try-finally 提前解锁的竞态。
+    private int _interruptLockDepth;
 
     /// <summary>
-    /// 进入倒计时状态（引用计数 +1）。
-    /// 倒计时（关机/休眠/启动自动运行等）期间，<see cref="CanInterrupt"/> 返回 false，
-    /// <see cref="UntilIdleAsync"/> 会持续等待。
+    /// 锁定中断（引用计数 +1）。
+    /// 锁定期间（关机/休眠倒计时、结束后脚本、退出游戏、杀模拟器等），
+    /// <see cref="CanInterrupt"/> 返回 false，<see cref="UntilIdleAsync"/> 会持续等待。
     /// </summary>
     /// <param name="caller">调用方名称。</param>
-    public void EnterCountingDown([CallerMemberName] string caller = "")
+    public void LockInterrupt([CallerMemberName] string caller = "")
     {
-        var newValue = Interlocked.Increment(ref _countingDownDepth);
-        _logger.Information("CountingDown enter: depth={Depth} (called from {Caller})", newValue, caller);
+        var newValue = Interlocked.Increment(ref _interruptLockDepth);
+        _logger.Information("InterruptLock: depth={Depth} (called from {Caller})", newValue, caller);
     }
 
     /// <summary>
-    /// 离开倒计时状态（引用计数 -1，不小于 0）。
+    /// 解除锁定（引用计数 -1，不小于 0）。
     /// </summary>
     /// <param name="caller">调用方名称。</param>
-    public void LeaveCountingDown([CallerMemberName] string caller = "")
+    public void UnlockInterrupt([CallerMemberName] string caller = "")
     {
-        var newValue = Interlocked.Decrement(ref _countingDownDepth);
+        var newValue = Interlocked.Decrement(ref _interruptLockDepth);
         if (newValue < 0)
         {
-            _logger.Warning("CountingDown leave: depth underflow, clamping to 0 (called from {Caller})", caller);
-            newValue = Interlocked.Exchange(ref _countingDownDepth, 0);
+            _logger.Warning("InterruptLock unlock: depth underflow, clamping to 0 (called from {Caller})", caller);
+            newValue = Interlocked.Exchange(ref _interruptLockDepth, 0);
         }
         else
         {
-            _logger.Information("CountingDown leave: depth={Depth} (called from {Caller})", newValue, caller);
+            _logger.Information("InterruptLock: depth={Depth} (called from {Caller})", newValue, caller);
         }
     }
 
     /// <summary>
-    /// 当前是否正处于倒计时状态。
+    /// 当前中断是否被锁定。
     /// </summary>
-    public bool GetCountingDown() => Volatile.Read(ref _countingDownDepth) > 0;
+    public bool IsInterruptLocked() => Volatile.Read(ref _interruptLockDepth) > 0;
 
     /// <summary>
-    /// 当前是否可以安全打断（空闲且没在倒计时）。
-    /// 倒计时（关机/休眠/启动自动运行等）期间不属于可安全打断的状态。
+    /// 当前是否可以安全打断（空闲且中断未锁定）。
+    /// 中断锁定期间（关机/休眠倒计时、结束后脚本、退出游戏、杀模拟器等）不属于可安全打断的状态。
     /// </summary>
-    /// <returns>空闲且没在倒计时返回 <see langword="true"/>，否则返回 <see langword="false"/>。</returns>
-    public bool CanInterrupt() => GetIdle() && !GetCountingDown();
+    /// <returns>空闲且中断未锁定返回 <see langword="true"/>，否则返回 <see langword="false"/>。</returns>
+    public bool CanInterrupt() => GetIdle() && !IsInterruptLocked();
 
     private bool _inited;
 

--- a/src/MaaWpfGui/States/RunningState.cs
+++ b/src/MaaWpfGui/States/RunningState.cs
@@ -14,6 +14,7 @@
 #nullable enable
 using System;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 using MaaWpfGui.Configuration.Factory;
 using MaaWpfGui.Constants;
@@ -219,6 +220,12 @@ public class RunningState
         }
     }
 
+    /// <summary>
+    /// 是否空闲（仅反映任务运行状态）。
+    /// 仅供 UI 绑定和按钮状态使用。需要判断"是否可以安全执行打断性操作"（如自动更新重启）时，
+    /// 应使用 <see cref="CanInterrupt"/>，它会额外排除倒计时等情况。
+    /// </summary>
+    /// <returns>当前是否空闲。</returns>
     public bool GetIdle() => Idle;
 
     public void SetIdle(bool idle, [CallerMemberName] string caller = "")
@@ -227,31 +234,51 @@ public class RunningState
         Idle = idle;
     }
 
-    private volatile bool _countingDown;
+    // 引用计数：CheckAfterCompleted 外层和 TimerCanceledAsync 内层各自 Enter/Leave，
+    // 只有当计数归零时才真正清除倒计时状态，避免嵌套 try-finally 提前清零的竞态。
+    private int _countingDownDepth;
 
     /// <summary>
-    /// 设置是否正在进行倒计时（关机/休眠/启动等）。
-    /// 倒计时期间不属于真正的空闲，UntilIdleAsync 会持续等待。
+    /// 进入倒计时状态（引用计数 +1）。
+    /// 倒计时（关机/休眠/启动自动运行等）期间，<see cref="CanInterrupt"/> 返回 false，
+    /// <see cref="UntilIdleAsync"/> 会持续等待。
     /// </summary>
-    /// <param name="value">是否正在倒计时</param>
-    /// <param name="caller">调用方名称</param>
-    public void SetCountingDown(bool value, [CallerMemberName] string caller = "")
+    /// <param name="caller">调用方名称。</param>
+    public void EnterCountingDown([CallerMemberName] string caller = "")
     {
-        if (_countingDown == value)
-        {
-            return;
-        }
-
-        _logger.Information("CountingDown: {Old} to {New} (called from {Caller})", _countingDown, value, caller);
-        _countingDown = value;
+        var newValue = Interlocked.Increment(ref _countingDownDepth);
+        _logger.Information("CountingDown enter: depth={Depth} (called from {Caller})", newValue, caller);
     }
 
     /// <summary>
-    /// 空闲且没在倒计时。
-    /// 倒计时（关机/休眠/启动自动运行等）期间不属于可安全操作的状态。
+    /// 离开倒计时状态（引用计数 -1，不小于 0）。
+    /// </summary>
+    /// <param name="caller">调用方名称。</param>
+    public void LeaveCountingDown([CallerMemberName] string caller = "")
+    {
+        var newValue = Interlocked.Decrement(ref _countingDownDepth);
+        if (newValue < 0)
+        {
+            _logger.Warning("CountingDown leave: depth underflow, clamping to 0 (called from {Caller})", caller);
+            newValue = Interlocked.Exchange(ref _countingDownDepth, 0);
+        }
+        else
+        {
+            _logger.Information("CountingDown leave: depth={Depth} (called from {Caller})", newValue, caller);
+        }
+    }
+
+    /// <summary>
+    /// 当前是否正处于倒计时状态。
+    /// </summary>
+    public bool GetCountingDown() => Volatile.Read(ref _countingDownDepth) > 0;
+
+    /// <summary>
+    /// 当前是否可以安全打断（空闲且没在倒计时）。
+    /// 倒计时（关机/休眠/启动自动运行等）期间不属于可安全打断的状态。
     /// </summary>
     /// <returns>空闲且没在倒计时返回 <see langword="true"/>，否则返回 <see langword="false"/>。</returns>
-    public bool GetIdleAndNotCountingDown() => _idle && !_countingDown;
+    public bool CanInterrupt() => GetIdle() && !GetCountingDown();
 
     private bool _inited;
 
@@ -317,7 +344,7 @@ public class RunningState
     {
         while (true)
         {
-            while (!GetIdleAndNotCountingDown())
+            while (!CanInterrupt())
             {
                 await Task.Delay(time);
             }
@@ -327,7 +354,7 @@ public class RunningState
             {
                 await Task.Delay(confirmInterval);
 
-                if (GetIdleAndNotCountingDown())
+                if (CanInterrupt())
                 {
                     confirmed++;
                 }

--- a/src/MaaWpfGui/States/RunningState.cs
+++ b/src/MaaWpfGui/States/RunningState.cs
@@ -227,6 +227,32 @@ public class RunningState
         Idle = idle;
     }
 
+    private volatile bool _countingDown;
+
+    /// <summary>
+    /// 设置是否正在进行倒计时（关机/休眠/启动等）。
+    /// 倒计时期间不属于真正的空闲，UntilIdleAsync 会持续等待。
+    /// </summary>
+    /// <param name="value">是否正在倒计时</param>
+    /// <param name="caller">调用方名称</param>
+    public void SetCountingDown(bool value, [CallerMemberName] string caller = "")
+    {
+        if (_countingDown == value)
+        {
+            return;
+        }
+
+        _logger.Information("CountingDown: {Old} to {New} (called from {Caller})", _countingDown, value, caller);
+        _countingDown = value;
+    }
+
+    /// <summary>
+    /// 空闲且没在倒计时。
+    /// 倒计时（关机/休眠/启动自动运行等）期间不属于可安全操作的状态。
+    /// </summary>
+    /// <returns>空闲且没在倒计时返回 <see langword="true"/>，否则返回 <see langword="false"/>。</returns>
+    public bool GetIdleAndNotCountingDown() => _idle && !_countingDown;
+
     private bool _inited;
 
     public bool Inited
@@ -291,7 +317,7 @@ public class RunningState
     {
         while (true)
         {
-            while (!GetIdle())
+            while (!GetIdleAndNotCountingDown())
             {
                 await Task.Delay(time);
             }
@@ -301,7 +327,7 @@ public class RunningState
             {
                 await Task.Delay(confirmInterval);
 
-                if (GetIdle())
+                if (GetIdleAndNotCountingDown())
                 {
                     confirmed++;
                 }

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -468,7 +468,7 @@ public class TaskQueueViewModel : Screen
     /// <returns>Task</returns>
     public async Task CheckAfterCompleted()
     {
-        RunningState.Instance.EnterCountingDown();
+        RunningState.Instance.LockInterrupt();
         try
         {
             await Task.Run(() => SettingsViewModel.GameSettings.RunScript("EndsWithScript"));
@@ -548,7 +548,7 @@ public class TaskQueueViewModel : Screen
         }
         finally
         {
-            RunningState.Instance.LeaveCountingDown();
+            RunningState.Instance.UnlockInterrupt();
         }
 
         return;
@@ -1023,7 +1023,7 @@ public class TaskQueueViewModel : Screen
         {
             var canceled = false;
             var delay = TimeSpan.FromSeconds(seconds);
-            RunningState.Instance.EnterCountingDown();
+            RunningState.Instance.LockInterrupt();
             try
             {
                 var dialogUserControl = new Views.Dialogs.TextWithTimerDialogView(
@@ -1046,7 +1046,7 @@ public class TaskQueueViewModel : Screen
             }
             finally
             {
-                RunningState.Instance.LeaveCountingDown();
+                RunningState.Instance.UnlockInterrupt();
             }
         }
     }

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -468,80 +468,89 @@ public class TaskQueueViewModel : Screen
     /// <returns>Task</returns>
     public async Task CheckAfterCompleted()
     {
-        await Task.Run(() => SettingsViewModel.GameSettings.RunScript("EndsWithScript"));
-        var actions = PostActionSetting;
-        _logger.Information("Post actions: " + actions.ActionDescription);
-
-        if (actions.BackToAndroidHome)
+        RunningState.Instance.EnterCountingDown();
+        try
         {
-            Instances.AsstProxy.AsstBackToHome();
-            await Task.Delay(1000);
-        }
+            await Task.Run(() => SettingsViewModel.GameSettings.RunScript("EndsWithScript"));
+            var actions = PostActionSetting;
+            _logger.Information("Post actions: " + actions.ActionDescription);
 
-        if (actions.ExitArknights)
-        {
-            var clientType = SettingsViewModel.GameSettings.ClientType;
-            if (!Instances.AsstProxy.AsstStartCloseDown(clientType))
+            if (actions.BackToAndroidHome)
             {
-                AddLog(LocalizationHelper.GetString("CloseArknightsFailed"), UiLogColor.Error);
+                Instances.AsstProxy.AsstBackToHome();
+                await Task.Delay(1000);
             }
 
-            await Task.Delay(1000);
-        }
+            if (actions.ExitArknights)
+            {
+                var clientType = SettingsViewModel.GameSettings.ClientType;
+                if (!Instances.AsstProxy.AsstStartCloseDown(clientType))
+                {
+                    AddLog(LocalizationHelper.GetString("CloseArknightsFailed"), UiLogColor.Error);
+                }
 
-        if (actions.ExitEmulator && !SettingsViewModel.ConnectSettings.IsPCConnectConfig)
-        {
-            DoKillEmulator();
-            await Task.Delay(1000);
-        }
+                await Task.Delay(1000);
+            }
 
-        if (actions.ExitSelf && !(actions.Hibernate || actions.Shutdown || actions.Sleep))
-        {
-            Bootstrapper.Shutdown();
-        }
+            if (actions.ExitEmulator && !SettingsViewModel.ConnectSettings.IsPCConnectConfig)
+            {
+                DoKillEmulator();
+                await Task.Delay(1000);
+            }
 
-        if (actions.Hibernate)
-        {
-            if (actions.IfNoOtherMaa && HasOtherMaa())
+            if (actions.ExitSelf && !(actions.Hibernate || actions.Shutdown || actions.Sleep))
             {
                 Bootstrapper.Shutdown();
             }
-            else
-            {
-                await DoHibernate();
-            }
-        }
 
-        if (actions.Shutdown)
-        {
-            if (actions.IfNoOtherMaa && HasOtherMaa())
+            if (actions.Hibernate)
+            {
+                if (actions.IfNoOtherMaa && HasOtherMaa())
+                {
+                    Bootstrapper.Shutdown();
+                }
+                else
+                {
+                    await DoHibernate();
+                }
+            }
+
+            if (actions.Shutdown)
+            {
+                if (actions.IfNoOtherMaa && HasOtherMaa())
+                {
+                    Bootstrapper.Shutdown();
+                }
+                else
+                {
+                    await DoShutDown();
+                }
+            }
+
+            if (actions.Sleep)
+            {
+                if (actions.IfNoOtherMaa && HasOtherMaa())
+                {
+                    Bootstrapper.Shutdown();
+                }
+                else
+                {
+                    await DoSleep();
+                }
+            }
+
+            if (actions.ExitSelf)
             {
                 Bootstrapper.Shutdown();
             }
-            else
-            {
-                await DoShutDown();
-            }
-        }
 
-        if (actions.Sleep)
+            actions.LoadPostActions();
+        }
+        finally
         {
-            if (actions.IfNoOtherMaa && HasOtherMaa())
-            {
-                Bootstrapper.Shutdown();
-            }
-            else
-            {
-                await DoSleep();
-            }
+            RunningState.Instance.LeaveCountingDown();
         }
 
-        if (actions.ExitSelf)
-        {
-            Bootstrapper.Shutdown();
-        }
-
-        actions.LoadPostActions();
         return;
 
         bool HasOtherMaa()
@@ -902,7 +911,7 @@ public class TaskQueueViewModel : Screen
 
     private async Task HandleTimerLogic(DateTime currentTime)
     {
-        if (!_runningState.GetIdle() && !SettingsViewModel.TimerSettings.ForceScheduledStart)
+        if (!_runningState.CanInterrupt() && !SettingsViewModel.TimerSettings.ForceScheduledStart)
         {
             return;
         }
@@ -1014,7 +1023,7 @@ public class TaskQueueViewModel : Screen
         {
             var canceled = false;
             var delay = TimeSpan.FromSeconds(seconds);
-            RunningState.Instance.SetCountingDown(true);
+            RunningState.Instance.EnterCountingDown();
             try
             {
                 var dialogUserControl = new Views.Dialogs.TextWithTimerDialogView(
@@ -1037,7 +1046,7 @@ public class TaskQueueViewModel : Screen
             }
             finally
             {
-                RunningState.Instance.SetCountingDown(false);
+                RunningState.Instance.LeaveCountingDown();
             }
         }
     }

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -1014,23 +1014,31 @@ public class TaskQueueViewModel : Screen
         {
             var canceled = false;
             var delay = TimeSpan.FromSeconds(seconds);
-            var dialogUserControl = new Views.Dialogs.TextWithTimerDialogView(
-                content,
-                tipContent,
-                buttonContent,
-                delay.TotalMilliseconds);
-            var dialog = HandyControl.Controls.Dialog.Show(dialogUserControl, nameof(Views.UI.RootView));
-            var tcs = new TaskCompletionSource<bool>();
-            dialogUserControl.Click += (_, _) => {
-                canceled = true;
+            RunningState.Instance.SetCountingDown(true);
+            try
+            {
+                var dialogUserControl = new Views.Dialogs.TextWithTimerDialogView(
+                    content,
+                    tipContent,
+                    buttonContent,
+                    delay.TotalMilliseconds);
+                var dialog = HandyControl.Controls.Dialog.Show(dialogUserControl, nameof(Views.UI.RootView));
+                var tcs = new TaskCompletionSource<bool>();
+                dialogUserControl.Click += (_, _) => {
+                    canceled = true;
+                    dialog.Close();
+                    tcs.TrySetResult(true);
+                };
+                _logger.Information("Timer wait time: {Seconds}", seconds);
+                await Task.WhenAny(Task.Delay(delay), tcs.Task);
                 dialog.Close();
-                tcs.TrySetResult(true);
-            };
-            _logger.Information("Timer wait time: {Seconds}", seconds);
-            await Task.WhenAny(Task.Delay(delay), tcs.Task);
-            dialog.Close();
-            _logger.Information("Timer canceled: {Canceled}", canceled);
-            return canceled;
+                _logger.Information("Timer canceled: {Canceled}", canceled);
+                return canceled;
+            }
+            finally
+            {
+                RunningState.Instance.SetCountingDown(false);
+            }
         }
     }
 


### PR DESCRIPTION
任务完成后关机/休眠倒计时、启动时自动运行倒计时等场景下，
RunningState.Idle 已为 true，但此时不应执行自动安装更新重启

## Summary by Sourcery

通过引入一个可感知中断的空闲状态，防止在后置完成脚本和倒计时期间执行自动更新重启以及其他可被中断的操作。

增强内容：
- 在 `RunningState` 中添加中断锁机制以及派生的“可中断空闲”检查，用于区分 UI 空闲状态与可安全中断的状态。
- 使用中断锁保护后置完成动作和倒计时对话框，确保只有在中断是安全的情况下，调度器和快捷键触发的启动才会发生。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent automatic update restart and other interruptible operations from running during post-completion scripts and countdown periods by introducing an interrupt-aware idle state.

Enhancements:
- Add an interrupt lock mechanism and a derived interruptible-idle check in RunningState to distinguish UI idle from safely-interruptible state.
- Guard post-completion actions and countdown dialogs with the interrupt lock so that scheduler and hotkey-triggered starts only occur when interruption is safe.

</details>

增强内容：
- 在 `RunningState` 中引入专用的倒计时状态，并确保在 `UntilIdleAsync` 中的空闲检查遵守此状态。
- 使用倒计时状态更新包装倒计时对话框的显示逻辑，以保持运行时状态一致，并记录倒计时状态转换。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过引入一个可感知中断的空闲状态，防止在后置完成脚本和倒计时期间执行自动更新重启以及其他可被中断的操作。

增强内容：
- 在 `RunningState` 中添加中断锁机制以及派生的“可中断空闲”检查，用于区分 UI 空闲状态与可安全中断的状态。
- 使用中断锁保护后置完成动作和倒计时对话框，确保只有在中断是安全的情况下，调度器和快捷键触发的启动才会发生。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Prevent automatic update restart and other interruptible operations from running during post-completion scripts and countdown periods by introducing an interrupt-aware idle state.

Enhancements:
- Add an interrupt lock mechanism and a derived interruptible-idle check in RunningState to distinguish UI idle from safely-interruptible state.
- Guard post-completion actions and countdown dialogs with the interrupt lock so that scheduler and hotkey-triggered starts only occur when interruption is safe.

</details>

</details>