### PR TITLE
feat: WPF GUI 增加 Waydroid 连接配置

### DIFF
--- a/src/MaaWpfGui/Constants/Enums/ConnectConfig.cs
+++ b/src/MaaWpfGui/Constants/Enums/ConnectConfig.cs
@@ -31,4 +31,5 @@ public enum ConnectConfig
     Compatible,
     SecondResolution,
     GeneralWithoutScreencapErr,
+    Waydroid,
 }

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -215,6 +215,7 @@ To customize rotation schedules, please use ｢{key=InfrastModeCustom}｣.</syst
     <system:String x:Key="Compatible">Compatible Mode</system:String>
     <system:String x:Key="SecondResolution">2nd Resolution</system:String>
     <system:String x:Key="GeneralWithoutScreencapErr">General Mode (Blocked exception output)</system:String>
+    <system:String x:Key="Waydroid">Waydroid</system:String>
     <system:String x:Key="DormThreshold">Morale Threshold</system:String>
     <system:String x:Key="InfrastThresholdTip">If custom shifts are enabled, this field is only valid for rooms with autofill and {key=Operator} groups</system:String>
     <system:String x:Key="RoguelikeStrategyExp">Gain Experience Points, clear as many nodes as possible</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -215,6 +215,7 @@
     <system:String x:Key="Compatible">互換モード</system:String>
     <system:String x:Key="SecondResolution">2番目の決議</system:String>
     <system:String x:Key="GeneralWithoutScreencapErr">一般モード（ブロックされた例外出力）</system:String>
+    <system:String x:Key="Waydroid">Waydroid</system:String>
     <system:String x:Key="DormThreshold">体力が設定した%以下になれば宿舎へ移動する</system:String>
     <system:String x:Key="InfrastThresholdTip">カスタム シフトが有効な場合、このフィールドは自動入力と{key=Operator} グループのあるルームに対してのみ有効です</system:String>
     <system:String x:Key="RoguelikeStrategyExp">経験値を取得し、できるだけクリア</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -215,6 +215,7 @@
     <system:String x:Key="Compatible">호환 모드</system:String>
     <system:String x:Key="SecondResolution">분할 화면</system:String>
     <system:String x:Key="GeneralWithoutScreencapErr">일반 모드 (예외 출력 차단)</system:String>
+    <system:String x:Key="Waydroid">Waydroid</system:String>
     <system:String x:Key="DormThreshold">{key=Operator} 컨디션 한계점</system:String>
     <system:String x:Key="InfrastThresholdTip">커스텀 교대 근무 변경이 활성화된 경우 이 필드는 자동 채우기 및 {key=Operator} 교체를 사용하는 회의실에만 유효합니다</system:String>
     <system:String x:Key="RoguelikeStrategyExp">레벨 우선, 최대한 많은 구역 클리어</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -215,6 +215,7 @@
     <system:String x:Key="Compatible">兼容模式</system:String>
     <system:String x:Key="SecondResolution">第二分辨率</system:String>
     <system:String x:Key="GeneralWithoutScreencapErr">通用模式（屏蔽异常输出）</system:String>
+    <system:String x:Key="Waydroid">Waydroid</system:String>
     <system:String x:Key="DormThreshold">基建工作心情阈值</system:String>
     <system:String x:Key="InfrastThresholdTip">若启用自定义换班，该字段仅针对 autofill 和使用{key=Operator}编组的房间有效</system:String>
     <system:String x:Key="RoguelikeStrategyExp">刷等级，尽可能稳定地打更多层数</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -215,6 +215,7 @@
     <system:String x:Key="Compatible">相容模式</system:String>
     <system:String x:Key="SecondResolution">第二解析度</system:String>
     <system:String x:Key="GeneralWithoutScreencapErr">通用模式（阻擋異常輸出）</system:String>
