### PR TITLE
feat: 增加奇象巡展自动停止条件

### DIFF
--- a/resource/tasks/MiniGame/InteractiveExhibition.json
+++ b/resource/tasks/MiniGame/InteractiveExhibition.json
@@ -13,12 +13,12 @@
         ]
     },
     "MiniGame@InteractiveExhibition@CheckConnection": {
-        "doc": "联网门禁：OCR 左上角延迟「数字ms」(roi [15,90,80,50])。命中=在活动界面且联网正常，可继续走动；未命中则原地重试。",
+        "doc": "联网门禁：OCR 左上角延迟「数字ms」(roi [20,100,80,40])。命中=在活动界面且联网正常，可继续走动；未命中则原地重试。",
         "algorithm": "OcrDetect",
         "action": "DoNothing",
         "text": ["ONLINE"],
         "ocrReplace": [["\\d+ms", "ONLINE"]],
-        "roi": [15, 90, 80, 50],
+        "roi": [20, 100, 80, 40],
         "next": ["MiniGame@InteractiveExhibition@CheckConnection"]
     },
     "MiniGame@InteractiveExhibition@CheckConnection-Then-WalkRight": {
@@ -118,5 +118,131 @@
         "text": ["取消"],
         "roi": [415, 460, 65, 50],
         "next": ["MiniGame@InteractiveExhibition@Loop"]
+    },
+    "MiniGame@InteractiveExhibition@Target@ConnectionBase": {
+        "algorithm": "OcrDetect",
+        "action": "DoNothing",
+        "text": ["ONLINE"],
+        "ocrReplace": [["\\d+ms", "ONLINE"]],
+        "roi": [0, 0, 1280, 720],
+        "next": []
+    },
+    "MiniGame@InteractiveExhibition@Target@ScanOnce@Begin": {
+        "doc": "执行一轮右移、左移探索；遇到任意生物后返回目标判断流程。",
+        "algorithm": "JustReturn",
+        "next": [
+            "MiniGame@InteractiveExhibition@Target@ScanOnce@CheckConnectionRight",
+            "MiniGame@InteractiveExhibition@Target@ScanOnce@WaitConnection"
+        ]
+    },
+    "MiniGame@InteractiveExhibition@Target@ScanOnce@CheckConnectionRight": {
+        "baseTask": "MiniGame@InteractiveExhibition@Target@ConnectionBase",
+        "next": ["MiniGame@InteractiveExhibition@Target@ScanOnce@WalkRight"]
+    },
+    "MiniGame@InteractiveExhibition@Target@ScanOnce@WaitConnection": {
+        "algorithm": "JustReturn",
+        "action": "DoNothing",
+        "postDelay": 500,
+        "next": ["MiniGame@InteractiveExhibition@Target@ScanOnce@Begin"]
+    },
+    "MiniGame@InteractiveExhibition@Target@ScanOnce@WalkRight": {
+        "baseTask": "MiniGame@InteractiveExhibition@WalkRight",
+        "next": [
+            "MiniGame@InteractiveExhibition@Target@ScanOnce@Encounter",
+            "MiniGame@InteractiveExhibition@Target@ScanOnce@CheckConnectionLeft"
+        ]
+    },
+    "MiniGame@InteractiveExhibition@Target@ScanOnce@CheckConnectionLeft": {
+        "baseTask": "MiniGame@InteractiveExhibition@Target@ConnectionBase",
+        "next": ["MiniGame@InteractiveExhibition@Target@ScanOnce@WalkLeft"]
+    },
+    "MiniGame@InteractiveExhibition@Target@ScanOnce@WalkLeft": {
+        "baseTask": "MiniGame@InteractiveExhibition@WalkLeft",
+        "next": [
+            "MiniGame@InteractiveExhibition@Target@ScanOnce@Encounter",
+            "MiniGame@InteractiveExhibition@Target@ScanOnce@Done"
+        ]
+    },
+    "MiniGame@InteractiveExhibition@Target@ScanOnce@Encounter": {
+        "algorithm": "OcrDetect",
+        "action": "DoNothing",
+        "text": ["已收录", "暂未收录"],
+        "roi": [300, 500, 120, 45]
+    },
+    "MiniGame@InteractiveExhibition@Target@ScanOnce@Done": {
+        "baseTask": "MiniGame@InteractiveExhibition@Target@ConnectionBase",
+        "action": "DoNothing",
+        "next": []
+    },
+    "MiniGame@InteractiveExhibition@Target@ExitEncounter@Begin": {
+        "algorithm": "JustReturn",
+        "action": "ClickRect",
+        "specificRect": [50, 50, 10, 10],
+        "postDelay": 500,
+        "next": [
+            "MiniGame@InteractiveExhibition@Target@ExitEncounter@DontRemindToday",
+            "MiniGame@InteractiveExhibition@Target@ExitEncounter@LeaveExhibition",
+            "MiniGame@InteractiveExhibition@Target@ExitEncounter@StillCollected",
+            "MiniGame@InteractiveExhibition@Target@ExitEncounter@MapReady",
+            "MiniGame@InteractiveExhibition@Target@ExitEncounter@Wait"
+        ]
+    },
+    "MiniGame@InteractiveExhibition@Target@ExitEncounter@DontRemindToday": {
+        "baseTask": "MiniGame@InteractiveExhibition@DontRemindToday",
+        "next": ["MiniGame@InteractiveExhibition@Target@ExitEncounter@DontRemindTodayConfirm"]
+    },
+    "MiniGame@InteractiveExhibition@Target@ExitEncounter@DontRemindTodayConfirm": {
+        "baseTask": "MiniGame@InteractiveExhibition@DontRemindTodayConfirm",
+        "next": [
+            "MiniGame@InteractiveExhibition@Target@ExitEncounter@DontRemindToday",
+            "MiniGame@InteractiveExhibition@Target@ExitEncounter@LeaveExhibition",
+            "MiniGame@InteractiveExhibition@Target@ExitEncounter@StillCollected",
+            "MiniGame@InteractiveExhibition@Target@ExitEncounter@MapReady",
+            "MiniGame@InteractiveExhibition@Target@ExitEncounter@Wait"
+        ]
+    },
+    "MiniGame@InteractiveExhibition@Target@ExitEncounter@LeaveExhibition": {
+        "baseTask": "MiniGame@InteractiveExhibition@LeaveExhibition",
+        "next": ["MiniGame@InteractiveExhibition@Target@ExitEncounter@LeaveExhibitionCancel"]
+    },
+    "MiniGame@InteractiveExhibition@Target@ExitEncounter@LeaveExhibitionCancel": {
+        "baseTask": "MiniGame@InteractiveExhibition@LeaveExhibitionCancel",
+        "next": [
+            "MiniGame@InteractiveExhibition@Target@ExitEncounter@MapReady",
+            "MiniGame@InteractiveExhibition@Target@ExitEncounter@Wait"
+        ]
+    },
+    "MiniGame@InteractiveExhibition@Target@ExitEncounter@StillCollected": {
+        "baseTask": "MiniGame@InteractiveExhibition@CheckEncounter-Collected",
+        "next": ["MiniGame@InteractiveExhibition@Target@ExitEncounter@Begin"]
+    },
+    "MiniGame@InteractiveExhibition@Target@ExitEncounter@MapReady": {
+        "algorithm": "OcrDetect",
+        "action": "DoNothing",
+        "text": ["ONLINE"],
+        "ocrReplace": [["\\d+ms", "ONLINE"]],
+        "roi": [0, 0, 1280, 720],
+        "next": []
+    },
+    "MiniGame@InteractiveExhibition@Target@ExitEncounter@Wait": {
+        "algorithm": "JustReturn",
+        "action": "DoNothing",
+        "postDelay": 500,
+        "next": ["MiniGame@InteractiveExhibition@Target@ExitEncounter@Begin#next"]
+    },
+    "MiniGame@InteractiveExhibition@Target@BeginBase": {
+        "algorithm": "JustReturn",
+        "sub": ["MiniGame@InteractiveExhibition@Target@ScanOnce@Begin"]
+    },
+    "MiniGame@InteractiveExhibition@Target@CollectedBase": {
+        "baseTask": "MiniGame@InteractiveExhibition@CheckEncounter-Collected",
+        "action": "DoNothing",
+        "sub": ["MiniGame@InteractiveExhibition@Target@ExitEncounter@Begin"]
+    },
+    "MiniGame@InteractiveExhibition@Target@MatchBase": {
+        "algorithm": "OcrDetect",
+        "action": "DoNothing",
+        "roi": [0, 0, 1280, 720],
+        "next": ["Stop"]
     }
 }

