### PR TITLE
feat: 拖入资源包更新资源版本

### DIFF
--- a/src/MaaWpfGui/Models/ResourceUpdater.cs
+++ b/src/MaaWpfGui/Models/ResourceUpdater.cs
@@ -16,6 +16,7 @@
 using System;
 using System.IO;
 using System.IO.Compression;
+using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using MaaWpfGui.Constants;
@@ -40,7 +41,10 @@ public static class ResourceUpdater
     {
         ToastNotification.ShowDirect(LocalizationHelper.GetString("GameResourceUpdating"));
 
-        if (!await DownloadFullPackageAsync(MaaUrls.GithubResourceUpdate, "MaaResourceGithub.zip", true).ConfigureAwait(false))
+        const string GithubZipFile = "MaaResourceGithub.zip";
+        const string ExtractFolder = "MaaResourceGithub";
+
+        if (!await DownloadFullPackageAsync(MaaUrls.GithubResourceUpdate, GithubZipFile, true).ConfigureAwait(false))
         {
             Fail();
             return false;
@@ -48,54 +52,13 @@ public static class ResourceUpdater
 
         OutputDownloadProgress(downloading: false, output: LocalizationHelper.GetString("GameResourceUpdatePreparing"));
 
-        const string GithubZipFile = "MaaResourceGithub.zip";
-        const string ExtractFolder = "MaaResourceGithub";
-
-        // 解压到 MaaResource 文件夹
-        try
+        if (!ExtractAndMergeResourcePackage(GithubZipFile, ExtractFolder))
         {
-            if (Directory.Exists(ExtractFolder))
-            {
-                Directory.Delete(ExtractFolder, true);
-            }
-
-            ZipFile.ExtractToDirectory(GithubZipFile, ExtractFolder);
-        }
-        catch (Exception e)
-        {
-            _logger.Error("Failed to extract MaaResourceGithub.zip: " + e.Message);
             Fail();
             return false;
         }
 
-        // 把 \MaaResource-main 中的 resource 文件夹复制到当前目录
-        try
-        {
-            string basePath = Path.Combine(ExtractFolder, "MaaResource-main");
-            foreach (var folder in new[] { "resource" })
-            {
-                DirectoryMerge(
-                    Path.Combine(basePath, folder),
-                    Path.Combine(PathsHelper.BaseDir, folder));
-            }
-        }
-        catch (Exception e)
-        {
-            _logger.Error("Failed to copy folders: " + e.Message);
-            Fail();
-            return false;
-        }
-
-        // 删除 MaaResource 文件夹 和 MaaResource.zip
-        try
-        {
-            Directory.Delete(ExtractFolder, true);
-            File.Delete(GithubZipFile);
-        }
-        catch (Exception e)
-        {
-            _logger.Error("Failed to delete MaaResource files: " + e.Message);
-        }
+        SafeDeleteFile(GithubZipFile);
 
         SettingsViewModel.VersionUpdateSettings.NewResourceFoundInfo = string.Empty;
         OutputDownloadProgress(
@@ -432,6 +395,260 @@ public static class ResourceUpdater
         SettingsViewModel.VersionUpdateSettings.ResourceInfoUpdate();
         ToastNotification.ShowDirect(LocalizationHelper.GetString("GameResourceUpdated"));
         _isReloading = false;
+    }
+
+    /// <summary>
+    /// 本地资源包导入结果。
+    /// </summary>
+    public enum LocalResourcePackageImportStatus
+    {
+        /// <summary>不是资源更新包。</summary>
+        NotResourcePackage,
+
+        /// <summary>资源版本低于或等于本地版本，已拒绝。</summary>
+        VersionTooOld,
+
+        /// <summary>导入成功。</summary>
+        Imported,
+
+        /// <summary>导入失败。</summary>
+        Failed,
+    }
+
+    /// <summary>
+    /// 检测压缩包是否为资源更新包（包含 resource/version.json），并尝试读取其版本时间戳。
+    /// </summary>
+    /// <param name="packagePath">压缩包路径。</param>
+    /// <param name="versionDateTime">包内资源版本时间戳（last_updated），无法读取则为 MinValue。</param>
+    /// <returns>包含 resource/version.json 则返回 true。</returns>
+    public static bool IsResourcePackage(string packagePath, out DateTimeOffset versionDateTime)
+    {
+        versionDateTime = DateTimeOffset.MinValue;
+        try
+        {
+            using var archive = ZipFile.OpenRead(packagePath);
+            // 只匹配根目录的 resource/version.json，排除 global/*/resource/version.json
+            var versionEntry = archive.Entries.FirstOrDefault(e =>
+                (e.FullName.Equals("resource/version.json", StringComparison.OrdinalIgnoreCase) ||
+                 e.FullName.EndsWith("/resource/version.json", StringComparison.OrdinalIgnoreCase)) &&
+                !e.FullName.Contains("/global/", StringComparison.OrdinalIgnoreCase));
+            if (versionEntry == null)
+            {
+                return false;
+            }
+
+            TryReadLastUpdated(versionEntry, out versionDateTime);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.Error(ex, "Failed to inspect zip for resource package detection: {PackagePath}", packagePath);
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// 导入本地资源更新包。校验版本（小于等于本地则拒绝）、解压合并到 resource 目录并重载。
+    /// </summary>
+    /// <param name="packagePath">压缩包路径。</param>
+    /// <returns>导入结果状态。</returns>
+    public static async Task<LocalResourcePackageImportStatus> ImportLocalResourcePackageAsync(string packagePath)
+    {
+        if (SettingsViewModel.VersionUpdateSettings.IsCheckingForUpdates)
+        {
+            return LocalResourcePackageImportStatus.Failed;
+        }
+
+        SettingsViewModel.VersionUpdateSettings.IsCheckingForUpdates = true;
+        try
+        {
+            var localDateTime = SettingsViewModel.VersionUpdateSettings.ResourceDateTime;
+
+            // 读取 zip 内的版本信息（后台线程，避免阻塞 UI）
+            var (isResource, packageDateTime) = await Task.Run(() =>
+            {
+                bool result = IsResourcePackage(packagePath, out var dt);
+                return (result, dt);
+            }).ConfigureAwait(false);
+
+            if (!isResource)
+            {
+                return LocalResourcePackageImportStatus.NotResourcePackage;
+            }
+
+            // 版本校验：包内版本小于等于本地版本则拒绝（不执行解压）
+            if (packageDateTime != DateTimeOffset.MinValue && packageDateTime <= localDateTime)
+            {
+                _logger.Information(
+                    "Resource package rejected: package version {PackageVersion} (UTC) / {PackageVersionLocal} (local) is not newer than local {LocalVersion} (UTC) / {LocalVersionLocal} (local)",
+                    packageDateTime,
+                    packageDateTime.ToLocalTime(),
+                    localDateTime,
+                    localDateTime.ToLocalTime());
+                ToastNotification.ShowDirect(LocalizationHelper.GetStringFormat(
+                    "LocalResourcePackageTooOld",
+                    packageDateTime.ToLocalTimeString(),
+                    localDateTime.ToLocalTimeString()));
+                return LocalResourcePackageImportStatus.VersionTooOld;
+            }
+
+            ToastNotification.ShowDirect(LocalizationHelper.GetString("GameResourceUpdating"));
+
+            // 解压 + 合并到本地 resource 目录（后台线程）
+            const string ExtractFolder = "MaaResourceImport";
+            bool extractSuccess = await Task.Run(() =>
+                ExtractAndMergeResourcePackage(packagePath, ExtractFolder)).ConfigureAwait(false);
+
+            if (!extractSuccess)
+            {
+                ToastNotification.ShowDirect(LocalizationHelper.GetString("GameResourceFailed"));
+                return LocalResourcePackageImportStatus.Failed;
+            }
+
+            SettingsViewModel.VersionUpdateSettings.NewResourceFoundInfo = string.Empty;
+
+            // 重载资源（内部会显示更新完成提示）
+            await ResourceReloadWhenIdleAsync();
+            return LocalResourcePackageImportStatus.Imported;
+        }
+        finally
+        {
+            SettingsViewModel.VersionUpdateSettings.IsCheckingForUpdates = false;
+        }
+    }
+
+    /// <summary>
+    /// 解压资源包并合并到本地 resource 目录（GitHub / MirrorChyan / 拖入导入共用）。
+    /// 支持 resource/ 在根目录或子目录（如 MaaResource-main/resource/）两种结构。
+    /// </summary>
+    /// <param name="zipPath">压缩包路径。</param>
+    /// <param name="extractFolder">临时解压目录。</param>
+    /// <returns>成功返回 true。</returns>
+    private static bool ExtractAndMergeResourcePackage(string zipPath, string extractFolder)
+    {
+        // 解压
+        try
+        {
+            if (Directory.Exists(extractFolder))
+            {
+                Directory.Delete(extractFolder, true);
+            }
+
+            ZipFile.ExtractToDirectory(zipPath, extractFolder);
+        }
+        catch (Exception e)
+        {
+            _logger.Error("Failed to extract resource package {ZipPath}: {Message}", zipPath, e.Message);
+            SafeDeleteDirectory(extractFolder);
+            return false;
+        }
+
+        // 查找 resource 目录（根目录 resource/ 或子目录 XXX/resource/）
+        string? resourceDir = FindResourceDirectory(extractFolder);
+        if (resourceDir == null)
+        {
+            _logger.Warning("No resource/ directory found in package: {ZipPath}", zipPath);
+            SafeDeleteDirectory(extractFolder);
+            return false;
+        }
+
+        // 合并到本地 resource 目录
+        try
+        {
+            DirectoryMerge(resourceDir, PathsHelper.ResourceDir);
+        }
+        catch (Exception e)
+        {
+            _logger.Error("Failed to merge resource package: {Message}", e.Message);
+            SafeDeleteDirectory(extractFolder);
+            return false;
+        }
+
+        SafeDeleteDirectory(extractFolder);
+        return true;
+    }
+
+    /// <summary>
+    /// 在解压目录中查找 resource 文件夹（支持根目录或一级子目录下的 resource/）。
+    /// </summary>
+    /// <param name="extractFolder">解压目录路径。</param>
+    /// <returns>resource 目录完整路径，未找到则返回 null。</returns>
+    private static string? FindResourceDirectory(string extractFolder)
+    {
+        // 先检查根目录下是否有 resource/
+        string directPath = Path.Combine(extractFolder, "resource");
+        if (Directory.Exists(directPath))
+        {
+            return directPath;
+        }
+
+        // 再检查子目录下（如 MaaResource-main/resource/）
+        string[] matches = Directory.GetDirectories(extractFolder, "resource", SearchOption.AllDirectories);
+        return matches.Length > 0 ? matches[0] : null;
+    }
+
+    /// <summary>
+    /// 从 zip entry 中读取 version.json 的 last_updated 时间戳。
+    /// </summary>
+    /// <param name="entry">version.json 的 zip entry。</param>
+    /// <param name="dateTime">解析出的时间戳。</param>
+    /// <returns>解析成功返回 true。</returns>
+    private static bool TryReadLastUpdated(ZipArchiveEntry entry, out DateTimeOffset dateTime)
+    {
+        dateTime = DateTimeOffset.MinValue;
+        try
+        {
+            using var stream = entry.Open();
+            using var reader = new StreamReader(stream);
+            var json = JsonConvert.DeserializeObject<JObject>(reader.ReadToEnd());
+            var lastUpdated = json?["last_updated"]?.ToString();
+            if (string.IsNullOrEmpty(lastUpdated))
+            {
+                return false;
+            }
+
+            dateTime = DateTimeOffset.ParseExact(
+                lastUpdated,
+                "yyyy-MM-dd HH:mm:ss.fff",
+                null,
+                System.Globalization.DateTimeStyles.AssumeUniversal);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.Error(ex, "Failed to parse resource version.json from zip entry: {Entry}", entry.FullName);
+            return false;
+        }
+    }
+
+    private static void SafeDeleteFile(string filePath)
+    {
+        try
+        {
+            if (File.Exists(filePath))
+            {
+                File.Delete(filePath);
+            }
+        }
+        catch (Exception e)
+        {
+            _logger.Error("Failed to delete {FilePath}: {Message}", filePath, e.Message);
+        }
+    }
+
+    private static void SafeDeleteDirectory(string dirPath)
+    {
+        try
+        {
+            if (Directory.Exists(dirPath))
+            {
+                Directory.Delete(dirPath, true);
+            }
+        }
+        catch (Exception e)
+        {
+            _logger.Error("Failed to cleanup directory {DirPath}: {Message}", dirPath, e.Message);
+        }
     }
 
     private static async Task<bool> DownloadFullPackageAsync(string url, string saveTo, bool globalSource)

--- a/src/MaaWpfGui/Models/ResourceUpdater.cs
+++ b/src/MaaWpfGui/Models/ResourceUpdater.cs
@@ -41,10 +41,11 @@ public static class ResourceUpdater
     {
         ToastNotification.ShowDirect(LocalizationHelper.GetString("GameResourceUpdating"));
 
-        const string GithubZipFile = "MaaResourceGithub.zip";
-        const string ExtractFolder = "MaaResourceGithub";
+        const string GithubZipFileName = "MaaResourceGithub.zip";
+        string githubZipFile = Path.Combine(PathsHelper.BaseDir, GithubZipFileName);
+        string extractFolder = Path.Combine(PathsHelper.BaseDir, "MaaResourceGithub");
 
-        if (!await DownloadFullPackageAsync(MaaUrls.GithubResourceUpdate, GithubZipFile, true).ConfigureAwait(false))
+        if (!await DownloadFullPackageAsync(MaaUrls.GithubResourceUpdate, githubZipFile, true).ConfigureAwait(false))
         {
             Fail();
             return false;
@@ -52,13 +53,13 @@ public static class ResourceUpdater
 
         OutputDownloadProgress(downloading: false, output: LocalizationHelper.GetString("GameResourceUpdatePreparing"));
 
-        if (!ExtractAndMergeResourcePackage(GithubZipFile, ExtractFolder))
+        if (!ExtractAndMergeResourcePackage(githubZipFile, extractFolder))
         {
             Fail();
             return false;
         }
 
-        SafeDeleteFile(GithubZipFile);
+        SafeDeleteFile(githubZipFile);
 
         SettingsViewModel.VersionUpdateSettings.NewResourceFoundInfo = string.Empty;
         OutputDownloadProgress(
@@ -416,15 +417,13 @@ public static class ResourceUpdater
     }
 
     /// <summary>
-    /// 检测压缩包是否为资源更新包（包含 resource/version.json），并尝试读取其版本时间戳。
-    /// </summary>
-    /// <remarks>
+    /// 检测压缩包是否为资源更新包，并尝试读取其版本时间戳。
     /// 只认 <c>MaaResource-main/resource/version.json</c> 这一层固定前缀结构，
     /// 避免误匹配完整包根目录的 <c>resource/version.json</c> 或 global 子目录中的同名文件。
-    /// </remarks>
+    /// </summary>
     /// <param name="packagePath">压缩包路径。</param>
     /// <param name="versionDateTime">包内资源版本时间戳（last_updated），无法读取则为 MinValue。</param>
-    /// <returns>包含 resource/version.json 则返回 true。</returns>
+    /// <returns>匹配 <c>MaaResource-main/resource/version.json</c> 则返回 true。</returns>
     public static bool IsResourcePackage(string packagePath, out DateTimeOffset versionDateTime)
     {
         versionDateTime = DateTimeOffset.MinValue;
@@ -452,11 +451,15 @@ public static class ResourceUpdater
     /// 导入本地资源更新包。校验版本（小于等于本地则拒绝）、解压合并到 resource 目录并重载。
     /// </summary>
     /// <param name="packagePath">压缩包路径。</param>
+    /// <param name="packageDateTime">由 <see cref="IsResourcePackage"/> 预检测得到的时间戳，避免重复扫描 zip。</param>
     /// <returns>导入结果状态。</returns>
-    public static async Task<LocalResourcePackageImportStatus> ImportLocalResourcePackageAsync(string packagePath)
+    public static async Task<LocalResourcePackageImportStatus> ImportLocalResourcePackageAsync(
+        string packagePath,
+        DateTimeOffset packageDateTime)
     {
         if (SettingsViewModel.VersionUpdateSettings.IsCheckingForUpdates)
         {
+            ToastNotification.ShowDirect(LocalizationHelper.GetString("GameResourceFailed"));
             return LocalResourcePackageImportStatus.Failed;
         }
 
@@ -464,18 +467,6 @@ public static class ResourceUpdater
         try
         {
             var localDateTime = SettingsViewModel.VersionUpdateSettings.ResourceDateTime;
-
-            // 读取 zip 内的版本信息（后台线程，避免阻塞 UI）
-            var (isResource, packageDateTime) = await Task.Run(() =>
-            {
-                bool result = IsResourcePackage(packagePath, out var dt);
-                return (result, dt);
-            }).ConfigureAwait(false);
-
-            if (!isResource)
-            {
-                return LocalResourcePackageImportStatus.NotResourcePackage;
-            }
 
             // 版本校验：包内版本小于等于本地版本则拒绝（不执行解压）
             if (packageDateTime != DateTimeOffset.MinValue && packageDateTime <= localDateTime)
@@ -496,9 +487,9 @@ public static class ResourceUpdater
             ToastNotification.ShowDirect(LocalizationHelper.GetString("GameResourceUpdating"));
 
             // 解压 + 合并到本地 resource 目录（后台线程）
-            const string ExtractFolder = "MaaResourceImport";
+            string extractFolder = Path.Combine(PathsHelper.BaseDir, "MaaResourceImport");
             bool extractSuccess = await Task.Run(() =>
-                ExtractAndMergeResourcePackage(packagePath, ExtractFolder)).ConfigureAwait(false);
+                ExtractAndMergeResourcePackage(packagePath, extractFolder)).ConfigureAwait(false);
 
             if (!extractSuccess)
             {
@@ -507,9 +498,6 @@ public static class ResourceUpdater
             }
 
             SettingsViewModel.VersionUpdateSettings.NewResourceFoundInfo = string.Empty;
-
-            // 重载资源（内部会显示更新完成提示）
-            await ResourceReloadWhenIdleAsync();
             return LocalResourcePackageImportStatus.Imported;
         }
         finally
@@ -519,11 +507,31 @@ public static class ResourceUpdater
     }
 
     /// <summary>
+    /// 导入本地资源更新包并重载资源。重载采用 fire-and-forget，避免长时间占用 <see cref="VersionUpdateSettings.IsCheckingForUpdates"/>。
+    /// </summary>
+    /// <param name="packagePath">压缩包路径。</param>
+    /// <param name="packageDateTime">由 <see cref="IsResourcePackage"/> 预检测得到的时间戳。</param>
+    /// <returns>导入结果状态（重载是否完成不包含在内）。</returns>
+    public static async Task<LocalResourcePackageImportStatus> ImportLocalResourcePackageAndReloadAsync(
+        string packagePath,
+        DateTimeOffset packageDateTime)
+    {
+        var status = await ImportLocalResourcePackageAsync(packagePath, packageDateTime).ConfigureAwait(false);
+        if (status == LocalResourcePackageImportStatus.Imported)
+        {
+            // 先释放 IsCheckingForUpdates，再异步重载（可能等待任务队列空闲，耗时较长）
+            _ = ResourceReloadWhenIdleAsync();
+        }
+
+        return status;
+    }
+
+    /// <summary>
     /// 解压资源包并合并到本地 resource 目录（GitHub / MirrorChyan / 拖入导入共用）。
-    /// 支持 resource/ 在根目录或子目录（如 MaaResource-main/resource/）两种结构。
+    /// 包内须含 <c>MaaResource-main/resource/</c> 目录。
     /// </summary>
     /// <param name="zipPath">压缩包路径。</param>
-    /// <param name="extractFolder">临时解压目录。</param>
+    /// <param name="extractFolder">临时解压目录（应为绝对路径）。</param>
     /// <returns>成功返回 true。</returns>
     private static bool ExtractAndMergeResourcePackage(string zipPath, string extractFolder)
     {
@@ -544,7 +552,7 @@ public static class ResourceUpdater
             return false;
         }
 
-        // 查找 resource 目录（根目录 resource/ 或子目录 XXX/resource/）
+        // 查找 resource 目录（固定 MaaResource-main/resource/）
         string? resourceDir = FindResourceDirectory(extractFolder);
         if (resourceDir == null)
         {

--- a/src/MaaWpfGui/Models/ResourceUpdater.cs
+++ b/src/MaaWpfGui/Models/ResourceUpdater.cs
@@ -16,6 +16,7 @@
 using System;
 using System.IO;
 using System.IO.Compression;
+using System.Globalization;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
@@ -422,8 +423,8 @@ public static class ResourceUpdater
     /// 避免误匹配完整包根目录的 <c>resource/version.json</c> 或 global 子目录中的同名文件。
     /// </summary>
     /// <param name="packagePath">压缩包路径。</param>
-    /// <param name="versionDateTime">包内资源版本时间戳（last_updated），无法读取则为 MinValue。</param>
-    /// <returns>匹配 <c>MaaResource-main/resource/version.json</c> 则返回 true。</returns>
+    /// <param name="versionDateTime">包内资源版本时间戳（last_updated）；无法读取则为 MinValue，且方法返回 false。</param>
+    /// <returns>匹配 <c>MaaResource-main/resource/version.json</c> 且能解析出版本时间戳则返回 true。</returns>
     public static bool IsResourcePackage(string packagePath, out DateTimeOffset versionDateTime)
     {
         versionDateTime = DateTimeOffset.MinValue;
@@ -437,8 +438,8 @@ public static class ResourceUpdater
                 return false;
             }
 
-            TryReadLastUpdated(versionEntry, out versionDateTime);
-            return true;
+            // 必须能解析出版本时间戳才算有效资源包，避免绕过版本校验
+            return TryReadLastUpdated(versionEntry, out versionDateTime);
         }
         catch (Exception ex)
         {
@@ -527,7 +528,7 @@ public static class ResourceUpdater
     }
 
     /// <summary>
-    /// 解压资源包并合并到本地 resource 目录（GitHub / 拖入导入共用）。
+    /// 解压资源包并合并到本地 resource 目录（GitHub 更新 / 拖入导入共用）。
     /// 包内须含 <c>MaaResource-main/resource/</c> 目录。
     /// </summary>
     /// <param name="zipPath">压缩包路径。</param>
@@ -547,7 +548,7 @@ public static class ResourceUpdater
         }
         catch (Exception e)
         {
-            _logger.Error("Failed to extract resource package {ZipPath}: {Message}", zipPath, e.Message);
+            _logger.Error(e, "Failed to extract resource package {ZipPath}", zipPath);
             SafeDeleteDirectory(extractFolder);
             return false;
         }
@@ -568,7 +569,7 @@ public static class ResourceUpdater
         }
         catch (Exception e)
         {
-            _logger.Error("Failed to merge resource package: {Message}", e.Message);
+            _logger.Error(e, "Failed to merge resource package from {ZipPath}", zipPath);
             SafeDeleteDirectory(extractFolder);
             return false;
         }
@@ -612,8 +613,8 @@ public static class ResourceUpdater
             dateTime = DateTimeOffset.ParseExact(
                 lastUpdated,
                 "yyyy-MM-dd HH:mm:ss.fff",
-                null,
-                System.Globalization.DateTimeStyles.AssumeUniversal);
+                CultureInfo.InvariantCulture,
+                DateTimeStyles.AssumeUniversal);
             return true;
         }
         catch (Exception ex)

--- a/src/MaaWpfGui/Models/ResourceUpdater.cs
+++ b/src/MaaWpfGui/Models/ResourceUpdater.cs
@@ -527,7 +527,7 @@ public static class ResourceUpdater
     }
 
     /// <summary>
-    /// 解压资源包并合并到本地 resource 目录（GitHub / MirrorChyan / 拖入导入共用）。
+    /// 解压资源包并合并到本地 resource 目录（GitHub / 拖入导入共用）。
     /// 包内须含 <c>MaaResource-main/resource/</c> 目录。
     /// </summary>
     /// <param name="zipPath">压缩包路径。</param>

--- a/src/MaaWpfGui/Models/ResourceUpdater.cs
+++ b/src/MaaWpfGui/Models/ResourceUpdater.cs
@@ -418,6 +418,10 @@ public static class ResourceUpdater
     /// <summary>
     /// 检测压缩包是否为资源更新包（包含 resource/version.json），并尝试读取其版本时间戳。
     /// </summary>
+    /// <remarks>
+    /// 只认 <c>MaaResource-main/resource/version.json</c> 这一层固定前缀结构，
+    /// 避免误匹配完整包根目录的 <c>resource/version.json</c> 或 global 子目录中的同名文件。
+    /// </remarks>
     /// <param name="packagePath">压缩包路径。</param>
     /// <param name="versionDateTime">包内资源版本时间戳（last_updated），无法读取则为 MinValue。</param>
     /// <returns>包含 resource/version.json 则返回 true。</returns>
@@ -427,11 +431,8 @@ public static class ResourceUpdater
         try
         {
             using var archive = ZipFile.OpenRead(packagePath);
-            // 只匹配根目录的 resource/version.json，排除 global/*/resource/version.json
             var versionEntry = archive.Entries.FirstOrDefault(e =>
-                (e.FullName.Equals("resource/version.json", StringComparison.OrdinalIgnoreCase) ||
-                 e.FullName.EndsWith("/resource/version.json", StringComparison.OrdinalIgnoreCase)) &&
-                !e.FullName.Contains("/global/", StringComparison.OrdinalIgnoreCase));
+                e.FullName.Equals("MaaResource-main/resource/version.json", StringComparison.OrdinalIgnoreCase));
             if (versionEntry == null)
             {
                 return false;
@@ -569,22 +570,15 @@ public static class ResourceUpdater
     }
 
     /// <summary>
-    /// 在解压目录中查找 resource 文件夹（支持根目录或一级子目录下的 resource/）。
+    /// 在解压目录中查找 resource 文件夹（<c>MaaResource-main/resource/</c>）。
     /// </summary>
     /// <param name="extractFolder">解压目录路径。</param>
     /// <returns>resource 目录完整路径，未找到则返回 null。</returns>
     private static string? FindResourceDirectory(string extractFolder)
     {
-        // 先检查根目录下是否有 resource/
-        string directPath = Path.Combine(extractFolder, "resource");
-        if (Directory.Exists(directPath))
-        {
-            return directPath;
-        }
-
-        // 再检查子目录下（如 MaaResource-main/resource/）
-        string[] matches = Directory.GetDirectories(extractFolder, "resource", SearchOption.AllDirectories);
-        return matches.Length > 0 ? matches[0] : null;
+        // 固定结构：MaaResource-main/resource/
+        string path = Path.Combine(extractFolder, "MaaResource-main", "resource");
+        return Directory.Exists(path) ? path : null;
     }
 
     /// <summary>

--- a/src/MaaWpfGui/Models/ResourceUpdater.cs
+++ b/src/MaaWpfGui/Models/ResourceUpdater.cs
@@ -392,11 +392,17 @@ public static class ResourceUpdater
         }
 
         _isReloading = true;
