### PR TITLE
feat: Add drone auto-balance mode and multi-language support

### DIFF
--- a/docs/en-us/protocol/integration.md
+++ b/docs/en-us/protocol/integration.md
@@ -360,7 +360,14 @@ Facility name: `Mfg` | `Trade` | `Power` | `Control` | `Reception` | `Office` | 
 ::: field name="drones" type="string" optional default="\_NotUse"  
 Usage of drones. This field is ignored when `mode = 10000`.
 <br>
-Options: `_NotUse` | `Money` | `SyntheticJade` | `CombatRecord` | `PureGold` | `OriginStone` | `Chip`  
+Options: `_NotUse` | `Money` | `SyntheticJade` | `CombatRecord` | `PureGold` | `OriginStone` | `Chip` | `PureGold-Money` | `OriginStone-SyntheticJade`  
+:::  
+::: field name="drones_usage_threshold" type="number" optional default="10"  
+Drone auto-balance threshold, effective only when `drones = PureGold-Money` / `OriginStone-SyntheticJade`. Runs the Trading Station first to consume Pure Gold / Originium Shards below this value using drones, one order at a time: accelerate to produce an order, read the order's stock/consumption, then submit the order for delivery; after the delivery, judge whether to continue consuming based on the read stock (stop when it drops below the threshold). If there is still no completed order after accelerating, it means there are not enough drones, so it stops directly. Then uses all remaining drones for production.  
+:::  
+
+::: tip Facility order in drone auto-balance mode  
+When `drones = PureGold-Money` / `OriginStone-SyntheticJade`, `Trade` must come before `Mfg` in the `facility` array, otherwise the "consume first, then produce" semantics are not guaranteed. The GUI enforces this order automatically; when calling the interface directly, please ensure it yourself.  
 :::  
 ::: field name="threshold" type="number" optional default="0.3"  
 Morale threshold, range [0, 1.0].

--- a/docs/en-us/protocol/integration.md
+++ b/docs/en-us/protocol/integration.md
@@ -363,7 +363,7 @@ Usage of drones. This field is ignored when `mode = 10000`.
 Options: `_NotUse` | `Money` | `SyntheticJade` | `CombatRecord` | `PureGold` | `OriginStone` | `Chip` | `PureGold-Money` | `OriginStone-SyntheticJade`  
 :::  
 ::: field name="drones_usage_threshold" type="number" optional default="10"  
-Drone auto-balance threshold, effective only when `drones = PureGold-Money` / `OriginStone-SyntheticJade`. Runs the Trading Station first to consume Pure Gold / Originium Shards below this value using drones, one order at a time: accelerate to produce an order, read the order's stock/consumption, then submit the order for delivery; after the delivery, judge whether to continue consuming based on the read stock (stop when it drops below the threshold). If there is still no completed order after accelerating, it means there are not enough drones, so it stops directly. Then uses all remaining drones for production.  
+Drone auto-balance threshold, effective only when `drones = PureGold-Money` / `OriginStone-SyntheticJade`. Runs the Trading Station first to consume Pure Gold / Originium Shards below this value using drones, one order at a time: accelerate to produce an order, read the order's stock/consumption, then submit the order for delivery; after the delivery, judge whether to continue consuming based on the read stock (stop when it drops below the threshold). If there is still no completed order after accelerating, it means there are not enough drones, so it stops directly. It then uses all remaining drones for production.  
 :::  
 
 ::: tip Facility order in drone auto-balance mode  

--- a/docs/ja-jp/protocol/integration.md
+++ b/docs/ja-jp/protocol/integration.md
@@ -360,7 +360,14 @@ Bilibili：`张三`、入力可能：`张三`、`张`、`三`
 ::: field name="drones" type="string" optional default="\_NotUse"  
 ドローン使用目的。`mode = 10000` の場合、このフィールドは無効です。
 <br>
-オプション：`_NotUse` | `Money` | `SyntheticJade` | `CombatRecord` | `PureGold` | `OriginStone` | `Chip`  
+オプション：`_NotUse` | `Money` | `SyntheticJade` | `CombatRecord` | `PureGold` | `OriginStone` | `Chip` | `PureGold-Money` | `OriginStone-SyntheticJade`  
+:::  
+::: field name="drones_usage_threshold" type="number" optional default="10"  
+ドローン自動平衡のしきい値。`drones = PureGold-Money` / `OriginStone-SyntheticJade` の場合のみ有効です。実行時はまず貿易所でドローンを使って純金/源石の欠片をこの値未満まで、注文1件ずつ段階的に消費します：まず注文を加速して生産し、その注文の「在庫/消費量」を読み取って納品します。納品後、読み取った在庫数値で消費を続けるか判定します（しきい値未満なら停止）。加速後も未完了の注文が無い場合はドローン不足とみなし、そのまま停止します。残ったドローンは全て生産に使用します。  
+:::  
+
+::: tip ドローン自動平衡モードでの施設順序  
+`drones = PureGold-Money` / `OriginStone-SyntheticJade` の場合、`facility` 配列で `Trade` を `Mfg` より前に配置する必要があります。そうしないと「先に消費し、その後生産する」という意味合いが保証されません。GUI ではこの順序を自動的に強制します。インターフェースを直接呼び出す場合はご自身で順序を保証してください。  
 :::  
 ::: field name="threshold" type="number" optional default="0.3"  
 作業心情しきい値。範囲は [0, 1.0] です。

--- a/docs/ko-kr/protocol/integration.md
+++ b/docs/ko-kr/protocol/integration.md
@@ -350,7 +350,14 @@ Yituliu 전송 ID, 기본값 비어 있음. `report_to_yituliu`가 true일 때�
 ::: field name="drones" type="string" optional default="\_NotUse"  
 드론 용도. `mode = 10000`일 때 이 필드는 무효
 <br>
-옵션: `_NotUse` | `Money` | `SyntheticJade` | `CombatRecord` | `PureGold` | `OriginStone` | `Chip`  
+옵션: `_NotUse` | `Money` | `SyntheticJade` | `CombatRecord` | `PureGold` | `OriginStone` | `Chip` | `PureGold-Money` | `OriginStone-SyntheticJade`  
+:::  
+::: field name="drones_usage_threshold" type="number" optional default="10"  
+드론 자동 균형 임계값. `drones = PureGold-Money` / `OriginStone-SyntheticJade`일 때만 유효합니다. 실행 시 먼저 무역소에서 드론으로 순금/오리지늄 조각을 이 값 미만까지 주문 1건씩 단계적으로 소모합니다: 먼저 주문을 가속하여 생산하고, 해당 주문의 「재고/소모량」을 읽어 납품합니다. 납품 후 읽은 재고 수치로 소모를 계속할지 판단합니다(임계값 미만이면 중지). 가속 후에도 미완료 주문이 없으면 드론 부족으로 보고 그대로 중지합니다. 남은 드론은 모두 생산에 사용합니다.  
+:::  
+
+::: tip 드론 자동 균형 모드의 시설 순서  
+`drones = PureGold-Money` / `OriginStone-SyntheticJade`일 때 `facility` 배열에서 `Trade`가 `Mfg`보다 앞에 있어야 합니다. 그렇지 않으면 "먼저 소모하고 나중에 생산"이라는 의미가 보장되지 않습니다. GUI는 이 순서를 자동으로 강제합니다. 인터페이스를 직접 호출하는 경우 직접 순서를 보장하세요.  
 :::  
 ::: field name="threshold" type="number" optional default="0.3"  
 컨디션 임계값, 범위 [0, 1.0]

--- a/docs/zh-cn/protocol/integration.md
+++ b/docs/zh-cn/protocol/integration.md
@@ -360,7 +360,14 @@ Tag 等级（大于等于 3）和对应的希望招募时限，单位为分钟�
 ::: field name="drones" type="string" optional default="\_NotUse"  
 无人机用途。`mode = 10000` 时该字段无效。
 <br>
-选项：`_NotUse` | `Money` | `SyntheticJade` | `CombatRecord` | `PureGold` | `OriginStone` | `Chip`  
+选项：`_NotUse` | `Money` | `SyntheticJade` | `CombatRecord` | `PureGold` | `OriginStone` | `Chip` | `PureGold-Money` | `OriginStone-SyntheticJade`  
+:::  
+::: field name="drones_usage_threshold" type="number" optional default="10"  
+无人机自动平衡阈值，仅 `drones = PureGold-Money` / `OriginStone-SyntheticJade` 时生效。执行时先进贸易站，用无人机按「单个订单」粒度逐步把赤金/源石碎片消耗到低于该值：先加速生产一个订单，随后读取该订单的「库存/消耗量」并提交交付，交付完成后依据读取到的库存数字判读是否继续消耗（低于阈值即停止）；若加速后仍无未完成订单，说明无人机不足，直接停止。随后将剩余无人机全部用于生产。  
+:::  
+
+::: tip 无人机自动平衡模式的设施顺序  
+`drones = PureGold-Money` / `OriginStone-SyntheticJade` 时，要求 `facility` 数组中 `Trade` 在 `Mfg` 之前，否则“先消耗、再生产”的语义无法保证。GUI 会自动强制该顺序；直接调用接口请自行保证。  
 :::  
 ::: field name="threshold" type="number" optional default="0.3"  
 工作心情阈值，取值范围 [0, 1.0]。

