### PR TITLE
fix: PC 端截图前避让物理鼠标

### DIFF
--- a/src/MaaCore/Assistant.cpp
+++ b/src/MaaCore/Assistant.cpp
@@ -192,6 +192,16 @@ bool asst::Assistant::set_instance_option(InstanceOptionKey key, const std::stri
     case InstanceOptionKey::ClientType:
         m_ctrler->set_client_type(value);
         return true;
+    case InstanceOptionKey::Win32WindowCursorAvoidance:
+        if (constexpr std::string_view Enable = "1"; value == Enable) {
+            m_ctrler->set_win32_window_cursor_avoidance(true);
+            return true;
+        }
+        else if (constexpr std::string_view Disable = "0"; value == Disable) {
+            m_ctrler->set_win32_window_cursor_avoidance(false);
+            return true;
+        }
+        break;
     default:
         break;
     }

--- a/src/MaaCore/Common/AsstTypes.h
+++ b/src/MaaCore/Common/AsstTypes.h
@@ -41,13 +41,14 @@ enum class StaticOptionKey
 enum class InstanceOptionKey
 {
     Invalid = 0,
-    /* Deprecated */         // MinitouchEnabled = 1,
-    TouchMode = 2,           // 触控模式设置， "minitouch" | "maatouch" | "adb" | "MaaFwAdb" | "MumuExtras"
-    DeploymentWithPause = 3, // 自动战斗、肉鸽、保全 是否使用 暂停下干员， "0" | "1"
-    AdbLiteEnabled = 4,      // 是否使用 AdbLite， "0" | "1"
-    KillAdbOnExit = 5,       // 退出时是否杀掉 Adb 进程， "0" | "1"
-    ClientType = 6,          // 客户端类型（游戏渠道）。仅当连接配置在 connect 阶段需要 [PackageName] 时使用，
-                             // 当前内置配置为 Androws / WSA；不替代 StartUpTask 的 client_type 参数。
+    /* Deprecated */                // MinitouchEnabled = 1,
+    TouchMode = 2,                  // 触控模式设置， "minitouch" | "maatouch" | "adb" | "MaaFwAdb" | "MumuExtras"
+    DeploymentWithPause = 3,        // 自动战斗、肉鸽、保全 是否使用 暂停下干员， "0" | "1"
+    AdbLiteEnabled = 4,             // 是否使用 AdbLite， "0" | "1"
+    KillAdbOnExit = 5,              // 退出时是否杀掉 Adb 进程， "0" | "1"
+    ClientType = 6,                 // 客户端类型（游戏渠道）。仅当连接配置在 connect 阶段需要 [PackageName] 时使用，
+                                    // 当前内置配置为 Androws / WSA；不替代 StartUpTask 的 client_type 参数。
+    Win32WindowCursorAvoidance = 7, // Win32 WindowPos 输入后及截图前是否移动窗口避开物理鼠标， "0" | "1"
 };
 
 enum class TouchMode