-        await Instances.AsstProxy.LoadResourceWhenIdleAsync();
-        DataHelper.Reload();
-        SettingsViewModel.VersionUpdateSettings.ResourceInfoUpdate();
-        ToastNotification.ShowDirect(LocalizationHelper.GetString("GameResourceUpdated"));
-        _isReloading = false;
+        try
+        {
+            await Instances.AsstProxy.LoadResourceWhenIdleAsync();
+            DataHelper.Reload();
+            SettingsViewModel.VersionUpdateSettings.ResourceInfoUpdate();
+            ToastNotification.ShowDirect(LocalizationHelper.GetString("GameResourceUpdated"));
+        }
+        finally
+        {
+            _isReloading = false;
+        }
     }
 
     /// <summary>
@@ -469,8 +475,8 @@ public static class ResourceUpdater
         {
             var localDateTime = SettingsViewModel.VersionUpdateSettings.ResourceDateTime;
 
-            // 版本校验：包内版本小于等于本地版本则拒绝（不执行解压）
-            if (packageDateTime != DateTimeOffset.MinValue && packageDateTime <= localDateTime)
+            // 版本校验：无效时间戳或包内版本小于等于本地版本则拒绝（不执行解压）
+            if (packageDateTime == DateTimeOffset.MinValue || packageDateTime <= localDateTime)
             {
                 _logger.Information(
                     "Resource package rejected: package version {PackageVersion} (UTC) / {PackageVersionLocal} (local) is not newer than local {LocalVersion} (UTC) / {LocalVersionLocal} (local)",

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -472,6 +472,7 @@ Continue only after you have verified the directory layout and finished a manual
     <system:String x:Key="LocalUpdatePackageImportedTitle">Local update package ready</system:String>
     <system:String x:Key="LocalUpdatePackageImportedDesc">A compatible local update package was detected. Update MAA now? (Restart required)</system:String>
     <system:String x:Key="LocalUpdatePackageUnsupported">Cannot recognize archive: {0}\nOnly full packages for the current architecture, or OTA packages from the current version to a newer version, can be imported.\nCurrent version: {1}\nCurrent architecture: {2}\nSupported filename examples: MAA-vTARGET_VERSION-win-{2}.zip\nor MAAComponent-OTA-{1}_vTARGET_VERSION-win-{2}.zip</system:String>
+    <system:String x:Key="LocalResourcePackageTooOld">Resource package version ({0}) is not newer than the current version ({1}). Import skipped.</system:String>
     <system:String x:Key="NewVersionFoundButNoPackageTitle">New version found, but no update package</system:String>
     <system:String x:Key="NewVersionFoundButNoPackageDesc">Please manually download the full package to update!</system:String>
     <system:String x:Key="ForceScheduledStart">Force scheduled start</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -472,6 +472,7 @@ D:\
     <system:String x:Key="LocalUpdatePackageImportedTitle">ローカル更新パッケージの準備ができました</system:String>
     <system:String x:Key="LocalUpdatePackageImportedDesc">利用可能なローカル更新パッケージを検出しました。今すぐ MAA を更新しますか？（プロセスを再起動します）</system:String>
     <system:String x:Key="LocalUpdatePackageUnsupported">圧縮ファイルを認識できません: {0}\n現在のアーキテクチャ向けのフルパッケージ、または現在のバージョンからより新しいバージョンへの OTA パッケージのみインポートできます。\n現在のバージョン: {1}\n現在のアーキテクチャ: {2}\n対応するファイル名の例: MAA-vTARGET_VERSION-win-{2}.zip\nまたは MAAComponent-OTA-{1}_vTARGET_VERSION-win-{2}.zip</system:String>
+    <system:String x:Key="LocalResourcePackageTooOld">リソースパッケージのバージョン（{0}）は現在のバージョン（{1}）と同じか古いため、インポートをスキップしました。</system:String>
     <system:String x:Key="NewVersionFoundButNoPackageTitle">新バージョンが見つかりましたが、アップデートパッケージがありません</system:String>
     <system:String x:Key="NewVersionFoundButNoPackageDesc">アップデートするには、手動でフルパッケージをダウンロードしてください！</system:String>
     <system:String x:Key="ForceScheduledStart">強制的なタイミングで起動</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -472,6 +472,7 @@ D:\
     <system:String x:Key="LocalUpdatePackageImportedTitle">로컬 업데이트 패키지가 준비되었습니다</system:String>
     <system:String x:Key="LocalUpdatePackageImportedDesc">사용 가능한 로컬 업데이트 패키지를 감지했습니다. 지금 MAA를 업데이트하시겠습니까? (프로세스 재시작)</system:String>
     <system:String x:Key="LocalUpdatePackageUnsupported">압축 파일을 인식할 수 없습니다: {0}\n현재 아키텍처용 전체 패키지 또는 현재 버전에서 더 높은 버전으로 가는 OTA 패키지만 가져올 수 있습니다.\n현재 버전: {1}\n현재 아키텍처: {2}\n지원되는 파일명 예시: MAA-vTARGET_VERSION-win-{2}.zip\n또는 MAAComponent-OTA-{1}_vTARGET_VERSION-win-{2}.zip</system:String>
+    <system:String x:Key="LocalResourcePackageTooOld">리소스 패키지 버전({0})이 현재 버전({1})보다 새롭지 않아 가져오기를 건너뛰었습니다.</system:String>
     <system:String x:Key="NewVersionFoundButNoPackageTitle">새로운 버전이 확인되지만 업데이트 패키지가 없음</system:String>
     <system:String x:Key="NewVersionFoundButNoPackageDesc">전체 패키지를 수동으로 다운로드해 업데이트해 주세요!</system:String>
     <system:String x:Key="ForceScheduledStart">강제 예약 시작</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -472,6 +472,7 @@ D:\
     <system:String x:Key="LocalUpdatePackageImportedTitle">本地更新包已就绪</system:String>
     <system:String x:Key="LocalUpdatePackageImportedDesc">检测到可用的本地更新包，是否立即更新 MAA？（重启进程）</system:String>
     <system:String x:Key="LocalUpdatePackageUnsupported">无法识别压缩包：{0}\n仅支持拖入当前架构的完整包，或当前版本到更高版本的 OTA 更新包。\n当前版本：{1}\n当前架构：{2}\n支持的包名示例：MAA-v新版本-win-{2}.zip\n或 MAAComponent-OTA-{1}_v新版本-win-{2}.zip</system:String>
+    <system:String x:Key="LocalResourcePackageTooOld">资源包版本（{0}）小于等于当前版本（{1}），已跳过导入。</system:String>
     <system:String x:Key="NewVersionFoundButNoPackageTitle">检测到新版本，但未找到增量包</system:String>
     <system:String x:Key="NewVersionFoundButNoPackageDesc">请手动下载完整包更新！</system:String>
     <system:String x:Key="ForceScheduledStart">强制定时启动</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -472,6 +472,7 @@ D:\
     <system:String x:Key="LocalUpdatePackageImportedTitle">本機更新包已就緒</system:String>
     <system:String x:Key="LocalUpdatePackageImportedDesc">偵測到可用的本機更新包，是否立即更新 MAA？（將重啟程式）</system:String>
     <system:String x:Key="LocalUpdatePackageUnsupported">無法識別壓縮檔：{0}\n僅支援拖入目前架構的完整包，或目前版本到更高版本的 OTA 更新包。\n目前版本：{1}\n目前架構：{2}\n支援的包名範例：MAA-v新版本-win-{2}.zip\n或 MAAComponent-OTA-{1}_v新版本-win-{2}.zip</system:String>
+    <system:String x:Key="LocalResourcePackageTooOld">資源包版本（{0}）小於等於目前版本（{1}），已跳過匯入。</system:String>
     <system:String x:Key="NewVersionFoundButNoPackageTitle">偵測到新版本，但未找到更新檔</system:String>
     <system:String x:Key="NewVersionFoundButNoPackageDesc">請手動下載完整檔案更新！</system:String>
     <system:String x:Key="ForceScheduledStart">強制定時啟動</system:String>

--- a/src/MaaWpfGui/Services/PendingUpdateApplier.cs
+++ b/src/MaaWpfGui/Services/PendingUpdateApplier.cs
@@ -128,11 +128,6 @@ internal static partial class PendingUpdateApplier
         return updateTag != string.Empty && updatePackageName != string.Empty && File.Exists(updatePackageName);
     }
 
-    public static LocalPackageImportResult TryRegisterLocalPackage(string packagePath, string currentVersion, string architecture)
-    {
-        return TryRegisterLocalPackage(packagePath, currentVersion, architecture, null);
-    }
-
     public static LocalPackageImportResult TryRegisterLocalPackage(
         string packagePath,
         string currentVersion,

--- a/src/MaaWpfGui/Services/PendingUpdateApplier.cs
+++ b/src/MaaWpfGui/Services/PendingUpdateApplier.cs
@@ -87,29 +87,38 @@ internal static partial class PendingUpdateApplier
         string? SourceVersion = null,
         string? TargetVersion = null);
 
-    public enum FullPackageInspectionStatus
+    public enum PackageInspectionStatus
     {
         /// <summary>文件不存在。</summary>
         MissingFile,
 
-        /// <summary>文件名不匹配完整包命名模式（也不是 OTA 包）。</summary>
+        /// <summary>文件名不匹配任何已知更新包模式（完整包 / OTA 包）。</summary>
         NotMatched,
 
-        /// <summary>文件名匹配完整包模式，但架构或版本升级方向不符合要求。</summary>
-        Rejected,
+        /// <summary>完整包：架构或版本升级方向不符合要求。</summary>
+        FullRejected,
 
-        /// <summary>文件名匹配且架构、版本方向均符合要求。</summary>
-        Supported,
+        /// <summary>完整包：架构、版本方向均符合要求。</summary>
+        FullSupported,
+
+        /// <summary>OTA 包：架构、源版本或版本升级方向不符合要求。</summary>
+        OtaRejected,
+
+        /// <summary>OTA 包：架构、源版本、版本方向均符合要求。</summary>
+        OtaSupported,
     }
 
-    public sealed record FullPackageInspectionResult(
-        FullPackageInspectionStatus Status,
+    public sealed record PackageInspectionResult(
+        PackageInspectionStatus Status,
+        string? SourceVersion = null,
         string? TargetVersion = null)
     {
-        public bool IsSupported => Status == FullPackageInspectionStatus.Supported;
+        public bool IsSupported =>
+            Status is PackageInspectionStatus.FullSupported or PackageInspectionStatus.OtaSupported;
 
+        /// <summary>是否匹配了任意一种版本更新包文件名模式（完整包或 OTA 包）。</summary>
         public bool MatchedPattern =>
-            Status == FullPackageInspectionStatus.Rejected || Status == FullPackageInspectionStatus.Supported;
+            Status is not (PackageInspectionStatus.MissingFile or PackageInspectionStatus.NotMatched);
     }
 
     public static bool HasPendingUpdatePackage()
@@ -128,33 +137,46 @@ internal static partial class PendingUpdateApplier
         string packagePath,
         string currentVersion,
         string architecture,
-        FullPackageInspectionResult? fullPackageInspection)
+        PackageInspectionResult? inspection)
     {
-        FullPackageInspectionResult inspection = fullPackageInspection ?? InspectSupportedLocalFullPackage(packagePath, currentVersion, architecture);
-        if (inspection.Status == FullPackageInspectionStatus.MissingFile)
-        {
-            _logger.Warning("Dropped update package does not exist: {PackagePath}", packagePath);
-            return new(LocalPackageImportStatus.Unsupported);
-        }
+        inspection ??= InspectLocalUpdatePackage(packagePath, currentVersion, architecture);
 
-        if (inspection.IsSupported)
+        switch (inspection.Status)
         {
-            return RegisterSupportedLocalFullPackage(packagePath, inspection.TargetVersion);
-        }
+            case PackageInspectionStatus.MissingFile:
+                _logger.Warning("Dropped update package does not exist: {PackagePath}", packagePath);
+                return new(LocalPackageImportStatus.Unsupported);
 
-        if (inspection.MatchedPattern)
-        {
-            return new(LocalPackageImportStatus.Unsupported, null, inspection.TargetVersion);
-        }
+            case PackageInspectionStatus.FullSupported:
+                return RegisterSupportedLocalFullPackage(packagePath, inspection.TargetVersion);
 
-        return TryRegisterNonFullLocalPackage(packagePath, currentVersion, architecture);
+            case PackageInspectionStatus.OtaSupported:
+                return RegisterSupportedLocalOtaPackage(packagePath, inspection.SourceVersion, inspection.TargetVersion);
+
+            // FullRejected / OtaRejected / NotMatched
+            default:
+                _logger.Warning(
+                    "Dropped package rejected or unrecognized: status={Status}, sourceVersion={SourceVersion}, targetVersion={TargetVersion}",
+                    inspection.Status,
+                    inspection.SourceVersion,
+                    inspection.TargetVersion);
+                return new(LocalPackageImportStatus.Unsupported, inspection.SourceVersion, inspection.TargetVersion);
+        }
     }
 
