### PR TITLE
fix(controller): 划火柴开关参数传递

### DIFF
--- a/src/MaaCore/Controller/Controller.cpp
+++ b/src/MaaCore/Controller/Controller.cpp
@@ -197,7 +197,8 @@ bool asst::Controller::swipe(
     bool with_pause)
 {
     CHECK_EXIST(m_controller, false);
-    return m_scale_proxy->swipe(p1, p2, duration, extra_swipe, slope_in, slope_out, with_pause);
+    const bool effective_with_pause = with_pause && m_swipe_with_pause;
+    return m_scale_proxy->swipe(p1, p2, duration, extra_swipe, slope_in, slope_out, effective_with_pause);
 }
 
 bool asst::Controller::swipe(
@@ -211,8 +212,9 @@ bool asst::Controller::swipe(
     bool high_resolution_swipe_fix)
 {
     CHECK_EXIST(m_controller, false);
+    const bool effective_with_pause = with_pause && m_swipe_with_pause;
     return m_scale_proxy
-        ->swipe(r1, r2, duration, extra_swipe, slope_in, slope_out, with_pause, high_resolution_swipe_fix);
+        ->swipe(r1, r2, duration, extra_swipe, slope_in, slope_out, effective_with_pause, high_resolution_swipe_fix);
 }
 
 bool asst::Controller::inject_input_event(InputEvent& event)
@@ -232,7 +234,11 @@ bool asst::Controller::press_esc()
 asst::ControlFeat::Feat asst::Controller::support_features()
 {
     CHECK_EXIST(m_controller, ControlFeat::NONE);
-    return m_controller->support_features();
+    auto feat = m_controller->support_features();
+    if (!m_swipe_with_pause) {
+        feat &= ~ControlFeat::SWIPE_WITH_PAUSE;
+    }
+    return feat;
 }
 
 bool asst::Controller::connect(const std::string& adb_path, const std::string& address, const std::string& config)

--- a/src/MaaCore/Controller/Controller.cpp
+++ b/src/MaaCore/Controller/Controller.cpp
@@ -3,6 +3,7 @@
 #include "Utils/Platform.hpp"
 
 #include <boost/regex.hpp>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -187,6 +188,11 @@ bool asst::Controller::input(const std::string& text)
     return m_controller->input(text);
 }
 
+bool asst::Controller::resolve_swipe_with_pause(bool with_pause) const noexcept
+{
+    return with_pause && m_swipe_with_pause;
+}
+
 bool asst::Controller::swipe(
     const Point& p1,
     const Point& p2,
@@ -197,8 +203,8 @@ bool asst::Controller::swipe(
     bool with_pause)
 {
     CHECK_EXIST(m_controller, false);
-    const bool effective_with_pause = with_pause && m_swipe_with_pause;
-    return m_scale_proxy->swipe(p1, p2, duration, extra_swipe, slope_in, slope_out, effective_with_pause);
+    return m_scale_proxy->swipe(
+        p1, p2, duration, extra_swipe, slope_in, slope_out, resolve_swipe_with_pause(with_pause));
 }
 
 bool asst::Controller::swipe(
@@ -212,9 +218,15 @@ bool asst::Controller::swipe(
     bool high_resolution_swipe_fix)
 {
     CHECK_EXIST(m_controller, false);
-    const bool effective_with_pause = with_pause && m_swipe_with_pause;
-    return m_scale_proxy
-        ->swipe(r1, r2, duration, extra_swipe, slope_in, slope_out, effective_with_pause, high_resolution_swipe_fix);
+    return m_scale_proxy->swipe(
+        r1,
+        r2,
+        duration,
+        extra_swipe,
+        slope_in,
+        slope_out,
+        resolve_swipe_with_pause(with_pause),
+        high_resolution_swipe_fix);
 }
 
 bool asst::Controller::inject_input_event(InputEvent& event)
@@ -233,6 +245,11 @@ bool asst::Controller::press_esc()
 
 asst::ControlFeat::Feat asst::Controller::support_features()
 {
+    static_assert(std::is_integral_v<ControlFeat::Feat>, "ControlFeat::Feat must be an integral bitmask type");
+    static_assert(
+        (ControlFeat::SWIPE_WITH_PAUSE & (ControlFeat::SWIPE_WITH_PAUSE - 1)) == 0,
+        "ControlFeat::SWIPE_WITH_PAUSE must be a single bit flag");
+
     CHECK_EXIST(m_controller, ControlFeat::NONE);
     auto feat = m_controller->support_features();
     if (!m_swipe_with_pause) {

--- a/src/MaaCore/Controller/Controller.h
+++ b/src/MaaCore/Controller/Controller.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <memory>
 #include <optional>
 #include <random>
@@ -112,6 +113,7 @@ private:
     void clear_info() noexcept;
     void callback(AsstMsg msg, const json::value& details);
     void sync_params();
+    bool resolve_swipe_with_pause(bool with_pause) const noexcept;
 
     AsstCallback m_callback = nullptr;
 
@@ -127,7 +129,7 @@ private:
 
     std::pair<int, int> m_scale_size = { WindowWidthDefault, WindowHeightDefault };
 
-    bool m_swipe_with_pause = false;
+    std::atomic_bool m_swipe_with_pause = false;
     bool m_kill_adb_on_exit = false;
     std::string m_client_type;
 


### PR DESCRIPTION
MuMu 触控爆屎山了

## Summary by Sourcery

确保“滑动并暂停”行为以及对该功能的支持声明遵循控制器的配置开关。

Bug 修复：
- 当控制器的“滑动并暂停”功能被禁用时，防止滑动操作仍然启用暂停行为。
- 当“滑动并暂停”功能实际上不可用时，停止在能力标志中宣称对该功能的支持。

增强：
- 将“滑动并暂停”配置开关改为原子变量，以实现线程安全的更新。
- 添加编译期断言，用于验证“滑动并暂停”功能位掩码的类型及标志布局。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure swipe-with-pause behavior and advertised support respect the controller’s configuration flag.

Bug Fixes:
- Prevent swipe operations from enabling pause behavior when the controller’s swipe-with-pause feature is disabled.
- Stop reporting swipe-with-pause support in capability flags when the feature is effectively unavailable.

Enhancements:
- Make the swipe-with-pause configuration flag atomic for thread-safe updates.
- Add compile-time assertions to validate the swipe-with-pause feature bitmask type and flag layout.

</details>

Bug 修复：
- 当“滑动并暂停”被禁用时，防止滑动操作错误地启用暂停行为。
- 修正已报告的支持功能，在实际不可用时省略“滑动并暂停”功能。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

确保“滑动并暂停”行为以及对该功能的支持声明遵循控制器的配置开关。

Bug 修复：
- 当控制器的“滑动并暂停”功能被禁用时，防止滑动操作仍然启用暂停行为。
- 当“滑动并暂停”功能实际上不可用时，停止在能力标志中宣称对该功能的支持。

增强：
- 将“滑动并暂停”配置开关改为原子变量，以实现线程安全的更新。
- 添加编译期断言，用于验证“滑动并暂停”功能位掩码的类型及标志布局。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure swipe-with-pause behavior and advertised support respect the controller’s configuration flag.

Bug Fixes:
- Prevent swipe operations from enabling pause behavior when the controller’s swipe-with-pause feature is disabled.
- Stop reporting swipe-with-pause support in capability flags when the feature is effectively unavailable.

Enhancements:
- Make the swipe-with-pause configuration flag atomic for thread-safe updates.
- Add compile-time assertions to validate the swipe-with-pause feature bitmask type and flag layout.

</details>

</details>