--- a/docs/zh-cn/protocol/integration.md
+++ b/docs/zh-cn/protocol/integration.md
@@ -363,7 +363,7 @@ Tag 等级（大于等于 3）和对应的希望招募时限，单位为分钟�
 选项：`_NotUse` | `Money` | `SyntheticJade` | `CombatRecord` | `PureGold` | `OriginStone` | `Chip` | `PureGold-Money` | `OriginStone-SyntheticJade`  
 :::  
 ::: field name="drones_usage_threshold" type="number" optional default="10"  
-无人机自动平衡阈值，仅 `drones = PureGold-Money` / `OriginStone-SyntheticJade` 时生效。执行时先进贸易站，用无人机按「单个订单」粒度逐步把赤金/源石碎片消耗到低于该值：先加速生产一个订单，随后读取该订单的「库存/消耗量」并提交交付，交付完成后依据读取到的库存数字判读是否继续消耗（低于阈值即停止）；若加速后仍无未完成订单，说明无人机不足，直接停止。随后将剩余无人机全部用于生产。  
+无人机自动平衡阈值，仅 `drones = PureGold-Money` / `OriginStone-SyntheticJade` 时生效。执行时先进贸易站，用无人机按「单个订单」粒度逐步把赤金/源石碎片消耗到低于该值：先加速生产一个订单，随后读取该订单的「库存/消耗量」并提交交付，交付完成后依据读取到的库存数字判断是否继续消耗（低于阈值即停止）；若加速后仍无未完成订单，说明无人机不足，直接停止。随后将剩余无人机全部用于生产。  
 :::  
 
 ::: tip 无人机自动平衡模式的设施顺序  

--- a/docs/zh-tw/protocol/integration.md
+++ b/docs/zh-tw/protocol/integration.md
@@ -363,7 +363,7 @@ Tag 等級（大於等於 3）對應的期望招募時限（單位：分鐘）�
 選項：`_NotUse` | `Money` | `SyntheticJade` | `CombatRecord` | `PureGold` | `OriginStone` | `Chip` | `PureGold-Money` | `OriginStone-SyntheticJade`  
 :::  
 ::: field name="drones_usage_threshold" type="number" optional default="10"  
-無人機自動平衡門檻值，僅 `drones = PureGold-Money` / `OriginStone-SyntheticJade` 時生效。執行時先進貿易站，用無人機按「單個訂單」粒度逐步把赤金/源石碎片消耗到低於該值：先加速生產一個訂單，隨後讀取該訂單的「庫存/消耗量」並提交交付，交付完成後依據讀取到的庫存數字判讀是否繼續消耗（低於門檻值即停止）；若加速後仍無未完成訂單，說明無人機不足，直接停止。隨後將剩餘無人機全部用於生產。  
+無人機自動平衡門檻值，僅 `drones = PureGold-Money` / `OriginStone-SyntheticJade` 時生效。執行時先進貿易站，用無人機按「單個訂單」粒度逐步把赤金/源石碎片消耗到低於該值：先加速生產一個訂單，隨後讀取該訂單的「庫存/消耗量」並提交交付，交付完成後依據讀取到的庫存數字判斷是否繼續消耗（低於門檻值即停止）；若加速後仍無未完成訂單，說明無人機不足，直接停止。隨後將剩餘無人機全部用於生產。  
 :::  
 
 ::: tip 無人機自動平衡模式的設施順序  

--- a/docs/zh-tw/protocol/integration.md
+++ b/docs/zh-tw/protocol/integration.md
@@ -360,7 +360,14 @@ Tag 等級（大於等於 3）對應的期望招募時限（單位：分鐘）�
 ::: field name="drones" type="string" optional default="\_NotUse"  
 無人機用途。當 `mode = 10000` 時，此欄位無效。
 <br>
-選項：`_NotUse` | `Money` | `SyntheticJade` | `CombatRecord` | `PureGold` | `OriginStone` | `Chip`  
+選項：`_NotUse` | `Money` | `SyntheticJade` | `CombatRecord` | `PureGold` | `OriginStone` | `Chip` | `PureGold-Money` | `OriginStone-SyntheticJade`  
+:::  
+::: field name="drones_usage_threshold" type="number" optional default="10"  
+無人機自動平衡門檻值，僅 `drones = PureGold-Money` / `OriginStone-SyntheticJade` 時生效。執行時先進貿易站，用無人機按「單個訂單」粒度逐步把赤金/源石碎片消耗到低於該值：先加速生產一個訂單，隨後讀取該訂單的「庫存/消耗量」並提交交付，交付完成後依據讀取到的庫存數字判讀是否繼續消耗（低於門檻值即停止）；若加速後仍無未完成訂單，說明無人機不足，直接停止。隨後將剩餘無人機全部用於生產。  
+:::  
+
+::: tip 無人機自動平衡模式的設施順序  
+`drones = PureGold-Money` / `OriginStone-SyntheticJade` 時，要求 `facility` 陣列中 `Trade` 在 `Mfg` 之前，否則「先消耗、再生產」的語義無法保證。GUI 會自動強制該順序；直接呼叫介面請自行保證。  
 :::  
 ::: field name="threshold" type="number" optional default="0.3"  
 工作心情門檻值，取值範圍 [0, 1.0]。

--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -2531,6 +2531,49 @@
         "template": "DroneAssistTrade.png",
         "action": "Stop"
     },