-    public static FullPackageInspectionResult InspectSupportedLocalFullPackage(string packagePath, string currentVersion, string architecture)
+    /// <summary>
+    /// 通过文件名检测拖入的压缩包是完整更新包还是 OTA 更新包，并校验架构与版本方向。
+    /// 两种正则都不匹配时返回 <see cref="PackageInspectionStatus.NotMatched"/>（可能是资源包或无关文件）。
+    /// </summary>
+    /// <param name="packagePath">拖入的压缩包路径。</param>
+    /// <param name="currentVersion">当前 MAA 版本号（如 v5.10.0）。</param>
+    /// <param name="architecture">当前系统架构（如 x64、arm64）。</param>
+    /// <returns>检测结果，包含状态、源版本（OTA）、目标版本。</returns>
+    public static PackageInspectionResult InspectLocalUpdatePackage(string packagePath, string currentVersion, string architecture)
     {
         if (!File.Exists(packagePath))
         {
-            return new(FullPackageInspectionStatus.MissingFile);
+            return new(PackageInspectionStatus.MissingFile);
         }
 
         string fullPackagePath = Path.GetFullPath(packagePath);
@@ -166,51 +188,33 @@ internal static partial class PendingUpdateApplier
             currentVersion,
             normalizedArchitecture);
 
