### PR TITLE
feat: 为像素画自动填色加入了粘贴功能

### DIFF
--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -1093,7 +1093,7 @@ Only level rewards can be farmed; to get the Engraved Medal, all ｢Key Objectiv
     <system:String x:Key="MiniGame@SecretFrontTip" xml:space="preserve">Start from the squad selection screen;&#10;If there is a saved game, please delete it manually.&#10;Close the tutorial after playing it for the first time.&#10;Recommended to enable in-game ｢Inherit previous squad's data｣.</system:String>
     <system:String x:Key="MiniGame@PixelPaint">Pixel Paint Autofill</system:String>
     <system:String x:Key="MiniGame@PixelPaintTip" xml:space="preserve">Enter the in-game 24×24 pixel editor first, then start.&#10;Drag/scroll the preview to reframe; white is skipped by default.&#10;Parameters lock while running; see the right log for progress.</system:String>
-    <system:String x:Key="MiniGame@PixelPaint@DropHint">Drop an image or pick below</system:String>
+    <system:String x:Key="MiniGame@PixelPaint@DropHint">Drop or paste an image, or pick below</system:String>
     <system:String x:Key="MiniGame@PixelPaint@PickImage">Pick Image</system:String>
     <system:String x:Key="MiniGame@PixelPaint@ResetView">Reset View</system:String>
     <system:String x:Key="MiniGame@PixelPaint@ResetParams">Reset Parameters</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -1094,7 +1094,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="MiniGame@SecretFrontTip">小隊選択画面で開始します。セーブデータがある場合は手動で削除する必要があります。ゲーム内の ｢前の小隊からのデータを引き継ぐ｣ にチェックすることを推奨します。</system:String>
     <system:String x:Key="MiniGame@PixelPaint">ピクセル画自動描画</system:String>
     <system:String x:Key="MiniGame@PixelPaintTip">ゲーム内の 24×24 ピクセル画編集ページに手動で入ってから開始してください。&#10;プレビューはドラッグ/ホイールで構図調整。デフォルトで白はスキップ。&#10;開始後はパラメータ固定。進捗は右のログ参照。</system:String>
-    <system:String x:Key="MiniGame@PixelPaint@DropHint">画像をドロップ、または下のボタンで選択</system:String>
+    <system:String x:Key="MiniGame@PixelPaint@DropHint">画像をドロップ、貼り付け、または下のボタンで選択</system:String>
     <system:String x:Key="MiniGame@PixelPaint@PickImage">画像を選択</system:String>
     <system:String x:Key="MiniGame@PixelPaint@ResetView">構図をリセット</system:String>
     <system:String x:Key="MiniGame@PixelPaint@ResetParams">パラメータをリセット</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -1095,7 +1095,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="MiniGame@SecretFrontTip">소대 선택 화면에서 시작합니다. 기존 세이브 데이터가 있으면 수동으로 삭제해야 합니다.\n게임 내  ｢이전 소대의 데이터 전승받기｣  옵션을 체크하는 것을 권장합니다.</system:String>
     <system:String x:Key="MiniGame@PixelPaint">픽셀 아트 자동 그리기</system:String>
     <system:String x:Key="MiniGame@PixelPaintTip">게임 내 24×24 픽셀 아트 편집 페이지에 직접 들어간 뒤 시작하세요.&#10;미리보기는 드래그/휠로 구도 조정. 기본적으로 흰색은 건너뜀.&#10;시작 후 파라미터는 고정. 진행 상황은 오른쪽 로그 참조.</system:String>
-    <system:String x:Key="MiniGame@PixelPaint@DropHint">이미지를 드래그하거나 아래 버튼으로 선택</system:String>
+    <system:String x:Key="MiniGame@PixelPaint@DropHint">이미지를 드래그하거나 붙여넣기하거나 아래 버튼으로 선택</system:String>
     <system:String x:Key="MiniGame@PixelPaint@PickImage">이미지 선택</system:String>
     <system:String x:Key="MiniGame@PixelPaint@ResetView">구도 초기화</system:String>
     <system:String x:Key="MiniGame@PixelPaint@ResetParams">파라미터 초기화</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -1094,7 +1094,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="MiniGame@SecretFrontTip" xml:space="preserve">在选小队界面开始，如有存档须手动删除。&#10;第一次打自己看完把教程关了。&#10;推荐勾选游戏内 ｢继承上一支队伍发回的数据｣</system:String>
     <system:String x:Key="MiniGame@PixelPaint">像素画自动填色</system:String>
     <system:String x:Key="MiniGame@PixelPaintTip" xml:space="preserve">请先手动进入游戏内 24×24 像素画编辑页，再开始。&#10;中间预览可拖移/滚轮取景；默认跳过白色。&#10;开始后参数锁定，进度见右侧日志。</system:String>
