### PR TITLE
fix: 处理黑流树海默认零件商店

### DIFF
--- a/resource/roguelike/BlackFlow/node_execution.json
+++ b/resource/roguelike/BlackFlow/node_execution.json
@@ -65,6 +65,15 @@
             "completion_task": "BlackFlow@Roguelike@LegacyCompletion-NodePage"
         },
         {
+            "id": "default_scrap_shop",
+            "page_intent": "default",
+            "node_types": ["scrap_shop"],
+            "rank": 0,
+            "alias": "BlackFlow@Roguelike@NodeDispatchAction",
+            "task": "BlackFlow@Roguelike@Page-Shop",
+            "completion_task": "BlackFlow@Roguelike@LegacyCompletion-NodePage"
+        },
+        {
             "id": "default_expedition",
             "page_intent": "default",
             "node_types": ["expedition"],


### PR DESCRIPTION
## 改动

- 为 `scrap_shop` 增加 `default` 页面意图路由。
- 默认意图复用现有 `BlackFlow@Roguelike@Page-Shop` 离开流程。
- 保留 `scrap_shop.cultivate` 到 `Page-Cultivate` 的原有培育流程。

## 原因

隐藏节点揭示为“机械师的园圃”时，节点类型会解析为 `scrap_shop`。当前配置只有 `scrap_shop.cultivate` 路由；刷等级策略使用 `default` 意图，因此会落到 rank 100 的 `default_node_page`，进入 `Page-Default` 后无法处理零件商店页面，最终以 `state_machine_dead_end` / `RecoveryFailed` 结束。

## 影响

刷等级等默认意图路线遇到“机械师的园圃”时，会按普通商店页面安全退出并继续规划，不再因缺少页面路由中止整局。培育目标流程不受影响。

## 验证

- JSON 解析通过：`schema_version=3`，24 条路由且 ID 无重复。
- 路由断言通过：`default + scrap_shop -> default_scrap_shop / Page-Shop`。
- 回归断言通过：`scrap_shop.cultivate + scrap_shop -> cultivate_scrap_shop / Page-Cultivate`。
- `git diff --check` 通过。
- 在 v6.17.0-beta.4.d004.g099a819d73 实机跑黑流树海刷等级：第 5 局 OCR 识别“机械师的园圃”，日志确认 `type=scrap_shop`、`intent=default`、派发 `Page-Shop`，节点随后报告 `progress=completed`，本局正常抵达第三层。

## Summary by Sourcery

通过正常的商店退出流程处理默认的 BlackFlow 废料商店节点，同时保留专用的栽培路线。

Bug Fixes:
- 将 `scrap_shop` 节点的默认意图通过标准的商店页面流程进行路由，防止默认意图的运行在遇到 Mechanist's Garden 时被终止。

Enhancements:
- 保留针对 `scrap_shop.cultivate` 节点的现有栽培专用路线。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle default BlackFlow scrap shop nodes through the normal shop exit flow while retaining the dedicated cultivation route.

Bug Fixes:
- Route the default intent for `scrap_shop` nodes through the standard shop page flow, preventing default-intent runs from terminating when encountering the Mechanist's Garden.

Enhancements:
- Preserve the existing cultivation-specific route for `scrap_shop.cultivate` nodes.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过正常的商店退出流程处理默认的 BlackFlow 废料商店节点，同时保留专用的栽培路线。

Bug Fixes:
- 将 `scrap_shop` 节点的默认意图通过标准的商店页面流程进行路由，防止默认意图的运行在遇到 Mechanist's Garden 时被终止。

Enhancements:
- 保留针对 `scrap_shop.cultivate` 节点的现有栽培专用路线。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle default BlackFlow scrap shop nodes through the normal shop exit flow while retaining the dedicated cultivation route.

Bug Fixes:
- Route the default intent for `scrap_shop` nodes through the standard shop page flow, preventing default-intent runs from terminating when encountering the Mechanist's Garden.

Enhancements:
- Preserve the existing cultivation-specific route for `scrap_shop.cultivate` nodes.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过正常的商店退出流程处理默认的 BlackFlow 废料商店节点，同时保留专用的栽培路线。

Bug Fixes:
- 将 `scrap_shop` 节点的默认意图通过标准的商店页面流程进行路由，防止默认意图的运行在遇到 Mechanist's Garden 时被终止。

Enhancements:
- 保留针对 `scrap_shop.cultivate` 节点的现有栽培专用路线。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle default BlackFlow scrap shop nodes through the normal shop exit flow while retaining the dedicated cultivation route.

Bug Fixes:
- Route the default intent for `scrap_shop` nodes through the standard shop page flow, preventing default-intent runs from terminating when encountering the Mechanist's Garden.

Enhancements:
- Preserve the existing cultivation-specific route for `scrap_shop.cultivate` nodes.

</details>

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

通过正常的商店退出流程处理默认的 BlackFlow 废料商店节点，同时保留专用的栽培路线。

Bug Fixes:
- 将 `scrap_shop` 节点的默认意图通过标准的商店页面流程进行路由，防止默认意图的运行在遇到 Mechanist's Garden 时被终止。

Enhancements:
- 保留针对 `scrap_shop.cultivate` 节点的现有栽培专用路线。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle default BlackFlow scrap shop nodes through the normal shop exit flow while retaining the dedicated cultivation route.

Bug Fixes:
- Route the default intent for `scrap_shop` nodes through the standard shop page flow, preventing default-intent runs from terminating when encountering the Mechanist's Garden.

Enhancements:
- Preserve the existing cultivation-specific route for `scrap_shop.cultivate` nodes.

</details>

</details>

</details>