+        // ① 完整包：MAA-vX.X.X-win-x64.zip
         Match fullPackageMatch = FullPackageNameRegex().Match(fileName);
-        if (!fullPackageMatch.Success)
+        if (fullPackageMatch.Success)
         {
-            return new(FullPackageInspectionStatus.NotMatched);
+            string targetVersion = fullPackageMatch.Groups["version"].Value;
+            string packageArchitecture = fullPackageMatch.Groups["arch"].Value;
+            bool architectureMatched = string.Equals(normalizedArchitecture, packageArchitecture, StringComparison.OrdinalIgnoreCase);
+            bool isUpgradeTarget = IsUpgradeTarget(currentVersion, targetVersion);
+
+            _logger.Information(
+                "Dropped package matched full package pattern: targetVersion={TargetVersion}, packageArchitecture={PackageArchitecture}",
+                targetVersion,
+                packageArchitecture);
+
+            if (!architectureMatched || !isUpgradeTarget)
+            {
+                _logger.Warning(
+                    "Dropped full package rejected: architectureMatched={ArchitectureMatched}, isUpgradeTarget={IsUpgradeTarget}",
+                    architectureMatched,
+                    isUpgradeTarget);
+                return new(PackageInspectionStatus.FullRejected, TargetVersion: targetVersion);
+            }
+
+            return new(PackageInspectionStatus.FullSupported, TargetVersion: targetVersion);
         }
 
