### PR TITLE
fix: MaaFwAndroidNativeController 抬起后补齐点击间隔

### DIFF
--- a/src/MaaCore/Controller/MaaFwAndroidNativeController.cpp
+++ b/src/MaaCore/Controller/MaaFwAndroidNativeController.cpp
@@ -14,6 +14,10 @@
 namespace asst
 {
 
+// 与 Minitoucher::DefaultClickDelay 对齐：按下与抬起各等待一次。
+// 抬起后同样要留间隔，否则高频连点会被并成同一手势而丢点
+constexpr int ClickDelay = 50;
+
 MaaFwAndroidNativeController::MaaFwAndroidNativeController(const AsstCallback& callback, Assistant* inst) :
     InstHelper(inst),
     m_callback(callback)
@@ -209,8 +213,10 @@ bool MaaFwAndroidNativeController::click(const Point& p)
     if (!m_unit_handle->touch_down(0, p.x, p.y, 1)) {
         return false;
     }
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
-    return m_unit_handle->touch_up(0);
+    std::this_thread::sleep_for(std::chrono::milliseconds(ClickDelay));
+    const bool ret = m_unit_handle->touch_up(0);
+    std::this_thread::sleep_for(std::chrono::milliseconds(ClickDelay));
+    return ret;
 }
 
 bool MaaFwAndroidNativeController::input(const std::string& text)
@@ -324,6 +330,7 @@ bool MaaFwAndroidNativeController::swipe(
     }
 
     m_unit_handle->touch_up(0);
+    std::this_thread::sleep_for(std::chrono::milliseconds(ClickDelay));
     return true;
 }
 


### PR DESCRIPTION
## 问题

`MaaFwAndroidNativeController::click()` 只在 `touch_down` 与 `touch_up` 之间等待 50ms，抬起后直接返回，没有留出到下一次操作的间隔。

这与其它 controller 的约定不一致：

| 实现 | 抬起后间隔 |
|---|---|
| minitouch / maatouch | ✅ `down()` / `up()` 默认均带 `wait_ms = DefaultClickDelay`（`MinitouchController.h:105,115`） |
| MumuController | ✅ `MumuController.cpp:102`「之后 up 再等同样时间，为下一次 click 留出间隔。与 minitouch 的 down w50、up w50 对齐」 |
| AdbController | ✅ `AdbController.cpp:463`「adb click 没有内置间隔，与 minitouch/maatouch 的 `DefaultClickDelay` 对齐，避免高频连点丢点」 |
| **MaaFwAndroidNativeController** | ❌ 缺失 |

缺少抬起后的间隔会让相邻两次点击首尾相接，被系统并成同一手势而丢点。`AdbController::click` 曾经修正过完全相同的问题，注释里也写明了症状。

## 复现

在 `TouchMode::Android` 下跑高频连点的任务。像素画（`MiniGame@PixelPaint@Begin`）逐格填色时最明显，`GridClickDelay = 0`，相邻两格的点击间隔为 0，表现为**部分格子没有画上**。

## 改动

- `click()` 在 `touch_up` 之后补齐一次 `ClickDelay`，与 minitouch 的 `down w50、up w50` 对齐；
- `swipe()` 结尾的 `touch_up` 同样补齐，避免紧接着的下一次按下被并进同一手势；
- 把两处重复的 `50` 提为文件作用域常量 `ClickDelay`。

## 影响范围

仅 `__ANDROID__` 下的 `MaaFwAndroidNativeController`。每次点击增加 50ms，与其它 controller 的既有行为一致。

## Summary by Sourcery

通过在释放触点后添加延迟，使 MaaFwAndroidNativeController 的点击和滑动行为与其他控制器保持一致，避免高频点击被合并为单个手势。

Bug Fixes:
- 确保 MaaFwAndroidNativeController 中的点击在触摸释放后包含一个延迟，以防止连续点击被合并并导致遗漏。
- 确保 MaaFwAndroidNativeController 中的滑动操作在最后一次触摸释放后包含一个延迟，以将后续手势区分开来。

Enhancements:
- 引入共享的 `ClickDelay` 常量，用于控制 Android 原生控制器的触摸时序，以匹配其他控制器使用的默认点击延迟。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Align MaaFwAndroidNativeController click and swipe behavior with other controllers by adding a post-release delay to avoid high-frequency taps being merged into a single gesture.

Bug Fixes:
- Ensure clicks in MaaFwAndroidNativeController include a delay after touch release to prevent consecutive taps from being merged and missed.
- Ensure swipe operations in MaaFwAndroidNativeController include a delay after the final touch release to separate subsequent gestures.

Enhancements:
- Introduce a shared ClickDelay constant for Android native controller touch timing to match the default click delay used by other controllers.

</details>