### PR TITLE
fix: 界园新藏品弹窗关闭点击坐标错误 (#17599)

### DIFF
--- a/resource/tasks/Roguelike/JieGarden.json
+++ b/resource/tasks/Roguelike/JieGarden.json
@@ -124,8 +124,7 @@
         "next": ["#next"]
     },
     "JieGarden@Roguelike@CloseEvent": {
-        "action": "ClickRect",
-        "specificRect": [153, 79, 63, 29],
+        "action": "ClickSelf",
         "next": [
             "JieGarden@Roguelike@StageEncounterEnter",
             "JieGarden@Roguelike@CloseEvent@(JieGarden@Roguelike@CloseCollectionContinue)",


### PR DESCRIPTION
### 问题描述

在界园肉鸽出现新藏品弹窗时，MAA 无法关闭弹窗，画面长期卡住（#17599）。

根本原因：`JieGarden@Roguelike@CloseEvent` 任务使用 `ClickRect` 并写死了 `specificRect: [153, 79, 63, 29]`。该坐标位于画面左上角附近，而模板 `JieGarden@Roguelike@CloseEvent.png` 实际匹配到的 X 按钮位置为 `[622, 641, 35, 35]`（1280x720 分辨率下）。`ClickRect` 不参考识别结果，导致点击始终落在错误位置。

日志佐证：
- 识别：`match_templ | JieGarden@Roguelike@CloseEvent.png [opencv] score: 0.968784 rect: [622, 641, 35, 35]`
- 实际点击：`Click with scaled coordinates (191, 90) 2` → `PlayTools click: (382, 180)`（对应写死 rect 内的随机点）

### 修改内容

将 `JieGarden@Roguelike@CloseEvent` 的动作从 `ClickRect` 改为 `ClickSelf`，直接点击模板匹配到的 X 按钮位置，并移除写死的 `specificRect`。

### 验证

- 模板在 1280x720 下匹配位置为 `[622, 641, 35, 35]`，`ClickSelf` 后点击点会落在该区域内。
- `resource/tasks/Roguelike/JieGarden.json` JSON 语法校验通过。
- 该任务无其他代码引用其 `specificRect`，派生任务（`CloseEvent@(CloseCollectionContinue)` 等）继承自其他任务，不受影响。

fix #17599

## Summary by Sourcery

错误修复：
- 修复了捷园 Roguelike 新藏品弹窗关闭按钮点击坐标不正确的问题，该问题会导致对话框无法关闭。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Resolve incorrect click coordinates for the JieGarden roguelike new collection popup close button that prevented the dialog from closing.

</details>