### PR TITLE
fix(win32): restore control unit state after tasks / 任务结束后恢复控制单元状态

### DIFF
--- a/src/MaaCore/Assistant.cpp
+++ b/src/MaaCore/Assistant.cpp
@@ -552,11 +552,17 @@ void Assistant::working_proc()
         append_callback(msg, callback_json);
 
         if (m_thread_idle) {
+            if (!m_ctrler->inactive()) {
+                Log.warn("Failed to set controller inactive after task stopped");
+            }
             finished_tasks.clear();
             continue;
         }
 
         if (m_tasks_list.empty()) {
+            if (!m_ctrler->inactive()) {
+                Log.warn("Failed to set controller inactive after all tasks completed");
+            }
             callback_json["finished_tasks"] = json::array(finished_tasks);
             append_callback(AsstMsg::AllTasksCompleted, callback_json);
             finished_tasks.clear();
@@ -568,6 +574,9 @@ void Assistant::working_proc()
         m_condvar.wait_for(lock, std::chrono::milliseconds(delay), [&]() -> bool { return m_thread_idle; });
 
         if (m_thread_idle) {
+            if (!m_ctrler->inactive()) {
+                Log.warn("Failed to set controller inactive after task stopped");
+            }
             append_callback(AsstMsg::TaskChainStopped, callback_json);
         }
     }

--- a/src/MaaCore/Controller/Controller.cpp
+++ b/src/MaaCore/Controller/Controller.cpp
@@ -143,6 +143,12 @@ bool asst::Controller::back_to_home()
     return true;
 }
 
+bool asst::Controller::inactive()
+{
+    CHECK_EXIST(m_controller, false);
+    return m_controller->inactive();
+}
+
 cv::Mat asst::Controller::get_resized_image_cache() const
 {
     const cv::Size d_size(m_scale_size.first, m_scale_size.second);

--- a/src/MaaCore/Controller/Controller.h
+++ b/src/MaaCore/Controller/Controller.h
@@ -48,6 +48,7 @@ public:
         Win32InputMethod keyboard_method);
 #endif
     bool inited() noexcept;
+    bool inactive();
     void set_touch_mode(const TouchMode& mode) noexcept;
     void set_swipe_with_pause(bool enable) noexcept;
     void set_adb_lite_enabled(bool enable) noexcept;

--- a/src/MaaCore/Controller/ControllerAPI.h
+++ b/src/MaaCore/Controller/ControllerAPI.h
@@ -34,6 +34,7 @@ public:
 
     virtual bool connect(const std::string& adb_path, const std::string& address, const std::string& config) = 0;
     virtual bool inited() const noexcept = 0;
+    virtual bool inactive() { return true; }
 
     virtual void set_swipe_with_pause([[maybe_unused]] bool enable) noexcept {}
 

--- a/src/MaaCore/Controller/Win32Controller.cpp
+++ b/src/MaaCore/Controller/Win32Controller.cpp
@@ -107,6 +107,14 @@ bool Win32Controller::inited() const noexcept
     return m_inited && m_unit_handle;
 }
 
