### PR TITLE
fix: 降低理智倍率列表展开标记的识别阈值

### DIFF
--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -1280,7 +1280,7 @@
     "FightSeries-Opened": {
         "template": "FightSeries-Indicator.png",
         "roi": [900, 370, 70, 40],
-        "templThreshold": 0.9,
+        "templThreshold": 0.89,
         "maskRange": [1, 255]
     },
     "FightSeries-Open": {


### PR DESCRIPTION
Fixes #17707\n\n用户日志中倍率列表已展开，但 FightSeries-Indicator 的模板匹配得分为 0.899192，低于当前 0.9 阈值，导致重试后仍被识别为未展开。\n\n将国服该标记的阈值下调至 0.89，使该已打开界面能够被稳定识别；识别区域、模板及后续流程不变。\n\n已验证 esource/tasks/tasks.json JSON 语法有效，并通过差异空白检查。

## Summary by Sourcery

Bug Fixes:
- 通过降低任务配置中相应指示器的识别阈值，修复对扩展的健全性乘数列表的误检测问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix misdetection of the expanded sanity multiplier list by reducing the recognition threshold for the corresponding indicator in tasks configuration.

</details>