--- a/src/MaaCore/Task/Interface/CustomTask.cpp
+++ b/src/MaaCore/Task/Interface/CustomTask.cpp
@@ -38,6 +38,12 @@ bool asst::CustomTask::set_params(const json::value& params)
         if (parse_and_register_secretfront(task_name, resolved_task)) {
             Log.info("Parsed and registered SecretFront task: ", task_name, " -> ", resolved_task);
         }
+        else if (task_name == "MiniGame@InteractiveExhibition@Target@Runtime@Begin") {
+            if (!parse_and_register_interactive_exhibition(task_name, params)) {
+                return false;
+            }
+            Log.info("Parsed and registered InteractiveExhibition task: ", task_name);
+        }
         else if (parse_and_register_pixel_paint(task_name, params)) {
             Log.info("Parsed and registered PixelPaint task: ", task_name);
         }
@@ -52,6 +58,81 @@ bool asst::CustomTask::set_params(const json::value& params)
     m_custom_task_ptr->set_tasks(std::move(tasks));
     m_subtasks.emplace_back(m_custom_task_ptr);
     return true;
+}
+
+bool
+    asst::CustomTask::parse_and_register_interactive_exhibition(const std::string& task_name, const json::value& params)
+{
+    if (task_name != "MiniGame@InteractiveExhibition@Target@Runtime@Begin") {
+        return false;
+    }
+
+    auto params_opt = params.find<json::object>("params");
+    if (!params_opt) {
+        Log.error("set_params failed, params not found for interactive exhibition");
+        return false;
+    }
+    auto exhibition_opt = params_opt->find<json::object>("interactive_exhibition");
+    if (!exhibition_opt) {
+        Log.error("set_params failed, params.interactive_exhibition not found");
+        return false;
+    }
+
+    const bool stop_on_uncollected = exhibition_opt->get("stop_on_uncollected", true);
+    json::array targets;
+    if (auto targets_opt = exhibition_opt->find<json::array>("targets")) {
+        for (const auto& target : *targets_opt) {
+            if (!target.is_string()) {
+                Log.error("set_params failed, interactive exhibition target is not string");
+                return false;
+            }
+            targets.emplace_back(target.as_string());
+        }
+    }
+    if (!stop_on_uncollected && targets.empty()) {
+        Log.error("set_params failed, no interactive exhibition stop condition");
+        return false;
+    }
+    json::object uncollected_task {
+        { "baseTask", "MiniGame@InteractiveExhibition@CheckEncounter-Uncollected" },
+    };
+    if (!stop_on_uncollected) {
+        uncollected_task["action"] = "DoNothing";
+        uncollected_task["sub"] = json::array { "MiniGame@InteractiveExhibition@Target@ExitEncounter@Begin" };
+        uncollected_task["next"] = json::array { task_name };
+    }
+
+    json::array runtime_next;
+    if (!targets.empty()) {
+        runtime_next.emplace_back("MiniGame@InteractiveExhibition@Target@Runtime@Match");
+    }
+    runtime_next.emplace_back("MiniGame@InteractiveExhibition@Target@Runtime@Uncollected");
+    runtime_next.emplace_back("MiniGame@InteractiveExhibition@Target@Runtime@Collected");
+    runtime_next.emplace_back("#self");
+
+    json::object runtime_tasks {
+        { task_name,
+          json::object {
+              { "baseTask", "MiniGame@InteractiveExhibition@Target@BeginBase" },
+              { "next", std::move(runtime_next) },
+          } },
+        { "MiniGame@InteractiveExhibition@Target@Runtime@Uncollected", std::move(uncollected_task) },
+        { "MiniGame@InteractiveExhibition@Target@Runtime@Collected",
+          json::object {
+              { "baseTask", "MiniGame@InteractiveExhibition@Target@CollectedBase" },
+              { "next", json::array { task_name } },
+          } },
+    };
+    if (!targets.empty()) {
+        runtime_tasks.emplace(
+            "MiniGame@InteractiveExhibition@Target@Runtime@Match",
+            json::object {
+                { "baseTask", "MiniGame@InteractiveExhibition@Target@MatchBase" },
+                { "text", std::move(targets) },
+            });
+    }
+
+    return Task.lazy_parse(runtime_tasks);
 }
 
 bool asst::CustomTask::parse_and_register_pixel_paint(const std::string& task_name, const json::value& params)

