### PR TITLE
fix: 为软件更新包下载添加重试

### DIFF
--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -445,6 +445,7 @@ You can cancel this popup by clicking the ｢{key=Settings} - {key=IssueReport}�
     <system:String x:Key="MirrorChyanBuildingOta">MirrorChyan is building the OTA incremental update for this version, will automatically retry in 10 seconds</system:String>
     <system:String x:Key="NewVersionNoOtaPackage">A new version has been detected, but no OTA incremental update package is available. The full package will be downloaded. It will keep cache, config, data, debug, achievement (screenshots), background (custom background images), and MAA.Updater.exe. All other files will be moved to the Recycle Bin and .old. Please back them up manually if necessary.</system:String>
     <system:String x:Key="NewVersionDownloadPreparing">Preparing to download update package……</system:String>
+    <system:String x:Key="NewVersionDownloadRetrying">Update package download failed. Retrying in {0} seconds (download attempt {1}/{2} failed).</system:String>
     <system:String x:Key="NewVersionDownloadFailedTitle">Download of Update Package Failed</system:String>
     <system:String x:Key="NewVersionDownloadFailedDesc">Please download the zip file manually and place it in the directory</system:String>
     <system:String x:Key="NewVersionDownloadCompletedTitle">Update Package Download Completed</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -445,6 +445,7 @@
     <system:String x:Key="MirrorChyanBuildingOta">MirrorChyan がこのバージョンの OTA 増分アップデートをビルド中です。約 10 秒後に自動的に再試行します</system:String>
     <system:String x:Key="NewVersionNoOtaPackage">新しいバージョンが検出されましたが、利用可能な OTA 増分アップデートパッケージはありません。完全パッケージをダウンロードし、cache、config、data、debug、achievement（クリアスクリーンショット）、background（背景画像）、MAA.Updater.exe は保持され、それ以外のファイルはごみ箱と .old に移動されます。必要に応じて手動でバックアップしてください。</system:String>
     <system:String x:Key="NewVersionDownloadPreparing">アップデートパッケージのダウンロードを準備中です……</system:String>
+    <system:String x:Key="NewVersionDownloadRetrying">アップデートパッケージのダウンロードに失敗しました。{0} 秒後に再試行します（{1}/{2} 回目のダウンロードに失敗）。</system:String>
     <system:String x:Key="NewVersionDownloadFailedTitle">アップデートパッケージのダウンロードに失敗しました</system:String>
     <system:String x:Key="NewVersionDownloadFailedDesc">ZIPファイルを手動でダウンロードし、ディレクトリに配置してください</system:String>
     <system:String x:Key="NewVersionDownloadCompletedTitle">アップデートパッケージのダウンロードが完了しました</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -445,6 +445,7 @@
     <system:String x:Key="MirrorChyanBuildingOta">MirrorChyan이 이 버전에 대한 OTA 증분 업데이트를 빌드 중입니다. 약 10초 후에 자동으로 다시 시도합니다</system:String>
     <system:String x:Key="NewVersionNoOtaPackage">새 버전이 감지되었지만 사용할 수 있는 OTA 증분 업데이트 패키지가 없습니다. 전체 패키지를 다운로드하며, cache, config, data, debug, achievement(클리어 스크린샷), background(배경 이미지), MAA.Updater.exe 는 유지되고 그 외의 파일은 휴지통과 .old 폴더로 이동합니다. 필요하다면 수동으로 백업해 주세요.</system:String>
     <system:String x:Key="NewVersionDownloadPreparing">업데이트 패키지 다운로드 준비 중……</system:String>
