### PR TITLE
feat(wpf): PC 端连接支持配置游戏路径以适配“开始唤醒”

### DIFF
--- a/src/MaaWpfGui/Configuration/Single/Settings/StartUpSettings.cs
+++ b/src/MaaWpfGui/Configuration/Single/Settings/StartUpSettings.cs
@@ -40,4 +40,8 @@ public partial class StartUpSettings
     public string EmulatorAddCommand { get; set; } = string.Empty;
 
     public int EmulatorWaitSeconds { get; set; } = 60;
+
+    public bool StartGameExe { get; set; }
+
+    public string GameExePath { get; set; } = string.Empty;
 }

--- a/src/MaaWpfGui/Configuration/Single/Settings/StartUpSettings.cs
+++ b/src/MaaWpfGui/Configuration/Single/Settings/StartUpSettings.cs
@@ -41,7 +41,5 @@ public partial class StartUpSettings
 
     public int EmulatorWaitSeconds { get; set; } = 60;
 
-    public bool StartGameExe { get; set; }
-
     public string GameExePath { get; set; } = string.Empty;
 }

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -2542,7 +2542,7 @@ public class AsstProxy
     /// </summary>
     /// <param name="windowName">窗口标题（完全匹配）。</param>
     /// <returns>找到的窗口句柄列表。</returns>