+    "DroneAssistTradeBalance": {
+        "Doc": "无人机自动平衡专用：单次仅加速并交付一个订单，便于逐单识别库存",
+        "action": "ClickSelf",
+        "roi": [250, 430, 460, 120],
+        "template": "DroneAssistTrade.png",
+        "maxTimes": 1,
+        "next": ["DroneAssistTradeBalanceReTry", "DroneMaxBalance", "DroneConfirmBalance", "DroneCancel"]
+    },
+    "DroneAssistTradeBalanceReTry": {
+        "action": "ClickSelf",
+        "roi": [250, 430, 460, 120],
+        "template": "DroneAssistTrade.png",
+        "maxTimes": 20,
+        "next": ["DroneAssistTradeBalance#next"]
+    },
+    "DroneMaxBalance": {
+        "action": "ClickSelf",
+        "roi": [900, 300, 120, 80],
+        "template": "DroneMax.png",
+        "next": ["DroneConfirmBalance", "DroneCancel"]
+    },
+    "DroneConfirmBalance": {
+        "action": "ClickSelf",
+        "postDelay": 3500,
+        "roi": [778, 501, 377, 165],
+        "template": "DroneConfirm.png",
+        "next": ["DroneConfirmBalance@LoadingText", "Stop"]
+    },
+    "DeliverableOrderBalance": {
+        "action": "ClickSelf",
+        "roi": [250, 300, 230, 250],
+        "template": "DeliverableOrder.png",
+        "postDelay": 2000,
+        "next": ["Stop"]
+    },
+
+    "DroneTradeStock": {
+        "algorithm": "OcrDetect",
+        "baseTask": "NumberOcrReplace",
+        "Doc": "识别贸易站的库存",
+        "roi": [ 370, 309, 104, 30 ],
+        "text": []
+    },
     "ReplenishToMax": {
         "action": "ClickSelf",
         "roi": [882, 128, 165, 149],

--- a/src/MaaCore/Task/Infrast/InfrastProductionTask.cpp
+++ b/src/MaaCore/Task/Infrast/InfrastProductionTask.cpp
@@ -1017,7 +1017,8 @@ bool asst::InfrastProductionTask::try_get_stock_and_consumption(int& stock, int&
     analyzer.set_task_info("DroneTradeStock");
     analyzer.set_replace(Task.get<OcrTaskInfo>("NumberOcrReplace")->replace_map);
     analyzer.set_use_char_model(true);
-    if (!analyzer.analyze()) {
+    // OCR 成功但结果为空时同样视为失败，避免对空结果取 front()
+    if (!analyzer.analyze() || analyzer.get_result().empty()) {
         return false;
     }
     const std::string& text = analyzer.get_result().front().text;

--- a/src/MaaCore/Task/Infrast/InfrastProductionTask.cpp
+++ b/src/MaaCore/Task/Infrast/InfrastProductionTask.cpp
@@ -12,10 +12,12 @@
 #include "Status.h"
 #include "Task/ProcessTask.h"
 #include "Utils/Logger.hpp"
+#include "Utils/StringMisc.hpp"
 #include "Vision/Hasher.h"
 #include "Vision/Infrast/InfrastOperImageAnalyzer.h"
 #include "Vision/Matcher.h"
 #include "Vision/MultiMatcher.h"
+#include "Vision/OCRer.h"
 #include "Vision/RegionOCRer.h"
 
 asst::InfrastProductionTask& asst::InfrastProductionTask::set_drones_usage_from_params(std::string usage) noexcept
@@ -27,6 +29,14 @@ asst::InfrastProductionTask& asst::InfrastProductionTask::set_drones_usage_from_
 std::string asst::InfrastProductionTask::get_drones_usage_from_params() const noexcept
 {
     return m_drones_usage_from_params;
+}
+
+asst::InfrastProductionTask& asst::InfrastProductionTask::set_drones_balance_config(std::string mode, int threshold) noexcept
+{
+    m_drones_balance_mode = std::move(mode);
+    m_drones_balance_threshold = threshold;
+    m_drones_balance_consume_done = m_drones_balance_mode.empty();
+    return *this;
 }
 
 void asst::InfrastProductionTask::set_custom_drones_config(infrast::CustomDronesConfig drones_config)
@@ -432,6 +442,11 @@ bool asst::InfrastProductionTask::shift_facility_list()
                 m_custom_drones_config.index == m_cur_facility_index) {
                 use_drone();
             }
+        }
+        else if (
+            // 无人机自动平衡：贸易站消耗对应物品至低于阈值，制造站无人机走下方普通 params 分支
+            !m_drones_balance_mode.empty() && facility_name() == "Trade") {
+            drones_balance_consume();
         }
         else if (
             // 普通 params 无人机只在非自定义模式下使用
@@ -902,6 +917,127 @@ bool asst::InfrastProductionTask::use_drone()
     std::string task_name = "DroneAssist" + facility_name();
     ProcessTask task_temp(*this, { task_name });
     return task_temp.run();
+}
+
+bool asst::InfrastProductionTask::use_drone_once()
+{
+    ProcessTask task_temp(*this, { "DroneAssistTradeBalance" });
+    return task_temp.run();
+}
+
+bool asst::InfrastProductionTask::use_drone_once_deliver()
+{
+    ProcessTask task_temp(*this, { "DeliverableOrderBalance" });
+    return task_temp.run();
+}
+
+bool asst::InfrastProductionTask::is_accelerate_button_visible()
+{
+    Matcher analyzer(ctrler()->get_image());
+    analyzer.set_task_info("DroneAssistTrade");
+    return static_cast<bool>(analyzer.analyze());
+}
+
+void asst::InfrastProductionTask::drones_balance_consume()
+{
+    LogTraceFunction;
+    if (m_drones_balance_consume_done) {
+        return;
+    }
+    m_drones_balance_consume_done = true;
+
+    // 尽力切换订单类型，确保加速的是目标消耗订单
+    const std::string order_task =
+        (m_drones_balance_mode == "PureGold-Money") ? "ChangeToMoneyOrder" : "ChangeToSyntheticJadeFlagOrder";
+    if (!ProcessTask(*this, { order_task }).run()) {
+        Log.warn(__FUNCTION__, "| failed to switch order type, continue best-effort");
+    }
+
+    constexpr int ConsumeMaxTimes = 10;
+    int last_stock = -1;
+    int unchanged_times = 0;
+    for (int i = 0; i < ConsumeMaxTimes; ++i) {
+        if (need_exit()) {
+            return;
+        }
+
+        // 状态1（第一格无未完成订单，加速按钮可见）：加速生产一个订单。
+        // 无人机充足 → 弹窗消失 → 状态2；无人机不足 → 弹窗消失 → 仍状态1 → 停止。
+        if (is_accelerate_button_visible()) {
+            if (!use_drone_once()) {
+                Log.info(__FUNCTION__, "| use drone once failed, stop consuming");
+                return;
+            }
+            if (is_accelerate_button_visible()) {
+                Log.warn(__FUNCTION__, "| no enough drones to complete an order, stop consuming");
+                return;
+            }
+        }
+
+        // 状态2（有未完成订单，库存/消耗量 X/Y 可读）
+        int stock = 0, consumption = 0;
+        if (!try_get_stock_and_consumption(stock, consumption)) {
+            Log.warn(__FUNCTION__, "| failed to recognize stock/consumption, stop consuming");
+            return;
+        }
+        Log.info(__FUNCTION__, "| stock", stock, "| consumption", consumption,
+                 "| threshold", m_drones_balance_threshold);
+
+        // 记录本次消耗（相对上一轮读取的库存），并守卫“库存未下降”的空转
+        Log.info(__FUNCTION__, "| consumed in this order", last_stock >= 0 ? (last_stock - stock) : 0);
+        if (last_stock >= 0 && stock >= last_stock) {
+            if (++unchanged_times >= 2) {
+                Log.warn(__FUNCTION__, "| stock not decreasing, stop consuming");
+                return;
+            }
+        }
+        else {
+            unchanged_times = 0;
+        }
+        last_stock = stock;
+
+        // 交付订单消耗库存 → 回状态1
+        if (!use_drone_once_deliver()) {
+            Log.info(__FUNCTION__, "| deliver order failed, stop consuming");
+            return;
+        }
+
+        // 回状态1时根据读取到的数字判读是否要进行下一次循环
+        if (stock < m_drones_balance_threshold) {
+            Log.info(__FUNCTION__, "| below threshold, stop consuming");
+            return;
+        }
+    }
+}
+
+bool asst::InfrastProductionTask::try_get_stock_and_consumption(int& stock, int& consumption)
+{
+    LogTraceFunction;
+    OCRer analyzer(ctrler()->get_image());
+    analyzer.set_task_info("DroneTradeStock");
+    analyzer.set_replace(Task.get<OcrTaskInfo>("NumberOcrReplace")->replace_map);
+    analyzer.set_use_char_model(true);
+    if (!analyzer.analyze()) {
+        return false;
+    }
+    const std::string& text = analyzer.get_result().front().text;
+    // 库存/消耗量 形如 X/Y
+    auto slash_pos = text.find('/');
+    if (slash_pos == std::string::npos) {
+        Log.warn(__FUNCTION__, "| ocr result without '/':", text);
+        return false;
+    }
+    // 游戏内大于 999 会显示为 999+，按 1000 处理
+    auto parse_number = [](std::string_view num_text, int& out) -> bool {
+        if (num_text.find('+') != std::string_view::npos) {
+            out = 1000;
+            return true;
+        }
+        return utils::chars_to_number(num_text, out);
+    };
+    const std::string_view text_view(text);
+    return parse_number(text_view.substr(0, slash_pos), stock) &&
+           parse_number(text_view.substr(slash_pos + 1), consumption);
 }
 
 asst::infrast::SkillsComb

--- a/src/MaaCore/Task/Infrast/InfrastProductionTask.h
+++ b/src/MaaCore/Task/Infrast/InfrastProductionTask.h
@@ -16,6 +16,8 @@ public:
     // 来自params的无人机使用参数，自定义基建配置启用时不触发
     InfrastProductionTask& set_drones_usage_from_params(std::string usage) noexcept;
     std::string get_drones_usage_from_params() const noexcept;
+    // 无人机自动平衡（贸易站消耗至低于阈值），参数为模式（"PureGold-Money"/"OriginStone-SyntheticJade"），空表示未启用
+    InfrastProductionTask& set_drones_balance_config(std::string mode, int threshold) noexcept;
     void set_custom_drones_config(infrast::CustomDronesConfig drones_config);
     void clear_custom_drones_config();
 
@@ -30,12 +32,28 @@ protected:
     bool optimal_calc();
     bool opers_choose();
     bool use_drone();
+    // 无人机自动平衡专用：单次加速并完成一个贸易站订单（点加速→MAX→确认），返回是否成功
+    bool use_drone_once();
+    // 无人机自动平衡专用：提交当前已完成的贸易站订单（交付），返回是否成功
+    bool use_drone_once_deliver();
+    // 无人机自动平衡专用：判断第一格是否处于「无未完成订单」状态（加速按钮可见）
+    bool is_accelerate_button_visible();
     void set_product(std::string product_name) noexcept;
+    // 贸易站无人机自动平衡：识别当前物品剩余量并加速消耗订单直至低于阈值，尽力而为
+    void drones_balance_consume();
+    // 识别贸易站界面当前订单的「库存/消耗量」（OCR 形如 X/Y，999+ 按 1000 计），成功返回 true；失败表示第一格处于「无未完成订单」状态
+    bool try_get_stock_and_consumption(int& stock, int& consumption);
 
     infrast::SkillsComb efficient_regex_calc(std::unordered_set<infrast::Skill> skills) const;
 
     std::string m_product;
     std::string m_drones_usage_from_params;
+    // 无人机自动平衡模式（"PureGold-Money"/"OriginStone-SyntheticJade"），为空表示未启用
+    std::string m_drones_balance_mode;
+    // 无人机自动平衡阈值：剩余量小于该值即停止消耗
+    int m_drones_balance_threshold = 10;
+    // 防止一个 visit 内重复执行消耗循环
+    bool m_drones_balance_consume_done = true;
     int m_cur_num_of_locked_opers = 0;
     std::vector<infrast::Oper> m_all_available_opers;
     std::vector<infrast::SkillsComb> m_optimal_combs;

--- a/src/MaaCore/Task/Infrast/InfrastProductionTask.h
+++ b/src/MaaCore/Task/Infrast/InfrastProductionTask.h
@@ -41,7 +41,7 @@ protected:
     void set_product(std::string product_name) noexcept;
     // 贸易站无人机自动平衡：识别当前物品剩余量并加速消耗订单直至低于阈值，尽力而为
     void drones_balance_consume();
-    // 识别贸易站界面当前订单的「库存/消耗量」（OCR 形如 X/Y，999+ 按 1000 计），成功返回 true；失败表示第一格处于「无未完成订单」状态
+    // 识别贸易站界面当前订单的「库存/消耗量」（OCR 形如 X/Y，999+ 按 1000 计），成功返回 true；失败表示未能读取到「库存/消耗量」（OCR 失败或无未完成订单）
     bool try_get_stock_and_consumption(int& stock, int& consumption);
 
     infrast::SkillsComb efficient_regex_calc(std::unordered_set<infrast::Skill> skills) const;

--- a/src/MaaCore/Task/Interface/InfrastTask.cpp
+++ b/src/MaaCore/Task/Interface/InfrastTask.cpp
@@ -144,9 +144,21 @@ bool asst::InfrastTask::set_params(const json::value& params)
 
     if (mode != Mode::Custom) {
         std::string drones = params.get("drones", "_NotUse");
-        m_mfg_task_ptr->set_drones_usage_from_params(drones);
-        m_trade_task_ptr->set_drones_usage_from_params(drones);
-        m_trade_task_ptr->register_plugin<DronesForShamareTaskPlugin>()->set_retry_times(0);
+        if (drones == "PureGold-Money" || drones == "OriginStone-SyntheticJade") {
+            // 无人机自动平衡：贸易站消耗对应物品至低于阈值（消耗循环），制造站一次性清空剩余无人机用于生产对应物品
+            const int balance_threshold = params.get("drones_usage_threshold", 10);
+            const std::string target_product = (drones == "PureGold-Money") ? "PureGold" : "OriginStone";
+            m_mfg_task_ptr->set_drones_usage_from_params(target_product);
+            m_trade_task_ptr->set_drones_usage_from_params("_NotUse");
+            m_trade_task_ptr->set_drones_balance_config(drones, balance_threshold);
+            // 无人机已由平衡流程统一消耗，不再注册 Shamare 无人机插件
+        }
+        else {
+            m_mfg_task_ptr->set_drones_usage_from_params(drones);
+            m_trade_task_ptr->set_drones_usage_from_params(drones);
+            m_trade_task_ptr->set_drones_balance_config(std::string(), 0);
+            m_trade_task_ptr->register_plugin<DronesForShamareTaskPlugin>()->set_retry_times(0);
+        }
     }
 
     double threshold = params.get("threshold", 0.3);

--- a/src/MaaWpfGui/Configuration/Single/MaaTask/InfrastTask.cs
+++ b/src/MaaWpfGui/Configuration/Single/MaaTask/InfrastTask.cs
@@ -44,6 +44,11 @@ public class InfrastTask : BaseTask, IJsonOnDeserialized
     public string UsesOfDrones { get; set; } = "Money";
 
     /// <summary>
+    /// Gets or sets 无人机自动平衡阈值（PureGold-Money / OriginStone-SyntheticJade 使用），剩余量小于该值即停止消耗
+    /// </summary>
+    public int DroneUsageThreshold { get; set; } = 10;
+
+    /// <summary>
     /// Gets or sets 基建心情阈值
     /// </summary>
     public int DormThreshold { get; set; } = 30;

--- a/src/MaaWpfGui/Constants/Enums/InfrastRoomType.cs
+++ b/src/MaaWpfGui/Constants/Enums/InfrastRoomType.cs
@@ -16,14 +16,14 @@ namespace MaaWpfGui.Constants.Enums;
 public enum InfrastRoomType
 {
     /// <summary>
-    /// 制造站
-    /// </summary>
-    Mfg,
-
-    /// <summary>
     /// 贸易站
     /// </summary>
     Trade,
+
+    /// <summary>
+    /// 制造站
+    /// </summary>
+    Mfg,
 
     /// <summary>
     /// 控制中心

--- a/src/MaaWpfGui/Constants/Enums/InfrastRoomType.cs
+++ b/src/MaaWpfGui/Constants/Enums/InfrastRoomType.cs
@@ -15,48 +15,49 @@ namespace MaaWpfGui.Constants.Enums;
 
 public enum InfrastRoomType
 {
+    // 显式指定枚举值，保证序列化/配置兼容性稳定
     /// <summary>
     /// 贸易站
     /// </summary>
-    Trade,
+    Trade = 0,
 
     /// <summary>
     /// 制造站
     /// </summary>
-    Mfg,
+    Mfg = 1,
 
     /// <summary>
     /// 控制中心
     /// </summary>
-    Control,
+    Control = 2,
 
     /// <summary>
     /// 发电站
     /// </summary>
-    Power,
+    Power = 3,
 
     /// <summary>
     /// 会客室
     /// </summary>
-    Reception,
+    Reception = 4,
 
     /// <summary>
     /// 办公室(+速公招那个
     /// </summary>
-    Office,
+    Office = 5,
 
     /// <summary>
     /// 宿舍
     /// </summary>
-    Dorm,
+    Dorm = 6,
 
     /// <summary>
     /// 加工站(合精英材料
     /// </summary>
-    Processing,
+    Processing = 7,
 
     /// <summary>
     /// 训练室
     /// </summary>
-    Training,
+    Training = 8,
 }

--- a/src/MaaWpfGui/Models/AsstTasks/AsstInfrastTask.cs
+++ b/src/MaaWpfGui/Models/AsstTasks/AsstInfrastTask.cs
@@ -46,9 +46,16 @@ public class AsstInfrastTask : AsstBaseTask
     /// <item><c>PureGold</c></item>
     /// <item><c>OriginStone</c></item>
     /// <item><c>Chip</c></item>
+    /// <item><c>PureGold-Money</c></item>
+    /// <item><c>OriginStone-SyntheticJade</c></item>
     /// </list>
     /// </summary>
     public string UsesOfDrones { get; set; } = "_NotUse";
+
+    /// <summary>
+    /// Gets or sets 无人机自动平衡阈值（PureGold-Money / OriginStone-SyntheticJade 使用）
+    /// </summary>
+    public int DroneUsageThreshold { get; set; } = 10;
 
     /// <summary>
     /// Gets or sets a value indicating whether 训练室是否尝试连续专精
@@ -116,6 +123,11 @@ public class AsstInfrastTask : AsstBaseTask
             ["reception_send_clue"] = ReceptionSendClue,
             ["mode"] = (int)Mode,
         };
+
+        if (UsesOfDrones is "PureGold-Money" or "OriginStone-SyntheticJade")
+        {
+            taskParams["drones_usage_threshold"] = DroneUsageThreshold;
+        }
 
         if (Mode == InfrastMode.Custom)
         {

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -152,6 +152,8 @@
     <system:String x:Key="PureGold">Pure Gold</system:String>
     <system:String x:Key="OriginStone">Originium Shards</system:String>
     <system:String x:Key="Chip">Chip Packs</system:String>
+    <system:String x:Key="PureGoldMoney">Pure Gold - LMD</system:String>
+    <system:String x:Key="OriginStoneSyntheticJade">Originium Shards - Orundums</system:String>
     <system:String x:Key="DormTrustEnabled">Trust farming in Dormitory</system:String>
     <system:String x:Key="DormFilterNotStationedEnabled">Do not put stationed {key=Operator}s in Dormitory</system:String>
     <system:String x:Key="DormFilterNotStationedTips">Checking this box will not remove {key=Operator}s like Irene from the Training Room; this will also prevent {key=Operator}s from the Workshop from entering the Dormitory.</system:String>
@@ -645,6 +647,9 @@ Please do not check it when the stage OF-1 is not unlocked.</system:String>
     <system:String x:Key="ReceiveMining">Collect daily Orundum reward from the provisional mining permit</system:String>
     <system:String x:Key="ReceiveSpecialAccess">Collect Special Access rewards</system:String>
     <system:String x:Key="DroneUsage">Drone Usage</system:String>
+    <system:String x:Key="DroneUsageThreshold">Remaining Stock Threshold</system:String>
+    <system:String x:Key="DroneUsageThresholdToolTip">First consumes Pure Gold / Originium Shards in the Trading Station down to below this value using drones, then uses all remaining drones for production. In-game stock above 999 is shown as 999+, so the max value here (999) is treated as 1000.</system:String>
+    <system:String x:Key="DroneBalanceOrderRollback">The Manufacturing Station (Mfg) cannot come before the Trading Station (Trade). In drone balance mode the Trading Station must run first, the order has been restored automatically.</system:String>
     <system:String x:Key="UseTray">Display Tray Icon</system:String>
     <system:String x:Key="HideTray">Disable Tray Icon</system:String>
     <system:String x:Key="MinimizeToTray">Hide to tray when minimized</system:String>

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -649,6 +649,7 @@ Please do not check it when the stage OF-1 is not unlocked.</system:String>
     <system:String x:Key="DroneUsage">Drone Usage</system:String>
     <system:String x:Key="DroneUsageThreshold">Remaining Stock Threshold</system:String>
     <system:String x:Key="DroneUsageThresholdToolTip">First consumes Pure Gold / Originium Shards in the Trading Station down to below this value using drones, then uses all remaining drones for production. In-game stock above 999 is shown as 999+, so the max value here (999) is treated as 1000.</system:String>
+    <system:String x:Key="DroneUsageRoomMissing">Drone usage "{1}" requires {0}, but this room is not enabled. Drones may not work as expected.</system:String>
     <system:String x:Key="DroneBalanceOrderRollback">The Manufacturing Station (Mfg) cannot come before the Trading Station (Trade). In drone balance mode the Trading Station must run first, the order has been restored automatically.</system:String>
     <system:String x:Key="UseTray">Display Tray Icon</system:String>
     <system:String x:Key="HideTray">Disable Tray Icon</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -649,6 +649,7 @@ MAA は非インストール型のアプリケーションであり、レジス�
     <system:String x:Key="DroneUsage">ドローンの使用</system:String>
     <system:String x:Key="DroneUsageThreshold">残量閾値</system:String>
     <system:String x:Key="DroneUsageThresholdToolTip">実行時はまず貿易所でドローンを使って純金/源石の欠片を閾値未満まで消費し、残ったドローンを全て生産に使用します。ゲーム内で在庫が999を超えると999+と表示されるため、ここでの上限999は1000として扱われます。</system:String>
+    <system:String x:Key="DroneUsageRoomMissing">ドローンの使用「{1}」には{0}が必要ですが、この部屋は無効です。ドローンが正常に動作しない可能性があります。</system:String>
     <system:String x:Key="DroneBalanceOrderRollback">製造所( Mfg )を貿易所( Trade )より前に配置することはできません。ドローン自動平衡モードでは貿易所が先に実行される必要があるため、順序を自動的に戻しました。</system:String>
     <system:String x:Key="UseTray">トレイアイコンを表示</system:String>
     <system:String x:Key="HideTray">トレイアイコンを隠す</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -152,6 +152,8 @@
     <system:String x:Key="PureGold">製造所-純金</system:String>
     <system:String x:Key="OriginStone">製造所-源石の欠片</system:String>
     <system:String x:Key="Chip">製造所-中級SoC</system:String>
+    <system:String x:Key="PureGoldMoney">純金-竜門幣</system:String>
+    <system:String x:Key="OriginStoneSyntheticJade">源石の欠片-合成玉</system:String>
     <system:String x:Key="DormTrustEnabled">宿舎の空き位置で信頼度を上げる</system:String>
     <system:String x:Key="DormFilterNotStationedEnabled">作業中の{key=Operator}を宿舎に移動しない（例:訓練所でのアイリーニなど）</system:String>
     <system:String x:Key="DormFilterNotStationedTips">チェックした場合、アイリーニのような{key=Operator}が訓練室から外れなくなり、また、加工所の{key=Operator}が宿舎に送られることを防止します。</system:String>
@@ -645,6 +647,9 @@ MAA は非インストール型のアプリケーションであり、レジス�
     <system:String x:Key="ReceiveMining">期間限定の採掘許可で毎日合成玉の報酬を受け取る</system:String>
     <system:String x:Key="ReceiveSpecialAccess">スペシャルアクセス特典を集める</system:String>
     <system:String x:Key="DroneUsage">ドローンの使用</system:String>
+    <system:String x:Key="DroneUsageThreshold">残量閾値</system:String>
+    <system:String x:Key="DroneUsageThresholdToolTip">実行時はまず貿易所でドローンを使って純金/源石の欠片を閾値未満まで消費し、残ったドローンを全て生産に使用します。ゲーム内で在庫が999を超えると999+と表示されるため、ここでの上限999は1000として扱われます。</system:String>
+    <system:String x:Key="DroneBalanceOrderRollback">製造所( Mfg )を貿易所( Trade )より前に配置することはできません。ドローン自動平衡モードでは貿易所が先に実行される必要があるため、順序を自動的に戻しました。</system:String>
     <system:String x:Key="UseTray">トレイアイコンを表示</system:String>
     <system:String x:Key="HideTray">トレイアイコンを隠す</system:String>
     <system:String x:Key="MinimizeToTray">最小化した際にトレイに表示</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -152,6 +152,8 @@
     <system:String x:Key="PureGold">제조소-순금</system:String>
     <system:String x:Key="OriginStone">제조소-오리지늄 조각</system:String>
     <system:String x:Key="Chip">제조소-칩</system:String>
+    <system:String x:Key="PureGoldMoney">순금-용문폐</system:String>
+    <system:String x:Key="OriginStoneSyntheticJade">오리지늄 조각-합성옥</system:String>
     <system:String x:Key="DormTrustEnabled">숙소의 남은 자리로 신뢰도 증가</system:String>
     <system:String x:Key="DormFilterNotStationedEnabled">업무 중 {key=Operator} 휴식 제한</system:String>
     <system:String x:Key="DormFilterNotStationedTips">체크할 경우 아이린과 같은 {key=Operator}를 훈련실에서 제거하지 않고, 가공소의 {key=Operator}가 숙소에 배치되는 것을 방지합니다.</system:String>
@@ -645,6 +647,9 @@ OF-1 스테이지가 개방되지 않은 경우에는 선택하지 마세요.</s
     <system:String x:Key="ReceiveMining">한정 채굴 일일 합성옥 수령</system:String>
     <system:String x:Key="ReceiveSpecialAccess">스페셜 액세스 보상 수령</system:String>
     <system:String x:Key="DroneUsage">드론 사용처</system:String>
+    <system:String x:Key="DroneUsageThreshold">남은 수량 임계값</system:String>
+    <system:String x:Key="DroneUsageThresholdToolTip">실행 시 먼저 무역소에서 드론으로 순금/오리지늄 조각을 임계값 미만까지 소모한 뒤, 남은 드론을 모두 생산에 사용합니다. 게임 내 재고가 999를 넘으면 999+로 표시되므로 여기서 상한 999는 1000으로 취급됩니다.</system:String>
+    <system:String x:Key="DroneBalanceOrderRollback">제조소( Mfg )는 무역소( Trade )보다 앞에 올 수 없습니다. 드론 자동 균형 모드에서는 무역소가 먼저 실행되어야 하므로 순서를 자동으로 되돌렸습니다.</system:String>
     <system:String x:Key="UseTray">트레이 아이콘 표시</system:String>
     <system:String x:Key="HideTray">트레이 아이콘 숨기기</system:String>
     <system:String x:Key="MinimizeToTray">최소화 시 트레이에 숨기기</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -649,6 +649,7 @@ OF-1 스테이지가 개방되지 않은 경우에는 선택하지 마세요.</s
     <system:String x:Key="DroneUsage">드론 사용처</system:String>
     <system:String x:Key="DroneUsageThreshold">남은 수량 임계값</system:String>
     <system:String x:Key="DroneUsageThresholdToolTip">실행 시 먼저 무역소에서 드론으로 순금/오리지늄 조각을 임계값 미만까지 소모한 뒤, 남은 드론을 모두 생산에 사용합니다. 게임 내 재고가 999를 넘으면 999+로 표시되므로 여기서 상한 999는 1000으로 취급됩니다.</system:String>
+    <system:String x:Key="DroneUsageRoomMissing">드론 사용처「{1}」에는 {0}이(가) 필요하지만 해당 시설이 선택되지 않았습니다. 드론이 정상적으로 작동하지 않을 수 있습니다.</system:String>
     <system:String x:Key="DroneBalanceOrderRollback">제조소( Mfg )는 무역소( Trade )보다 앞에 올 수 없습니다. 드론 자동 균형 모드에서는 무역소가 먼저 실행되어야 하므로 순서를 자동으로 되돌렸습니다.</system:String>
     <system:String x:Key="UseTray">트레이 아이콘 표시</system:String>
     <system:String x:Key="HideTray">트레이 아이콘 숨기기</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -649,6 +649,7 @@ D:\
     <system:String x:Key="DroneUsage">无人机用途</system:String>
     <system:String x:Key="DroneUsageThreshold">剩余量阈值</system:String>
     <system:String x:Key="DroneUsageThresholdToolTip">执行时先进贸易站，用无人机加速对应订单把赤金/源石碎片消耗到低于该值，再将剩余无人机全部用于生产。游戏内库存大于 999 显示为 999+，此处上限 999 即视为 1000。</system:String>
+    <system:String x:Key="DroneUsageRoomMissing">无人机用途「{1}」需要{0}，但该房间未勾选，无人机可能无法正常使用。</system:String>
     <system:String x:Key="DroneBalanceOrderRollback">制造站( Mfg )不可在贸易站( Trade )之前。无人机平衡模式下贸易站需先于制造站执行，已自动恢复顺序。</system:String>
     <system:String x:Key="UseTray">显示托盘图标</system:String>
     <system:String x:Key="HideTray">隐藏托盘图标</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -152,6 +152,8 @@
     <system:String x:Key="PureGold">制造站-赤金</system:String>
     <system:String x:Key="OriginStone">制造站-源石碎片</system:String>
     <system:String x:Key="Chip">制造站-芯片组</system:String>
+    <system:String x:Key="PureGoldMoney">赤金-龙门币</system:String>
+    <system:String x:Key="OriginStoneSyntheticJade">源石碎片-合成玉</system:String>
     <system:String x:Key="DormTrustEnabled">宿舍空余位置蹭信赖</system:String>
     <system:String x:Key="DormFilterNotStationedEnabled">不将已进驻的{key=Operator}放入宿舍</system:String>
     <system:String x:Key="DormFilterNotStationedTips">勾选则不会将艾丽妮等{key=Operator}从训练室移除，但也会导致加工站{key=Operator}不能进入宿舍。</system:String>
@@ -645,6 +647,9 @@ D:\
     <system:String x:Key="ReceiveMining">领取限时开采许可的每日合成玉奖励</system:String>
     <system:String x:Key="ReceiveSpecialAccess">领取周年赠送月卡奖励</system:String>
     <system:String x:Key="DroneUsage">无人机用途</system:String>
+    <system:String x:Key="DroneUsageThreshold">剩余量阈值</system:String>
+    <system:String x:Key="DroneUsageThresholdToolTip">执行时先进贸易站，用无人机加速对应订单把赤金/源石碎片消耗到低于该值，再将剩余无人机全部用于生产。游戏内库存大于 999 显示为 999+，此处上限 999 即视为 1000。</system:String>
+    <system:String x:Key="DroneBalanceOrderRollback">制造站( Mfg )不可在贸易站( Trade )之前。无人机平衡模式下贸易站需先于制造站执行，已自动恢复顺序。</system:String>
     <system:String x:Key="UseTray">显示托盘图标</system:String>
     <system:String x:Key="HideTray">隐藏托盘图标</system:String>
     <system:String x:Key="MinimizeToTray">最小化时隐藏至托盘</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -152,6 +152,8 @@
     <system:String x:Key="PureGold">製造站-赤金</system:String>
     <system:String x:Key="OriginStone">製造站-源石碎片</system:String>
     <system:String x:Key="Chip">製造站-晶片組</system:String>
+    <system:String x:Key="PureGoldMoney">赤金-龍門幣</system:String>
+    <system:String x:Key="OriginStoneSyntheticJade">源石碎片-合成玉</system:String>
     <system:String x:Key="DormTrustEnabled">宿舍空位蹭信賴</system:String>
     <system:String x:Key="DormFilterNotStationedEnabled">不將已進駐的{key=Operator}放入宿舍</system:String>
     <system:String x:Key="DormFilterNotStationedTips">勾選則不會將艾麗妮等{key=Operator}從訓練室移除，但也會導致加工站{key=Operator}不能進入宿舍。</system:String>
@@ -645,6 +647,9 @@ D:\
     <system:String x:Key="ReceiveMining">領取限時開採許可的每日合成玉獎勵</system:String>
     <system:String x:Key="ReceiveSpecialAccess">領取特殊贈送月卡獎勵</system:String>
     <system:String x:Key="DroneUsage">無人機用途</system:String>
+    <system:String x:Key="DroneUsageThreshold">剩餘量閾值</system:String>
+    <system:String x:Key="DroneUsageThresholdToolTip">執行時先進貿易站，用無人機加速對應訂單把赤金/源石碎片消耗到低於該值，再將剩餘無人機全部用於生產。遊戲內庫存大於 999 顯示為 999+，此處上限 999 即視為 1000。</system:String>
+    <system:String x:Key="DroneBalanceOrderRollback">製造站( Mfg )不可在貿易站( Trade )之前。無人機平衡模式下貿易站需先於製造站執行，已自動恢復順序。</system:String>
     <system:String x:Key="UseTray">顯示工作列圖示</system:String>
     <system:String x:Key="HideTray">隱藏工作列圖示</system:String>
     <system:String x:Key="MinimizeToTray">最小化時隱藏至工作列</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -649,6 +649,7 @@ D:\
     <system:String x:Key="DroneUsage">無人機用途</system:String>
     <system:String x:Key="DroneUsageThreshold">剩餘量閾值</system:String>
     <system:String x:Key="DroneUsageThresholdToolTip">執行時先進貿易站，用無人機加速對應訂單把赤金/源石碎片消耗到低於該值，再將剩餘無人機全部用於生產。遊戲內庫存大於 999 顯示為 999+，此處上限 999 即視為 1000。</system:String>
+    <system:String x:Key="DroneUsageRoomMissing">無人機用途「{1}」需要{0}，但該房間未勾選，無人機可能無法正常使用。</system:String>
     <system:String x:Key="DroneBalanceOrderRollback">製造站( Mfg )不可在貿易站( Trade )之前。無人機平衡模式下貿易站需先於製造站執行，已自動恢復順序。</system:String>
     <system:String x:Key="UseTray">顯示工作列圖示</system:String>
     <system:String x:Key="HideTray">隱藏工作列圖示</system:String>

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/InfrastSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/InfrastSettingsUserControlModel.cs
@@ -18,6 +18,8 @@ using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.IO;
 using System.Linq;
+using System.Windows;
+using System.Windows.Threading;
 using JetBrains.Annotations;
 using MaaWpfGui.Configuration.Single.MaaTask;
 using MaaWpfGui.Constants;
@@ -58,6 +60,9 @@ public class InfrastSettingsUserControlModel : TaskSettingsViewModel, InfrastSet
     private static readonly ILogger _logger = Log.ForContext<InfrastSettingsUserControlModel>();
     private readonly RunningState _runningState;
 
+    // 程序性重排（平衡模式自动纠正顺序）时置位，避免触发“用户拖回”的弹窗检测
+    private bool _isProgrammaticReorder;
+
     /// <summary>
     /// Gets the visibility of task setting views.
     /// </summary>
@@ -96,6 +101,9 @@ public class InfrastSettingsUserControlModel : TaskSettingsViewModel, InfrastSet
 
         InfrastRoomModels = new ObservableCollection<InfrastRoomItemViewModel>(roomList);
         InfrastRoomModels.CollectionChanged += InfrastOrderSelectionChanged;
+
+        // 加载配置时同样保证平衡模式的“贸易站在制造站前”顺序
+        EnsureDroneBalanceOrder();
     }
 
     /// <summary>
@@ -113,7 +121,9 @@ public class InfrastSettingsUserControlModel : TaskSettingsViewModel, InfrastSet
         ("CombatRecord", "CombatRecord"),
         ("PureGold", "PureGold"),
         ("OriginStone", "OriginStone"),
-        ("Chip", "Chip"));
+        ("Chip", "Chip"),
+        ("PureGold-Money", "PureGoldMoney"),
+        ("OriginStone-SyntheticJade", "OriginStoneSyntheticJade"));
 
     /// <summary>
     /// Gets the list of uses of default infrast.
