### PR TITLE
feat(wpf): add reliable crash diagnostics

### DIFF
--- a/src/MaaCore/Utils/Logger.hpp
+++ b/src/MaaCore/Utils/Logger.hpp
@@ -33,6 +33,10 @@
 #include "Platform.hpp"
 #include "WorkingDir.hpp"
 
+#ifdef _WIN32
+#include "WindowsCrashDetails.hpp"
+#endif
+
 #if defined(__APPLE__) || defined(__linux__)
 #include <unistd.h>
 #endif
@@ -761,6 +765,14 @@ private:
         m_buff(nullptr),
         m_of(&m_buff)
     {
+#ifdef ASST_DEBUG
+        g_crash_path = UserDir.get() / "debug" / "crash.log";
+#else
+        g_crash_path = UserDir.get() / "crash.log";
+#endif // ASST_DEBUG
+#ifdef _WIN32
+        g_crash_fallback_path = UserDir.get() / std::format("crash-{}.log", GetCurrentProcessId());
+#endif // _WIN32
         initialize_exception_handlers();
 
         try {
@@ -857,6 +869,8 @@ private:
     }
 
     inline static std::atomic<int> g_last_signal { 0 };
+    inline static std::filesystem::path g_crash_path;
+    inline static std::filesystem::path g_crash_fallback_path;
 
     static const char* format_signal_reason(int sig) noexcept
     {
@@ -876,19 +890,14 @@ private:
 
     static void write_crash_file(const char* reason, const char* detail = nullptr) noexcept
     {
-        FILE* f = nullptr;
-#ifdef ASST_DEBUG
-        auto path = (UserDir.get() / "debug" / "crash.log").string();
-#else
-        auto path = (UserDir.get() / "crash.log").string();
-#endif // ASST_DEBUG
 #ifdef _WIN32
-        if (fopen_s(&f, path.c_str(), "a") != 0) {
-            return;
-        }
+        utils::write_windows_crash_file_with_fallback(
+            g_crash_path.c_str(),
+            g_crash_fallback_path.c_str(),
+            reason,
+            detail);
 #else
-        f = fopen(path.c_str(), "a");
-#endif // _WIN32
+        FILE* f = fopen(g_crash_path.c_str(), "a");
         if (!f) {
             return;
         }
@@ -902,28 +911,23 @@ private:
         fprintf(f, "===================\n\n");
         fflush(f);
         fclose(f);
+#endif // _WIN32
     }
 
 #ifdef _WIN32
     // SEH 未处理异常过滤器
-    static LONG WINAPI unhandled_exception_filter([[maybe_unused]] PEXCEPTION_POINTERS pExceptionInfo)
+    static LONG WINAPI unhandled_exception_filter(PEXCEPTION_POINTERS exception_info)
     {
-        try {
-            auto& logger = Logger::get_instance();
-            logger.error("=== UNHANDLED EXCEPTION ===");
-            logger.error("Version", MAA_VERSION);
-            logger.error("Built at", __DATE__, __TIME__);
-            logger.error("User Dir", UserDir.get());
-            logger.error("============================");
-            logger.flush();
-            write_crash_file("UNHANDLED EXCEPTION");
+        static volatile LONG handling = 0;
+        if (InterlockedExchange(&handling, 1) != 0) {
+            return EXCEPTION_EXECUTE_HANDLER;
         }
-        catch (...) {
-            std::cerr << "=== FATAL ERROR ===" << std::endl;
-            std::cerr << "Failed to log exception details to file" << std::endl;
-            std::cerr << "Unhandled exception caught, program terminating..." << std::endl;
-            std::cerr << "===================" << std::endl;
-        }
+
+        // 原生异常可能发生在常规日志线程持有互斥锁时；最后机会处理器不能重入 Logger，
+        // 否则进程可能在退出前死锁，连 crash.log 也无法落盘。
+        char detail[1024] {};
+        utils::format_windows_exception_detail(exception_info, detail, sizeof(detail));
+        write_crash_file("UNHANDLED EXCEPTION", detail);
 
         // 返回 EXCEPTION_EXECUTE_HANDLER 让程序正常终止
         return EXCEPTION_EXECUTE_HANDLER;
@@ -1121,9 +1125,8 @@ private:
         std::signal(SIGILL, signal_handler);
 
 #ifdef ASST_DEBUG
-        const auto& path = UserDir.get() / "debug" / "crash.log";
-        if (std::filesystem::exists(path)) {
-            std::filesystem::remove(path);
+        if (std::filesystem::exists(g_crash_path)) {
+            std::filesystem::remove(g_crash_path);
         }
 #endif // ASST_DEBUG
     }

--- a/src/MaaCore/Utils/WindowsCrashDetails.hpp
+++ b/src/MaaCore/Utils/WindowsCrashDetails.hpp
@@ -1,0 +1,176 @@
+#pragma once
+
+#ifdef _WIN32
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+
+#include "MaaUtils/SafeWindows.hpp"
+
+namespace asst::utils
+{
+inline bool write_windows_crash_bytes(HANDLE file, const char* value) noexcept
+{
+    if (value == nullptr) {
+        return true;
+    }
+
+    std::size_t remaining = std::strlen(value);
+    while (remaining > 0) {
+        DWORD written = 0;
+        const DWORD requested = static_cast<DWORD>(std::min<std::size_t>(remaining, MAXDWORD));
+        if (!WriteFile(file, value, requested, &written, nullptr) || written == 0) {
+            return false;
+        }
+
+        value += written;
+        remaining -= written;
+    }
+
+    return true;
+}
+
+inline bool write_windows_crash_file(const wchar_t* path, const char* reason, const char* detail) noexcept
+{
+    if (path == nullptr) {
+        return false;
+    }
+
+    const HANDLE file = CreateFileW(
+        path,
+        FILE_APPEND_DATA,
+        FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+        nullptr,
+        OPEN_ALWAYS,
+        FILE_ATTRIBUTE_NORMAL | FILE_FLAG_WRITE_THROUGH,
+        nullptr);
+    if (file == INVALID_HANDLE_VALUE) {
+        return false;
+    }
+
+    bool written = write_windows_crash_bytes(file, "=== FATAL ERROR ===\n");
+    if (reason != nullptr) {
+        written = write_windows_crash_bytes(file, "Reason: ") && written;
+        written = write_windows_crash_bytes(file, reason) && written;
+        written = write_windows_crash_bytes(file, "\n") && written;
+    }
+    if (detail != nullptr) {
+        written = write_windows_crash_bytes(file, "Detail: ") && written;
+        written = write_windows_crash_bytes(file, detail) && written;
+        written = write_windows_crash_bytes(file, "\n") && written;
+    }
+    written = write_windows_crash_bytes(file, "===================\n\n") && written;
+    written = FlushFileBuffers(file) && written;
+    written = CloseHandle(file) && written;
+    return written;
+}
+
+inline bool write_windows_crash_file_with_fallback(
+    const wchar_t* primary_path,
+    const wchar_t* fallback_path,
+    const char* reason,
+    const char* detail) noexcept
+{
+    return write_windows_crash_file(primary_path, reason, detail) ||
+           write_windows_crash_file(fallback_path, reason, detail);
+}
+
+inline const char* format_windows_access_type(ULONG_PTR operation) noexcept
+{
+    switch (operation) {
+    case 0:
+        return "read";
+    case 1:
+        return "write";
+    case 8:
+        return "execute";
+    default:
+        return "unknown";
+    }
+}
+
+inline void format_windows_module_path(HMODULE module, char* destination, std::size_t destination_size) noexcept
+{
+    if (destination == nullptr || destination_size == 0) {
+        return;
+    }
+    if (destination_size == 1) {
+        destination[0] = '\0';
+        return;
+    }
+
+    wchar_t wide_path[MAX_PATH] {};
+    const DWORD wide_length =
+        GetModuleFileNameW(module, wide_path, static_cast<DWORD>(sizeof(wide_path) / sizeof(wchar_t)));
+    if (wide_length == 0 || wide_length >= sizeof(wide_path) / sizeof(wchar_t)) {
+        std::snprintf(destination, destination_size, "<module-base:%p>", static_cast<void*>(module));
+        return;
+    }
+
+    const int utf8_length = WideCharToMultiByte(
+        CP_UTF8,
+        WC_ERR_INVALID_CHARS,
+        wide_path,
+        static_cast<int>(wide_length),
+        destination,
+        static_cast<int>(destination_size - 1),
+        nullptr,
+        nullptr);
+    if (utf8_length <= 0) {
+        std::snprintf(destination, destination_size, "<module-base:%p>", static_cast<void*>(module));
+        return;
+    }
+
+    destination[utf8_length] = '\0';
+}
+
+inline void format_windows_exception_detail(
+    PEXCEPTION_POINTERS exception_info,
+    char* destination,
+    std::size_t destination_size) noexcept
+{
+    if (destination == nullptr || destination_size == 0) {
+        return;
+    }
+    if (exception_info == nullptr || exception_info->ExceptionRecord == nullptr) {
+        std::snprintf(destination, destination_size, "Exception information was unavailable");
+        return;
+    }
+
+    const auto* record = exception_info->ExceptionRecord;
+    const auto fault_address = reinterpret_cast<std::uintptr_t>(record->ExceptionAddress);
+    char module_path[MAX_PATH * 3] = "<unknown>";
+    std::uintptr_t module_offset = 0;
+    MEMORY_BASIC_INFORMATION memory_info {};
+    if (record->ExceptionAddress != nullptr &&
+        VirtualQuery(record->ExceptionAddress, &memory_info, sizeof(memory_info)) == sizeof(memory_info)) {
+        const auto module = static_cast<HMODULE>(memory_info.AllocationBase);
+        format_windows_module_path(module, module_path, sizeof(module_path));
+        module_offset = fault_address - reinterpret_cast<std::uintptr_t>(memory_info.AllocationBase);
+    }
+
+    const bool is_access_violation =
+        record->ExceptionCode == EXCEPTION_ACCESS_VIOLATION && record->NumberParameters >= 2;
+    const char* access_type =
+        is_access_violation ? format_windows_access_type(record->ExceptionInformation[0]) : "not-applicable";
+    const void* accessed_address =
+        is_access_violation ? reinterpret_cast<const void*>(record->ExceptionInformation[1]) : nullptr;
+    std::snprintf(
+        destination,
+        destination_size,
+        "ExceptionCode: 0x%08lX; ExceptionFlags: 0x%08lX; FaultAddress: %p; "
+        "FaultingModule: %s; ModuleOffset: 0x%llX; AccessType: %s; AccessedAddress: %p",
+        static_cast<unsigned long>(record->ExceptionCode),
+        static_cast<unsigned long>(record->ExceptionFlags),
+        record->ExceptionAddress,
+        module_path,
+        static_cast<unsigned long long>(module_offset),
+        access_type,
+        accessed_address);
+}
+} // namespace asst::utils
+
+#endif

--- a/src/MaaWpfGui/Main/Bootstrapper.cs
+++ b/src/MaaWpfGui/Main/Bootstrapper.cs
@@ -32,8 +32,10 @@ using MaaWpfGui.Configuration.Factory;
 using MaaWpfGui.Constants;
 using MaaWpfGui.Extensions;
 using MaaWpfGui.Helper;
+using MaaWpfGui.Models.Diagnostics;
 using MaaWpfGui.Properties;
 using MaaWpfGui.Services;
+using MaaWpfGui.Services.Diagnostics;
 using MaaWpfGui.Services.HotKeys;
 using MaaWpfGui.Services.Managers;
 using MaaWpfGui.Services.RemoteControl;
@@ -51,6 +53,7 @@ using Serilog.Core;
 using Serilog.Events;
 using Stylet;
 using StyletIoC;
+using FailureSource = MaaWpfGui.Models.Diagnostics.DiagnosticSource;
 
 namespace MaaWpfGui.Main;
 
@@ -66,6 +69,8 @@ public class Bootstrapper : Bootstrapper<RootViewModel>
     private static EventWaitHandle _instanceActivationEvent;
     private static CancellationTokenSource _instanceActivationListenerCancellation;
 
+    private static WpfDiagnosticManager Diagnostics => WpfDiagnosticManager.Instance;
+
     public static readonly string UiLogFile = Path.Combine(PathsHelper.DebugDir, "gui.log");
     public static readonly string UiLogBakFile = Path.Combine(PathsHelper.DebugDir, "gui.bak.log");
     public static readonly string CoreLogFile = Path.Combine(PathsHelper.DebugDir, "asst.log");
@@ -76,6 +81,9 @@ public class Bootstrapper : Bootstrapper<RootViewModel>
 
     [DllImport("kernel32.dll", CharSet = CharSet.Auto)]
     private static extern bool FreeLibrary(IntPtr hModule);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode, EntryPoint = "MessageBoxW")]
+    private static extern int NativeMessageBox(IntPtr owner, string text, string caption, uint type);
 
     private static List<string> UnknownDllDetected()
     {
@@ -308,118 +316,26 @@ public class Bootstrapper : Bootstrapper<RootViewModel>
             : path + Path.DirectorySeparatorChar;
     }
 
-    public static void ParseCrashLog()
-    {
-        var crashFile = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "crash.log");
-        if (!File.Exists(crashFile))
-        {
-            return;
-        }
-
-        try
-        {
-            var localAppData = Environment.GetEnvironmentVariable("LocalAppData");
-            if (localAppData is not null && Directory.Exists($"{localAppData}/CrashDumps"))
-            {
-                var crashDumpsSource = Path.Combine(localAppData, "CrashDumps");
-                var dumpDir = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "debug", "dumps");
-                if (Directory.Exists(dumpDir))
-                {
-                    Directory.Delete(dumpDir, true);
-                }
-                Directory.CreateDirectory(dumpDir);
-
-                var time = File.GetLastWriteTime(crashFile);
-                bool foundDump = false;
-                foreach (var file in new DirectoryInfo(crashDumpsSource).EnumerateFiles("MAA.exe.*.dmp"))
-                {
-                    if (file.LastWriteTime >= time.AddMinutes(-10) && file.LastWriteTime <= time.AddMinutes(10))
-                    {
-                        _logger.Information("Found crash dump file: {CrashDumpFile}", file.FullName);
-                        File.Copy(file.FullName, Path.Combine(dumpDir, file.Name), true);
-                        foundDump = true;
-                    }
-                }
-                if (foundDump)
-                {
-                    _logger.Information("Crash dumps are copied to {DumpDir}", dumpDir);
-                }
-            }
-            else
-            {
-                _logger.Information("%LocalAppData%/CrashDumps not found");
-            }
-
-            string[] lines = File.ReadAllLines(crashFile, Encoding.UTF8);
-
-            StringBuilder message = new StringBuilder();
-            string currentReason = null;
-            string currentDetail = null;
-
-            foreach (var line in lines)
-            {
-                if (line.StartsWith("Reason: "))
-                {
-                    currentReason = line[7..].Trim();
-                }
-                else if (line.StartsWith("Detail: "))
-                {
-                    currentDetail = line[8..].Trim();
-                }
-                else if (line.StartsWith("==================="))
-                {
-                    if (!string.IsNullOrEmpty(currentReason))
-                    {
-                        message.AppendLine($"Reason: {currentReason}");
-                        if (!string.IsNullOrEmpty(currentDetail))
-                        {
-                            message.AppendLine($"Detail: {currentDetail}");
-                        }
-
-                        message.AppendLine();
-                    }
-
-                    currentReason = null;
-                    currentDetail = null;
-                }
-            }
-
-            if (message.Length > 0)
-            {
-                message.AppendLine(LocalizationHelper.GetString("ErrorCrashMessageHeader"));
-                message.AppendLine();
-                message.AppendLine(LocalizationHelper.GetString("ErrorCrashMessageOpenLog"));
-                message.AppendLine(LocalizationHelper.GetString("ErrorCrashMessageGenerateReport"));
-                message.AppendLine();
-                message.AppendLine(LocalizationHelper.GetString("ErrorCrashMessageHelpTip"));
-
-                _logger.Warning(message.ToString());
-
-                MessageBoxHelper.Show(
-                    message.ToString(),
-                    LocalizationHelper.GetString("ErrorCrashDialogTitle"),
-                    MessageBoxButton.OK,
-                    MessageBoxImage.Error);
-            }
-
-            try
-            {
-                File.Delete(crashFile);
-            }
-            catch
-            {
-                // ignored
-            }
-        }
-        catch
-        {
-            // ignored
-        }
-    }
-
     /// <inheritdoc/>
     /// <remarks>初始化些啥自己加。</remarks>
     protected override void OnStart()