-        string targetVersion = fullPackageMatch.Groups["version"].Value;
-        string packageArchitecture = fullPackageMatch.Groups["arch"].Value;
-        bool architectureMatched = string.Equals(normalizedArchitecture, packageArchitecture, StringComparison.OrdinalIgnoreCase);
-        bool isUpgradeTarget = IsUpgradeTarget(currentVersion, targetVersion);
-
-        _logger.Information(
-            "Dropped package matched full package pattern: targetVersion={TargetVersion}, packageArchitecture={PackageArchitecture}",
-            targetVersion,
-            packageArchitecture);
-
-        if (!architectureMatched || !isUpgradeTarget)
-        {
-            _logger.Warning(
-                "Dropped full package rejected: architectureMatched={ArchitectureMatched}, isUpgradeTarget={IsUpgradeTarget}",
-                architectureMatched,
-                isUpgradeTarget);
-            return new(FullPackageInspectionStatus.Rejected, targetVersion);
-        }
-
-        return new(FullPackageInspectionStatus.Supported, targetVersion);
-    }
-
-    private static LocalPackageImportResult RegisterSupportedLocalFullPackage(string packagePath, string? targetVersion)
-    {
-        string fullPackagePath = Path.GetFullPath(packagePath);
-        RegisterPendingUpdatePackage(targetVersion ?? string.Empty, fullPackagePath);
-        _logger.Information(
-            "Dropped full package registered successfully: packagePath={PackagePath}, targetVersion={TargetVersion}",
-            fullPackagePath,
-            targetVersion);
-        return new(LocalPackageImportStatus.FullPackageRegistered, null, targetVersion);
-    }
-
-    private static LocalPackageImportResult TryRegisterNonFullLocalPackage(string packagePath, string currentVersion, string architecture)
-    {
-        string fullPackagePath = Path.GetFullPath(packagePath);
-        string fileName = Path.GetFileName(fullPackagePath);
-        string normalizedArchitecture = NormalizeArchitecture(architecture);
-
+        // ② OTA 包：MAAComponent-OTA-vFROM_vTO-win-x64.zip
         Match otaMatch = OtaPackageNameRegex().Match(fileName);
         if (otaMatch.Success)
         {
@@ -235,19 +239,37 @@ internal static partial class PendingUpdateApplier
                     architectureMatched,
                     sourceVersionMatched,
                     isUpgradeTarget);
-                return new(LocalPackageImportStatus.Unsupported, sourceVersion, targetVersion);
+                return new(PackageInspectionStatus.OtaRejected, sourceVersion, targetVersion);
             }
 