@@ -170,6 +180,102 @@ public class InfrastSettingsUserControlModel : TaskSettingsViewModel, InfrastSet
     {
         var list = InfrastRoomModels.Select<InfrastRoomItemViewModel, InfrastTask.RoomInfo>(i => new(i.RoomType, i.IsEnabled)).ToList();
         SetTaskConfig<InfrastTask>(t => t.RoomList.SequenceEqual(list), t => t.RoomList = list);
+
+        // 平衡模式下强制贸易站在制造站前：用户手动把制造站拖回贸易站前时，弹窗并回滚顺序
+        if (!_isProgrammaticReorder && IsDroneBalanceOrderViolated())
+        {
+            _isProgrammaticReorder = true;
+            Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.Background, (Action)(() => {
+                try
+                {
+                    MessageBoxHelper.Show(
+                        LocalizationHelper.GetString("DroneBalanceOrderRollback"),
+                        buttons: MessageBoxButton.OK,
+                        icon: MessageBoxImage.Warning);
+                    EnsureDroneBalanceOrder();
+                }
+                finally
+                {
+                    _isProgrammaticReorder = false;
+                }
+            }));
+        }
+    }
+
+    /// <summary>
+    /// 无人机自动平衡模式（PureGold-Money / OriginStone-SyntheticJade）是否激活且非自定义模式
+    /// </summary>
+    private bool IsDroneBalanceModeEnabled()
+        => UsesOfDrones is "PureGold-Money" or "OriginStone-SyntheticJade" && InfrastMode != Mode.Custom;
+
+    /// <summary>
+    /// 平衡模式下是否违反了“贸易站在制造站前”的顺序（仅统计启用中的房间）
+    /// </summary>
+    private bool IsDroneBalanceOrderViolated()
+    {
+        if (!IsDroneBalanceModeEnabled())
+        {
+            return false;
+        }
+
+        int? mfgIndex = null;
+        int? tradeIndex = null;
+        for (int i = 0; i < InfrastRoomModels.Count; ++i)
+        {
+            var item = InfrastRoomModels[i];
+            if (!item.IsEnabled)
+            {
+                continue;
+            }
+            if (item.RoomType == InfrastRoomType.Mfg && mfgIndex == null)
+            {
+                mfgIndex = i;
+            }
+            else if (item.RoomType == InfrastRoomType.Trade && tradeIndex == null)
+            {
+                tradeIndex = i;
+            }
+        }
+
+        return mfgIndex != null && tradeIndex != null && mfgIndex < tradeIndex;
+    }
+
+    /// <summary>
+    /// 平衡模式下把贸易站提到制造站前（其余保持原序），并持久化
+    /// </summary>
+    private void EnsureDroneBalanceOrder()
+    {
+        if (!IsDroneBalanceModeEnabled())
+        {
+            return;
+        }
+
+        int mfgIndex = IndexOfRoom(InfrastRoomType.Mfg);
+        int tradeIndex = IndexOfRoom(InfrastRoomType.Trade);
+        if (mfgIndex >= 0 && tradeIndex >= 0 && mfgIndex < tradeIndex)
+        {
+            _isProgrammaticReorder = true;
+            try
+            {
+                InfrastRoomModels.Move(tradeIndex, mfgIndex);
+            }
+            finally
+            {
+                _isProgrammaticReorder = false;
+            }
+        }
+    }
+
+    private int IndexOfRoom(InfrastRoomType roomType)
+    {
+        for (int i = 0; i < InfrastRoomModels.Count; ++i)
+        {
+            if (InfrastRoomModels[i].RoomType == roomType)
+            {
+                return i;
+            }
+        }
+        return -1;
     }
 
     /// <summary>