-    private static List<IntPtr> FindWindowsByName(string windowName)
+    internal static List<IntPtr> FindWindowsByName(string windowName)
     {
         var results = new List<IntPtr>();
 

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -71,6 +71,11 @@ namespace MaaWpfGui.Main;
 /// </summary>
 public class AsstProxy
 {
+    /// <summary>
+    /// PC 端窗口绑定模式下的目标窗口标题（完全匹配）
+    /// </summary>
+    public const string AttachWindowName = "明日方舟";
+
     private readonly RunningState _runningState;
     private static readonly ILogger _logger = Log.ForContext<AsstProxy>();
 
@@ -2604,14 +2609,13 @@ public class AsstProxy
 
         Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("UseAttachWindowWarning"), UiLogColor.Warning);
 
-        const string TargetWindowName = "明日方舟";
-        var foundWindows = FindWindowsByName(TargetWindowName);
+        var foundWindows = FindWindowsByName(AttachWindowName);
 
         if (foundWindows.Count == 0)
         {
-            error = LocalizationHelper.GetStringFormat("AttachWindowNotFound", TargetWindowName);
+            error = LocalizationHelper.GetStringFormat("AttachWindowNotFound", AttachWindowName);
             Instances.TaskQueueViewModel.AddLog(error, UiLogColor.Error);
-            _logger.Warning("AttachWindow: No window found with name {WindowName}", TargetWindowName);
+            _logger.Warning("AttachWindow: No window found with name {WindowName}", AttachWindowName);
             return false;
         }
 
@@ -2620,15 +2624,15 @@ public class AsstProxy
         if (foundWindows.Count > 1)
         {
             // 找到多个窗口，使用第一个并记录日志
-            var multipleMsg = LocalizationHelper.GetStringFormat("AttachWindowMultipleFound", foundWindows.Count, TargetWindowName);
+            var multipleMsg = LocalizationHelper.GetStringFormat("AttachWindowMultipleFound", foundWindows.Count, AttachWindowName);
             Instances.TaskQueueViewModel.AddLog(multipleMsg, UiLogColor.Info);
-            _logger.Warning("AttachWindow: Multiple windows found with name {WindowName}, count: {Count}, using first one: {Hwnd}", TargetWindowName, foundWindows.Count, hwnd);
+            _logger.Warning("AttachWindow: Multiple windows found with name {WindowName}, count: {Count}, using first one: {Hwnd}", AttachWindowName, foundWindows.Count, hwnd);
         }
         else
         {
-            var foundMsg = LocalizationHelper.GetStringFormat("AttachWindowFound", TargetWindowName);
+            var foundMsg = LocalizationHelper.GetStringFormat("AttachWindowFound", AttachWindowName);
             Instances.TaskQueueViewModel.AddLog(foundMsg, UiLogColor.Info);
-            _logger.Information("AttachWindow: Found window \"{WindowName}\" with HWND: {Hwnd}", TargetWindowName, hwnd);
+            _logger.Information("AttachWindow: Found window \"{WindowName}\" with HWND: {Hwnd}", AttachWindowName, hwnd);
         }
 
         if (SettingsViewModel.ConnectSettings.ExtraConfig is not Win32Extra win32Extra)

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -514,8 +514,16 @@ If you choose ｢{key=ManualRestart}｣ and start MAA manually later, ｢{key=Ru
     <system:String x:Key="HelpUsWithOverseasServersTip">The adaptation for Overseas clients is very difficult and we need your help! No programming knowledge is required.</system:String>
     <system:String x:Key="OpenEmulatorAfterLaunch">Startup Emulator after launched</system:String>
     <system:String x:Key="WaitForEmulator">Delay time (s)</system:String>
+    <system:String x:Key="WaitForGameWindow">Waiting for game window to appear, {0}s elapsed (max {1}s)</system:String>
     <system:String x:Key="WaitForEmulatorFinish">End of wait</system:String>
     <system:String x:Key="EmulatorPath">Emulator path</system:String>
+    <system:String x:Key="GameExePath">Game path</system:String>
+    <system:String x:Key="GameExePathTip">Select the game executable or a shortcut</system:String>
+    <system:String x:Key="OpenGameAfterLaunch">Launch game when MAA starts</system:String>
+    <system:String x:Key="GameExePathEmptyWarning">Game path cannot be empty</system:String>
+    <system:String x:Key="GameExePathNotExist">Game path does not exist</system:String>
+    <system:String x:Key="Browse">Browse</system:String>
+    <system:String x:Key="GameExeStartFailed">Failed to start the game, please verify the game path and ensure MAA is running with administrator privileges</system:String>
     <system:String x:Key="SelectShortcutTip" xml:space="preserve">You may select the emulator executable (with ｢{key=AdditionCommand}｣ launch parameters to specify the instance), or directly choose the emulator/game shortcut.&#10;If the ｢{key=WakeUp}｣ task fails due to prolonged emulator startup, it's recommended to use the game shortcut and increase ｢{key=WaitForEmulator}｣.</system:String>
     <system:String x:Key="EmulatorPathSelectionErrorPrompt">Do you also want to order a bar in a bar?</system:String>
     <system:String x:Key="EmulatorPathSelectionErrorImSure">I'm sure I haven't selected the wrong one</system:String>
@@ -1421,6 +1429,7 @@ Right-click to clear inactive jobs</system:String>
     <system:String x:Key="ConnectFailed">Connection Failed</system:String>
     <system:String x:Key="TryToReconnectByAdb">Attempting to reconnect</system:String>
     <system:String x:Key="TryToStartEmulator">Trying to start the emulator</system:String>
+    <system:String x:Key="TryToStartGameExe">Trying to start the game</system:String>
     <system:String x:Key="RestartAdb">Trying to restart the ADB Server</system:String>
     <system:String x:Key="HardRestartAdb">Trying to kill and restart the ADB process</system:String>
     <system:String x:Key="CheckSettings">Please ｢Check connection settings｣ → ｢Try restarting the emulator and ADB｣ → ｢Restart the computer｣</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -516,6 +516,13 @@ MAA は非インストール型のアプリケーションであり、レジス�
     <system:String x:Key="WaitForEmulator">エミュレータを待つ時間（秒）</system:String>
     <system:String x:Key="WaitForEmulatorFinish">待ち時間は終わりました</system:String>
     <system:String x:Key="EmulatorPath">エミュレータパス</system:String>
+    <system:String x:Key="GameExePath">ゲームパス</system:String>
+    <system:String x:Key="GameExePathTip">ゲーム本体またはショートカットを選択してください</system:String>
+    <system:String x:Key="OpenGameAfterLaunch">MAA 起動時にゲームを自動起動</system:String>
+    <system:String x:Key="GameExePathEmptyWarning">ゲームパスを入力してください</system:String>
+    <system:String x:Key="GameExePathNotExist">ゲームパスが存在しません</system:String>
+    <system:String x:Key="Browse">参照</system:String>
+    <system:String x:Key="GameExeStartFailed">ゲームの起動に失敗しました。パスを確認し、管理者権限で MAA を実行してください</system:String>
     <system:String x:Key="SelectShortcutTip" xml:space="preserve">エミュレーター本体を選択（ ｢{key=AdditionCommand}｣ 起動パラメータでインスタンス指定可能）、または直接エミュレーター/ゲームのショートカットを選択できます。&#10; ｢{key=WakeUp}｣ タスクがエミュレーター起動遅延で失敗する場合、ゲームショートカットを使用し ｢{key=WaitForEmulator}｣ を延長することを推奨します。</system:String>
     <system:String x:Key="EmulatorPathSelectionErrorPrompt">バーでバーを注文したいですか？</system:String>
     <system:String x:Key="EmulatorPathSelectionErrorImSure">確かに間違って選択していないと思います</system:String>
@@ -1422,6 +1429,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="ConnectFailed">接続失敗</system:String>
     <system:String x:Key="TryToReconnectByAdb">再接続を試みています</system:String>
     <system:String x:Key="TryToStartEmulator">エミュレータを起動しようとしています</system:String>
+    <system:String x:Key="TryToStartGameExe">ゲームを起動しようとしています</system:String>
     <system:String x:Key="RestartAdb">ADBサーバーの再起動を試みています</system:String>
     <system:String x:Key="HardRestartAdb">ADBプロセスの再起動を試みています</system:String>
     <system:String x:Key="CheckSettings">｢接続設定を確認｣ → ｢エミュレーターとADBを再起動してみる｣ → ｢コンピュータを再起動｣ してください</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -516,6 +516,13 @@ MAA는 비설치형 응용 프로그램으로, 삭제 시 레지스트리 항목
     <system:String x:Key="WaitForEmulator">에뮬레이터 실행 대기 (초)</system:String>
     <system:String x:Key="WaitForEmulatorFinish">대기 시간 종료</system:String>
     <system:String x:Key="EmulatorPath">에뮬레이터 경로</system:String>
+    <system:String x:Key="GameExePath">게임 경로</system:String>
+    <system:String x:Key="GameExePathTip">게임 실행 파일 또는 바로 가기를 선택하세요</system:String>
+    <system:String x:Key="OpenGameAfterLaunch">MAA 시작 시 게임 자동 실행</system:String>
+    <system:String x:Key="GameExePathEmptyWarning">게임 경로를 입력해 주세요</system:String>
+    <system:String x:Key="GameExePathNotExist">게임 경로가 존재하지 않습니다</system:String>
+    <system:String x:Key="Browse">찾아보기</system:String>
+    <system:String x:Key="GameExeStartFailed">게임 시작에 실패했습니다. 경로를 확인하고 관리자 권한으로 MAA를 실행해 주세요</system:String>
     <system:String x:Key="SelectShortcutTip" xml:space="preserve">에뮬레이터 실행 파일 선택 (｢{key=AdditionCommand}｣ 매개변수로 인스턴스 지정 가능) 또는 직접 에뮬레이터/게임 바로 가기 선택 가능합니다.&#10;｢{key=WakeUp}｣ 작업이 에뮬레이터 시작 지연으로 실패할 경우, 게임 바로 가기 사용 후 ｢{key=WaitForEmulator}｣ 시간 연장을 권장합니다.</system:String>
     <system:String x:Key="EmulatorPathSelectionErrorPrompt">바에서 바를 주문하고 싶습니까?</system:String>
     <system:String x:Key="EmulatorPathSelectionErrorImSure">잘못 선택한 것이 확실히 아닙니다</system:String>
@@ -1423,6 +1430,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="ConnectFailed">연결 실패</system:String>
     <system:String x:Key="TryToReconnectByAdb">재접속을 시도하고 있습니다</system:String>
     <system:String x:Key="TryToStartEmulator">에뮬레이터를 시작하는 중입니다</system:String>
+    <system:String x:Key="TryToStartGameExe">게임을 시작하는 중입니다</system:String>
     <system:String x:Key="RestartAdb">ADB 서버 재시작을 시도 중입니다</system:String>
     <system:String x:Key="HardRestartAdb">ADB 프로세스 재시작을 시도 중입니다</system:String>
     <system:String x:Key="CheckSettings">｢연결 설정 확인｣ → ｢에뮬레이터와 ADB 재시작 시도｣ → ｢컴퓨터 재부팅｣ 해 주세요</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -514,8 +514,16 @@ D:\
     <system:String x:Key="HelpUsWithOverseasServersTip">外服适配滞销，帮帮我们！不会编程也可以。</system:String>
     <system:String x:Key="OpenEmulatorAfterLaunch">启动 MAA 后自动开启模拟器</system:String>
     <system:String x:Key="WaitForEmulator">等待模拟器启动时间（秒）</system:String>
+    <system:String x:Key="WaitForGameWindow">正在等待窗口唤起，已等待 {0} 秒（最多 {1} 秒）</system:String>
     <system:String x:Key="WaitForEmulatorFinish">等待结束</system:String>
     <system:String x:Key="EmulatorPath">模拟器路径</system:String>
+    <system:String x:Key="GameExePath">游戏路径</system:String>
+    <system:String x:Key="GameExePathTip">可选择游戏本体或快捷方式</system:String>
+    <system:String x:Key="OpenGameAfterLaunch">启动 MAA 后自动开启游戏</system:String>
+    <system:String x:Key="GameExePathEmptyWarning">游戏路径不能为空</system:String>
+    <system:String x:Key="GameExePathNotExist">游戏路径不存在</system:String>
+    <system:String x:Key="Browse">浏览</system:String>
+    <system:String x:Key="GameExeStartFailed">启动游戏失败，请确认游戏路径正确且 MAA 以管理员权限运行</system:String>
     <system:String x:Key="SelectShortcutTip" xml:space="preserve">可选择模拟器本体（配合 ｢{key=AdditionCommand}｣ 启动参数可指定启动模拟器实例），也可直接选择模拟器或游戏的快捷方式。&#10;如因模拟器启动时间过长导致 ｢{key=WakeUp}｣ 任务失败，推荐填写游戏快捷方式并延长 ｢{key=WaitForEmulator}｣。</system:String>
     <system:String x:Key="EmulatorPathSelectionErrorPrompt">你也想在酒吧里点酒吧？</system:String>
     <system:String x:Key="EmulatorPathSelectionErrorImSure">我确定没选错</system:String>
@@ -1422,6 +1430,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="ConnectFailed">连接失败</system:String>
     <system:String x:Key="TryToReconnectByAdb">正在尝试重连</system:String>
     <system:String x:Key="TryToStartEmulator">正在尝试启动模拟器</system:String>
+    <system:String x:Key="TryToStartGameExe">正在尝试启动游戏</system:String>
     <system:String x:Key="RestartAdb">正在尝试重启 ADB Server</system:String>
     <system:String x:Key="HardRestartAdb">正在尝试关闭并重启 ADB 进程</system:String>
     <system:String x:Key="CheckSettings">请 ｢检查连接设置｣ → ｢尝试重启模拟器与 ADB｣ → ｢重启电脑｣</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -514,8 +514,16 @@ D:\
     <system:String x:Key="HelpUsWithOverseasServersTip">外服支援人力吃緊，幫幫我們！不會寫程式也可以參與。</system:String>
     <system:String x:Key="OpenEmulatorAfterLaunch">啟動 MAA 後自動開啟模擬器</system:String>
     <system:String x:Key="WaitForEmulator">等待模擬器啟動時間（秒）</system:String>
+    <system:String x:Key="WaitForGameWindow">正在等待視窗喚起，已等待 {0} 秒（最多 {1} 秒）</system:String>
     <system:String x:Key="WaitForEmulatorFinish">等待結束</system:String>
     <system:String x:Key="EmulatorPath">模擬器路徑</system:String>
+    <system:String x:Key="GameExePath">遊戲路徑</system:String>
+    <system:String x:Key="GameExePathTip">可選擇遊戲本體或捷徑</system:String>
+    <system:String x:Key="OpenGameAfterLaunch">啟動 MAA 後自動開啟遊戲</system:String>
+    <system:String x:Key="GameExePathEmptyWarning">遊戲路徑不能為空</system:String>
+    <system:String x:Key="GameExePathNotExist">遊戲路徑不存在</system:String>
+    <system:String x:Key="Browse">瀏覽</system:String>
+    <system:String x:Key="GameExeStartFailed">啟動遊戲失敗，請確認遊戲路徑正確且 MAA 以系統管理員權限執行</system:String>
     <system:String x:Key="SelectShortcutTip" xml:space="preserve">可選擇模擬器本體（配合 ｢{key=AdditionCommand}｣ 啟動參數可指定啟動模擬器實例），也可直接選擇模擬器或遊戲的捷徑。&#10;如因模擬器啟動時間過長導致 ｢{key=WakeUp}｣ 任務失敗，推薦填寫遊戲捷徑並延長 ｢{key=WaitForEmulator}｣。</system:String>
     <system:String x:Key="EmulatorPathSelectionErrorPrompt">你也想在酒吧裡點酒吧？</system:String>
     <system:String x:Key="EmulatorPathSelectionErrorImSure">我確定沒選錯</system:String>
@@ -1422,6 +1430,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="ConnectFailed">連線失敗</system:String>
     <system:String x:Key="TryToReconnectByAdb">正在嘗試重連</system:String>
     <system:String x:Key="TryToStartEmulator">正在嘗試啟動模擬器</system:String>
+    <system:String x:Key="TryToStartGameExe">正在嘗試啟動遊戲</system:String>
     <system:String x:Key="RestartAdb">正在嘗試重開 ADB 服務</system:String>
     <system:String x:Key="HardRestartAdb">正在嘗試重開 ADB</system:String>
     <system:String x:Key="CheckSettings">請 ｢檢查連接設定｣ → ｢嘗試重開模擬器與 ADB｣ → ｢重開電腦｣</system:String>

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -1795,7 +1795,6 @@ public class TaskQueueViewModel : Screen
 
             // 等待游戏窗口出现，最多等 30 秒
             const int MaxWaitSeconds = 30;
-            const string TargetWindowName = "明日方舟";
             var gameStarted = false;
 
             for (var i = 0; i < MaxWaitSeconds; ++i)
@@ -1815,7 +1814,7 @@ public class TaskQueueViewModel : Screen
                 }
 
                 // 检测窗口是否出现
-                var found = await Task.Run(() => AsstProxy.FindWindowsByName(TargetWindowName));
+                var found = await Task.Run(() => AsstProxy.FindWindowsByName(AsstProxy.AttachWindowName));
                 if (found.Count > 0)
                 {
                     gameStarted = true;

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -1781,11 +1781,65 @@ public class TaskQueueViewModel : Screen
         ResetTaskSelection();
     }
 
-    private async Task<bool> ConnectToEmulator()
+    private async Task<bool> ConnectToEmulator(bool hasStartUpTask)
     {
         string errMsg = string.Empty;
         bool connected = await Task.Run(() => Instances.AsstProxy.AsstConnect(ref errMsg));
 
+        // 尝试启动游戏（PC端）
+        if (!connected && SettingsViewModel.ConnectSettings.IsPCConnectConfig && hasStartUpTask)
+        {
+            AddLog(LocalizationHelper.GetString("ConnectFailed") + "\n" + LocalizationHelper.GetString("TryToStartGameExe"));
+
+            SettingsViewModel.StartSettings.TryToStartGameExe();
+
+            // 等待游戏窗口出现，最多等 30 秒
+            const int MaxWaitSeconds = 30;
+            const string TargetWindowName = "明日方舟";
+            var gameStarted = false;
+
+            for (var i = 0; i < MaxWaitSeconds; ++i)
+            {
+                if (_runningState.GetStopping())
+                {
+                    SetStopped();
+                    return false;
+                }
+
+                await Task.Delay(1000);
+
+                // 每 5 秒播报一次等待进度
+                if (i % 5 == 0)
+                {
+                    AddLog(LocalizationHelper.GetStringFormat("WaitForGameWindow", i, MaxWaitSeconds), UiLogColor.Info);
+                }
+
+                // 检测窗口是否出现
+                var found = await Task.Run(() => AsstProxy.FindWindowsByName(TargetWindowName));
+                if (found.Count > 0)
+                {
+                    gameStarted = true;
+                    break;
+                }
+            }
+
+            if (gameStarted)
+            {
+                // 窗口已出现，调用一次 AsstConnect
+                connected = await Task.Run(() => Instances.AsstProxy.AsstConnect(ref errMsg));
+                if (connected)
+                {
+                    return true;
+                }
+            }
+
+            AddLog(errMsg, UiLogColor.Error);
+            _runningState.SetIdle(true);
+            SetStopped();
+            return false;
+        }
+
+        // PC 模式无开始唤醒任务时，直接失败
         if (!connected && SettingsViewModel.ConnectSettings.IsPCConnectConfig)
         {
             AddLog(errMsg, UiLogColor.Error);
@@ -2043,7 +2097,7 @@ public class TaskQueueViewModel : Screen
             return;
         }
 
-        if (!await ConnectToEmulator())
+        if (!await ConnectToEmulator(tasks.Any(t => t.IsEnable == true && t.TaskType == AsstProxy.TaskType.StartUp)))
         {
             return;
         }

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/StartSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/StartSettingsUserControlModel.cs
@@ -601,12 +601,14 @@ public class StartSettingsUserControlModel : PropertyChangedBase
 
         try
         {
+            var (fileName, _) = ResolveShortcut(GameExePath);
+            _logger.Information("Try to start game exe: {GameExePath}", fileName);
+
             using Process process = new Process {
-                StartInfo = new ProcessStartInfo(GameExePath) {
+                StartInfo = new ProcessStartInfo(fileName) {
                     UseShellExecute = true,
                 },
             };
-            _logger.Information("Try to start game exe: {GameExePath}", GameExePath);
             process.Start();
         }
         catch (Exception e)

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/StartSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/StartSettingsUserControlModel.cs
@@ -27,6 +27,7 @@ using JetBrains.Annotations;
 using MaaWpfGui.Configuration.Factory;
 using MaaWpfGui.Constants;
 using MaaWpfGui.Helper;
+using MaaWpfGui.Main;
 using MaaWpfGui.States;
 using MaaWpfGui.Utilities;
 using MaaWpfGui.ViewModels.UI;
@@ -206,6 +207,30 @@ public class StartSettingsUserControlModel : PropertyChangedBase
             ConfigFactory.CurrentConfig.Gui.StartUpSettings.EmulatorWaitSeconds = value;
         }
     } = ConfigFactory.CurrentConfig.Gui.StartUpSettings.EmulatorWaitSeconds;
+
+    /// <summary>
+    /// Gets or sets游戏路径（PC端）
+    /// </summary>
+    public string GameExePath
+    {
+        get; set {
+            value = value.Trim();
+
+            // 这里不用 SetAndNotify 判断
+            if (value == field)
+            {
+                return;
+            }
+
+            if (!string.IsNullOrEmpty(value) && !File.Exists(value))
+            {
+                Growl.Warning(LocalizationHelper.GetString("GameExePathNotExist"));
+            }
+
+            SetAndNotify(ref field, value);
+            ConfigFactory.CurrentConfig.Gui.StartUpSettings.GameExePath = value;
+        }
+    } = ConfigFactory.CurrentConfig.Gui.StartUpSettings.GameExePath;
 
     private (string FileName, string Arguments) ResolveShortcut(string path)
     {
@@ -493,5 +518,100 @@ public class StartSettingsUserControlModel : PropertyChangedBase
         }
 
         Task.Run(() => TryToStartEmulator(test: true));
+    }
+
+    /// <summary>
+    /// 浏览选择游戏 exe
+    /// UI 绑定的方法
+    /// </summary>
+    [UsedImplicitly]
+    public void SelectGameExeExec()
+    {
+        var dialog = new OpenFileDialog {
+            Filter = LocalizationHelper.GetString("Executable") + "|*.exe;*.bat;*.lnk",
+        };
+
+        if (dialog.ShowDialog() == true)
+        {
+            GameExePath = dialog.FileName;
+        }
+    }
+
+    /// <summary>
+    /// 测试启动游戏 exe
+    /// UI 绑定的方法
+    /// </summary>
+    [UsedImplicitly]
+    public void TestGameExeExec()
+    {
+        if (GameExePath.Length == 0)
+        {
+            MessageBoxHelper.Show(LocalizationHelper.GetString("GameExePathEmptyWarning"), LocalizationHelper.GetString("Warning"), icon: MessageBoxImage.Warning);
+            return;
+        }
+
+        if (!File.Exists(GameExePath))
+        {
+            MessageBoxHelper.Show(LocalizationHelper.GetString("GameExePathNotExist"), LocalizationHelper.GetString("Warning"), icon: MessageBoxImage.Warning);
+            return;
+        }
+
+        if (!Bootstrapper.IsUserAdministrator())
+        {
+            var result = MessageBoxHelper.Show(
+                LocalizationHelper.GetString("AttachWindowNeedAdmin"),
+                "MAA",
+                MessageBoxButton.YesNo,
+                MessageBoxImage.Question);
+
+            if (result == MessageBoxResult.No)
+            {
+                return;
+            }
+
+            Bootstrapper.RestartAsAdmin();
+            return;
+        }
+
+        try
+        {
+            using Process process = new Process {
+                StartInfo = new ProcessStartInfo(GameExePath) {
+                    UseShellExecute = true,
+                },
+            };
+            process.Start();
+        }
+        catch (Exception e)
+        {
+            _logger.Warning("Game exe start failed with error: {ErrorMessage}", e.Message);
+            Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("GameExeStartFailed"), UiLogColor.Warning);
+        }
+    }
+
+    /// <summary>
+    /// 尝试启动游戏（PC端）
+    /// </summary>
+    public void TryToStartGameExe()
+    {
+        if (GameExePath.Length == 0 || !File.Exists(GameExePath))
+        {
+            return;
+        }
+
+        try
+        {
+            using Process process = new Process {
+                StartInfo = new ProcessStartInfo(GameExePath) {
+                    UseShellExecute = true,
+                },
+            };
+            _logger.Information("Try to start game exe: {GameExePath}", GameExePath);
+            process.Start();
+        }
+        catch (Exception e)
+        {
+            _logger.Warning("Game exe start failed with error: {ErrorMessage}", e.Message);
+        }
     }
 }

