### PR TITLE
fix: 增加黑流树海加工品选择尝试次数并在失败后重开

### DIFF
--- a/resource/tasks/Roguelike/BlackFlow.json
+++ b/resource/tasks/Roguelike/BlackFlow.json
@@ -946,8 +946,18 @@
     },
     "BlackFlow@Roguelike@MovementPanelBackClick": {
         "algorithm": "JustReturn",
+        "sub": [
+            "BlackFlow@Roguelike@MovementPanelBackClickOnce*2",
+            "BlackFlow@Roguelike@MovementPanelBackClickWait"
+        ]
+    },
+    "BlackFlow@Roguelike@MovementPanelBackClickOnce": {
+        "algorithm": "JustReturn",
         "action": "ClickRect",
-        "specificRect": [2, 138, 36, 293],
+        "specificRect": [18, 138, 20, 293]
+    },
+    "BlackFlow@Roguelike@MovementPanelBackClickWait": {
+        "algorithm": "JustReturn",
         "postDelay": 500
     },
     "BlackFlow@Roguelike@MovementPanelItems": {

--- a/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowMovementTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowMovementTaskPlugin.cpp
@@ -117,7 +117,7 @@ bool BlackFlowMovementTaskPlugin::_run()
         m_session->fail(
             "movement_selection_failed",
             error.empty() ? "movement selection failed" : error,
-            FailureDisposition::StopTask);
+            FailureDisposition::RestartRun);
         Log.error("BlackFlow movement selection failed", error);
     }
     report_outputs();


### PR DESCRIPTION
fix: #17830 

## Sourcery 总结

错误修复：
- 通过在移动选择失败时重试产品选择并重新启动运行，改进 BlackFlow 运行恢复功能。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Improve BlackFlow run recovery by retrying product selection and restarting the run when movement selection fails.

</details>