### PR TITLE
perf(core): 查找干员在职业为unknown时回退到单name版本

### DIFF
--- a/src/MaaCore/Config/Miscellaneous/BattleDataConfig.h
+++ b/src/MaaCore/Config/Miscellaneous/BattleDataConfig.h
@@ -48,11 +48,11 @@ public:
 
     const std::shared_ptr<battle::OperProps> find_oper(battle::Role role, const std::string& name) const
     {
+        if (role == battle::Role::Unknown) {
+            return find_oper(name);
+        }
         if (name.empty()) {
             return nullptr;
-        }
-        if (role == battle::Role::Unknown) {
-            role = get_role_strict(name);
         }
         auto role_it = m_chars_by_role.find(role);
         if (role_it == m_chars_by_role.cend()) {
@@ -89,15 +89,6 @@ public:
         const auto& oper_it = find_oper(name);
         if (oper_it) {
             return oper_it->role;
-        }
-        return battle::Role::Unknown;
-    }
-
-    battle::Role get_role_strict(const std::string& name) const
-    {
-        auto roles = get_roles(name);
-        if (roles.size() == 1) {
-            return *roles.begin();
         }
         return battle::Role::Unknown;
     }

--- a/src/MaaCore/Config/Miscellaneous/BattleDataConfig.h
+++ b/src/MaaCore/Config/Miscellaneous/BattleDataConfig.h
@@ -51,6 +51,9 @@ public:
         if (name.empty()) {
             return nullptr;
         }
+        if (role == battle::Role::Unknown) {
+            role = get_role_strict(name);
+        }
         auto role_it = m_chars_by_role.find(role);
         if (role_it == m_chars_by_role.cend()) {
             return nullptr;
@@ -86,6 +89,15 @@ public:
         const auto& oper_it = find_oper(name);
         if (oper_it) {
             return oper_it->role;
+        }
+        return battle::Role::Unknown;
+    }
+
+    battle::Role get_role_strict(const std::string& name) const
+    {
+        auto roles = get_roles(name);
+        if (roles.size() == 1) {
+            return *roles.begin();
         }
         return battle::Role::Unknown;
     }

--- a/src/MaaCore/Config/Miscellaneous/BattleDataConfig.h
+++ b/src/MaaCore/Config/Miscellaneous/BattleDataConfig.h
@@ -208,7 +208,7 @@ protected:
 
 private:
     std::map<battle::Role, std::unordered_map<std::string, std::shared_ptr<battle::OperProps>>>
-        m_chars_by_role;                                                         // role -> (name -> oper)
+        m_chars_by_role;                                                         // role -> (id -> oper)
     std::unordered_map<std::string, std::shared_ptr<battle::OperProps>> m_chars; // id -> oper
 
     std::unordered_map<std::string, battle::AttackRange> m_ranges;


### PR DESCRIPTION
## Summary by Sourcery

更稳健地处理职能未知的干员，以避免在战斗流程和技能使用中出现失败。

Bug Fixes（错误修复）:
- 在战斗数据查找和自动战斗配置解析中，当干员职能未知时，从干员名称解析其职能，以便技能仍能被触发。
- 即使干员已存储的职能为未知，也允许在战斗编组中匹配这些干员，避免编组与执行过程中的问题。

Enhancements（改进）:
- 引入严格的职能查找辅助方法，根据干员名称返回唯一解析出的职能或未知值。
- 通过文档说明角色映射中以职能为键的映射实际上是以干员 ID 而非名称作为键，从而使战斗数据映射更清晰。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle operators with unknown roles more robustly to avoid failures in battle processing and skill usage.

Bug Fixes:
- Resolve operator role from name when the role is unknown in both battle data lookup and copilot config parsing so skills can still be triggered.
- Allow matching operators in battle groups even when their stored role is unknown, preventing grouping and execution issues.

Enhancements:
- Introduce a strict role lookup helper that returns a single resolved role or unknown based on the operator name.
- Clarify battle data mappings by documenting that role-keyed maps are keyed by operator ID rather than name.

</details>