--- a/src/MaaWpfGui/Views/UserControl/Settings/ConnectSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/Settings/ConnectSettingsUserControl.xaml
@@ -13,6 +13,7 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:s="https://github.com/canton7/Stylet"
     xmlns:settings_vms="clr-namespace:MaaWpfGui.ViewModels.UserControl.Settings"
+    xmlns:ui_vms="clr-namespace:MaaWpfGui.ViewModels.UI"
     d:Background="White"
     d:DataContext="{d:DesignInstance {x:Type settings_vms:ConnectSettingsUserControlModel}}"
     d:DesignWidth="550"
@@ -248,6 +249,37 @@
                         </DataTemplate>
                         <DataTemplate DataType="{x:Type extra:Win32Extra}">
                             <StackPanel d:DataContext="{d:DesignInstance {x:Type extra:Win32Extra}}">
+                                <!--  游戏路径（PC端启动游戏 exe） -->
+                                <StackPanel
+                                    Margin="5"
+                                    HorizontalAlignment="Center"
+                                    DataContext="{Binding Source={x:Static ui_vms:SettingsViewModel.StartSettings}}"
+                                    s:View.ActionTarget="{Binding DataContext, RelativeSource={RelativeSource Self}}">
+                                    <StackPanel HorizontalAlignment="Center" Orientation="Horizontal">
+                                        <controls:TextBlock
+                                            Margin="3"
+                                            VerticalAlignment="Center"
+                                            Block.TextAlignment="Center"
+                                            Text="{DynamicResource GameExePath}" />
+                                        <controls:TooltipBlock TooltipText="{DynamicResource GameExePathTip}" />
+                                        <Button
+                                            Margin="10,0,0,0"
+                                            hc:BorderElement.CornerRadius="4,0,0,4"
+                                            Command="{s:Action SelectGameExeExec}"
+                                            Content="{DynamicResource Browse}" />
+                                        <Button
+                                            hc:BorderElement.CornerRadius="0,4,4,0"
+                                            BorderThickness="0,1,1,1"
+                                            Command="{s:Action TestGameExeExec}"
+                                            Content="{DynamicResource Test}" />
+                                    </StackPanel>
+                                    <hc:TextBox
+                                        Width="300"
+                                        Height="30"
+                                        Margin="5"
+                                        hc:TitleElement.TitlePlacement="Left"
+                                        Text="{Binding GameExePath}" />
+                                </StackPanel>
                                 <StackPanel
                                     Margin="5"
                                     HorizontalAlignment="Center"