-    <system:String x:Key="MiniGame@PixelPaint@DropHint">拖入图片或点下方选图</system:String>
+    <system:String x:Key="MiniGame@PixelPaint@DropHint">拖入图片、粘贴图片或点下方选图</system:String>
     <system:String x:Key="MiniGame@PixelPaint@PickImage">选择图片</system:String>
     <system:String x:Key="MiniGame@PixelPaint@ResetView">重置取景</system:String>
     <system:String x:Key="MiniGame@PixelPaint@ResetParams">重置参数</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -1094,7 +1094,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="MiniGame@SecretFrontTip">在選擇小隊介面開始，如有存檔須手動刪除。&#10;第一次打請先看完教學後關閉。&#10;推薦勾選遊戲內 ｢繼承上一支隊伍發回的資料｣ 。</system:String>
     <system:String x:Key="MiniGame@PixelPaint">像素畫自動填色</system:String>
     <system:String x:Key="MiniGame@PixelPaintTip">請先手動進入遊戲內 24×24 像素畫編輯頁，再開始。&#10;中間預覽可拖移/滾輪取景；預設跳過白色。&#10;開始後參數鎖定，進度見右側日誌。</system:String>
-    <system:String x:Key="MiniGame@PixelPaint@DropHint">拖入圖片或點下方選圖</system:String>
+    <system:String x:Key="MiniGame@PixelPaint@DropHint">拖入圖片、貼上圖片或點下方選圖</system:String>
     <system:String x:Key="MiniGame@PixelPaint@PickImage">選擇圖片</system:String>
     <system:String x:Key="MiniGame@PixelPaint@ResetView">重置取景</system:String>
     <system:String x:Key="MiniGame@PixelPaint@ResetParams">重置參數</system:String>

--- a/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
@@ -2422,6 +2422,7 @@ public class ToolboxViewModel : Screen
 
     #region PixelPaint
 
+    /// <summary>像素画支持的图片扩展名，文件对话框过滤器与剪贴板文件判断共用。</summary>
     private static readonly string[] _pixelPaintImageExtensions = [".png", ".jpg", ".jpeg", ".bmp", ".webp", ".gif"];
 
     private BitmapSource? _pixelPaintSourceImage;
@@ -2589,6 +2590,13 @@ public class ToolboxViewModel : Screen
         e.Handled = true;
     }
 
+    /// <summary>
+    /// 像素画：响应 Ctrl+V，从剪贴板粘贴图片。
+    /// 先按剪贴板位图处理（截图工具、浏览器 ｢复制图片｣ 等无文件场景），
+    /// 否则按已复制的图片文件处理；加载失败时与文件加载一致地提示。
+    /// </summary>
+    /// <param name="sender">事件源（绑定 KeyDown 的 MiniGame Grid）。</param>
+    /// <param name="e">按键事件数据。</param>
     public void PixelPaintKeyDown(object sender, KeyEventArgs e)
     {
         if (e.Key != Key.V || Keyboard.Modifiers != ModifierKeys.Control || !IsPixelPaintSelected || PixelPaintParametersLocked)
@@ -2615,13 +2623,20 @@ public class ToolboxViewModel : Screen
                 }
             }
         }
-        catch
+        catch (Exception ex)
         {
-            
+            // 剪贴板位图加载异常（如格式不被 Prepare 支持），与文件加载一致地提示
+            _logger.Warning(ex, "Paste pixel paint image failed");
+            PixelPaintStatusText = LocalizationHelper.GetString("MiniGame@PixelPaint@LoadFailed");
         }
     }
 
-    /// <summary> 优先用 DIB 原始数据自行解码 </summary>
+    /// <summary>
+    /// 从剪贴板取图。优先用 DIB 原始数据自行解码——
+    /// WPF 的 Clipboard.GetImage() 对 DIB 的转换存在通道错乱/尺寸错乱问题，
+    /// 重建 BMP 文件头自行解码可规避该缺陷；失败则回退到 GetImage()。
+    /// </summary>
+    /// <returns>解码后的 BitmapSource；剪贴板无图或解码失败时返回 null。</returns>
     private static BitmapSource? GetClipboardImage()
     {
         try
@@ -2646,6 +2661,12 @@ public class ToolboxViewModel : Screen
         }
     }
 