+    <system:String x:Key="Waydroid">Waydroid</system:String>
     <system:String x:Key="DormThreshold">基建工作心情閾值</system:String>
     <system:String x:Key="InfrastThresholdTip">若啟用自定義換班，該欄位僅針對自動填充 (autofill) 和{key=Operator}編組的房間有效</system:String>
     <system:String x:Key="RoguelikeStrategyExp">刷等級，盡可能穩定地打更多層數</system:String>

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/ConnectSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/ConnectSettingsUserControlModel.cs
@@ -471,15 +471,7 @@ public class ConnectSettingsUserControlModel : PropertyChangedBase
 
         if (ConnectAddress.Length == 0)
         {
-            if (DefaultAddress.TryGetValue(ConnectConfig.ToString(), out var defaultAddresses) && defaultAddresses.Count > 0)
-            {
-                ConnectAddress = defaultAddresses[0];
-            }
-            else
-            {
-                error = LocalizationHelper.GetString("AutoDetectConnectionNotSupported");
-                return false;
-            }
+            ConnectAddress = DefaultAddress[ConnectConfig.ToString()][0];
         }
 
         return true;

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/ConnectSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/ConnectSettingsUserControlModel.cs
@@ -90,7 +90,8 @@ public class ConnectSettingsUserControlModel : PropertyChangedBase
         (ConnectConfig.WSA, "WSA"),
         (ConnectConfig.Compatible, "Compatible"),
         (ConnectConfig.SecondResolution, "SecondResolution"),
-        (ConnectConfig.GeneralWithoutScreencapErr, "GeneralWithoutScreencapErr"));
+        (ConnectConfig.GeneralWithoutScreencapErr, "GeneralWithoutScreencapErr"),
+        (ConnectConfig.Waydroid, "Waydroid"));
 
     public static string TouchModeVideoPath => Path.Combine(PathsHelper.BaseDir, "Res", "Video", "TouchMode.mp4");
 
@@ -470,7 +471,15 @@ public class ConnectSettingsUserControlModel : PropertyChangedBase
 
         if (ConnectAddress.Length == 0)
         {
-            ConnectAddress = DefaultAddress[ConnectConfig.ToString()][0];
+            if (DefaultAddress.TryGetValue(ConnectConfig.ToString(), out var defaultAddresses) && defaultAddresses.Count > 0)
+            {
+                ConnectAddress = defaultAddresses[0];
+            }
+            else
+            {
+                error = LocalizationHelper.GetString("AutoDetectConnectionNotSupported");
+                return false;
+            }
         }
 
         return true;


### PR DESCRIPTION
## 变更内容

- 在 WPF GUI 的连接配置中增加已存在的 `Waydroid` 预设入口。
- 补齐了五种界面语言的 `Waydroid` 本地化文本。
- 没修改 MaaCore、`resource/config.json`、自动检测或默认连接地址。

Closes #16943

## 验证

- `dotnet build src\MaaWpfGui\MaaWpfGui.csproj -c Release -p:Platform=x64` 通过。
- 已手动验证 Waydroid 选项显示、窗口标题更新、配置保存与重启恢复。
- 真实 Linux + Wine + Waydroid 的连接与截图测试尚待具备对应环境者烟测。

## Sourcery 摘要

为 WPF GUI 添加 Waydroid 连接配置支持。

新功能：
- 在 WPF GUI 中添加 Waydroid 作为可选的连接预设。

文档：
- 为所有受支持的界面语言添加本地化的 Waydroid 标签。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add Waydroid connection configuration support to the WPF GUI.

New Features:
- Add Waydroid as a selectable connection preset in the WPF GUI.

Documentation:
- Add localized Waydroid labels for all supported interface languages.

</details>

新功能：
- 在 WPF 图形界面的连接设置中引入 Waydroid 连接配置选项。

文档：
- 为 WPF 图形界面中所有五种受支持的界面语言添加本地化的 Waydroid 标签和文本。

<details>
<summary>Original summary in English</summary>



</details>



新功能：
- 在 WPF 图形界面中添加 Waydroid 作为可选连接预设。

错误修复：
- 通过报告不支持自动检测的错误来处理未配置默认地址的连接预设，而不是在查找过程中失败。

文档：
- 为所有支持的语言添加本地化的 Waydroid 界面文本。

<details>
<summary>Original summary in English</summary>



</details>

新功能：
- 在 WPF 图形界面的连接设置中引入 Waydroid 连接配置预设。

文档：
- 在 WPF 图形界面中为所有五种受支持的界面语言添加本地化的 Waydroid 标签和文本。

<details>
<summary>Original summary in English</summary>



新功能：
- 在 WPF 图形界面中添加 Waydroid 作为可选连接预设。

错误修复：
- 通过报告不支持自动检测的错误来处理未配置默认地址的连接预设，而不是在查找过程中失败。

文档：
- 为所有支持的语言添加本地化的 Waydroid 界面文本。

<details>
<summary>Original summary in English</summary>



</details>

</details>