--- a/src/MaaWpfGui/Views/UserControl/TaskQueue/StartUpTaskUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/TaskQueue/StartUpTaskUserControl.xaml
@@ -212,6 +212,38 @@
                 </StackPanel>
             </StackPanel>
 
+            <!--  游戏路径（PC端启动游戏 exe） -->
+            <StackPanel
+                d:Visibility="Visible"
+                Visibility="{c:Binding 'ConnectConfig == enums:ConnectConfig.PC'}"
+                DataContext="{Binding Source={x:Static ui_vms:SettingsViewModel.StartSettings}}"
+                s:View.ActionTarget="{Binding DataContext, RelativeSource={RelativeSource Self}}">
+                <StackPanel
+                    Margin="0,5"
+                    HorizontalAlignment="Center"
+                    Orientation="Horizontal">
+                    <controls:TextBlock
+                        Margin="3"
+                        VerticalAlignment="Center"
+                        Block.TextAlignment="Center"
+                        Text="{DynamicResource GameExePath}" />
+                    <controls:TooltipBlock TooltipText="{DynamicResource GameExePathTip}" />
+                    <Button
+                        Margin="10,0,0,0"
+                        hc:BorderElement.CornerRadius="4,0,0,4"
+                        Command="{s:Action SelectGameExeExec}"
+                        Content="{DynamicResource Browse}" />
+                    <Button
+                        hc:BorderElement.CornerRadius="0,4,4,0"
+                        BorderThickness="0,1,1,1"
+                        Command="{s:Action TestGameExeExec}"
+                        Content="{DynamicResource Test}" />
+                </StackPanel>
+                <TextBox
+                    Margin="0,5"
+                    Text="{Binding GameExePath}" />
+            </StackPanel>
+
             <!--  额外配置  -->
             <ContentControl d:Content="{d:DesignInstance Type=extra:MuMu12Extra}" Content="{Binding ExtraConfig}">
                 <ContentControl.Resources>


