### PR TITLE
fix(win32): 修复 PC 端公招刷新确认弹窗卡死

### DIFF
--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -2347,12 +2347,28 @@
         "roi": [850, 340, 220, 170]
     },
     "RecruitRefreshConfirm": {
+        "Doc": "PC 客户端会在刷新按钮位置保留游戏内光标，使用亮部掩膜避免遮挡确认按钮模板",
         "template": "PopupConfirm.png",
         "action": "ClickSelf",
         "roi": [630, 400, 650, 160],
+        "templThreshold": 0.7,
+        "maskRange": [150, 255],
+        "maxTimes": 3,
         "preDelay": 500,
         "postDelay": 500,
-        "next": ["RecruitRefreshConfirm@LoadingText", "Recruit@OfflineConfirm", "SleepThenStop"]
+        "next": ["RecruitRefreshConfirm@LoadingText", "Recruit@OfflineConfirm", "#self", "SleepThenStop"]
+    },
+    "RecruitRefreshCancel": {
+        "Doc": "刷新确认失败时取消弹窗并返回公招主页，避免阻塞后续任务",
+        "template": "PopupCancel.png",
+        "action": "ClickSelf",
+        "roi": [0, 400, 650, 160],
+        "templThreshold": 0.7,
+        "maskRange": [150, 255],
+        "maxTimes": 3,
+        "postDelay": 500,
+        "next": ["Return", "#self"],
+        "exceededNext": ["Return"]
     },
     "SleepThenStop": {
         "algorithm": "JustReturn",

--- a/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.cpp
@@ -347,7 +347,7 @@ asst::AutoRecruitTask::recruit_result asst::AutoRecruitTask::recruit_one(const R
             info["why"] = "识别错误";
             callback(AsstMsg::SubTaskError, info);
         }
-        if (!ProcessTask(*this, { "RecruitContinue", "Return" }).run()) {
+        if (!ProcessTask(*this, { "RecruitRefreshCancel", "RecruitContinue", "Return" }).run()) {
             m_force_skipped.emplace(slot_index_from_rect(button));
         }
         return recruit_result::failed;
@@ -639,7 +639,10 @@ asst::AutoRecruitTask::calc_task_result_type asst::AutoRecruitTask::recruit_calc
                 return {};
             }
 
-            refresh();
+            if (!refresh()) {
+                Log.error("Failed to refresh recruit tags.", "slot index:", index, "refresh count:", refresh_count);
+                return {};
+            }
 
             ++refresh_count;
 


### PR DESCRIPTION
## 概述

修复 PC 客户端自动公招刷新后无法识别确认弹窗，导致弹窗残留并使后续任务连续失败的问题。

## 问题表现

在 PC 客户端使用 `SendMessageWithWindowPos` 鼠标输入时，自动公招点击刷新后可能无法点击“确认”。公招任务随后结束，但确认弹窗仍停留在游戏中，后续信用收支、领取奖励、自动肉鸽等任务会因界面不符而连续报错。

## 问题原因

PC 客户端会独立渲染游戏内光标及点击动画，可能遮挡 `PopupConfirm.png` 的部分区域。现场截图中，原始模板匹配分数约为 `0.738381`，低于默认阈值 `0.8`，因此 `RecruitRefreshConfirm` 未执行。

此外，`AutoRecruitTask` 原先没有检查 `refresh()` 的返回值。即使刷新确认流程失败，任务仍会继续计算并结束，未主动清理残留弹窗。

## 修改内容

- 为 `RecruitRefreshConfirm` 增加亮部掩膜、适配阈值和最多 3 次重试，降低 PC 客户端独立渲染光标的干扰。
- 增加 `RecruitRefreshCancel` 恢复路径；刷新失败时优先取消弹窗并返回公招主页，避免污染后续任务。
- 检查 `refresh()` 返回值，刷新流程失败时按识别错误退出并执行清理，不再把失败当作成功继续。

## 验证

- [x] `git diff --check`
- [x] JSON 解析通过
- [x] Prettier 3.7.4 检查通过
- [x] clang-format 21.1.8 检查通过
- [x] Windows x64 Release 完整构建通过
- [x] PC 客户端 1280×720、UI 缩放 100%、WGC FramePool、`SendMessageWithWindowPos` 实机测试
- [x] 连续完成 2 次标签刷新，确认模板得分分别为 `0.899199`、`0.899295`
- [x] 两次均收到 `RecruitTagsRefreshed`，最终收到 `TaskChainCompleted` 与 `AllTasksCompleted`
- [x] 非目标剧情截图匹配得分为 `0.176952`，未出现误匹配
- [ ] GitHub CI

## 相关内容

- #16781

## Summary by Sourcery

更稳健地处理 PC 端自动招募刷新确认失败的问题，防止卡住的确认弹窗破坏后续任务。

Bug Fixes:
- 确保招募刷新失败时及早退出并停止任务结果计算，避免残留的确认弹窗干扰后续任务。

Enhancements:
- 在继续或从招募流程返回之前，新增专门的 `RecruitRefreshCancel` 路径，主动关闭刷新失败的对话框。
- 当刷新步骤未成功时记录刷新标签失败日志，提高对自动招募问题的可观测性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle PC auto recruit refresh confirmation failures more robustly to prevent stuck confirmation popups from breaking subsequent tasks.

Bug Fixes:
- Ensure failed recruit refresh exits early and stops task result calculation, avoiding lingering confirmation popups that disrupt later tasks.

Enhancements:
- Add a dedicated RecruitRefreshCancel path before continuing or returning from recruit flow to actively close failed refresh dialogs.
- Log refresh tag failures when the refresh step does not succeed, improving observability of auto recruit issues.

</details>