### PR TITLE
perf(core): 自动战斗作业自动读取关卡名进行导航

### DIFF
--- a/src/MaaCore/Task/Interface/CopilotTask.cpp
+++ b/src/MaaCore/Task/Interface/CopilotTask.cpp
@@ -105,8 +105,7 @@ bool asst::CopilotTask::set_params(const json::value& params)
             if (!copilot_opt) {
                 return false;
             }
-            const auto& stage_data= Copilot.get_data();
-            const auto& stage_name = stage_data.info.stage_name;
+            const auto& stage_name = Copilot.get_stage_name();
             const auto& map_data = Tile.find(stage_name);
             if (!map_data || !json::open(map_data->second)) {
                 return false;

--- a/src/MaaCore/Task/Interface/CopilotTask.cpp
+++ b/src/MaaCore/Task/Interface/CopilotTask.cpp
@@ -99,18 +99,26 @@ bool asst::CopilotTask::set_params(const json::value& params)
         m_battle_task_ptr->set_wait_until_end(true);
         auto configs = static_cast<std::vector<MultiCopilotConfig>>(*multi_tasks_opt);
         std::vector<MultiCopilotTaskPlugin::MultiCopilotConfig> configs_cvt;
-        for (const auto& [id, filename, stage_name, is_raid] : configs) {
+        for (const auto& [id, filename, nav_name, is_raid] : configs) {
             MultiCopilotTaskPlugin::MultiCopilotConfig config_cvt;
             auto copilot_opt = parse_copilot_filename(filename);
             if (!copilot_opt) {
                 return false;
             }
-            m_stage_name = Copilot.get_stage_name();
-            if (auto result = Tile.find(m_stage_name); !result || !json::open(result->second)) {
+            const auto& stage_data= Copilot.get_data();
+            const auto& stage_name = stage_data.info.stage_name;
+            const auto& map_data = Tile.find(stage_name);
+            if (!map_data || !json::open(map_data->second)) {
                 return false;
             }
+            if (!nav_name) {
+                config_cvt.nav_name = map_data->first.code;
+            }
+            else {
+                LogInfo << __FUNCTION__ << " | navigation name override: " << *nav_name;
+                config_cvt.nav_name = *nav_name;
+            }
             config_cvt.copilot_file = *copilot_opt;
-            config_cvt.nav_name = stage_name;
             config_cvt.is_raid = is_raid;
             config_cvt.id = id; // ID 从0开始
             configs_cvt.emplace_back(std::move(config_cvt));

--- a/src/MaaCore/Task/Interface/CopilotTask.h
+++ b/src/MaaCore/Task/Interface/CopilotTask.h
@@ -19,9 +19,9 @@ public:
     struct MultiCopilotConfig
     {
         int id = -1;
-        std::string filename;   // 文件名
+        std::string filename;                         // 文件名
         std::optional<std::string> nav_name_override; // 关卡名
-        bool is_raid = false;   // 是否是突袭
+        bool is_raid = false;                         // 是否是突袭
 
         MEO_JSONIZATION(MEO_OPT id, filename, MEO_OPT nav_name_override, MEO_OPT is_raid);
     };

--- a/src/MaaCore/Task/Interface/CopilotTask.h
+++ b/src/MaaCore/Task/Interface/CopilotTask.h
@@ -20,10 +20,10 @@ public:
     {
         int id = -1;
         std::string filename;   // 文件名
-        std::string stage_name; // 关卡名
+        std::optional<std::string> nav_name_override; // 关卡名
         bool is_raid = false;   // 是否是突袭
 
-        MEO_JSONIZATION(MEO_OPT id, filename, stage_name, MEO_OPT is_raid);
+        MEO_JSONIZATION(MEO_OPT id, filename, MEO_OPT nav_name_override, MEO_OPT is_raid);
     };
 
 public:

--- a/src/MaaWpfGui/Models/AsstTasks/AsstCopilotTask.cs
+++ b/src/MaaWpfGui/Models/AsstTasks/AsstCopilotTask.cs
@@ -79,8 +79,7 @@ public class AsstCopilotTask : AsstBaseTask
 
     public override (AsstTaskType TaskType, JObject Params) Serialize()
     {
-        var taskParams = new JObject
-        {
+        var taskParams = new JObject {
             ["formation"] = Formation,
             ["support_unit_usage"] = SupportUnitUsage,
             ["add_trust"] = AddTrust,
@@ -151,10 +150,10 @@ public class AsstCopilotTask : AsstBaseTask
         public string FileName { get; set; } = string.Empty;
 
         /// <summary>
-        /// Gets or sets 关卡名，仅导航用，Wpf 会自动读取地图对应的关卡名
+        /// Gets or sets 导航识别名，Core 会自动读取地图对应的关卡名
         /// </summary>
-        [JsonProperty("stage_name")]
-        public string StageName { get; set; } = string.Empty;
+        [JsonProperty("nav_name_override", NullValueHandling = NullValueHandling.Ignore)]
+        public string? StageName { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether 突袭难度

--- a/src/MaaWpfGui/ViewModels/Items/CopilotItemViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/Items/CopilotItemViewModel.cs
@@ -29,13 +29,15 @@ public class CopilotItemViewModel : PropertyChangedBase
     /// <param name="isRaid">是否为突袭关</param>
     /// <param name="copilotId">作业站对应 id，本地作业应为默认值 0</param>
     /// <param name="isChecked">isChecked</param>
-    public CopilotItemViewModel(string name, string filePath, bool isRaid = false, int copilotId = 0, bool isChecked = true)
+    /// <param name="isNavNameOverride">是否覆盖导航识别名</param>
+    public CopilotItemViewModel(string name, string filePath, bool isRaid = false, int copilotId = 0, bool isChecked = true, bool isNavNameOverride = false)
     {
         Name = name;
         FilePath = filePath;
         _isRaid = isRaid;
         CopilotId = copilotId;
         _isChecked = isChecked;
+        IsNavNameOverride = isNavNameOverride;
     }
 
     [System.Text.Json.Serialization.JsonConstructor]
@@ -48,6 +50,8 @@ public class CopilotItemViewModel : PropertyChangedBase
     /// </summary>
     [JsonProperty("name")]
     public string Name { get; set; } = string.Empty;
+
+    public bool IsNavNameOverride { get; set; }
 
     /// <summary>
     /// Gets the original_name.

--- a/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
@@ -915,6 +915,7 @@ public partial class CopilotViewModel : Screen
     public async Task AddCopilotTask()
     {
         await AddCopilotTaskToList(CopilotTaskName, false);
+        CopilotTaskName = string.Empty;
     }
 
     // UI 绑定的方法
@@ -922,6 +923,7 @@ public partial class CopilotViewModel : Screen
     public async Task AddCopilotTask_Adverse()
     {
         await AddCopilotTaskToList(CopilotTaskName, true);
+        CopilotTaskName = string.Empty;
     }
 
     // UI 绑定的方法
@@ -1225,7 +1227,6 @@ public partial class CopilotViewModel : Screen
             AchievementTrackerHelper.Instance.Unlock(AchievementIds.MapOutdated);
             return true;
         }
-        CopilotTaskName = navigateName;
 
         if (mapInfo?.StageId is { } stageId)
         {
@@ -1247,10 +1248,10 @@ public partial class CopilotViewModel : Screen
             switch (copilot.Difficulty)
             {
                 case CopilotModel.DifficultyFlags.None:
-                    await AddCopilotTaskToList(copilot, CopilotModel.DifficultyFlags.Normal, navigateName, is_corrected ? default : copilotId);
+                    await AddCopilotTaskToList(copilot, CopilotModel.DifficultyFlags.Normal, copilotId: is_corrected ? default : copilotId);
                     break;
                 default:
-                    await AddCopilotTaskToList(copilot, copilot.Difficulty, navigateName, is_corrected ? default : copilotId);
+                    await AddCopilotTaskToList(copilot, copilot.Difficulty, copilotId: is_corrected ? default : copilotId);
                     break;
             }
         }
@@ -1600,7 +1601,7 @@ public partial class CopilotViewModel : Screen
 
     private async Task AddCopilotTaskToList(string? stageName, bool isRaid)
     {
-        if (string.IsNullOrEmpty(stageName) || InvalidStageNameRegex().IsMatch(stageName))
+        if (!string.IsNullOrEmpty(stageName) && InvalidStageNameRegex().IsMatch(stageName))
         {
             AddLog(LocalizationHelper.GetString("CopilotInvalidStageNameForNavigation"), UiLogColor.Error, showTime: false);
             return;
@@ -1632,10 +1633,10 @@ public partial class CopilotViewModel : Screen
     /// </summary>
     /// <param name="copilot">作业</param>
     /// <param name="flags">难度等级</param>
-    /// <param name="navigateName">关卡 code，用于导航</param>
+    /// <param name="navName">关卡 code，用于导航</param>
     /// <param name="copilotId">作业站 id</param>
     /// <returns>是否添加了作业</returns>
-    private async Task<bool> AddCopilotTaskToList(CopilotModel copilot, CopilotModel.DifficultyFlags flags, string? navigateName = null, int copilotId = 0)
+    private async Task<bool> AddCopilotTaskToList(CopilotModel copilot, CopilotModel.DifficultyFlags flags, string? navName = null, int copilotId = 0)
     {
         if (string.IsNullOrEmpty(copilot.StageName))
         {
@@ -1660,18 +1661,18 @@ public partial class CopilotViewModel : Screen
         var stageId = mapInfo?.StageId;
         if (mapInfo is null)
         {
-            AddLog(LocalizationHelper.GetStringFormat("CopilotStageNameNotFound", $"{navigateName}"), UiLogColor.Error, showTime: false);
+            AddLog(LocalizationHelper.GetStringFormat("CopilotStageNameNotFound", $"{copilot.StageName}({navName})"), UiLogColor.Error, showTime: false);
             return false;
         }
 
-        navigateName = string.IsNullOrEmpty(navigateName) ? stageCode : navigateName;
+        var navigateName = string.IsNullOrEmpty(navName) ? stageCode : navName;
         if (stageCode != navigateName)
         {
             stageCode = navigateName;
             AddLog(LocalizationHelper.GetString("CopilotStageNameNotEqualWithNavigateName"), UiLogColor.Warning, showTime: false);
         }
 
-        if (stageId is null || stageCode is null || navigateName is null)
+        if (stageId is null || stageCode is null || string.IsNullOrEmpty(navigateName))
         {
             return false;
         }
@@ -1720,13 +1721,13 @@ public partial class CopilotViewModel : Screen
         {
             if (flags.HasFlag(CopilotModel.DifficultyFlags.Normal))
             {
-                var item = new CopilotItemViewModel(stageCode, cachePath, false, copilotId) { Index = CopilotItemViewModels.Count, };
+                var item = new CopilotItemViewModel(stageCode, cachePath, false, copilotId, isNavNameOverride: !string.IsNullOrEmpty(navName)) { Index = CopilotItemViewModels.Count, };
                 CopilotItemViewModels.Add(item);
             }
 
             if (flags.HasFlag(CopilotModel.DifficultyFlags.Raid))
             {
-                var item = new CopilotItemViewModel(stageCode, cachePath, true, copilotId) { Index = CopilotItemViewModels.Count, };
+                var item = new CopilotItemViewModel(stageCode, cachePath, true, copilotId, isNavNameOverride: !string.IsNullOrEmpty(navName)) { Index = CopilotItemViewModels.Count, };
                 CopilotItemViewModels.Add(item);
             }
         }
@@ -2031,7 +2032,7 @@ public partial class CopilotViewModel : Screen
 
             var t = CopilotItemViewModels.Where(i => i.IsChecked).Select(i => {
                 _copilotIdList.Add(i.CopilotId);
-                return new MultiTask { Index = i.Index, FileName = i.FilePath, IsRaid = i.IsRaid, StageName = i.Name, };
+                return new MultiTask { Index = i.Index, FileName = i.FilePath, IsRaid = i.IsRaid, StageName = i.IsNavNameOverride ? i.Name : null, };
             });
 
             var task = new AsstCopilotTask() {


### PR DESCRIPTION
## Summary by Sourcery

使用 copilot 关卡数据来推导自动战斗任务的导航目标，在验证对应地图数据的同时，允许可选的导航名称覆盖。

Enhancements:
- 将固定关卡名称配置替换为 copilot 多任务参数中的可选导航名称覆盖字段。
- 当未提供显式覆盖时，根据 copilot 关卡数据及关联的地块元数据推导导航名称。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Use copilot stage data to derive navigation targets for automatic battle tasks, allowing optional navigation name overrides while validating corresponding map data.

Enhancements:
- Replace fixed stage name configuration with an optional navigation name override field in copilot multi-task parameters.
- Derive navigation name from copilot stage data and associated tile metadata when no explicit override is provided.

</details>