### PR TITLE
docs: 新增 MaaFramework 控制单元自动下载脚本及开发文档说明

### DIFF
--- a/docs/en-us/develop/development.md
+++ b/docs/en-us/develop/development.md
@@ -78,7 +78,7 @@ We've preset several different development environments for you to choose from:
    - Press F5 to run
 
    ::: tip
-   To run Win32Controller (Windows window control) / MaaFwAdbController (MaaFwAdb touch mode) features, you need to manually download the package for your platform from [MaaFramework Releases](https://github.com/MaaXYZ/MaaFramework/releases), and place `MaaWin32ControlUnit.dll` / `MaaAdbControlUnit.dll` from the `bin` directory into MAA's DLL directory (e.g. `build/bin/Debug`). PRs for an auto-download script are welcome!
+   To run Win32Controller (Windows window control) / MaaFwAdbController (MaaFramework touch mode) features, run `python tools/maafw-control-unit-download.py` to automatically download the `MaaWin32ControlUnit.dll` / `MaaAdbControlUnit.dll` for your platform into the build output directory (the newest directory under `build/bin` by default, or the one given by `--output-dir`).
 
    To debug these features, [compile the Debug version of MaaFramework yourself](https://maafw.com/docs/4.1-BuildGuide) and use the corresponding DLLs, or it will randomly crash at breakpoints.
    :::

--- a/docs/ja-jp/develop/development.md
+++ b/docs/ja-jp/develop/development.md
@@ -84,7 +84,7 @@ icon: iconoir:developer
    - F5 キーを押して実行
 
    ::: tip
-   Win32Controller（Windows ウィンドウ制御）/ MaaFwAdbController（MaaFwAdb のタッチモード）関連機能を実行する場合は、[MaaFramework Releases](https://github.com/MaaXYZ/MaaFramework/releases) から対応プラットフォームのアーカイブをダウンロードし、`bin` ディレクトリ内の `MaaWin32ControlUnit.dll` / `MaaAdbControlUnit.dll` を MAA の DLL と同じディレクトリ（例：`build/bin/Debug`）に配置してください。自動ダウンロードスクリプトの PR 歓迎！
+   Win32Controller（Windows ウィンドウ制御）/ MaaFwAdbController（MaaFramework のタッチモード）関連機能を実行する場合は、`python tools/maafw-control-unit-download.py` を実行すると、対応プラットフォームの `MaaWin32ControlUnit.dll` / `MaaAdbControlUnit.dll` をビルド出力ディレクトリ（デフォルトでは `build/bin` 配下の最新ディレクトリ、`--output-dir` で指定可）に自動で配置します。
 
    関連機能をデバッグする場合は、[MaaFramework の Debug バージョンを自分でコンパイル](https://maafw.com/docs/4.1-BuildGuide)し、対応する DLL ファイルを使用する必要があります。そうしないと、ブレークポイントデバッグ中に謎のクラッシュが発生します。
    :::

--- a/docs/ko-kr/develop/development.md
+++ b/docs/ko-kr/develop/development.md
@@ -83,7 +83,7 @@ icon: iconoir:developer
    - F5 키를 눌러 실행
 
    ::: tip
-   Win32Controller(Windows 창 제어) / MaaFwAdbController(MaaFwAdb 터치 수행 방식) 관련 기능을 실행하려면 [MaaFramework Releases](https://github.com/MaaXYZ/MaaFramework/releases)에서 해당 플랫폼 압축 파일을 다운로드하고, `bin` 디렉토리의 `MaaWin32ControlUnit.dll` / `MaaAdbControlUnit.dll`을 MAA DLL과 같은 디렉토리(예: `build/bin/Debug`)에 배치해야 합니다. 자동 다운로드 스크립트 PR 환영!
+   Win32Controller(Windows 창 제어) / MaaFwAdbController(MaaFramework 터치 수행 방식) 관련 기능을 실행하려면 `python tools/maafw-control-unit-download.py`를 실행하면 해당 플랫폼의 `MaaWin32ControlUnit.dll` / `MaaAdbControlUnit.dll`을 빌드 출력 디렉터리(기본값: `build/bin` 아래 최신 디렉터리, `--output-dir`로 지정 가능)에 자동으로 배치합니다.
 
    若需调试相关功能，则需要自行编译 MaaFramework 的 Debug 版本，使用对应的 DLL 文件，否则在断点调试时会神秘闪退。
    :::

--- a/docs/zh-cn/develop/development.md
+++ b/docs/zh-cn/develop/development.md
@@ -78,7 +78,7 @@ icon: iconoir:developer
    - 按 F5 运行
 
    ::: tip
-   若需运行 Win32Controller（Windows 窗口控制）/ MaaFwAdbController（MaaFwAdb 触控模式）相关功能，需要自行从 [MaaFramework Releases](https://github.com/MaaXYZ/MaaFramework/releases) 下载对应平台的压缩包，将 `bin` 目录中的 `MaaWin32ControlUnit.dll` / `MaaAdbControlUnit.dll` 放到 MAA 的 DLL 同目录下（如 `build/bin/Debug`）。欢迎 PR 一个自动下载脚本！
+   若需运行 Win32Controller（Windows 窗口控制）/ MaaFwAdbController（MaaFramework 触控模式）相关功能，运行 `python tools/maafw-control-unit-download.py` 即可自动下载对应平台的 `MaaWin32ControlUnit.dll` / `MaaAdbControlUnit.dll` 到构建输出目录（默认取 `build/bin` 下最新生成的目录，也可用 `--output-dir` 指定）。
 
    若需调试相关功能，则需要[自行编译 MaaFramework](https://maafw.com/docs/4.1-BuildGuide) 的 Debug 版本，使用对应的 DLL 文件，否则在断点调试时会神秘闪退。
    :::

--- a/docs/zh-tw/develop/development.md
+++ b/docs/zh-tw/develop/development.md
@@ -78,7 +78,7 @@ icon: iconoir:developer
    - 按 F5 執行。
 
    ::: tip
-   若需執行 Win32Controller（Windows 視窗控制）/ MaaFwAdbController（MaaFwAdb 觸控模式）相關功能，需要自行從 [MaaFramework Releases](https://github.com/MaaModular/MaaFramework/releases) 下載對應平台的壓縮檔案，將 `bin` 目錄中的 `MaaWin32ControlUnit.dll` / `MaaAdbControlUnit.dll` 放到 MAA 的 DLL 同目錄下（例如 `build/bin/Debug`）。歡迎 PR 一個自動下載腳本！
+   若需執行 Win32Controller（Windows 視窗控制）/ MaaFwAdbController（MaaFramework 觸控模式）相關功能，執行 `python tools/maafw-control-unit-download.py` 即可自動下載對應平台的 `MaaWin32ControlUnit.dll` / `MaaAdbControlUnit.dll` 到建置輸出目錄（預設取 `build/bin` 下最新產生的目錄，也可用 `--output-dir` 指定）。
 
    若需針對相關功能進行除錯，則需要自行編譯 MaaFramework 的 Debug 版本，使用對應的 DLL 檔案，否則在斷點除錯時會神秘閃退。
    :::

--- a/tools/maafw-control-unit-download.py
+++ b/tools/maafw-control-unit-download.py
@@ -20,7 +20,10 @@ Note: these are Release builds of MaaFramework. They are ABI-compatible with
 Release/RelWithDebInfo builds of MAA, but NOT with Debug builds of MAA (MSVC
 debug/release STL layouts differ and mixing them crashes). For Debug builds you
 have to compile the Debug version of MaaFramework yourself, see
-docs/zh-cn/develop/development.md.
+docs/zh-cn/develop/development.md. If a target control unit is locked by a
+running MAA process, the script skips it with a note when it is already
+present, or fails with a clear message otherwise — close MAA before replacing
+them.
 """
 
 import argparse
@@ -176,7 +179,7 @@ def download_asset(asset, dest: Path):
     verify_digest(dest, asset.get("digest"))
 
 
-def extract_control_units(archive: Path, output_dir: Path):
+def extract_control_units(archive: Path, output_dir: Path, force: bool = False):
     staging = Path(tempfile.mkdtemp(prefix="maafw-"))
     try:
         print("extracting", archive.name)
@@ -190,8 +193,24 @@ def extract_control_units(archive: Path, output_dir: Path):
         copied = []
         for entry in sorted(bin_dir.iterdir()):
             if entry.is_file() and "ControlUnit" in entry.name:
-                shutil.copy2(entry, output_dir / entry.name)
-                copied.append(entry.name)
+                dst = output_dir / entry.name
+                try:
+                    shutil.copy2(entry, dst)
+                    copied.append(entry.name)
+                except PermissionError:
+                    # A running MAA process keeps the target DLL loaded and locked.
+                    # If it is already present, the provisioning goal is met; only
+                    # fail loudly when the user asked to replace it or it is missing.
+                    if not force and dst.exists():
+                        print(
+                            f"note: {entry.name} is in use (a running MAA process?) "
+                            f"and already present, skipped"
+                        )
+                    else:
+                        raise RuntimeError(
+                            f"cannot copy {entry.name} into {output_dir}: the target file "
+                            f"is in use by a running MAA process. Close MAA and retry."
+                        )
         if not copied:
             raise RuntimeError(f"no control unit binaries found in {bin_dir}")
         return copied
@@ -268,7 +287,7 @@ def main():
     with tempfile.TemporaryDirectory(prefix="maafw-dl-") as tmp:
         archive = Path(tmp) / asset["name"]
         download_asset(asset, archive)
-        copied = extract_control_units(archive, output_dir)
+        copied = extract_control_units(archive, output_dir, args.force)
 
     print("copied control units into", output_dir)
     for name in copied:

--- a/tools/maafw-control-unit-download.py
+++ b/tools/maafw-control-unit-download.py
@@ -293,7 +293,7 @@ def main():
     for name in copied:
         print("  -", name)
 
-    if platform_name == "win" and missing:
+    if platform_name == "win":
         print(
             "note: these are Release builds; use them with Release/RelWithDebInfo builds of MAA, not Debug"
         )

--- a/tools/maafw-control-unit-download.py
+++ b/tools/maafw-control-unit-download.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""Download MaaFramework control unit binaries into a build output directory.
+
+The MaaCore Win32 controller (Win32Controller) and the MaaFramework touch-mode
+ADB controller (MaaFwAdbController) dynamically load "control unit" binaries
+that are shipped by MaaFramework releases rather than built from this
+repository. Without them the PC window binding (AttachWindow) and the
+MaaFramework touch mode fail to initialize.
+
+This script mirrors what CI does (see .github/workflows/ci.yml): fetch the
+MaaFramework release archive matching the host platform and copy the control
+unit binaries (MaaWin32ControlUnit.dll, MaaAdbControlUnit.dll, ...) out of its
+``bin`` directory into the target directory. The download is skipped when the
+expected control units are already present unless ``--force`` is given.
+
+Usage:
+    python tools/maafw-control-unit-download.py [--tag v5.9.2] [--output-dir DIR] [--force]
+
+Note: these are Release builds of MaaFramework. They are ABI-compatible with
+Release/RelWithDebInfo builds of MAA, but NOT with Debug builds of MAA (MSVC
+debug/release STL layouts differ and mixing them crashes). For Debug builds you
+have to compile the Debug version of MaaFramework yourself, see
+docs/zh-cn/develop/development.md.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import platform
+import shutil
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+import zipfile
+from pathlib import Path
+
+REPO = "MaaXYZ/MaaFramework"
+# Keep in sync with the pin used in .github/workflows/ci.yml
+DEFAULT_TAG = "v5.9.2"
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def format_size(num, suffix="B"):
+    for unit in ["", "Ki", "Mi", "Gi", "Ti", "Pi", "Ei", "Zi"]:
+        if abs(num) < 1024.0:
+            return f"{num:3.1f}{unit}{suffix}"
+        num /= 1024.0
+    return f"{num:.1f}Yi{suffix}"
+
+
+class ProgressHook:
+    def __init__(self):
+        self.downloaded = 0
+        self.last_print = 0
+
+    def __call__(self, block, chunk, total):
+        self.downloaded += chunk
+        t = time.monotonic()
+        if t - self.last_print >= 0.5 or self.downloaded == total:
+            self.last_print = t
+            if total > 0:
+                print(
+                    f"\r [{self.downloaded / total * 100.0:3.1f}%] {format_size(self.downloaded)} / {format_size(total)}      \r",
+                    end="",
+                )
+        if self.downloaded == total:
+            print("")
+
+
+def host_platform():
+    """Return (platform, arch) in MaaFramework asset naming, e.g. ("win", "x86_64")."""
+    system = platform.system().lower()
+    if system == "windows":
+        system = "win"
+    elif system == "darwin":
+        system = "macos"
+    elif system == "linux":
+        system = "linux"
+    elif "mingw" in system or "cygwin" in system:
+        system = "win"
+    else:
+        raise RuntimeError(f"unsupported system: {system}")
+
+    machine = platform.machine().lower()
+    if machine in {"amd64", "x86_64"}:
+        arch = "x86_64"
+    elif machine in {"aarch64", "arm64", "armv8l"}:
+        arch = "aarch64"
+    else:
+        raise RuntimeError(f"unsupported architecture: {machine}")
+
+    return system, arch
+
+
+def expected_control_units(platform_name: str):
+    """Control unit names whose presence means the download can be skipped."""
+    if platform_name == "win":
+        return ["MaaWin32ControlUnit.dll", "MaaAdbControlUnit.dll"]
+    if platform_name == "macos":
+        return ["libMaaAdbControlUnit.dylib"]
+    return ["libMaaAdbControlUnit.so"]
+
+
+def query_release(tag: str):
+    """Return the release JSON from the GitHub API, or None on failure."""
+    req = urllib.request.Request(
+        f"https://api.github.com/repos/{REPO}/releases/tags/{tag}"
+    )
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            return json.loads(resp.read())
+    except (urllib.error.URLError, urllib.error.HTTPError, TimeoutError) as e:
+        print(
+            f"warning: failed to query GitHub API ({e}), will construct the download URL directly"
+        )
+        return None
+
+
+def find_asset(release, platform_name: str, arch: str, tag: str):
+    """Find the archive asset for the host platform."""
+    needle = f"-{platform_name}-{arch}-{tag}.zip"
+    if release:
+        for asset in release.get("assets", []):
+            if asset["name"].endswith(".zip") and needle in asset["name"]:
+                return asset
+        available = ", ".join(a["name"] for a in release.get("assets", []))
+        raise RuntimeError(
+            f"no asset matching {needle} in {REPO} {tag}; available: {available or '(none)'}"
+        )
+    # Fallback: the asset name is regular, build the direct download URL.
+    return {
+        "name": f"MAA-{platform_name}-{arch}-{tag}.zip",
+        "browser_download_url": f"https://github.com/{REPO}/releases/download/{tag}/MAA-{platform_name}-{arch}-{tag}.zip",
+        "digest": None,
+    }
+
+
+def sha256_of(path: Path) -> str:
+    hasher = hashlib.sha256()
+    with path.open("rb") as f:
+        while True:
+            chunk = f.read(1024 * 1024)
+            if not chunk:
+                break
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def verify_digest(path: Path, digest):
+    if not digest:
+        print("note: no digest available from the release, skipped integrity check")
+        return
+    if not digest.startswith("sha256:"):
+        print("warning: unsupported digest format:", digest)
+        return
+    expected = digest[len("sha256:") :]
+    actual = sha256_of(path)
+    if actual != expected:
+        raise RuntimeError(
+            f"sha256 mismatch for {path.name}: expected {expected}, got {actual}"
+        )
+    print("sha256 verified:", actual)
+
+
+def download_asset(asset, dest: Path):
+    url = asset["browser_download_url"]
+    print("downloading from", url)
+    urllib.request.urlretrieve(url, dest, reporthook=ProgressHook())
+    verify_digest(dest, asset.get("digest"))
+
+
+def extract_control_units(archive: Path, output_dir: Path):
+    staging = Path(tempfile.mkdtemp(prefix="maafw-"))
+    try:
+        print("extracting", archive.name)
+        with zipfile.ZipFile(archive) as zf:
+            zf.extractall(staging)
+        bin_dir = staging / "bin"
+        if not bin_dir.is_dir():
+            raise RuntimeError(
+                f"archive does not contain a bin/ directory: {archive.name}"
+            )
+        copied = []
+        for entry in sorted(bin_dir.iterdir()):
+            if entry.is_file() and "ControlUnit" in entry.name:
+                shutil.copy2(entry, output_dir / entry.name)
+                copied.append(entry.name)
+        if not copied:
+            raise RuntimeError(f"no control unit binaries found in {bin_dir}")
+        return copied
+    finally:
+        shutil.rmtree(staging, ignore_errors=True)
+
+
+def detect_output_dir():
+    """Pick the newest existing build output directory under build/bin."""
+    base = ROOT / "build" / "bin"
+    if not base.is_dir():
+        return None
+    candidates = []
+    for d in base.iterdir():
+        if d.is_dir() and any(
+            (d / name).exists()
+            for name in ("MAA.exe", "MaaCore.dll", "libMaaCore.dylib")
+        ):
+            candidates.append(d)
+    if not candidates:
+        return None
+    return max(candidates, key=lambda p: p.stat().st_mtime)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--tag",
+        default=DEFAULT_TAG,
+        help=f"MaaFramework release tag (default: {DEFAULT_TAG})",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=None,
+        help="directory to place the control units into (default: newest dir under build/bin)",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="re-download even if the control units already exist",
+    )
+    args = parser.parse_args()
+
+    platform_name, arch = host_platform()
+    print(f"host platform: {platform_name}-{arch}, MaaFramework tag: {args.tag}")
+
+    if args.output_dir:
+        output_dir = Path(args.output_dir)
+    else:
+        output_dir = detect_output_dir()
+        if output_dir is None:
+            parser.error(
+                "could not find a build output directory; build the project first or pass --output-dir"
+            )
+        print("target output directory:", output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    if not args.force:
+        missing = [
+            name
+            for name in expected_control_units(platform_name)
+            if not (output_dir / name).exists()
+        ]
+        if not missing:
+            print(
+                "control units already present, nothing to do (use --force to re-download)"
+            )
+            return 0
+
+    release = query_release(args.tag)
+    asset = find_asset(release, platform_name, arch, args.tag)
+    print("asset:", asset["name"])
+
+    with tempfile.TemporaryDirectory(prefix="maafw-dl-") as tmp:
+        archive = Path(tmp) / asset["name"]
+        download_asset(asset, archive)
+        copied = extract_control_units(archive, output_dir)
+
+    print("copied control units into", output_dir)
+    for name in copied:
+        print("  -", name)
+
+    if platform_name == "win" and missing:
+        print(
+            "note: these are Release builds; use them with Release/RelWithDebInfo builds of MAA, not Debug"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 背景
Win32Controller（PC 窗口绑定）与 MaaFwAdbController（MaaFramework 触控模式）需要从 MaaFramework Releases 下载控制单元 DLL（`MaaWin32ControlUnit.dll` / `MaaAdbControlUnit.dll`），源码构建并不会自动带上它们。此前开发文档要求手动下载放置，并注明"欢迎 PR 一个自动下载脚本"。

## 改动
- 新增 `tools/maafw-control-unit-download.py`：自动查询 MaaFramework 指定 tag 的发布资产（默认 `v5.9.2`，与 `.github/workflows/ci.yml` 一致，`--tag` 可覆盖），按宿主平台/架构匹配压缩包，下载后校验 sha256，将 `bin/` 下的控制单元复制到构建输出目录（默认取 `build/bin` 下最新目录，`--output-dir` 可指定）。
  - 幂等：目标控制单元已存在时直接跳过（`--force` 强制重下）。
  - 若目标文件被运行中的 MAA 进程占用：已存在时跳过并提示，否则给出清晰错误提示先关闭 MAA。
- 同步更新五种语言（zh-cn/en-us/zh-tw/ja-jp/ko-kr）开发文档，将手动下载步骤替换为脚本命令。

## 验证
- Windows x64 实测：自动下载 `MAA-win-x86_64-v5.9.2.zip`（68.4MB），sha256 校验通过，解压复制 4 个控制单元；二次运行秒级跳过；产物与发行包内 DLL 字节级一致（SHA256 相同）。
- `ruff format --check` / `ruff check` 通过。
- 占用场景单测覆盖（已存在跳过 / `--force` 报错 / 缺失报错）。

## 备注
- CI 中 tag 与脚本 `DEFAULT_TAG` 为两处独立钉版，升级 MaaFramework 时需同步修改（脚本内已有注释提醒）。

## Sourcery 摘要

自动化本地开发环境中的 MaaFramework 控制单元配置。

新功能：
- 添加脚本，用于下载所选版本的平台专用 MaaFramework 控制单元二进制文件，并在进行完整性验证和可配置输出处理后，将其安装到构建输出目录中。

增强功能：
- 使控制单元配置具备幂等性，并清晰处理被正在运行的 MAA 进程锁定的文件。

文档：
- 更新所有受支持语言的开发文档，使用自动控制单元下载脚本替代手动安装说明。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Automate MaaFramework control unit provisioning for local development.

New Features:
- Add a script that downloads platform-specific MaaFramework control unit binaries for a selected release and installs them into the build output directory with integrity verification and configurable output handling.

Enhancements:
- Make control unit provisioning idempotent and provide clear handling for files locked by a running MAA process.

Documentation:
- Update development documentation in all supported languages to use the automatic control unit download script instead of manual installation instructions.

</details>

新功能：
- 添加一个脚本，用于将特定平台的 MaaFramework 控制单元二进制文件下载到构建输出目录，支持发布版本选择、校验和验证以及可配置的输出处理。

增强：
- 使控制单元的配置过程具备幂等性，并为被正在运行的 MAA 进程锁定的文件提供明确的处理方式。

文档：
- 更新所有受支持语言的开发文档，使其使用自动控制单元下载脚本，而不是手动安装说明。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

自动化本地开发环境中的 MaaFramework 控制单元配置。

新功能：
- 添加脚本，用于下载所选版本的平台专用 MaaFramework 控制单元二进制文件，并在进行完整性验证和可配置输出处理后，将其安装到构建输出目录中。

增强功能：
- 使控制单元配置具备幂等性，并清晰处理被正在运行的 MAA 进程锁定的文件。

文档：
- 更新所有受支持语言的开发文档，使用自动控制单元下载脚本替代手动安装说明。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Automate MaaFramework control unit provisioning for local development.

New Features:
- Add a script that downloads platform-specific MaaFramework control unit binaries for a selected release and installs them into the build output directory with integrity verification and configurable output handling.

Enhancements:
- Make control unit provisioning idempotent and provide clear handling for files locked by a running MAA process.

Documentation:
- Update development documentation in all supported languages to use the automatic control unit download script instead of manual installation instructions.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

自动化本地开发环境中的 MaaFramework 控制单元配置。

新功能：
- 添加脚本，用于下载所选版本的平台专用 MaaFramework 控制单元二进制文件，并在进行完整性验证和可配置输出处理后，将其安装到构建输出目录中。

增强功能：
- 使控制单元配置具备幂等性，并清晰处理被正在运行的 MAA 进程锁定的文件。

文档：
- 更新所有受支持语言的开发文档，使用自动控制单元下载脚本替代手动安装说明。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Automate MaaFramework control unit provisioning for local development.

New Features:
- Add a script that downloads platform-specific MaaFramework control unit binaries for a selected release and installs them into the build output directory with integrity verification and configurable output handling.

Enhancements:
- Make control unit provisioning idempotent and provide clear handling for files locked by a running MAA process.

Documentation:
- Update development documentation in all supported languages to use the automatic control unit download script instead of manual installation instructions.

</details>

新功能：
- 添加一个脚本，用于将特定平台的 MaaFramework 控制单元二进制文件下载到构建输出目录，支持发布版本选择、校验和验证以及可配置的输出处理。

增强：
- 使控制单元的配置过程具备幂等性，并为被正在运行的 MAA 进程锁定的文件提供明确的处理方式。

文档：
- 更新所有受支持语言的开发文档，使其使用自动控制单元下载脚本，而不是手动安装说明。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

自动化本地开发环境中的 MaaFramework 控制单元配置。

新功能：
- 添加脚本，用于下载所选版本的平台专用 MaaFramework 控制单元二进制文件，并在进行完整性验证和可配置输出处理后，将其安装到构建输出目录中。

增强功能：
- 使控制单元配置具备幂等性，并清晰处理被正在运行的 MAA 进程锁定的文件。

文档：
- 更新所有受支持语言的开发文档，使用自动控制单元下载脚本替代手动安装说明。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Automate MaaFramework control unit provisioning for local development.

New Features:
- Add a script that downloads platform-specific MaaFramework control unit binaries for a selected release and installs them into the build output directory with integrity verification and configurable output handling.

Enhancements:
- Make control unit provisioning idempotent and provide clear handling for files locked by a running MAA process.

Documentation:
- Update development documentation in all supported languages to use the automatic control unit download script instead of manual installation instructions.

</details>

</details>

</details>