### PR TITLE
fix: 添加精英等级需求解析

### DIFF
--- a/src/MaaCore/Config/Miscellaneous/CopilotConfig.cpp
+++ b/src/MaaCore/Config/Miscellaneous/CopilotConfig.cpp
@@ -103,6 +103,7 @@ std::optional<asst::battle::OperUsage> asst::CopilotConfig::parse_oper_usage(con
                          << ", but elite requirement is set to" << *elite_opt;
                 return std::nullopt;
             }
+            oper.requirements.elite = *elite_opt;
         }
     }
 


### PR DESCRIPTION
没绷住，改了半天没看到漏了最关键的一句

## Summary by Sourcery

Bug Fixes:
- 当精英约束被成功解析时，设置干员精英需求字段，以避免忽略该配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Set the operator elite requirement field when an elite constraint is successfully parsed to avoid ignoring the configuration.

</details>