### PR TITLE
feat: 奇象巡展发现未收录奇象时发送通知

### DIFF
--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -1680,6 +1680,26 @@ public class AsstProxy
                             ToastNotification.ShowDirect(LocalizationHelper.GetString("FightMissionFailedAndStop"));
                             break;
 
+                        case "MiniGame@InteractiveExhibition@CheckEncounter-Uncollected":
+                            {
+                                var title = LocalizationHelper.GetString("MiniGame@InteractiveExhibition@UncollectedNotificationTitle");
+                                var content = LocalizationHelper.GetString("MiniGame@InteractiveExhibition@UncollectedNotificationContent");
+
+                                Instances.TaskQueueViewModel.AddLog(content, UiLogColor.Warning, updateCardImage: true);
+
+                                using (var toast = new ToastNotification(title))
+                                {
+                                    toast.AppendContentText(content).Show();
+                                }
+
+                                if (SettingsViewModel.ExternalNotificationSettings.ExternalNotificationSendWhenComplete)
+                                {
+                                    ExternalNotificationService.Send(title, content);
+                                }
+
+                                break;
+                            }
+
                         case "RecruitRefreshConfirm":
                             Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("LabelsRefreshed"), UiLogColor.Info);
                             break;

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -1097,6 +1097,8 @@ Only level rewards can be farmed; to get the Engraved Medal, all ｢Key Objectiv
     <system:String x:Key="MiniGame@SecretFront@Event3">Sly Shadows</system:String>
     <system:String x:Key="MiniGame@SecretFront">Hidden Front</system:String>
     <system:String x:Key="MiniGame@SecretFrontTip" xml:space="preserve">Start from the squad selection screen;&#10;If there is a saved game, please delete it manually.&#10;Close the tutorial after playing it for the first time.&#10;Recommended to enable in-game ｢Inherit previous squad's data｣.</system:String>
+    <system:String x:Key="MiniGame@InteractiveExhibition@UncollectedNotificationTitle">Interactive Exhibition: Unrecorded Wonder Found</system:String>
+    <system:String x:Key="MiniGame@InteractiveExhibition@UncollectedNotificationContent">MAA has stopped exploring. Return to the game and complete the battle manually.</system:String>
     <system:String x:Key="MiniGame@PixelPaint">Pixel Paint Autofill</system:String>
     <system:String x:Key="MiniGame@PixelPaintTip" xml:space="preserve">Enter the in-game 24×24 pixel editor first, then start.&#10;Drag/scroll the preview to reframe; white is skipped by default.&#10;Parameters lock while running; see the right log for progress.</system:String>
     <system:String x:Key="MiniGame@PixelPaint@DropHint">Drop or paste an image or text, or pick below</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -1098,6 +1098,8 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="MiniGame@SecretFront@Event3">揺蕩う影</system:String>
     <system:String x:Key="MiniGame@SecretFront">隠密戦線</system:String>
     <system:String x:Key="MiniGame@SecretFrontTip">小隊選択画面で開始します。セーブデータがある場合は手動で削除する必要があります。ゲーム内の ｢前の小隊からのデータを引き継ぐ｣ にチェックすることを推奨します。</system:String>
+    <system:String x:Key="MiniGame@InteractiveExhibition@UncollectedNotificationTitle">奇象巡展：未収録の奇象を発見</system:String>
+    <system:String x:Key="MiniGame@InteractiveExhibition@UncollectedNotificationContent">MAAは自動探索を停止しました。ゲームに戻って手動で戦闘を完了してください。</system:String>
     <system:String x:Key="MiniGame@PixelPaint">ピクセル画自動描画</system:String>
     <system:String x:Key="MiniGame@PixelPaintTip">ゲーム内の 24×24 ピクセル画編集ページに手動で入ってから開始してください。&#10;プレビューはドラッグ/ホイールで構図調整。デフォルトで白はスキップ。&#10;開始後はパラメータ固定。進捗は右のログ参照。</system:String>
     <system:String x:Key="MiniGame@PixelPaint@DropHint">画像をドロップ、画像/テキストを貼り付け、または下のボタンで選択</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -1099,6 +1099,8 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="MiniGame@SecretFront@Event3">수상한 그림자</system:String>
     <system:String x:Key="MiniGame@SecretFront">비밀 전선</system:String>
     <system:String x:Key="MiniGame@SecretFrontTip">소대 선택 화면에서 시작합니다. 기존 세이브 데이터가 있으면 수동으로 삭제해야 합니다.\n게임 내  ｢이전 소대의 데이터 전승받기｣  옵션을 체크하는 것을 권장합니다.</system:String>