+    {
+        try
+        {
+            OnStartCore();
+        }
+        catch (Exception ex)
+        {
+            RunDiagnosticsSafely(static () => Diagnostics.Initialize(), "initialize diagnostics after startup failure");
+            var writeResult = RecordDiagnosticFailureSafely(ex, FailureSource.Startup);
+            RunDiagnosticsSafely(static () => Diagnostics.MarkPhase(DiagnosticStartupPhase.StartupFailed), "mark startup failed");
+            ShowImmediateFailureNotice(writeResult);
+
+            Environment.Exit(1);
+        }
+    }
+
+    private void OnStartCore()
     {
         Directory.SetCurrentDirectory(AppContext.BaseDirectory);
         if (!Directory.Exists("debug"))
@@ -442,6 +358,7 @@ public class Bootstrapper : Bootstrapper<RootViewModel>
             .WriteTo.Debug(outputTemplate: "[{Timestamp:HH:mm:ss}][{Level:u3}]{ClassName} <{ThreadId}> {Message:lj}{NewLine}{Exception}")
             .WriteTo.File(
                 UiLogFile,
+                shared: true,
                 outputTemplate: "[{Timestamp:yyyy-MM-dd HH:mm:ss.fff}][{Level:u3}]{ClassName} <{ThreadId}> {Message:lj}{NewLine}{Exception}")
             .Enrich.With<ClassNameEnricher>()
             .Enrich.FromLogContext()
@@ -468,6 +385,7 @@ public class Bootstrapper : Bootstrapper<RootViewModel>
 
         Log.Logger = loggerConfiguration.CreateLogger();
         _logger = Log.Logger.ForContext<Bootstrapper>();
+        RunDiagnosticsSafely(static () => Diagnostics.Initialize(), "initialize diagnostics");
         _logger.Information("===================================");
         _logger.Information("MaaAssistantArknights GUI started");
         _logger.Information("Version {UiVersion}", uiVersion);
@@ -504,6 +422,7 @@ public class Bootstrapper : Bootstrapper<RootViewModel>
 
         ConfigurationHelper.Load();
         LocalizationHelper.Load();
+        RunDiagnosticsSafely(static () => Diagnostics.MarkPhase(DiagnosticStartupPhase.ConfigurationLoaded), "mark configuration loaded");
         if (PendingUpdateApplier.TryConsumeDelegatedUpdateSuccess())
         {
             _logger.Information("Delegated pending update completed successfully");
@@ -578,6 +497,14 @@ public class Bootstrapper : Bootstrapper<RootViewModel>
             _logger.Information("Using software rendering mode due to user preference (bad modules detected)");
         }
 
+        if (!HandleMultipleInstances())
+        {
+            Shutdown();
+            return;
+        }
+
+        RunDiagnosticsSafely(static () => Diagnostics.ImportNativeCrashLogs(), "import native crash log");
+
         // 检查 MaaCore.dll 是否存在
         if (!File.Exists("MaaCore.dll"))
         {
@@ -609,30 +536,10 @@ public class Bootstrapper : Bootstrapper<RootViewModel>
 
         if (!IsVCppInstalled())
         {
-            var ret = MessageBoxHelper.Show(
-                LocalizationHelper.GetString("VC++NotInstalled"),
-                "MAA",
-                MessageBoxButton.OKCancel,
-                MessageBoxImage.Information,
-                ok: LocalizationHelper.GetString("Confirm"),
-                cancel: LocalizationHelper.GetString("Cancel"));
-            if (ret == MessageBoxResult.OK)
-            {
-                var startInfo = new ProcessStartInfo {
-                    FileName = "DependencySetup_依赖库安装.bat",
-                    WorkingDirectory = AppDomain.CurrentDomain.BaseDirectory, // 设置工作目录
-                    WindowStyle = ProcessWindowStyle.Normal, // 显示窗口让用户看到进度
-                };
-
-                Process.Start(startInfo);
-            }
-
-            Shutdown();
-            return;
-        }
-
-        if (!HandleMultipleInstances())
-        {
+            var writeResult = RecordDiagnosticFailureSafely(
+                new DllNotFoundException("MaaCore could not be loaded because a VC++ runtime dependency such as VCRUNTIME or MSVCP is missing."),
+                FailureSource.Startup);
+            ShowImmediateFailureNotice(writeResult);
             Shutdown();
             return;
         }
@@ -642,8 +549,7 @@ public class Bootstrapper : Bootstrapper<RootViewModel>
             Task.Run(() => MessageBoxHelper.Show(LocalizationHelper.GetString("SoftwareLocationWarning"), LocalizationHelper.GetString("Error"), MessageBoxButton.OK, MessageBoxImage.Error));
         }
 
-        Task.Run(ParseCrashLog);
-
+        RunDiagnosticsSafely(static () => Diagnostics.MarkPhase(DiagnosticStartupPhase.PreflightPassed), "mark preflight passed");
         base.OnStart();
         _hasMutex = true;
 
@@ -716,8 +622,7 @@ public class Bootstrapper : Bootstrapper<RootViewModel>
 
     public static string InstanceKey
     {
-        get
-        {
+        get {
             var normalizedBaseDir = Path.GetFullPath(PathsHelper.BaseDir)
                 .TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
                 .ToUpperInvariant();
@@ -878,6 +783,7 @@ public class Bootstrapper : Bootstrapper<RootViewModel>
         bool wasFirstBoot = Instances.VersionUpdateDialogViewModel.IsFirstBootAfterUpdate;
 
         Instances.WindowManager.ShowWindow(rootViewModel);
+        RunDiagnosticsSafely(static () => Diagnostics.MarkMainWindowShown(), "mark main window shown");
         Instances.InstantiateOnRootViewDisplayed(Container);
         StartInstanceActivationListener();
 
@@ -1194,8 +1100,28 @@ public class Bootstrapper : Bootstrapper<RootViewModel>
     protected override void OnUnhandledException(DispatcherUnhandledExceptionEventArgs e)
     {
         LogUnhandledException(e.Exception);
-        ShowErrorDialog(e.Exception);
+        var details = e.Exception.ToString();
+        var comException = e.Exception as COMException;
+        const int DwmECompositionDisabled = unchecked((int)0x80263001);
+        bool isDragDropException = comException is not null && details.Contains("DragDrop.DoDragSourceMove", StringComparison.Ordinal);
+        bool isDwmCompositionDisabledException = comException is not null &&
+                                                 (comException.HResult == DwmECompositionDisabled ||
+                                                  details.Contains("Desktop composition is disabled", StringComparison.OrdinalIgnoreCase) ||
+                                                  details.Contains("0x80263001", StringComparison.OrdinalIgnoreCase));
+
+        // 拖拽和 DWM 组合异常沿用原有的非致命处理，诊断只留痕，不能把它升级为下次启动提示。
+        if (isDragDropException || isDwmCompositionDisabledException)
+        {
+            _ = RecordDiagnosticFailureSafely(e.Exception, FailureSource.Dispatcher, makePending: false, severity: DiagnosticSeverity.Error);
+            new ErrorDialogView(e.Exception, shouldExit: false).ShowDialog();
+            e.Handled = true;
+            return;
+        }
+
+        var writeResult = RecordDiagnosticFailureSafely(e.Exception, FailureSource.Dispatcher);
+        ShowImmediateFailureNotice(writeResult);
         e.Handled = true;
+        Environment.Exit(1);
     }
 
     private static void LogUnhandledException(Exception exception)
@@ -1206,31 +1132,131 @@ public class Bootstrapper : Bootstrapper<RootViewModel>
         }
     }
 
-    private static void ShowErrorDialog(Exception exception)
+    private static void ShowImmediateFailureNotice(DiagnosticStoreWriteResult writeResult)
     {
-        Application.Current.Dispatcher.Invoke(() => {
-            // 这些异常虽然会导致崩溃，但不需要退出程序
-            // 这是一坨屎，但是没办法，只能这样了
-            var comEx = exception as COMException;
+        var failure = writeResult.Failure;
+        string culture = GetDiagnosticCulture();
+        bool zh = culture.StartsWith("zh", StringComparison.OrdinalIgnoreCase);
+        string followUp = (writeResult.HistoryWritten, writeResult.PendingWritten) switch {
+            (_, true) when zh => "下次正常启动后可选择生成诊断报告。",
+            (_, true) => "After the next successful startup, you can choose whether to generate a diagnostic report.",
+            (true, false) when zh => "诊断记录已保存；下次正常启动后可在“问题反馈”页面生成报告。",
+            (true, false) => "The diagnostic record was saved. After the next successful startup, you can generate a report from the Issue Report page.",
+            _ when zh => "诊断记录未能保存，请截图当前窗口并在反馈时提供错误码和诊断编号。",
+            _ => "The diagnostic record could not be saved. Take a screenshot of this window and include the error code and case ID when reporting the problem.",
+        };
+        string message = zh
+            ? $"MAA 遇到异常，将安全退出。\n\n错误码：{failure.Code}\n诊断编号：{failure.CaseId}\n\n{followUp}"
+            : $"MAA encountered an error and will exit safely.\n\nError code: {failure.Code}\nCase ID: {failure.CaseId}\n\n{followUp}";
+        try
+        {
+            NativeMessageBox(IntPtr.Zero, message, "MAA", 0x10);
+        }
+        catch
+        {
+            // Nothing else is safe to do in a last-chance exception handler.
+        }
+    }
 
-            var details = exception.ToString();
+    internal static void SchedulePendingDiagnosticReportPrompt()
+    {
+        try
+        {
+            Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.ApplicationIdle, PromptForPendingDiagnosticReport);
+        }
+        catch (Exception ex)
+        {
+            _logger.Warning(ex, "Failed to schedule pending diagnostic report prompt");
+        }
+    }
 
-            // DragDrop.DoDragSourceMove 会在拖拽时偶发崩溃
-            var isDragDropException = comEx != null && details.Contains("DragDrop.DoDragSourceMove");
+    private static DiagnosticStoreWriteResult RecordDiagnosticFailureSafely(
+        Exception exception,
+        string source,
+        bool makePending = true,
+        string severity = DiagnosticSeverity.Fatal)
+    {
+        try
+        {
+            return Diagnostics.RecordException(exception, source, makePending, severity);
+        }
+        catch (Exception diagnosticException)
+        {
+            _logger.Warning(diagnosticException, "Diagnostics failed while recording {Source}", source);
+            var failure = new DiagnosticFailure {
+                Source = source,
+                StartupPhase = DiagnosticStartupPhase.Unknown,
+                Severity = severity,
+                Code = DiagnosticErrorCode.UiError,
+                Confidence = DiagnosticConfidence.Unknown,
+                ExceptionType = exception.GetType().FullName ?? exception.GetType().Name,
+                HResult = exception.HResult,
+                Message = exception.Message,
+                TechnicalDetails = exception.ToString(),
+            };
+            return new(failure, HistoryWritten: false, PendingWritten: false);
+        }
+    }
 
-            // DWM 桌面组合被禁用（0x80263001），通常是瞬时的显卡驱动问题，DWM 会自行恢复
-            // 同时用 HResult 与异常文本双重判断，避免不同 .NET 版本/语言环境下 HRESULT 暴露不一致
-            const int DwmECompositionDisabled = unchecked((int)0x80263001);
-            var isDwmCompositionDisabledException = comEx != null &&
-                (comEx.HResult == DwmECompositionDisabled ||
-                 details.Contains("Desktop composition is disabled") ||
-                 details.Contains("0x80263001"));
+    private static void RunDiagnosticsSafely(Action action, string operation)
+    {
+        try
+        {
+            action();
+        }
+        catch (Exception ex)
+        {
+            if (_logger != Logger.None)
+            {
+                _logger.Warning(ex, "Optional diagnostic operation failed: {Operation}", operation);
+            }
+        }
+    }
 
-            var shouldExit = !isDragDropException && !isDwmCompositionDisabledException;
+    private static void PromptForPendingDiagnosticReport()
+    {
+        try
+        {
+            var mainWindow = Application.Current.MainWindow;
+            var blockingWindow = Application.Current.Windows
+                .Cast<Window>()
+                .FirstOrDefault(window => window != mainWindow && window.IsVisible && window is not CrashDiagnosticDialog);
+            if (blockingWindow is not null)
+            {
+                EventHandler closedHandler = null;
+                closedHandler = (_, _) => {
+                    blockingWindow.Closed -= closedHandler;
+                    SchedulePendingDiagnosticReportPrompt();
+                };
+                blockingWindow.Closed += closedHandler;
+                return;
+            }
 
-            var errorView = new ErrorDialogView(exception, shouldExit);
-            errorView.ShowDialog();
-        });
+            var failure = Diagnostics.TryConsumePendingFailure();
+            if (failure is null)
+            {
+                return;
+            }
+
+            new CrashDiagnosticDialog(Diagnostics, failure).ShowDialog();
+        }
+        catch (Exception ex)
+        {
+            // A diagnostic prompt is optional UI and must never affect the running app.
+            _logger.Warning(ex, "Pending diagnostic report prompt failed and was skipped");
+        }
+    }
+
+    private static string GetDiagnosticCulture()
+    {
+        try
+        {
+            return LocalizationHelper.CurrentCulture;
+        }
+        catch
+        {
+            return LocalizationHelper.DefaultLanguage;
+        }
     }
 
     private static Dictionary<string, string> ParseArgs(string[] args, params string[] flags)

--- a/src/MaaWpfGui/Models/Diagnostics/DiagnosticContracts.cs
+++ b/src/MaaWpfGui/Models/Diagnostics/DiagnosticContracts.cs
@@ -1,0 +1,203 @@
+// <copyright file="DiagnosticContracts.cs" company="MaaAssistantArknights">
+// Part of the MaaWpfGui project, maintained by the MaaAssistantArknights team (Maa Team)
+// Copyright (C) 2021-2025 MaaAssistantArknights Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License v3.0 only as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY
+// </copyright>
+
+#pragma warning disable SA1402, SA1636, SA1649
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+
+namespace MaaWpfGui.Models.Diagnostics;
+
+/// <summary>
+/// Stable error codes shared by the WPF diagnostic protocol. Existing MAAUnified
+/// codes are reused where they already describe the same failure.
+/// </summary>
+internal static class DiagnosticErrorCode
+{
+    public const string UiError = "UiError";
+    public const string StartupDependencyMissing = "WpfStartupDependencyMissing";
+    public const string StartupPackageMissing = "WpfStartupPackageMissing";
+    public const string DwmUnavailable = "WpfDwmUnavailable";
+    public const string GraphicsDeviceLost = "WpfGraphicsDeviceLost";
+    public const string GraphicsRenderingFailed = "WpfGraphicsRenderingFailed";
+    public const string GpuInferenceFailed = "WpfGpuInferenceFailed";
+    public const string InjectedModuleConflict = "WpfInjectedModuleConflict";
+    public const string ManagedCrash = "WpfManagedCrash";
+    public const string NativeCrash = "WpfNativeCrash";
+    public const string StartupUnknown = "WpfStartupUnknown";
+}
+
+internal static class DiagnosticSource
+{
+    public const string Startup = "startup";
+    public const string Dispatcher = "dispatcher";
+    public const string AppDomain = "appDomain";
+    public const string NativeCrash = "nativeCrash";
+    public const string Unknown = "unknown";
+}
+
+internal static class DiagnosticSeverity
+{
+    public const string Fatal = "fatal";
+    public const string Error = "error";
+}
+
+internal static class DiagnosticConfidence
+{
+    public const string High = "high";
+    public const string Medium = "medium";
+    public const string Unknown = "unknown";
+}
+
+internal static class DiagnosticStartupPhase
+{
+    public const string ProcessStarted = "processStarted";
+    public const string ConfigurationLoaded = "configurationLoaded";
+    public const string PreflightPassed = "preflightPassed";
+    public const string StartupFailed = "startupFailed";
+    public const string PreviousProcess = "previousProcess";
+    public const string MainWindowShown = "mainWindowShown";
+    public const string Unknown = "unknown";
+}
+
+internal sealed class DiagnosticFailure
+{
+    public int SchemaVersion { get; set; } = 1;
+
+    public string CaseId { get; set; } = Guid.NewGuid().ToString("N");
+
+    public DateTimeOffset TimestampUtc { get; set; } = DateTimeOffset.UtcNow;
+
+    public int ProcessId { get; set; } = System.Environment.ProcessId;
+
+    public string Source { get; set; } = DiagnosticSource.Dispatcher;
+
+    public string StartupPhase { get; set; } = DiagnosticStartupPhase.Unknown;
+
+    public string Code { get; set; } = DiagnosticErrorCode.UiError;
+
+    public string Severity { get; set; } = DiagnosticSeverity.Fatal;
+
+    public string Confidence { get; set; } = DiagnosticConfidence.Unknown;
+
+    public string Fingerprint { get; set; } = string.Empty;
+
+    public string RuleId { get; set; } = string.Empty;
+
+    public string ExceptionType { get; set; } = string.Empty;
+
+    public int? HResult { get; set; }
+
+    public string Message { get; set; } = string.Empty;
+
+    public List<DiagnosticEvidence> Evidence { get; set; } = [];
+
+    public string TechnicalDetails { get; set; } = string.Empty;
+
+    public string AppVersion { get; set; } = string.Empty;
+
+    public string ResourceVersion { get; set; } = string.Empty;
+
+    public string RuleVersion { get; set; } = string.Empty;
+
+    public Dictionary<string, string> Environment { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+
+    public int OccurrenceCount { get; set; } = 1;
+}
+
+internal sealed record DiagnosticEvidence(string Kind, string Value);
+
+internal sealed class DiagnosticInput
+{
+    public string Source { get; init; } = DiagnosticSource.Dispatcher;
+
+    public string StartupPhase { get; init; } = DiagnosticStartupPhase.Unknown;
+
+    public string Severity { get; init; } = DiagnosticSeverity.Fatal;
+
+    public string ExceptionType { get; init; } = string.Empty;
+
+    public int? HResult { get; init; }
+
+    public string Message { get; init; } = string.Empty;
+
+    public string Details { get; init; } = string.Empty;
+
+    public IReadOnlyList<string> Modules { get; init; } = [];
+}
+
+internal sealed class DiagnosticReportOptions
+{
+    public bool IncludeConfigurationSummary { get; set; } = true;
+
+    public bool IncludeScreenshots { get; set; } = true;
+
+    public bool IncludeDumps { get; set; } = true;
+}
+
+internal sealed record DiagnosticReportResult(string ReportPath, IReadOnlyList<string> AttachmentParts, bool IsMinimal);
+
+internal sealed record DiagnosticStoreWriteResult(
+    DiagnosticFailure Failure,
+    bool HistoryWritten,
+    bool PendingWritten);
+
+internal sealed record DiagnosticAttachmentBuildResult(
+    IReadOnlyList<string> TemporaryPartPaths,
+    DiagnosticCollectionStatus CollectionStatus);
+
+internal sealed class DiagnosticCollectionStatus
+{
+    public Dictionary<string, DiagnosticCollectorStatus> Collectors { get; } = new(StringComparer.OrdinalIgnoreCase);
+
+    public DiagnosticAttachmentCategoryStatus Screenshots { get; } = new();
+
+    public DiagnosticAttachmentCategoryStatus Dumps { get; } = new();
+
+    public List<DiagnosticAttachmentStatus> Attachments { get; } = [];
+}
+
+internal class DiagnosticCollectorStatus
+{
+    public string Status { get; set; } = "success";
+
+    public string? ExceptionType { get; set; }
+
+    public string? ExceptionMessage { get; set; }
+}
+
+internal sealed class DiagnosticAttachmentCategoryStatus : DiagnosticCollectorStatus
+{
+    internal DiagnosticAttachmentCategoryStatus()
+    {
+        Status = "unavailable";
+    }
+
+    public bool Requested { get; set; }
+
+    public int CandidatesFound { get; set; }
+
+    public int Included { get; set; }
+
+    public int Failed { get; set; }
+}
+
+internal sealed class DiagnosticAttachmentStatus : DiagnosticCollectorStatus
+{
+    public string EntryName { get; set; } = string.Empty;
+
+    public long Size { get; set; }
+
+    public string? PartFileName { get; set; }
+}

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -1273,6 +1273,21 @@ Right-click to clear inactive jobs</system:String>
     <system:String x:Key="ErrorCrashMessageHelpTip">If you need help from others, please send the generated error report file instead of sending screenshots, screen recordings, photos of the screen, recorded videos, hand-drawn pictures, or transcribed content of this window. A single GitHub attachment cannot exceed 20 MB; please split it if larger.</system:String>
     <system:String x:Key="ErrorCrashDialogTitle">Reason for the last crash</system:String>
     <system:String x:Key="CopyErrorMessage">Copy error message</system:String>
+    <system:String x:Key="DiagnosticGenerateCrashReport">Generate crash report</system:String>
+    <system:String x:Key="DiagnosticNoFailure">There is no crash record available for a report.</system:String>
+    <system:String x:Key="DiagnosticPreviousFailureTitle">Run diagnostics</system:String>
+    <system:String x:Key="DiagnosticPreviousFailurePrompt">MAA detected a problem during the previous run. Generate a diagnostic report now? It is saved locally and never uploaded automatically.</system:String>
+    <system:String x:Key="DiagnosticTechnicalDetails">Technical details</system:String>
+    <system:String x:Key="DiagnosticReportContents">Diagnostic report contents</system:String>
+    <system:String x:Key="DiagnosticDialogPrivacy">All items below are included by default. The report stays local and is not uploaded automatically. Its contents are not sanitized and may include user paths, account information, credentials from logs, screenshots, or dumps. Review it before sharing.</system:String>
+    <system:String x:Key="DiagnosticIncludeConfiguration">Include configuration summary</system:String>
+    <system:String x:Key="DiagnosticIncludeScreenshots">Include screenshots near the failure (may contain game information)</system:String>
+    <system:String x:Key="DiagnosticIncludeDumps">Include memory dumps (may contain process memory)</system:String>
+    <system:String x:Key="DiagnosticBuildReport">Build diagnostic report</system:String>
+    <system:String x:Key="DiagnosticBuildingReport">Building diagnostic report…</system:String>
+    <system:String x:Key="DiagnosticMinimalReportCreated">Full collection encountered a problem. A minimal diagnostic report was created.</system:String>
+    <system:String x:Key="DiagnosticReportFailed">The diagnostic report could not be generated.</system:String>
+    <system:String x:Key="DiagnosticDismiss">Ignore</system:String>
     <!--  !ErrorView  -->
     <!--  AsstProxy  -->
     <system:String x:Key="UpdateApplyFailed">The update could not be applied and the current installation may be incomplete. Please download the full package again and migrate your config, data, and debug folders manually as described below.\n\n{key=FullPackageUpgradeTips}</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -1275,6 +1275,21 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="ErrorCrashMessageHelpTip">他人に助けを求める場合は、このウィンドウのスクリーンショット、画面録画、写真、撮影した動画、手描きの図、写し書きした内容ではなく、生成されたエラーレポートファイルを送信してください。GitHub の添付ファイルは 1 つにつき 20 MB までです。超える場合は分割圧縮してください。</system:String>
     <system:String x:Key="ErrorCrashDialogTitle">前回のクラッシュ原因</system:String>
     <system:String x:Key="CopyErrorMessage">エラー情報をコピーする</system:String>
+    <system:String x:Key="DiagnosticGenerateCrashReport">クラッシュ報告を作成</system:String>
+    <system:String x:Key="DiagnosticNoFailure">報告に使用できるクラッシュ記録がありません。</system:String>
+    <system:String x:Key="DiagnosticPreviousFailureTitle">実行異常の診断</system:String>
+    <system:String x:Key="DiagnosticPreviousFailurePrompt">前回の実行で問題が検出されました。診断報告を作成しますか？報告はローカルに保存され、自動送信されません。</system:String>
+    <system:String x:Key="DiagnosticTechnicalDetails">技術詳細</system:String>
+    <system:String x:Key="DiagnosticReportContents">診断報告の内容</system:String>
+    <system:String x:Key="DiagnosticDialogPrivacy">以下はすべて既定で含まれます。報告はローカルに保存され、自動送信されません。内容は匿名化されておらず、ユーザーパス、アカウント情報、ログ内の認証情報、画像、dmp が含まれる場合があります。共有前に確認してください。</system:String>
+    <system:String x:Key="DiagnosticIncludeConfiguration">設定概要を含める</system:String>
+    <system:String x:Key="DiagnosticIncludeScreenshots">障害時刻付近の画像を含める（ゲーム情報を含む場合があります）</system:String>
+    <system:String x:Key="DiagnosticIncludeDumps">メモリーダンプを含める（プロセスのメモリー情報を含む場合があります）</system:String>
+    <system:String x:Key="DiagnosticBuildReport">診断報告を作成</system:String>
+    <system:String x:Key="DiagnosticBuildingReport">診断報告を作成しています…</system:String>
+    <system:String x:Key="DiagnosticMinimalReportCreated">完全な収集で問題が発生したため、最小限の診断報告を作成しました。</system:String>
+    <system:String x:Key="DiagnosticReportFailed">診断報告を作成できませんでした。</system:String>
+    <system:String x:Key="DiagnosticDismiss">無視</system:String>
     <!--  !ErrorView  -->
     <!--  AsstProxy  -->
     <system:String x:Key="UpdateApplyFailed">更新の適用に失敗し、現在のインストールが不完全になっている可能性があります。完全パッケージを再ダウンロードし、以下の説明に従って config、data、debug を手動で移行してください。\n\n{key=FullPackageUpgradeTips}</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -1276,6 +1276,21 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="ErrorCrashMessageHelpTip">다른 사람에게 도움을 요청할 경우, 이 창의 스크린샷, 화면 녹화, 화면 사진, 촬영한 영상, 손그림, 옮겨 적은 내용이 아니라 생성된 오류 보고서 파일을 보내 주세요. GitHub 첨부파일은 1개당 20 MB까지이며, 초과 시 분할 압축해 주세요.</system:String>
     <system:String x:Key="ErrorCrashDialogTitle">마지막 충돌 원인</system:String>
     <system:String x:Key="CopyErrorMessage">오류 메시지 복사</system:String>
+    <system:String x:Key="DiagnosticGenerateCrashReport">충돌 보고서 생성</system:String>
+    <system:String x:Key="DiagnosticNoFailure">보고서에 사용할 충돌 기록이 없습니다.</system:String>
+    <system:String x:Key="DiagnosticPreviousFailureTitle">실행 오류 진단</system:String>
+    <system:String x:Key="DiagnosticPreviousFailurePrompt">이전 실행 중 문제가 감지되었습니다. 지금 진단 보고서를 생성하시겠습니까? 보고서는 로컬에 저장되며 자동 업로드되지 않습니다.</system:String>
+    <system:String x:Key="DiagnosticTechnicalDetails">기술 세부 정보</system:String>
+    <system:String x:Key="DiagnosticReportContents">진단 보고서 내용</system:String>
+    <system:String x:Key="DiagnosticDialogPrivacy">아래 항목은 기본적으로 모두 포함됩니다. 보고서는 로컬에 저장되며 자동으로 업로드되지 않습니다. 내용은 익명화되지 않으며 사용자 경로, 계정 정보, 로그의 인증 정보, 스크린샷 또는 dmp가 포함될 수 있습니다. 공유 전에 확인하세요.</system:String>
+    <system:String x:Key="DiagnosticIncludeConfiguration">설정 요약 포함</system:String>
+    <system:String x:Key="DiagnosticIncludeScreenshots">오류 시점 주변의 스크린샷 포함(게임 정보가 포함될 수 있음)</system:String>
+    <system:String x:Key="DiagnosticIncludeDumps">메모리 덤프 포함(프로세스 메모리 정보가 포함될 수 있음)</system:String>
+    <system:String x:Key="DiagnosticBuildReport">진단 보고서 생성</system:String>
+    <system:String x:Key="DiagnosticBuildingReport">진단 보고서를 생성하는 중…</system:String>
+    <system:String x:Key="DiagnosticMinimalReportCreated">전체 수집 중 문제가 발생하여 최소 진단 보고서를 생성했습니다.</system:String>
+    <system:String x:Key="DiagnosticReportFailed">진단 보고서를 생성할 수 없습니다.</system:String>
+    <system:String x:Key="DiagnosticDismiss">무시</system:String>
     <!--  !ErrorView  -->
     <!--  AsstProxy  -->
     <system:String x:Key="UpdateApplyFailed">업데이트 적용에 실패하여 현재 설치가 불완전할 수 있습니다. 전체 패키지를 다시 다운로드하고, 아래 안내에 따라 config, data 및 debug를 수동으로 옮겨 주세요.\n\n{key=FullPackageUpgradeTips}</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -1274,6 +1274,21 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="ErrorCrashMessageHelpTip">如果向他人寻求帮助，请发送生成的错误报告文件，而不是发送此窗口的截图、录屏视频、屏幕照片、拍摄的视频、手绘图片或誊抄的画面内容。上传至 GitHub 时单个附件不能超过 20 MB，超限请分卷压缩。</system:String>
     <system:String x:Key="ErrorCrashDialogTitle">上次程序崩溃原因</system:String>
     <system:String x:Key="CopyErrorMessage">复制错误信息</system:String>
+    <system:String x:Key="DiagnosticGenerateCrashReport">生成崩溃报告</system:String>
+    <system:String x:Key="DiagnosticNoFailure">没有可用于生成报告的崩溃记录。</system:String>
+    <system:String x:Key="DiagnosticPreviousFailureTitle">运行异常诊断</system:String>
+    <system:String x:Key="DiagnosticPreviousFailurePrompt">MAA 检测到上次运行异常。是否现在生成一次诊断报告？报告只保存在本地，不会自动上传。</system:String>
+    <system:String x:Key="DiagnosticTechnicalDetails">技术详情</system:String>
+    <system:String x:Key="DiagnosticReportContents">诊断报告内容</system:String>
+    <system:String x:Key="DiagnosticDialogPrivacy">以下内容默认全部包含。报告只保存在本地且不会自动上传；内容未经脱敏，可能包含用户路径、账号信息、日志凭据、截图或 dmp，分享前请自行检查。</system:String>
+    <system:String x:Key="DiagnosticIncludeConfiguration">包含配置摘要</system:String>
+    <system:String x:Key="DiagnosticIncludeScreenshots">包含故障前后的识别截图（可能含游戏信息）</system:String>
+    <system:String x:Key="DiagnosticIncludeDumps">包含内存转储 dmp（可能含进程内存信息）</system:String>
+    <system:String x:Key="DiagnosticBuildReport">生成诊断报告</system:String>
+    <system:String x:Key="DiagnosticBuildingReport">正在生成诊断报告…</system:String>
+    <system:String x:Key="DiagnosticMinimalReportCreated">完整采集遇到问题，已生成精简诊断报告。</system:String>
+    <system:String x:Key="DiagnosticReportFailed">诊断报告暂时无法生成。</system:String>
+    <system:String x:Key="DiagnosticDismiss">忽略</system:String>
     <!--  !ErrorDialogView  -->
     <!--  AsstProxy  -->
     <system:String x:Key="UpdateApplyFailed">更新失败，当前安装可能已不完整。请重新下载完整包，并按下方说明手动迁移 config、data 与 debug。\n\n{key=FullPackageUpgradeTips}</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -1275,6 +1275,21 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="ErrorCrashMessageHelpTip">若要尋求協助，請直接傳送產生的  ｢錯誤報告檔案｣ ；請勿傳送此視窗的截圖、錄影、螢幕照片、翻拍影片、手繪圖片或抄寫的內容。上傳至 GitHub 時單一附件不能超過 20 MB，超限請分卷壓縮。</system:String>
     <system:String x:Key="ErrorCrashDialogTitle">上次程式崩潰原因</system:String>
     <system:String x:Key="CopyErrorMessage">複製錯誤資訊</system:String>
+    <system:String x:Key="DiagnosticGenerateCrashReport">產生崩潰報告</system:String>
+    <system:String x:Key="DiagnosticNoFailure">沒有可用於產生報告的崩潰記錄。</system:String>
+    <system:String x:Key="DiagnosticPreviousFailureTitle">執行異常診斷</system:String>
+    <system:String x:Key="DiagnosticPreviousFailurePrompt">MAA 偵測到上次執行異常。是否現在產生一次診斷報告？報告只會保存在本機，不會自動上傳。</system:String>
+    <system:String x:Key="DiagnosticTechnicalDetails">技術詳情</system:String>
+    <system:String x:Key="DiagnosticReportContents">診斷報告內容</system:String>
+    <system:String x:Key="DiagnosticDialogPrivacy">以下內容預設全部包含。報告只保存在本機且不會自動上傳；內容未經脫敏，可能包含使用者路徑、帳號資訊、日誌憑證、截圖或 dmp，分享前請自行檢查。</system:String>
+    <system:String x:Key="DiagnosticIncludeConfiguration">包含設定摘要</system:String>
+    <system:String x:Key="DiagnosticIncludeScreenshots">包含故障前後的辨識截圖（可能含遊戲資訊）</system:String>
+    <system:String x:Key="DiagnosticIncludeDumps">包含記憶體傾印 dmp（可能含程序記憶體資訊）</system:String>
+    <system:String x:Key="DiagnosticBuildReport">產生診斷報告</system:String>
+    <system:String x:Key="DiagnosticBuildingReport">正在產生診斷報告…</system:String>
+    <system:String x:Key="DiagnosticMinimalReportCreated">完整收集發生問題，已產生精簡診斷報告。</system:String>
+    <system:String x:Key="DiagnosticReportFailed">暫時無法產生診斷報告。</system:String>
+    <system:String x:Key="DiagnosticDismiss">忽略</system:String>
     <!--  !ErrorView  -->
     <!--  AsstProxy  -->
     <system:String x:Key="UpdateApplyFailed">更新失敗，目前的安裝可能已不完整。請重新下載完整安裝檔案，並依照下方說明手動搬移 config、data 與 debug。\n\n{key=FullPackageUpgradeTips}</system:String>

--- a/src/MaaWpfGui/Services/Diagnostics/DiagnosticEnvironmentCollector.cs
+++ b/src/MaaWpfGui/Services/Diagnostics/DiagnosticEnvironmentCollector.cs
@@ -1,0 +1,62 @@
+// <copyright file="DiagnosticEnvironmentCollector.cs" company="MaaAssistantArknights">
+// Part of the MaaWpfGui project, maintained by the MaaAssistantArknights team (Maa Team)
+// Copyright (C) 2021-2025 MaaAssistantArknights Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License v3.0 only as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY
+// </copyright>
+
+#pragma warning disable SA1636
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Windows.Media;
+using MaaWpfGui.Configuration.Factory;
+using MaaWpfGui.Helper;
+
+namespace MaaWpfGui.Services.Diagnostics;
+
+internal static class DiagnosticEnvironmentCollector
+{
+    public static Dictionary<string, string> Collect()
+    {
+        var result = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["os"] = RuntimeInformation.OSDescription,
+            ["osArchitecture"] = RuntimeInformation.OSArchitecture.ToString(),
+            ["processArchitecture"] = RuntimeInformation.ProcessArchitecture.ToString(),
+            ["framework"] = RuntimeInformation.FrameworkDescription,
+            ["wpfRenderMode"] = RenderOptions.ProcessRenderMode.ToString(),
+            ["maaCorePresent"] = File.Exists(Path.Combine(PathsHelper.BaseDir, "MaaCore.dll")).ToString(),
+            ["resourcePresent"] = Directory.Exists(PathsHelper.ResourceDir).ToString(),
+            ["sessionName"] = Environment.GetEnvironmentVariable("SESSIONNAME") ?? string.Empty,
+            ["remoteDesktopSession"] = (Environment.GetEnvironmentVariable("SESSIONNAME")?.StartsWith("RDP-", StringComparison.OrdinalIgnoreCase) == true).ToString(),
+        };
+
+        TryAddConfiguration(result);
+        return result;
+    }
+
+    private static void TryAddConfiguration(IDictionary<string, string> result)
+    {
+        try
+        {
+            result["gpuInferenceEnabled"] = ConfigFactory.CurrentConfig.Gui.Performance.UseGpu.ToString();
+            result["gpuPreference"] = ConfigFactory.CurrentConfig.Gui.Performance.GpuDescription;
+            result["softwareRenderingConfigured"] = ConfigFactory.Root.Gui.IgnoreBadModulesAndUseSoftwareRendering.ToString();
+            result["locale"] = ConfigFactory.Root.Gui.Localization;
+        }
+        catch (Exception ex)
+        {
+            result["configurationProbe"] = $"unavailable:{ex.GetType().Name}";
+        }
+    }
+}

--- a/src/MaaWpfGui/Services/Diagnostics/DiagnosticNativeCrashImporter.cs
+++ b/src/MaaWpfGui/Services/Diagnostics/DiagnosticNativeCrashImporter.cs
@@ -1,0 +1,148 @@
+// <copyright file="DiagnosticNativeCrashImporter.cs" company="MaaAssistantArknights">
+// Part of the MaaWpfGui project, maintained by the MaaAssistantArknights team (Maa Team)
+// Copyright (C) 2021-2025 MaaAssistantArknights Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License v3.0 only as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY
+// </copyright>
+
+#pragma warning disable SA1636
+#nullable enable
+
+using System;
+using System.IO;
+using System.Linq;
+using MaaWpfGui.Models.Diagnostics;
+
+namespace MaaWpfGui.Services.Diagnostics;
+
+internal sealed class DiagnosticNativeCrashImporter
+{
+    private readonly DiagnosticStateStore _store;
+
+    internal DiagnosticNativeCrashImporter(DiagnosticStateStore store)
+    {
+        _store = store;
+    }
+
+    internal DiagnosticFailure? Import(
+        string sourcePath,
+        string sourceKind,
+        string details,
+        DiagnosticFailure nativeFailure)
+    {
+        var history = _store.GetHistory();
+
+        // native 日志通常在托管异常记录之后才由下次启动导入，优先并入同一时间附近的记录，
+        // 使归档日志、待处理状态和最终报告始终使用同一个 Case ID。
+        var managedRecord = history.FirstOrDefault(failure =>
+            failure.Source is DiagnosticSource.Dispatcher or DiagnosticSource.AppDomain &&
+            Math.Abs((failure.TimestampUtc - nativeFailure.TimestampUtc).TotalSeconds) <= 10);
+        var existingNativeRecord = history.FirstOrDefault(failure =>
+            string.Equals(failure.Source, DiagnosticSource.NativeCrash, StringComparison.Ordinal) &&
+            string.Equals(failure.Fingerprint, nativeFailure.Fingerprint, StringComparison.Ordinal) &&
+            Math.Abs((failure.TimestampUtc - nativeFailure.TimestampUtc).TotalSeconds) <= 5);
+        var finalRecord = managedRecord ?? existingNativeRecord ?? nativeFailure;
+
+        string safeCaseId = DiagnosticPathSafety.FileNamePart(finalRecord.CaseId, "unknown-case", 64);
+        string archivedName = $"crash-{safeCaseId}-{sourceKind}.log";
+        var archiveResult = ArchiveCrashLogAtomically(sourcePath, archivedName);
+        string evidenceValue = $"{sourceKind}/{Path.GetFileName(sourcePath)}";
+        if (!finalRecord.Evidence.Any(item =>
+                string.Equals(item.Kind, "nativeCrashLog", StringComparison.Ordinal) &&
+                string.Equals(item.Value, evidenceValue, StringComparison.Ordinal)))
+        {
+            finalRecord.Evidence.Add(new("nativeCrashLog", evidenceValue));
+        }
+
+        string detailMarker = $"--- Native crash record ({sourceKind}) ---";
+        if (!finalRecord.TechnicalDetails.Contains(detailMarker, StringComparison.Ordinal))
+        {
+            string currentDetails = finalRecord.TechnicalDetails.Trim();
+            string importedDetails = details.Trim();
+            finalRecord.TechnicalDetails = string.Equals(currentDetails, importedDetails, StringComparison.Ordinal)
+                ? $"{detailMarker}{Environment.NewLine}{details}"
+                : $"{finalRecord.TechnicalDetails}{Environment.NewLine}{Environment.NewLine}{detailMarker}{Environment.NewLine}{details}";
+        }
+
+        var writeResult = managedRecord is not null || existingNativeRecord is not null
+            ? _store.UpdateFailure(finalRecord)
+            : _store.RecordFailure(finalRecord);
+
+        // 只有历史记录确认落盘后才能删除源日志；否则保留现场，供下次启动重新导入。
+        if (!writeResult.HistoryWritten)
+        {
+            if (archiveResult.Created)
+            {
+                DeleteBestEffort(archiveResult.Path);
+            }
+
+            return null;
+        }
+
+        DeleteBestEffort(sourcePath);
+        CleanupArchiveRetentionBestEffort();
+        return finalRecord;
+    }
+
+    private NativeArchiveResult ArchiveCrashLogAtomically(string sourcePath, string archivedName)
+    {
+        string destinationDirectory = Path.Combine(_store.DirectoryPath, "native");
+        Directory.CreateDirectory(destinationDirectory);
+        string destinationPath = Path.Combine(destinationDirectory, archivedName);
+        if (File.Exists(destinationPath))
+        {
+            return new(destinationPath, Created: false);
+        }
+
+        string temporaryPath = $"{destinationPath}.{Environment.ProcessId}.{Guid.NewGuid():N}.tmp";
+        try
+        {
+            File.Copy(sourcePath, temporaryPath, true);
+            File.Move(temporaryPath, destinationPath);
+            return new(destinationPath, Created: true);
+        }
+        finally
+        {
+            DeleteBestEffort(temporaryPath);
+        }
+    }
+
+    private void CleanupArchiveRetentionBestEffort()
+    {
+        try
+        {
+            string destinationDirectory = Path.Combine(_store.DirectoryPath, "native");
+            var cutoff = DateTime.UtcNow.AddDays(-30);
+            foreach (var oldFile in new DirectoryInfo(destinationDirectory).EnumerateFiles("crash-*.log")
+                         .OrderByDescending(static file => file.LastWriteTimeUtc)
+                         .Where((file, index) => index >= 20 || file.LastWriteTimeUtc < cutoff))
+            {
+                DeleteBestEffort(oldFile.FullName);
+            }
+        }
+        catch
+        {
+            // Retention cleanup must never turn a successfully imported crash into a failure.
+        }
+    }
+
+    private static void DeleteBestEffort(string path)
+    {
+        try
+        {
+            File.Delete(path);
+        }
+        catch
+        {
+            // The imported record and source log remain sufficient for a later retry.
+        }
+    }
+
+    private sealed record NativeArchiveResult(string Path, bool Created);
+}

--- a/src/MaaWpfGui/Services/Diagnostics/DiagnosticNativeCrashLog.cs
+++ b/src/MaaWpfGui/Services/Diagnostics/DiagnosticNativeCrashLog.cs
@@ -1,0 +1,145 @@
+// <copyright file="DiagnosticNativeCrashLog.cs" company="MaaAssistantArknights">
+// Part of the MaaWpfGui project, maintained by the MaaAssistantArknights team (Maa Team)
+// Copyright (C) 2021-2025 MaaAssistantArknights Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License v3.0 only as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY
+// </copyright>
+
+#pragma warning disable SA1636
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace MaaWpfGui.Services.Diagnostics;
+
+internal static class DiagnosticNativeCrashLog
+{
+    private const int SectionByteLimit = 512 * 1024;
+    private const string TruncationMarker = "[middle of native crash log omitted by diagnostics]";
+    private static readonly string[] KnownModules =
+    [
+        "MaaCore",
+        "DirectML",
+        "onnxruntime",
+        "MilCore",
+        "NahimicOSD",
+        "AudioDevProps2",
+        "GTII-OSD64",
+        "GTIII-OSD64",
+    ];
+
+    internal static string ReadBounded(string path)
+    {
+        using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+        long length = stream.Length;
+        if (length <= SectionByteLimit * 2L)
+        {
+            return Decode(ReadAtMost(stream, checked((int)length)));
+        }
+
+        byte[] head = ReadAtMost(stream, SectionByteLimit);
+        stream.Seek(Math.Max(head.Length, length - SectionByteLimit), SeekOrigin.Begin);
+        byte[] tail = ReadAtMost(stream, SectionByteLimit);
+        return $"{Decode(head)}{Environment.NewLine}{TruncationMarker}{Environment.NewLine}{Decode(tail)}";
+    }
+
+    internal static string GetLatestRecord(string details)
+    {
+        const string header = "=== FATAL ERROR ===";
+        int index = details.LastIndexOf(header, StringComparison.OrdinalIgnoreCase);
+        return index >= 0 ? details[index..] : details;
+    }
+
+    internal static string GetMessage(string details)
+    {
+        string[] lines = details.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries);
+        string? reason = lines.LastOrDefault(static line => line.StartsWith("Reason:", StringComparison.OrdinalIgnoreCase));
+        string? detail = lines.LastOrDefault(static line => line.StartsWith("Detail:", StringComparison.OrdinalIgnoreCase));
+        string reasonText = ValueAfterColon(reason);
+        string detailText = ValueAfterColon(detail);
+        string message = string.IsNullOrWhiteSpace(detailText)
+            ? reasonText
+            : $"{reasonText}: {detailText}".TrimStart(' ', ':');
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            return "Native crash record found";
+        }
+
+        return message.Length <= 500 ? message : message[..500];
+    }
+
+    internal static string[] GetRelevantModules(string details) => KnownModules
+        .Where(module => details.Contains(module, StringComparison.OrdinalIgnoreCase))
+        .ToArray();
+
+    internal static string GetFingerprintDetail(string details)
+    {
+        string[] keys = ["ExceptionCode", "FaultingModule", "ModuleOffset", "AccessType"];
+        var parts = new List<string>(keys.Length);
+        foreach (string key in keys)
+        {
+            string value = GetField(details, key);
+            if (key == "FaultingModule")
+            {
+                value = value.Replace('\\', '/').Split('/').LastOrDefault() ?? value;
+            }
+
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                parts.Add($"{key}={value}");
+            }
+        }
+
+        return parts.Count > 0 ? string.Join('|', parts) : GetMessage(details);
+    }
+
+    private static byte[] ReadAtMost(Stream stream, int byteLimit)
+    {
+        var buffer = new byte[byteLimit];
+        int total = 0;
+        while (total < buffer.Length)
+        {
+            int count = stream.Read(buffer, total, buffer.Length - total);
+            if (count == 0)
+            {
+                break;
+            }
+
+            total += count;
+        }
+
+        return total == buffer.Length ? buffer : buffer[..total];
+    }
+
+    private static string Decode(byte[] bytes) => Encoding.UTF8.GetString(bytes);
+
+    private static string ValueAfterColon(string? value)
+    {
+        int index = value?.IndexOf(':') ?? -1;
+        return index >= 0 ? value![(index + 1)..].Trim() : string.Empty;
+    }
+
+    private static string GetField(string details, string key)
+    {
+        string prefix = $"{key}:";
+        int start = details.LastIndexOf(prefix, StringComparison.OrdinalIgnoreCase);
+        if (start < 0)
+        {
+            return string.Empty;
+        }
+
+        start += prefix.Length;
+        int end = details.IndexOfAny([';', '\r', '\n'], start);
+        return details[start..(end < 0 ? details.Length : end)].Trim();
+    }
+}

