### PR TITLE
feat(wpf): 为 CustomWebhook 预置模板新增 KOOK 频道与私聊选项

### DIFF
--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -86,7 +86,7 @@
     <system:String x:Key="ExternalNotificationCustomWebhook.Body">Message body template</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.Placeholders">Placeholders: {title}, {content}, {time}</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.Presets">Preset Template</system:String>
-    <system:String x:Key="ExternalNotificationCustomWebhook.PresetsPlaceholders">Please replace placeholders wrapped in {} other than {title}, {content}, {time} (e.g. {nickname}) with actual values</system:String>
+    <system:String x:Key="ExternalNotificationCustomWebhook.PresetsPlaceholders">Please replace the &lt;&gt; placeholders in the preset template (e.g. &lt;nickname&gt;) with actual values</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.TemplateCustom">Custom</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.TemplateMeoW">MeoW</system:String>
     <system:String x:Key="UseGpuForInference">Use GPU for inference acceleration</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -86,7 +86,7 @@
     <system:String x:Key="ExternalNotificationCustomWebhook.Body">メッセージ本文</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.Placeholders">プレホルダー: {title}、{content}、{time}</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.Presets">プリセットテンプレート</system:String>
-    <system:String x:Key="ExternalNotificationCustomWebhook.PresetsPlaceholders">{title}、{content}、{time} 以外の {} で囲まれたプレースホルダー（例：{nickname}）を実際の値に置き換えてください</system:String>
+    <system:String x:Key="ExternalNotificationCustomWebhook.PresetsPlaceholders">プリセットテンプレートの &lt;&gt; プレースホルダー（例：&lt;nickname&gt;）を実際の値に置き換えてください</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.TemplateCustom">カスタム</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.TemplateMeoW">MeoW</system:String>
     <system:String x:Key="UseGpuForInference">推論加速のためにGPUを使用する</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -86,7 +86,7 @@
     <system:String x:Key="ExternalNotificationCustomWebhook.Body">메시지 본문 템플릿</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.Placeholders">플레이스홀더: {title}, {content}, {time}</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.Presets">사전 설정 템플릿</system:String>
-    <system:String x:Key="ExternalNotificationCustomWebhook.PresetsPlaceholders">{title}, {content}, {time} 외에 {}로 감싸진 플레이스홀더(예: {nickname})를 실제 값으로 바꿔주세요</system:String>
+    <system:String x:Key="ExternalNotificationCustomWebhook.PresetsPlaceholders">사전 설정 템플릿의 &lt;&gt; 플레이스홀더(예: &lt;nickname&gt;)를 실제 값으로 바꿔주세요</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.TemplateCustom">사용자 정의</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.TemplateMeoW">MeoW</system:String>
     <system:String x:Key="UseGpuForInference">추론 가속화를 위해 GPU 사용</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -86,7 +86,7 @@
     <system:String x:Key="ExternalNotificationCustomWebhook.Body">消息体模板</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.Placeholders">可用占位符：{title}、{content}、{time}</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.Presets">预置模板</system:String>
-    <system:String x:Key="ExternalNotificationCustomWebhook.PresetsPlaceholders">请将预置模板中除 {title}、{content}、{time} 以外的 {} 占位符（如 {nickname}）替换为实际值</system:String>
+    <system:String x:Key="ExternalNotificationCustomWebhook.PresetsPlaceholders">请将预制模板中的 &lt;&gt; 占位符（如 &lt;nickname&gt;）替换为实际值</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.TemplateCustom">自定义</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.TemplateMeoW">MeoW</system:String>
     <system:String x:Key="UseGpuForInference">使用 GPU 加速推理</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -86,7 +86,7 @@
     <system:String x:Key="ExternalNotificationCustomWebhook.Body">訊息本文範本</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.Placeholders">可用佔位符：{title}、{content}、{time}</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.Presets">預製模板</system:String>
-    <system:String x:Key="ExternalNotificationCustomWebhook.PresetsPlaceholders">請將預製模板中除 {title}、{content}、{time} 以外的 {} 佔位符（如 {nickname}）替換為實際值</system:String>
+    <system:String x:Key="ExternalNotificationCustomWebhook.PresetsPlaceholders">請將預製模板中的 &lt;&gt; 佔位符（如 &lt;nickname&gt;）替換為實際值</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.TemplateCustom">自訂</system:String>
     <system:String x:Key="ExternalNotificationCustomWebhook.TemplateMeoW">MeoW</system:String>
     <system:String x:Key="UseGpuForInference">使用 GPU 加速推理</system:String>

