### PR TITLE
fix: add match_operator_groups support for Power, Reception, and Office tasks

### DIFF
--- a/src/MaaCore/Task/Infrast/InfrastOfficeTask.cpp
+++ b/src/MaaCore/Task/Infrast/InfrastOfficeTask.cpp
@@ -28,6 +28,10 @@ bool asst::InfrastOfficeTask::_run()
 
     close_quick_formation_expand_role();
 
+    if (current_room_config().use_operator_groups) {
+        match_operator_groups();
+    }
+
     for (int i = 0; i <= OperSelectRetryTimes; ++i) {
         if (need_exit()) {
             return false;

--- a/src/MaaCore/Task/Infrast/InfrastPowerTask.cpp
+++ b/src/MaaCore/Task/Infrast/InfrastPowerTask.cpp
@@ -31,6 +31,10 @@ bool asst::InfrastPowerTask::_run()
 
         close_quick_formation_expand_role();
 
+        if (current_room_config().use_operator_groups) {
+            match_operator_groups();
+        }
+
         for (int j = 0; j <= OperSelectRetryTimes; ++j) {
             if (is_use_custom_opers()) {
                 bool name_select_ret = swipe_and_select_custom_opers();

--- a/src/MaaCore/Task/Infrast/InfrastReceptionTask.cpp
+++ b/src/MaaCore/Task/Infrast/InfrastReceptionTask.cpp
@@ -361,6 +361,10 @@ bool asst::InfrastReceptionTask::shift()
 
     close_quick_formation_expand_role();
 
+    if (current_room_config().use_operator_groups) {
+        match_operator_groups();
+    }
+
     int retry_times;
     for (retry_times = 0; retry_times <= OperSelectRetryTimes; ++retry_times) {
         if (need_exit()) {


### PR DESCRIPTION
## Summary

- `use_operator_groups` was parsed from custom infrast JSON config for all facility types, but `match_operator_groups()` was only called in `InfrastControlTask` and `InfrastProductionTask`
- This caused operator group rotation to be **silently ignored** for power stations (`InfrastPowerTask`), reception (`InfrastReceptionTask`), and office (`InfrastOfficeTask`) rooms
- Added the missing `match_operator_groups()` call to all three tasks, following the same pattern used in the existing implementations

## Test plan

- [ ] Configure custom infrast JSON with `use_operator_groups: true` for power station rooms and verify operators rotate correctly
- [ ] Configure custom infrast JSON with `use_operator_groups: true` for reception rooms and verify operators rotate correctly
- [ ] Configure custom infrast JSON with `use_operator_groups: true` for office rooms and verify operators rotate correctly
- [ ] Verify existing behavior without `use_operator_groups` is unchanged for all three facility types

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

确保操作员组轮换应用于所有相关的基础设施房间任务。

Bug Fixes:
- 当房间配置中启用操作员组时，将操作员组匹配应用于发电站任务。
- 当房间配置中启用操作员组时，将操作员组匹配应用于接待处任务。
- 当房间配置中启用操作员组时，将操作员组匹配应用于办公室任务。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure operator group rotation is applied to all relevant infrastructure room tasks.

Bug Fixes:
- Apply operator group matching to power station tasks when operator groups are enabled in room configuration.
- Apply operator group matching to reception tasks when operator groups are enabled in room configuration.
- Apply operator group matching to office tasks when operator groups are enabled in room configuration.

</details>