--- a/src/MaaWpfGui/Services/Diagnostics/DiagnosticPathSafety.cs
+++ b/src/MaaWpfGui/Services/Diagnostics/DiagnosticPathSafety.cs
@@ -1,0 +1,43 @@
+// <copyright file="DiagnosticPathSafety.cs" company="MaaAssistantArknights">
+// Part of the MaaWpfGui project, maintained by the MaaAssistantArknights team (Maa Team)
+// Copyright (C) 2021-2025 MaaAssistantArknights Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License v3.0 only as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY
+// </copyright>
+
+#pragma warning disable SA1636
+#nullable enable
+
+using System;
+using System.IO;
+using System.Linq;
+
+namespace MaaWpfGui.Services.Diagnostics;
+
+internal static class DiagnosticPathSafety
+{
+    internal static string FileNamePart(string? value, string fallback, int maxLength)
+    {
+        char[] invalid = Path.GetInvalidFileNameChars();
+        string sanitized = new((value ?? string.Empty)
+            .Where(character => !invalid.Contains(character) &&
+                                character != Path.DirectorySeparatorChar &&
+                                character != Path.AltDirectorySeparatorChar &&
+                                !char.IsControl(character))
+            .Select(character => char.IsWhiteSpace(character) ? '-' : character)
+            .ToArray());
+        sanitized = sanitized.Trim('.', '-', '_');
+        if (string.IsNullOrWhiteSpace(sanitized))
+        {
+            sanitized = fallback;
+        }
+
+        return sanitized.Length <= maxLength ? sanitized : sanitized[..maxLength];
+    }
+}