+    <system:String x:Key="NewVersionDownloadRetrying">업데이트 패키지 다운로드에 실패했습니다. {0}초 후 재시도합니다(다운로드 {1}/{2}회차 실패).</system:String>
     <system:String x:Key="NewVersionDownloadFailedTitle">업데이트 패키지 다운로드 실패</system:String>
     <system:String x:Key="NewVersionDownloadFailedDesc">ZIP 파일을 수동으로 다운로드해 폴더 안에 놓아 주세요</system:String>
     <system:String x:Key="NewVersionDownloadCompletedTitle">업데이트 패키지 다운로드 완료</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -445,6 +445,7 @@
     <system:String x:Key="MirrorChyanBuildingOta">MirrorChyan 正在为此版本打包 OTA 增量更新包，将在 10 秒后自动重试</system:String>
     <system:String x:Key="NewVersionNoOtaPackage">检测到新版本，但无可用的 OTA 增量更新包。将下载完整包，保留 cache、config、data、debug、achievement（通关截图）、background（背景图）和 MAA.Updater.exe，其余文件将移至回收站及 .old。如有需要请手动备份</system:String>
     <system:String x:Key="NewVersionDownloadPreparing">正在准备下载更新包……</system:String>
+    <system:String x:Key="NewVersionDownloadRetrying">更新包下载失败，将在 {0} 秒后重试（第 {1}/{2} 次下载失败）。</system:String>
     <system:String x:Key="NewVersionDownloadFailedTitle">新版本下载失败</system:String>
     <system:String x:Key="NewVersionDownloadFailedDesc">请尝试手动下载后，将压缩包放到目录下_(:з」∠)_</system:String>
     <system:String x:Key="NewVersionDownloadCompletedTitle">新版本下载完成</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -445,6 +445,7 @@
     <system:String x:Key="MirrorChyanBuildingOta">MirrorChyan 正在為此版本打包 OTA 增量更新檔，將在 10 秒後自動重試</system:String>
     <system:String x:Key="NewVersionNoOtaPackage">偵測到新版本，但無可用的 OTA 增量更新檔案。將下載完整安裝檔案，保留 cache、config、data、debug、achievement（通關截圖）、background（背景圖片）和 MAA.Updater.exe，其餘檔案將移至資源回收桶及 .old，如有需要請手動備份</system:String>
     <system:String x:Key="NewVersionDownloadPreparing">正在準備下載更新檔……</system:String>
+    <system:String x:Key="NewVersionDownloadRetrying">更新檔下載失敗，將在 {0} 秒後重試（第 {1}/{2} 次下載失敗）。</system:String>
     <system:String x:Key="NewVersionDownloadFailedTitle">新版本下載失敗</system:String>
     <system:String x:Key="NewVersionDownloadFailedDesc">請嘗試手動下載後，將壓縮檔放到目錄下 _(:з」∠)_</system:String>
     <system:String x:Key="NewVersionDownloadCompletedTitle">新版本下載完成</system:String>

--- a/src/MaaWpfGui/ViewModels/Dialogs/VersionUpdateDialogViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/Dialogs/VersionUpdateDialogViewModel.cs
@@ -168,6 +168,7 @@ public class VersionUpdateDialogViewModel : Screen
     */
 
     private const string MaaUpdateApi = "version/summary.json";
+    private const int UpdatePackageDownloadMaxAttempts = 3;
 
     private JObject? _latestJson;
     private JObject? _assetsObject;