--- a/src/MaaWpfGui/Services/ExternalNotification/WebhookPresetTemplate.cs
+++ b/src/MaaWpfGui/Services/ExternalNotification/WebhookPresetTemplate.cs
@@ -57,18 +57,18 @@ public class WebhookPresetTemplate
         new()
         {
             Id = "Kook Channel",
-            Name = "KOOK 频道",
+            Name = "KOOK Channel",
             Url = "https://www.kookapp.cn/api/v3/message/create",
-            Headers = "Authorization: Bot <在此填写机器人 Token>",
-            Body = "{\"type\": 9, \"target_id\": \"<在此填写频道 ID>\", \"content\": \"**{title}**\\n{content}\"}",
+            Headers = "Authorization: Bot <bot_token>",
+            Body = @"{""type"": 9, ""target_id"": ""<channel_id>"", ""content"": ""**{title}**\n{content}""}",
         },
         new()
         {
             Id = "Kook Direct",
-            Name = "KOOK 私聊",
+            Name = "KOOK Direct",
             Url = "https://www.kookapp.cn/api/v3/direct-message/create",
-            Headers = "Authorization: Bot <在此填写机器人 Token>",
-            Body = "{\"type\": 9, \"target_id\": \"<在此填写用户 ID>\", \"content\": \"**{title}**\\n{content}\"}",
+            Headers = "Authorization: Bot <bot_token>",
+            Body = @"{""type"": 9, ""target_id"": ""<user_id>"", ""content"": ""**{title}**\n{content}""}",
         },
     ];
 

--- a/src/MaaWpfGui/Services/ExternalNotification/WebhookPresetTemplate.cs
+++ b/src/MaaWpfGui/Services/ExternalNotification/WebhookPresetTemplate.cs
@@ -54,6 +54,22 @@ public class WebhookPresetTemplate
             Name = "Discord Webhook",
             Body = $"{{\"content\": \"{{content}}\"}}",
         },
+        new()
+        {
+            Id = "Kook Channel",
+            Name = "KOOK 频道",
+            Url = "https://www.kookapp.cn/api/v3/message/create",
+            Headers = "Authorization: Bot <在此填写机器人 Token>",
+            Body = "{\"type\": 9, \"target_id\": \"<在此填写频道 ID>\", \"content\": \"**{title}**\\n{content}\"}",
+        },
+        new()
+        {
+            Id = "Kook Direct",
+            Name = "KOOK 私聊",
+            Url = "https://www.kookapp.cn/api/v3/direct-message/create",
+            Headers = "Authorization: Bot <在此填写机器人 Token>",
+            Body = "{\"type\": 9, \"target_id\": \"<在此填写用户 ID>\", \"content\": \"**{title}**\\n{content}\"}",
+        },
     ];
 
     public static IReadOnlyList<WebhookPresetTemplate> BuiltInTemplates => _builtInTemplates;


### PR DESCRIPTION
## 背景

为 MAA 的「外部通知」功能新增 KOOK 渠道。用户可通过 CustomWebhook 预置模板配置 KOOK 机器人，将 MAA 的任务完成、出错、停滞等通知推送到 KOOK 的频道或私聊。

KOOK 官方 API 将频道消息与私聊消息分为两个独立接口，因此将模板拆分为两个独立配置项，便于用户分别配置与启用。

此外，在开发过程中我注意到对于用户的引导文案与实际模板不符，于是同时对该文案进行了修改。
`原文案：请将预置模板中除{title}、{content}、{time}以外的{}占位符(如{nickname})替换为实际值`
`原有meow模板-Webhook URL示例：https://api.chuckfang.com/<nickname>`
`新文案： 请将预制模板中的<>占位符(如<nickname>)替换为实际值`


### 修改文件（6 个）

| 文件 | 改动 |
| --- | --- |
| `src/MaaWpfGui/Services/ExternalNotification/WebhookPresetTemplate.cs` | `_builtInTemplates` 新增「KOOK 频道」「KOOK 私聊」两个预置模板 |
| `src/MaaWpfGui/Res/Localizations/zh-cn.xaml` | 更新预置模板占位符提示文案为 `<>` 占位符 |
| `src/MaaWpfGui/Res/Localizations/en-us.xaml` | 同上 |
| `src/MaaWpfGui/Res/Localizations/zh-tw.xaml` | 同上 |
| `src/MaaWpfGui/Res/Localizations/ja-jp.xaml` | 同上 |
| `src/MaaWpfGui/Res/Localizations/ko-kr.xaml` | 同上 |

