### PR TITLE
feat: 为Webhook的预置模板增加了WeCom和ntfy

### DIFF
--- a/src/MaaWpfGui/Services/ExternalNotification/WebhookPresetTemplate.cs
+++ b/src/MaaWpfGui/Services/ExternalNotification/WebhookPresetTemplate.cs
@@ -70,6 +70,13 @@ public class WebhookPresetTemplate
             Headers = "Authorization: Bot <bot_token>",
             Body = @"{""type"": 9, ""target_id"": ""<user_id>"", ""content"": ""**{title}**\n{content}""}",
         },
+        new()
+        {
+            Id = "WeCom",
+            Name = "WeCom",
+            Url = "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=<key>",
+            Body = @"{""msgtype"": ""text"", ""text"": {""content"": ""{content}""}}",
+        },
     ];
 
     public static IReadOnlyList<WebhookPresetTemplate> BuiltInTemplates => _builtInTemplates;

--- a/src/MaaWpfGui/Services/ExternalNotification/WebhookPresetTemplate.cs
+++ b/src/MaaWpfGui/Services/ExternalNotification/WebhookPresetTemplate.cs
@@ -77,6 +77,13 @@ public class WebhookPresetTemplate
             Url = "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=<key>",
             Body = @"{""msgtype"": ""text"", ""text"": {""content"": ""{content}""}}",
         },
+        new()
+        {
+            Id = "ntfy",
+            Name = "ntfy",
+            Url = "https://ntfy.sh/<topic>",
+            Body = @"{""message"": ""{content}"", ""title"": ""{title}""}",
+        },
     ];
 
     public static IReadOnlyList<WebhookPresetTemplate> BuiltInTemplates => _builtInTemplates;

--- a/src/MaaWpfGui/Services/ExternalNotification/WebhookPresetTemplate.cs
+++ b/src/MaaWpfGui/Services/ExternalNotification/WebhookPresetTemplate.cs
@@ -43,13 +43,6 @@ public class WebhookPresetTemplate
         },
         new()
         {
-            Id = "meow",
-            NameResourceKey = "ExternalNotificationCustomWebhook.TemplateMeoW",
-            Url = "https://api.chuckfang.com/<nickname>",
-            Body = "{\"title\":\"{title}\",\"msg\":\"{content}\\n{time}\"}",
-        },
-        new()
-        {
             Id = "Discord Webhook",
             Name = "Discord Webhook",
             Body = $"{{\"content\": \"{{content}}\"}}",
@@ -72,10 +65,10 @@ public class WebhookPresetTemplate
         },
         new()
         {
-            Id = "WeCom",
-            Name = "WeCom",
-            Url = "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=<key>",
-            Body = @"{""msgtype"": ""text"", ""text"": {""content"": ""{content}""}}",
+            Id = "meow",
+            NameResourceKey = "ExternalNotificationCustomWebhook.TemplateMeoW",
+            Url = "https://api.chuckfang.com/<nickname>",
+            Body = "{\"title\":\"{title}\",\"msg\":\"{content}\\n{time}\"}",
         },
         new()
         {
@@ -83,6 +76,13 @@ public class WebhookPresetTemplate
             Name = "ntfy",
             Url = "https://ntfy.sh/<topic>",
             Body = @"{""message"": ""{content}"", ""title"": ""{title}""}",
+        },
+        new()
+        {
+            Id = "WeCom",
+            Name = "WeCom",
+            Url = "https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=<key>",
+            Body = @"{""msgtype"": ""text"", ""text"": {""content"": ""{content}""}}",
         },
     ];
 


### PR DESCRIPTION
**改动：**  
为Webhook的预置模板增加了WeCom和ntfy
将Webhook内的预置模板按照字典序进行了排序

## Summary by Sourcery

添加新的内置 webhook 预设模板，以支持更多通知提供商。

新功能：
- 提供用于 WeCom 文本通知的内置 webhook 预设模板。
- 提供用于 ntfy 通知（包含标题和消息负载）的内置 webhook 预设模板。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add new built-in webhook preset templates for additional notification providers.

New Features:
- Provide a built-in webhook preset template for WeCom text notifications.
- Provide a built-in webhook preset template for ntfy notifications with title and message payloads.

</details>