### PR TITLE
fix: 修复黑流树海商店确认离开识别

### DIFF
--- a/resource/tasks/Roguelike/BlackFlow.json
+++ b/resource/tasks/Roguelike/BlackFlow.json
@@ -1140,7 +1140,7 @@
     },
     "BlackFlow@Roguelike@Page-Shop": {
         "algorithm": "JustReturn",
-        "next": ["BlackFlow@Roguelike@StageTraderLeave"]
+        "next": ["BlackFlow@Roguelike@StageTraderLeaveConfirm", "BlackFlow@Roguelike@StageTraderLeave"]
     },
     "BlackFlow@Roguelike@RecoverMap": {
         "baseTask": "BlackFlow@Roguelike@RecoverMap-Exit",


### PR DESCRIPTION
## 改动

- 黑流树海进入商店节点后，优先识别并点击“确认离开”。
- 保留原有“离开”识别作为兼容回退。

## 原因

`MovePreviewConfirm` 偶发在界面切换期间重复点击。第二次点击坐标可能落入商店离开按钮区域，使商店加载完成时已经处于“确认离开”状态。此时 `BlackFlow@Roguelike@Page-Shop` 原流程只尝试 `StageTraderLeave`，会重试 20 次后触发 `TaskChainError`。

本改动让 `Page-Shop` 同时接受“确认离开”和普通“离开”两种合法状态，从而恢复流程；正常商店退出路径保持不变。

## 影响

路线进入“诡意行商”且发生前置重复点击时，可以正常退出商店并继续路线，不再因此中止整批自动肉鸽。

## 验证

- `BlackFlow.json` 可正常解析，任务后继顺序为 `StageTraderLeaveConfirm`、`StageTraderLeave`。
- `git diff --check` 通过。
- 项目 `Prettier (Config Files)` pre-commit 钩子通过。
- 失败截图离线模板匹配：`StageTraderLeaveConfirm` 为 `0.999033`，旧 `StageTraderLeave` 为 `0.472969`。
- 更新到 `v6.17.0-beta.5` 后，使用实际 MuMu 商店画面与更新后的 MaaCore 做无点击真机回放：命中 `Roguelike@StageTraderLeaveConfirm.png`，分数 `0.999033`，识别框 `[1035, 497, 242, 103]`，测试任务正常完成且无错误。