### PR TITLE
fix: 修复黑流树海商店页面未显示“刷新”时的误判

### DIFF
--- a/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowPageIdentity.cpp
+++ b/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowPageIdentity.cpp
@@ -16,7 +16,7 @@ EnteredPageObservation classify_entered_page_texts(std::vector<std::string> matc
     observation.matched_texts.assign(texts.begin(), texts.end());
 
     const bool final = texts.contains("险路尽头");
-    const bool shop = texts.contains("前瞻性投资系统") && texts.contains("刷新");
+    const bool shop = texts.contains("前瞻性投资系统");
     const bool scrap_shop = texts.contains("机械师的园圃");
     const bool emergency_aid = texts.size() == 1 && texts.contains("刷新");
     const int classifications = static_cast<int>(final) + static_cast<int>(shop) + static_cast<int>(scrap_shop) +


### PR DESCRIPTION
## 说明

Fix #17794

黑流树海的诡意行商页面在部分账号上不会显示“刷新”。

原有页面分类逻辑要求同时识别到“前瞻性投资系统”和“刷新”，才会将当前页面判定为商店。当页面没有“刷新”时，即使已经识别到“前瞻性投资系统”，分类仍会失败。

分类失败后流程会进入 Encounter fallback 并点击屏幕中央，可能误点商店商品、打开购买确认框，最终导致投资入口识别失败和任务报错。

## 修改内容

- 将“前瞻性投资系统”作为商店页面的识别条件，不再强制要求同时出现“刷新”。
- 保持仅识别到“刷新”时归类为应急助力的现有行为。

## 影响

未显示“刷新”的诡意行商页面可以正常进入商店处理流程，不再因分类失败执行可能误点商品的 fallback。

其他页面的分类逻辑保持不变。

## 验证

- [x] `MaaCore` Release 构建通过