### PR TITLE
feat: 像素画允许粘贴 4 字以内的文本

### DIFF
--- a/src/MaaWpfGui/Helper/PixelPaintHelper.cs
+++ b/src/MaaWpfGui/Helper/PixelPaintHelper.cs
@@ -15,8 +15,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Drawing;
 using System.Globalization;
+using System.Runtime.InteropServices;
 using System.Windows;
+using System.Windows.Forms;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
 
@@ -273,18 +276,13 @@ public static class PixelPaintHelper
     }
 
     /// <summary>
-    /// 将最多 4 个字渲染为黑字白底位图。含非 ASCII 字符（如中文）时按四角布局（左上 / 右上 / 左下 / 右下，每字一象限）；
-    /// 纯英文 / 数字时改为单行横排。每字（或整行）按墨迹外接框最大化、不裁切字形，以提升 24×24 下的辨识度。
-    /// 未覆盖区域保持白色，由像素画流水线默认跳过。
+    /// 将最多 4 个字渲染为黑字白底位图（24×24）。中文按自适应网格（1 字占满、2~4 字分 2 列）以 SimSun 直接绘制（点阵）；
+    /// 英文 / 数字单行横排，放大字号、无抗锯齿渲染后裁掉墨迹空白，1:1 放入（不降采样，保持锐利）。
     /// </summary>
     /// <param name="text">输入文字；取前 4 个字素（按 <see cref="StringInfo"/> 拆分，避免拆开代理对），超出忽略。</param>
-    /// <returns>已冻结的 512×512 Pbgra32 位图，可直接作为像素画原图。</returns>
+    /// <returns>已冻结的 24×24 Bgra32 位图，可直接作为像素画原图。</returns>
     public static BitmapSource RenderTextToBitmap(string text)
     {
-        const int canvas = 512;
-        const int quadrant = canvas / 2;
-        const double emSize = 400;
-
         // 按字素取前 4 个，正确处理代理对 / 组合字符
         var chars = new List<string>(4);
         var enumerator = StringInfo.GetTextElementEnumerator(text);
@@ -293,103 +291,119 @@ public static class PixelPaintHelper
             chars.Add((string)enumerator.Current);
         }
 
-        var typeface = new Typeface(new FontFamily("Microsoft YaHei"), FontStyles.Normal, FontWeights.Bold, FontStretches.Normal);
-        var culture = CultureInfo.GetCultureInfo("zh-CN");
-
-        // 含非 ASCII 字符 → 四角布局；纯英文 / 数字 → 单行横排
         var wide = chars.Exists(HasNonAscii);
+        const TextFormatFlags flags = TextFormatFlags.NoPadding | TextFormatFlags.HorizontalCenter | TextFormatFlags.VerticalCenter | TextFormatFlags.SingleLine;
 
