### PR TITLE
fix: 修复 NotifyIcon 双击间隔为 0 时的启动崩溃

### DIFF
--- a/src/MaaWpfGui/Views/UI/NotifyIcon.xaml.cs
+++ b/src/MaaWpfGui/Views/UI/NotifyIcon.xaml.cs
@@ -42,6 +42,10 @@ public partial class NotifyIcon
         InitializeComponent();
 
         uint doubleClickTime = GetDoubleClickTime();
+        if (doubleClickTime == 0)
+        {
+            doubleClickTime = 500;
+        }
         _clickTimer = new(doubleClickTime) {
             AutoReset = false,
         };


### PR DESCRIPTION
Fixes #17660

任务计划程序以非交互会话启动时，GetDoubleClickTime() 可能返回 0，导致 Timer 初始化抛出异常。

将双击间隔限制为至少 1ms，避免启动时崩溃。

已构建并手动确认常规环境下托盘图标可正常使用。

## Summary by Sourcery

Bug Fixes:
- 将 NotifyIcon 双击间隔限制到至少 1 毫秒，以避免在 `GetDoubleClickTime()` 返回零时定时器初始化异常。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Clamp the NotifyIcon double-click interval to a minimum of 1ms to avoid timer initialization exceptions when GetDoubleClickTime() returns zero.

</details>