### PR DESCRIPTION
# feat(wpf): PC 端连接支持配置游戏路径并自动启动游戏

## 背景

PC 端（窗口绑定模式）连接前需要用户手动打开明日方舟客户端。本次改动在"开始唤醒"任务面板和"连接设置"页面新增游戏路径配置，LinkStart 时自动启动游戏并等待窗口出现后绑窗。

## 设计概要

- **游戏路径为全局设置**，存储在 `StartUpSettings.GameExePath`，非 per-task 配置
- **两处 UI 入口**（设置-连接设置、开始唤醒任务面板）共同读写同一份全局数据，任意一处修改即全局同步
- **启动逻辑独立于窗口绑定**，`TryToStartGameExe()` 中 `Process.Start(UseShellExecute = true)` 一发即走，不等待窗口、不阻塞、不牵连 Attach 流程
- **LinkStart 时**，PC 模式连接失败后会启动游戏 exe，然后轮询等待窗口出现（最多 30 秒，每 5 秒播报进度），窗口出现后**仅调用一次** `AsstConnect` 绑窗
- 不影响原有的 PC 检测到已有窗口的绑定逻辑

### 修改文件（8 个）

| 文件 | 改动 |
| --- | --- |
| `src/MaaWpfGui/Configuration/Single/Settings/StartUpSettings.cs` | 新增 `StartGameExe`、`GameExePath` 配置字段 |
| `src/MaaWpfGui/ViewModels/UserControl/Settings/StartSettingsUserControlModel.cs` | 新增 `GameExePath` 属性、`SelectGameExeExec()`（浏览）、`TestGameExeExec()`（测试）、`TryToStartGameExe()`（启动）方法 |
| `src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs` | `ConnectToEmulator()` 中 PC 模式连接失败改为启动游戏 + 等待窗口后重试 |
| `src/MaaWpfGui/Main/AsstProxy.cs` | `FindWindowsByName` 改为 `internal static` 供外部检测窗口 |
| `src/MaaWpfGui/Views/UserControl/Settings/ConnectSettingsUserControl.xaml` | Win32Extra 模板内"连接PC端（实验性）"警告下方新增游戏路径 UI |
| `src/MaaWpfGui/Views/UserControl/TaskQueue/StartUpTaskUserControl.xaml` | PC 模式下显示游戏路径配置区域 |
| `src/MaaWpfGui/Res/Localizations/zh-cn.xaml` | 新增中文本地化字符串 |
| `src/MaaWpfGui/Res/Localizations/en-us.xaml` `zh-tw.xaml` `ja-jp.xaml` `ko-kr.xaml` | 新增对应本地化字符串 |