--- a/src/MaaCore/Controller/Controller.cpp
+++ b/src/MaaCore/Controller/Controller.cpp
@@ -315,6 +315,7 @@ bool asst::Controller::attach_window(
     clear_info();
 
     auto win32_controller = std::make_shared<Win32Controller>(m_callback, m_inst);
+    win32_controller->set_window_cursor_avoidance(m_win32_window_cursor_avoidance);
     if (!win32_controller->attach(hwnd, screencap_method, mouse_method, keyboard_method)) {
         Log.error("attach_window failed");
         return false;
@@ -422,6 +423,16 @@ void asst::Controller::set_kill_adb_on_exit(bool enable) noexcept
 void asst::Controller::set_client_type(const std::string& client_type) noexcept
 {
     m_client_type = client_type;
+}
+
+void asst::Controller::set_win32_window_cursor_avoidance(bool enable) noexcept
+{
+    m_win32_window_cursor_avoidance = enable;
+#ifdef _WIN32
+    if (auto win32_controller = std::dynamic_pointer_cast<Win32Controller>(m_controller)) {
+        win32_controller->set_window_cursor_avoidance(enable);
+    }
+#endif
 }
 
 const std::string& asst::Controller::get_client_type() const noexcept

--- a/src/MaaCore/Controller/Controller.h
+++ b/src/MaaCore/Controller/Controller.h
@@ -53,6 +53,7 @@ public:
     void set_adb_lite_enabled(bool enable) noexcept;
     void set_kill_adb_on_exit(bool enable) noexcept;
     void set_client_type(const std::string& client_type) noexcept;
+    void set_win32_window_cursor_avoidance(bool enable) noexcept;
     const std::string& get_client_type() const noexcept;
 
     const std::string& get_uuid() const;
@@ -129,6 +130,7 @@ private:
 
     bool m_swipe_with_pause = false;
     bool m_kill_adb_on_exit = false;
+    bool m_win32_window_cursor_avoidance = false;
     std::string m_client_type;
 
     mutable std::shared_mutex m_image_mutex;

--- a/src/MaaCore/Controller/Win32Controller.cpp
+++ b/src/MaaCore/Controller/Win32Controller.cpp
@@ -2,6 +2,10 @@
 
 #include "Win32Controller.h"
 
+#include <algorithm>
+#include <chrono>
+#include <cstdlib>
+#include <optional>
 #include <sstream>
 #include <thread>
 
@@ -12,6 +16,136 @@
 
 namespace asst
 {
+namespace
+{
+constexpr LONG CursorAvoidancePadding = 8;
+constexpr int NormalWindowParkingAttempts = 3;
+constexpr auto WindowMoveSettleTimeout = std::chrono::milliseconds(250);
+constexpr auto WindowPosTrackingSettleDelay = std::chrono::milliseconds(40);
+
+struct WindowParkingCandidate
+{
+    LONG left = 0;
+    LONG top = 0;
+    long long overflow = 0;
+    long long movement = 0;
+    bool preferred = false;
+};
+
+LONG fit_window_axis(LONG current, LONG bound_begin, LONG bound_end, LONG size)
+{
+    const LONG available = bound_end - bound_begin;
+    if (size >= available) {
+        return bound_begin;
+    }
+    return std::clamp(current, bound_begin, bound_end - size);
+}
+
+long long rect_overflow(const RECT& rect, const RECT& bounds)
+{
+    return static_cast<long long>(std::max(bounds.left - rect.left, 0L)) +
+           static_cast<long long>(std::max(bounds.top - rect.top, 0L)) +
+           static_cast<long long>(std::max(rect.right - bounds.right, 0L)) +
+           static_cast<long long>(std::max(rect.bottom - bounds.bottom, 0L));
+}
+
+bool get_client_screen_rect(HWND hwnd, RECT& rect)
+{
+    RECT client_rect = {};
+    if (!GetClientRect(hwnd, &client_rect)) {
+        return false;
+    }
+
+    POINT top_left = { client_rect.left, client_rect.top };
+    POINT bottom_right = { client_rect.right, client_rect.bottom };
+    if (!ClientToScreen(hwnd, &top_left) || !ClientToScreen(hwnd, &bottom_right)) {
+        return false;
+    }
+
+    rect = { top_left.x, top_left.y, bottom_right.x, bottom_right.y };
+    return true;
+}
+
+std::optional<WindowParkingCandidate> make_parking_candidate(
+    LONG left,
+    LONG top,
+    bool preferred,
+    const POINT& cursor,
+    const RECT& window_rect,
+    const RECT& client_rect,
+    const RECT& monitor_rect,
+    LONG cursor_clearance)
+{
+    RECT predicted_window = window_rect;
+    OffsetRect(&predicted_window, left - window_rect.left, top - window_rect.top);
+
+    RECT predicted_client = client_rect;
+    OffsetRect(&predicted_client, left - window_rect.left, top - window_rect.top);
+    InflateRect(&predicted_client, cursor_clearance, cursor_clearance);
+    if (PtInRect(&predicted_client, cursor)) {
+        return std::nullopt;
+    }
+
+    return WindowParkingCandidate {
+        .left = left,
+        .top = top,
+        .overflow = rect_overflow(predicted_window, monitor_rect),
+        .movement = std::abs(static_cast<long long>(left) - window_rect.left) +
+                    std::abs(static_cast<long long>(top) - window_rect.top),
+        .preferred = preferred,
+    };
+}
+
+void select_parking_candidate(
+    std::optional<WindowParkingCandidate>& best,
+    std::optional<WindowParkingCandidate> candidate)
+{
+    if (!candidate) {
+        return;
+    }
+    if (!best || candidate->overflow < best->overflow ||
+        (candidate->overflow == best->overflow && candidate->preferred && !best->preferred) ||
+        (candidate->overflow == best->overflow && candidate->preferred == best->preferred &&
+         candidate->movement < best->movement)) {
+        best = candidate;
+    }
+}
+
+HWND find_mouse_target(HWND root, const POINT& cursor)
+{
+    HWND target = root;
+    while (target && IsWindow(target)) {
+        POINT local = cursor;
+        if (!ScreenToClient(target, &local)) {
+            break;
+        }
+
+        HWND child = ChildWindowFromPointEx(target, local, CWP_SKIPDISABLED | CWP_SKIPINVISIBLE | CWP_SKIPTRANSPARENT);
+        if (!child || child == target) {
+            break;
+        }
+        target = child;
+    }
+    return target;
+}
+
+void send_mouse_leave(HWND root, HWND target)
+{
+    auto send = [](HWND hwnd) {
+        if (!hwnd || !IsWindow(hwnd)) {
+            return;
+        }
+        DWORD_PTR result = 0;
+        SendMessageTimeoutW(hwnd, WM_MOUSELEAVE, 0, 0, SMTO_ABORTIFHUNG, 25, &result);
+    };
+
+    send(target);
+    if (target != root) {
+        send(root);
+    }
+}
+}
+
 Win32Controller::Win32Controller(const AsstCallback& callback, Assistant* inst) :
     InstHelper(inst),
     m_callback(callback),
@@ -28,6 +162,7 @@ Win32Controller::~Win32Controller()
         m_loader->destroy(m_unit_handle);
         m_unit_handle = nullptr;
     }
+    restore_window_position();
 }
 
 bool Win32Controller::attach(
@@ -39,16 +174,18 @@ bool Win32Controller::attach(
     LogTraceFunction;
 
     m_inited = false;
-    m_hwnd = hwnd;
-    m_screencap_method = screencap_method;
-    m_mouse_method = mouse_method;
-    m_keyboard_method = keyboard_method;
 
     // 销毁旧的控制单元
     if (m_unit_handle && m_loader) {
         m_loader->destroy(m_unit_handle);
         m_unit_handle = nullptr;
     }
+    restore_window_position();
+
+    m_hwnd = hwnd;
+    m_screencap_method = screencap_method;
+    m_mouse_method = mouse_method;
+    m_keyboard_method = keyboard_method;
 
     // 加载 DLL
     if (!m_loader->loaded()) {
@@ -115,6 +252,25 @@ const std::string& Win32Controller::get_uuid() const
 bool Win32Controller::screencap(cv::Mat& image_payload, bool allow_reconnect [[maybe_unused]])
 {
     LogTraceFunction;
+
+    if (should_avoid_window_cursor()) {
+        auto hwnd = static_cast<HWND>(m_hwnd);
+        constexpr auto PseudoMinimizeMethods = Win32Screencap::FramePool | Win32Screencap::PrintWindow;
+        if (hwnd && IsWindow(hwnd) && IsIconic(hwnd) && (m_screencap_method & PseudoMinimizeMethods) != 0) {
+            // These capture methods convert a real minimized window into a transparent pseudo-minimized
+            // window inside the control unit's screencap call. Discard that transition frame, then park
+            // the restored window before producing the image exposed to recognition.
+            cv::Mat transition_frame;
+            if (!unit_screencap(transition_frame)) {
+                return false;
+            }
+        }
+
+        if (!park_window_away_from_cursor()) {
+            Log.warn("Failed to move Win32 window away from the physical cursor; skip this screencap");
+            return false;
+        }
+    }
 
     if (!unit_screencap(image_payload)) {
         return false;
@@ -219,6 +375,9 @@ bool Win32Controller::click(const Point& p)
     std::this_thread::sleep_for(std::chrono::milliseconds(click_delay_ms));
     bool up = unit_touch_up(0);
     std::this_thread::sleep_for(std::chrono::milliseconds(click_delay_ms));
+    if (up && should_avoid_window_cursor() && !park_window_away_from_cursor()) {
+        Log.warn("Failed to move Win32 window away from the physical cursor after click");
+    }
 
     return up && down;
 }
@@ -301,7 +460,14 @@ bool Win32Controller::swipe(
         do_swipe(x2, y2, x2, y2 - opt.minitouch_extra_swipe_dist, opt.minitouch_extra_swipe_duration);
     }
 
-    return unit_touch_up(0);
+    bool up = unit_touch_up(0);
+    if (up && should_avoid_window_cursor()) {
+        std::this_thread::sleep_for(WindowPosTrackingSettleDelay);
+        if (!park_window_away_from_cursor()) {
+            Log.warn("Failed to move Win32 window away from the physical cursor after swipe");
+        }
+    }
+    return up;
 }
 
 bool Win32Controller::inject_input_event(const InputEvent& event)
@@ -311,8 +477,16 @@ bool Win32Controller::inject_input_event(const InputEvent& event)
     switch (event.type) {
     case InputEvent::Type::TOUCH_DOWN:
         return unit_touch_down(event.pointerId, event.point.x, event.point.y, 0);
-    case InputEvent::Type::TOUCH_UP:
-        return unit_touch_up(event.pointerId);
+    case InputEvent::Type::TOUCH_UP: {
+        bool up = unit_touch_up(event.pointerId);
+        if (up && should_avoid_window_cursor()) {
+            std::this_thread::sleep_for(WindowPosTrackingSettleDelay);
+            if (!park_window_away_from_cursor()) {
+                Log.warn("Failed to move Win32 window away from the physical cursor after touch up");
+            }
+        }
+        return up;
+    }
     case InputEvent::Type::TOUCH_MOVE:
         return unit_touch_move(event.pointerId, event.point.x, event.point.y, 0);
     case InputEvent::Type::KEY_DOWN: {
@@ -357,6 +531,317 @@ void Win32Controller::callback(AsstMsg msg, const json::value& details)
     if (m_callback) {
         m_callback(msg, details, m_inst);
     }
+}
+
+bool Win32Controller::should_avoid_window_cursor() const noexcept
+{
+    constexpr auto WindowPosMethods = Win32Input::SendMessageWithWindowPos | Win32Input::PostMessageWithWindowPos;
+    return m_window_cursor_avoidance.load() && (m_mouse_method & WindowPosMethods) != 0;
+}
+
+bool Win32Controller::park_window_away_from_cursor()
+{
+    if (!should_avoid_window_cursor()) {
+        return true;
+    }
+
+    auto hwnd = static_cast<HWND>(m_hwnd);
+    if (!hwnd || !IsWindow(hwnd)) {
+        return false;
+    }
+    if (IsIconic(hwnd)) {
+        return true;
+    }
+
+    std::scoped_lock lock(m_window_move_mutex);
+    auto previous_dpi_context = SetThreadDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+
+    bool result = [&]() {
+        for (int attempt = 0; attempt <= NormalWindowParkingAttempts; ++attempt) {
+            const bool use_offscreen_fallback = attempt == NormalWindowParkingAttempts;
+            POINT cursor = {};
+            RECT window_rect = {};
+            RECT client_rect = {};
+            if (!GetCursorPos(&cursor) || !GetWindowRect(hwnd, &window_rect) ||
+                !get_client_screen_rect(hwnd, client_rect)) {
+                return false;
+            }
+
+            const LONG client_width = client_rect.right - client_rect.left;
+            const LONG client_height = client_rect.bottom - client_rect.top;
+            const LONG window_width = window_rect.right - window_rect.left;
+            const LONG window_height = window_rect.bottom - window_rect.top;
+            const LONG client_offset_x = client_rect.left - window_rect.left;
+            const LONG client_offset_y = client_rect.top - window_rect.top;
+            const LONG cursor_clearance = std::max(
+                                              { static_cast<LONG>(GetSystemMetrics(SM_CXCURSOR)),
+                                                static_cast<LONG>(GetSystemMetrics(SM_CYCURSOR)),
+                                                32L }) +
+                                          CursorAvoidancePadding;
+            if (client_width <= 0 || client_height <= 0) {
+                return false;
+            }
+
+            RECT anchor_rect = m_window_position_saved ? m_saved_window_rect : window_rect;
+            HMONITOR monitor = MonitorFromRect(&anchor_rect, MONITOR_DEFAULTTONEAREST);
+            MONITORINFO monitor_info = { sizeof(MONITORINFO) };
+            if (!monitor || !GetMonitorInfoW(monitor, &monitor_info)) {
+                return false;
+            }
+            const RECT& monitor_rect = monitor_info.rcMonitor;
+            const LONG fitted_left =
+                fit_window_axis(window_rect.left, monitor_rect.left, monitor_rect.right, window_width);
+            const LONG fitted_top =
+                fit_window_axis(window_rect.top, monitor_rect.top, monitor_rect.bottom, window_height);
+
+            RECT cursor_safe_client_rect = client_rect;
+            InflateRect(&cursor_safe_client_rect, cursor_clearance, cursor_clearance);
+            if (!PtInRect(&cursor_safe_client_rect, cursor)) {
+                return true;
+            }
+            HWND mouse_target = find_mouse_target(hwnd, cursor);
+
+            std::optional<WindowParkingCandidate> best;
+            if (!use_offscreen_fallback && m_window_position_saved) {
+                select_parking_candidate(
+                    best,
+                    make_parking_candidate(
+                        m_saved_window_rect.left,
+                        m_saved_window_rect.top,
+                        true,
+                        cursor,
+                        window_rect,
+                        client_rect,
+                        monitor_rect,
+                        cursor_clearance));
+            }
+            if (!use_offscreen_fallback) {
+                select_parking_candidate(
+                    best,
+                    make_parking_candidate(
+                        window_rect.left,
+                        window_rect.top,
+                        false,
+                        cursor,
+                        window_rect,
+                        client_rect,
+                        monitor_rect,
+                        cursor_clearance));
+                select_parking_candidate(
+                    best,
+                    make_parking_candidate(
+                        cursor.x + cursor_clearance + 1 - client_offset_x,
+                        fitted_top,
+                        false,
+                        cursor,
+                        window_rect,
+                        client_rect,
+                        monitor_rect,
+                        cursor_clearance));
+                select_parking_candidate(
+                    best,
+                    make_parking_candidate(
+                        cursor.x - cursor_clearance - client_width - client_offset_x,
+                        fitted_top,
+                        false,
+                        cursor,
+                        window_rect,
+                        client_rect,
+                        monitor_rect,
+                        cursor_clearance));
+                select_parking_candidate(
+                    best,
+                    make_parking_candidate(
+                        fitted_left,
+                        cursor.y + cursor_clearance + 1 - client_offset_y,
+                        false,
+                        cursor,
+                        window_rect,
+                        client_rect,
+                        monitor_rect,
+                        cursor_clearance));
+                select_parking_candidate(
+                    best,
+                    make_parking_candidate(
+                        fitted_left,
+                        cursor.y - cursor_clearance - client_height - client_offset_y,
+                        false,
+                        cursor,
+                        window_rect,
+                        client_rect,
+                        monitor_rect,
+                        cursor_clearance));
+            }
+            else {
+                const LONG virtual_left = GetSystemMetrics(SM_XVIRTUALSCREEN);
+                const LONG virtual_top = GetSystemMetrics(SM_YVIRTUALSCREEN);
+                const LONG virtual_width = GetSystemMetrics(SM_CXVIRTUALSCREEN);
+                const LONG virtual_height = GetSystemMetrics(SM_CYVIRTUALSCREEN);
+                if (virtual_width <= 0 || virtual_height <= 0) {
+                    return false;
+                }
+
+                const RECT virtual_screen = {
+                    virtual_left,
+                    virtual_top,
+                    virtual_left + virtual_width,
+                    virtual_top + virtual_height,
+                };
+                const LONG virtual_fitted_left =
+                    fit_window_axis(window_rect.left, virtual_screen.left, virtual_screen.right, window_width);
+                const LONG virtual_fitted_top =
+                    fit_window_axis(window_rect.top, virtual_screen.top, virtual_screen.bottom, window_height);
+
+                Log.info("Physical cursor kept entering the Win32 client; park the window outside the virtual screen");
+                select_parking_candidate(
+                    best,
+                    make_parking_candidate(
+                        virtual_screen.right + cursor_clearance + 1 - client_offset_x,
+                        virtual_fitted_top,
+                        false,
+                        cursor,
+                        window_rect,
+                        client_rect,
+                        monitor_rect,
+                        cursor_clearance));
+                select_parking_candidate(
+                    best,
+                    make_parking_candidate(
+                        virtual_screen.left - cursor_clearance - client_width - client_offset_x,
+                        virtual_fitted_top,
+                        false,
+                        cursor,
+                        window_rect,
+                        client_rect,
+                        monitor_rect,
+                        cursor_clearance));
+                select_parking_candidate(
+                    best,
+                    make_parking_candidate(
+                        virtual_fitted_left,
+                        virtual_screen.bottom + cursor_clearance + 1 - client_offset_y,
+                        false,
+                        cursor,
+                        window_rect,
+                        client_rect,
+                        monitor_rect,
+                        cursor_clearance));
+                select_parking_candidate(
+                    best,
+                    make_parking_candidate(
+                        virtual_fitted_left,
+                        virtual_screen.top - cursor_clearance - client_height - client_offset_y,
+                        false,
+                        cursor,
+                        window_rect,
+                        client_rect,
+                        monitor_rect,
+                        cursor_clearance));
+            }
+
+            if (!best) {
+                return false;
+            }
+
+            const bool needs_move = std::abs(static_cast<long long>(best->left) - window_rect.left) > 1 ||
+                                    std::abs(static_cast<long long>(best->top) - window_rect.top) > 1;
+            if (needs_move) {
+                const bool saved_now = !m_window_position_saved;
+                if (saved_now) {
+                    m_saved_window_rect = window_rect;
+                    m_window_position_saved = true;
+                    m_saved_window_placement.length = sizeof(m_saved_window_placement);
+                    m_window_placement_saved = GetWindowPlacement(hwnd, &m_saved_window_placement) != FALSE;
+                }
+                if (!SetWindowPos(
+                        hwnd,
+                        nullptr,
+                        best->left,
+                        best->top,
+                        0,
+                        0,
+                        SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOSENDCHANGING | SWP_ASYNCWINDOWPOS)) {
+                    if (saved_now) {
+                        m_window_position_saved = false;
+                        m_window_placement_saved = false;
+                    }
+                    continue;
+                }
+            }
+
+            if (needs_move) {
+                bool settled = false;
+                const auto settle_deadline = std::chrono::steady_clock::now() + WindowMoveSettleTimeout;
+                do {
+                    RECT settled_rect = {};
+                    if (GetWindowRect(hwnd, &settled_rect) &&
+                        std::abs(static_cast<long long>(settled_rect.left) - best->left) <= 1 &&
+                        std::abs(static_cast<long long>(settled_rect.top) - best->top) <= 1) {
+                        settled = true;
+                        break;
+                    }
+                    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+                } while (std::chrono::steady_clock::now() < settle_deadline);
+                if (!settled) {
+                    continue;
+                }
+            }
+
+            send_mouse_leave(hwnd, mouse_target);
+            if (needs_move) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(17));
+            }
+
+            POINT current_cursor = {};
+            RECT current_client_rect = {};
+            if (GetCursorPos(&current_cursor) && get_client_screen_rect(hwnd, current_client_rect)) {
+                InflateRect(&current_client_rect, cursor_clearance, cursor_clearance);
+                if (!PtInRect(&current_client_rect, current_cursor)) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }();
+
+    if (previous_dpi_context) {
+        SetThreadDpiAwarenessContext(previous_dpi_context);
+    }
+    return result;
+}
+
+void Win32Controller::restore_window_position()
+{
+    std::scoped_lock lock(m_window_move_mutex);
+    auto hwnd = static_cast<HWND>(m_hwnd);
+    if (!m_window_position_saved || !hwnd || !IsWindow(hwnd)) {
+        m_window_position_saved = false;
+        m_window_placement_saved = false;
+        return;
+    }
+
+    bool restored = false;
+    if (IsIconic(hwnd) && m_window_placement_saved) {
+        WINDOWPLACEMENT current_placement = { sizeof(WINDOWPLACEMENT) };
+        if (GetWindowPlacement(hwnd, &current_placement)) {
+            current_placement.rcNormalPosition = m_saved_window_placement.rcNormalPosition;
+            restored = SetWindowPlacement(hwnd, &current_placement) != FALSE;
+        }
+    }
+
+    if (!restored && !SetWindowPos(
+                         hwnd,
+                         nullptr,
+                         m_saved_window_rect.left,
+                         m_saved_window_rect.top,
+                         0,
+                         0,
+                         SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOSENDCHANGING | SWP_ASYNCWINDOWPOS)) {
+        Log.warn("Failed to restore Win32 window position", GetLastError());
+    }
+    m_window_position_saved = false;
+    m_window_placement_saved = false;
 }
 
 bool Win32Controller::unit_connect()

--- a/src/MaaCore/Controller/Win32Controller.cpp
+++ b/src/MaaCore/Controller/Win32Controller.cpp
@@ -32,6 +32,21 @@ struct WindowParkingCandidate
     bool preferred = false;
 };
 
+struct WindowParkingContext
+{
+    POINT cursor = {};
+    RECT window_rect = {};
+    RECT client_rect = {};
+    RECT monitor_rect = {};
+    LONG client_width = 0;
+    LONG client_height = 0;
+    LONG window_width = 0;
+    LONG window_height = 0;
+    LONG client_offset_x = 0;
+    LONG client_offset_y = 0;
+    LONG cursor_clearance = 0;
+};
+
 LONG fit_window_axis(LONG current, LONG bound_begin, LONG bound_end, LONG size)
 {
     const LONG available = bound_end - bound_begin;
@@ -66,32 +81,65 @@ bool get_client_screen_rect(HWND hwnd, RECT& rect)
     return true;
 }
 
-std::optional<WindowParkingCandidate> make_parking_candidate(
-    LONG left,
-    LONG top,
-    bool preferred,
-    const POINT& cursor,
-    const RECT& window_rect,
-    const RECT& client_rect,
-    const RECT& monitor_rect,
-    LONG cursor_clearance)
+std::optional<WindowParkingContext> make_window_parking_context(HWND hwnd, const RECT* saved_window_rect)
 {
-    RECT predicted_window = window_rect;
-    OffsetRect(&predicted_window, left - window_rect.left, top - window_rect.top);
+    WindowParkingContext context;
+    if (!GetCursorPos(&context.cursor) || !GetWindowRect(hwnd, &context.window_rect) ||
+        !get_client_screen_rect(hwnd, context.client_rect)) {
+        return std::nullopt;
+    }
 
-    RECT predicted_client = client_rect;
-    OffsetRect(&predicted_client, left - window_rect.left, top - window_rect.top);
-    InflateRect(&predicted_client, cursor_clearance, cursor_clearance);
-    if (PtInRect(&predicted_client, cursor)) {
+    context.client_width = context.client_rect.right - context.client_rect.left;
+    context.client_height = context.client_rect.bottom - context.client_rect.top;
+    context.window_width = context.window_rect.right - context.window_rect.left;
+    context.window_height = context.window_rect.bottom - context.window_rect.top;
+    context.client_offset_x = context.client_rect.left - context.window_rect.left;
+    context.client_offset_y = context.client_rect.top - context.window_rect.top;
+    context.cursor_clearance = std::max(
+                                   { static_cast<LONG>(GetSystemMetrics(SM_CXCURSOR)),
+                                     static_cast<LONG>(GetSystemMetrics(SM_CYCURSOR)),
+                                     32L }) +
+                               CursorAvoidancePadding;
+    if (context.client_width <= 0 || context.client_height <= 0) {
+        return std::nullopt;
+    }
+
+    const RECT& anchor_rect = saved_window_rect ? *saved_window_rect : context.window_rect;
+    HMONITOR monitor = MonitorFromRect(&anchor_rect, MONITOR_DEFAULTTONEAREST);
+    MONITORINFO monitor_info = { sizeof(MONITORINFO) };
+    if (!monitor || !GetMonitorInfoW(monitor, &monitor_info)) {
+        return std::nullopt;
+    }
+    context.monitor_rect = monitor_info.rcMonitor;
+    return context;
+}
+
+bool cursor_intersects_safe_client(const WindowParkingContext& context)
+{
+    RECT safe_client_rect = context.client_rect;
+    InflateRect(&safe_client_rect, context.cursor_clearance, context.cursor_clearance);
+    return PtInRect(&safe_client_rect, context.cursor) != FALSE;
+}
+
+std::optional<WindowParkingCandidate>
+    make_parking_candidate(LONG left, LONG top, bool preferred, const WindowParkingContext& context)
+{
+    RECT predicted_window = context.window_rect;
+    OffsetRect(&predicted_window, left - context.window_rect.left, top - context.window_rect.top);
+
+    RECT predicted_client = context.client_rect;
+    OffsetRect(&predicted_client, left - context.window_rect.left, top - context.window_rect.top);
+    InflateRect(&predicted_client, context.cursor_clearance, context.cursor_clearance);
+    if (PtInRect(&predicted_client, context.cursor)) {
         return std::nullopt;
     }
 
     return WindowParkingCandidate {
         .left = left,
         .top = top,
-        .overflow = rect_overflow(predicted_window, monitor_rect),
-        .movement = std::abs(static_cast<long long>(left) - window_rect.left) +
-                    std::abs(static_cast<long long>(top) - window_rect.top),
+        .overflow = rect_overflow(predicted_window, context.monitor_rect),
+        .movement = std::abs(static_cast<long long>(left) - context.window_rect.left) +
+                    std::abs(static_cast<long long>(top) - context.window_rect.top),
         .preferred = preferred,
     };
 }
@@ -109,6 +157,113 @@ void select_parking_candidate(
          candidate->movement < best->movement)) {
         best = candidate;
     }
+}
+
+std::optional<WindowParkingCandidate>
+    select_normal_parking_candidate(const WindowParkingContext& context, const RECT* saved_window_rect)
+{
+    const LONG fitted_left = fit_window_axis(
+        context.window_rect.left,
+        context.monitor_rect.left,
+        context.monitor_rect.right,
+        context.window_width);
+    const LONG fitted_top = fit_window_axis(
+        context.window_rect.top,
+        context.monitor_rect.top,
+        context.monitor_rect.bottom,
+        context.window_height);
+
+    std::optional<WindowParkingCandidate> best;
+    if (saved_window_rect) {
+        select_parking_candidate(
+            best,
+            make_parking_candidate(saved_window_rect->left, saved_window_rect->top, true, context));
+    }
+    select_parking_candidate(
+        best,
+        make_parking_candidate(context.window_rect.left, context.window_rect.top, false, context));
+    select_parking_candidate(
+        best,
+        make_parking_candidate(
+            context.cursor.x + context.cursor_clearance + 1 - context.client_offset_x,
+            fitted_top,
+            false,
+            context));
+    select_parking_candidate(
+        best,
+        make_parking_candidate(
+            context.cursor.x - context.cursor_clearance - context.client_width - context.client_offset_x,
+            fitted_top,
+            false,
+            context));
+    select_parking_candidate(
+        best,
+        make_parking_candidate(
+            fitted_left,
+            context.cursor.y + context.cursor_clearance + 1 - context.client_offset_y,
+            false,
+            context));
+    select_parking_candidate(
+        best,
+        make_parking_candidate(
+            fitted_left,
+            context.cursor.y - context.cursor_clearance - context.client_height - context.client_offset_y,
+            false,
+            context));
+    return best;
+}
+
+std::optional<WindowParkingCandidate> select_offscreen_parking_candidate(const WindowParkingContext& context)
+{
+    const LONG virtual_left = GetSystemMetrics(SM_XVIRTUALSCREEN);
+    const LONG virtual_top = GetSystemMetrics(SM_YVIRTUALSCREEN);
+    const LONG virtual_width = GetSystemMetrics(SM_CXVIRTUALSCREEN);
+    const LONG virtual_height = GetSystemMetrics(SM_CYVIRTUALSCREEN);
+    if (virtual_width <= 0 || virtual_height <= 0) {
+        return std::nullopt;
+    }
+
+    const RECT virtual_screen = {
+        virtual_left,
+        virtual_top,
+        virtual_left + virtual_width,
+        virtual_top + virtual_height,
+    };
+    const LONG fitted_left =
+        fit_window_axis(context.window_rect.left, virtual_screen.left, virtual_screen.right, context.window_width);
+    const LONG fitted_top =
+        fit_window_axis(context.window_rect.top, virtual_screen.top, virtual_screen.bottom, context.window_height);
+
+    std::optional<WindowParkingCandidate> best;
+    select_parking_candidate(
+        best,
+        make_parking_candidate(
+            virtual_screen.right + context.cursor_clearance + 1 - context.client_offset_x,
+            fitted_top,
+            false,
+            context));
+    select_parking_candidate(
+        best,
+        make_parking_candidate(
+            virtual_screen.left - context.cursor_clearance - context.client_width - context.client_offset_x,
+            fitted_top,
+            false,
+            context));
+    select_parking_candidate(
+        best,
+        make_parking_candidate(
+            fitted_left,
+            virtual_screen.bottom + context.cursor_clearance + 1 - context.client_offset_y,
+            false,
+            context));
+    select_parking_candidate(
+        best,
+        make_parking_candidate(
+            fitted_left,
+            virtual_screen.top - context.cursor_clearance - context.client_height - context.client_offset_y,
+            false,
+            context));
+    return best;
 }
 
 HWND find_mouse_target(HWND root, const POINT& cursor)
@@ -143,6 +298,73 @@ void send_mouse_leave(HWND root, HWND target)
     if (target != root) {
         send(root);
     }
+}
+
+bool move_window_to_candidate(
+    HWND hwnd,
+    const WindowParkingContext& context,
+    const WindowParkingCandidate& candidate,
+    bool& window_position_saved,
+    RECT& saved_window_rect,
+    bool& window_placement_saved,
+    WINDOWPLACEMENT& saved_window_placement,
+    bool& window_moved)
+{
+    window_moved = std::abs(static_cast<long long>(candidate.left) - context.window_rect.left) > 1 ||
+                   std::abs(static_cast<long long>(candidate.top) - context.window_rect.top) > 1;
+    if (!window_moved) {
+        return true;
+    }
+
+    const bool saved_now = !window_position_saved;
+    if (saved_now) {
+        saved_window_rect = context.window_rect;
+        window_position_saved = true;
+        saved_window_placement.length = sizeof(saved_window_placement);
+        window_placement_saved = GetWindowPlacement(hwnd, &saved_window_placement) != FALSE;
+    }
+    if (!SetWindowPos(
+            hwnd,
+            nullptr,
+            candidate.left,
+            candidate.top,
+            0,
+            0,
+            SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOSENDCHANGING | SWP_ASYNCWINDOWPOS)) {
+        if (saved_now) {
+            window_position_saved = false;
+            window_placement_saved = false;
+        }
+        return false;
+    }
+
+    const auto settle_deadline = std::chrono::steady_clock::now() + WindowMoveSettleTimeout;
+    do {
+        RECT settled_rect = {};
+        if (GetWindowRect(hwnd, &settled_rect) &&
+            std::abs(static_cast<long long>(settled_rect.left) - candidate.left) <= 1 &&
+            std::abs(static_cast<long long>(settled_rect.top) - candidate.top) <= 1) {
+            return true;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    } while (std::chrono::steady_clock::now() < settle_deadline);
+    return false;
+}
+
+bool finish_window_parking(HWND hwnd, HWND mouse_target, bool window_moved, LONG cursor_clearance)
+{
+    send_mouse_leave(hwnd, mouse_target);
+    if (window_moved) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(17));
+    }
+
+    POINT current_cursor = {};
+    RECT current_client_rect = {};
+    if (!GetCursorPos(&current_cursor) || !get_client_screen_rect(hwnd, current_client_rect)) {
+        return false;
+    }
+    InflateRect(&current_client_rect, cursor_clearance, cursor_clearance);
+    return PtInRect(&current_client_rect, current_cursor) == FALSE;
 }
 }
 
