### PR TITLE
fix: 校验黑流树海移动确认结果

### DIFF
--- a/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowTaskPort.cpp
+++ b/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowTaskPort.cpp
@@ -32,6 +32,7 @@ constexpr std::string_view MovePreviewCannotEnterTask = "BlackFlow@Roguelike@Mov
 constexpr std::string_view MovePreviewCostTask = "BlackFlow@Roguelike@MovePreviewCost";
 constexpr std::string_view MovePreviewDisplayedNameTask = "BlackFlow@Roguelike@MovePreviewDisplayedName";
 constexpr std::string_view MovePreviewConfirmTask = "BlackFlow@Roguelike@MovePreviewConfirm";
+constexpr std::string_view MovePreviewConfirmCompletedTask = "BlackFlow@Roguelike@MovePreviewConfirmCompletedDone";
 constexpr std::string_view EnteredPageClassificationTask = "BlackFlow@Roguelike@EnteredPageClassification";
 constexpr std::string_view EnteredPageClassificationEncounterPrepareTask =
     "BlackFlow@Roguelike@EnteredPageClassificationEncounterPrepare";
@@ -293,6 +294,11 @@ bool BlackFlowTaskPort::confirm(
         return false;
     }
     if (!m_task_context->execute({ std::string(MovePreviewConfirmTask) }, error)) {
+        return false;
+    }
+    // ProcessTask treats an exhausted task without exceededNext as a successful terminal chain.
+    if (m_task_context->last_task() != MovePreviewConfirmCompletedTask) {
+        set_error(error, "move confirmation did not reach the completed state: " + m_task_context->last_task());
         return false;
     }
     entered_page = {};


### PR DESCRIPTION
## 改动

- 在黑流树海移动确认后校验 ProcessTask 的最终任务。
- 只有抵达 MovePreviewConfirmCompletedDone 才提交移动事务。
- 点击进入耗尽时返回 move_confirmation_failed，由现有路线流程按 RestartRun 处理。

## 原因

实机刷等级第 8 局在第二层进入“险路尽头”时，MovePreviewConfirm 连续点击 3 次后按钮仍存在。ProcessTask 对没有 exceededNext 的次数耗尽任务会返回成功，导致 BlackFlowTaskPort::confirm 误认为已进入节点并提交事务。随后事件插件在移动预览画面上 OCR，只得到“E险”，最终以 EncounterOcrError / internal_failure 停止整批任务。

正常移动确认会以 MovePreviewConfirmCompletedDone 结束；点击耗尽则停留在 MovePreviewConfirm，因此可以用最终任务名可靠地区分。

## 验证

- 仓库锁定版本 clang-format：通过。
- git diff --check：通过。
- 现有实机日志状态回放：识别到 591 次正常完成标记和 4 次点击耗尽标记，新校验可准确区分。
- 等待 PR Windows x64/ARM64 CI 完整编译。

## Sourcery 总结

在接受 BlackFlow 移动结果之前，验证最终的移动确认任务。

错误修复：
- 确保仅当移动确认达到完成状态时，才提交 BlackFlow 移动事务。
- 当确认流程耗尽且未进入目的地时，返回移动确认失败，以便现有路线流程安全地重新启动。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Validate the final movement-confirmation task before accepting BlackFlow movement results.

Bug Fixes:
- Ensure BlackFlow movement transactions are committed only when movement confirmation reaches the completed state.
- Return a movement-confirmation failure when confirmation exhausts without entering the destination, allowing the existing route flow to restart safely.

</details>