@@ -193,6 +299,7 @@ public class InfrastSettingsUserControlModel : TaskSettingsViewModel, InfrastSet
             }
 
             ParseCustomInfrastPlan();
+            EnsureDroneBalanceOrder();
         }
     }
 
@@ -202,8 +309,27 @@ public class InfrastSettingsUserControlModel : TaskSettingsViewModel, InfrastSet
     public string UsesOfDrones
     {
         get => GetTaskConfig<InfrastTask>().UsesOfDrones;
-        set => SetTaskConfig<InfrastTask>(t => t.UsesOfDrones == value, t => t.UsesOfDrones = value);
+        set {
+            SetTaskConfig<InfrastTask>(t => t.UsesOfDrones == value, t => t.UsesOfDrones = value);
+            EnsureDroneBalanceOrder();
+        }
     }
+
+    /// <summary>
+    /// Gets or sets 无人机自动平衡阈值（PureGold-Money / OriginStone-SyntheticJade 使用）
+    /// </summary>
+    public int DroneUsageThreshold
+    {
+        get => GetTaskConfig<InfrastTask>().DroneUsageThreshold;
+        set => SetTaskConfig<InfrastTask>(t => t.DroneUsageThreshold == value, t => t.DroneUsageThreshold = value);
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether 是否显示无人机自动平衡阈值输入（选择 PureGold-Money / OriginStone-SyntheticJade 且非自定义模式）
+    /// </summary>
+    [PropertyDependsOn(nameof(UsesOfDrones), nameof(InfrastMode))]
+    public bool IsDroneUsageThresholdVisible
+        => UsesOfDrones is "PureGold-Money" or "OriginStone-SyntheticJade" && InfrastMode != Mode.Custom;
 
     public bool ReceptionMessageBoardReceive
     {
@@ -576,6 +702,11 @@ public class InfrastSettingsUserControlModel : TaskSettingsViewModel, InfrastSet
                 ReceptionSendClue = infrast.SendClue,
                 Filename = infrast.Filename,
             };
+
+            if (infrast.UsesOfDrones is "PureGold-Money" or "OriginStone-SyntheticJade")
+            {
+                task.DroneUsageThreshold = infrast.DroneUsageThreshold;
+            }
 
             if (infrast.Mode != Mode.Custom)
             {

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/InfrastSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/InfrastSettingsUserControlModel.cs
@@ -63,6 +63,9 @@ public class InfrastSettingsUserControlModel : TaskSettingsViewModel, InfrastSet
     // 程序性重排（平衡模式自动纠正顺序）时置位，避免触发“用户拖回”的弹窗检测
     private bool _isProgrammaticReorder;
 
+    // 上次检查时“无人机用途所需房间未勾选”的状态，用于仅在进入非法状态时弹窗一次
+    private bool _lastDroneRoomMissing;
+
     /// <summary>
     /// Gets the visibility of task setting views.
     /// </summary>
@@ -104,6 +107,9 @@ public class InfrastSettingsUserControlModel : TaskSettingsViewModel, InfrastSet
 
         // 加载配置时同样保证平衡模式的“贸易站在制造站前”顺序
         EnsureDroneBalanceOrder();
+
+        // 加载配置时不弹窗，仅记录当前“无人机用途所需房间未勾选”的基线状态
+        _lastDroneRoomMissing = GetMissingDroneRooms().Count > 0;
     }
 
     /// <summary>
@@ -200,6 +206,9 @@ public class InfrastSettingsUserControlModel : TaskSettingsViewModel, InfrastSet
                 }
             }));
         }
