### PR TITLE
feat(tools): 新增 MaaFramework 控制单元自动下载脚本

### DIFF
--- a/tools/maafw-download.py
+++ b/tools/maafw-download.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+import argparse
+import sys
+from pathlib import Path
+
+sub_path = Path(__file__).parent.parent / "src" / "MaaUtils" / "tools"
+sys.path.append(str(sub_path))
+
+from maafw_download import detect_host_platform
+from maafw_download import main as download_main
+
+REPO = "MaaXYZ/MaaFramework"
+VERSION = None
+
+parser = argparse.ArgumentParser()
+parser.add_argument("platform", nargs="?")
+parser.add_argument("--cache-asset", action="store_true")
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+
+    if args.platform:
+        target_platform = args.platform
+    else:
+        target_platform = detect_host_platform()
+
+    download_main(target_platform, REPO, VERSION, args.cache_asset)


### PR DESCRIPTION
# feat(tools): 新增 MaaFramework 控制单元自动下载脚本

## 背景

MaaAssistantArknights 的 Win32Controller / MaaFwAdbController 功能需要 MaaFramework
控制单元 DLL（`MaaWin32ControlUnit.dll` / `MaaAdbControlUnit.dll`），但 MAA 的构建产物不包含它们，
开发文档此前要求开发者手动从 MaaFramework Releases 下载。
<img width="926" height="235" alt="image" src="https://github.com/user-attachments/assets/95ec8e7e-0c2a-4f3d-8871-53430f387b1f" />

## 设计概要

- **薄封装 + 共享实现**，与现有 `tools/maadeps-download.py` 完全同构：CLI 与常量（REPO / VERSION）
  留在 `tools/maafw-download.py`，下载/解压/安装逻辑放在 MaaUtils 子模块
  `src/MaaUtils/tools/maafw_download.py`（对齐 `maadeps_download.py`），另有离线手动解压脚本
  `maafw-extract.py`（对齐 `maadeps-extract.py`）
- **平台自动探测**：win-x86_64 / win-aarch64 / linux-x86_64 / linux-aarch64 / macos-x86_64 /
  macos-aarch64，资产按 MaaFramework 实际命名匹配（`MAA-<platform>-v<version>.zip`，
  兼容 `.tar.gz`，忽略 `.sha256` 旁路与 android 资产）
- **默认目标 `build/bin/Release`**：预编译 Release 控制单元仅适配 Release 构建，
  Debug 调试仍需自行编译 MaaFramework Debug 版
- **缓存与 digest 复用**：压缩包缓存于 `build/MaaFramework/`，与 GitHub API 返回的 `sha256:` digest
  一致即跳过下载；`--cache-asset` 追加 `.cache_digest.json` 记录已安装资产，再次运行整体跳过
- **只安装控制单元**：解压到 `build/MaaFramework/<资产名>/` 后仅复制 `bin/` 下 `*ControlUnit*`
  到目标目录，不污染构建产物

### 修改文件（本仓库，1 个）

| 文件 | 改动 |
| --- | --- |
| `tools/maafw-download.py` | 新增：薄封装 CLI，按位置传参调用 MaaUtils 侧实现 |

[MaaUtils配套 PR](https://github.com/MaaXYZ/MaaUtils/pull/21)：

| 文件 | 改动 |
| --- | --- |
| `src/MaaUtils/tools/maafw_download.py` | 新增：下载/解压/安装实现，结构与 `maadeps_download.py` 一致 |
| `src/MaaUtils/tools/maafw-extract.py` | 新增：离线手动解压脚本，结构与 `maadeps-extract.py` 一致 |

### 用法

```cmd
python tools/maafw-download.py
```

### 局限

- 如前所述，Debug版本仍需自行编译。
- 仅基于win-x86_64进行了测试。

## Summary by Sourcery

新功能：
- 引入 `tools/maafw-download.py` 作为 MaaUtils 的轻量封装，用于获取并安装 MaaFramework 控制单元，并支持可选的资源缓存功能。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

New Features:
- Introduce tools/maafw-download.py as a thin wrapper around MaaUtils to fetch and install MaaFramework control units with optional asset caching.

</details>