### PR TITLE
perf: 刷理智 代理倍率列表标识匹配方法更换为RGB

### DIFF
--- a/resource/global/YoStarEN/resource/tasks/tasks.json
+++ b/resource/global/YoStarEN/resource/tasks/tasks.json
@@ -1156,6 +1156,7 @@
     "FightSeries-Opened": {
         "template": "FightSeries-Indicator.png",
         "roi": [940, 190, 80, 380],
+        "method": "Ccoeff",
         "templThreshold": 0.9,
         "maskRange": [1, 255]
     },

--- a/resource/global/YoStarJP/resource/tasks/tasks.json
+++ b/resource/global/YoStarJP/resource/tasks/tasks.json
@@ -1135,6 +1135,7 @@
     "FightSeries-Opened": {
         "template": "FightSeries-Indicator.png",
         "roi": [940, 190, 80, 380],
+        "method": "Ccoeff",
         "templThreshold": 0.9,
         "maskRange": [1, 255]
     },

--- a/resource/global/YoStarKR/resource/tasks/tasks.json
+++ b/resource/global/YoStarKR/resource/tasks/tasks.json
@@ -1279,6 +1279,7 @@
     "FightSeries-Opened": {
         "template": "FightSeries-Indicator.png",
         "roi": [940, 190, 80, 380],
+        "method": "Ccoeff",
         "templThreshold": 0.9,
         "maskRange": [1, 255]
     },

--- a/resource/global/txwy/resource/tasks/tasks.json
+++ b/resource/global/txwy/resource/tasks/tasks.json
@@ -939,6 +939,7 @@
     "FightSeries-Opened": {
         "template": "FightSeries-Indicator.png",
         "roi": [940, 190, 80, 380],
+        "method": "Ccoeff",
         "templThreshold": 0.9,
         "maskRange": [1, 255]
     },

--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -1280,8 +1280,8 @@
     "FightSeries-Opened": {
         "template": "FightSeries-Indicator.png",
         "roi": [900, 370, 70, 40],
-        "templThreshold": 0.9,
-        "maskRange": [1, 255]
+        "method": "RGBCount",
+        "colorScales": [[0, 255]]
     },
     "FightSeries-Open": {
         "baseTask": "FightSeries-Icon",


### PR DESCRIPTION
- link to #8951, #17707

## Summary by Sourcery

增强功能：
- 对 EN、JP、KR、txwy 和全局资源的 `tasks.json` 定义进行统一，使其使用新的代理费率列表识别方案。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Align tasks.json definitions for EN, JP, KR, txwy, and global resources to use the new identification scheme for proxy rate listings.

</details>