### PR TITLE
fix(wpf): synchronize ETag cache access

### DIFF
--- a/src/MaaWpfGui/Helper/ETagCache.cs
+++ b/src/MaaWpfGui/Helper/ETagCache.cs
@@ -25,6 +25,7 @@ namespace MaaWpfGui.Helper;
 
 public class ETagCache
 {
+    private static readonly object _lock = new();
     private static readonly ILogger _logger = Log.ForContext<ETagCache>();
 
     private static readonly string _etagFile = Path.Combine(PathsHelper.CacheDir, "etag.json");
@@ -33,6 +34,14 @@ public class ETagCache
     private static Dictionary<string, DateTimeOffset> _lastModifiedCache = [];
 
     public static void Load()
+    {
+        lock (_lock)
+        {
+            LoadCore();
+        }
+    }
+
+    private static void LoadCore()
     {
         // ETag
         if (File.Exists(_etagFile))
@@ -67,26 +76,50 @@ public class ETagCache
 
     public static void Save()
     {
+        lock (_lock)
+        {
+            SaveCore();
+        }
+    }
+
+    private static void SaveCore()
+    {
         File.WriteAllText(_etagFile, JsonConvert.SerializeObject(_etagCache, Formatting.Indented));
         File.WriteAllText(_lastModifiedFile, JsonConvert.SerializeObject(_lastModifiedCache, Formatting.Indented));
     }
 
-    public static string GetETag(string? url) =>
-        url != null && _etagCache.TryGetValue(url, out var etag) ? etag : string.Empty;
+    public static string GetETag(string? url)
+    {
+        lock (_lock)
+        {
+            return url != null && _etagCache.TryGetValue(url, out var etag) ? etag : string.Empty;
+        }
+    }
 
-    public static DateTimeOffset? GetLastModified(string? url) =>
-        url != null && _lastModifiedCache.TryGetValue(url, out var lm) ? lm : null;
+    public static DateTimeOffset? GetLastModified(string? url)
+    {
+        lock (_lock)
+        {
+            return url != null && _lastModifiedCache.TryGetValue(url, out var lm) ? lm : null;
+        }
+    }
 
     public static void SetETag(string url, string etag)
     {
-        _etagCache[url] = etag;
+        lock (_lock)
+        {
+            _etagCache[url] = etag;
+        }
     }
 
     public static void SetLastModified(string url, DateTimeOffset? dt)
     {
-        if (dt.HasValue)
+        lock (_lock)
         {
-            _lastModifiedCache[url] = dt.Value;
+            if (dt.HasValue)
+            {
+                _lastModifiedCache[url] = dt.Value;
+            }
         }
     }
 
@@ -101,17 +134,20 @@ public class ETagCache
         var etag = response.Headers.ETag?.Tag;
         var lastModified = response.Content?.Headers?.LastModified;
 
-        if (!string.IsNullOrEmpty(etag))
+        lock (_lock)
         {
-            SetETag(uri, etag);
-        }
+            if (!string.IsNullOrEmpty(etag))
+            {
+                _etagCache[uri] = etag;
+            }
 
-        if (lastModified.HasValue)
-        {
-            SetLastModified(uri, lastModified.Value);
-        }
+            if (lastModified.HasValue)
+            {
+                _lastModifiedCache[uri] = lastModified.Value;
+            }
 
-        Save();
+            SaveCore();
+        }
     }
 
     public static async Task<HttpResponseMessage?> FetchResponseWithEtag(string url, bool force = false)

--- a/src/MaaWpfGui/Helper/ETagCache.cs
+++ b/src/MaaWpfGui/Helper/ETagCache.cs
@@ -32,6 +32,7 @@ public class ETagCache
     private static readonly string _lastModifiedFile = Path.Combine(PathsHelper.CacheDir, "last_modified.json");
     private static Dictionary<string, string> _etagCache = [];
     private static Dictionary<string, DateTimeOffset> _lastModifiedCache = [];
+    private static bool _isDirty;
 
     public static void Load()
     {
@@ -72,6 +73,8 @@ public class ETagCache
                 _lastModifiedCache = [];
             }
         }
+
+        _isDirty = false;
     }
 
     public static void Save()
