### PR TITLE
feat: resolve PC client window title by ClientType

### DIFF
--- a/src/MaaWpfGui/Extensions/ClientTypeExtension.cs
+++ b/src/MaaWpfGui/Extensions/ClientTypeExtension.cs
@@ -40,4 +40,16 @@ public static class ClientTypeExtension
             _ => throw new ArgumentOutOfRangeException(nameof(clientType), clientType, null),
         };
     }
+
+    public static string ToGameWindowName(this ClientType clientType)
+    {
+        return clientType switch {
+            ClientType.Official or ClientType.Bilibili => "明日方舟",
+            ClientType.EN => "Arknights",
+            ClientType.JP => "アークナイツ",
+            ClientType.KR => "명일방주",
+            ClientType.Txwy => "明日方舟",
+            _ => throw new ArgumentOutOfRangeException(nameof(clientType), clientType, null),
+        };
+    }
 }

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -2598,7 +2598,7 @@ public class AsstProxy
 
     /// <summary>
     /// 通过 AttachWindow 绑定 Win32 窗口。
-    /// 自动搜索 "明日方舟" 窗口。
+    /// 自动搜索当前客户端版本对应的游戏窗口。
     /// </summary>
     /// <param name="error">具体的连接错误。</param>
     /// <returns>是否成功。</returns>
@@ -2627,14 +2627,14 @@ public class AsstProxy
 
         Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("UseAttachWindowWarning"), UiLogColor.Error);
 
-        const string TargetWindowName = "明日方舟";
-        var foundWindows = FindWindowsByName(TargetWindowName);
+        string targetWindowName = SettingsViewModel.GameSettings.ClientType.ToGameWindowName();
+        var foundWindows = FindWindowsByName(targetWindowName);
 
         if (foundWindows.Count == 0)
         {
-            error = LocalizationHelper.GetStringFormat("AttachWindowNotFound", TargetWindowName);
+            error = LocalizationHelper.GetStringFormat("AttachWindowNotFound", targetWindowName);
             Instances.TaskQueueViewModel.AddLog(error, UiLogColor.Error);
-            _logger.Warning("AttachWindow: No window found with name {WindowName}", TargetWindowName);
+            _logger.Warning("AttachWindow: No window found with name {WindowName}", targetWindowName);
             return false;
         }
 
@@ -2643,15 +2643,15 @@ public class AsstProxy
         if (foundWindows.Count > 1)
         {
             // 找到多个窗口，使用第一个并记录日志
-            var multipleMsg = LocalizationHelper.GetStringFormat("AttachWindowMultipleFound", foundWindows.Count, TargetWindowName);
+            var multipleMsg = LocalizationHelper.GetStringFormat("AttachWindowMultipleFound", foundWindows.Count, targetWindowName);
             Instances.TaskQueueViewModel.AddLog(multipleMsg, UiLogColor.Info);
-            _logger.Warning("AttachWindow: Multiple windows found with name {WindowName}, count: {Count}, using first one: {Hwnd}", TargetWindowName, foundWindows.Count, hwnd);
+            _logger.Warning("AttachWindow: Multiple windows found with name {WindowName}, count: {Count}, using first one: {Hwnd}", targetWindowName, foundWindows.Count, hwnd);
         }
         else
         {
-            var foundMsg = LocalizationHelper.GetStringFormat("AttachWindowFound", TargetWindowName);
+            var foundMsg = LocalizationHelper.GetStringFormat("AttachWindowFound", targetWindowName);
             Instances.TaskQueueViewModel.AddLog(foundMsg, UiLogColor.Info);
-            _logger.Information("AttachWindow: Found window \"{WindowName}\" with HWND: {Hwnd}", TargetWindowName, hwnd);
+            _logger.Information("AttachWindow: Found window \"{WindowName}\" with HWND: {Hwnd}", targetWindowName, hwnd);
         }
 
         if (SettingsViewModel.ConnectSettings.ExtraConfig is not Win32Extra win32Extra)

--- a/src/MaaWpfGui/Views/UserControl/GuideUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/GuideUserControl.xaml
@@ -433,8 +433,8 @@
                                     </ContentControl>
                                 </StackPanel>
 
-                                <!--  截图测试（ADB 模式）  -->
-                                <StackPanel HorizontalAlignment="Center" Visibility="{c:Binding '!IsPCConnectConfig'}">
+                                <!--  截图测试  -->
+                                <StackPanel HorizontalAlignment="Center">
                                     <Button
                                         Height="30"
                                         Margin="5"

--- a/src/MaaWpfGui/Views/UserControl/TaskQueue/StartUpTaskUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/TaskQueue/StartUpTaskUserControl.xaml
@@ -324,20 +324,18 @@
             </ContentControl>
 
             <!--  截图测试  -->