-            RegisterPendingUpdatePackage(targetVersion, fullPackagePath);
-            _logger.Information(
-                "Dropped OTA package registered successfully: packagePath={PackagePath}, targetVersion={TargetVersion}",
-                fullPackagePath,
-                targetVersion);
-            return new(LocalPackageImportStatus.OtaPackageRegistered, sourceVersion, targetVersion);
+            return new(PackageInspectionStatus.OtaSupported, sourceVersion, targetVersion);
         }
 
-        _logger.Warning("Dropped package did not match any supported update package pattern: {PackageName}", fileName);
-        return new(LocalPackageImportStatus.Unsupported);
+        // ③ 都不匹配（资源包或无关文件），交给调用方决定后续处理
+        return new(PackageInspectionStatus.NotMatched);
+    }
+
+    private static LocalPackageImportResult RegisterSupportedLocalFullPackage(string packagePath, string? targetVersion)
+    {
+        string fullPackagePath = Path.GetFullPath(packagePath);
+        RegisterPendingUpdatePackage(targetVersion ?? string.Empty, fullPackagePath);
+        _logger.Information(
+            "Dropped full package registered successfully: packagePath={PackagePath}, targetVersion={TargetVersion}",
+            fullPackagePath,
+            targetVersion);
+        return new(LocalPackageImportStatus.FullPackageRegistered, null, targetVersion);
+    }
+
+    private static LocalPackageImportResult RegisterSupportedLocalOtaPackage(string packagePath, string? sourceVersion, string? targetVersion)
+    {
+        string fullPackagePath = Path.GetFullPath(packagePath);
+        RegisterPendingUpdatePackage(targetVersion ?? string.Empty, fullPackagePath);
+        _logger.Information(
+            "Dropped OTA package registered successfully: packagePath={PackagePath}, sourceVersion={SourceVersion}, targetVersion={TargetVersion}",
+            fullPackagePath,
+            sourceVersion,
+            targetVersion);
+        return new(LocalPackageImportStatus.OtaPackageRegistered, sourceVersion, targetVersion);
     }
 
     public static PendingUpdateApplyResult TryApplyPendingUpdatePackage()