@@ -375,8 +597,8 @@ bool Win32Controller::click(const Point& p)
     std::this_thread::sleep_for(std::chrono::milliseconds(click_delay_ms));
     bool up = unit_touch_up(0);
     std::this_thread::sleep_for(std::chrono::milliseconds(click_delay_ms));
-    if (up && should_avoid_window_cursor() && !park_window_away_from_cursor()) {
-        Log.warn("Failed to move Win32 window away from the physical cursor after click");
+    if (up) {
+        avoid_window_cursor_after_input("click", false);
     }
 
     return up && down;
@@ -461,11 +683,8 @@ bool Win32Controller::swipe(
     }
 
     bool up = unit_touch_up(0);
-    if (up && should_avoid_window_cursor()) {
-        std::this_thread::sleep_for(WindowPosTrackingSettleDelay);
-        if (!park_window_away_from_cursor()) {
-            Log.warn("Failed to move Win32 window away from the physical cursor after swipe");
-        }
+    if (up) {
+        avoid_window_cursor_after_input("swipe", true);
     }
     return up;
 }
@@ -479,11 +698,8 @@ bool Win32Controller::inject_input_event(const InputEvent& event)
         return unit_touch_down(event.pointerId, event.point.x, event.point.y, 0);
     case InputEvent::Type::TOUCH_UP: {
         bool up = unit_touch_up(event.pointerId);
-        if (up && should_avoid_window_cursor()) {
-            std::this_thread::sleep_for(WindowPosTrackingSettleDelay);
-            if (!park_window_away_from_cursor()) {
-                Log.warn("Failed to move Win32 window away from the physical cursor after touch up");
-            }
+        if (up) {
+            avoid_window_cursor_after_input("touch up", true);
         }
         return up;
     }
@@ -539,6 +755,19 @@ bool Win32Controller::should_avoid_window_cursor() const noexcept
     return m_window_cursor_avoidance.load() && (m_mouse_method & WindowPosMethods) != 0;
 }
 
+void Win32Controller::avoid_window_cursor_after_input(const char* action, bool wait_for_window_pos_tracking)
+{
+    if (!should_avoid_window_cursor()) {
+        return;
+    }
+    if (wait_for_window_pos_tracking) {
+        std::this_thread::sleep_for(WindowPosTrackingSettleDelay);
+    }
+    if (!park_window_away_from_cursor()) {
+        Log.warn("Failed to move Win32 window away from the physical cursor after", action);
+    }
+}
+
 bool Win32Controller::park_window_away_from_cursor()
 {
     if (!should_avoid_window_cursor()) {
@@ -559,246 +788,39 @@ bool Win32Controller::park_window_away_from_cursor()
     bool result = [&]() {
         for (int attempt = 0; attempt <= NormalWindowParkingAttempts; ++attempt) {
             const bool use_offscreen_fallback = attempt == NormalWindowParkingAttempts;
-            POINT cursor = {};
-            RECT window_rect = {};
-            RECT client_rect = {};
-            if (!GetCursorPos(&cursor) || !GetWindowRect(hwnd, &window_rect) ||
-                !get_client_screen_rect(hwnd, client_rect)) {
+            const RECT* saved_window_rect = m_window_position_saved ? &m_saved_window_rect : nullptr;
+            auto context = make_window_parking_context(hwnd, saved_window_rect);
+            if (!context) {
                 return false;
             }
-
-            const LONG client_width = client_rect.right - client_rect.left;
-            const LONG client_height = client_rect.bottom - client_rect.top;
-            const LONG window_width = window_rect.right - window_rect.left;
-            const LONG window_height = window_rect.bottom - window_rect.top;
-            const LONG client_offset_x = client_rect.left - window_rect.left;
-            const LONG client_offset_y = client_rect.top - window_rect.top;
-            const LONG cursor_clearance = std::max(
-                                              { static_cast<LONG>(GetSystemMetrics(SM_CXCURSOR)),
-                                                static_cast<LONG>(GetSystemMetrics(SM_CYCURSOR)),
-                                                32L }) +
-                                          CursorAvoidancePadding;
-            if (client_width <= 0 || client_height <= 0) {
-                return false;
-            }
-
-            RECT anchor_rect = m_window_position_saved ? m_saved_window_rect : window_rect;
-            HMONITOR monitor = MonitorFromRect(&anchor_rect, MONITOR_DEFAULTTONEAREST);
-            MONITORINFO monitor_info = { sizeof(MONITORINFO) };
-            if (!monitor || !GetMonitorInfoW(monitor, &monitor_info)) {
-                return false;
-            }
-            const RECT& monitor_rect = monitor_info.rcMonitor;
-            const LONG fitted_left =
-                fit_window_axis(window_rect.left, monitor_rect.left, monitor_rect.right, window_width);
-            const LONG fitted_top =
-                fit_window_axis(window_rect.top, monitor_rect.top, monitor_rect.bottom, window_height);
-
-            RECT cursor_safe_client_rect = client_rect;
-            InflateRect(&cursor_safe_client_rect, cursor_clearance, cursor_clearance);
-            if (!PtInRect(&cursor_safe_client_rect, cursor)) {
+            if (!cursor_intersects_safe_client(*context)) {
                 return true;
             }
-            HWND mouse_target = find_mouse_target(hwnd, cursor);
 
-            std::optional<WindowParkingCandidate> best;
-            if (!use_offscreen_fallback && m_window_position_saved) {
-                select_parking_candidate(
-                    best,
-                    make_parking_candidate(
-                        m_saved_window_rect.left,
-                        m_saved_window_rect.top,
-                        true,
-                        cursor,
-                        window_rect,
-                        client_rect,
-                        monitor_rect,
-                        cursor_clearance));
-            }
-            if (!use_offscreen_fallback) {
-                select_parking_candidate(
-                    best,
-                    make_parking_candidate(
-                        window_rect.left,
-                        window_rect.top,
-                        false,
-                        cursor,
-                        window_rect,
-                        client_rect,
-                        monitor_rect,
-                        cursor_clearance));
-                select_parking_candidate(
-                    best,
-                    make_parking_candidate(
-                        cursor.x + cursor_clearance + 1 - client_offset_x,
-                        fitted_top,
-                        false,
-                        cursor,
-                        window_rect,
-                        client_rect,
-                        monitor_rect,
-                        cursor_clearance));
-                select_parking_candidate(
-                    best,
-                    make_parking_candidate(
-                        cursor.x - cursor_clearance - client_width - client_offset_x,
-                        fitted_top,
-                        false,
-                        cursor,
-                        window_rect,
-                        client_rect,
-                        monitor_rect,
-                        cursor_clearance));
-                select_parking_candidate(
-                    best,
-                    make_parking_candidate(
-                        fitted_left,
-                        cursor.y + cursor_clearance + 1 - client_offset_y,
-                        false,
-                        cursor,
-                        window_rect,
-                        client_rect,
-                        monitor_rect,
-                        cursor_clearance));
-                select_parking_candidate(
-                    best,
-                    make_parking_candidate(
-                        fitted_left,
-                        cursor.y - cursor_clearance - client_height - client_offset_y,
-                        false,
-                        cursor,
-                        window_rect,
-                        client_rect,
-                        monitor_rect,
-                        cursor_clearance));
-            }
-            else {
-                const LONG virtual_left = GetSystemMetrics(SM_XVIRTUALSCREEN);
-                const LONG virtual_top = GetSystemMetrics(SM_YVIRTUALSCREEN);
-                const LONG virtual_width = GetSystemMetrics(SM_CXVIRTUALSCREEN);
-                const LONG virtual_height = GetSystemMetrics(SM_CYVIRTUALSCREEN);
-                if (virtual_width <= 0 || virtual_height <= 0) {
-                    return false;
-                }
-
-                const RECT virtual_screen = {
-                    virtual_left,
-                    virtual_top,
-                    virtual_left + virtual_width,
-                    virtual_top + virtual_height,
-                };
-                const LONG virtual_fitted_left =
-                    fit_window_axis(window_rect.left, virtual_screen.left, virtual_screen.right, window_width);
-                const LONG virtual_fitted_top =
-                    fit_window_axis(window_rect.top, virtual_screen.top, virtual_screen.bottom, window_height);
-
-                Log.info("Physical cursor kept entering the Win32 client; park the window outside the virtual screen");
-                select_parking_candidate(
-                    best,
-                    make_parking_candidate(
-                        virtual_screen.right + cursor_clearance + 1 - client_offset_x,
-                        virtual_fitted_top,
-                        false,
-                        cursor,
-                        window_rect,
-                        client_rect,
-                        monitor_rect,
-                        cursor_clearance));
-                select_parking_candidate(
-                    best,
-                    make_parking_candidate(
-                        virtual_screen.left - cursor_clearance - client_width - client_offset_x,
-                        virtual_fitted_top,
-                        false,
-                        cursor,
-                        window_rect,
-                        client_rect,
-                        monitor_rect,
-                        cursor_clearance));
-                select_parking_candidate(
-                    best,
-                    make_parking_candidate(
-                        virtual_fitted_left,
-                        virtual_screen.bottom + cursor_clearance + 1 - client_offset_y,
-                        false,
-                        cursor,
-                        window_rect,
-                        client_rect,
-                        monitor_rect,
-                        cursor_clearance));
-                select_parking_candidate(
-                    best,
-                    make_parking_candidate(
-                        virtual_fitted_left,
-                        virtual_screen.top - cursor_clearance - client_height - client_offset_y,
-                        false,
-                        cursor,
-                        window_rect,
-                        client_rect,
-                        monitor_rect,
-                        cursor_clearance));
-            }
-
-            if (!best) {
+            HWND mouse_target = find_mouse_target(hwnd, context->cursor);
+            auto candidate = use_offscreen_fallback ? select_offscreen_parking_candidate(*context)
+                                                    : select_normal_parking_candidate(*context, saved_window_rect);
+            if (!candidate) {
                 return false;
             }
-
-            const bool needs_move = std::abs(static_cast<long long>(best->left) - window_rect.left) > 1 ||
-                                    std::abs(static_cast<long long>(best->top) - window_rect.top) > 1;
-            if (needs_move) {
-                const bool saved_now = !m_window_position_saved;
-                if (saved_now) {
-                    m_saved_window_rect = window_rect;
-                    m_window_position_saved = true;
-                    m_saved_window_placement.length = sizeof(m_saved_window_placement);
-                    m_window_placement_saved = GetWindowPlacement(hwnd, &m_saved_window_placement) != FALSE;
-                }
-                if (!SetWindowPos(
-                        hwnd,
-                        nullptr,
-                        best->left,
-                        best->top,
-                        0,
-                        0,
-                        SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE | SWP_NOSENDCHANGING | SWP_ASYNCWINDOWPOS)) {
-                    if (saved_now) {
-                        m_window_position_saved = false;
-                        m_window_placement_saved = false;
-                    }
-                    continue;
-                }
+            if (use_offscreen_fallback) {
+                Log.info("Physical cursor kept entering the Win32 client; park the window outside the virtual screen");
             }
 
-            if (needs_move) {
-                bool settled = false;
-                const auto settle_deadline = std::chrono::steady_clock::now() + WindowMoveSettleTimeout;
-                do {
-                    RECT settled_rect = {};
-                    if (GetWindowRect(hwnd, &settled_rect) &&
-                        std::abs(static_cast<long long>(settled_rect.left) - best->left) <= 1 &&
-                        std::abs(static_cast<long long>(settled_rect.top) - best->top) <= 1) {
-                        settled = true;
-                        break;
-                    }
-                    std::this_thread::sleep_for(std::chrono::milliseconds(5));
-                } while (std::chrono::steady_clock::now() < settle_deadline);
-                if (!settled) {
-                    continue;
-                }
+            bool window_moved = false;
+            if (!move_window_to_candidate(
+                    hwnd,
+                    *context,
+                    *candidate,
+                    m_window_position_saved,
+                    m_saved_window_rect,
+                    m_window_placement_saved,
+                    m_saved_window_placement,
+                    window_moved)) {
+                continue;
             }
-
-            send_mouse_leave(hwnd, mouse_target);
-            if (needs_move) {
-                std::this_thread::sleep_for(std::chrono::milliseconds(17));
-            }
-
-            POINT current_cursor = {};
-            RECT current_client_rect = {};
-            if (GetCursorPos(&current_cursor) && get_client_screen_rect(hwnd, current_client_rect)) {
-                InflateRect(&current_client_rect, cursor_clearance, cursor_clearance);
-                if (!PtInRect(&current_client_rect, current_cursor)) {
-                    return true;
-                }
+            if (finish_window_parking(hwnd, mouse_target, window_moved, context->cursor_clearance)) {
+                return true;
             }
         }
 

--- a/src/MaaCore/Controller/Win32Controller.h
+++ b/src/MaaCore/Controller/Win32Controller.h
@@ -2,7 +2,9 @@
 
 #ifdef _WIN32
 
+#include <atomic>
 #include <memory>
+#include <mutex>
 #include <string>
 
 #include "MaaUtils/SafeWindows.hpp"
@@ -33,6 +35,8 @@ public:
         Win32ScreencapMethod screencap_method,
         Win32InputMethod mouse_method,
         Win32InputMethod keyboard_method);
+
+    void set_window_cursor_avoidance(bool enable) noexcept { m_window_cursor_avoidance.store(enable); }
 
 public: // ControllerAPI 接口
     virtual bool connect(const std::string& adb_path, const std::string& address, const std::string& config) override;
@@ -69,6 +73,9 @@ public: // ControllerAPI 接口
 
 private:
     void callback(AsstMsg msg, const json::value& details);
+    bool should_avoid_window_cursor() const noexcept;
+    bool park_window_away_from_cursor();
+    void restore_window_position();
 
     // 封装 MaaWin32ControlUnit 的调用
     bool unit_connect();
@@ -96,6 +103,13 @@ private:
     Win32ScreencapMethod m_screencap_method = Win32Screencap::None;
     Win32InputMethod m_mouse_method = Win32Input::None;
     Win32InputMethod m_keyboard_method = Win32Input::None;
+
+    std::atomic_bool m_window_cursor_avoidance = false;
+    bool m_window_position_saved = false;
+    bool m_window_placement_saved = false;
+    RECT m_saved_window_rect = {};
+    WINDOWPLACEMENT m_saved_window_placement = { sizeof(WINDOWPLACEMENT) };
+    std::mutex m_window_move_mutex;
 };
 } // namespace asst
 

--- a/src/MaaCore/Controller/Win32Controller.h
+++ b/src/MaaCore/Controller/Win32Controller.h
@@ -74,6 +74,7 @@ public: // ControllerAPI 接口
 private:
     void callback(AsstMsg msg, const json::value& details);
     bool should_avoid_window_cursor() const noexcept;
+    void avoid_window_cursor_after_input(const char* action, bool wait_for_window_pos_tracking);
     bool park_window_away_from_cursor();
     void restore_window_position();
 

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -2658,6 +2658,7 @@ public class AsstProxy
         var screencapMethod = (ulong)win32Extra.ScreencapMethod;
         var mouseMethod = (ulong)win32Extra.MouseMethod;
         var keyboardMethod = (ulong)win32Extra.KeyboardMethod;
+        AsstSetInstanceOption(InstanceOptionKey.Win32WindowCursorAvoidance, win32Extra.WindowCursorAvoidance ? "1" : "0");
         bool ret = AsstAttachWindow(_handle, hwnd, screencapMethod, mouseMethod, keyboardMethod);
 
         if (!ret)
@@ -3349,4 +3350,9 @@ public enum InstanceOptionKey
     /// Indicates the client type (game channel) used for resolving PackageName on connect.
     /// </summary>
     ClientType = 6,
+
+    /// <summary>
+    /// Indicates whether WindowPos input moves the Win32 target window away from the physical cursor.
+    /// </summary>
+    Win32WindowCursorAvoidance = 7,
 }

--- a/src/MaaWpfGui/Models/EmulatorConnectionExtra/Win32Extra.cs
+++ b/src/MaaWpfGui/Models/EmulatorConnectionExtra/Win32Extra.cs
@@ -119,6 +119,23 @@ public class Win32Extra() : ExtraConfig
         }
     }
 
+    [JsonInclude]
+    [JsonPropertyName("WindowCursorAvoidance")]
+    private bool _windowCursorAvoidance = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether WindowPos input should move the target window away from the physical cursor.
+    /// </summary>
+    [JsonIgnore]
+    public bool WindowCursorAvoidance
+    {
+        get => _windowCursorAvoidance;
+        set {
+            Instances.AsstProxy.Connected = false;
+            SetAndNotify(ref _windowCursorAvoidance, value);
+        }
+    }
+
     /// <summary>
     /// Win32 键盘输入方式枚举（与 AsstCaller.h 中 AsstWin32InputMethodEnum 对应）
     /// </summary>

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -1484,6 +1484,8 @@ Before use, please ensure:
     <system:String x:Key="AttachWindowInputSeize">Seize (Foreground, Fully Captures Mouse)</system:String>
     <system:String x:Key="AttachWindowInputSendWithCursor">SendMsg-CursorPos (Semi-background, Briefly Captures Mouse)</system:String>
     <system:String x:Key="AttachWindowInputSendWithWindowPos">SendMsg-WindowPos (Full Background, No Mouse Capture, Window May Move, Recommend Minimizing)</system:String>
+    <system:String x:Key="AttachWindowCursorAvoidance">Avoid Physical Cursor Automatically</system:String>
+    <system:String x:Key="AttachWindowCursorAvoidanceTip">Only applies to WindowPos mouse input. Moves the game window away from the physical cursor after input and before screenshots so an app-rendered cursor does not obstruct recognition.</system:String>
     <system:String x:Key="AttachWindowInputSendMsg">SendMsg (Stable)</system:String>
     <system:String x:Key="AttachWindowInputPostMsg">PostMsg (Efficient)</system:String>
     <!--  !AsstProxy  -->

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -1486,6 +1486,8 @@ MAA Team の開発リソースが限られているため、この機能はコ�
     <system:String x:Key="AttachWindowInputSeize">Seize（フォアグラウンド、マウスを完全に取得）</system:String>
     <system:String x:Key="AttachWindowInputSendWithCursor">SendMsg-CursorPos（半バックグラウンド、一時的にマウスを取得）</system:String>
     <system:String x:Key="AttachWindowInputSendWithWindowPos">SendMsg-WindowPos（フルバックグラウンド、マウス不要、ウィンドウが動く可能性あり、最小化推奨）</system:String>
+    <system:String x:Key="AttachWindowCursorAvoidance">物理カーソルを自動回避</system:String>
+    <system:String x:Key="AttachWindowCursorAvoidanceTip">WindowPos マウス入力でのみ有効です。入力後およびスクリーンショット前にゲームウィンドウを物理カーソルの外へ移動し、ゲームが描画するカーソルによる認識妨害を防ぎます。</system:String>
     <system:String x:Key="AttachWindowInputSendMsg">SendMsg（安定）</system:String>
     <system:String x:Key="AttachWindowInputPostMsg">PostMsg（高効率）</system:String>
     <!--  !AsstProxy  -->

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -1487,6 +1487,8 @@ MAA Team의 개발 여력이 제한되어 있어 이 기능은 커뮤니티에�
     <system:String x:Key="AttachWindowInputSeize">Seize (포그라운드, 마우스 완전 점유)</system:String>
     <system:String x:Key="AttachWindowInputSendWithCursor">SendMsg-CursorPos (반 백그라운드, 마우스 일시 점유)</system:String>
     <system:String x:Key="AttachWindowInputSendWithWindowPos">SendMsg-WindowPos (완전 백그라운드, 마우스 비점유, 창 이동 가능하나 사용 무관, 최소화 권장)</system:String>
+    <system:String x:Key="AttachWindowCursorAvoidance">물리 마우스 자동 회피</system:String>
+    <system:String x:Key="AttachWindowCursorAvoidanceTip">WindowPos 마우스 입력에만 적용됩니다. 입력 후와 스크린샷 전에 게임 창을 물리 커서 밖으로 이동하여 게임이 그린 커서가 인식을 방해하지 않도록 합니다.</system:String>
     <system:String x:Key="AttachWindowInputSendMsg">SendMsg (안정적)</system:String>
     <system:String x:Key="AttachWindowInputPostMsg">PostMsg (효율적)</system:String>
     <!--  !AsstProxy  -->

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -1485,6 +1485,8 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="AttachWindowInputSeize">Seize（前台，完全抢鼠标）</system:String>
     <system:String x:Key="AttachWindowInputSendWithCursor">SendMsg-CursorPos（半后台，短暂抢鼠标）</system:String>
     <system:String x:Key="AttachWindowInputSendWithWindowPos">SendMsg-WindowPos（全后台，不抢鼠标，窗口会乱飞但不影响使用，建议最小化）</system:String>
+    <system:String x:Key="AttachWindowCursorAvoidance">自动避让物理鼠标</system:String>
+    <system:String x:Key="AttachWindowCursorAvoidanceTip">仅对 WindowPos 鼠标输入生效。点击后及截图前将游戏窗口移到物理鼠标之外，避免游戏自绘光标遮挡识别区域。</system:String>
     <system:String x:Key="AttachWindowInputSendMsg">SendMsg（稳定）</system:String>
     <system:String x:Key="AttachWindowInputPostMsg">PostMsg（高效）</system:String>
     <!--  !AsstProxy  -->

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -1486,6 +1486,8 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="AttachWindowInputSeize">Seize（前台，完全搶滑鼠）</system:String>
     <system:String x:Key="AttachWindowInputSendWithCursor">SendMsg-CursorPos（半背景，短暫搶滑鼠）</system:String>
     <system:String x:Key="AttachWindowInputSendWithWindowPos">SendMsg-WindowPos（全背景，不搶滑鼠，視窗可能亂飛但不影響使用，建議最小化）</system:String>
+    <system:String x:Key="AttachWindowCursorAvoidance">自動避讓實體滑鼠</system:String>
+    <system:String x:Key="AttachWindowCursorAvoidanceTip">僅對 WindowPos 滑鼠輸入生效。點擊後及截圖前會將遊戲視窗移到實體滑鼠之外，避免遊戲自行繪製的游標遮擋辨識區域。</system:String>
     <system:String x:Key="AttachWindowInputSendMsg">SendMsg（穩定）</system:String>
     <system:String x:Key="AttachWindowInputPostMsg">PostMsg（高效）</system:String>
     <!--  !AsstProxy  -->

--- a/src/MaaWpfGui/Views/UserControl/GuideUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/GuideUserControl.xaml
@@ -418,6 +418,16 @@
                                                         SelectedValue="{Binding MouseMethod}"
                                                         SelectedValuePath="Value" />
 
+                                                    <StackPanel
+                                                        Margin="0,5"
+                                                        HorizontalAlignment="Center"
+                                                        Orientation="Horizontal">
+                                                        <CheckBox
+                                                            Content="{DynamicResource AttachWindowCursorAvoidance}"
+                                                            IsChecked="{Binding WindowCursorAvoidance}" />
+                                                        <controls:TooltipBlock TooltipText="{DynamicResource AttachWindowCursorAvoidanceTip}" />
+                                                    </StackPanel>
+
                                                     <hc:ComboBox
                                                         Width="300"
                                                         Margin="0,5"

--- a/src/MaaWpfGui/Views/UserControl/Settings/ConnectSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/Settings/ConnectSettingsUserControl.xaml
@@ -282,6 +282,16 @@
                                     Margin="5"
                                     HorizontalAlignment="Center"
                                     Orientation="Horizontal">
+                                    <CheckBox
+                                        Content="{DynamicResource AttachWindowCursorAvoidance}"
+                                        IsChecked="{Binding WindowCursorAvoidance}" />
+                                    <controls:TooltipBlock TooltipText="{DynamicResource AttachWindowCursorAvoidanceTip}" />
+                                </StackPanel>
+
+                                <StackPanel
+                                    Margin="5"
+                                    HorizontalAlignment="Center"
+                                    Orientation="Horizontal">
                                     <hc:ComboBox
                                         Width="300"
                                         Height="30"

--- a/src/MaaWpfGui/Views/UserControl/TaskQueue/StartUpTaskUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/TaskQueue/StartUpTaskUserControl.xaml
@@ -308,6 +308,13 @@
                                 SelectedValue="{Binding MouseMethod}"
                                 SelectedValuePath="Value" />
 
+                            <StackPanel Margin="0,5" Orientation="Horizontal">
+                                <CheckBox
+                                    Content="{DynamicResource AttachWindowCursorAvoidance}"
+                                    IsChecked="{Binding WindowCursorAvoidance}" />
+                                <controls:TooltipBlock TooltipText="{DynamicResource AttachWindowCursorAvoidanceTip}" />
+                            </StackPanel>
+
                             <hc:ComboBox
                                 Margin="0,5"
                                 hc:InfoElement.Title="{DynamicResource AttachWindowKeyboardMethod}"


### PR DESCRIPTION
## 概述

修复 PC 端使用 `SendMessageWithWindowPos` / `PostMessageWithWindowPos` 时，应用自绘光标进入截图并遮挡识别区域的问题。

- 在合成输入结束后，以及每次截图前，将游戏窗口移到当前物理鼠标之外，并发送 `WM_MOUSELEAVE` 清理应用内悬停状态。
- 严格保证“窗口完成移动并复检光标已离开”后才截图；避让未完成时不向识别层交付该帧。
- 用户持续移动鼠标、连续三次重新进入窗口时，将窗口临时停放到虚拟桌面边界外，避免首次绑定因追逐鼠标失败。
- 保存原始窗口位置与窗口状态，断开或销毁 Win32 控制器时恢复。
- 兼容当前使用的 MaaFramework v5.9.2：处理 WGC / PrintWindow 从真实最小化切换到伪最小化时的过渡帧，无需升级 Win32 控制单元。
- 在 PC 连接的常规设置、开始唤醒设置和首次引导中增加“自动避让物理鼠标”开关，默认开启；仅对 WindowPos 鼠标输入生效。

## 根因

WindowPos 输入会通过移动目标窗口，让目标客户区坐标与物理鼠标位置对齐后发送鼠标消息。明日方舟 PC 客户端会据此在应用画面中自行渲染光标；该光标已成为窗口画面的一部分，因此关闭 WGC 的系统光标捕获也无法移除。

本 PR 不移动用户的物理鼠标，而是在 MAA Core 层调整目标窗口位置，使应用自绘光标在截图前收到离开事件并消失。

## 与 #17644 的关系和实现差异

#17644 与本 PR 都用于缓解 PC 端应用自绘光标对识别的影响，并复用现有 Win32 输入能力，但两者关注的场景和避让策略不同。

| | 本 PR | #17644 |
|---|---|---|
| 主要目标 | 解决 WindowPos 输入后，物理鼠标重新进入窗口或应用自绘光标残留的问题 | 在截图前将光标目标移到较少干扰识别的位置 |
| 输入方式 | 仅对 WindowPos 生效，不改变用户鼠标坐标 | 调用 `unit_touch_move()`，实际移动鼠标或窗口由 CursorPos / WindowPos 配置决定 |
| 避让位置 | 根据当前物理鼠标位置动态选择窗口停放位置 | 主界面移动到中心，其他界面移动到左下角 |
| 主界面适配 | **没有主界面专门适配**，不识别任务场景，也未针对视差动画设置中心点或等待 | 由 `ProcessTask` 判断主界面识别，将目标移动到窗口中心，并等待 300ms 视差动画稳定 |
| 执行时机 | 合成输入后及截图前检查；鼠标已在窗口外时不移动 | 当前提交在每次 Win32 截图前，根据识别场景设置目标位置 |
| 持续鼠标操作 | 移动后复检，最多三次常规避让，并提供虚拟桌面外兜底 | 每次截图前重新设置当前场景对应的目标位置 |
| 配置 | GUI 提供 WindowPos 专用开关，默认开启 | 复用用户选择的 Win32 鼠标输入方式 |

因此，#17644 包含本 PR 尚未实现的主界面视差动画特殊适配；本 PR 则专注于 WindowPos 模式下，根据真实物理鼠标位置动态停放窗口、复检避让结果并恢复原始窗口状态。两者存在功能交集，但不能互相视为完整替代。

## 与其他 PR 的关系

- #17644 同样面向 PC 端光标干扰，但采用截图前设置目标坐标的方案，并包含本 PR 没有覆盖的主界面视差动画特殊适配；本 PR 不作为 #17644 的完整替代。
- MaaXYZ/MaaFramework#1435 的 MAA Core 层替代实现；保留现有 MaaFramework v5.9.2，避免实机验证中 v5.12.3 最小化截图黑屏的问题。
- #17643 负责 PC 客户端自动启动与绑定前窗口状态；本 PR 负责绑定后的输入/截图光标避让，两者相互独立且可组合使用。
- Follow-up to #17620.

## 验证

- [x] `git diff --check`
- [x] MaaCore Clang-Format pre-commit hook
- [x] `cmake --build build --config Release --target MaaCore`
- [x] `dotnet build src/MaaWpfGui/MaaWpfGui.csproj --configuration Release --property:Platform=x64 --no-restore`（0 errors）
- [x] MaaFramework v5.9.2、1280×720、UI 100%、WGC FramePool、`SendMessageWithWindowPos` 实机验证
- [x] 点击 `Link Start!` 后持续移动物理鼠标，首次绑定成功并完整执行任务（11m47s）
- [x] 最小化前绑定、绑定后最小化、连续截图及断开恢复窗口位置
- [ ] GitHub CI

## 实机结果

<img width="801" height="606" alt="PC 端物理鼠标避让连续任务执行成功" src="https://github.com/user-attachments/assets/50ee211a-9431-48e3-85f5-a91b9e1c2a8b" />

## Summary by Sourcery

为 PC 截图/输入流程新增可选的 Win32 窗口光标避让机制，并通过核心与 GUI 配置进行串联。

New Features:
- 引入基于 `WindowPos` 的“窗口停泊”策略，在截图前和触摸输入后，将游戏窗口移离物理鼠标光标位置，防止游戏内光标进入捕获画面。
- 增加按实例配置的 `Win32WindowCursorAvoidance` 选项，并通过 MaaCore 与 WPF GUI 设置对外暴露，用于启用或禁用针对 `WindowPos` 输入的自动窗口光标避让。

Enhancements:
- 在控制器分离或销毁时，持久化并恢复原始 Win32 窗口位置和布局，确保游戏窗口返回到之前的状态。
- 在使用 WGC `FramePool` 或 `PrintWindow` 处理最小化窗口时，丢弃第一帧“伪最小化”画面，以正确处理过渡帧后再进行识别。

Documentation:
- 更新 WPF GUI 指南与连接/启动设置的本地化资源，说明 PC 连接中新增加的自动物理鼠标避让选项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add an optional Win32 window cursor avoidance mechanism for PC screenshot/input flows and wire it through core and GUI configuration.

New Features:
- Introduce a WindowPos-based window parking strategy that moves the game window away from the physical mouse cursor before screenshots and after touch input, preventing in-game cursors from entering capture frames.
- Add a per-instance Win32WindowCursorAvoidance option, exposed via MaaCore and WPF GUI settings, to enable or disable automatic window cursor avoidance for WindowPos input.

Enhancements:
- Persist and restore the original Win32 window position and placement when the controller is detached or destroyed, ensuring the game window returns to its prior state.
- Handle transition frames when using WGC FramePool or PrintWindow on minimized windows by discarding the first pseudo-minimized frame before recognition.

Documentation:
- Update WPF GUI guides and connection/startup settings localization resources to describe the new automatic physical mouse avoidance option for PC connections.

</details>