### PR TITLE
fix: 修复成就“不务正业”中的落后文本描述

### DIFF
--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -2409,7 +2409,7 @@ These directories are not suitable places to keep MAA; files there can be easily
 
     <system:String x:Key="Achievement.SlackingOff.Title">Slacking Off</system:String>
     <system:String x:Key="Achievement.SlackingOff.Description">Done with serious business, time to play something else.</system:String>
-    <system:String x:Key="Achievement.SlackingOff.Conditions">Launch Useful Tasks once</system:String>
+    <system:String x:Key="Achievement.SlackingOff.Conditions">Launch {key=MiniGame} once</system:String>
 
     <system:String x:Key="AchievementDlcProgressNotice">Achievement DLC: #1 shipped with the system, later DLCs were added via updates. Some achievements can only be progressed after their DLC goes live.</system:String>
     <system:String x:Key="AchievementDlcReleaseDate">Release date</system:String>

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -2409,7 +2409,7 @@ These directories are not suitable places to keep MAA; files there can be easily
 
     <system:String x:Key="Achievement.SlackingOff.Title">Slacking Off</system:String>
     <system:String x:Key="Achievement.SlackingOff.Description">Done with serious business, time to play something else.</system:String>
-    <system:String x:Key="Achievement.SlackingOff.Conditions">Launch a mini-game once</system:String>
+    <system:String x:Key="Achievement.SlackingOff.Conditions">Launch Useful Tasks once</system:String>
 
     <system:String x:Key="AchievementDlcProgressNotice">Achievement DLC: #1 shipped with the system, later DLCs were added via updates. Some achievements can only be progressed after their DLC goes live.</system:String>
     <system:String x:Key="AchievementDlcReleaseDate">Release date</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -2411,7 +2411,7 @@ MAA を複数開くには、新しい MAA を他のフォルダにコピーし�
 
     <system:String x:Key="Achievement.SlackingOff.Title">本業を怠る</system:String>
     <system:String x:Key="Achievement.SlackingOff.Description">本業に疲れたら、ちょっと別の遊びを。</system:String>
-    <system:String x:Key="Achievement.SlackingOff.Conditions">ミニゲームを1回起動する</system:String>
+    <system:String x:Key="Achievement.SlackingOff.Conditions">便利機能を1回起動する</system:String>
 
     <system:String x:Key="AchievementDlcProgressNotice">実績 DLC 識別子：#1 は実績システムと同時公開、以降はアップデートで追加されます。一部実績の進捗は所属 DLC 公開後にのみ加算されます。</system:String>
     <system:String x:Key="AchievementDlcReleaseDate">公開日</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -2411,7 +2411,7 @@ MAA を複数開くには、新しい MAA を他のフォルダにコピーし�
 
     <system:String x:Key="Achievement.SlackingOff.Title">本業を怠る</system:String>
     <system:String x:Key="Achievement.SlackingOff.Description">本業に疲れたら、ちょっと別の遊びを。</system:String>
-    <system:String x:Key="Achievement.SlackingOff.Conditions">便利機能を1回起動する</system:String>
+    <system:String x:Key="Achievement.SlackingOff.Conditions">{key=MiniGame}を1回起動する</system:String>
 
     <system:String x:Key="AchievementDlcProgressNotice">実績 DLC 識別子：#1 は実績システムと同時公開、以降はアップデートで追加されます。一部実績の進捗は所属 DLC 公開後にのみ加算されます。</system:String>
     <system:String x:Key="AchievementDlcReleaseDate">公開日</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -2411,7 +2411,7 @@ MAA를 독립된 새 폴더에 압축 해제하거나, MAA에 속하지 않는 D
 
     <system:String x:Key="Achievement.SlackingOff.Title">월급 루팡</system:String>
     <system:String x:Key="Achievement.SlackingOff.Description">업무 효율을 위해서 가끔은 쉬어줘야죠.</system:String>
-    <system:String x:Key="Achievement.SlackingOff.Conditions">편의 기능 1회 실행</system:String>
+    <system:String x:Key="Achievement.SlackingOff.Conditions">{key=MiniGame} 1회 실행</system:String>
 
     <system:String x:Key="AchievementDlcProgressNotice">업적 DLC 식별자: #1은 시스템과 함께 출시, 이후 DLC는 업데이트로 추가됩니다. 일부 업적은 해당 DLC 공개 후에만 진행도가 누적됩니다.</system:String>
     <system:String x:Key="AchievementDlcReleaseDate">출시일</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -2411,7 +2411,7 @@ MAA를 독립된 새 폴더에 압축 해제하거나, MAA에 속하지 않는 D
 
     <system:String x:Key="Achievement.SlackingOff.Title">월급 루팡</system:String>
     <system:String x:Key="Achievement.SlackingOff.Description">업무 효율을 위해서 가끔은 쉬어줘야죠.</system:String>