+bool Win32Controller::inactive()
+{
+    if (!m_unit_handle) {
+        return true;
+    }
+    return static_cast<MaaFwControlUnitAPI*>(m_unit_handle)->inactive();
+}
+
 const std::string& Win32Controller::get_uuid() const
 {
     return m_uuid;

--- a/src/MaaCore/Controller/Win32Controller.h
+++ b/src/MaaCore/Controller/Win32Controller.h
@@ -37,6 +37,7 @@ public:
 public: // ControllerAPI 接口
     virtual bool connect(const std::string& adb_path, const std::string& address, const std::string& config) override;
     virtual bool inited() const noexcept override;
+    virtual bool inactive() override;
 
     virtual const std::string& get_uuid() const override;
 


### PR DESCRIPTION
## 概述

- 在助手完成或停止任务队列后，调用现有 ControlUnit 的 `inactive()` 生命周期方法。
- 恢复 `SendMessageWithWindowPos` 输入方式临时移动的窗口位置。
- 通过默认成功的空操作，保持非 Win32 Controller 的现有行为不变。

## 问题原因

MaaFramework 通过 `MessageInput::inactive()` 恢复窗口状态。MaaFramework
自身的 Tasker 会在任务结束后调用该生命周期方法，但 MAA 使用自己的
`Assistant::working_proc` 执行任务，任务队列结束时没有通知 ControlUnit。

因此，使用 `SendMessageWithWindowPos` 时，被控窗口可能一直停留在临时
输入位置，直到 ControlUnit 被销毁。

## 修改内容

- 为 `ControllerAPI` 增加默认成功的 `inactive()` 空操作。
- 通过 `Controller` 转发该调用。
- 在 `Win32Controller` 中调用现有的 `MaaFwControlUnitAPI::inactive()`。
- 在任务队列正常完成、最终任务失败以及手动停止后调用 `inactive()`。
- 手动停止时等待当前 `task_ptr->run()` 返回，避免从其他线程恢复窗口。
- ControlUnit 返回失败时记录警告日志。

## 实现方式

窗口位置状态继续由 MaaFramework 管理，MAA 不重复保存或恢复 HWND 状态。

与 #16711 的实现相比，本 PR 不在 MAA 内保存窗口位置，不使用
`dynamic_cast`，也不会在恢复窗口位置时额外修改窗口大小。

## 验证

- [x] 阶段 1 修改已完成本地 `MAA.exe` 构建
- [x] 实机验证 WindowPos 任务结束后能够恢复原窗口位置
- [x] 静态确认 `inactive()` 仅在 `task_ptr->run()` 返回后调用
- [x] 静态确认非 Win32 Controller 保持默认成功的空操作
- [x] 静态确认无 ControlUnit handle 时安全返回成功
- [x] `git diff --check`
- [ ] GitHub CI

## 相关内容

- #16711：相同问题的另一种实现
- #16528：此前的 `inactive()` 调用链实现
- MaaXYZ/MaaFramework#1316：相关 MaaFramework 生命周期调整
- #16506、#16339：相关 WindowPos 问题报告

本 PR 不声明完整解决 #16506 或 #16339 的所有场景。

## Summary by Sourcery

在任务队列完成或被停止后，恢复对控制器不活动状态的处理，以确保 Win32 窗口状态被重置，同时保持非 Win32 控制器的行为不变。

Bug 修复：
- 当任务队列完成、失败或被手动停止时，调用控制器的“不活动”生命周期方法，以便由 Win32 控制的窗口能够从临时输入位置恢复。
- 通过仅在当前任务的 `run` 方法返回之后调用“不活动”方法，避免在与正在运行任务不同的线程上触发“不活动”。
- 当缺少 Win32 控制单元句柄时，将其视为成功的空操作，同时在“不活动”调用失败时记录警告日志。

增强功能：
- 在 `ControllerAPI` 中添加默认的空操作 `inactive` 方法，并通过 `Controller` 进行转发，以确保现有的非 Win32 控制器保持其原有行为不变。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore controller inactive handling after task queues finish or are stopped to ensure Win32 window state is reset while keeping non‑Win32 controllers behavior unchanged.

Bug Fixes:
- Invoke the controller's inactive lifecycle when task queues complete, fail, or are manually stopped so Win32-controlled windows are restored from temporary input positions.
- Avoid calling inactive from a different thread than the running task by only invoking it after the current task's run method returns.
- Treat missing Win32 control unit handles as a successful no-op while logging a warning when inactive fails.

Enhancements:
- Add a default no-op inactive method to ControllerAPI and forward it through Controller so existing non‑Win32 controllers retain their behavior.

</details>

Bug 修复：
- 在任务队列完成、失败或被手动停止时调用控制器的 `inactive()`，以便将 Win32 窗口从临时输入位置恢复。
- 确保仅在当前任务的 `run()` 返回之后才调用 `inactive()`，以避免从其他线程恢复窗口状态。
- 处理缺失的 Win32 控制单元句柄：将 `inactive()` 视为无操作但成功，并在失败时记录警告日志。

增强功能：
- 在 `ControllerAPI` 中添加默认的无操作 `inactive()` 方法，并通过 `Controller` 进行转发，以便非 Win32 控制器保留现有行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在任务队列完成或被停止后，恢复对控制器不活动状态的处理，以确保 Win32 窗口状态被重置，同时保持非 Win32 控制器的行为不变。

Bug 修复：
- 当任务队列完成、失败或被手动停止时，调用控制器的“不活动”生命周期方法，以便由 Win32 控制的窗口能够从临时输入位置恢复。
- 通过仅在当前任务的 `run` 方法返回之后调用“不活动”方法，避免在与正在运行任务不同的线程上触发“不活动”。
- 当缺少 Win32 控制单元句柄时，将其视为成功的空操作，同时在“不活动”调用失败时记录警告日志。

增强功能：
- 在 `ControllerAPI` 中添加默认的空操作 `inactive` 方法，并通过 `Controller` 进行转发，以确保现有的非 Win32 控制器保持其原有行为不变。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore controller inactive handling after task queues finish or are stopped to ensure Win32 window state is reset while keeping non‑Win32 controllers behavior unchanged.

Bug Fixes:
- Invoke the controller's inactive lifecycle when task queues complete, fail, or are manually stopped so Win32-controlled windows are restored from temporary input positions.
- Avoid calling inactive from a different thread than the running task by only invoking it after the current task's run method returns.
- Treat missing Win32 control unit handles as a successful no-op while logging a warning when inactive fails.

Enhancements:
- Add a default no-op inactive method to ControllerAPI and forward it through Controller so existing non‑Win32 controllers retain their behavior.

</details>

</details>