-        var visual = new DrawingVisual();
-        using (var dc = visual.RenderOpen())
+        const int size = 24;          // 目标网格分辨率，1:1 映射
+
+        using var bmp = new Bitmap(size, size, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
+        using var g = Graphics.FromImage(bmp);
+        g.Clear(System.Drawing.Color.White);
+
+        if (wide)
         {
-            dc.DrawRectangle(Brushes.White, null, new Rect(0, 0, canvas, canvas));
-            if (wide)
+            // 中文：自适应网格，1 字占满整张、2~4 字分 2 列；每格 SimSun 该尺寸直接绘制（点阵）
+            var n = chars.Count;
+            var cols = Math.Min(n, 2);
+            var rows = (n + cols - 1) / cols;
+            var cellW = size / cols;
+            var cellH = size / rows;
+            using var cf = new Font("SimSun", Math.Min(cellW, cellH), System.Drawing.FontStyle.Regular, GraphicsUnit.Pixel);
+            for (var i = 0; i < n; i++)
             {
-                for (var i = 0; i < chars.Count; i++)
-                {
-                    var glyph = RenderGlyph(chars[i], typeface, culture, emSize, quadrant);
-                    if (glyph.Bitmap == null)
-                    {
-                        continue;
-                    }
+                var bounds = new Rectangle((i % cols) * cellW, (i / cols) * cellH, cellW, cellH);
+                TextRenderer.DrawText(g, chars[i], cf, bounds, System.Drawing.Color.Black, flags);
+            }
+        }
+        else
+        {
+            // 英文 / 数字：整串单行横排，放大字号、无抗锯齿渲染后裁墨迹空白，1:1 放入（不降采样）
+            DrawInkFit(g, string.Concat(chars), new Rectangle(0, 0, size, size));
+        }
 
-                    var col = i % 2;
-                    var row = i / 2;
-                    var ox = col * quadrant;
-                    var oy = row * quadrant;
+        // GDI Bitmap → WPF BitmapSource：逐像素拷贝
+        var lockRect = new Rectangle(0, 0, size, size);
+        var data = bmp.LockBits(lockRect, System.Drawing.Imaging.ImageLockMode.ReadOnly, bmp.PixelFormat);
+        var pixels = new byte[data.Stride * size];
+        Marshal.Copy(data.Scan0, pixels, 0, pixels.Length);
+        bmp.UnlockBits(data);
 
-                    // 居中放入象限（已按墨迹最大化，字形基本占满象限）
-                    var x = ox + ((quadrant - glyph.Width) / 2.0);
-                    var y = oy + ((quadrant - glyph.Height) / 2.0);
-                    dc.DrawImage(glyph.Bitmap, new Rect(x, y, glyph.Width, glyph.Height));
-                }
+        var wb = new WriteableBitmap(size, size, 96, 96, PixelFormats.Bgra32, null);
+        wb.WritePixels(new Int32Rect(0, 0, size, size), pixels, data.Stride, 0);
+        wb.Freeze();
+        return wb;
+    }
+
+    /// <summary>
+    /// 在目标区域内以 ｢能放下｣ 的最大字号绘制文本：放大字号渲染、裁掉墨迹空白，取墨迹外接框恰能放入区域的字号，
+    /// 再 1:1 居中绘制（不做降采样，保持锐利）。
+    /// </summary>
+    /// <param name="g">目标 GDI 绘图面。</param>
+    /// <param name="text">待绘制文本。</param>
+    /// <param name="rect">目标区域。</param>
+    private static void DrawInkFit(Graphics g, string text, Rectangle rect)
+    {
+        const TextFormatFlags flags = TextFormatFlags.NoPadding | TextFormatFlags.HorizontalCenter | TextFormatFlags.VerticalCenter | TextFormatFlags.SingleLine;
+
+        // 二分找最大字号，使墨迹外接框（裁空白后）放入 rect
+        var lo = 8f;
+        var hi = 128f;
+        for (var i = 0; i < 12; i++)
+        {
+            var mid = (lo + hi) / 2f;
+            using var probe = RenderInk(g, text, mid, flags);
+            if (probe != null && probe.Width <= rect.Width && probe.Height <= rect.Height)
+            {
+                lo = mid;
             }
             else
             {
-                // 英文 / 数字：整串单行横排，最大化占满画布
-                var glyph = RenderGlyph(string.Concat(chars), typeface, culture, emSize, canvas);
-                if (glyph.Bitmap != null)
-                {
-                    var x = (canvas - glyph.Width) / 2.0;
-                    var y = (canvas - glyph.Height) / 2.0;
-                    dc.DrawImage(glyph.Bitmap, new Rect(x, y, glyph.Width, glyph.Height));
-                }
+                hi = mid;
             }
         }
 
-        var bmp = new RenderTargetBitmap(canvas, canvas, 96, 96, PixelFormats.Pbgra32);
-        bmp.Render(visual);
-        bmp.Freeze();
-        return bmp;
+        using var ink = RenderInk(g, text, lo, flags);
+        if (ink == null)
+        {
+            return;
+        }
+
+        // 1:1 居中放入 rect（DrawImage 在整数坐标、原始尺寸下不重采样）
+        var dx = rect.X + ((rect.Width - ink.Width) / 2);
+        var dy = rect.Y + ((rect.Height - ink.Height) / 2);
+        g.DrawImage(ink, dx, dy);
     }
 
     /// <summary>
-    /// 判断字素中是否含非 ASCII 字符（如中文），用于决定四角布局还是单行横排。
+    /// 以给定字号渲染文本，扫描 alpha 通道取墨迹外接框，裁掉四周空白后返回墨迹位图。
     /// </summary>