--- a/src/MaaWpfGui/Services/Diagnostics/DiagnosticReportAttachmentWriter.cs
+++ b/src/MaaWpfGui/Services/Diagnostics/DiagnosticReportAttachmentWriter.cs
@@ -1,0 +1,266 @@
+// <copyright file="DiagnosticReportAttachmentWriter.cs" company="MaaAssistantArknights">
+// Part of the MaaWpfGui project, maintained by the MaaAssistantArknights team (Maa Team)
+// Copyright (C) 2021-2025 MaaAssistantArknights Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License v3.0 only as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY
+// </copyright>
+
+#pragma warning disable SA1636
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using MaaWpfGui.Models.Diagnostics;
+
+namespace MaaWpfGui.Services.Diagnostics;
+
+internal sealed class DiagnosticReportAttachmentWriter
+{
+    private const long MaxPartBytes = 20L * 1024L * 1024L;
+    private readonly string _baseDirectory;
+
+    internal DiagnosticReportAttachmentWriter(string baseDirectory)
+    {
+        _baseDirectory = baseDirectory;
+    }
+
+    internal DiagnosticAttachmentBuildResult Build(
+        string transactionDirectory,
+        string reportFileStem,
+        DiagnosticFailure failure,
+        DiagnosticReportOptions options)
+    {
+        string stagingDirectory = Path.Combine(transactionDirectory, "attachments");
+        Directory.CreateDirectory(stagingDirectory);
+        var collection = new DiagnosticCollectionStatus();
+        var candidates = new List<AttachmentCandidate>();
+        DiscoverCategory(
+            collection.Screenshots,
+            options.IncludeScreenshots,
+            Path.Combine(_baseDirectory, "debug"),
+            "screenshots",
+            failure.TimestampUtc,
+            new HashSet<string>([".png", ".jpg", ".jpeg"], StringComparer.OrdinalIgnoreCase),
+            candidates);
+        DiscoverCategory(
+            collection.Dumps,
+            options.IncludeDumps,
+            Path.Combine(_baseDirectory, "debug", "dumps"),
+            "dumps",
+            failure.TimestampUtc,
+            new HashSet<string>([".dmp"], StringComparer.OrdinalIgnoreCase),
+            candidates);
+        DiscoverCategory(
+            collection.Dumps,
+            options.IncludeDumps,
+            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "CrashDumps"),
+            "dumps/windows-crash-dumps",
+            failure.TimestampUtc,
+            new HashSet<string>([".dmp"], StringComparer.OrdinalIgnoreCase),
+            candidates,
+            "MAA*.dmp");
+
+        var staged = new List<StagedAttachment>();
+        int attachmentIndex = 0;
+        foreach (var candidate in candidates
+                     .DistinctBy(static item => item.SourcePath, StringComparer.OrdinalIgnoreCase)
+                     .OrderBy(static item => item.EntryName, StringComparer.OrdinalIgnoreCase))
+        {
+            var itemStatus = new DiagnosticAttachmentStatus
+            {
+                EntryName = candidate.EntryName,
+                Size = candidate.Length,
+                Status = "error",
+            };
+            collection.Attachments.Add(itemStatus);
+            string stagedPath = Path.Combine(stagingDirectory, $"{attachmentIndex++:D6}.bin");
+            try
+            {
+                // 先完整复制并刷盘，再让附件进入分卷；源文件被占用或中途读取失败时不会留下半截 ZIP 条目。
+                using var source = new FileStream(candidate.SourcePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+                using var destination = new FileStream(stagedPath, FileMode.CreateNew, FileAccess.Write, FileShare.None);
+                source.CopyTo(destination);
+                destination.Flush(flushToDisk: true);
+                staged.Add(new(stagedPath, candidate.EntryName, destination.Length, itemStatus));
+                itemStatus.Size = destination.Length;
+                itemStatus.Status = "staged";
+            }
+            catch (Exception ex)
+            {
+                DeleteBestEffort(stagedPath);
+                itemStatus.ExceptionType = ex.GetType().FullName ?? ex.GetType().Name;
+                itemStatus.ExceptionMessage = ex.Message;
+            }
+        }
+
+        var partPaths = new List<string>();
+        int partNumber = 2;
+        int index = 0;
+        while (index < staged.Count)
+        {
+            var partItems = new List<StagedAttachment>();
+            long currentBytes = 0;
+            while (index < staged.Count)
+            {
+                var next = staged[index];
+                if (partItems.Count > 0 && currentBytes + next.Length > MaxPartBytes)
+                {
+                    break;
+                }
+
+                partItems.Add(next);
+                currentBytes += next.Length;
+                index++;
+                if (next.Length > MaxPartBytes)
+                {
+                    break;
+                }
+            }
+
+            string partFileName = $"{reportFileStem}_part{partNumber++:00}.zip";
+            string partPath = Path.Combine(transactionDirectory, partFileName);
+            using (var archive = ZipFile.Open(partPath, ZipArchiveMode.Create))
+            {
+                foreach (var item in partItems)
+                {
+                    archive.CreateEntryFromFile(item.StagedPath, item.EntryName, CompressionLevel.SmallestSize);
+                    item.Status.Status = "included";
+                    item.Status.PartFileName = partFileName;
+                }
+            }
+
+            ValidateArchive(partPath);
+            partPaths.Add(partPath);
+        }
+
+        DeleteDirectoryBestEffort(stagingDirectory);
+        UpdateSummary(collection.Screenshots, collection.Attachments, "screenshots/");
+        UpdateSummary(collection.Dumps, collection.Attachments, "dumps/");
+        return new(partPaths, collection);
+    }
+
+    private static void DiscoverCategory(
+        DiagnosticAttachmentCategoryStatus category,
+        bool requested,
+        string directory,
+        string entryRoot,
+        DateTimeOffset timestamp,
+        IReadOnlySet<string> extensions,
+        ICollection<AttachmentCandidate> destination,
+        string searchPattern = "*")
+    {
+        category.Requested |= requested;
+        if (!requested)
+        {
+            category.Status = "not-requested";
+            return;
+        }
+
+        if (!Directory.Exists(directory))
+        {
+            return;
+        }
+
+        var start = timestamp.LocalDateTime.AddMinutes(-10);
+        var end = timestamp.LocalDateTime.AddMinutes(10);
+        try
+        {
+            foreach (string path in Directory.EnumerateFiles(directory, searchPattern, SearchOption.AllDirectories))
+            {
+                var info = new FileInfo(path);
+                if (!extensions.Contains(info.Extension) || info.LastWriteTime < start || info.LastWriteTime > end)
+                {
+                    continue;
+                }
+
+                string relativePath = Path.GetRelativePath(directory, info.FullName).Replace('\\', '/');
+                string entryName = NormalizeEntryName($"{entryRoot}/{relativePath}");
+                destination.Add(new(info.FullName, entryName, info.Length));
+                category.CandidatesFound++;
+            }
+
+            if (category.Status != "error")
+            {
+                category.Status = "success";
+            }
+        }
+        catch (Exception ex)
+        {
+            category.Status = "error";
+            category.ExceptionType = ex.GetType().FullName ?? ex.GetType().Name;
+            category.ExceptionMessage = ex.Message;
+        }
+    }
+
+    private static string NormalizeEntryName(string entryName)
+    {
+        string normalized = entryName.Replace('\\', '/').TrimStart('/');
+        if (Path.IsPathRooted(normalized) || normalized.Split('/').Any(static segment => segment is ".." or "." or ""))
+        {
+            throw new InvalidDataException("An attachment entry contained an unsafe relative path.");
+        }
+
+        return normalized;
+    }
+
+    private static void UpdateSummary(
+        DiagnosticAttachmentCategoryStatus category,
+        IEnumerable<DiagnosticAttachmentStatus> attachments,
+        string prefix)
+    {
+        var matching = attachments.Where(item => item.EntryName.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)).ToList();
+        category.Included = matching.Count(static item => item.Status == "included");
+        category.Failed = matching.Count(static item => item.Status == "error");
+    }
+
+    private static void ValidateArchive(string path)
+    {
+        using var archive = ZipFile.OpenRead(path);
+        foreach (var entry in archive.Entries)
+        {
+            using var stream = entry.Open();
+            stream.CopyTo(Stream.Null);
+        }
+    }
+
+    private static void DeleteBestEffort(string path)
+    {
+        try
+        {
+            File.Delete(path);
+        }
+        catch
+        {
+            // The transaction directory cleanup gets another chance to remove this file.
+        }
+    }
+
+    private static void DeleteDirectoryBestEffort(string path)
+    {
+        try
+        {
+            Directory.Delete(path, recursive: true);
+        }
+        catch
+        {
+            // The transaction directory cleanup gets another chance to remove staged data.
+        }
+    }
+
+    private sealed record AttachmentCandidate(string SourcePath, string EntryName, long Length);
+
+    private sealed record StagedAttachment(
+        string StagedPath,
+        string EntryName,
+        long Length,
+        DiagnosticAttachmentStatus Status);
+}