--- a/src/MaaWpfGui/Services/PendingUpdateApplier.cs
+++ b/src/MaaWpfGui/Services/PendingUpdateApplier.cs
@@ -89,9 +89,16 @@ internal static partial class PendingUpdateApplier
 
     public enum FullPackageInspectionStatus
     {
+        /// <summary>文件不存在。</summary>
         MissingFile,
+
+        /// <summary>文件名不匹配完整包命名模式（也不是 OTA 包）。</summary>
         NotMatched,
+
+        /// <summary>文件名匹配完整包模式，但架构或版本升级方向不符合要求。</summary>
         Rejected,
+
+        /// <summary>文件名匹配且架构、版本方向均符合要求。</summary>
         Supported,
     }
 

--- a/src/MaaWpfGui/ViewModels/UI/RootViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/RootViewModel.cs
@@ -343,10 +343,10 @@ public class RootViewModel : Conductor<Screen>.Collection.OneActive
         // 不是版本更新包文件名模式时，尝试作为资源更新包导入（需读取 zip entry，开销较高）
         if (!packageInspection.MatchedPattern)
         {
-            if (ResourceUpdater.IsResourcePackage(packagePath, out _))
+            if (ResourceUpdater.IsResourcePackage(packagePath, out var resourceDateTime))
             {
                 _logger.Information("Dropped package detected as resource package: {PackagePath}", packagePath);
-                _ = ResourceUpdater.ImportLocalResourcePackageAsync(packagePath);
+                _ = ResourceUpdater.ImportLocalResourcePackageAndReloadAsync(packagePath, resourceDateTime);
                 return;
             }
 

--- a/src/MaaWpfGui/ViewModels/UI/RootViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/RootViewModel.cs
@@ -25,6 +25,7 @@ using HandyControl.Data;
 using HandyControl.Tools;
 using JetBrains.Annotations;
 using MaaWpfGui.Configuration.Factory;
+using MaaWpfGui.Extensions;
 using MaaWpfGui.Helper;
 using MaaWpfGui.Main;
 using MaaWpfGui.Models;
@@ -327,11 +328,20 @@ public class RootViewModel : Conductor<Screen>.Collection.OneActive
             ? "arm64"
             : "x64";
 
-        PendingUpdateApplier.FullPackageInspectionResult fullPackageInspection =
-            PendingUpdateApplier.InspectSupportedLocalFullPackage(packagePath, currentVersion, architecture);
+        PendingUpdateApplier.PackageInspectionResult packageInspection =
+            PendingUpdateApplier.InspectLocalUpdatePackage(packagePath, currentVersion, architecture);
+
+#if DEBUG
+        // Debug 专用：Ctrl+Shift 拖入时只做检测判断，不实际注册，用于快速验证正则匹配
+        if (Keyboard.Modifiers == (ModifierKeys.Control | ModifierKeys.Shift))
+        {
+            DebugInspectDroppedPackage(packagePath, packageInspection, currentVersion, normalizedArchitecture);
+            return;
+        }
+#endif
 
         // 不是版本更新包文件名模式时，尝试作为资源更新包导入（需读取 zip entry，开销较高）
-        if (!fullPackageInspection.MatchedPattern)
+        if (!packageInspection.MatchedPattern)
         {
             if (ResourceUpdater.IsResourcePackage(packagePath, out _))
             {
@@ -345,14 +355,15 @@ public class RootViewModel : Conductor<Screen>.Collection.OneActive
         }
 
         // 版本更新包模式匹配，但架构或版本方向被拒
-        if (!fullPackageInspection.IsSupported)
+        if (!packageInspection.IsSupported)
         {
             ShowUnsupportedPackageWarning(packagePath, currentVersion, normalizedArchitecture);
             return;
         }
 
-        // 完整包：用户二次确认
-        if (!Dialogs.VersionUpdateDialogViewModel.ConfirmFullPackageUpdate(packagePath))
+        // 完整包覆盖安装需用户二次确认（OTA 增量包不需要）
+        if (packageInspection.Status == PendingUpdateApplier.PackageInspectionStatus.FullSupported
+            && !Dialogs.VersionUpdateDialogViewModel.ConfirmFullPackageUpdate(packagePath))
         {
             _logger.Information("Dropped full package import canceled by user before registration: {PackagePath}", packagePath);
             return;
@@ -362,7 +373,7 @@ public class RootViewModel : Conductor<Screen>.Collection.OneActive
             packagePath,
             currentVersion,
             architecture,
-            fullPackageInspection);
+            packageInspection);
         _logger.Information(
             "Dropped zip import result: status={Status}, sourceVersion={SourceVersion}, targetVersion={TargetVersion}",
             importResult.Status,
@@ -403,6 +414,56 @@ public class RootViewModel : Conductor<Screen>.Collection.OneActive
             MessageBoxImage.Warning,
             ok: LocalizationHelper.GetString("Ok"));
     }