+    /// <summary>
+    /// 将剪贴板 DIB（BITMAPINFOHEADER + 调色板 + 像素数据）解码为 BitmapSource：
+    /// 在前面补一个 14 字节的 BITMAPFILEHEADER，拼成完整 BMP 后交给解码器。
+    /// </summary>
+    /// <param name="dib">剪贴板 DIB 数据流（BITMAPINFOHEADER + 调色板 + 像素）。</param>
+    /// <returns>解码后的 BitmapSource；数据非法或过短时返回 null。</returns>
     private static BitmapSource? DecodeDibAsBmp(Stream dib)
     {
         if (dib.Length < 40)
@@ -2653,6 +2674,7 @@ public class ToolboxViewModel : Screen
             return null;
         }
 
+        // 读取 BITMAPINFOHEADER 固定前 40 字节，计算像素数据在文件中的偏移
         var info = new byte[40];
         dib.Position = 0;
         dib.ReadExactly(info, 0, info.Length);
@@ -2668,6 +2690,7 @@ public class ToolboxViewModel : Screen
             return null;
         }
 
+        // 构造 BMP 文件头：'BM' 标志、文件总长度、像素数据偏移
         var header = new byte[14];
         header[0] = (byte)'B';
         header[1] = (byte)'M';

--- a/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
@@ -2422,6 +2422,8 @@ public class ToolboxViewModel : Screen
 
     #region PixelPaint
 
+    private static readonly string[] _pixelPaintImageExtensions = [".png", ".jpg", ".jpeg", ".bmp", ".webp", ".gif"];
+
     private BitmapSource? _pixelPaintSourceImage;
 
     private BitmapSource? _pixelPaintPreview;
@@ -2547,7 +2549,7 @@ public class ToolboxViewModel : Screen
         }
 
         var dialog = new Microsoft.Win32.OpenFileDialog {
-            Filter = "Image|*.png;*.jpg;*.jpeg;*.bmp;*.webp;*.gif|All|*.*",
+            Filter = "Image|" + string.Join(";", _pixelPaintImageExtensions.Select(ext => "*" + ext)) + "|All|*.*",
             CheckFileExists = true,
             Multiselect = false,
         };
@@ -2585,6 +2587,106 @@ public class ToolboxViewModel : Screen
             ? DragDropEffects.Copy
             : DragDropEffects.None;
         e.Handled = true;