--- a/src/MaaCore/Task/Interface/CustomTask.h
+++ b/src/MaaCore/Task/Interface/CustomTask.h
@@ -18,6 +18,8 @@ public:
 
     bool parse_and_register_pixel_paint(const std::string& task_name, const json::value& params);
 
+    bool parse_and_register_interactive_exhibition(const std::string& task_name, const json::value& params);
+
 private:
     std::shared_ptr<ProcessTask> m_custom_task_ptr = nullptr;
 };

--- a/src/MaaWpfGui/Configuration/Single/Settings/Toolbox.cs
+++ b/src/MaaWpfGui/Configuration/Single/Settings/Toolbox.cs
@@ -50,4 +50,10 @@ public partial class Toolbox
     public bool AutoSetTime { get; set; } = true;
 
     public bool ShowPotential { get; set; } = true;
+
+    public bool InteractiveExhibitionStopOnUncollected { get; set; } = true;
+
+    public bool InteractiveExhibitionStopOnRarity3 { get; set; }
+
+    public bool InteractiveExhibitionStopOnSelectedTargets { get; set; } = true;
 }

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -3057,6 +3057,24 @@ public class AsstProxy
     }
 
     /// <summary>
+    /// 奇象巡展目标筛选。停止条件仅随本次任务传给 Core，不写入资源目录。
+    /// </summary>
+    public bool AsstInteractiveExhibition(IReadOnlyList<string> targets, bool stopOnUncollected)
+    {
+        var task = new AsstCustomTask {
+            CustomTasks = ["MiniGame@InteractiveExhibition@Target@Runtime@Begin"],
+            Params = JObject.FromObject(new {
+                interactive_exhibition = new {
+                    stop_on_uncollected = stopOnUncollected,
+                    targets,
+                },
+            }),
+        };
+        var (type, param) = task.Serialize();
+        return AsstAppendTaskWithEncoding(TaskType.MiniGame, type, param) && AsstStart();
+    }
+
+    /// <summary>
     /// 像素画自动填色（牛杂）。短 task 入口 + params.pixel_paint 分组点列。
     /// </summary>
     /// <param name="groups">按色分组后的格子，color 为 0~39。</param>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -1122,6 +1122,20 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="MiniGame@PixelPaint@StartLog">开始像素画：{0} 格，{1} 色</system:String>
     <system:String x:Key="MiniGame@PixelPaint@ProgressLog">像素画 {0}/{1}</system:String>
     <system:String x:Key="MiniGame@PixelPaint@DoneLog">像素画完成</system:String>