-    /// <param name="textElement">单个字素。</param>
-    /// <returns>含非 ASCII 字符返回 true。</returns>
-    private static bool HasNonAscii(string textElement)
+    /// <param name="g">GDI 绘图面（用于度量）。</param>
+    /// <param name="text">待绘制文本。</param>
+    /// <param name="emSize">字号（像素）。</param>
+    /// <param name="flags">文本格式标志。</param>
+    /// <returns>裁空白后的墨迹位图；无墨迹返回 null。</returns>
+    private static Bitmap? RenderInk(Graphics g, string text, float emSize, TextFormatFlags flags)
     {
-        foreach (var c in textElement)
+        using var f = new Font("SimSun", emSize, System.Drawing.FontStyle.Regular, GraphicsUnit.Pixel);
+        var m = TextRenderer.MeasureText(g, text, f);
+        var pad = (int)Math.Ceiling(emSize * 0.2);
+        var w = m.Width + (pad * 2);
+        var h = m.Height + (pad * 2);
+
+        using var tmp = new Bitmap(w, h, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
+        using (var tg = Graphics.FromImage(tmp))
         {
-            if (c >= 128)
-            {
-                return true;
-            }
+            // 透明底：让墨迹扫描只命中笔画；无抗锯齿：保持锐利
+            tg.Clear(System.Drawing.Color.Transparent);
+            tg.TextRenderingHint = System.Drawing.Text.TextRenderingHint.SingleBitPerPixelGridFit;
+            TextRenderer.DrawText(tg, text, f, new Rectangle(0, 0, w, h), System.Drawing.Color.Black, flags);
         }
 
-        return false;
-    }
+        var ld = tmp.LockBits(new Rectangle(0, 0, w, h), System.Drawing.Imaging.ImageLockMode.ReadOnly, tmp.PixelFormat);
+        var px = new byte[ld.Stride * h];
+        Marshal.Copy(ld.Scan0, px, 0, px.Length);
+        tmp.UnlockBits(ld);
 
-    /// <summary>
-    /// 渲染单个字素，扫描 alpha 通道取墨迹外接框，裁剪后按较长边缩放到目标边长
-    /// （占满象限较长边、字形不裁切），最大化字形而避开字体的行距留白。
-    /// </summary>
-    /// <param name="ch">单个字素。</param>
-    /// <param name="typeface">字体。</param>
-    /// <param name="culture">区域信息。</param>
-    /// <param name="emSize">测量用字号。</param>
-    /// <param name="target">目标边长（象限大小）。</param>
-    /// <returns>缩放后的字形位图及其绘制尺寸；无墨迹（如空白）位图为 null。</returns>
-    private static (BitmapSource? Bitmap, double Width, double Height) RenderGlyph(string ch, Typeface typeface, CultureInfo culture, double emSize, int target)
-    {
-        var ft = new FormattedText(ch, culture, FlowDirection.LeftToRight, typeface, emSize, Brushes.Black, 1.0);
-        var pad = (int)Math.Ceiling(emSize * 0.15);
-        var w = (int)Math.Ceiling(ft.Width) + (pad * 2);
-        var h = (int)Math.Ceiling(ft.Height) + (pad * 2);
-
-        var mv = new DrawingVisual();
-        using (var dc = mv.RenderOpen())
-        {
-            dc.DrawText(ft, new Point(pad, pad));
-        }
-
-        var rtb = new RenderTargetBitmap(w, h, 96, 96, PixelFormats.Pbgra32);
-        rtb.Render(mv);
-
-        // 扫描 alpha 通道取墨迹外接框（>16 视为有墨迹，与 TrimBorder 一致）
-        var pixels = new byte[(long)w * h * 4];
-        rtb.CopyPixels(pixels, w * 4, 0);
         var minX = w;
         var minY = h;
         var maxX = -1;
@@ -398,7 +412,7 @@ public static class PixelPaintHelper
         {
             for (var x = 0; x < w; x++)
             {
-                if (pixels[(((y * w) + x) * 4) + 3] > 16)
+                if (px[(((y * w) + x) * 4) + 3] > 16)
                 {
                     if (x < minX)
                     {
@@ -425,16 +439,36 @@ public static class PixelPaintHelper
 
         if (maxX < 0)
         {
-            return (null, 0, 0);
+            return null;
         }
 
-        var gw = maxX - minX + 1;
-        var gh = maxY - minY + 1;
+        var iw = maxX - minX + 1;
+        var ih = maxY - minY + 1;
+        var ink = new Bitmap(iw, ih, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
+        using (var ig = Graphics.FromImage(ink))
+        {
+            ig.DrawImage(tmp, new Rectangle(0, 0, iw, ih), new Rectangle(minX, minY, iw, ih), GraphicsUnit.Pixel);
+        }
 
-        // 按较长边缩放到目标边长：字形占满象限且不裁切
-        var scale = target / (double)Math.Max(gw, gh);
-        var cropped = new CroppedBitmap(rtb, new Int32Rect(minX, minY, gw, gh));
-        return (cropped, gw * scale, gh * scale);
+        return ink;
+    }
+
+    /// <summary>
+    /// 判断字素中是否含非 ASCII 字符（如中文），用于决定四角布局还是单行横排。
+    /// </summary>
+    /// <param name="textElement">单个字素。</param>
+    /// <returns>含非 ASCII 字符返回 true。</returns>
+    private static bool HasNonAscii(string textElement)
+    {
+        foreach (var c in textElement)
+        {
+            if (c >= 128)
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/src/MaaWpfGui/Helper/PixelPaintHelper.cs
+++ b/src/MaaWpfGui/Helper/PixelPaintHelper.cs
@@ -15,6 +15,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Windows;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
@@ -269,6 +270,171 @@ public static class PixelPaintHelper
         bmp.WritePixels(new Int32Rect(0, 0, PreviewPixelSize, PreviewPixelSize), pixels, PreviewPixelSize * 4, 0);
         bmp.Freeze();
         return bmp;
+    }
+
+    /// <summary>
+    /// 将最多 4 个字渲染为黑字白底位图。含非 ASCII 字符（如中文）时按四角布局（左上 / 右上 / 左下 / 右下，每字一象限）；
+    /// 纯英文 / 数字时改为单行横排。每字（或整行）按墨迹外接框最大化、不裁切字形，以提升 24×24 下的辨识度。
+    /// 未覆盖区域保持白色，由像素画流水线默认跳过。
+    /// </summary>
+    /// <param name="text">输入文字；取前 4 个字素（按 <see cref="StringInfo"/> 拆分，避免拆开代理对），超出忽略。</param>
+    /// <returns>已冻结的 512×512 Pbgra32 位图，可直接作为像素画原图。</returns>
+    public static BitmapSource RenderTextToBitmap(string text)
+    {
+        const int canvas = 512;
+        const int quadrant = canvas / 2;
+        const double emSize = 400;
+
+        // 按字素取前 4 个，正确处理代理对 / 组合字符
+        var chars = new List<string>(4);
+        var enumerator = StringInfo.GetTextElementEnumerator(text);
+        while (enumerator.MoveNext() && chars.Count < 4)
+        {
+            chars.Add((string)enumerator.Current);
+        }
+
+        var typeface = new Typeface(new FontFamily("Microsoft YaHei"), FontStyles.Normal, FontWeights.Bold, FontStretches.Normal);
+        var culture = CultureInfo.GetCultureInfo("zh-CN");
+
+        // 含非 ASCII 字符 → 四角布局；纯英文 / 数字 → 单行横排
+        var wide = chars.Exists(HasNonAscii);
+
+        var visual = new DrawingVisual();
+        using (var dc = visual.RenderOpen())
+        {
+            dc.DrawRectangle(Brushes.White, null, new Rect(0, 0, canvas, canvas));
+            if (wide)
+            {
+                for (var i = 0; i < chars.Count; i++)
+                {
+                    var glyph = RenderGlyph(chars[i], typeface, culture, emSize, quadrant);
+                    if (glyph.Bitmap == null)
+                    {
+                        continue;
+                    }
+
+                    var col = i % 2;
+                    var row = i / 2;
+                    var ox = col * quadrant;
+                    var oy = row * quadrant;
+
+                    // 居中放入象限（已按墨迹最大化，字形基本占满象限）
+                    var x = ox + ((quadrant - glyph.Width) / 2.0);
+                    var y = oy + ((quadrant - glyph.Height) / 2.0);
+                    dc.DrawImage(glyph.Bitmap, new Rect(x, y, glyph.Width, glyph.Height));
+                }
+            }
+            else
+            {
+                // 英文 / 数字：整串单行横排，最大化占满画布
+                var glyph = RenderGlyph(string.Concat(chars), typeface, culture, emSize, canvas);
+                if (glyph.Bitmap != null)
+                {
+                    var x = (canvas - glyph.Width) / 2.0;
+                    var y = (canvas - glyph.Height) / 2.0;
+                    dc.DrawImage(glyph.Bitmap, new Rect(x, y, glyph.Width, glyph.Height));
+                }
+            }
+        }
+
+        var bmp = new RenderTargetBitmap(canvas, canvas, 96, 96, PixelFormats.Pbgra32);
+        bmp.Render(visual);
+        bmp.Freeze();
+        return bmp;
+    }
+
+    /// <summary>
+    /// 判断字素中是否含非 ASCII 字符（如中文），用于决定四角布局还是单行横排。
+    /// </summary>
+    /// <param name="textElement">单个字素。</param>
+    /// <returns>含非 ASCII 字符返回 true。</returns>
+    private static bool HasNonAscii(string textElement)
+    {
+        foreach (var c in textElement)
+        {
+            if (c >= 128)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// 渲染单个字素，扫描 alpha 通道取墨迹外接框，裁剪后按较长边缩放到目标边长
+    /// （占满象限较长边、字形不裁切），最大化字形而避开字体的行距留白。
+    /// </summary>
+    /// <param name="ch">单个字素。</param>
+    /// <param name="typeface">字体。</param>
+    /// <param name="culture">区域信息。</param>
+    /// <param name="emSize">测量用字号。</param>
+    /// <param name="target">目标边长（象限大小）。</param>
+    /// <returns>缩放后的字形位图及其绘制尺寸；无墨迹（如空白）位图为 null。</returns>
+    private static (BitmapSource? Bitmap, double Width, double Height) RenderGlyph(string ch, Typeface typeface, CultureInfo culture, double emSize, int target)
+    {
+        var ft = new FormattedText(ch, culture, FlowDirection.LeftToRight, typeface, emSize, Brushes.Black, 1.0);
+        var pad = (int)Math.Ceiling(emSize * 0.15);
+        var w = (int)Math.Ceiling(ft.Width) + (pad * 2);
+        var h = (int)Math.Ceiling(ft.Height) + (pad * 2);
+
+        var mv = new DrawingVisual();
+        using (var dc = mv.RenderOpen())
+        {
+            dc.DrawText(ft, new Point(pad, pad));
+        }
+
+        var rtb = new RenderTargetBitmap(w, h, 96, 96, PixelFormats.Pbgra32);
+        rtb.Render(mv);
+
+        // 扫描 alpha 通道取墨迹外接框（>16 视为有墨迹，与 TrimBorder 一致）
+        var pixels = new byte[(long)w * h * 4];
+        rtb.CopyPixels(pixels, w * 4, 0);
+        var minX = w;
+        var minY = h;
+        var maxX = -1;
+        var maxY = -1;
+        for (var y = 0; y < h; y++)
+        {
+            for (var x = 0; x < w; x++)
+            {
+                if (pixels[(((y * w) + x) * 4) + 3] > 16)
+                {
+                    if (x < minX)
+                    {
+                        minX = x;
+                    }
+
+                    if (x > maxX)
+                    {
+                        maxX = x;
+                    }
+
+                    if (y < minY)
+                    {
+                        minY = y;
+                    }
+
+                    if (y > maxY)
+                    {
+                        maxY = y;
+                    }
+                }
+            }
+        }
+
+        if (maxX < 0)
+        {
+            return (null, 0, 0);
+        }
+
+        var gw = maxX - minX + 1;
+        var gh = maxY - minY + 1;
+
+        // 按较长边缩放到目标边长：字形占满象限且不裁切
+        var scale = target / (double)Math.Max(gw, gh);
+        var cropped = new CroppedBitmap(rtb, new Int32Rect(minX, minY, gw, gh));
+        return (cropped, gw * scale, gh * scale);
     }
 
     /// <summary>

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -1094,7 +1094,7 @@ Only level rewards can be farmed; to get the Engraved Medal, all ｢Key Objectiv
     <system:String x:Key="MiniGame@SecretFrontTip" xml:space="preserve">Start from the squad selection screen;&#10;If there is a saved game, please delete it manually.&#10;Close the tutorial after playing it for the first time.&#10;Recommended to enable in-game ｢Inherit previous squad's data｣.</system:String>
     <system:String x:Key="MiniGame@PixelPaint">Pixel Paint Autofill</system:String>
     <system:String x:Key="MiniGame@PixelPaintTip" xml:space="preserve">Enter the in-game 24×24 pixel editor first, then start.&#10;Drag/scroll the preview to reframe; white is skipped by default.&#10;Parameters lock while running; see the right log for progress.</system:String>
-    <system:String x:Key="MiniGame@PixelPaint@DropHint">Drop or paste an image, or pick below</system:String>
+    <system:String x:Key="MiniGame@PixelPaint@DropHint">Drop or paste an image or text, or pick below</system:String>
     <system:String x:Key="MiniGame@PixelPaint@PickImage">Pick Image</system:String>
     <system:String x:Key="MiniGame@PixelPaint@ResetView">Reset View</system:String>
     <system:String x:Key="MiniGame@PixelPaint@ResetParams">Reset Parameters</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -1095,7 +1095,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="MiniGame@SecretFrontTip">小隊選択画面で開始します。セーブデータがある場合は手動で削除する必要があります。ゲーム内の ｢前の小隊からのデータを引き継ぐ｣ にチェックすることを推奨します。</system:String>
     <system:String x:Key="MiniGame@PixelPaint">ピクセル画自動描画</system:String>
     <system:String x:Key="MiniGame@PixelPaintTip">ゲーム内の 24×24 ピクセル画編集ページに手動で入ってから開始してください。&#10;プレビューはドラッグ/ホイールで構図調整。デフォルトで白はスキップ。&#10;開始後はパラメータ固定。進捗は右のログ参照。</system:String>
-    <system:String x:Key="MiniGame@PixelPaint@DropHint">画像をドロップ、貼り付け、または下のボタンで選択</system:String>
+    <system:String x:Key="MiniGame@PixelPaint@DropHint">画像をドロップ、画像/テキストを貼り付け、または下のボタンで選択</system:String>
     <system:String x:Key="MiniGame@PixelPaint@PickImage">画像を選択</system:String>
     <system:String x:Key="MiniGame@PixelPaint@ResetView">構図をリセット</system:String>
     <system:String x:Key="MiniGame@PixelPaint@ResetParams">パラメータをリセット</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -1096,7 +1096,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="MiniGame@SecretFrontTip">소대 선택 화면에서 시작합니다. 기존 세이브 데이터가 있으면 수동으로 삭제해야 합니다.\n게임 내  ｢이전 소대의 데이터 전승받기｣  옵션을 체크하는 것을 권장합니다.</system:String>
     <system:String x:Key="MiniGame@PixelPaint">픽셀 아트 자동 그리기</system:String>
     <system:String x:Key="MiniGame@PixelPaintTip">게임 내 24×24 픽셀 아트 편집 페이지에 직접 들어간 뒤 시작하세요.&#10;미리보기는 드래그/휠로 구도 조정. 기본적으로 흰색은 건너뜀.&#10;시작 후 파라미터는 고정. 진행 상황은 오른쪽 로그 참조.</system:String>
-    <system:String x:Key="MiniGame@PixelPaint@DropHint">이미지를 드래그하거나 붙여넣기하거나 아래 버튼으로 선택</system:String>
+    <system:String x:Key="MiniGame@PixelPaint@DropHint">이미지를 드래그하거나 이미지/텍스트를 붙여넣거나 아래 버튼으로 선택</system:String>
     <system:String x:Key="MiniGame@PixelPaint@PickImage">이미지 선택</system:String>
     <system:String x:Key="MiniGame@PixelPaint@ResetView">구도 초기화</system:String>
     <system:String x:Key="MiniGame@PixelPaint@ResetParams">파라미터 초기화</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -1095,7 +1095,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="MiniGame@SecretFrontTip" xml:space="preserve">在选小队界面开始，如有存档须手动删除。&#10;第一次打自己看完把教程关了。&#10;推荐勾选游戏内 ｢继承上一支队伍发回的数据｣</system:String>
     <system:String x:Key="MiniGame@PixelPaint">像素画自动填色</system:String>
     <system:String x:Key="MiniGame@PixelPaintTip" xml:space="preserve">请先手动进入游戏内 24×24 像素画编辑页，再开始。&#10;中间预览可拖移/滚轮取景；默认跳过白色。&#10;开始后参数锁定，进度见右侧日志。</system:String>
-    <system:String x:Key="MiniGame@PixelPaint@DropHint">拖入图片、粘贴图片或点下方选图</system:String>
+    <system:String x:Key="MiniGame@PixelPaint@DropHint">拖入图片、粘贴图片/文字或点下方选图</system:String>
     <system:String x:Key="MiniGame@PixelPaint@PickImage">选择图片</system:String>
     <system:String x:Key="MiniGame@PixelPaint@ResetView">重置取景</system:String>
     <system:String x:Key="MiniGame@PixelPaint@ResetParams">重置参数</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -1095,7 +1095,7 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="MiniGame@SecretFrontTip">在選擇小隊介面開始，如有存檔須手動刪除。&#10;第一次打請先看完教學後關閉。&#10;推薦勾選遊戲內 ｢繼承上一支隊伍發回的資料｣ 。</system:String>
     <system:String x:Key="MiniGame@PixelPaint">像素畫自動填色</system:String>
     <system:String x:Key="MiniGame@PixelPaintTip">請先手動進入遊戲內 24×24 像素畫編輯頁，再開始。&#10;中間預覽可拖移/滾輪取景；預設跳過白色。&#10;開始後參數鎖定，進度見右側日誌。</system:String>
-    <system:String x:Key="MiniGame@PixelPaint@DropHint">拖入圖片、貼上圖片或點下方選圖</system:String>
+    <system:String x:Key="MiniGame@PixelPaint@DropHint">拖入圖片、貼上圖片/文字或點下方選圖</system:String>
     <system:String x:Key="MiniGame@PixelPaint@PickImage">選擇圖片</system:String>
     <system:String x:Key="MiniGame@PixelPaint@ResetView">重置取景</system:String>
     <system:String x:Key="MiniGame@PixelPaint@ResetParams">重置參數</system:String>

--- a/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
@@ -2592,9 +2592,10 @@ public class ToolboxViewModel : Screen
     }
 
     /// <summary>
-    /// 像素画：响应 Ctrl+V，从剪贴板粘贴图片。
-    /// 先按剪贴板位图处理（截图工具、浏览器 ｢复制图片｣ 等无文件场景），
-    /// 否则按已复制的图片文件处理；加载失败时与文件加载一致地提示。
+    /// 像素画：响应 Ctrl+V，从剪贴板粘贴。
+    /// 优先剪贴板位图（截图、浏览器 ｢复制图片｣ 等无文件场景），
+    /// 其次已复制的图片文件，最后剪贴板文字——文字会渲染成四角布局图片；
+    /// 加载失败时与文件加载一致地提示。
     /// </summary>
     /// <param name="sender">事件源（绑定 KeyDown 的 MiniGame Grid）。</param>
     /// <param name="e">按键事件数据。</param>
@@ -2621,6 +2622,15 @@ public class ToolboxViewModel : Screen
                 if (_pixelPaintImageExtensions.Contains(ext))
                 {
                     LoadPixelPaintImage(file);
+                }
+            }
+            else if (Clipboard.ContainsText())
+            {
+                // 复制的是文字：渲染成四角布局图片（取前 4 个字素）
+                var text = Clipboard.GetText().Trim();
+                if (text.Length > 0)
+                {
+                    LoadPixelPaintImage(PixelPaintHelper.RenderTextToBitmap(text));
                 }
             }
         }


### PR DESCRIPTION
## Summary by Sourcery

为像素画添加从剪贴板粘贴文本的支持，通过将最多四个字符渲染为 24×24 位图，用作像素画源图像。

新功能：
- 允许像素画在粘贴时，除了图像和图像文件之外，还能粘贴剪贴板文本。
- 将最多四个文本字符（中文或 ASCII）渲染为 24×24 的白底黑字位图，并采用自适应布局，以供作为像素画输入使用。

增强：
- 改进像素画的粘贴处理流程：在粘贴时按顺序从位图回退到图像文件，最后回退到基于文本的渲染方式。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for pasting clipboard text into pixel paint by rendering up to four characters into a 24×24 bitmap suitable as the pixel art source image.

New Features:
- Allow pixel paint to paste clipboard text in addition to images and image files.
- Render up to four text characters (Chinese or ASCII) into a 24×24 black-on-white bitmap with adaptive layout for use as pixel art input.

Enhancements:
- Improve pixel paint paste handling to fall back from bitmap to image file and finally to text-based rendering.

</details>