### PR TITLE
fix: 修复自动肉鸽-开局干员 ui 问题

### DIFF
--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/RoguelikeSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/RoguelikeSettingsUserControlModel.cs
@@ -348,7 +348,16 @@ public class RoguelikeSettingsUserControlModel : TaskSettingsViewModel, Roguelik
             }
         }
 
-        RoguelikeCoreCharList = roguelikeCoreCharList;
+        if (!string.IsNullOrEmpty(RoguelikeCoreChar) && !roguelikeCoreCharList.Contains(RoguelikeCoreChar))
+        {
+            roguelikeCoreCharList.Add(RoguelikeCoreChar);
+        }
+
+        RoguelikeCoreCharList.Clear();
+        foreach (var coreChar in roguelikeCoreCharList)
+        {
+            RoguelikeCoreCharList.Add(coreChar);
+        }
     }
 
     private ObservableCollection<GenericCombinedData<int>> _roguelikeDifficultyList = [];

--- a/src/MaaWpfGui/Views/UserControl/TaskQueue/RoguelikeSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/TaskQueue/RoguelikeSettingsUserControl.xaml
@@ -124,6 +124,7 @@
                     IsEditable="True"
                     IsTextSearchEnabled="False"
                     ItemsSource="{Binding RoguelikeCoreCharList}"
+                    ScrollViewer.CanContentScroll="False"
                     Loaded="{s:Action MakeComboBoxSearchable,
                                       Target={x:Type ui_vms:SettingsViewModel}}">
                     <hc:ComboBox.Text>


### PR DESCRIPTION
## 滚动错乱

<img width="591" height="1200" alt="image" src="https://github.com/user-attachments/assets/1d08bd7f-80bb-4b4a-8716-cb4aeb5f7126" />
<img width="588" height="1194" alt="image" src="https://github.com/user-attachments/assets/0e6f8644-5ca2-4568-a74a-cd18b2750c5c" />
<img width="606" height="1200" alt="image" src="https://github.com/user-attachments/assets/04e24e4c-6eb9-4d68-8345-13d57eb31631" />


#17042 向 ComboBoxExtensions.MakeComboBoxSearchable() 新增了 targetComboBox.ItemsSource = independentView.View;
会覆盖原有的 WPF ItemsSource Binding，导致主题切换后下拉框继续持有首次加载的招募集合。

关闭招募表时，StartingCoreCharComboBox_DropDownClosed() 会把当前主题的集合重新赋给 ItemsSource。于是从 A 切到 B时显示 A，收起后写入 B；再切到 C 时显示 B，收起后写入 C……


## 滚轮滑动

此外，`MouseWheelHelper` 为隔离外层页面滚动，会将滚轮增量除以 3 后传给下拉框的 `ScrollViewer`。常见增量 120 会得到偏移 40；默认逻辑滚动将其解释为 40 个候选项，导致一滚到底。

## Sourcery 总结

修复自动肉鸽开局干员选择界面在主题切换和列表刷新时显示异常的问题。

Bug 修复：
- 修复主题切换后自动肉鸽开局干员下拉框列表无法及时更新的问题。
- 修复开局干员列表刷新时当前已选干员可能丢失的问题。

改进：
- 改进开局干员候选列表的更新方式，保持现有绑定并正确刷新界面内容。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修复自动肉鸽开局干员选择界面在主题切换和列表刷新时显示异常的问题。

Bug Fixes:
- 修复主题切换后自动肉鸽开局干员下拉框列表无法及时更新的问题。
- 修复开局干员列表刷新时当前已选干员可能丢失的问题。

Enhancements:
- 改进开局干员候选列表的更新方式，保持现有绑定并正确刷新界面内容。

</details>