+    }
+
+    public void PixelPaintKeyDown(object sender, KeyEventArgs e)
+    {
+        if (e.Key != Key.V || Keyboard.Modifiers != ModifierKeys.Control || !IsPixelPaintSelected || PixelPaintParametersLocked)
+        {
+            return;
+        }
+
+        try
+        {
+            if (Clipboard.ContainsImage() || Clipboard.ContainsData(DataFormats.Dib))
+            {
+                var bmp = GetClipboardImage();
+                if (bmp != null)
+                {
+                    LoadPixelPaintImage(bmp);
+                }
+            }
+            else if (Clipboard.GetFileDropList() is { Count: > 0 } files && files[0] is { } file)
+            {
+                var ext = Path.GetExtension(file).ToLowerInvariant();
+                if (_pixelPaintImageExtensions.Contains(ext))
+                {
+                    LoadPixelPaintImage(file);
+                }
+            }
+        }
+        catch
+        {
+            
+        }
+    }
+
+    /// <summary> 优先用 DIB 原始数据自行解码 </summary>
+    private static BitmapSource? GetClipboardImage()
+    {
+        try
+        {
+            if (Clipboard.ContainsData(DataFormats.Dib) && Clipboard.GetData(DataFormats.Dib) is Stream dib)
+            {
+                return DecodeDibAsBmp(dib);
+            }
+        }
+        catch
+        {
+            // ignored
+        }
+
+        try
+        {
+            return Clipboard.GetImage();
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static BitmapSource? DecodeDibAsBmp(Stream dib)
+    {
+        if (dib.Length < 40)
+        {
+            return null;
+        }
+
+        var info = new byte[40];
+        dib.Position = 0;
+        dib.ReadExactly(info, 0, info.Length);
+        var biSize = BitConverter.ToInt32(info, 0);
+        var biBitCount = BitConverter.ToInt16(info, 14);
+        var biClrUsed = BitConverter.ToInt32(info, 32);
+        var paletteSize = biBitCount <= 8
+            ? (biClrUsed > 0 ? biClrUsed : 1 << biBitCount) * 4
+            : 0;
+        var offset = 14 + biSize + paletteSize;
+        if (biSize < 40 || offset > dib.Length)
+        {
+            return null;
+        }
+
+        var header = new byte[14];
+        header[0] = (byte)'B';
+        header[1] = (byte)'M';
+        BitConverter.GetBytes((int)dib.Length + 14).CopyTo(header, 2);
+        BitConverter.GetBytes(offset).CopyTo(header, 10);
+
+        var merged = new MemoryStream();
+        merged.Write(header, 0, header.Length);
+        dib.Position = 0;
+        dib.CopyTo(merged);
+        merged.Position = 0;
+
+        var bmp = new BitmapImage();
+        bmp.BeginInit();
+        bmp.CacheOption = BitmapCacheOption.OnLoad;
+        bmp.StreamSource = merged;
+        bmp.EndInit();
+        bmp.Freeze();
+        return bmp;
     }
 
     public void PixelPaintPreviewMouseWheel(object sender, MouseWheelEventArgs e)
@@ -2699,16 +2801,26 @@ public class ToolboxViewModel : Screen
             bmp.EndInit();
             bmp.Freeze();
 
-            _pixelPaintSourceImage = bmp;
-            _pixelPaintPrepared = PixelPaintHelper.Prepare(bmp, trimEmptyBorder: true);
-            _pixelPaintView = new System.Windows.Rect(0, 0, 1, 1);
-            ReconvertPixelPaint();
+            LoadPixelPaintImage(bmp);
         }
         catch (Exception ex)
         {
             _logger.Warning(ex, "Load pixel paint image failed: {Path}", path);
             PixelPaintStatusText = LocalizationHelper.GetString("MiniGame@PixelPaint@LoadFailed");
         }
+    }
+
+    private void LoadPixelPaintImage(BitmapSource bmp)
+    {
+        if (bmp.CanFreeze)
+        {
+            bmp.Freeze();
+        }
+
+        _pixelPaintSourceImage = bmp;
+        _pixelPaintPrepared = PixelPaintHelper.Prepare(bmp, trimEmptyBorder: true);
+        _pixelPaintView = new System.Windows.Rect(0, 0, 1, 1);
+        ReconvertPixelPaint();
     }
 
     private void ReconvertPixelPaint()

--- a/src/MaaWpfGui/Views/UI/ToolboxView.xaml
+++ b/src/MaaWpfGui/Views/UI/ToolboxView.xaml
@@ -801,7 +801,7 @@
             </Grid>
         </TabItem>
         <TabItem Header="{DynamicResource MiniGame}">
-            <Grid Margin="20,0,20,20">
+            <Grid Margin="20,0,20,20" KeyDown="{s:Action PixelPaintKeyDown}">
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="*" />
                     <ColumnDefinition Width="*" />


### PR DESCRIPTION
在像素画自动填色界面CTRL+v可以粘贴图像

## Summary by Sourcery

为 Pixel Paint 自动上色工具添加剪贴板粘贴支持，并重构图像加载逻辑，以同时处理文件和剪贴板来源。

New Features:
- 允许通过剪贴板使用 Ctrl+V 将图像粘贴到 Pixel Paint 自动上色界面中，支持直接图像数据以及常见格式的图像文件。

Enhancements:
- 将共享的图像加载逻辑提取为基于 `BitmapSource` 的辅助工具，以便在基于文件和基于剪贴板的 Pixel Paint 图像中复用。
- 集中管理 Pixel Paint 图像选择所支持的图像扩展名，并在“打开文件”对话框和剪贴板文件处理逻辑中复用这些扩展名。

Documentation:
- 更新本地化资源，在所有支持的语言中描述 Pixel Paint 新增的粘贴（Ctrl+V）功能。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add clipboard paste support to the Pixel Paint auto-color tool and refactor image loading to handle both file and clipboard sources.

New Features:
- Allow pasting images into the Pixel Paint auto-color interface via Ctrl+V from the clipboard, including direct image data and image files with common formats.

Enhancements:
- Extract shared image-loading logic into a BitmapSource-based helper to reuse for both file-based and clipboard-based Pixel Paint images.
- Centralize supported image extensions for Pixel Paint image selection and reuse them in the open file dialog and clipboard file handling.

Documentation:
- Update localization resources to describe the new Pixel Paint paste (Ctrl+V) capability in all supported languages.

</details>