@@ -84,8 +87,21 @@ public class ETagCache
 
     private static void SaveCore()
     {
-        File.WriteAllText(_etagFile, JsonConvert.SerializeObject(_etagCache, Formatting.Indented));
-        File.WriteAllText(_lastModifiedFile, JsonConvert.SerializeObject(_lastModifiedCache, Formatting.Indented));
+        if (!_isDirty)
+        {
+            return;
+        }
+
+        try
+        {
+            File.WriteAllText(_etagFile, JsonConvert.SerializeObject(_etagCache, Formatting.Indented));
+            File.WriteAllText(_lastModifiedFile, JsonConvert.SerializeObject(_lastModifiedCache, Formatting.Indented));
+            _isDirty = false;
+        }
+        catch (Exception e)
+        {
+            _logger.Warning(e, "Failed to save HTTP cache metadata");
+        }
     }
 
     public static string GetETag(string? url)
@@ -108,19 +124,39 @@ public class ETagCache
     {
         lock (_lock)
         {
-            _etagCache[url] = etag;
+            SetETagCore(url, etag);
         }
+    }
+
+    private static void SetETagCore(string url, string etag)
+    {
+        if (_etagCache.TryGetValue(url, out var cachedETag) && cachedETag == etag)
+        {
+            return;
+        }
+
+        _etagCache[url] = etag;
+        _isDirty = true;
     }
 
     public static void SetLastModified(string url, DateTimeOffset? dt)
     {
         lock (_lock)
         {
-            if (dt.HasValue)
-            {
-                _lastModifiedCache[url] = dt.Value;
-            }
+            SetLastModifiedCore(url, dt);
         }
+    }
+
+    private static void SetLastModifiedCore(string url, DateTimeOffset? dt)
+    {
+        if (!dt.HasValue ||
+            (_lastModifiedCache.TryGetValue(url, out var cachedLastModified) && cachedLastModified == dt.Value))
+        {
+            return;
+        }
+
+        _lastModifiedCache[url] = dt.Value;
+        _isDirty = true;
     }
 
     // UPDATE: 重定向会导致 uri 变成其他地址，导致存的 ETag 无法匹配原始地址，所以要传入原始地址
@@ -138,13 +174,10 @@ public class ETagCache
         {
             if (!string.IsNullOrEmpty(etag))
             {
-                _etagCache[uri] = etag;
+                SetETagCore(uri, etag);
             }
 
-            if (lastModified.HasValue)
-            {
-                _lastModifiedCache[uri] = lastModified.Value;
-            }
+            SetLastModifiedCore(uri, lastModified);
 
             SaveCore();
         }


### PR DESCRIPTION
## 说明

`StageManager.LoadWebStages` 会并行请求关卡和任务数据，后台定时更新时这些请求会在线程池中继续执行。

请求成功后会同时进入 `ETagCache.Set`。原实现使用未同步的 `Dictionary`，并可能并发写入同一组 `etag.json` 和 `last_modified.json`，从而触发集合并发修改或文件写入异常。该异常会使已经成功下载的数据被当作 API 更新失败处理。

## 修改

- 同步 ETag 和 Last-Modified 缓存的加载、读取和更新
- 将缓存元数据更新与文件持久化放在同一临界区
- 复用内部 setter，并仅在元数据实际变化时标记缓存为 dirty
- 仅持久化 dirty 缓存；保存失败时记录日志并保留 dirty 状态以便重试
- 保持网络请求和响应处理在锁外

## 验证

- `dotnet build src/MaaWpfGui/MaaWpfGui.csproj --configuration Release`
- `dotnet format --verify-no-changes`
- 5 轮并发压力测试，每轮 8 个调用者 × 250 次 `ETagCache.Set`
- 共 10,000 次调用，无异常；两份缓存 JSON 每轮均可解析且数据完整
- 模拟保存路径故障，验证异常不向上传播，并在恢复路径后成功重试
- 重复设置相同元数据，验证两份缓存文件均未被重写

## Summary by Sourcery

在 WPF 客户端中同步对 ETag 和 Last-Modified 缓存的访问，以防止在并行请求下出现并发修改和文件写入错误。

Bug 修复：
- 在并发加载 Web 阶段时，防止在更新内存中的 ETag 和 Last-Modified 字典以及持久化其 JSON 文件过程中出现竞争条件。

增强功能：
- 将缓存加载和保存逻辑集中到加锁的核心方法中，确保元数据更新和 JSON 持久化操作的原子性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Synchronize ETag and Last-Modified cache access in the WPF client to prevent concurrent modification and file write errors under parallel requests.

Bug Fixes:
- Prevent race conditions when updating in-memory ETag and Last-Modified dictionaries and persisting their JSON files during concurrent web stage loads.

Enhancements:
- Centralize cache loading and saving logic into locked core methods to ensure atomic updates of metadata and JSON persistence.

</details>