+    <system:String x:Key="MiniGame@InteractiveExhibition@AutoStopConditions">自动停止条件</system:String>
+    <system:String x:Key="MiniGame@InteractiveExhibition@StopOnUncollected">遇到未收录生物</system:String>
+    <system:String x:Key="MiniGame@InteractiveExhibition@StopOnRarity3">遇到任意三星生物</system:String>
+    <system:String x:Key="MiniGame@InteractiveExhibition@StopOnSelectedTargets">遇到指定生物</system:String>
+    <system:String x:Key="MiniGame@InteractiveExhibition@TargetSettings">设置指定生物</system:String>
+    <system:String x:Key="MiniGame@InteractiveExhibition@ArcaneTab">奇术 (12)</system:String>
+    <system:String x:Key="MiniGame@InteractiveExhibition@InstinctTab">本能 (12)</system:String>
+    <system:String x:Key="MiniGame@InteractiveExhibition@VariableTab">百变 (13)</system:String>
+    <system:String x:Key="MiniGame@InteractiveExhibition@TargetDisplay">{0}星  {1}</system:String>
+    <system:String x:Key="MiniGame@InteractiveExhibition@TargetSelectionDisabled">指定生物条件未启用</system:String>
+    <system:String x:Key="MiniGame@InteractiveExhibition@TargetSummary">已选 {0} 个指定生物</system:String>
+    <system:String x:Key="MiniGame@InteractiveExhibition@TargetSummaryWithRarity3">已选三星生物及 {0} 个指定生物</system:String>
+    <system:String x:Key="MiniGame@InteractiveExhibition@NoStopCondition">请至少勾选一个停止条件。</system:String>
+    <system:String x:Key="MiniGame@InteractiveExhibitionTip" xml:space="preserve">在所选地图的高级区草地右下角开始任务。&#10;在草地来回走动，遇到任一勾选条件后自动停止。</system:String>
     <system:String x:Key="MiniGameNameGreenTicketStore">绿票商店</system:String>
     <system:String x:Key="MiniGameNameGreenTicketStoreTip" xml:space="preserve">1层全买。&#10;2层买寻访凭证和招聘许可。</system:String>
     <system:String x:Key="MiniGameNameYellowTicketStore">黄票商店</system:String>