+
+#if DEBUG
+    /// <summary>
+    /// Debug 专用：展示拖入包的检测结果（状态、版本、架构），不执行注册或解压。
+    /// 触发方式：按住 Ctrl+Shift 拖入 zip。
+    /// </summary>
+    private static void DebugInspectDroppedPackage(
+        string packagePath,
+        PendingUpdateApplier.PackageInspectionResult inspection,
+        string currentVersion,
+        string normalizedArchitecture)
+    {
+        bool isResource = ResourceUpdater.IsResourcePackage(packagePath, out var resourceDateTime);
+
+        string detail = string.Format(
+            """
+            [DebugInspectDroppedPackage] 仅检测，不注册
+
+            文件: {0}
+            当前版本: {1}
+            当前架构: {2}
+
+            检测状态: {3}
+            MatchedPattern: {4}
+            IsSupported: {5}
+            SourceVersion: {6}
+            TargetVersion: {7}
+
+            是资源包: {8}
+            资源包版本: {9}
+            """,
+            Path.GetFileName(packagePath),
+            currentVersion,
+            normalizedArchitecture,
+            inspection.Status,
+            inspection.MatchedPattern,
+            inspection.IsSupported,
+            inspection.SourceVersion ?? "(null)",
+            inspection.TargetVersion ?? "(null)",
+            isResource,
+            isResource ? resourceDateTime.ToLocalTimeString() : "—");
+
+        _logger.Information("DebugInspectDroppedPackage:\n{Detail}", detail);
+        MessageBoxHelper.Show(
+            detail,
+            "DebugInspectDroppedPackage",
+            MessageBoxButton.OK,
+            MessageBoxImage.Information);
+    }
+#endif
 
     public string GifPath
     {

--- a/src/MaaWpfGui/ViewModels/UI/RootViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/RootViewModel.cs
@@ -27,11 +27,13 @@ using JetBrains.Annotations;
 using MaaWpfGui.Configuration.Factory;
 using MaaWpfGui.Helper;
 using MaaWpfGui.Main;
+using MaaWpfGui.Models;
 using MaaWpfGui.Services;
 using MaaWpfGui.ViewModels.UserControl.Settings;
 using Microsoft.WindowsAPICodePack.Taskbar;
 using Serilog;
 using Stylet;
+using Point = System.Windows.Point;
 
 namespace MaaWpfGui.ViewModels.UI;
 
@@ -328,8 +330,29 @@ public class RootViewModel : Conductor<Screen>.Collection.OneActive
         PendingUpdateApplier.FullPackageInspectionResult fullPackageInspection =
             PendingUpdateApplier.InspectSupportedLocalFullPackage(packagePath, currentVersion, architecture);
 
-        if (fullPackageInspection.IsSupported
-            && !Dialogs.VersionUpdateDialogViewModel.ConfirmFullPackageUpdate(packagePath))
+        // 不是版本更新包文件名模式时，尝试作为资源更新包导入（需读取 zip entry，开销较高）
+        if (!fullPackageInspection.MatchedPattern)
+        {
+            if (ResourceUpdater.IsResourcePackage(packagePath, out _))
+            {
+                _logger.Information("Dropped package detected as resource package: {PackagePath}", packagePath);
+                _ = ResourceUpdater.ImportLocalResourcePackageAsync(packagePath);
+                return;
+            }
+
+            ShowUnsupportedPackageWarning(packagePath, currentVersion, normalizedArchitecture);
+            return;
+        }
+
+        // 版本更新包模式匹配，但架构或版本方向被拒
+        if (!fullPackageInspection.IsSupported)
+        {
+            ShowUnsupportedPackageWarning(packagePath, currentVersion, normalizedArchitecture);
+            return;
+        }
+
+        // 完整包：用户二次确认
+        if (!Dialogs.VersionUpdateDialogViewModel.ConfirmFullPackageUpdate(packagePath))
         {
             _logger.Information("Dropped full package import canceled by user before registration: {PackagePath}", packagePath);
             return;
@@ -346,36 +369,39 @@ public class RootViewModel : Conductor<Screen>.Collection.OneActive
             importResult.SourceVersion,
             importResult.TargetVersion);
 
-        switch (importResult.Status)
+        if (importResult.Status
+            is PendingUpdateApplier.LocalPackageImportStatus.OtaPackageRegistered
+            or PendingUpdateApplier.LocalPackageImportStatus.FullPackageRegistered)
         {
-            case PendingUpdateApplier.LocalPackageImportStatus.OtaPackageRegistered:
-            case PendingUpdateApplier.LocalPackageImportStatus.FullPackageRegistered:
-                string targetVersion = importResult.TargetVersion ?? string.Empty;
-                bool preserveExistingUpdateInfo = PendingUpdateApplier.ShouldPreserveExistingUpdateBody(targetVersion);
-                Instances.VersionUpdateDialogViewModel.UpdateTag = targetVersion;
-                if (!preserveExistingUpdateInfo)
-                {
-                    Instances.VersionUpdateDialogViewModel.UpdateInfo = string.Empty;
-                }
+            string targetVersion = importResult.TargetVersion ?? string.Empty;
+            bool preserveExistingUpdateInfo = PendingUpdateApplier.ShouldPreserveExistingUpdateBody(targetVersion);
+            Instances.VersionUpdateDialogViewModel.UpdateTag = targetVersion;
+            if (!preserveExistingUpdateInfo)
+            {
+                Instances.VersionUpdateDialogViewModel.UpdateInfo = string.Empty;
+            }
 
-                Instances.VersionUpdateDialogViewModel.UpdatePackageName = packagePath;
-                _logger.Information(
-                    "Showing restart prompt for imported update package: {PackagePath}, status={Status}",
-                    packagePath,
-                    importResult.Status);
-                _ = Instances.VersionUpdateDialogViewModel.AskToRestartForImportedPackage();
-                return;
-
-            default:
-                _logger.Warning("Showing unsupported package warning for dropped package: {PackagePath}", packagePath);
-                MessageBoxHelper.Show(
-                    LocalizationHelper.GetStringFormat("LocalUpdatePackageUnsupported", Path.GetFileName(packagePath), currentVersion, normalizedArchitecture),
-                    LocalizationHelper.GetString("Warning"),
-                    MessageBoxButton.OK,
-                    MessageBoxImage.Warning,
-                    ok: LocalizationHelper.GetString("Ok"));
-                return;
+            Instances.VersionUpdateDialogViewModel.UpdatePackageName = packagePath;
+            _logger.Information(
+                "Showing restart prompt for imported update package: {PackagePath}, status={Status}",
+                packagePath,
+                importResult.Status);
+            _ = Instances.VersionUpdateDialogViewModel.AskToRestartForImportedPackage();
+            return;
         }
+
+        ShowUnsupportedPackageWarning(packagePath, currentVersion, normalizedArchitecture);
+    }
+
+    private static void ShowUnsupportedPackageWarning(string packagePath, string currentVersion, string normalizedArchitecture)
+    {
+        _logger.Warning("Showing unsupported package warning for dropped package: {PackagePath}", packagePath);
+        MessageBoxHelper.Show(
+            LocalizationHelper.GetStringFormat("LocalUpdatePackageUnsupported", Path.GetFileName(packagePath), currentVersion, normalizedArchitecture),
+            LocalizationHelper.GetString("Warning"),
+            MessageBoxButton.OK,
+            MessageBoxImage.Warning,
+            ok: LocalizationHelper.GetString("Ok"));
     }
 
     public string GifPath


### PR DESCRIPTION
## Summary by Sourcery

支持通过拖拽导入资源更新包，与现有的版本更新包并行使用，实现统一的包检查流程以及更安全的资源解压/合并处理。

新特性：
- 新增本地资源更新 ZIP 包的检测与导入流程，包括版本校验以及可选的资源重新加载。
- 当拖拽的 ZIP 文件不符合版本更新命名模式时，允许将其视为资源更新包处理。
- 引入仅用于调试的拖拽检查模式，用于展示详细的包检测结果，而不进行注册或应用更新。

改进：
- 将资源包的解压和合并逻辑重构为共享的辅助方法，并在清理临时文件和目录时更安全。
- 统一本地更新包检查流程，用于区分完整包与 OTA 包，并在匹配、拒绝和支持的情况下提供更丰富的状态报告。
- 改进针对拖拽的更新/资源包的日志和用户提示信息，包括在包被拒绝或不受支持时给出更明确的原因说明。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Support importing resource update packages via drag-and-drop alongside existing version update packages, with unified package inspection and safer resource extraction/merge handling.

New Features:
- Add detection and import flow for local resource update zip packages, including version validation and optional resource reload.
- Allow drag-and-dropped zip files to be treated as resource update packages when they do not match version update naming patterns.
- Introduce a debug-only drag-and-drop inspection mode to show detailed package detection results without registering or applying updates.

Enhancements:
- Refactor resource package extraction and merging into shared helper methods with safer cleanup of temporary files and directories.
- Unify local update package inspection to distinguish full packages from OTA packages, with richer status reporting for matched, rejected, and supported cases.
- Improve logging and user messaging around dropped update/resource packages, including clearer reasons when packages are rejected or unsupported.

</details>