--- a/src/MaaWpfGui/Services/Diagnostics/DiagnosticReportRuntimeCollector.cs
+++ b/src/MaaWpfGui/Services/Diagnostics/DiagnosticReportRuntimeCollector.cs
@@ -1,0 +1,193 @@
+// <copyright file="DiagnosticReportRuntimeCollector.cs" company="MaaAssistantArknights">
+// Part of the MaaWpfGui project, maintained by the MaaAssistantArknights team (Maa Team)
+// Copyright (C) 2021-2025 MaaAssistantArknights Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License v3.0 only as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY
+// </copyright>
+
+#pragma warning disable SA1636
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Runtime;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+
+namespace MaaWpfGui.Services.Diagnostics;
+
+internal sealed class DiagnosticReportRuntimeCollector
+{
+    private readonly string _baseDirectory;
+
+    internal DiagnosticReportRuntimeCollector(string baseDirectory)
+    {
+        _baseDirectory = baseDirectory;
+    }
+
+    internal static Dictionary<string, object?> CollectProcessRuntime()
+    {
+        var result = new Dictionary<string, object?>
+        {
+            ["capturedAtUtc"] = DateTimeOffset.UtcNow,
+            ["frameworkDescription"] = RuntimeInformation.FrameworkDescription,
+            ["runtimeIdentifier"] = RuntimeInformation.RuntimeIdentifier,
+            ["osDescription"] = RuntimeInformation.OSDescription,
+            ["osArchitecture"] = RuntimeInformation.OSArchitecture.ToString(),
+            ["processArchitecture"] = RuntimeInformation.ProcessArchitecture.ToString(),
+            ["environmentVersion"] = Environment.Version.ToString(),
+            ["processorCount"] = Environment.ProcessorCount,
+            ["is64BitOperatingSystem"] = Environment.Is64BitOperatingSystem,
+            ["is64BitProcess"] = Environment.Is64BitProcess,
+            ["isServerGc"] = GCSettings.IsServerGC,
+            ["gcLatencyMode"] = GCSettings.LatencyMode.ToString(),
+            ["currentCulture"] = CultureInfo.CurrentCulture.Name,
+            ["currentUiCulture"] = CultureInfo.CurrentUICulture.Name,
+            ["timeZone"] = TimeZoneInfo.Local.Id,
+            ["commandLine"] = Environment.CommandLine,
+            ["baseDirectory"] = AppContext.BaseDirectory,
+            ["currentDirectory"] = Environment.CurrentDirectory,
+            ["systemUptime"] = TimeSpan.FromMilliseconds(Environment.TickCount64).ToString(),
+        };
+
+        try
+        {
+            using var process = Process.GetCurrentProcess();
+            result["processId"] = process.Id;
+            result["processName"] = process.ProcessName;
+            result["processStartTimeUtc"] = process.StartTime.ToUniversalTime();
+            result["processUptime"] = DateTime.UtcNow - process.StartTime.ToUniversalTime();
+            result["workingSetBytes"] = process.WorkingSet64;
+            result["privateMemoryBytes"] = process.PrivateMemorySize64;
+            result["virtualMemoryBytes"] = process.VirtualMemorySize64;
+            result["handleCount"] = process.HandleCount;
+            result["threadCount"] = process.Threads.Count;
+        }
+        catch (Exception ex)
+        {
+            result["processProbe"] = $"unavailable:{ex.GetType().Name}";
+        }
+
+        return result;
+    }
+
+    internal static IReadOnlyList<Dictionary<string, object?>> CollectLoadedModules()
+    {
+        var result = new List<Dictionary<string, object?>>();
+        try
+        {
+            using var process = Process.GetCurrentProcess();
+            foreach (ProcessModule module in process.Modules)
+            {
+                try
+                {
+                    var version = module.FileVersionInfo;
+                    result.Add(new()
+                    {
+                        ["moduleName"] = module.ModuleName,
+                        ["fileName"] = module.FileName,
+                        ["fileVersion"] = version.FileVersion,
+                        ["productVersion"] = version.ProductVersion,
+                        ["companyName"] = version.CompanyName,
+                        ["fileDescription"] = version.FileDescription,
+                        ["moduleMemorySize"] = module.ModuleMemorySize,
+                        ["baseAddress"] = $"0x{module.BaseAddress.ToInt64():X}",
+                    });
+                }
+                catch (Exception ex)
+                {
+                    result.Add(new() { ["moduleName"] = module.ModuleName, ["probe"] = $"unavailable:{ex.GetType().Name}" });
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            result.Add(new() { ["moduleEnumeration"] = $"unavailable:{ex.GetType().Name}" });
+        }
+
+        return result.OrderBy(static item => item.GetValueOrDefault("moduleName")?.ToString(), StringComparer.OrdinalIgnoreCase).ToList();
+    }
+
+    internal IReadOnlyList<Dictionary<string, object?>> CollectApplicationFiles()
+    {
+        var result = new List<Dictionary<string, object?>>();
+        string[] fileNames;
+        try
+        {
+            fileNames = Directory.Exists(_baseDirectory)
+                ? Directory.EnumerateFiles(_baseDirectory, "*", SearchOption.TopDirectoryOnly)
+                    .Where(IsRelevantApplicationFile)
+                    .Select(Path.GetFileName)
+                    .Where(static name => !string.IsNullOrWhiteSpace(name))
+                    .Cast<string>()
+                    .OrderBy(static name => name, StringComparer.OrdinalIgnoreCase)
+                    .ToArray()
+                : [];
+        }
+        catch (Exception ex)
+        {
+            return [new() { ["applicationFileEnumeration"] = $"unavailable:{ex.GetType().Name}" }];
+        }
+
+        foreach (string fileName in fileNames)
+        {
+            string path = Path.Combine(_baseDirectory, fileName);
+            var item = new Dictionary<string, object?> { ["name"] = fileName, ["exists"] = File.Exists(path) };
+            if (File.Exists(path))
+            {
+                try
+                {
+                    var info = new FileInfo(path);
+                    var version = FileVersionInfo.GetVersionInfo(path);
+                    using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+                    item["length"] = info.Length;
+                    item["lastWriteTimeUtc"] = info.LastWriteTimeUtc;
+                    item["fileVersion"] = version.FileVersion;
+                    item["productVersion"] = version.ProductVersion;
+                    item["sha256"] = Convert.ToHexString(SHA256.HashData(stream));
+                }
+                catch (Exception ex)
+                {
+                    item["probe"] = $"unavailable:{ex.GetType().Name}";
+                }
+            }
+
+            result.Add(item);
+        }
+
+        return result;
+    }
+
+    private static bool IsRelevantApplicationFile(string path)
+    {
+        string fileName = Path.GetFileName(path);
+        string extension = Path.GetExtension(fileName);
+        if (!extension.Equals(".dll", StringComparison.OrdinalIgnoreCase) &&
+            !extension.Equals(".exe", StringComparison.OrdinalIgnoreCase) &&
+            !extension.Equals(".json", StringComparison.OrdinalIgnoreCase) &&
+            !extension.Equals(".pdb", StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        return fileName.StartsWith("MAA", StringComparison.OrdinalIgnoreCase) ||
+               fileName.StartsWith("Maa", StringComparison.OrdinalIgnoreCase) ||
+               fileName.Contains("DirectML", StringComparison.OrdinalIgnoreCase) ||
+               fileName.Contains("onnxruntime", StringComparison.OrdinalIgnoreCase) ||
+               fileName.Contains("opencv", StringComparison.OrdinalIgnoreCase) ||
+               fileName.Contains("fastdeploy", StringComparison.OrdinalIgnoreCase) ||
+               fileName.Contains("vcruntime", StringComparison.OrdinalIgnoreCase) ||
+               fileName.Contains("D3DCompiler", StringComparison.OrdinalIgnoreCase) ||
+               fileName.Equals("libloader.dll", StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/MaaWpfGui/Services/Diagnostics/DiagnosticReportService.cs
+++ b/src/MaaWpfGui/Services/Diagnostics/DiagnosticReportService.cs
@@ -1,0 +1,671 @@
+// <copyright file="DiagnosticReportService.cs" company="MaaAssistantArknights">
+// Part of the MaaWpfGui project, maintained by the MaaAssistantArknights team (Maa Team)
+// Copyright (C) 2021-2025 MaaAssistantArknights Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License v3.0 only as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY
+// </copyright>
+
+#pragma warning disable SA1636
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using MaaWpfGui.Models.Diagnostics;
+
+namespace MaaWpfGui.Services.Diagnostics;
+
+internal sealed class DiagnosticReportService
+{
+    private const int MaxTextCharacters = 4_000_000;
+    private const int TailLineCount = 500;
+    private const string SharingWarning = "This report is stored locally and is not uploaded automatically. Its contents are not sanitized and may include user paths, account information, credentials from logs, screenshots, or dumps. Review it before sharing.";
+    private const string TransactionDirectoryPrefix = ".maa-diagnostic-transaction-";
+    private readonly string _baseDirectory;
+    private readonly string _reportsDirectory;
+    private readonly DiagnosticStateStore _store;
+    private readonly DiagnosticReportRuntimeCollector _runtimeCollector;
+    private readonly DiagnosticReportAttachmentWriter _attachmentWriter;
+    private readonly SemaphoreSlim _buildGate = new(1, 1);
+    private readonly JsonSerializerOptions _jsonOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase, WriteIndented = true };
+
+    internal DiagnosticReportService(string baseDirectory, string reportsDirectory, DiagnosticStateStore store)
+    {
+        _baseDirectory = baseDirectory;
+        _reportsDirectory = reportsDirectory;
+        _store = store;
+        _runtimeCollector = new(baseDirectory);
+        _attachmentWriter = new(baseDirectory);
+    }
+
+    internal async Task<DiagnosticReportResult> BuildAsync(
+        DiagnosticFailure failure,
+        DiagnosticReportOptions? options = null)
+    {
+        // 报告文件名、事务目录和分卷发布共享同一输出位置，串行化可避免重复点击造成发布竞争。
+        await _buildGate.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            return await Task.Run(() => BuildCore(failure, options ?? new())).ConfigureAwait(false);
+        }
+        finally
+        {
+            _buildGate.Release();
+        }
+    }
+
+    private DiagnosticReportResult BuildCore(DiagnosticFailure failure, DiagnosticReportOptions options)
+    {
+        failure.Evidence ??= [];
+        failure.Environment ??= new(StringComparer.OrdinalIgnoreCase);
+        var outputFailures = new List<Exception>();
+        foreach (string reportsDirectory in GetOutputDirectories())
+        {
+            try
+            {
+                return BuildFullReport(reportsDirectory, failure, options);
+            }
+            catch (Exception fullReportException)
+            {
+                try
+                {
+                    return BuildMinimalReport(reportsDirectory, failure, fullReportException);
+                }
+                catch (Exception minimalException)
+                {
+                    outputFailures.Add(new AggregateException(fullReportException, minimalException));
+                }
+            }
+        }
+
+        throw new IOException("No writable location was available for the diagnostic report.", new AggregateException(outputFailures));
+    }
+
+    private DiagnosticReportResult BuildFullReport(
+        string reportsDirectory,
+        DiagnosticFailure failure,
+        DiagnosticReportOptions options)
+    {
+        Directory.CreateDirectory(reportsDirectory);
+        CleanupStaleTransactions(reportsDirectory);
+        string reportFileStem = CreateReportFileStem(failure);
+        string outputPath = Path.Combine(reportsDirectory, $"{reportFileStem}.zip");
+
+        // 事务目录放在目标目录内，确保最终发布是同卷移动，并将所有半成品限制在可统一清理的范围内。
+        string transactionDirectory = Path.Combine(reportsDirectory, $"{TransactionDirectoryPrefix}{Guid.NewGuid():N}.tmpdir");
+        Directory.CreateDirectory(transactionDirectory);
+        var publishedParts = new List<string>();
+        try
+        {
+            DiagnosticAttachmentBuildResult attachmentResult;
+            try
+            {
+                attachmentResult = _attachmentWriter.Build(transactionDirectory, reportFileStem, failure, options);
+            }
+            catch (Exception ex)
+            {
+                DeleteDirectoryContentsBestEffort(transactionDirectory);
+                attachmentResult = CreateFailedAttachmentResult(options, ex);
+            }
+
+            var status = attachmentResult.CollectionStatus;
+            var entries = CollectMainEntries(failure, options, status);
+            var manifest = CreateManifest(failure, options, "full", attachmentResult.TemporaryPartPaths.Count);
+            entries.Insert(0, new("report-manifest.json", JsonSerializer.Serialize(manifest, _jsonOptions)));
+            entries.Add(new("diagnostics/collection-status.json", JsonSerializer.Serialize(status, _jsonOptions)));
+
+            string temporaryMainPath = Path.Combine(transactionDirectory, $"{reportFileStem}.zip");
+            WriteArchive(temporaryMainPath, entries);
+            ValidateArchive(temporaryMainPath);
+
+            // 先发布附件分卷，主 ZIP 最后发布并作为事务完成标记；主 ZIP 失败时回滚本轮分卷。
+            foreach (string temporaryPartPath in attachmentResult.TemporaryPartPaths)
+            {
+                string finalPartPath = Path.Combine(reportsDirectory, Path.GetFileName(temporaryPartPath));
+                File.Move(temporaryPartPath, finalPartPath);
+                publishedParts.Add(finalPartPath);
+            }
+
+            File.Move(temporaryMainPath, outputPath);
+            return new(outputPath, publishedParts, IsMinimal: false);
+        }
+        catch
+        {
+            foreach (string publishedPart in publishedParts)
+            {
+                DeleteBestEffort(publishedPart);
+            }
+
+            throw;
+        }
+        finally
+        {
+            DeleteDirectoryBestEffort(transactionDirectory);
+        }
+    }
+
+    private DiagnosticReportResult BuildMinimalReport(
+        string reportsDirectory,
+        DiagnosticFailure failure,
+        Exception reportException)
+    {
+        Directory.CreateDirectory(reportsDirectory);
+        string reportFileStem = $"{CreateReportFileStem(failure)}_minimal";
+        string outputPath = Path.Combine(reportsDirectory, $"{reportFileStem}.zip");
+        string temporaryPath = Path.Combine(reportsDirectory, $".{reportFileStem}.{Guid.NewGuid():N}.tmp");
+        var manifest = CreateManifest(failure, new(), "minimal", 0);
+        var summary = new StringBuilder()
+            .AppendLine($"Case ID: {failure.CaseId}")
+            .AppendLine($"Error code: {failure.Code}")
+            .AppendLine($"Time: {failure.TimestampUtc:O}")
+            .AppendLine($"Exception: {failure.ExceptionType}")
+            .AppendLine($"Message: {failure.Message}")
+            .AppendLine()
+            .AppendLine("--- Original technical details ---")
+            .AppendLine(failure.TechnicalDetails)
+            .ToString();
+        var error = $"{reportException.GetType().FullName}: {reportException.Message}{Environment.NewLine}{reportException}";
+
+        try
+        {
+            WriteArchive(temporaryPath,
+            [
+                new("report-manifest.json", JsonSerializer.Serialize(manifest, _jsonOptions)),
+                new("failure-summary.txt", summary),
+                new("report-generation-error.txt", error),
+            ]);
+            ValidateArchive(temporaryPath);
+            File.Move(temporaryPath, outputPath);
+            return new(outputPath, [], IsMinimal: true);
+        }
+        finally
+        {
+            DeleteBestEffort(temporaryPath);
+        }
+    }
+
+    private List<ReportTextEntry> CollectMainEntries(
+        DiagnosticFailure failure,
+        DiagnosticReportOptions options,
+        DiagnosticCollectionStatus status)
+    {
+        var entries = new List<ReportTextEntry>
+        {
+            new("failure.json", JsonSerializer.Serialize(failure, _jsonOptions)),
+            new("issue.md", BuildIssueMarkdown(failure)),
+        };
+        CollectJson(entries, status, "failureHistory", "diagnostics/failure-history.json", _store.GetHistoryForReport);
+        CollectJson(entries, status, "processRuntime", "runtime/process.json", DiagnosticReportRuntimeCollector.CollectProcessRuntime);
+        CollectJson(entries, status, "loadedModules", "runtime/loaded-modules.json", DiagnosticReportRuntimeCollector.CollectLoadedModules);
+        CollectJson(entries, status, "applicationFiles", "runtime/application-files.json", _runtimeCollector.CollectApplicationFiles);
+
+        AddLog(entries, status, Path.Combine(_baseDirectory, "debug", "gui.log"), "logs/gui.log", failure, required: true);
+        AddLog(entries, status, Path.Combine(_baseDirectory, "debug", "asst.log"), "logs/asst.log", failure, required: true);
+        AddLog(entries, status, Path.Combine(_baseDirectory, "debug", "gui.bak.log"), "logs/gui.bak.log", failure);
+        AddLog(entries, status, Path.Combine(_baseDirectory, "debug", "asst.bak.log"), "logs/asst.bak.log", failure);
+        AddNativeLogs(entries, status, failure);
+        AddLog(entries, status, Path.Combine(_baseDirectory, "crash.log"), "logs/unconsumed-crash.log", failure);
+        AddLog(entries, status, Path.Combine(_baseDirectory, "debug", "crash.log"), "logs/unconsumed-debug-crash.log", failure);
+
+        AddTextFile(entries, status, Path.Combine(_baseDirectory, "MAA.runtimeconfig.json"), "application/MAA.runtimeconfig.json");
+        AddTextFile(entries, status, Path.Combine(_baseDirectory, "MAA.deps.json"), "application/MAA.deps.json");
+        AddTextFile(entries, status, Path.Combine(_baseDirectory, "resource", "version.json"), "application/resource-version.json");
+
+        if (options.IncludeConfigurationSummary)
+        {
+            var summary = new Dictionary<string, string> {
+                ["locale"] = failure.Environment.GetValueOrDefault("locale", string.Empty),
+                ["gpuInferenceEnabled"] = failure.Environment.GetValueOrDefault("gpuInferenceEnabled", string.Empty),
+                ["gpuPreference"] = failure.Environment.GetValueOrDefault("gpuPreference", string.Empty),
+                ["softwareRenderingConfigured"] = failure.Environment.GetValueOrDefault("softwareRenderingConfigured", string.Empty),
+            };
+            entries.Add(new("configuration-summary.json", JsonSerializer.Serialize(summary, _jsonOptions)));
+            status.Collectors["configurationSummary"] = new();
+        }
+
+        return entries;
+    }
+
+    private void CollectJson<T>(
+        ICollection<ReportTextEntry> entries,
+        DiagnosticCollectionStatus status,
+        string collectorName,
+        string entryName,
+        Func<T> collect)
+    {
+        try
+        {
+            entries.Add(new(entryName, JsonSerializer.Serialize(collect(), _jsonOptions)));
+            status.Collectors[collectorName] = new();
+        }
+        catch (Exception ex)
+        {
+            entries.Add(new($"{entryName}.error.txt", FormatCollectionError(ex)));
+            status.Collectors[collectorName] = ErrorStatus(ex);
+        }
+    }
+
+    private void AddNativeLogs(
+        ICollection<ReportTextEntry> entries,
+        DiagnosticCollectionStatus status,
+        DiagnosticFailure failure)
+    {
+        string directory = Path.Combine(_store.DirectoryPath, "native");
+        try
+        {
+            if (!Directory.Exists(directory))
+            {
+                status.Collectors["nativeCrashLogs"] = new() { Status = "unavailable" };
+                return;
+            }
+
+            string safeCaseId = DiagnosticPathSafety.FileNamePart(failure.CaseId, "unknown-case", 64);
+            string prefix = $"crash-{safeCaseId}-";
+            string[] paths = Directory.EnumerateFiles(directory, "crash-*.log", SearchOption.TopDirectoryOnly)
+                .Where(path => Path.GetFileName(path).StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+                .OrderBy(static path => path, StringComparer.OrdinalIgnoreCase)
+                .ToArray();
+            if (paths.Length == 0)
+            {
+                status.Collectors["nativeCrashLogs"] = new() { Status = "unavailable" };
+                return;
+            }
+
+            foreach (string path in paths)
+            {
+                AddLog(entries, status, path, $"logs/native/{Path.GetFileName(path)}", failure);
+            }
+
+            status.Collectors["nativeCrashLogs"] = new();
+        }
+        catch (Exception ex)
+        {
+            status.Collectors["nativeCrashLogs"] = ErrorStatus(ex);
+        }
+    }
+
+    private static void AddLog(
+        ICollection<ReportTextEntry> entries,
+        DiagnosticCollectionStatus status,
+        string sourcePath,
+        string entryName,
+        DiagnosticFailure failure,
+        bool required = false)
+    {
+        string collectorName = $"log:{entryName}";
+        if (!File.Exists(sourcePath))
+        {
+            status.Collectors[collectorName] = new() { Status = "unavailable" };
+            if (required)
+            {
+                entries.Add(new($"{entryName}.missing.txt", "Log file was not available when the report was generated."));
+            }
+
+            return;
+        }
+
+        try
+        {
+            entries.Add(new(entryName, ReadRelevantLog(sourcePath, failure.TimestampUtc)));
+            status.Collectors[collectorName] = new();
+        }
+        catch (Exception ex)
+        {
+            entries.Add(new($"{entryName}.error.txt", FormatCollectionError(ex)));
+            status.Collectors[collectorName] = ErrorStatus(ex);
+        }
+    }
+
+    private static void AddTextFile(
+        ICollection<ReportTextEntry> entries,
+        DiagnosticCollectionStatus status,
+        string sourcePath,
+        string entryName)
+    {
+        string collectorName = $"file:{entryName}";
+        if (!File.Exists(sourcePath))
+        {
+            status.Collectors[collectorName] = new() { Status = "unavailable" };
+            return;
+        }
+
+        try
+        {
+            entries.Add(new(entryName, ReadTextBounded(sourcePath)));
+            status.Collectors[collectorName] = new();
+        }
+        catch (Exception ex)
+        {
+            entries.Add(new($"{entryName}.error.txt", FormatCollectionError(ex)));
+            status.Collectors[collectorName] = ErrorStatus(ex);
+        }
+    }
+
+    private Dictionary<string, object?> CreateManifest(
+        DiagnosticFailure failure,
+        DiagnosticReportOptions options,
+        string reportKind,
+        int attachmentPartCount) => new() {
+            ["schemaVersion"] = 3,
+            ["reportKind"] = reportKind,
+            ["generatedAtUtc"] = DateTimeOffset.UtcNow,
+            ["caseId"] = failure.CaseId,
+            ["code"] = failure.Code,
+            ["appVersion"] = failure.AppVersion,
+            ["resourceVersion"] = failure.ResourceVersion,
+            ["ruleVersion"] = failure.RuleVersion,
+            ["includesConfigurationSummary"] = options.IncludeConfigurationSummary,
+            ["includesScreenshots"] = options.IncludeScreenshots,
+            ["includesDumps"] = options.IncludeDumps,
+            ["actualAttachmentPartCount"] = attachmentPartCount,
+            ["collectionStatusEntry"] = reportKind == "full" ? "diagnostics/collection-status.json" : null,
+            ["contentSanitized"] = false,
+            ["sharingWarning"] = SharingWarning,
+            ["defaultContents"] = "Failure history, crash-process snapshot, process/runtime details, loaded modules, application binary inventory, dependency manifests and relevant logs.",
+            ["captureContext"] = "failure.json contains the recorded crash process snapshot; runtime entries describe the process that generated this report.",
+        };
+
+    private IEnumerable<string> GetOutputDirectories()
+    {
+        string[] candidates =
+        [
+            _reportsDirectory,
+            Path.Combine(_baseDirectory, "diagnostic-reports"),
+            Path.Combine(Path.GetTempPath(), "MaaAssistantArknights", "diagnostic-reports"),
+        ];
+        return candidates.Where(static path => !string.IsNullOrWhiteSpace(path)).Distinct(StringComparer.OrdinalIgnoreCase);
+    }
+
+    private static string CreateReportFileStem(DiagnosticFailure failure)
+    {
+        string incidentTime = failure.TimestampUtc.ToLocalTime().ToString("yyyy-MM-dd_HH-mm-ss", CultureInfo.InvariantCulture);
+        string errorCode = DiagnosticPathSafety.FileNamePart(failure.Code, "UnknownError", 48);
+        string caseId = DiagnosticPathSafety.FileNamePart(failure.CaseId, "unknown-case", 12);
+        string uniqueSuffix = Guid.NewGuid().ToString("N")[..8];
+        return $"{incidentTime}_MAA_diagnostic_report_{errorCode}_{caseId}_{uniqueSuffix}";
+    }
+
+    private static string BuildIssueMarkdown(DiagnosticFailure failure) => new StringBuilder()
+        .AppendLine("## MAA diagnostic summary")
+        .AppendLine()
+        .AppendLine($"- Case ID: `{failure.CaseId}`")
+        .AppendLine($"- Error code: `{failure.Code}`")
+        .AppendLine($"- Time: `{failure.TimestampUtc:O}`")
+        .AppendLine($"- App version: `{failure.AppVersion}`")
+        .AppendLine($"- Rule version: `{failure.RuleVersion}`")
+        .AppendLine($"- OS: `{failure.Environment.GetValueOrDefault("os", "unknown")}`")
+        .AppendLine($"- GPU: `{failure.Environment.GetValueOrDefault("gpu.0.description", "unknown")}`")
+        .AppendLine()
+        .AppendLine("The report was created locally and was not uploaded automatically. Its contents were not sanitized; review it before sharing.")
+        .ToString();
+
+    private static string ReadRelevantLog(string sourcePath, DateTimeOffset failureTimestamp)
+    {
+        var selected = new BoundedLineBuffer(MaxTextCharacters, int.MaxValue);
+        var tail = new BoundedLineBuffer(MaxTextCharacters, TailLineCount);
+        var cutoffStart = failureTimestamp.ToLocalTime().AddMinutes(-10);
+        var cutoffEnd = failureTimestamp.ToLocalTime().AddMinutes(10);
+        bool matchedTimestamp = false;
+        bool includeContinuation = false;
+        using var stream = new FileStream(sourcePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+        using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
+        while (reader.ReadLine() is { } line)
+        {
+            tail.Add(line);
+            if (TryParseLogTimestamp(line, out var timestamp))
+            {
+                includeContinuation = timestamp >= cutoffStart && timestamp <= cutoffEnd;
+                matchedTimestamp |= includeContinuation;
+            }
+
+            if (includeContinuation)
+            {
+                selected.Add(line);
+            }
+        }
+
+        return matchedTimestamp ? selected.ToString() : tail.ToString();
+    }
+
+    private static bool TryParseLogTimestamp(string line, out DateTimeOffset timestamp)
+    {
+        timestamp = default;
+        if (line.Length < 21 || line[0] != '[')
+        {
+            return false;
+        }
+
+        int end = line.IndexOf(']', 1, Math.Min(line.Length - 1, 40));
+        if (end <= 1)
+        {
+            return false;
+        }
+
+        string value = line[1..end];
+        string[] formats = ["yyyy-MM-dd HH:mm:ss.fff", "yyyy-MM-dd HH:mm:ss"];
+        if (DateTime.TryParseExact(value, formats, CultureInfo.InvariantCulture, DateTimeStyles.None, out var localTime))
+        {
+            timestamp = new(localTime, TimeZoneInfo.Local.GetUtcOffset(localTime));
+            return true;
+        }
+
+        return DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.AssumeLocal, out timestamp);
+    }
+
+    private static string ReadTextBounded(string sourcePath)
+    {
+        var builder = new StringBuilder(Math.Min(MaxTextCharacters, 64 * 1024));
+        char[] buffer = new char[8192];
+        using var stream = new FileStream(sourcePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+        using var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true);
+        while (builder.Length < MaxTextCharacters)
+        {
+            int requested = Math.Min(buffer.Length, MaxTextCharacters - builder.Length);
+            int count = reader.Read(buffer, 0, requested);
+            if (count == 0)
+            {
+                return builder.ToString();
+            }
+
+            builder.Append(buffer, 0, count);
+        }
+
+        if (!reader.EndOfStream)
+        {
+            builder.AppendLine().Append("[truncated by diagnostic report]");
+        }
+
+        return builder.ToString();
+    }
+
+    private static void WriteArchive(string path, IEnumerable<ReportTextEntry> entries)
+    {
+        using var archive = ZipFile.Open(path, ZipArchiveMode.Create);
+        foreach (var item in entries)
+        {
+            var entry = archive.CreateEntry(item.EntryName, CompressionLevel.SmallestSize);
+            using var writer = new StreamWriter(entry.Open(), new UTF8Encoding(false));
+            writer.Write(item.Contents);
+        }
+    }
+
+    private static void ValidateArchive(string path)
+    {
+        using var archive = ZipFile.OpenRead(path);
+        foreach (var entry in archive.Entries)
+        {
+            using var reader = entry.Open();
+            reader.CopyTo(Stream.Null);
+        }
+    }
+
+    private static DiagnosticAttachmentBuildResult CreateFailedAttachmentResult(
+        DiagnosticReportOptions options,
+        Exception exception)
+    {
+        var status = new DiagnosticCollectionStatus();
+        status.Screenshots.Requested = options.IncludeScreenshots;
+        status.Dumps.Requested = options.IncludeDumps;
+        ApplyError(status.Screenshots, exception);
+        ApplyError(status.Dumps, exception);
+        status.Collectors["attachmentWriter"] = ErrorStatus(exception);
+        return new([], status);
+    }
+
+    private static void ApplyError(DiagnosticCollectorStatus status, Exception exception)
+    {
+        status.Status = "error";
+        status.ExceptionType = exception.GetType().FullName ?? exception.GetType().Name;
+        status.ExceptionMessage = exception.Message;
+    }
+
+    private static DiagnosticCollectorStatus ErrorStatus(Exception exception)
+    {
+        var result = new DiagnosticCollectorStatus();
+        ApplyError(result, exception);
+        return result;
+    }
+
+    private static string FormatCollectionError(Exception exception) =>
+        $"Could not collect this entry: {exception.GetType().FullName}: {exception.Message}";
+
+    private static void CleanupStaleTransactions(string reportsDirectory)
+    {
+        DateTime cutoff = DateTime.UtcNow.AddHours(-24);
+        try
+        {
+            foreach (string directory in Directory.EnumerateDirectories(reportsDirectory, $"{TransactionDirectoryPrefix}*.tmpdir"))
+            {
+                try
+                {
+                    if (Directory.GetLastWriteTimeUtc(directory) < cutoff)
+                    {
+                        Directory.Delete(directory, recursive: true);
+                    }
+                }
+                catch
+                {
+                    // Stale cleanup is strictly best effort.
+                }
+            }
+
+            foreach (string partPath in Directory.EnumerateFiles(reportsDirectory, "*_MAA_diagnostic_report_*_part??.zip"))
+            {
+                try
+                {
+                    if (File.GetLastWriteTimeUtc(partPath) >= cutoff)
+                    {
+                        continue;
+                    }
+
+                    string fileName = Path.GetFileNameWithoutExtension(partPath);
+                    int partIndex = fileName.LastIndexOf("_part", StringComparison.OrdinalIgnoreCase);
+                    if (partIndex > 0)
+                    {
+                        string mainPath = Path.Combine(reportsDirectory, $"{fileName[..partIndex]}.zip");
+                        if (!File.Exists(mainPath))
+                        {
+                            File.Delete(partPath);
+                        }
+                    }
+                }
+                catch
+                {
+                    // Stale cleanup is strictly best effort.
+                }
+            }
+        }
+        catch
+        {
+            // Enumeration failures may not prevent report generation.
+        }
+    }
+
+    private static void DeleteBestEffort(string path)
+    {
+        try
+        {
+            File.Delete(path);
+        }
+        catch
+        {
+            // Cleanup must not mask the report result.
+        }
+    }
+
+    private static void DeleteDirectoryBestEffort(string path)
+    {
+        try
+        {
+            Directory.Delete(path, recursive: true);
+        }
+        catch
+        {
+            // Cleanup must not mask the report result.
+        }
+    }
+
+    private static void DeleteDirectoryContentsBestEffort(string path)
+    {
+        try
+        {
+            foreach (string directory in Directory.EnumerateDirectories(path))
+            {
+                Directory.Delete(directory, recursive: true);
+            }
+
+            foreach (string file in Directory.EnumerateFiles(path))
+            {
+                File.Delete(file);
+            }
+        }
+        catch
+        {
+            // The final transaction cleanup gets another chance.
+        }
+    }
+
+    private sealed record ReportTextEntry(string EntryName, string Contents);
+
+    private sealed class BoundedLineBuffer
+    {
+        private readonly Queue<string> _lines = new();
+        private readonly int _maxCharacters;
+        private readonly int _maxLines;
+        private int _characters;
+
+        internal BoundedLineBuffer(int maxCharacters, int maxLines)
+        {
+            _maxCharacters = maxCharacters;
+            _maxLines = maxLines;
+        }
+
+        internal void Add(string line)
+        {
+            int maxLineCharacters = Math.Max(1, _maxCharacters - Environment.NewLine.Length);
+            string boundedLine = line.Length <= maxLineCharacters ? line : line[^maxLineCharacters..];
+            _lines.Enqueue(boundedLine);
+            _characters += boundedLine.Length + Environment.NewLine.Length;
+            while (_lines.Count > _maxLines || _characters > _maxCharacters)
+            {
+                string removed = _lines.Dequeue();
+                _characters -= removed.Length + Environment.NewLine.Length;
+            }
+        }
+
+        public override string ToString() => string.Join(Environment.NewLine, _lines);
+    }
+}

--- a/src/MaaWpfGui/Services/Diagnostics/DiagnosticRuleEngine.cs
+++ b/src/MaaWpfGui/Services/Diagnostics/DiagnosticRuleEngine.cs
@@ -1,0 +1,200 @@
+// <copyright file="DiagnosticRuleEngine.cs" company="MaaAssistantArknights">
+// Part of the MaaWpfGui project, maintained by the MaaAssistantArknights team (Maa Team)
+// Copyright (C) 2021-2025 MaaAssistantArknights Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License v3.0 only as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY
+// </copyright>
+
+#pragma warning disable SA1636
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using MaaWpfGui.Models.Diagnostics;
+
+namespace MaaWpfGui.Services.Diagnostics;
+
+internal static class DiagnosticRuleEngine
+{
+    private const string EmbeddedRuleVersion = "wpf-2026.08.3";
+    private static readonly DiagnosticRule[] Rules = CreateRules()
+        .OrderByDescending(static rule => rule.Priority)
+        .ToArray();
+
+    internal static DiagnosticFailure Classify(DiagnosticInput input, string appVersion = "", string resourceVersion = "")
+    {
+        var rule = Rules.FirstOrDefault(x => Matches(x, input))
+            ?? CreateUnknownRule(input.Source);
+
+        var normalized = $"{rule.Code}|{input.ExceptionType}|{FormatHResult(input.HResult)}|{FirstStableDetail(input)}";
+        var fingerprintBytes = SHA256.HashData(Encoding.UTF8.GetBytes(normalized));
+        var failure = new DiagnosticFailure {
+            Source = input.Source,
+            StartupPhase = input.StartupPhase,
+            Severity = input.Severity,
+            Code = rule.Code,
+            Confidence = rule.Confidence,
+            Fingerprint = Convert.ToHexString(fingerprintBytes)[..16],
+            RuleId = rule.Id,
+            ExceptionType = input.ExceptionType,
+            HResult = input.HResult,
+            Message = input.Message,
+            TechnicalDetails = input.Details,
+            AppVersion = appVersion,
+            ResourceVersion = resourceVersion,
+            RuleVersion = EmbeddedRuleVersion,
+        };
+
+        if (input.HResult is not null)
+        {
+            failure.Evidence.Add(new("hresult", FormatHResult(input.HResult)));
+        }
+
+        if (!string.IsNullOrWhiteSpace(input.ExceptionType))
+        {
+            failure.Evidence.Add(new("exceptionType", input.ExceptionType));
+        }
+
+        foreach (var module in input.Modules.Take(8))
+        {
+            failure.Evidence.Add(new("module", Path.GetFileName(module)));
+        }
+
+        return failure;
+    }
+
+    private static bool Matches(DiagnosticRule rule, DiagnosticInput input)
+    {
+        if (rule.Sources.Count > 0 && !rule.Sources.Any(x => EqualsIgnoreCase(x, input.Source)))
+        {
+            return false;
+        }
+
+        if (rule.ExceptionTypes.Count > 0 && !rule.ExceptionTypes.Any(x => ContainsIgnoreCase(input.ExceptionType, x)))
+        {
+            return false;
+        }
+
+        if (rule.HResults.Count > 0 && !rule.HResults.Any(x => EqualsIgnoreCase(x, FormatHResult(input.HResult))))
+        {
+            return false;
+        }
+
+        if (rule.DetailContains.Count > 0 && !rule.DetailContains.Any(x => ContainsIgnoreCase(input.Details, x) || ContainsIgnoreCase(input.Message, x)))
+        {
+            return false;
+        }
+
+        if (rule.ModuleContains.Count > 0 && !rule.ModuleContains.Any(x => input.Modules.Any(m => ContainsIgnoreCase(m, x))))
+        {
+            return false;
+        }
+
+        return rule.ExceptionTypes.Count + rule.HResults.Count + rule.DetailContains.Count + rule.ModuleContains.Count > 0;
+    }
+
+    private static DiagnosticRule[] CreateRules() =>
+        [
+            Rule("missing-core", 1000, DiagnosticErrorCode.StartupPackageMissing, DiagnosticConfidence.High, details: ["MaaCore.dll not found", "resource folder not found"]),
+            Rule("missing-vcpp", 990, DiagnosticErrorCode.StartupDependencyMissing, DiagnosticConfidence.High, exceptionTypes: ["DllNotFoundException"], details: ["MaaCore", "VCRUNTIME", "MSVCP"]),
+            Rule("dwm-disabled", 980, DiagnosticErrorCode.DwmUnavailable, DiagnosticConfidence.High, hresults: ["0x80263001"]),
+            Rule("dwm-disabled-text", 979, DiagnosticErrorCode.DwmUnavailable, DiagnosticConfidence.High, details: ["Desktop composition is disabled"]),
+            Rule("gpu-inference-device-lost", 977, DiagnosticErrorCode.GpuInferenceFailed, DiagnosticConfidence.High, hresults: ["0x887A0005", "0x887A0006", "0x887A0007"], moduleContains: ["onnxruntime", "DirectML"]),
+            Rule("gpu-inference-device-lost-text", 976, DiagnosticErrorCode.GpuInferenceFailed, DiagnosticConfidence.High, details: ["DXGI_ERROR_DEVICE_REMOVED", "DXGI_ERROR_DEVICE_RESET", "DXGI_ERROR_DEVICE_HUNG", "0x887A0005", "0x887A0006", "0x887A0007"], moduleContains: ["onnxruntime", "DirectML"]),
+            Rule("graphics-device-lost", 975, DiagnosticErrorCode.GraphicsDeviceLost, DiagnosticConfidence.High, hresults: ["0x887A0005", "0x887A0006", "0x887A0007"]),
+            Rule("graphics-device-lost-text", 974, DiagnosticErrorCode.GraphicsDeviceLost, DiagnosticConfidence.High, details: ["DXGI_ERROR_DEVICE_REMOVED", "DXGI_ERROR_DEVICE_RESET", "DXGI_ERROR_DEVICE_HUNG", "0x887A0005", "0x887A0006", "0x887A0007"]),
+            Rule("injected-module", 960, DiagnosticErrorCode.InjectedModuleConflict, DiagnosticConfidence.High, details: ["NahimicOSD", "AudioDevProps2", "GTII-OSD64", "GTIII-OSD64"]),
+            Rule("gpu-inference-provider", 910, DiagnosticErrorCode.GpuInferenceFailed, DiagnosticConfidence.High, details: ["DmlExecutionProvider", "OrtSessionOptionsAppendExecutionProvider_DML"]),
+            Rule("gpu-inference", 900, DiagnosticErrorCode.GpuInferenceFailed, DiagnosticConfidence.Medium, details: ["DirectML", "DmlExecutionProvider", "OrtSessionOptionsAppendExecutionProvider_DML", "onnxruntime", "D3D12"], moduleContains: ["MaaCore", "onnxruntime", "DirectML"]),
+            Rule("wpf-render", 850, DiagnosticErrorCode.GraphicsRenderingFailed, DiagnosticConfidence.Medium, details: ["System.Windows.Media", "MilCore", "UCEERR", "D3DImage"]),
+            Rule("native-crash", 300, DiagnosticErrorCode.NativeCrash, DiagnosticConfidence.Unknown, sources: [DiagnosticSource.NativeCrash], details: ["FATAL ERROR", "UNHANDLED EXCEPTION", "SIGNAL"]),
+            Rule("managed-crash", 200, DiagnosticErrorCode.ManagedCrash, DiagnosticConfidence.Unknown, sources: [DiagnosticSource.Dispatcher, DiagnosticSource.AppDomain], details: ["Exception"]),
+        ];
+
+    private static DiagnosticRule Rule(
+        string id,
+        int priority,
+        string code,
+        string confidence,
+        string[]? sources = null,
+        string[]? exceptionTypes = null,
+        string[]? hresults = null,
+        string[]? details = null,
+        string[]? moduleContains = null) => new() {
+            Id = id,
+            Priority = priority,
+            Code = code,
+            Confidence = confidence,
+            Sources = sources ?? [],
+            ExceptionTypes = exceptionTypes ?? [],
+            HResults = hresults ?? [],
+            DetailContains = details ?? [],
+            ModuleContains = moduleContains ?? [],
+        };
+
+    private static DiagnosticRule CreateUnknownRule(string source) => new() {
+        Id = "unknown",
+        Code = source switch {
+            DiagnosticSource.Startup => DiagnosticErrorCode.StartupUnknown,
+            DiagnosticSource.NativeCrash => DiagnosticErrorCode.NativeCrash,
+            _ => DiagnosticErrorCode.ManagedCrash,
+        },
+        Confidence = DiagnosticConfidence.Unknown,
+    };
+
+    private static string FirstStableDetail(DiagnosticInput input)
+    {
+        string details = string.Equals(input.Source, DiagnosticSource.NativeCrash, StringComparison.Ordinal)
+            ? DiagnosticNativeCrashLog.GetFingerprintDetail(input.Details)
+            : input.Details;
+        if (string.IsNullOrWhiteSpace(details))
+        {
+            return string.Empty;
+        }
+
+        string[] lines = details.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries);
+        var line = lines.FirstOrDefault(static value =>
+                !value.Contains("FATAL ERROR", StringComparison.OrdinalIgnoreCase) &&
+                !value.All(static character => character is '=' or '-' or ' '))
+            ?? lines.FirstOrDefault()
+            ?? details;
+        return line.Length <= 240 ? line : line[..240];
+    }
+
+    private static string FormatHResult(int? value) => value is null ? string.Empty : $"0x{unchecked((uint)value.Value):X8}";
+
+    private static bool ContainsIgnoreCase(string value, string expected) => value.Contains(expected, StringComparison.OrdinalIgnoreCase);
+
+    private static bool EqualsIgnoreCase(string left, string right) => string.Equals(left, right, StringComparison.OrdinalIgnoreCase);
+
+    private sealed record DiagnosticRule
+    {
+        internal string Id { get; init; } = string.Empty;
+
+        internal int Priority { get; init; }
+
+        internal IReadOnlyList<string> Sources { get; init; } = [];
+
+        internal IReadOnlyList<string> ExceptionTypes { get; init; } = [];
+
+        internal IReadOnlyList<string> HResults { get; init; } = [];
+
+        internal IReadOnlyList<string> DetailContains { get; init; } = [];
+
+        internal IReadOnlyList<string> ModuleContains { get; init; } = [];
+
+        internal string Code { get; init; } = DiagnosticErrorCode.UiError;
+
+        internal string Confidence { get; init; } = DiagnosticConfidence.Unknown;
+    }
+}

--- a/src/MaaWpfGui/Services/Diagnostics/DiagnosticStateStore.cs
+++ b/src/MaaWpfGui/Services/Diagnostics/DiagnosticStateStore.cs
@@ -1,0 +1,277 @@
+// <copyright file="DiagnosticStateStore.cs" company="MaaAssistantArknights">
+// Part of the MaaWpfGui project, maintained by the MaaAssistantArknights team (Maa Team)
+// Copyright (C) 2021-2025 MaaAssistantArknights Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License v3.0 only as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY
+// </copyright>
+
+#pragma warning disable SA1636
+#nullable enable
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using MaaWpfGui.Models.Diagnostics;
+
+namespace MaaWpfGui.Services.Diagnostics;
+
+internal sealed class DiagnosticStateStore
+{
+    private const int MaxHistoryCount = 20;
+    private static readonly TimeSpan MaxHistoryAge = TimeSpan.FromDays(30);
+    private static readonly ConcurrentDictionary<string, object> DirectoryGates = new(StringComparer.OrdinalIgnoreCase);
+    private readonly object _gate;
+    private readonly string _directory;
+    private readonly JsonSerializerOptions _jsonOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase, WriteIndented = true };
+
+    internal DiagnosticStateStore(string directory)
+    {
+        _directory = Path.GetFullPath(directory);
+        _gate = DirectoryGates.GetOrAdd(_directory, static _ => new());
+    }
+
+    internal string DirectoryPath => _directory;
+
+    private string PendingPath => Path.Combine(_directory, "pending-failure.json");
+
+    private string HistoryPath => Path.Combine(_directory, "history.json");
+
+    internal DiagnosticStoreWriteResult RecordFailure(DiagnosticFailure failure, bool makePending = true)
+    {
+        lock (_gate)
+        {
+            Normalize(failure);
+            bool historyWritten = false;
+            bool pendingWritten = !makePending;
+            try
+            {
+                Directory.CreateDirectory(_directory);
+                var history = ReadHistory();
+                var now = DateTimeOffset.UtcNow;
+                var cutoff = now - MaxHistoryAge;
+                history.RemoveAll(x => x.TimestampUtc < cutoff);
+
+                // 同一次未处理异常可能先后进入 Dispatcher 和 AppDomain 回调；复用已有记录，
+                // 避免重复增加发生次数，也避免在下次启动时生成两条待处理提示。
+                var duplicate = history.LastOrDefault(x =>
+                    x.ProcessId == failure.ProcessId &&
+                    string.Equals(x.Fingerprint, failure.Fingerprint, StringComparison.Ordinal) &&
+                    Math.Abs((x.TimestampUtc - failure.TimestampUtc).TotalSeconds) < 5);
+                if (duplicate is null)
+                {
+                    int occurrences = history.Count(x =>
+                        string.Equals(x.Fingerprint, failure.Fingerprint, StringComparison.Ordinal) &&
+                        x.TimestampUtc >= now.AddHours(-24));
+                    failure.OccurrenceCount = occurrences + 1;
+                    history.Add(failure);
+                }
+                else
+                {
+                    failure = duplicate;
+                }
+
+                history = history.OrderByDescending(static x => x.TimestampUtc).Take(MaxHistoryCount).OrderBy(static x => x.TimestampUtc).ToList();
+                WriteAtomic(HistoryPath, history);
+                historyWritten = true;
+            }
+            catch
+            {
+                // Diagnostics are strictly best effort and may never break the calling feature.
+            }
+
+            if (makePending)
+            {
+                try
+                {
+                    WriteAtomic(PendingPath, failure);
+                    pendingWritten = true;
+                }
+                catch
+                {
+                    // A pending write failure must not invalidate an otherwise persisted history record.
+                }
+            }
+
+            return new(failure, historyWritten, pendingWritten);
+        }
+    }
+
+    internal DiagnosticFailure? TryConsumePending()
+    {
+        lock (_gate)
+        {
+            var pending = Read<DiagnosticFailure>(PendingPath);
+            if (pending is null)
+            {
+                return null;
+            }
+
+            Normalize(pending);
+
+            try
+            {
+                File.Delete(PendingPath);
+                return File.Exists(PendingPath) ? null : pending;
+            }
+            catch
+            {
+                // Do not display a prompt that cannot be acknowledged, or it may recur forever.
+                return null;
+            }
+        }
+    }
+
+    internal IReadOnlyList<DiagnosticFailure> GetHistory()
+    {
+        lock (_gate)
+        {
+            return ReadHistory().OrderByDescending(static x => x.TimestampUtc).ToList();
+        }
+    }
+
+    internal IReadOnlyList<DiagnosticFailure> GetHistoryForReport()
+    {
+        lock (_gate)
+        {
+            if (!File.Exists(HistoryPath))
+            {
+                return [];
+            }
+
+            var history = JsonSerializer.Deserialize<List<DiagnosticFailure>>(
+                File.ReadAllText(HistoryPath),
+                _jsonOptions) ?? [];
+            foreach (var failure in history)
+            {
+                Normalize(failure);
+            }
+
+            return history.OrderByDescending(static failure => failure.TimestampUtc).ToList();
+        }
+    }
+
+    internal DiagnosticFailure? GetLatestFailure() => GetHistory()
+        .FirstOrDefault(static failure => string.Equals(failure.Severity, DiagnosticSeverity.Fatal, StringComparison.Ordinal));
+
+    internal DiagnosticStoreWriteResult UpdateFailure(DiagnosticFailure failure)
+    {
+        lock (_gate)
+        {
+            Normalize(failure);
+            bool historyWritten = false;
+            bool pendingWritten = true;
+            try
+            {
+                var history = ReadHistory();
+                int index = history.FindIndex(x => string.Equals(x.CaseId, failure.CaseId, StringComparison.Ordinal));
+                if (index >= 0)
+                {
+                    history[index] = failure;
+                    WriteAtomic(HistoryPath, history);
+                    historyWritten = true;
+                }
+            }
+            catch
+            {
+                // Best effort enrichment only.
+            }
+
+            try
+            {
+                var pending = Read<DiagnosticFailure>(PendingPath);
+                if (pending is not null && string.Equals(pending.CaseId, failure.CaseId, StringComparison.Ordinal))
+                {
+                    WriteAtomic(PendingPath, failure);
+                }
+            }
+            catch
+            {
+                // Best effort enrichment only.
+                pendingWritten = false;
+            }
+
+            return new(failure, historyWritten, pendingWritten);
+        }
+    }
+
+    private T? Read<T>(string path)
+    {
+        try
+        {
+            if (!File.Exists(path))
+            {
+                return default;
+            }
+
+            return JsonSerializer.Deserialize<T>(File.ReadAllText(path), _jsonOptions);
+        }
+        catch
+        {
+            return default;
+        }
+    }
+
+    private List<DiagnosticFailure> ReadHistory()
+    {
+        var history = (Read<List<DiagnosticFailure>>(HistoryPath) ?? [])
+            .OfType<DiagnosticFailure>()
+            .ToList();
+        foreach (var failure in history)
+        {
+            Normalize(failure);
+        }
+
+        return history;
+    }
+
+    private static void Normalize(DiagnosticFailure failure)
+    {
+        failure.CaseId ??= Guid.NewGuid().ToString("N");
+        failure.Source ??= DiagnosticSource.Unknown;
+        failure.StartupPhase ??= DiagnosticStartupPhase.Unknown;
+        failure.Code ??= DiagnosticErrorCode.UiError;
+        failure.Severity ??= DiagnosticSeverity.Fatal;
+        failure.Confidence ??= DiagnosticConfidence.Unknown;
+        failure.Fingerprint ??= string.Empty;
+        failure.RuleId ??= string.Empty;
+        failure.ExceptionType ??= string.Empty;
+        failure.Message ??= string.Empty;
+        failure.Evidence ??= [];
+        failure.TechnicalDetails ??= string.Empty;
+        failure.AppVersion ??= string.Empty;
+        failure.ResourceVersion ??= string.Empty;
+        failure.RuleVersion ??= string.Empty;
+        failure.Environment ??= new(StringComparer.OrdinalIgnoreCase);
+    }
+
+    private void WriteAtomic<T>(string path, T value)
+    {
+        Directory.CreateDirectory(_directory);
+        string tempPath = $"{path}.{Environment.ProcessId}.{Guid.NewGuid():N}.tmp";
+        try
+        {
+            File.WriteAllText(tempPath, JsonSerializer.Serialize(value, _jsonOptions));
+            File.Move(tempPath, path, true);
+        }
+        finally
+        {
+            try
+            {
+                File.Delete(tempPath);
+            }
+            catch
+            {
+                // Best effort cleanup after a failed atomic replace.
+            }
+        }
+    }
+}

--- a/src/MaaWpfGui/Services/Diagnostics/DiagnosticTechnicalDetailsFormatter.cs
+++ b/src/MaaWpfGui/Services/Diagnostics/DiagnosticTechnicalDetailsFormatter.cs
@@ -1,0 +1,183 @@
+// <copyright file="DiagnosticTechnicalDetailsFormatter.cs" company="MaaAssistantArknights">
+// Part of the MaaWpfGui project, maintained by the MaaAssistantArknights team (Maa Team)
+// Copyright (C) 2021-2025 MaaAssistantArknights Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License v3.0 only as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY
+// </copyright>
+
+#pragma warning disable SA1636
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using MaaWpfGui.Models.Diagnostics;
+
+namespace MaaWpfGui.Services.Diagnostics;
+
+internal static class DiagnosticTechnicalDetailsFormatter
+{
+    public static string Format(DiagnosticFailure failure)
+    {
+        var lines = new List<string>
+        {
+            $"Summary: {DescribeFailure(failure.Code)}",
+            $"Time: {failure.TimestampUtc.ToLocalTime():yyyy-MM-dd HH:mm:ss zzz}  |  Source: {Compact(failure.Source, 32)} / {Compact(failure.StartupPhase, 32)}  |  Severity: {Compact(failure.Severity, 16)}  |  Occurrences: {failure.OccurrenceCount}",
+            $"Code: {Compact(failure.Code, 56)}  |  Confidence: {Compact(failure.Confidence, 16)}  |  Case: {Compact(failure.CaseId, 64)}",
+            $"Rule: {Compact(failure.RuleId, 64)} ({Compact(failure.RuleVersion, 32)})  |  Fingerprint: {Compact(failure.Fingerprint, 32)}",
+        };
+
+        var exceptionParts = new List<string>();
+        AddPart(exceptionParts, "Exception", failure.ExceptionType, 96);
+        if (failure.HResult is not null)
+        {
+            exceptionParts.Add($"HRESULT: 0x{unchecked((uint)failure.HResult.Value):X8}");
+        }
+
+        exceptionParts.Add($"PID: {failure.ProcessId}");
+        lines.Add(string.Join("  |  ", exceptionParts));
+
+        var buildParts = new List<string>();
+        AddPart(buildParts, "MAA", failure.AppVersion, 40);
+        AddPart(buildParts, "Resource", failure.ResourceVersion, 48);
+        AddEnvironmentPart(buildParts, failure, ".NET", 64, "framework");
+        if (buildParts.Count > 0)
+        {
+            lines.Add($"Build: {string.Join("  |  ", buildParts)}");
+        }
+
+        var contextParts = new List<string>();
+        AddEnvironmentPart(contextParts, failure, "OS", 80, "os", "os.description");
+        AddEnvironmentPart(contextParts, failure, "Arch", 20, "processArchitecture", "process.architecture");
+        AddEnvironmentPart(contextParts, failure, "Locale", 20, "locale");
+        AddEnvironmentPart(contextParts, failure, "GPU", 80, "gpuPreference", "gpu.0.description");
+        AddEnvironmentPart(contextParts, failure, "GPU inference", 8, "gpuInferenceEnabled");
+        AddEnvironmentPart(contextParts, failure, "WPF", 24, "wpfRenderMode");
+        AddEnvironmentPart(contextParts, failure, "Software render", 8, "softwareRenderingConfigured");
+        AddEnvironmentPart(contextParts, failure, "RDP", 8, "remoteDesktopSession");
+        if (contextParts.Count > 0)
+        {
+            lines.Add($"Context: {string.Join("  |  ", contextParts)}");
+        }
+
+        var snapshotParts = new List<string>();
+        AddByteEnvironmentPart(snapshotParts, failure, "Working set", "failureSnapshot.workingSetBytes");
+        AddByteEnvironmentPart(snapshotParts, failure, "Private", "failureSnapshot.privateMemoryBytes");
+        AddEnvironmentPart(snapshotParts, failure, "Handles", 10, "failureSnapshot.handleCount");
+        AddEnvironmentPart(snapshotParts, failure, "Threads", 10, "failureSnapshot.threadCount");
+        if (snapshotParts.Count > 0)
+        {
+            lines.Add($"Process snapshot: {string.Join("  |  ", snapshotParts)}");
+        }
+
+        string evidence = string.Join("; ", (failure.Evidence ?? [])
+            .Where(static item => item is not null &&
+                                  !string.Equals(item.Kind, "hresult", StringComparison.OrdinalIgnoreCase) &&
+                                  !string.Equals(item.Kind, "exceptionType", StringComparison.OrdinalIgnoreCase))
+            .Take(4)
+            .Select(static item => $"{Compact(item.Kind, 24)}={Compact(item.Value, 72)}"));
+        if (!string.IsNullOrWhiteSpace(evidence))
+        {
+            lines.Add($"Signals: {evidence}");
+        }
+
+        string message = Compact(failure.Message, 200);
+        string technicalDetails = failure.TechnicalDetails.Trim();
+        string firstTechnicalLine = Compact(technicalDetails.Split(['\r', '\n'], StringSplitOptions.RemoveEmptyEntries).FirstOrDefault(), 200);
+        bool messageDuplicatesDetails = !string.IsNullOrWhiteSpace(firstTechnicalLine) &&
+                                        (firstTechnicalLine.Contains(message, StringComparison.OrdinalIgnoreCase) ||
+                                         message.Contains(firstTechnicalLine, StringComparison.OrdinalIgnoreCase));
+        if (!string.IsNullOrWhiteSpace(message) && !messageDuplicatesDetails)
+        {
+            lines.Add($"Message: {message}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(technicalDetails))
+        {
+            lines.Add("--- Original exception details ---");
+            lines.Add(technicalDetails);
+        }
+
+        return string.Join(Environment.NewLine, lines);
+    }
+
+    private static string DescribeFailure(string? code) => code switch
+    {
+        DiagnosticErrorCode.StartupDependencyMissing => "A required startup dependency could not be loaded.",
+        DiagnosticErrorCode.StartupPackageMissing => "A required MAA application file or resource was missing.",
+        DiagnosticErrorCode.DwmUnavailable => "Windows desktop composition was unavailable to WPF.",
+        DiagnosticErrorCode.GraphicsDeviceLost => "The graphics device was removed, reset, or stopped responding.",
+        DiagnosticErrorCode.GraphicsRenderingFailed => "The WPF rendering pipeline reported a failure.",
+        DiagnosticErrorCode.GpuInferenceFailed => "GPU inference initialization or execution failed.",
+        DiagnosticErrorCode.InjectedModuleConflict => "A known overlay or injected module was present near the failure.",
+        DiagnosticErrorCode.NativeCrash => "A native crash record was detected from the previous process.",
+        DiagnosticErrorCode.ManagedCrash => "An unhandled managed exception ended or interrupted the previous run.",
+        DiagnosticErrorCode.StartupUnknown => "Startup failed without a recognized diagnostic signature.",
+        _ => "MAA recorded an unexpected application failure.",
+    };
+
+    private static void AddPart(ICollection<string> parts, string label, string? value, int maxLength)
+    {
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            parts.Add($"{label}: {Compact(value, maxLength)}");
+        }
+    }
+
+    private static void AddEnvironmentPart(ICollection<string> parts, DiagnosticFailure failure, string label, int maxLength, params string[] keys)
+    {
+        string? value = keys
+            .Select(key => failure.Environment?.GetValueOrDefault(key))
+            .FirstOrDefault(static item => !string.IsNullOrWhiteSpace(item));
+        if (!string.IsNullOrWhiteSpace(value))
+        {
+            parts.Add($"{label}: {Compact(value, maxLength)}");
+        }
+    }
+
+    private static void AddByteEnvironmentPart(ICollection<string> parts, DiagnosticFailure failure, string label, string key)
+    {
+        if (failure.Environment is not null &&
+            failure.Environment.TryGetValue(key, out string? value) &&
+            long.TryParse(value, NumberStyles.Integer, CultureInfo.InvariantCulture, out long bytes) &&
+            bytes >= 0)
+        {
+            parts.Add($"{label}: {FormatBytes(bytes)}");
+        }
+    }
+
+    private static string FormatBytes(long bytes)
+    {
+        string[] units = ["B", "KiB", "MiB", "GiB", "TiB"];
+        double size = bytes;
+        int unit = 0;
+        while (size >= 1024 && unit < units.Length - 1)
+        {
+            size /= 1024;
+            unit++;
+        }
+
+        return $"{size:0.#} {units[unit]}";
+    }
+
+    private static string Compact(string? value, int maxLength)
+    {
+        string compact = (value ?? string.Empty)
+            .Replace('\r', ' ')
+            .Replace('\n', ' ')
+            .Trim();
+        while (compact.Contains("  ", StringComparison.Ordinal))
+        {
+            compact = compact.Replace("  ", " ", StringComparison.Ordinal);
+        }
+
+        return compact.Length <= maxLength ? compact : $"{compact[..Math.Max(1, maxLength - 1)]}…";
+    }
+}

--- a/src/MaaWpfGui/Services/Diagnostics/WpfDiagnosticManager.cs
+++ b/src/MaaWpfGui/Services/Diagnostics/WpfDiagnosticManager.cs
@@ -1,0 +1,301 @@
+// <copyright file="WpfDiagnosticManager.cs" company="MaaAssistantArknights">
+// Part of the MaaWpfGui project, maintained by the MaaAssistantArknights team (Maa Team)
+// Copyright (C) 2021-2025 MaaAssistantArknights Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License v3.0 only as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY
+// </copyright>
+
+#pragma warning disable SA1636
+#nullable enable
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using MaaWpfGui.Helper;
+using MaaWpfGui.Models.Diagnostics;
+using Serilog;
+using FailureSource = MaaWpfGui.Models.Diagnostics.DiagnosticSource;
+
+namespace MaaWpfGui.Services.Diagnostics;
+
+internal sealed class WpfDiagnosticManager
+{
+    private static readonly Lazy<WpfDiagnosticManager> LazyInstance = new(static () => new());
+    private readonly ILogger _logger = Log.ForContext<WpfDiagnosticManager>();
+    private bool _initialized;
+    private string _appVersion = string.Empty;
+    private string _resourceVersion = string.Empty;
+
+    private WpfDiagnosticManager()
+    {
+        string diagnosticDataDirectory = Path.Combine(PathsHelper.DataDir, "diagnostics");
+        _store = new(diagnosticDataDirectory);
+        _reports = new(PathsHelper.BaseDir, PathsHelper.ReportsDir, _store);
+        _nativeCrashImporter = new(_store);
+    }
+
+    private readonly DiagnosticStateStore _store;
+
+    private readonly DiagnosticReportService _reports;
+
+    private readonly DiagnosticNativeCrashImporter _nativeCrashImporter;
+
+    internal static WpfDiagnosticManager Instance => LazyInstance.Value;
+
+    internal string StartupPhase { get; private set; } = DiagnosticStartupPhase.ProcessStarted;
+
+    internal void Initialize()
+    {
+        if (_initialized)
+        {
+            return;
+        }
+
+        _initialized = true;
+        _appVersion = Assembly.GetExecutingAssembly().GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion.Split('+')[0] ?? "unknown";
+        try
+        {
+            string resourceVersionFile = Path.Combine(PathsHelper.ResourceDir, "version.json");
+            _resourceVersion = File.Exists(resourceVersionFile)
+                ? File.GetLastWriteTimeUtc(resourceVersionFile).ToString("O")
+                : string.Empty;
+        }
+        catch
+        {
+            _resourceVersion = string.Empty;
+        }
+
+        try
+        {
+            AppDomain.CurrentDomain.UnhandledException += OnAppDomainUnhandledException;
+        }
+        catch (Exception ex)
+        {
+            _logger.Warning(ex, "Failed to attach diagnostic exception listeners");
+        }
+    }
+
+    internal void MarkPhase(string phase)
+    {
+        StartupPhase = phase;
+    }
+
+    internal DiagnosticStoreWriteResult RecordException(
+        Exception exception,
+        string source,
+        bool makePending = true,
+        string severity = DiagnosticSeverity.Fatal)
+    {
+        DiagnosticFailure failure;
+        try
+        {
+            var details = exception.ToString();
+            var input = new DiagnosticInput {
+                Source = source,
+                StartupPhase = StartupPhase,
+                Severity = severity,
+                ExceptionType = exception.GetType().FullName ?? exception.GetType().Name,
+                HResult = exception.HResult,
+                Message = exception.Message,
+                Details = details,
+                Modules = DiagnosticNativeCrashLog.GetRelevantModules(details),
+            };
+            failure = DiagnosticRuleEngine.Classify(input, _appVersion, _resourceVersion);
+        }
+        catch (Exception diagnosticException)
+        {
+            _logger.Warning(diagnosticException, "Diagnostic classification failed; recording a minimal fallback");
+            failure = new() {
+                Source = source,
+                StartupPhase = StartupPhase,
+                Severity = severity,
+                Code = DiagnosticErrorCode.UiError,
+                Confidence = DiagnosticConfidence.Unknown,
+                Fingerprint = $"{exception.GetType().FullName}:{exception.HResult:X8}",
+                RuleId = "diagnostic-fallback",
+                ExceptionType = exception.GetType().FullName ?? exception.GetType().Name,
+                HResult = exception.HResult,
+                Message = exception.Message,
+                TechnicalDetails = exception.ToString(),
+                AppVersion = _appVersion,
+                ResourceVersion = _resourceVersion,
+                RuleVersion = "fallback",
+            };
+        }
+
+        TryAttachFailureProcessSnapshot(failure);
+        if (!string.Equals(severity, DiagnosticSeverity.Fatal, StringComparison.Ordinal))
+        {
+            TryAttachEnvironment(failure);
+        }
+
+        return _store.RecordFailure(failure, makePending);
+    }
+
+    internal IReadOnlyList<DiagnosticFailure> ImportNativeCrashLogs()
+    {
+        var failures = new List<DiagnosticFailure>();
+        var candidates = GetNativeCrashLogCandidates();
+        foreach (var candidate in candidates.DistinctBy(static item => item.Path, StringComparer.OrdinalIgnoreCase))
+        {
+            string path = candidate.Path;
+            if (!File.Exists(path))
+            {
+                continue;
+            }
+
+            try
+            {
+                string details = DiagnosticNativeCrashLog.ReadBounded(path);
+                if (string.IsNullOrWhiteSpace(details))
+                {
+                    continue;
+                }
+
+                string latestRecord = DiagnosticNativeCrashLog.GetLatestRecord(details);
+                var failure = DiagnosticRuleEngine.Classify(new() {
+                    Source = FailureSource.NativeCrash,
+                    StartupPhase = DiagnosticStartupPhase.PreviousProcess,
+                    Severity = DiagnosticSeverity.Fatal,
+                    ExceptionType = "NativeCrash",
+                    Message = DiagnosticNativeCrashLog.GetMessage(latestRecord),
+                    Details = latestRecord,
+                    Modules = DiagnosticNativeCrashLog.GetRelevantModules(latestRecord),
+                }, _appVersion, _resourceVersion);
+                failure.TimestampUtc = File.GetLastWriteTimeUtc(path);
+                TryAttachEnvironment(failure);
+                var importedFailure = _nativeCrashImporter.Import(path, candidate.SourceKind, latestRecord, failure);
+                if (importedFailure is null)
+                {
+                    continue;
+                }
+
+                failures.Add(importedFailure);
+            }
+            catch (Exception ex)
+            {
+                _logger.Warning(ex, "Failed to import native crash log {CrashLog}", path);
+            }
+        }
+
+        return failures;
+    }
+
+    private static IReadOnlyList<(string Path, string SourceKind)> GetNativeCrashLogCandidates()
+    {
+        var candidates = new List<(string Path, string SourceKind)>
+        {
+            (Path.Combine(PathsHelper.BaseDir, "crash.log"), "root"),
+            (Path.Combine(PathsHelper.DebugDir, "crash.log"), "debug"),
+        };
+        AddFallbacks(PathsHelper.BaseDir, "root");
+        AddFallbacks(PathsHelper.DebugDir, "debug");
+        return candidates.DistinctBy(static item => item.Path, StringComparer.OrdinalIgnoreCase).ToArray();
+
+        void AddFallbacks(string directory, string sourceKind)
+        {
+            try
+            {
+                candidates.AddRange(Directory.EnumerateFiles(directory, "crash-*.log", SearchOption.TopDirectoryOnly)
+                    .OrderByDescending(File.GetLastWriteTimeUtc)
+                    .Take(10)
+                    .Select(path => (path, $"{sourceKind}-fallback")));
+            }
+            catch
+            {
+                // A fallback discovery failure must not block normal startup.
+            }
+        }
+    }
+
+    internal DiagnosticFailure? TryConsumePendingFailure()
+    {
+        try
+        {
+            var pending = _store.TryConsumePending();
+            if (pending is null)
+            {
+                return null;
+            }
+
+            TryAttachEnvironment(pending);
+            _store.UpdateFailure(pending);
+            return pending;
+        }
+        catch (Exception ex)
+        {
+            _logger.Warning(ex, "Failed to consume pending diagnostic failure");
+            return null;
+        }
+    }
+
+    internal DiagnosticFailure? GetLatestFailure() => _store.GetLatestFailure();
+
+    internal Task<DiagnosticReportResult> BuildReportAsync(
+        DiagnosticFailure failure,
+        DiagnosticReportOptions? options = null) => _reports.BuildAsync(failure, options);
+
+    internal void MarkMainWindowShown()
+    {
+        MarkPhase(DiagnosticStartupPhase.MainWindowShown);
+    }
+
+    private void TryAttachEnvironment(DiagnosticFailure failure)
+    {
+        try
+        {
+            foreach (var pair in DiagnosticEnvironmentCollector.Collect())
+            {
+                failure.Environment[pair.Key] = pair.Value;
+            }
+        }
+        catch (Exception ex)
+        {
+            failure.Environment["environmentProbe"] = $"unavailable:{ex.GetType().Name}";
+        }
+    }
+
+    private static void TryAttachFailureProcessSnapshot(DiagnosticFailure failure)
+    {
+        try
+        {
+            using var process = Process.GetCurrentProcess();
+            failure.Environment["failureSnapshot.capturedAtUtc"] = DateTimeOffset.UtcNow.ToString("O");
+            failure.Environment["failureSnapshot.processStartTimeUtc"] = process.StartTime.ToUniversalTime().ToString("O");
+            failure.Environment["failureSnapshot.workingSetBytes"] = process.WorkingSet64.ToString();
+            failure.Environment["failureSnapshot.privateMemoryBytes"] = process.PrivateMemorySize64.ToString();
+            failure.Environment["failureSnapshot.handleCount"] = process.HandleCount.ToString();
+            failure.Environment["failureSnapshot.threadCount"] = process.Threads.Count.ToString();
+            failure.Environment["failureSnapshot.totalManagedMemoryBytes"] = GC.GetTotalMemory(forceFullCollection: false).ToString();
+        }
+        catch (Exception ex)
+        {
+            failure.Environment["failureSnapshot.probe"] = $"unavailable:{ex.GetType().Name}";
+        }
+    }
+
+    private void OnAppDomainUnhandledException(object? sender, UnhandledExceptionEventArgs args)
+    {
+        if (args.ExceptionObject is Exception exception)
+        {
+            try
+            {
+                RecordException(exception, FailureSource.AppDomain);
+            }
+            catch
+            {
+                // Never throw from a last-chance exception handler.
+            }
+        }
+    }
+}

--- a/src/MaaWpfGui/ViewModels/UI/RootViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/RootViewModel.cs
@@ -63,29 +63,50 @@ public class RootViewModel : Conductor<Screen>.Collection.OneActive
             MessageBoxHelper.Show(LocalizationHelper.GetString("NightlyWarning"));
         }
 
-        Task.Run(async () => {
-            await Instances.AnnouncementDialogViewModel.CheckAndDownloadAnnouncement();
-            if (Instances.AnnouncementDialogViewModel.DoNotRemindThisAnnouncementAgain)
-            {
-                return;
-            }
-
-            if (Instances.AnnouncementDialogViewModel.DoNotShowAnnouncement)
-            {
-                return;
-            }
-
-            if (Instances.AnnouncementDialogViewModel.AnnouncementInfo != string.Empty)
-            {
-                _ = Execute.OnUIThreadAsync(() => Instances.WindowManager.ShowWindow(Instances.AnnouncementDialogViewModel));
-            }
-        });
+        _ = Task.Run(ShowAnnouncementThenScheduleDiagnosticsAsync);
 
         _ = Instances.VersionUpdateDialogViewModel.ShowUpdateOrDownload();
 
         // 主窗口已显示，此时弹窗不会导致 WPF 因无窗口而退出
         Task.Run(ConfigBrokenCheck);
         Task.Run(ToastNotificationCheck);
+    }
+
+    private static async Task ShowAnnouncementThenScheduleDiagnosticsAsync()
+    {
+        bool waitForAnnouncementToClose = false;
+        try
+        {
+            await Instances.AnnouncementDialogViewModel.CheckAndDownloadAnnouncement();
+            bool shouldShowAnnouncement =
+                !Instances.AnnouncementDialogViewModel.DoNotRemindThisAnnouncementAgain &&
+                !Instances.AnnouncementDialogViewModel.DoNotShowAnnouncement &&
+                Instances.AnnouncementDialogViewModel.AnnouncementInfo != string.Empty;
+            if (!shouldShowAnnouncement)
+            {
+                return;
+            }
+
+            await Execute.OnUIThreadAsync(() => {
+                Instances.WindowManager.ShowWindow(Instances.AnnouncementDialogViewModel);
+                if (Instances.AnnouncementDialogViewModel.View is System.Windows.Window announcementWindow && announcementWindow.IsVisible)
+                {
+                    waitForAnnouncementToClose = true;
+                    announcementWindow.Closed += (_, _) => Bootstrapper.SchedulePendingDiagnosticReportPrompt();
+                }
+            });
+        }
+        catch (Exception ex)
+        {
+            _logger.Warning(ex, "Failed to show startup announcement");
+        }
+        finally
+        {
+            if (!waitForAnnouncementToClose)
+            {
+                Bootstrapper.SchedulePendingDiagnosticReportPrompt();
+            }
+        }
     }
 
     private static void ConfigBrokenCheck()

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/IssueReportUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/IssueReportUserControlModel.cs
@@ -24,6 +24,7 @@ using HandyControl.Data;
 using JetBrains.Annotations;
 using MaaWpfGui.Constants;
 using MaaWpfGui.Helper;
+using MaaWpfGui.Services.Diagnostics;
 using Serilog;
 using Stylet;
 
@@ -34,12 +35,71 @@ namespace MaaWpfGui.ViewModels.UserControl.Settings;
 /// </summary>
 public class IssueReportUserControlModel : PropertyChangedBase
 {
+    private bool _isGeneratingDiagnosticReport;
+
     static IssueReportUserControlModel()
     {
         Instance = new();
     }
 
     public static IssueReportUserControlModel Instance { get; }
+
+    public bool HasLatestDiagnosticFailure => WpfDiagnosticManager.Instance.GetLatestFailure() is not null;
+
+    public bool CanGenerateLatestDiagnosticReport => !_isGeneratingDiagnosticReport;
+
+    public string GenerateLatestDiagnosticReportText => LocalizationHelper.GetString(
+        _isGeneratingDiagnosticReport ? "DiagnosticBuildingReport" : "DiagnosticGenerateCrashReport");
+
+    public async void GenerateLatestDiagnosticReport()
+    {
+        if (_isGeneratingDiagnosticReport)
+        {
+            return;
+        }
+
+        SetDiagnosticReportBusy(true);
+        try
+        {
+            var failure = WpfDiagnosticManager.Instance.GetLatestFailure();
+            if (failure is null)
+            {
+                NotifyOfPropertyChange(nameof(HasLatestDiagnosticFailure));
+                ShowGrowl(LocalizationHelper.GetString("DiagnosticNoFailure"));
+                return;
+            }
+
+            var result = await WpfDiagnosticManager.Instance.BuildReportAsync(failure);
+            string successMessage = result.IsMinimal
+                ? LocalizationHelper.GetString("DiagnosticMinimalReportCreated")
+                : LocalizationHelper.GetString("GenerateSupportPayloadSuccessful");
+            ShowGrowl(successMessage);
+            try
+            {
+                Process.Start(new ProcessStartInfo("explorer.exe", $"/select,\"{result.ReportPath}\"") { UseShellExecute = true });
+            }
+            catch (Exception ex)
+            {
+                Log.Warning(ex, "Diagnostic report was created but could not be revealed in Explorer");
+            }
+        }
+        catch (Exception ex)
+        {
+            ShowGrowl(LocalizationHelper.GetString("DiagnosticReportFailed"));
+            Log.Error(ex, "Failed to create diagnostic report");
+        }
+        finally
+        {
+            SetDiagnosticReportBusy(false);
+        }
+    }
+
+    private void SetDiagnosticReportBusy(bool value)
+    {
+        _isGeneratingDiagnosticReport = value;
+        NotifyOfPropertyChange(nameof(CanGenerateLatestDiagnosticReport));
+        NotifyOfPropertyChange(nameof(GenerateLatestDiagnosticReportText));
+    }
 
     public void OpenDebugFolder()
     {
@@ -278,7 +338,7 @@ public class IssueReportUserControlModel : PropertyChangedBase
             // 清理临时目录
             Directory.Delete(tempPath, recursive: true);
 
-            ShowGrowl($"{LocalizationHelper.GetString("GenerateSupportPayloadSuccessful")}\n{fullZipPath}");
+            ShowGrowl(LocalizationHelper.GetString("GenerateSupportPayloadSuccessful"));
             OpenReportsFolder();
         }
         catch (Exception ex)

--- a/src/MaaWpfGui/Views/Dialogs/CrashDiagnosticDialog.xaml
+++ b/src/MaaWpfGui/Views/Dialogs/CrashDiagnosticDialog.xaml
@@ -1,0 +1,71 @@
+<hc:Window
+    x:Class="MaaWpfGui.Views.Dialogs.CrashDiagnosticDialog"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:hc="https://handyorg.github.io/handycontrol"
+    Title="MAA"
+    Width="680"
+    Height="640"
+    MinWidth="560"
+    MinHeight="460"
+    Icon="../../newlogo.ico"
+    ResizeMode="CanResize"
+    ShowInTaskbar="False"
+    WindowStartupLocation="CenterOwner">
+    <Grid Margin="24">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <TextBlock
+            FontSize="24"
+            FontWeight="SemiBold"
+            Text="{Binding PromptTitle, RelativeSource={RelativeSource AncestorType=Window}}"
+            TextWrapping="Wrap" />
+
+        <StackPanel Grid.Row="1" Margin="0,14,0,0">
+            <TextBlock
+                FontSize="15"
+                Text="{Binding PromptMessage, RelativeSource={RelativeSource AncestorType=Window}}"
+                TextWrapping="Wrap" />
+            <Border Margin="0,12,0,0" Padding="12" Background="{DynamicResource RegionBrush}">
+                <TextBlock Text="{Binding FailureSummary, RelativeSource={RelativeSource AncestorType=Window}}" TextWrapping="Wrap" />
+            </Border>
+        </StackPanel>
+
+        <ScrollViewer Grid.Row="2" Margin="0,14,0,12" VerticalScrollBarVisibility="Auto">
+            <StackPanel>
+                <TextBlock
+                    FontSize="14"
+                    FontWeight="SemiBold"
+                    Text="{Binding TechnicalDetailsHeading, RelativeSource={RelativeSource AncestorType=Window}}" />
+                <TextBox
+                    Margin="0,8,0,0"
+                    Height="220"
+                    AcceptsReturn="True"
+                    IsReadOnly="True"
+                    Text="{Binding TechnicalDetails, RelativeSource={RelativeSource AncestorType=Window}, Mode=OneWay}"
+                    TextWrapping="Wrap"
+                    VerticalScrollBarVisibility="Auto" />
+                <TextBlock
+                    Margin="0,14,0,0"
+                    FontSize="14"
+                    FontWeight="SemiBold"
+                    Text="{Binding ReportOptionsHeading, RelativeSource={RelativeSource AncestorType=Window}}" />
+                <TextBlock Margin="0,6,0,0" Opacity="0.72" Text="{Binding PrivacyText, RelativeSource={RelativeSource AncestorType=Window}}" TextWrapping="Wrap" />
+                <CheckBox Margin="0,10,0,0" Content="{Binding IncludeConfigurationText, RelativeSource={RelativeSource AncestorType=Window}}" IsChecked="{Binding IncludeConfiguration, RelativeSource={RelativeSource AncestorType=Window}}" IsEnabled="{Binding CanInteract, RelativeSource={RelativeSource AncestorType=Window}}" />
+                <CheckBox Margin="0,5,0,0" Content="{Binding IncludeScreenshotsText, RelativeSource={RelativeSource AncestorType=Window}}" IsChecked="{Binding IncludeScreenshots, RelativeSource={RelativeSource AncestorType=Window}}" IsEnabled="{Binding CanInteract, RelativeSource={RelativeSource AncestorType=Window}}" />
+                <CheckBox Margin="0,5,0,0" Content="{Binding IncludeDumpsText, RelativeSource={RelativeSource AncestorType=Window}}" IsChecked="{Binding IncludeDumps, RelativeSource={RelativeSource AncestorType=Window}}" IsEnabled="{Binding CanInteract, RelativeSource={RelativeSource AncestorType=Window}}" />
+                <TextBlock Margin="0,10,0,0" Foreground="{DynamicResource PrimaryBrush}" Text="{Binding ReportResult, RelativeSource={RelativeSource AncestorType=Window}}" TextWrapping="Wrap" />
+            </StackPanel>
+        </ScrollViewer>
+
+        <WrapPanel Grid.Row="3" HorizontalAlignment="Right">
+            <Button Margin="4" Click="Dismiss_Click" Content="{Binding DismissText, RelativeSource={RelativeSource AncestorType=Window}}" IsCancel="True" IsEnabled="{Binding CanInteract, RelativeSource={RelativeSource AncestorType=Window}}" />
+            <Button Margin="4" Click="BuildReport_Click" Content="{Binding BuildReportText, RelativeSource={RelativeSource AncestorType=Window}}" IsDefault="True" IsEnabled="{Binding CanInteract, RelativeSource={RelativeSource AncestorType=Window}}" />
+        </WrapPanel>
+    </Grid>
+</hc:Window>

--- a/src/MaaWpfGui/Views/Dialogs/CrashDiagnosticDialog.xaml.cs
+++ b/src/MaaWpfGui/Views/Dialogs/CrashDiagnosticDialog.xaml.cs
@@ -1,0 +1,183 @@
+// <copyright file="CrashDiagnosticDialog.xaml.cs" company="MaaAssistantArknights">
+// Part of the MaaWpfGui project, maintained by the MaaAssistantArknights team (Maa Team)
+// Copyright (C) 2021-2025 MaaAssistantArknights Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License v3.0 only as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY
+// </copyright>
+
+#pragma warning disable SA1636
+#nullable enable
+
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Windows;
+using MaaWpfGui.Helper;
+using MaaWpfGui.Models.Diagnostics;
+using MaaWpfGui.Services.Diagnostics;
+
+namespace MaaWpfGui.Views.Dialogs;
+
+public partial class CrashDiagnosticDialog : INotifyPropertyChanged
+{
+    private readonly WpfDiagnosticManager _manager;
+    private readonly DiagnosticFailure _failure;
+    private bool _isBusy;
+    private string _buildReportText;
+    private string _reportResult = string.Empty;
+
+    internal CrashDiagnosticDialog(WpfDiagnosticManager manager, DiagnosticFailure failure)
+    {
+        _manager = manager;
+        _failure = failure;
+        PromptTitle = LocalizationHelper.GetString("DiagnosticPreviousFailureTitle");
+        PromptMessage = LocalizationHelper.GetString("DiagnosticPreviousFailurePrompt");
+        TechnicalDetailsHeading = LocalizationHelper.GetString("DiagnosticTechnicalDetails");
+        ReportOptionsHeading = LocalizationHelper.GetString("DiagnosticReportContents");
+        PrivacyText = LocalizationHelper.GetString("DiagnosticDialogPrivacy");
+        IncludeConfigurationText = LocalizationHelper.GetString("DiagnosticIncludeConfiguration");
+        IncludeScreenshotsText = LocalizationHelper.GetString("DiagnosticIncludeScreenshots");
+        IncludeDumpsText = LocalizationHelper.GetString("DiagnosticIncludeDumps");
+        _buildReportText = LocalizationHelper.GetString("DiagnosticBuildReport");
+        DismissText = LocalizationHelper.GetString("DiagnosticDismiss");
+        FailureSummary = $"{failure.TimestampUtc.ToLocalTime():yyyy-MM-dd HH:mm:ss}  ·  {failure.Code}  ·  {failure.CaseId}";
+        TechnicalDetails = BuildTechnicalDetailsSafely(failure);
+        InitializeComponent();
+        Title = PromptTitle;
+        Owner = Application.Current.MainWindow;
+        Closing += OnClosing;
+    }
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public string PromptTitle { get; }
+
+    public string PromptMessage { get; }
+
+    public string FailureSummary { get; }
+
+    public string TechnicalDetailsHeading { get; }
+
+    public string TechnicalDetails { get; }
+
+    public string ReportOptionsHeading { get; }
+
+    public string PrivacyText { get; }
+
+    public string IncludeConfigurationText { get; }
+
+    public string IncludeScreenshotsText { get; }
+
+    public string IncludeDumpsText { get; }
+
+    public string BuildReportText
+    {
+        get => _buildReportText;
+        private set {
+            _buildReportText = value;
+            OnPropertyChanged(nameof(BuildReportText));
+        }
+    }
+
+    public string DismissText { get; }
+
+    public bool IncludeConfiguration { get; set; } = true;
+
+    public bool IncludeScreenshots { get; set; } = true;
+
+    public bool IncludeDumps { get; set; } = true;
+
+    public bool CanInteract => !_isBusy;
+
+    public string ReportResult
+    {
+        get => _reportResult;
+        private set {
+            _reportResult = value;
+            OnPropertyChanged(nameof(ReportResult));
+        }
+    }
+
+    private void Dismiss_Click(object sender, RoutedEventArgs e)
+    {
+        Close();
+    }
+
+    private async void BuildReport_Click(object sender, RoutedEventArgs e)
+    {
+        if (_isBusy)
+        {
+            return;
+        }
+
+        SetBusy(true);
+        DiagnosticReportResult result;
+        try
+        {
+            result = await _manager.BuildReportAsync(_failure, new() {
+                IncludeConfigurationSummary = IncludeConfiguration,
+                IncludeScreenshots = IncludeScreenshots,
+                IncludeDumps = IncludeDumps,
+            });
+        }
+        catch
+        {
+            ReportResult = LocalizationHelper.GetString("DiagnosticReportFailed");
+            SetBusy(false);
+            return;
+        }
+
+        SetBusy(false);
+        if (result.IsMinimal)
+        {
+            MessageBoxHelper.Show(LocalizationHelper.GetString("DiagnosticMinimalReportCreated"));
+        }
+
+        try
+        {
+            Process.Start(new ProcessStartInfo("explorer.exe", $"/select,\"{result.ReportPath}\"") { UseShellExecute = true });
+        }
+        catch
+        {
+            // Revealing the completed report is optional and must not turn a successful build into an error.
+        }
+
+        Close();
+    }
+
+    private static string BuildTechnicalDetailsSafely(DiagnosticFailure failure)
+    {
+        try
+        {
+            return DiagnosticTechnicalDetailsFormatter.Format(failure);
+        }
+        catch
+        {
+            // A malformed legacy diagnostic record must never prevent this dialog from opening.
+            return failure.TechnicalDetails ?? string.Empty;
+        }
+    }
+
+    private void SetBusy(bool value)
+    {
+        _isBusy = value;
+        BuildReportText = LocalizationHelper.GetString(value ? "DiagnosticBuildingReport" : "DiagnosticBuildReport");
+        OnPropertyChanged(nameof(CanInteract));
+    }
+
+    private void OnClosing(object? sender, CancelEventArgs e)
+    {
+        if (_isBusy)
+        {
+            e.Cancel = true;
+        }
+    }
+
+    private void OnPropertyChanged(string propertyName) => PropertyChanged?.Invoke(this, new(propertyName));
+}

--- a/src/MaaWpfGui/Views/UserControl/Settings/IssueReportUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/Settings/IssueReportUserControl.xaml
@@ -77,6 +77,13 @@
                 <Button
                     Margin="5,2"
                     HorizontalAlignment="Left"
+                    Command="{s:Action GenerateLatestDiagnosticReport}"
+                    Content="{Binding GenerateLatestDiagnosticReportText}"
+                    IsEnabled="{Binding CanGenerateLatestDiagnosticReport}"
+                    Visibility="{c:Binding HasLatestDiagnosticFailure}" />
+                <Button
+                    Margin="5,2"
+                    HorizontalAlignment="Left"
                     Command="{s:Action GenerateSupportPayload}"
                     Content="{DynamicResource GenerateSupportPayload}" />
                 <Button


### PR DESCRIPTION
## 概述

为 WPF 增加崩溃诊断功能，记录托管及原生致命异常，并生成供开发人员排查问题的本地诊断报告。

## 主要改动

- 记录 WPF 与 MaaCore 的致命异常，保留异常详情和原生崩溃现场。
- 上次运行异常时提供一次性提示，并在问题反馈页提供崩溃报告入口。
- 生成包含相关日志、运行时信息及可选附件的诊断报告，支持失败降级和输出目录回退。

## 可靠性

- 诊断功能异常不会影响原有业务。
- 状态记录和报告生成采用原子写入，单项采集失败可独立降级。
- 拖拽和 DWM 异常保持原有非致命处理。
- 报告仅在本地生成且未经脱敏，分享前会提醒用户检查内容。

## 验证

- 本地诊断核心测试：49/49 通过。
- Debug x64 MaaCore、MAA.Updater 和 WPF 构建通过，0 错误。
