### PR TITLE
fix: 修复黑流树海策略重开和停止判定

### DIFF
--- a/resource/tasks/Roguelike/BlackFlow.json
+++ b/resource/tasks/Roguelike/BlackFlow.json
@@ -594,12 +594,6 @@
         "algorithm": "JustReturn",
         "next": ["BlackFlow@Roguelike@ExitThenAbandon"]
     },
-    "BlackFlow@Roguelike@ExitThenStop-Enter": {
-        "algorithm": "JustReturn",
-        "sub": ["BlackFlow@Roguelike@ExitThenAbandon-Enter"],
-        "subErrorIgnored": true,
-        "next": ["RoguelikeControlTaskPlugin-Stop"]
-    },
     "BlackFlow@Roguelike@GamePass": {
         "template": "BlackFlow@Roguelike@GamePass.png"
     },
@@ -1528,7 +1522,7 @@
         "roi": [958, 530, 322, 189]
     },
     "BlackFlow@Roguelike@StrategyTerminalAction": {
-        "baseTask": "BlackFlow@Roguelike@ExitThenStop-Enter"
+        "baseTask": "BlackFlow@Roguelike@ExitThenAbandon-Enter"
     },
     "BlackFlow@Roguelike@StrategyTerminated": {
         "Doc": "本任务注册了插件 BlackFlowLifecycleTaskPlugin，改基只能指向 StrategyTerminated-Enter。",

--- a/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowLifecycleTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowLifecycleTaskPlugin.cpp
@@ -124,7 +124,8 @@ void BlackFlowLifecycleTaskPlugin::reset_in_run_variables()
     m_pending_details = {};
     m_terminal_trigger.clear();
     m_terminal_pre_task.clear();
-    Task.set_task_base("BlackFlow@Roguelike@StrategyTerminalAction", "BlackFlow@Roguelike@ExitThenStop-Enter");
+    m_stop_after_abandon = false;
+    Task.set_task_base("BlackFlow@Roguelike@StrategyTerminalAction", "BlackFlow@Roguelike@ExitThenAbandon-Enter");
     if (m_session != nullptr && !m_session->profile().empty()) {
         m_session->reset_run();
     }
@@ -186,8 +187,13 @@ bool BlackFlowLifecycleTaskPlugin::_run()
         return true;
     }
     if (work == PendingWork::ResetAfterAbandon) {
+        const bool stop_after_abandon = m_stop_after_abandon;
         reset_in_run_variables();
         Log.info("BlackFlow run state reset after abandonment");
+        if (stop_after_abandon && m_task_ptr != nullptr) {
+            m_task_ptr->set_enable(false);
+            Log.info("BlackFlow task stopped after abandonment");
+        }
         return true;
     }
     if (work != PendingWork::ResolveTerminalAction) {
@@ -211,10 +217,9 @@ bool BlackFlowLifecycleTaskPlugin::_run()
 
     const std::string next_action =
         m_session != nullptr && m_session->result().has_value() ? m_session->result()->next_action : "stop_run";
-    // 两支都经 -Enter 转发：停止一支要让控制插件收到自己的任务名，
-    // 重开一支的目标带模板，占位任务继承不到。
-    const std::string task = next_action == "restart_current_run" ? "BlackFlow@Roguelike@ExitThenAbandon-Enter"
-                                                                  : "BlackFlow@Roguelike@ExitThenStop-Enter";
+    // 两支都在主 ProcessTask 上完成放弃；停止一支在 AbandonConfirm 完成后、StartExplore 之前停用主任务。
+    m_stop_after_abandon = next_action != "restart_current_run";
+    const std::string task = "BlackFlow@Roguelike@ExitThenAbandon-Enter";
     Task.set_task_base("BlackFlow@Roguelike@StrategyTerminalAction", task);
     Log.info(
         "BlackFlow strategy terminal action",

--- a/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowLifecycleTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowLifecycleTaskPlugin.h
@@ -29,5 +29,6 @@ private:
     mutable json::value m_pending_details;
     mutable std::string m_terminal_trigger;
     mutable std::string m_terminal_pre_task;
+    bool m_stop_after_abandon = false;
 };
 } // namespace asst::blackflow


### PR DESCRIPTION
做了两次测试，一次培育出目标后正确放弃、上报任务完成，一次没培育出目标继续重开下一局。

## Summary by Sourcery

修复黑流树海策略完成目标后的停止判定和未完成目标时的重开流程。

Bug Fixes:
- 修复黑流树海策略在培育出目标后无法正确停止并上报完成的问题。
- 修复未培育出目标时无法正确重开下一局的问题。

Enhancements:
- 统一通过放弃流程处理策略终止，并根据策略结果在放弃后停止主任务或继续重开。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修复黑流树海策略完成目标后的停止判定和未完成目标时的重开流程。

Bug Fixes:
- 修复黑流树海策略在培育出目标后无法正确停止并上报完成的问题。
- 修复未培育出目标时无法正确重开下一局的问题。

Enhancements:
- 统一通过放弃流程处理策略终止，并根据策略结果在放弃后停止主任务或继续重开。

</details>