-    <system:String x:Key="Achievement.SlackingOff.Conditions">미니게임 1회 실행</system:String>
+    <system:String x:Key="Achievement.SlackingOff.Conditions">편의 기능 1회 실행</system:String>
 
     <system:String x:Key="AchievementDlcProgressNotice">업적 DLC 식별자: #1은 시스템과 함께 출시, 이후 DLC는 업데이트로 추가됩니다. 일부 업적은 해당 DLC 공개 후에만 진행도가 누적됩니다.</system:String>
     <system:String x:Key="AchievementDlcReleaseDate">출시일</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -2408,7 +2408,7 @@ DEBUG 目录下保存的图片有数量限制，超出后会自动清理旧图�
 
     <system:String x:Key="Achievement.SlackingOff.Title">不务正业</system:String>
     <system:String x:Key="Achievement.SlackingOff.Description">正事做累了，玩点别的。</system:String>
-    <system:String x:Key="Achievement.SlackingOff.Conditions">启动一次牛杂</system:String>
+    <system:String x:Key="Achievement.SlackingOff.Conditions">启动一次{key=MiniGame}</system:String>
 
     <system:String x:Key="AchievementDlcProgressNotice" xml:space="preserve">成就 DLC 标识：#1 随成就系统首发，后续 DLC 由版本更新追加。
 部分成就的进度需在所属 DLC 上线后方可累计。</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -2408,7 +2408,7 @@ DEBUG 目录下保存的图片有数量限制，超出后会自动清理旧图�
 
     <system:String x:Key="Achievement.SlackingOff.Title">不务正业</system:String>
     <system:String x:Key="Achievement.SlackingOff.Description">正事做累了，玩点别的。</system:String>
-    <system:String x:Key="Achievement.SlackingOff.Conditions">启动一次小游戏</system:String>
+    <system:String x:Key="Achievement.SlackingOff.Conditions">启动一次牛杂</system:String>
 
     <system:String x:Key="AchievementDlcProgressNotice" xml:space="preserve">成就 DLC 标识：#1 随成就系统首发，后续 DLC 由版本更新追加。
 部分成就的进度需在所属 DLC 上线后方可累计。</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -2410,7 +2410,7 @@ DEBUG 目錄下儲存的圖片有數量限制，超出後會自動清理舊圖�
 
     <system:String x:Key="Achievement.SlackingOff.Title">不務正業</system:String>
     <system:String x:Key="Achievement.SlackingOff.Description">正事做累了，玩點別的。</system:String>
-    <system:String x:Key="Achievement.SlackingOff.Conditions">啟動一次快捷功能</system:String>
+    <system:String x:Key="Achievement.SlackingOff.Conditions">啟動一次{key=MiniGame}</system:String>
 
     <system:String x:Key="AchievementDlcProgressNotice">成就 DLC 標識：#1 隨成就系統首發，後續 DLC 由版本更新追加。部分成就的進度需在所屬 DLC 上線後方可累計。</system:String>
     <system:String x:Key="AchievementDlcReleaseDate">上線日期</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -2410,7 +2410,7 @@ DEBUG 目錄下儲存的圖片有數量限制，超出後會自動清理舊圖�
 
     <system:String x:Key="Achievement.SlackingOff.Title">不務正業</system:String>
     <system:String x:Key="Achievement.SlackingOff.Description">正事做累了，玩點別的。</system:String>
-    <system:String x:Key="Achievement.SlackingOff.Conditions">啟動一次小遊戲</system:String>
+    <system:String x:Key="Achievement.SlackingOff.Conditions">啟動一次快捷功能</system:String>
 
     <system:String x:Key="AchievementDlcProgressNotice">成就 DLC 標識：#1 隨成就系統首發，後續 DLC 由版本更新追加。部分成就的進度需在所屬 DLC 上線後方可累計。</system:String>
     <system:String x:Key="AchievementDlcReleaseDate">上線日期</system:String>


### PR DESCRIPTION
把游戏的落后文本改为了现在的牛杂/实用工具

## Sourcery 总结

错误修复：
- 更新过时的“不务正业”成就文本，准确描述当前所有受支持本地化版本中的牛杂/实用工具。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

修复问题：
- 更新所有受支持本地化版本中“不务正业”成就的过时文本，使其准确描述当前的牛杂/实用工具。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- 更新所有受支持本地化版本中“不务正业”成就的过时文本，使其准确描述当前的牛杂/实用工具。

</details>

</details>