+
+        // 无人机用途所需房间未勾选时提示
+        CheckDroneUsageRoomMissing();
     }
 
     /// <summary>
@@ -279,6 +288,72 @@ public class InfrastSettingsUserControlModel : TaskSettingsViewModel, InfrastSet
     }
 
     /// <summary>
+    /// 当前无人机用途所需、但未勾选的房间本地化名列表（Custom 模式或不使用无人机时为空）
+    /// </summary>
+    private List<string> GetMissingDroneRooms()
+        => GetMissingDroneRooms(UsesOfDrones, InfrastMode, InfrastRoomModels.Select(m => (m.RoomType, m.IsEnabled)));
+
+    /// <summary>
+    /// 根据无人机用途与房间勾选状态，返回所需但未勾选的房间本地化名列表（Custom 模式或不使用无人机时为空）
+    /// </summary>
+    /// <param name="usesOfDrones">无人机用途</param>
+    /// <param name="mode">基建模式</param>
+    /// <param name="rooms">房间类型与其勾选状态</param>
+    private static List<string> GetMissingDroneRooms(string usesOfDrones, Mode mode, IEnumerable<(InfrastRoomType Room, bool IsEnabled)> rooms)
+    {
+        if (mode == Mode.Custom || usesOfDrones == "_NotUse")
+        {
+            return [];
+        }
+
+        List<InfrastRoomType> required = usesOfDrones switch {
+            "Money" or "SyntheticJade" => [InfrastRoomType.Trade],
+            "CombatRecord" or "PureGold" or "OriginStone" or "Chip" => [InfrastRoomType.Mfg],
+            "PureGold-Money" or "OriginStone-SyntheticJade" => [InfrastRoomType.Trade, InfrastRoomType.Mfg],
+            _ => [],
+        };
+
+        return required.Where(r => rooms.FirstOrDefault(m => m.Room == r).IsEnabled != true)
+                       .Select(r => LocalizationHelper.GetString(r.ToString()))
+                       .ToList();
+    }
+
+    /// <summary>
+    /// 无人机用途所需房间未勾选时的非阻断提示（弹窗 + 日志）
+    /// </summary>
+    /// <param name="missing">缺失的房间本地化名列表</param>
+    /// <param name="usesOfDrones">无人机用途</param>
+    private static void ShowDroneUsageRoomMissingWarning(List<string> missing, string usesOfDrones)
+    {
+        if (missing.Count == 0)
+        {
+            return;
+        }
+
+        var usageDisplay = Instance.UsesOfDronesList.FirstOrDefault(i => i.Value == usesOfDrones)?.Display ?? usesOfDrones;
+        var message = LocalizationHelper.GetStringFormat("DroneUsageRoomMissing", string.Join(", ", missing), usageDisplay);
+        Instances.TaskQueueViewModel.AddLog(message, UiLogColor.Warning);
+        Application.Current.Dispatcher.BeginInvoke(DispatcherPriority.Background, (Action)(() => {
+            MessageBoxHelper.Show(message, LocalizationHelper.GetString("Warning"), MessageBoxButton.OK, MessageBoxImage.Warning);
+        }));
+    }
+
+    /// <summary>
+    /// 无人机用途所需房间检查：仅在配置从合法变为非法时提示一次（运行中配置被锁定，不会触发）
+    /// </summary>
+    private void CheckDroneUsageRoomMissing()
+    {
+        var missingRooms = GetMissingDroneRooms();
+        bool missing = missingRooms.Count > 0;
+        if (missing && !_lastDroneRoomMissing && !_isProgrammaticReorder)
+        {
+            ShowDroneUsageRoomMissingWarning(missingRooms, UsesOfDrones);
+        }
+
+        _lastDroneRoomMissing = missing;
+    }
+
+    /// <summary>
     /// Gets the list of uses of infrast mode.
     /// </summary>
     public LocalizedObservableList<Mode> InfrastModeList { get; } = new(
@@ -312,6 +387,7 @@ public class InfrastSettingsUserControlModel : TaskSettingsViewModel, InfrastSet
         set {
             SetTaskConfig<InfrastTask>(t => t.UsesOfDrones == value, t => t.UsesOfDrones = value);
             EnsureDroneBalanceOrder();
+            CheckDroneUsageRoomMissing();
         }
     }
 
