### PR TITLE
docs: 拖入更新的管理员权限说明

### DIFF
--- a/docs/en-us/manual/introduction/others.md
+++ b/docs/en-us/manual/introduction/others.md
@@ -108,7 +108,10 @@ If automatic downloads fail or your network is poor, you can manually download t
 - Dragging **resource update packages**: Supported since v6.16.5.
 
 ::: tip
-Only packages downloaded from [GitHub Releases](https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases) are supported. [MirrorChyan](https://mirrorchyan.com/en/projects?rid=MAA) packages have a different format and are for automatic updates only — **they cannot be dragged in**.
+
+- Only packages downloaded from [GitHub Releases](https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases) are supported. [MirrorChyan](https://mirrorchyan.com/en/projects?rid=MAA) packages have a different format and are for automatic updates only — **they cannot be dragged in**.
+- Do not run MAA **as an administrator** when using drag-and-drop updates. Otherwise, Windows privilege isolation may prevent you from dragging update packages in from File Explorer.
+
 :::
 
 #### Software Update Packages (Full / OTA)

--- a/docs/en-us/manual/introduction/others.md
+++ b/docs/en-us/manual/introduction/others.md
@@ -110,7 +110,7 @@ If automatic downloads fail or your network is poor, you can manually download t
 ::: tip
 
 - Only packages downloaded from [GitHub Releases](https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases) are supported. [MirrorChyan](https://mirrorchyan.com/en/projects?rid=MAA) packages have a different format and are for automatic updates only — **they cannot be dragged in**.
-- Do not run MAA **as an administrator** when using drag-and-drop updates. Otherwise, Windows privilege isolation may prevent you from dragging update packages in from File Explorer.
+- Do not run MAA **as an administrator** when using drag-and-drop updates. Otherwise, Windows privilege isolation may prevent update packages from being dragged in.
 
 :::
 

--- a/docs/ja-jp/manual/introduction/others.md
+++ b/docs/ja-jp/manual/introduction/others.md
@@ -106,7 +106,10 @@ MAA の更新は 2 種類のコンテンツに分かれます：
 - **リソース更新パッケージ**のドラッグ：v6.16.5 以降でサポート。
 
 ::: tip
-[GitHub Releases](https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases) からダウンロードしたパッケージのみサポートされます。[MirrorChyan](https://mirrorchyan.com/zh/projects?rid=MAA) の更新パッケージは形式が異なり、自動更新専用のため、**ドラッグはサポートされていません**。
+
+- [GitHub Releases](https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases) からダウンロードしたパッケージのみサポートされます。[MirrorChyan](https://mirrorchyan.com/zh/projects?rid=MAA) の更新パッケージは形式が異なり、自動更新専用のため、**ドラッグはサポートされていません**。
+- ドラッグによる更新を使用する場合は、MAA を**管理者権限**で実行しないでください。Windows の権限分離機構により、エクスプローラーから更新パッケージをドラッグできない場合があります。
+
 :::
 
 #### ソフトウェア更新パッケージ（フルパッケージ / OTA 増分パッケージ）

--- a/docs/ja-jp/manual/introduction/others.md
+++ b/docs/ja-jp/manual/introduction/others.md
@@ -108,7 +108,7 @@ MAA の更新は 2 種類のコンテンツに分かれます：
 ::: tip
 
 - [GitHub Releases](https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases) からダウンロードしたパッケージのみサポートされます。[MirrorChyan](https://mirrorchyan.com/zh/projects?rid=MAA) の更新パッケージは形式が異なり、自動更新専用のため、**ドラッグはサポートされていません**。
-- ドラッグによる更新を使用する場合は、MAA を**管理者権限**で実行しないでください。Windows の権限分離機構により、エクスプローラーから更新パッケージをドラッグできない場合があります。
+- ドラッグによる更新を使用する場合は、MAA を**管理者権限**で実行しないでください。Windows の権限分離機構により、更新パッケージをドラッグできない場合があります。
 
 :::
 

--- a/docs/ko-kr/manual/introduction/others.md
+++ b/docs/ko-kr/manual/introduction/others.md
@@ -110,7 +110,10 @@ MAA의 업데이트는 두 가지 콘텐츠로 나뉩니다:
 - **리소스 업데이트 패키지** 드래그: v6.16.5부터 지원.
 
 ::: tip
-[GitHub Releases](https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases)에서 다운로드한 패키지만 지원됩니다. [MirrorChyan](https://mirrorchyan.com/zh/projects?rid=MAA)의 업데이트 패키지는 형식이 다르며, 자동 업데이트 전용이므로 **드래그를 지원하지 않습니다**.
+
+- [GitHub Releases](https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases)에서 다운로드한 패키지만 지원됩니다. [MirrorChyan](https://mirrorchyan.com/zh/projects?rid=MAA)의 업데이트 패키지는 형식이 다르며, 자동 업데이트 전용이므로 **드래그를 지원하지 않습니다**.
+- 드래그 업데이트를 사용할 때는 MAA를 **관리자 권한**으로 실행하지 마세요. Windows 권한 격리 메커니즘으로 인해 파일 탐색기에서 업데이트 패키지를 드래그하지 못할 수 있습니다.
+
 :::
 
 #### 소프트웨어 업데이트 패키지(전체 패키지 / OTA 증분 패키지)

--- a/docs/ko-kr/manual/introduction/others.md
+++ b/docs/ko-kr/manual/introduction/others.md
@@ -112,7 +112,7 @@ MAA의 업데이트는 두 가지 콘텐츠로 나뉩니다:
 ::: tip
 
 - [GitHub Releases](https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases)에서 다운로드한 패키지만 지원됩니다. [MirrorChyan](https://mirrorchyan.com/zh/projects?rid=MAA)의 업데이트 패키지는 형식이 다르며, 자동 업데이트 전용이므로 **드래그를 지원하지 않습니다**.
-- 드래그 업데이트를 사용할 때는 MAA를 **관리자 권한**으로 실행하지 마세요. Windows 권한 격리 메커니즘으로 인해 파일 탐색기에서 업데이트 패키지를 드래그하지 못할 수 있습니다.
+- 드래그 업데이트를 사용할 때는 MAA를 **관리자 권한**으로 실행하지 마세요. Windows 권한 격리 메커니즘으로 인해 업데이트 패키지를 드래그하지 못할 수 있습니다.
 
 :::
 

--- a/docs/zh-cn/manual/introduction/others.md
+++ b/docs/zh-cn/manual/introduction/others.md
@@ -108,7 +108,10 @@ MAA 的更新分为两种内容：
 - 拖入**资源更新包**：v6.16.5 起支持。
 
 ::: tip
-仅支持从 [GitHub Releases](https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases) 下载的包。[Mirror酱](https://mirrorchyan.com/zh/projects?rid=MAA) 的更新包格式不同，且为自动更新专用，**不支持拖入**。
+
+- 仅支持从 [GitHub Releases](https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases) 下载的包。[Mirror酱](https://mirrorchyan.com/zh/projects?rid=MAA) 的更新包格式不同，且为自动更新专用，**不支持拖入**。
+- 使用拖入更新时请勿以**管理员权限**运行 MAA，否则受 Windows 权限隔离机制影响，可能无法从文件资源管理器拖入更新包。
+
 :::
 
 #### 软件更新包（完整包 / OTA 增量包）

--- a/docs/zh-cn/manual/introduction/others.md
+++ b/docs/zh-cn/manual/introduction/others.md
@@ -110,7 +110,7 @@ MAA 的更新分为两种内容：
 ::: tip
 
 - 仅支持从 [GitHub Releases](https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases) 下载的包。[Mirror酱](https://mirrorchyan.com/zh/projects?rid=MAA) 的更新包格式不同，且为自动更新专用，**不支持拖入**。
-- 使用拖入更新时请勿以**管理员权限**运行 MAA，否则受 Windows 权限隔离机制影响，可能无法从文件资源管理器拖入更新包。
+- 使用拖入更新时请勿以**管理员权限**运行 MAA，否则可能受 Windows 权限隔离机制影响而无法拖入更新包。
 
 :::
 

--- a/docs/zh-tw/manual/introduction/others.md
+++ b/docs/zh-tw/manual/introduction/others.md
@@ -110,7 +110,7 @@ MAA 的更新分為兩種內容：
 ::: tip
 
 - 僅支援從 [GitHub Releases](https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases) 下載的包。[Mirror醬](https://mirrorchyan.com/zh/projects?rid=MAA) 的更新包格式不同，且為自動更新專用，**不支援拖入**。
-- 使用拖入更新時請勿以**系統管理員權限**執行 MAA，否則受 Windows 權限隔離機制影響，可能無法從檔案總管拖入更新包。
+- 使用拖入更新時請勿以**系統管理員權限**執行 MAA，否則可能受 Windows 權限隔離機制影響而無法拖入更新包。
 
 :::
 

--- a/docs/zh-tw/manual/introduction/others.md
+++ b/docs/zh-tw/manual/introduction/others.md
@@ -108,7 +108,10 @@ MAA 的更新分為兩種內容：
 - 拖入**資源更新包**：v6.16.5 起支援。
 
 ::: tip
-僅支援從 [GitHub Releases](https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases) 下載的包。[Mirror醬](https://mirrorchyan.com/zh/projects?rid=MAA) 的更新包格式不同，且為自動更新專用，**不支援拖入**。
+
+- 僅支援從 [GitHub Releases](https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases) 下載的包。[Mirror醬](https://mirrorchyan.com/zh/projects?rid=MAA) 的更新包格式不同，且為自動更新專用，**不支援拖入**。
+- 使用拖入更新時請勿以**系統管理員權限**執行 MAA，否則受 Windows 權限隔離機制影響，可能無法從檔案總管拖入更新包。
+
 :::
 
 #### 軟體更新包（完整包 / OTA 增量包）


### PR DESCRIPTION
补充拖入压缩包更新时的管理员权限限制说明，并同步五种语言文档。

## Sourcery 总结

文档：
- 使用所有五种受支持的语言记录 Windows 管理员权限限制对拖放更新包的影响。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

文档：
- 以所有五种受支持的语言记录 Windows 管理员权限限制，该限制可能导致无法接受通过拖放方式提供的更新包。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

文档：
- 以所有五种受支持的语言记录 Windows 管理员权限限制，该限制可能导致拖放的更新包无法被接受。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Document the Windows administrator privilege limitation that can prevent drag-and-drop update packages from being accepted in all five supported languages.

</details>

</details>

</details>