--- a/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
@@ -87,6 +87,11 @@ public class ToolboxViewModel : Screen
         LocalizationHelper.LanguageChanged += () => {
             DisplayName = LocalizationHelper.GetString("Toolbox");
             RecruitInfo = LocalizationHelper.GetString("RecruitmentRecognitionTip");
+            foreach (var target in InteractiveExhibitionTargets)
+            {
+                target.RefreshDisplay();
+            }
+            NotifyOfPropertyChange(nameof(InteractiveExhibitionSelectedSummary));
             Application.Current.Dispatcher.InvokeAsync(
                 () => {
                     LoadDepotDetails();
@@ -109,6 +114,7 @@ public class ToolboxViewModel : Screen
         InitializeOperBoxRowPresentation();
         OperBoxSelectedIndex = OperBoxNotHaveList.Count > 0 ? 0 : 1;
 
+        InitializeInteractiveExhibitionTargets();
         UpdateMiniGameTaskList();
     }
 
@@ -2270,6 +2276,209 @@ public class ToolboxViewModel : Screen
         public bool IsSecretFront => Value == "MiniGame@SecretFront";
 
         public bool IsPixelPaint => Value is "MiniGame@PixelPaint" or "MiniGame@PixelPaint@Begin";
+
+        public bool IsInteractiveExhibition => Value == "MiniGame@InteractiveExhibition@Begin";
+    }
+
+    public sealed class InteractiveExhibitionTargetItem : PropertyChangedBase
+    {
+        private readonly Action<InteractiveExhibitionTargetItem> _selectionChanged;
+        private bool _isSelected;
+
+        public InteractiveExhibitionTargetItem(string attribute, int rarity, string name, bool isSelected, Action<InteractiveExhibitionTargetItem> selectionChanged)
+        {
+            Attribute = attribute;
+            Rarity = rarity;
+            Name = name;
+            _isSelected = isSelected;
+            _selectionChanged = selectionChanged;
+        }
+
+        public string Attribute { get; }
+
+        public int Rarity { get; }
+
+        public string Name { get; }
+
+        public string Display => LocalizationHelper.GetStringFormat("MiniGame@InteractiveExhibition@TargetDisplay", Rarity, Name);
+
+        public void RefreshDisplay() => NotifyOfPropertyChange(nameof(Display));
+
+        public bool IsSelected
+        {
+            get => _isSelected;
+            set {
+                if (SetAndNotify(ref _isSelected, value))
+                {
+                    _selectionChanged(this);
+                }
+            }
+        }
+    }
+
+    private const string InteractiveExhibitionTask = "MiniGame@InteractiveExhibition@Begin";
+    private const string InteractiveExhibitionRuntimeTask = "MiniGame@InteractiveExhibition@Target@Runtime@Begin";
+
+    private static readonly (string Attribute, int Rarity, string Name)[] _interactiveExhibitionCreatures =
+    [
+        ("Arcane", 3, "锐爪巨翼兽"),
+        ("Arcane", 3, "星术绒绒"),
+        ("Arcane", 3, "奥术绒绒"),
+        ("Arcane", 3, "青花"),
+        ("Arcane", 3, "赤霞"),
+        ("Arcane", 3, "“酩酊”"),
+        ("Arcane", 2, "大个子绒绒"),
+        ("Arcane", 2, "灼热跳跳蜥"),
+        ("Arcane", 1, "活泼绒绒"),
+        ("Arcane", 1, "“阿咬”"),
+        ("Arcane", 1, "大嘴捕食草"),
+        ("Arcane", 1, "爬行鬼伞"),
+        ("Instinct", 3, "高普尼克"),
+        ("Instinct", 3, "石背岩壳蟹"),
+        ("Instinct", 3, "不知足吞噬者"),
+        ("Instinct", 3, "孤独的巨像"),
+        ("Instinct", 2, "密林锋脊裂兽"),
+        ("Instinct", 2, "枯焦锋脊裂兽"),
+        ("Instinct", 2, "寒山大角驮兽"),
+        ("Instinct", 2, "温和驮兽"),
+        ("Instinct", 1, "固海凿石者"),
+        ("Instinct", 1, "困困荪茸"),
+        ("Instinct", 1, "浪花小壳蟹"),
+        ("Instinct", 1, "熔火小壳蟹"),
+        ("Variable", 3, "未定义石兽"),
+        ("Variable", 3, "花冠园丁"),
+        ("Variable", 3, "黑毛花冠园丁"),
+        ("Variable", 3, "果冻清道夫"),
+        ("Variable", 3, "钵海收割者"),
+        ("Variable", 2, "蓝冠羽镖客"),
+        ("Variable", 2, "橙冠羽镖客"),
+        ("Variable", 2, "深林伪形兽"),
+        ("Variable", 2, "赤黑伪形兽"),
+        ("Variable", 1, "直立小雪怪"),
+        ("Variable", 1, "红宝石投石虫"),
+        ("Variable", 1, "石榴弩手"),
+        ("Variable", 1, "椰壳蟹"),
+    ];
+
+    public ObservableCollection<InteractiveExhibitionTargetItem> InteractiveExhibitionTargets { get; } = [];
+
+    public IEnumerable<InteractiveExhibitionTargetItem> InteractiveExhibitionArcaneTargets =>
+        InteractiveExhibitionTargets.Where(target => target.Attribute == "Arcane");
+
+    public IEnumerable<InteractiveExhibitionTargetItem> InteractiveExhibitionInstinctTargets =>
+        InteractiveExhibitionTargets.Where(target => target.Attribute == "Instinct");
+
+    public IEnumerable<InteractiveExhibitionTargetItem> InteractiveExhibitionVariableTargets =>
+        InteractiveExhibitionTargets.Where(target => target.Attribute == "Variable");
+
+    public bool InteractiveExhibitionStopOnUncollected
+    {
+        get; set {
+            if (SetAndNotify(ref field, value))
+            {
+                ConfigFactory.CurrentConfig.Toolbox.InteractiveExhibitionStopOnUncollected = value;
+            }
+        }
+    } = ConfigFactory.CurrentConfig.Toolbox.InteractiveExhibitionStopOnUncollected;
+
+    public bool InteractiveExhibitionStopOnRarity3
+    {
+        get; set {
+            if (SetAndNotify(ref field, value))
+            {
+                ConfigFactory.CurrentConfig.Toolbox.InteractiveExhibitionStopOnRarity3 = value;
+                NotifyOfPropertyChange(nameof(InteractiveExhibitionSelectedSummary));
+            }
+        }
+    } = ConfigFactory.CurrentConfig.Toolbox.InteractiveExhibitionStopOnRarity3;
+
+    public bool InteractiveExhibitionStopOnSelectedTargets
+    {
+        get; set {
+            if (SetAndNotify(ref field, value))
+            {
+                ConfigFactory.CurrentConfig.Toolbox.InteractiveExhibitionStopOnSelectedTargets = value;
+                if (!value)
+                {
+                    InteractiveExhibitionTargetSettingsExpanded = false;
+                }
+                NotifyOfPropertyChange(nameof(InteractiveExhibitionSelectedSummary));
+            }
+        }
+    } = ConfigFactory.CurrentConfig.Toolbox.InteractiveExhibitionStopOnSelectedTargets;
+
+    public bool InteractiveExhibitionTargetSettingsExpanded { get; set => SetAndNotify(ref field, value); }
+
+    public void ToggleInteractiveExhibitionTargetSettings()
+    {
+        if (InteractiveExhibitionStopOnSelectedTargets)
+        {
+            InteractiveExhibitionTargetSettingsExpanded = !InteractiveExhibitionTargetSettingsExpanded;
+        }
+    }
+
+    public string InteractiveExhibitionSelectedSummary
+    {
+        get {
+            int count = InteractiveExhibitionTargets.Count(target => target.IsSelected);
+            if (!InteractiveExhibitionStopOnSelectedTargets)
+            {
+                return LocalizationHelper.GetString("MiniGame@InteractiveExhibition@TargetSelectionDisabled");
+            }
+
+            return InteractiveExhibitionStopOnRarity3
+                ? LocalizationHelper.GetStringFormat("MiniGame@InteractiveExhibition@TargetSummaryWithRarity3", count)
+                : LocalizationHelper.GetStringFormat("MiniGame@InteractiveExhibition@TargetSummary", count);
+        }
+    }
+
+    private void InitializeInteractiveExhibitionTargets()
+    {
+        foreach (var (attribute, rarity, name) in _interactiveExhibitionCreatures)
+        {
+            InteractiveExhibitionTargets.Add(new InteractiveExhibitionTargetItem(attribute, rarity, name, false, OnInteractiveExhibitionTargetChanged));
+        }
+    }
+
+    private void OnInteractiveExhibitionTargetChanged(InteractiveExhibitionTargetItem targetItem)
+    {
+        NotifyOfPropertyChange(nameof(InteractiveExhibitionSelectedSummary));
+    }
+
+    public void SelectAllInteractiveExhibitionTargets()
+    {
+        foreach (var target in InteractiveExhibitionTargets)
+        {
+            target.IsSelected = true;
+        }
+    }
+
+    public void ClearInteractiveExhibitionTargets()
+    {
+        foreach (var target in InteractiveExhibitionTargets)
+        {
+            target.IsSelected = false;
+        }
+    }
+
+    public void SelectAllInteractiveExhibitionArcaneTargets() => SetInteractiveExhibitionAttribute("Arcane", true);
+
+    public void ClearInteractiveExhibitionArcaneTargets() => SetInteractiveExhibitionAttribute("Arcane", false);
+
+    public void SelectAllInteractiveExhibitionInstinctTargets() => SetInteractiveExhibitionAttribute("Instinct", true);
+
+    public void ClearInteractiveExhibitionInstinctTargets() => SetInteractiveExhibitionAttribute("Instinct", false);
+
+    public void SelectAllInteractiveExhibitionVariableTargets() => SetInteractiveExhibitionAttribute("Variable", true);
+
+    public void ClearInteractiveExhibitionVariableTargets() => SetInteractiveExhibitionAttribute("Variable", false);
+
+    private void SetInteractiveExhibitionAttribute(string attribute, bool isSelected)
+    {
+        foreach (var target in InteractiveExhibitionTargets.Where(target => target.Attribute == attribute))
+        {
+            target.IsSelected = isSelected;
+        }
     }
 
     public ObservableCollection<MiniGameCategoryItem> MiniGameCategoryItems { get; } = [];
@@ -2342,8 +2551,30 @@ public class ToolboxViewModel : Screen
     {
         return MiniGameTaskName switch {
             "MiniGame@SecretFront" => $"{MiniGameTaskName}@Begin@Ending{SecretFrontEnding}{(string.IsNullOrEmpty(SecretFrontEvent) ? string.Empty : $"@{SecretFrontEvent}")}",
+            InteractiveExhibitionTask => InteractiveExhibitionRuntimeTask,
             _ => MiniGameTaskName,
         };
+    }
+
+    private bool TryGetInteractiveExhibitionTargets(out List<string> targets)
+    {
+        targets = InteractiveExhibitionTargets
+            .Where(target =>
+                (InteractiveExhibitionStopOnSelectedTargets && target.IsSelected)
+                || (InteractiveExhibitionStopOnRarity3 && target.Rarity == 3))
+            .Select(target => target.Name)
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
+        if (!InteractiveExhibitionStopOnUncollected && targets.Count == 0)
+        {
+            Instances.TaskQueueViewModel.AddLog(
+                LocalizationHelper.GetString("MiniGame@InteractiveExhibition@NoStopCondition"),
+                UiLogColor.Warning);
+            return false;
+        }
+
+        return true;
     }
 
     private string? _miniGameTip;
@@ -2359,6 +2590,11 @@ public class ToolboxViewModel : Screen
 
     private static string GetMiniGameTip(string name)
     {
+        if (name == InteractiveExhibitionTask)
+        {
+            return LocalizationHelper.GetString("MiniGame@InteractiveExhibitionTip");
+        }
+
         if (string.IsNullOrEmpty(name))
         {
             return LocalizationHelper.GetString("MiniGameNameEmptyTip");
@@ -2781,6 +3017,8 @@ public class ToolboxViewModel : Screen
         }
 
         var isPixelPaint = IsPixelPaintSelected;
+        var isInteractiveExhibition = MiniGameTaskName == InteractiveExhibitionTask;
+        List<string> interactiveExhibitionTargets = [];
         if (isPixelPaint && (_pixelPaintResult == null || _pixelPaintResult.Groups.Count == 0))
         {
             Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("MiniGame@PixelPaint@NeedImage"), UiLogColor.Warning);
@@ -2793,6 +3031,12 @@ public class ToolboxViewModel : Screen
         if (isPixelPaint)
         {
             PixelPaintParametersLocked = true;
+        }
+
+        if (isInteractiveExhibition && !TryGetInteractiveExhibitionTargets(out interactiveExhibitionTargets))
+        {
+            _runningState.SetIdle(true);
+            return;
         }
 
         string errMsg = string.Empty;
@@ -2824,6 +3068,12 @@ public class ToolboxViewModel : Screen
                         groups.Count),
                     UiLogColor.Info);
             }