### UI 布局
<img width="995" height="746" alt="image" src="https://github.com/user-attachments/assets/b69bf8f5-a9d9-480e-8f78-b6dc01d9472f" />
<img width="1000" height="746" alt="image" src="https://github.com/user-attachments/assets/b7226fad-3f8d-4d82-8cd1-113b8c93d94c" />



### 关键流程

```
LinkStart
  └─ AsstConnect 失败，且为 PC 模式并勾选开始唤醒
       ├─ 日志："连接失败 + 正在尝试启动游戏"
       ├─ TryToStartGameExe() 启动游戏 exe
       ├─ 循环等待（最多 30 秒）：
       │    ├─ 每秒静默检测窗口
       │    └─ 每 5 秒日志播报 "正在等待窗口唤起，已等待 X 秒"
       ├─ 窗口出现 → 调用一次 AsstConnect
       │    ├─ 成功 → 继续任务
       │    └─ 失败 → 报错退出
       └─ 30 秒超时 → 报错退出
```

### 测试按钮

- 点击「测试」按钮 → 检查路径非空与文件存在 → 非管理员弹出 `AttachWindowNeedAdmin` 提升权限对话框
- `Process.Start(UseShellExecute = true)`，由 Windows 处理关联与权限

## 测试情况

- [x] WPF 本地编译通过
- [x] 浏览按钮选择 exe、lnk 文件，路径正确写入文本框
- [x] 配置非空且未识别到游戏窗口时通过 开始唤醒 自动启动游戏 exe，同时不影响已有的识别游戏窗口的逻辑
- [x] 游戏未启动时手动点击 LinkStart，等待窗口出现后自动绑窗
- [x] 测试按钮无管理员权限时弹窗提示并以管理员重启
- [x] 不影响原有 PC 模式已有窗口的绑定流程
- [x] 两处 UI（连接设置、开始唤醒面板）修改同步