@@ -687,6 +763,11 @@ public class InfrastSettingsUserControlModel : TaskSettingsViewModel, InfrastSet
             {
                 return (null, []);
             }
+
+            // 启动时校验：无人机用途所需房间未勾选时弹窗 + 日志提醒（不阻断任务）
+            ShowDroneUsageRoomMissingWarning(
+                GetMissingDroneRooms(infrast.UsesOfDrones, infrast.Mode, infrast.RoomList.Select(r => (r.Room, r.IsEnabled))),
+                infrast.UsesOfDrones);
 
             var task = new AsstInfrastTask {
                 Mode = infrast.Mode,

--- a/src/MaaWpfGui/Views/UserControl/TaskQueue/InfrastSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/TaskQueue/InfrastSettingsUserControl.xaml
@@ -110,6 +110,29 @@
                 ItemsSource="{Binding UsesOfDronesList}"
                 SelectedValue="{Binding UsesOfDrones}"
                 SelectedValuePath="Value" />
+            <StackPanel
+                Margin="0,5"
+                d:Visibility="Visible"
+                Orientation="Horizontal"
+                Visibility="{c:Binding IsDroneUsageThresholdVisible,
+                                       Source={x:Static taskQueue_vms:InfrastSettingsUserControlModel.Instance}}">
+                <controls:TextBlock
+                    Margin="8,0,0,0"
+                    HorizontalAlignment="Left"
+                    VerticalAlignment="Center"
+                    Text="{DynamicResource DroneUsageThreshold}" />
+                <controls:TooltipBlock
+                    VerticalAlignment="Center"
+                    d:Visibility="Visible"
+                    TooltipText="{DynamicResource DroneUsageThresholdToolTip}" />
+                <hc:NumericUpDown
+                    Width="110"
+                    Margin="4,0,0,0"
+                    VerticalAlignment="Center"
+                    Maximum="999"
+                    Minimum="10"
+                    Value="{Binding DroneUsageThreshold, UpdateSourceTrigger=PropertyChanged}" />
+            </StackPanel>
             <controls:TextBlock
                 Width="220"
                 Margin="0,4"


