### PR TITLE
fix: 调整选中干员的颜色范围以处理阴影中的框

### DIFF
--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -540,7 +540,7 @@ std::vector<asst::BattleFormationTask::QuickFormationOper>
 
             // 判断是否已被选中
             cv::Mat selected_image = make_roi(image, res.flag_rect.move({ 0, -10, 5, 4 }));
-            cv::inRange(selected_image, cv::Scalar(200, 140, 0), cv::Scalar(255, 180, 100), selected_image);
+            cv::inRange(selected_image, cv::Scalar(170, 115, 0), cv::Scalar(255, 180, 100), selected_image);
             res.is_selected = cv::hasNonZero(selected_image);
 
             opers_result.emplace_back(std::move(res));


### PR DESCRIPTION
<img width="1222" height="513" alt="QQ_1787322370144" src="https://github.com/user-attachments/assets/d4403b29-7c51-410c-9a92-6eb749f57bbf" />

## Summary by Sourcery

Bug Fixes:
- 扩大选中干员的颜色检测范围，确保阴影区域中的选中框也能被正确识别。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- 扩大选中干员的颜色检测范围，确保阴影区域中的选中框也能被正确识别。

</details>