### PR TITLE
fix: 作业列表自动转换导航名

### DIFF
--- a/src/MaaCore/Task/Interface/CopilotTask.cpp
+++ b/src/MaaCore/Task/Interface/CopilotTask.cpp
@@ -110,12 +110,14 @@ bool asst::CopilotTask::set_params(const json::value& params)
             if (!result || !json::open(result->second)) {
                 return false;
             }
-            auto level = std::move(result->first);
+            const auto& level = result->first;
             if (stage_name == level.code) {
                 config_cvt.nav_name = stage_name;
-            } else if (level.match(stage_name)) {
+            }
+            else if (level.match(stage_name)) {
                 config_cvt.nav_name = level.code;
-            } else {
+            }
+            else {
                 Log.warn("Mismatched stage names", "Tile:", level.code, "Input:", stage_name);
                 config_cvt.nav_name = stage_name;
             }

--- a/src/MaaCore/Task/Interface/CopilotTask.cpp
+++ b/src/MaaCore/Task/Interface/CopilotTask.cpp
@@ -106,11 +106,20 @@ bool asst::CopilotTask::set_params(const json::value& params)
                 return false;
             }
             m_stage_name = Copilot.get_stage_name();
-            if (auto result = Tile.find(m_stage_name); !result || !json::open(result->second)) {
+            auto result = Tile.find(m_stage_name);
+            if (!result || !json::open(result->second)) {
                 return false;
             }
+            auto level = std::move(result->first);
+            if (stage_name == level.code) {
+                config_cvt.nav_name = stage_name;
+            } else if (level.match(stage_name)) {
+                config_cvt.nav_name = level.code;
+            } else {
+                Log.warn("Mismatched stage names", "Tile:", level.code, "Input:", stage_name);
+                config_cvt.nav_name = stage_name;
+            }
             config_cvt.copilot_file = *copilot_opt;
-            config_cvt.nav_name = stage_name;
             config_cvt.is_raid = is_raid;
             config_cvt.id = id; // ID 从0开始
             configs_cvt.emplace_back(std::move(config_cvt));


### PR DESCRIPTION
作业列表的关卡名只支持 code 形式，例如 TO-EX-1 可以但是 act53side_ex01 不行。Wpf 自行做了转换，但是我看 Core 直接实现更合适，方便其他客户端调用。

此外，对于张冠李戴的情况，例如 
```json
{
  "filename": "/path/to/act53side_ex01.json",
  "stage_name": "TO-EX-2"
}
```
也会打印出一个 warn 日志。

## Summary by Sourcery

在阶段名称与瓦片级别代码不一致时，更稳健地处理 Copilot 任务阶段导航名称。

Bug 修复：
- 确保在输入阶段名称使用与瓦片级别代码不同的格式时，仍能正确推导出 Copilot 任务导航名称。

增强功能：
- 当输入阶段名称与解析得到的瓦片级别不匹配时记录警告日志，同时仍然继续使用提供的阶段名称。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle Copilot task stage navigation names more robustly when stage names differ from tile level codes.

Bug Fixes:
- Ensure Copilot task navigation name is correctly derived when the input stage name uses an alternative format to the tile level code.

Enhancements:
- Log a warning when the input stage name does not correspond to the resolved tile level, while still proceeding with the provided name.

</details>
- 确保当输入阶段名称与磁贴级代码不同时，能够正确解析 Copilot 任务的导航名称。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

在阶段名称与瓦片级别代码不一致时，更稳健地处理 Copilot 任务阶段导航名称。

Bug 修复：
- 确保在输入阶段名称使用与瓦片级别代码不同的格式时，仍能正确推导出 Copilot 任务导航名称。

增强功能：
- 当输入阶段名称与解析得到的瓦片级别不匹配时记录警告日志，同时仍然继续使用提供的阶段名称。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle Copilot task stage navigation names more robustly when stage names differ from tile level codes.

Bug Fixes:
- Ensure Copilot task navigation name is correctly derived when the input stage name uses an alternative format to the tile level code.

Enhancements:
- Log a warning when the input stage name does not correspond to the resolved tile level, while still proceeding with the provided name.

</details>

</details>