@@ -1165,10 +1166,13 @@ public class VersionUpdateDialogViewModel : Screen
     {
         try
         {
-            return await Instances.HttpService.DownloadFileAsync(
-                    new(url),
-                    assetsObject["name"]!.ToString(),
-                    assetsObject["content_type"]?.ToString())
+            var uri = new Uri(url);
+            return await DownloadUpdatePackageWithRetryAsync(
+                    () => Instances.HttpService.DownloadFileAsync(
+                        uri,
+                        assetsObject["name"]!.ToString(),
+                        assetsObject["content_type"]?.ToString()),
+                    uri)
                 .ConfigureAwait(false);
         }
         catch (Exception)
@@ -1181,14 +1185,52 @@ public class VersionUpdateDialogViewModel : Screen
     {
         try
         {
-            return await Instances.HttpService.DownloadFileAsync(
-                    new(url), filename)
+            var uri = new Uri(url);
+            return await DownloadUpdatePackageWithRetryAsync(
+                    () => Instances.HttpService.DownloadFileAsync(uri, filename),
+                    uri)
                 .ConfigureAwait(false);
         }
         catch (Exception)
         {
             return false;
         }
+    }
+
+    private static async Task<bool> DownloadUpdatePackageWithRetryAsync(Func<Task<bool>> download, Uri uri)
+    {
+        for (var attempt = 1; attempt <= UpdatePackageDownloadMaxAttempts; attempt++)
+        {
+            if (await download().ConfigureAwait(false))
+            {
+                return true;
+            }
+
+            if (attempt < UpdatePackageDownloadMaxAttempts)
+            {
+                var delay = TimeSpan.FromSeconds(attempt);
+                _logger.Warning(
+                    "Update package download failed for {Uri} (attempt {Attempt}/{MaxAttempts}); retrying in {Delay}",
+                    uri.GetLeftPart(UriPartial.Path),
+                    attempt,
+                    UpdatePackageDownloadMaxAttempts,
+                    delay);
+                OutputDownloadProgress(
+                    LocalizationHelper.GetStringFormat(
+                        "NewVersionDownloadRetrying",
+                        delay.TotalSeconds,
+                        attempt,
+                        UpdatePackageDownloadMaxAttempts),
+                    downloading: false);
+                await Task.Delay(delay).ConfigureAwait(false);
+            }
+        }
+
+        _logger.Error(
+            "Update package download finally failed after reaching maximum attempts for {Uri} (max attempts {MaxAttempts})",
+            uri.GetLeftPart(UriPartial.Path),
+            UpdatePackageDownloadMaxAttempts);
+        return false;
     }
 
     public static void OutputDownloadProgress(long value = 0, long maximum = 1, int len = 0, double ts = 1, string? toolTip = null)


### PR DESCRIPTION
## 变更
- 为 GitHub 和 MirrorChyan 的软件更新包下载添加最多 3 次尝试。
- 第 1 次失败后等待 1 秒，第 2 次失败后等待 2 秒。

## 原因
更新 ZIP 包下载遇到瞬时网络失败时会立即失败，没有重试。

## 验证
- `dotnet build src\MaaWpfGui\MaaWpfGui.csproj -c Debug -r win-x64 --no-restore`
- 启动 Debug 版 MAA，并确认更新设置页可正常打开。

## Summary by Sourcery

为软件下载包的下载添加重试逻辑，以提高在临时网络故障情况下的可靠性。

新功能：
- 为从远程源下载更新包引入可配置的最大尝试次数。

改进：
- 使用共享的重试辅助工具封装 GitHub 和 MirrorChyan 的更新包下载过程，该工具会记录失败日志并在重试之间进行退避。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add retry logic for software update package downloads to improve resilience against transient network failures.

New Features:
- Introduce configurable maximum attempt count for update package downloads from remote sources.

Enhancements:
- Wrap GitHub and MirrorChyan update package downloads with a shared retry helper that logs failures and backs off between attempts.
</details>

Closes #17623

## Summary by Sourcery

为软件更新包下载添加重试处理，以提升对瞬时故障的鲁棒性。

Bug Fixes:
- 通过在首次出现瞬时网络错误时对失败的下载尝试进行重试，防止更新包下载在首次错误时永久失败。

Enhancements:
- 引入一个共享的重试辅助工具，对 GitHub 和 MirrorChyan 的更新包下载设置最大重试次数和退避延迟，并在重试时记录警告日志。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add retry handling for software update package downloads to improve resilience to transient failures.

Bug Fixes:
- Prevent update package downloads from failing permanently on first transient network error by retrying failed attempts.

Enhancements:
- Introduce a shared retry helper with capped attempts and backoff delays for GitHub and MirrorChyan update package downloads, including warning logs on retries.

</details>