### PR TITLE
fix: 修复黑流树海页面分类适配

### DIFF
--- a/resource/tasks/Roguelike/BlackFlow.json
+++ b/resource/tasks/Roguelike/BlackFlow.json
@@ -492,9 +492,10 @@
     },
     "BlackFlow@Roguelike@EnteredPageClassification": {
         "algorithm": "OcrDetect",
-        "roi": [100, 160, 505, 372],
+        "roi": [0, 420, 500, 115],
         "withoutDet": false,
-        "text": ["险路尽头", "前瞻性投资系统", "机械师的园圃", "刷新"],
+        "text": ["险路尽头", "坎诺特", "机械师", "佩德洛"],
+        "ocrReplace": [["^古怪商人\\s*坎诺特$", "坎诺特"]],
         "fullMatch": true
     },
     "BlackFlow@Roguelike@EnteredPageClassificationEncounterPrepare": {

--- a/resource/tasks/Roguelike/BlackFlow.json
+++ b/resource/tasks/Roguelike/BlackFlow.json
@@ -493,7 +493,6 @@
     "BlackFlow@Roguelike@EnteredPageClassification": {
         "algorithm": "OcrDetect",
         "roi": [0, 420, 500, 115],
-        "withoutDet": false,
         "text": ["险路尽头", "坎诺特", "机械师", "佩德洛"],
         "ocrReplace": [["^古怪商人\\s*坎诺特$", "坎诺特"]],
         "fullMatch": true

--- a/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowPageIdentity.cpp
+++ b/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowPageIdentity.cpp
@@ -16,9 +16,9 @@ EnteredPageObservation classify_entered_page_texts(std::vector<std::string> matc
     observation.matched_texts.assign(texts.begin(), texts.end());
 
     const bool final = texts.contains("险路尽头");
-    const bool shop = texts.contains("前瞻性投资系统") && texts.contains("刷新");
-    const bool scrap_shop = texts.contains("机械师的园圃");
-    const bool emergency_aid = texts.size() == 1 && texts.contains("刷新");
+    const bool shop = texts.contains("坎诺特");
+    const bool scrap_shop = texts.contains("机械师");
+    const bool emergency_aid = texts.contains("佩德洛");
     const int classifications = static_cast<int>(final) + static_cast<int>(shop) + static_cast<int>(scrap_shop) +
                                 static_cast<int>(emergency_aid);
     if (classifications > 1) {


### PR DESCRIPTION
由于部分用户未解锁科技树，秘境行商和诡意行商的刷新不可用，改为识别商人名字以区分。
在测试图上可以0.999匹配。
保留向右延伸的识别roi是为了框入险路尽头，因规划器不将其视作简单事件而是要更新里程碑。
感谢 @ocsin1 的建议。
fix: #17794 , #17867

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/46116135-708a-4ecb-a685-20e7a6ef8a05" />
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/39dfe42d-62d1-4c7b-81be-2ad4381bde56" />
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/10908224-3689-4c7e-ad5d-de1e2e66b536" />

## Summary by Sourcery

修复黑流树海中商人页面的分类识别。

Bug Fixes:
- 修复黑流树海页面分类在部分用户未解锁科技树时无法识别商人页面的问题。

Enhancements:
- 改用商人名称识别普通商店、废品商店和紧急援助页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修复黑流树海中商人页面的分类识别。

Bug Fixes:
- 修复黑流树海页面分类在部分用户未解锁科技树时无法识别商人页面的问题。

Enhancements:
- 改用商人名称识别普通商店、废品商店和紧急援助页面。

</details>

## Sourcery 总结

修复 Blackflow Forest 页面分类问题，确保无论科技树是否解锁，都能识别商人遭遇。

Bug 修复：
- 修复尚未解锁科技树的用户的 Blackflow Forest 商人页面分类问题。

功能增强：
- 根据商人名称而非科技树刷新文本，识别普通商店、废品商店和紧急援助页面。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Fix Blackflow Forest page classification so merchant encounters remain detectable regardless of technology-tree unlock status.

Bug Fixes:
- Fix Blackflow Forest merchant page classification for users who have not unlocked the technology tree.

Enhancements:
- Identify regular shops, scrap shops, and emergency aid pages by merchant names instead of technology-tree refresh text.

</details>