## 兼容性说明

- 仅影响 PC（窗口绑定）模式，ADB 连接模式行为不变
- 游戏路径为空时行为与改动前一致（直接报窗口未找到）
- 新增的本地化字符串不影响现有键值

## 已知局限

- 游戏启动后无进度/状态反馈（fire-and-forget），用户需通过等待日志判断
- 等待窗口硬编码窗口标题"明日方舟"，若国际服标题不同需适配

## 检查项

- [x] 遵循现有代码风格与注释规范
- [x] 游戏路径全局存储，非 per-task 配置
- [x] 启动逻辑不阻塞、不牵连 Attach 流程
- [ ] 本地化已覆盖 zh-cn / en-us / zh-tw / ja-jp / ko-kr（注：除简中外暂由 AI 辅助生成）

## Summary by Sourcery

在 WPF 客户端的启动/连接流程中，新增可配置的 PC 端游戏可执行文件路径，并集成自动启动游戏的功能。

新特性：
- 允许用户配置一个在启动任务中使用的全局 PC 游戏可执行文件路径。
- 在连接设置和启动任务面板中提供 UI 控件，用于浏览并测试已配置的游戏可执行文件路径。
- 当 PC 连接失败但启用了启动任务时，在 LinkStart 过程中自动启动 PC 游戏并绑定其窗口。

改进：
- 扩展连接逻辑，通过窗口标题检测《明日方舟》游戏窗口，并在窗口出现后重试附加。
- 从 AsstProxy 中暴露窗口搜索功能，以便在连接工作流中复用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable PC game executable path and automatic game startup integration into the WPF client’s startup/connection flow.

New Features:
- Allow users to configure a global PC game executable path used during startup tasks.
- Provide UI controls to browse and test the configured game executable path in both connection settings and the start-up task panel.
- Automatically start the PC game and bind to its window during LinkStart when PC connection fails but a start-up task is enabled.

Enhancements:
- Extend connection logic to detect the Arknights game window by title and retry attachment once the window appears.
- Expose window search functionality from AsstProxy for reuse in connection workflows.

</details>