### PR TITLE
docs: 将 CI 教程中的 master 更新为 master-v2

### DIFF
--- a/docs/en-us/develop/ci-tutorial.md
+++ b/docs/en-us/develop/ci-tutorial.md
@@ -89,11 +89,11 @@ Note that nightly builds are only released for Windows users; macOS and Linux us
 
 The release process for these two channels is relatively more complex. We'll explain the role of each workflow by simulating a release process:
 
-1. Create a PR from `dev-v2` to `master` branch, and the PR name must be `Release v******`
+1. Create a PR from `dev-v2` to `master-v2` branch, and the PR name must be `Release v******`
 2. `release-preparation.yml` generates a changelog from the most recent stable/beta version to the current version (as a new PR)
 3. Manually adjust the changelog and add brief descriptions
 4. Merge the PR, triggering `pr-auto-tag.yml` to create tags and sync branches
-5. The Release event triggers `release-ota.yml`, which builds OTA packages and uploads attachments after tagging master
+5. The Release event triggers `release-ota.yml`, which builds OTA packages and uploads attachments after tagging master-v2
 
 ### Resource Updates
 

--- a/docs/ja-jp/develop/ci-tutorial.md
+++ b/docs/ja-jp/develop/ci-tutorial.md
@@ -89,11 +89,11 @@ MAA は GitHub Action を活用して、ウェブサイトの構築、自動リ�
 
 これら 2 つのチャネルのリリースプロセスは比較的複雑です。リリース手順をシミュレートして、各ワークフローの役割を説明します：
 
-1. `dev-v2` から `master` ブランチへの pr を作成し、この pr の名前は `Release v******` である必要があります
+1. `dev-v2` から `master-v2` ブランチへの pr を作成し、この pr の名前は `Release v******` である必要があります
 2. `release-preparation.yml` が最近の正式版/公測版から現在のバージョンまでの changelog を生成します（新しい pr の形式で）
 3. changelog を手動で調整し、簡単な説明を追加します
 4. pr をマージし、`pr-auto-tag.yml` をトリガーして、tag を作成し、ブランチを同期します
-5. Release イベントが `release-ota.yml` をトリガーし、master に tag を付けた後、ota パッケージの構築と添付ファイルのアップロードを実行します
+5. Release イベントが `release-ota.yml` をトリガーし、master-v2 に tag を付けた後、ota パッケージの構築と添付ファイルのアップロードを実行します
 
 ### リソース更新
 

--- a/docs/ko-kr/develop/ci-tutorial.md
+++ b/docs/ko-kr/develop/ci-tutorial.md
@@ -87,11 +87,11 @@ MAA는 GitHub Action을 활용하여 웹사이트 구축, 자동 리소스 업�
 
 이 두 채널의 릴리즈 과정은 상대적으로 복잡합니다. 릴리즈 단계를 시뮬레이션하여 각 워크플로우의 역할을 설명하겠습니다:
 
-1. `dev-v2`에서 `master` 브랜치로의 PR을 생성하며, 해당 PR의 이름은 `Release v******` 형식이어야 합니다
+1. `dev-v2`에서 `master-v2` 브랜치로의 PR을 생성하며, 해당 PR의 이름은 `Release v******` 형식이어야 합니다
 2. `release-preparation.yml`이 최근 정식 버전/공개 베타 버전부터 현재 버전까지의 changelog를 생성합니다(새로운 PR 형태로)
 3. changelog를 수동으로 조정하고 간단한 설명을 추가합니다
 4. PR을 병합하면 `pr-auto-tag.yml`이 트리거되어 tag를 생성하고 브랜치를 동기화합니다
-5. Release 이벤트가 `release-ota.yml`을 트리거하여 master에 tag를 생성한 후 ota 패키지 빌드 및 첨부파일 업로드를 진행합니다
+5. Release 이벤트가 `release-ota.yml`을 트리거하여 master-v2에 tag를 생성한 후 ota 패키지 빌드 및 첨부파일 업로드를 진행합니다
 
 ## 리소스 업데이트
 

--- a/docs/zh-cn/develop/ci-tutorial.md
+++ b/docs/zh-cn/develop/ci-tutorial.md
@@ -89,11 +89,11 @@ MAA 借助 GitHub Action 完成了大量的自动化工作，包括网站的构�
 
 这两个通道的发版流程相对复杂一点，我们通过模拟一次发版步骤来解释各工作流的作用：
 
-1. 建立由 `dev-v2` 到 `master` 分支的 pr，且该 pr 的名字需要为 `Release v******`
+1. 建立由 `dev-v2` 到 `master-v2` 分支的 pr，且该 pr 的名字需要为 `Release v******`
 2. `release-preparation.yml` 会生成最近的正式版/公测版到当前版本的 changelog（以一个新 pr 的形式）
 3. 对 changelog 进行手动调整，并且添加简要描述
 4. 合并 pr，触发 `pr-auto-tag.yml`，创建 tag 并且同步分支
-5. Release 事件触发 `release-ota.yml`，对 master 打完 tag 后进行 ota 包的构建以及附件上传
+5. Release 事件触发 `release-ota.yml`，对 master-v2 打完 tag 后进行 ota 包的构建以及附件上传
 
 ### 资源更新
 

--- a/docs/zh-tw/develop/ci-tutorial.md
+++ b/docs/zh-tw/develop/ci-tutorial.md
@@ -89,11 +89,11 @@ MAA 藉由 GitHub Actions 完成了大量的自動化工作，包括網站建置
 
 這兩個版本的發布流程相對複雜，我們透過模擬一次發布步驟來解釋各工作流的作用：
 
-1. 建立從 `dev-v2` 到 `master` 分支的 PR，且該 PR 的標題需為 `Release v******`。
+1. 建立從 `dev-v2` 到 `master-v2` 分支的 PR，且該 PR 的標題需為 `Release v******`。
 2. `release-preparation.yml` 會產生從最近版本到當前版本的 Changelog（以一個新 PR 的形式呈現）。
 3. 對 Changelog 進行手動調整，並加入簡要描述。
 4. 合併 PR，觸發 `pr-auto-tag.yml` 建立 Tag 並同步分支。
-5. Release 事件觸發 `release-ota.yml`，對 master 標上 Tag 後進行 OTA 包建置及附件上傳。
+5. Release 事件觸發 `release-ota.yml`，對 master-v2 標上 Tag 後進行 OTA 包建置及附件上傳。
 
 ### 資源更新
 


### PR DESCRIPTION
## 修改说明

CI 教程中的发版流程仍将发布分支写作 `master`，与当前工作流使用的 `master-v2` 不一致。

本次将相关描述统一更新为 `master-v2`，涉及以下五种语言：

- 简体中文
- 繁体中文
- 英文
- 日文
- 韩文

## 检查结果

- Prettier 检查通过
- MarkdownLint 检查通过

## Summary by Sourcery

Documentation:
- 更新简体中文、繁体中文、英文、日文和韩文的 CI 发布教程，使其一致地引用 `master-v2` 发布分支。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Update the CI release tutorial in Simplified Chinese, Traditional Chinese, English, Japanese, and Korean to consistently reference the `master-v2` release branch.

</details>