### PR DESCRIPTION
## Sourcery 摘要

为基础设施生产和贸易工作流添加可配置的无人机自动平衡功能，并提供 GUI 验证和多语言协议文档。

新功能：
- 添加 PureGold-Money 和 OriginStone-SyntheticJade 无人机自动平衡模式，并支持配置消耗阈值。
- 在基础设施配置 UI 中公开无人机自动平衡设置和阈值控件。

错误修复：
- 当无人机使用需要启用已禁用的设施时发出警告，并防止无效的自动平衡配置静默运行。
- 确保自动平衡在将剩余无人机分配给制造之前，优先消耗贸易订单。

增强功能：
- 自动维护并持久化所需的“贸易优先于制造”设施顺序，并针对配置问题提供非阻塞式本地化警告和日志记录。

文档：
- 在所有受支持的集成协议语言中，记录新的无人机模式、阈值参数和设施顺序要求。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

为基础设施交易和制造工作流添加基于阈值的无人机自动平衡功能，并提供 GUI 验证和多语言协议文档。

新功能：
- 添加可配置的 PureGold-Money 和 OriginStone-SyntheticJade 无人机自动平衡模式，并支持调整消耗阈值。
- 在基础设施配置界面中提供无人机自动平衡选项和阈值控制项。

错误修复：
- 当无人机使用需要已禁用的设施时发出警告，并防止无效配置在无提示的情况下运行。
- 确保交易订单在制造流程接收剩余无人机之前消耗无人机。

增强功能：
- 自动维护并持久化自动平衡配置中的“交易优先于制造”顺序；对于缺少必需设施的情况，提供非阻塞的本地化警告和日志记录。

文档：
- 在受支持的集成协议语言中记录新的无人机模式、阈值设置和设施顺序要求。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add threshold-based drone auto-balancing for infrastructure trade and manufacturing workflows, with GUI validation and multilingual protocol documentation.

New Features:
- Add configurable PureGold-Money and OriginStone-SyntheticJade drone auto-balance modes with adjustable consumption thresholds.
- Expose drone auto-balance options and threshold controls in the infrastructure configuration UI.

Bug Fixes:
- Warn when drone usage requires disabled facilities and prevent invalid configurations from running silently.
- Ensure trade orders consume drones before manufacturing receives the remaining drones.

Enhancements:
- Automatically maintain and persist Trade-before-Mfg ordering for auto-balance configurations, with non-blocking localized warnings and logging for missing required facilities.

Documentation:
- Document the new drone modes, threshold setting, and facility ordering requirements across supported integration protocol languages.

</details>

</details>

为基础设施生产环境新增无人机自动平衡支持，包括基于阈值的贸易消耗新使用模式、相应的图形界面控制与校验，以及多语言协议文档更新。

New Features:
- 引入无人机自动平衡模式 `PureGold-Money` 和 `OriginStone-SyntheticJade`，支持为贸易消耗和制造生产配置可调阈值。

Bug Fixes:
- 当所选无人机使用模式所需房间未启用时发出警告，防止无效的基础设施配置，并在自动平衡模式下强制执行“先贸易、再制造”的顺序。

Enhancements:
- 添加图形界面逻辑以自动维护设施排序并持久化无人机平衡设置，当检测到配置问题时提供非阻塞式用户提示和日志记录。

Documentation:
- 在集成协议中，以所有受支持的语言记录新的无人机自动平衡模式、阈值参数以及所需的设施顺序。

<details>
<summary>Original summary in English</summary>



</details>