-            <StackPanel d:Visibility="Visible" Visibility="{c:Binding 'ConnectConfig != enums:ConnectConfig.PC'}">
-                <Button
-                    Height="30"
-                    Margin="0,5"
-                    HorizontalAlignment="Left"
-                    Command="{s:Action TestLinkAndGetImage}"
-                    Content="{DynamicResource ScreenshotTest}" />
-                <controls:TextBlock
-                    Margin="0,5"
-                    HorizontalAlignment="Left"
-                    Text="{Binding TestLinkInfo}"
-                    TextWrapping="Wrap"
-                    Visibility="{c:Binding 'TestLinkInfo!=&quot;&quot;'}" />
-            </StackPanel>
+            <Button
+                Height="30"
+                Margin="0,5"
+                HorizontalAlignment="Left"
+                Command="{s:Action TestLinkAndGetImage}"
+                Content="{DynamicResource ScreenshotTest}" />
+            <controls:TextBlock
+                Margin="0,5"
+                HorizontalAlignment="Left"
+                Text="{Binding TestLinkInfo}"
+                TextWrapping="Wrap"
+                Visibility="{c:Binding 'TestLinkInfo!=&quot;&quot;'}" />
         </StackPanel>
     </StackPanel>
 </UserControl>

--- a/src/MaaWpfGui/Views/UserControl/TaskQueue/StartUpTaskUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/TaskQueue/StartUpTaskUserControl.xaml
@@ -53,29 +53,32 @@
                         IsEnabled="{c:Binding 'AccountName != &quot;&quot;'}" />
                 </Grid>
             </StackPanel>
-
-            <controls:TextBlock
-                Margin="0,5"
-                HorizontalAlignment="Center"
-                FontWeight="Bold"
-                Text="{DynamicResource MultiTasksShareTip}"
-                TextAlignment="Left"
-                TextWrapping="Wrap" />
-            <CheckBox
-                Margin="0,5"
-                Content="{DynamicResource StartGameLaunchClient}"
-                IsChecked="{Binding StartGame, Source={x:Static settings_vms:GameSettingsUserControlModel.Instance}}" />
-            <hc:ComboBox
-                Margin="0,5"
-                hc:InfoElement.Title="{DynamicResource ClientType}"
-                DisplayMemberPath="Display"
-                IsHitTestVisible="{Binding Idle, Source={x:Static helper:Instances.SettingsViewModel}}"
-                ItemsSource="{Binding ClientTypeList, Source={x:Static settings_vms:GameSettingsUserControlModel.Instance}}"
-                SelectedValue="{Binding ClientType, Source={x:Static settings_vms:GameSettingsUserControlModel.Instance}}"
-                SelectedValuePath="Value"
-                Visibility="{c:Binding !TaskSettingVisibilities.Guide,
-                                       Source={x:Static helper:Instances.SettingsViewModel}}" />
         </StackPanel>
+
+        <controls:TextBlock
+            Margin="0,5"
+            HorizontalAlignment="Center"
+            FontWeight="Bold"
+            Text="{DynamicResource MultiTasksShareTip}"
+            TextAlignment="Left"
+            TextWrapping="Wrap" />
+        <CheckBox
+            Margin="0,5"
+            d:Visibility="Visible"
+            Content="{DynamicResource StartGameLaunchClient}"
+            IsChecked="{Binding StartGame, Source={x:Static settings_vms:GameSettingsUserControlModel.Instance}}"
+            Visibility="{c:Binding 'ConnectConfig != enums:ConnectConfig.PC',
+                                   Source={x:Static settings_vms:ConnectSettingsUserControlModel.Instance}}" />
+        <hc:ComboBox
+            Margin="0,5"
+            hc:InfoElement.Title="{DynamicResource ClientType}"
+            DisplayMemberPath="Display"
+            IsHitTestVisible="{Binding Idle, Source={x:Static helper:Instances.SettingsViewModel}}"
+            ItemsSource="{Binding ClientTypeList, Source={x:Static settings_vms:GameSettingsUserControlModel.Instance}}"
+            SelectedValue="{Binding ClientType, Source={x:Static settings_vms:GameSettingsUserControlModel.Instance}}"
+            SelectedValuePath="Value"
+            Visibility="{c:Binding !TaskSettingVisibilities.Guide,
+                                   Source={x:Static helper:Instances.SettingsViewModel}}" />
 
         <StackPanel s:View.ActionTarget="{Binding DataContext, RelativeSource={RelativeSource Self}}" DataContext="{Binding Source={x:Static settings_vms:ConnectSettingsUserControlModel.Instance}}">
             <StackPanel d:Visibility="Visible" Visibility="{c:Binding 'ConnectConfig != enums:ConnectConfig.PC'}">


### PR DESCRIPTION
## Summary by Sourcery

通过将 ClientType 映射到相应的本地化游戏窗口标题，解决 PC 客户端窗口附着问题。

新特性：
- 添加 ClientType 扩展，用于为不同的《明日方舟》客户端版本推导本地化的游戏窗口标题。

改进：
- 更新窗口附着逻辑，使用针对各客户端的游戏窗口标题，而非硬编码的默认值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Resolve PC client window attachment by mapping ClientType to the appropriate localized game window title.

New Features:
- Add ClientType extension to derive the localized game window title for different Arknights client variants.

Enhancements:
- Update window attachment logic to use the client-specific game window title instead of a hardcoded default.

</details>