+        }
+        else if (isInteractiveExhibition)
+        {
+            caught = Instances.AsstProxy.AsstInteractiveExhibition(
+                interactiveExhibitionTargets,
+                InteractiveExhibitionStopOnUncollected);
         }
         else
         {

--- a/src/MaaWpfGui/Views/UI/ToolboxView.xaml
+++ b/src/MaaWpfGui/Views/UI/ToolboxView.xaml
@@ -890,6 +890,163 @@
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="*" />
                         </Grid.RowDefinitions>
+                        <!--  奇象巡展  -->
+                        <Grid Grid.RowSpan="2" Visibility="{c:Binding 'SelectedMiniGameItem.IsInteractiveExhibition'}">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="*" />
+                                <RowDefinition Height="Auto" />
+                            </Grid.RowDefinitions>
+                            <StackPanel>
+                                <controls:TextBlock FontSize="16" FontWeight="Bold" Text="{DynamicResource MiniGame@InteractiveExhibition@AutoStopConditions}" />
+                                <CheckBox
+                                    Margin="0,10,0,0"
+                                    Content="{DynamicResource MiniGame@InteractiveExhibition@StopOnUncollected}"
+                                    IsChecked="{Binding InteractiveExhibitionStopOnUncollected}" />
+                                <CheckBox
+                                    Margin="0,8,0,0"
+                                    Content="{DynamicResource MiniGame@InteractiveExhibition@StopOnRarity3}"
+                                    IsChecked="{Binding InteractiveExhibitionStopOnRarity3}" />
+                                <Grid Margin="0,8,0,0">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
+                                    <CheckBox
+                                        VerticalAlignment="Center"
+                                        Content="{DynamicResource MiniGame@InteractiveExhibition@StopOnSelectedTargets}"
+                                        IsChecked="{Binding InteractiveExhibitionStopOnSelectedTargets}" />
+                                    <Button
+                                        Grid.Column="1"
+                                        Width="22"
+                                        Height="22"
+                                        MinWidth="22"
+                                        Padding="2"
+                                        hc:IconElement.Geometry="{StaticResource ConfigGeometry}"
+                                        BorderThickness="0"
+                                        Command="{s:Action ToggleInteractiveExhibitionTargetSettings}"
+                                        IsEnabled="{Binding InteractiveExhibitionStopOnSelectedTargets}"
+                                        ToolTip="{DynamicResource MiniGame@InteractiveExhibition@TargetSettings}" />
+                                </Grid>
+                            </StackPanel>
+                            <Grid
+                                Grid.Row="1"
+                                Visibility="{c:Binding 'InteractiveExhibitionStopOnSelectedTargets and InteractiveExhibitionTargetSettingsExpanded'}">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto" />
+                                    <RowDefinition Height="*" />
+                                </Grid.RowDefinitions>
+                                <StackPanel>
+                                    <controls:TextBlock
+                                        Margin="0,10,0,0"
+                                        Foreground="{DynamicResource TraceLogBrush}"
+                                        Text="{Binding InteractiveExhibitionSelectedSummary}" />
+                                    <StackPanel Margin="0,8,0,8" Orientation="Horizontal">
+                                        <Button
+                                            MinWidth="64"
+                                            Margin="0,0,8,0"
+                                            Command="{s:Action SelectAllInteractiveExhibitionTargets}"
+                                            Content="{DynamicResource SelectAll}" />
+                                        <Button
+                                            MinWidth="64"
+                                            Command="{s:Action ClearInteractiveExhibitionTargets}"
+                                            Content="{DynamicResource Clear}" />
+                                    </StackPanel>
+                                </StackPanel>
+                                <TabControl Grid.Row="1">
+                                    <TabItem Header="{DynamicResource MiniGame@InteractiveExhibition@ArcaneTab}">
+                                    <Grid Margin="4,6,0,0">
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto" />
+                                            <RowDefinition Height="*" />
+                                        </Grid.RowDefinitions>
+                                        <StackPanel Margin="0,0,0,4" Orientation="Horizontal">
+                                            <Button
+                                                MinWidth="56"
+                                                Margin="0,0,6,0"
+                                                Command="{s:Action SelectAllInteractiveExhibitionArcaneTargets}"
+                                                Content="{DynamicResource SelectAll}" />
+                                            <Button
+                                                MinWidth="56"
+                                                Command="{s:Action ClearInteractiveExhibitionArcaneTargets}"
+                                                Content="{DynamicResource Clear}" />
+                                        </StackPanel>
+                                        <ScrollViewer Grid.Row="1" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
+                                            <ItemsControl ItemsSource="{Binding InteractiveExhibitionArcaneTargets}">
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate>
+                                                        <CheckBox Margin="0,3" Content="{Binding Display}" IsChecked="{Binding IsSelected}" />
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
+                                        </ScrollViewer>
+                                    </Grid>
+                                    </TabItem>
+                                    <TabItem Header="{DynamicResource MiniGame@InteractiveExhibition@InstinctTab}">
+                                    <Grid Margin="4,6,0,0">
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto" />
+                                            <RowDefinition Height="*" />
+                                        </Grid.RowDefinitions>
+                                        <StackPanel Margin="0,0,0,4" Orientation="Horizontal">
+                                            <Button
+                                                MinWidth="56"
+                                                Margin="0,0,6,0"
+                                                Command="{s:Action SelectAllInteractiveExhibitionInstinctTargets}"
+                                                Content="{DynamicResource SelectAll}" />
+                                            <Button
+                                                MinWidth="56"
+                                                Command="{s:Action ClearInteractiveExhibitionInstinctTargets}"
+                                                Content="{DynamicResource Clear}" />
+                                        </StackPanel>
+                                        <ScrollViewer Grid.Row="1" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
+                                            <ItemsControl ItemsSource="{Binding InteractiveExhibitionInstinctTargets}">
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate>
+                                                        <CheckBox Margin="0,3" Content="{Binding Display}" IsChecked="{Binding IsSelected}" />
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
+                                        </ScrollViewer>
+                                    </Grid>
+                                    </TabItem>
+                                    <TabItem Header="{DynamicResource MiniGame@InteractiveExhibition@VariableTab}">
+                                    <Grid Margin="4,6,0,0">
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto" />
+                                            <RowDefinition Height="*" />
+                                        </Grid.RowDefinitions>
+                                        <StackPanel Margin="0,0,0,4" Orientation="Horizontal">
+                                            <Button
+                                                MinWidth="56"
+                                                Margin="0,0,6,0"
+                                                Command="{s:Action SelectAllInteractiveExhibitionVariableTargets}"
+                                                Content="{DynamicResource SelectAll}" />
+                                            <Button
+                                                MinWidth="56"
+                                                Command="{s:Action ClearInteractiveExhibitionVariableTargets}"
+                                                Content="{DynamicResource Clear}" />
+                                        </StackPanel>
+                                        <ScrollViewer Grid.Row="1" HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
+                                            <ItemsControl ItemsSource="{Binding InteractiveExhibitionVariableTargets}">
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate>
+                                                        <CheckBox Margin="0,3" Content="{Binding Display}" IsChecked="{Binding IsSelected}" />
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
+                                        </ScrollViewer>
+                                    </Grid>
+                                    </TabItem>
+                                </TabControl>
+                            </Grid>
+                            <TextBlock
+                                Grid.Row="2"
+                                Margin="0,10,0,0"
+                                Opacity="0.85"
+                                Text="{Binding MiniGameTip}"
+                                TextWrapping="Wrap" />
+                        </Grid>
                         <!--  像素画  -->
                         <Grid Visibility="{c:Binding 'SelectedMiniGameItem.IsPixelPaint'}">
                             <Grid.RowDefinitions>
@@ -1064,7 +1221,7 @@
                             Margin="0,12,0,0"
                             Stretch="Uniform"
                             StretchDirection="Both"
-                            Visibility="{c:Binding '!SelectedMiniGameItem.IsPixelPaint'}">
+                            Visibility="{c:Binding '!SelectedMiniGameItem.IsPixelPaint and !SelectedMiniGameItem.IsInteractiveExhibition'}">
                             <TextBlock
                                 MaxWidth="150"
                                 Text="{Binding MiniGameTip}"


### PR DESCRIPTION
为奇象巡展增加可勾选的自动停止条件，支持遇到未收录、任意三星或指定生物时停止。

## Summary by Sourcery

为互动展览（Interactive Exhibition）小游戏新增可配置的自动停止条件，并贯穿到图形界面、配置与核心任务处理流程中。

New Features:
- 为互动展览引入可选停止条件，包括：在存在未收集生物时停止、遇到任意 3 星稀有度时停止，以及基于用户自选目标的停止。
- 在工具箱 UI 中公开互动展览的目标列表和批量选择控件，用于基于属性的筛选。
- 新增专用的互动展览小游戏入口，通过新的代理 API 将每次运行的停止条件和目标传递给核心。

Enhancements:
- 在工具箱设置中持久化互动展览的停止条件偏好，并在 UI 概览中进行展示。
- 扩展核心自定义任务解析逻辑，根据提供的停止条件动态构建互动展览的运行时任务。

Documentation:
- 更新互动展览提示、目标选择状态以及关于缺失停止条件的警告的本地化资源。

Chores:
- 将互动展览的任务和目标资源添加到资源目录中，以支持小游戏处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable auto-stop conditions for the Interactive Exhibition mini-game and wire them through GUI, configuration, and core task handling.

New Features:
- Introduce selectable stop conditions for Interactive Exhibition, including stopping on uncollected creatures, any 3-star rarity, and user-chosen targets.
- Expose Interactive Exhibition target lists and bulk selection controls in the toolbox UI for attribute-based filtering.
- Add a dedicated Interactive Exhibition mini-game entry that passes per-run stop conditions and targets to the core via a new proxy API.

Enhancements:
- Persist Interactive Exhibition stop-condition preferences in toolbox settings and reflect them in UI summaries.
- Extend core custom task parsing to dynamically construct runtime tasks for Interactive Exhibition based on provided stop conditions.

Documentation:
- Update localization resources for Interactive Exhibition tips, target selection status, and warnings about missing stop conditions.

Chores:
- Add Interactive Exhibition task and target assets to the resource directory for mini-game handling.

</details>