### 模板定义

**KOOK Channel**（`message/create`）：

- 显示名：`KOOK Channel`
- Url：`https://www.kookapp.cn/api/v3/message/create`
- Headers：`Authorization: Bot <bot_token>`
- Body：`{"type": 9, "target_id": "<channel_id>", "content": "**{title}**\n{content}"}`

**KOOK Direct**（`direct-message/create`）：

- 显示名：`KOOK Direct`
- Url：`https://www.kookapp.cn/api/v3/direct-message/create`
- Headers：`Authorization: Bot <bot_token>`
- Body：`{"type": 9, "target_id": "<user_id>", "content": "**{title}**\n{content}"}`

### 模板实现说明

- 沿用 Discord Webhook 模板的 `Name` 硬编码方式，无需新增本地化 key
- 占位符 `{title}` / `{content}` / `{time}` 由 `CustomWebhookNotificationProvider` 统一替换
- 尖括号 `<在此填写...>` 为用户占位，选择模板后需手动替换为真实值

## KOOK API 说明

- 频道消息：`POST https://www.kookapp.cn/api/v3/message/create`，`target_id` 为频道 ID
- 私聊消息：`POST https://www.kookapp.cn/api/v3/direct-message/create`，`target_id` 为用户 ID（后端自动创建会话）
- 鉴权：请求头 `Authorization: Bot <Token>`
- 消息格式：`type=9`（KMarkdown）

参考：[KOOK 开发者文档 - 频道消息](https://developer.kookapp.cn/doc/http/message) · [私聊消息](https://developer.kookapp.cn/doc/http/direct-message)

## 使用方式

1. 在 KOOK 开发者平台创建机器人，获取 Token；在 KOOK 中开启开发者模式，右键频道/用户获取目标 ID
2. 设置 → 外部通知 → 添加推送 → 选择「Custom Webhook」
3. 预置模板下拉框 → 选择「KOOK 频道」或「KOOK 私聊」
4. 将 Headers 与 Body 中的尖括号占位替换为真实的 Token 与目标 ID
5. 点击「发送测试」验证

## 测试情况

- [x] WPF 本地编译通过
- [x] KOOK 频道模板推送测试
- [x] KOOK 私聊模板推送测试
- [x] Custom Webhook 既有模板（Discord Webhook / MeoW）未受影响

## 兼容性说明

- 仅新增两个预置模板，不改变 CustomWebhook 渠道本身的行为
- 不影响既有渠道的配置与使用
- 模板 `Name` 沿用硬编码方式，无需新增本地化 key；仅更新了既有提示文案（`PresetsPlaceholders`）以匹配 `<>` 占位符

## 已知局限

- 用户需手动将尖括号占位替换为真实 Token / ID，未替换时发送会失败
- `CustomWebhookNotificationProvider` 以 HTTP 状态码判定成功，KOOK 业务错误（HTTP 200 + `code != 0`）会被误判为成功，此为 CustomWebhook 机制的固有行为

## 检查项

- [x] 遵循现有模板定义与代码风格
- [ ] 两个模板（频道/私聊）endpoint 与字段正确
- [ ] 本地化已覆盖 zh-cn / en-us / zh-tw / ja-jp / ko-kr（注：除简中与繁中外暂由AI生成）

## Summary by Sourcery

为自定义 Webhook 外部通知功能添加 KOOK 频道和私信预设，并在所有本地化中统一占位符说明文本，使其与新的 `<>` 占位符格式保持一致。

新功能：
- 为外部通知引入内置的 KOOK 频道 Webhook 预设。
- 为外部通知引入内置的 KOOK 私信 Webhook 预设。

增强改进：
- 在所有支持的语言中更新预设的占位符提示文本，用于描述基于 `<>` 风格的用户可替换占位符，以取代之前的格式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add KOOK channel and direct message presets to the Custom Webhook external notification feature and align placeholder guidance text with the new <> placeholder format across localizations.

New Features:
- Introduce a built-in KOOK channel webhook preset for external notifications.
- Introduce a built-in KOOK direct message webhook preset for external notifications.

Enhancements:
- Update preset placeholder hint text in all supported languages to describe <>-style user-replaceable placeholders instead of the previous format.

</details>