+    <system:String x:Key="MiniGame@InteractiveExhibition@UncollectedNotificationTitle">기상 순회전: 미수록 기상 발견</system:String>
+    <system:String x:Key="MiniGame@InteractiveExhibition@UncollectedNotificationContent">MAA가 자동 탐색을 중지했습니다. 게임으로 돌아가 전투를 수동으로 완료하세요.</system:String>
     <system:String x:Key="MiniGame@PixelPaint">픽셀 아트 자동 그리기</system:String>
     <system:String x:Key="MiniGame@PixelPaintTip">게임 내 24×24 픽셀 아트 편집 페이지에 직접 들어간 뒤 시작하세요.&#10;미리보기는 드래그/휠로 구도 조정. 기본적으로 흰색은 건너뜀.&#10;시작 후 파라미터는 고정. 진행 상황은 오른쪽 로그 참조.</system:String>
     <system:String x:Key="MiniGame@PixelPaint@DropHint">이미지를 드래그하거나 이미지/텍스트를 붙여넣거나 아래 버튼으로 선택</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -1098,6 +1098,8 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="MiniGame@SecretFront@Event3">诡影迷踪</system:String>
     <system:String x:Key="MiniGame@SecretFront">隐秘战线</system:String>
     <system:String x:Key="MiniGame@SecretFrontTip" xml:space="preserve">在选小队界面开始，如有存档须手动删除。&#10;第一次打自己看完把教程关了。&#10;推荐勾选游戏内 ｢继承上一支队伍发回的数据｣</system:String>
+    <system:String x:Key="MiniGame@InteractiveExhibition@UncollectedNotificationTitle">奇象巡展：发现暂未收录奇象</system:String>
+    <system:String x:Key="MiniGame@InteractiveExhibition@UncollectedNotificationContent">MAA 已停止自动探索，请返回游戏完成战斗。</system:String>
     <system:String x:Key="MiniGame@PixelPaint">像素画自动填色</system:String>
     <system:String x:Key="MiniGame@PixelPaintTip" xml:space="preserve">请先手动进入游戏内 24×24 像素画编辑页，再开始。&#10;中间预览可拖移/滚轮取景；默认跳过白色。&#10;开始后参数锁定，进度见右侧日志。</system:String>
     <system:String x:Key="MiniGame@PixelPaint@DropHint">拖入图片、粘贴图片/文字或点下方选图</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -1098,6 +1098,8 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="MiniGame@SecretFront@Event3">詭影迷蹤</system:String>
     <system:String x:Key="MiniGame@SecretFront">隱秘戰線</system:String>
     <system:String x:Key="MiniGame@SecretFrontTip">在選擇小隊介面開始，如有存檔須手動刪除。&#10;第一次打請先看完教學後關閉。&#10;推薦勾選遊戲內 ｢繼承上一支隊伍發回的資料｣ 。</system:String>
+    <system:String x:Key="MiniGame@InteractiveExhibition@UncollectedNotificationTitle">奇象巡展：發現暫未收錄奇象</system:String>
+    <system:String x:Key="MiniGame@InteractiveExhibition@UncollectedNotificationContent">MAA 已停止自動探索，請返回遊戲完成戰鬥。</system:String>
     <system:String x:Key="MiniGame@PixelPaint">像素畫自動填色</system:String>
     <system:String x:Key="MiniGame@PixelPaintTip">請先手動進入遊戲內 24×24 像素畫編輯頁，再開始。&#10;中間預覽可拖移/滾輪取景；預設跳過白色。&#10;開始後參數鎖定，進度見右側日誌。</system:String>
     <system:String x:Key="MiniGame@PixelPaint@DropHint">拖入圖片、貼上圖片/文字或點下方選圖</system:String>


### PR DESCRIPTION
发送通知更方便

## Summary by Sourcery

在互动展览小游戏遇到未收集物品时新增通知处理，包括 UI 日志记录、吐司提示显示，以及可选的外部通知。

新功能：
- 当互动展览小游戏检测到未收集的遭遇事件时，通过应用内吐司提示以及可选的外部通知提醒用户。

增强项：
- 将互动展览小游戏中的未收集遭遇事件记录为任务队列视图中的警告条目。
- 为未收集遭遇通知的标题和内容在所有支持的语言中添加本地化条目。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add notification handling when the interactive exhibition mini-game encounters an uncollected item, including UI logging, toast display, and optional external notification.

New Features:
- Notify users when the interactive exhibition mini-game detects an uncollected encounter via in-app toast and optional external notification.

Enhancements:
- Log uncollected encounter events from the interactive exhibition mini-game with a warning entry in the task queue view.
- Add localization entries for the uncollected encounter notification title and content in all supported languages.

</details>