### PR TITLE
fix: 修复黑流树海事件奖励页无法继续

### DIFF
--- a/resource/tasks/Roguelike/BlackFlow.json
+++ b/resource/tasks/Roguelike/BlackFlow.json
@@ -111,7 +111,7 @@
         "template": "BlackFlow@Roguelike@CloseCollectionContinue.png",
         "action": "ClickSelf",
         "templThreshold": 0.9,
-        "roi": [500, 560, 280, 160],
+        "roi": [500, 520, 280, 200],
         "onErrorNext": ["#back"],
         "next": ["#next"]
     },


### PR DESCRIPTION
## 修改内容

- 将黑流树海 `CloseCollectionContinue` 的识别区域由 `[500, 560, 280, 160]` 扩大为 `[500, 520, 280, 200]`
- 保留原有横向范围和下边界，仅向上覆盖事件奖励页位置更高的 `NEXT` 按钮

## 原因

随机事件选择完成后，部分奖励会显示带 `NEXT` 按钮的自然物弹窗。本次“血蕈”现场中，模板最佳匹配坐标为 `(604, 547)`，而原 ROI 从 `y=560` 开始，裁掉了按钮上半部分。MAA 因此连续 20 次无法识别奖励页，最终以 `StageEncounterResult` / `TaskChainError` 结束任务。

## 影响

黑流树海随机事件出现这类奖励弹窗时，可以正常点击 `NEXT` 并继续流程；原有藏品弹窗识别范围仍被完整保留。

## 验证

- `python -m json.tool resource/tasks/Roguelike/BlackFlow.json`
- `git diff --check upstream/dev-v2...HEAD`
- 使用失败现场截图和现有 `CloseCollectionContinue` 模板进行 OpenCV 回放：
  - 原 ROI 内最高匹配分数：`0.270265`
  - 新 ROI 内最高匹配分数：`0.947307`
  - 配置阈值：`0.9`
  - 命中坐标：`(604, 547)`

## Summary by Sourcery

Bug Fixes:
- 扩大黑流树海事件奖励页的继续按钮识别区域，修复部分奖励弹窗无法点击 NEXT 导致流程失败的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- 扩大黑流树海事件奖励页的继续按钮识别区域，修复部分奖励弹窗无法点击 NEXT 导致流程失败的问题。

</details>