### PR TITLE
feat: 将 MuMu 扩展输入检查推迟至游戏开始渲染时进行

### DIFF
--- a/src/MaaCore/Controller/MumuController.cpp
+++ b/src/MaaCore/Controller/MumuController.cpp
@@ -17,6 +17,7 @@ bool MumuController::connect(const std::string& adb_path, const std::string& add
     LogTraceFunction;
 
     m_mumu_input_ready = false;
+    m_mumu_input_notify = MumuInputNotify::None;
     release_minitouch();
 
 #ifdef ASST_DEBUG
@@ -33,40 +34,43 @@ bool MumuController::connect(const std::string& adb_path, const std::string& add
         return false;
     }
 
+    // 连接时游戏可能还没开始渲染，此时 display 是 fallback 的桌面，其尺寸与游戏触控
+    // 坐标系无关；这种情况下不做 mismatch 判定，推迟到输入入口（try_enable_mumu_input）
+    bool deferred = false;
+
     if (m_mumu_extras.input_available()) {
         // ControlScaleProxy 会把坐标缩放到 get_screen_res() 的尺寸，而 nemu 期望的是
         // display 自身的坐标系。两者不一致时点击会全部偏掉，宁可降级也不要乱点。
-        auto [mumu_width, mumu_height] = m_mumu_extras.get_display_size();
-        if (mumu_width == m_width && mumu_height == m_height) {
-            m_mumu_input_ready = true;
-            LogInfo << "MuMu extras input is ready" << VAR(m_width) << VAR(m_height);
-
-            // 通知 GUI：MuMu 触控增强已实际生效
-            json::value input_info = json::object {
-                { "uuid", m_uuid },
-                { "what", "MuMuExtrasInputStatus" },
-                { "details", json::object { { "available", true } } },
-            };
-            callback(AsstMsg::ConnectionInfo, input_info);
-
-            return true;
+        if (!m_mumu_extras.has_target_display()) {
+            deferred = true;
+            LogInfo << "Target package is not rendering, defer MuMu extras input check";
         }
-        LogWarn << "MuMu display size mismatches adb screen size" << VAR(mumu_width) << VAR(mumu_height) << VAR(m_width)
-                << VAR(m_height);
+        else {
+            auto [mumu_width, mumu_height] = m_mumu_extras.get_display_size();
+            if (mumu_width == m_width && mumu_height == m_height) {
+                m_mumu_input_ready = true;
+                LogInfo << "MuMu extras input is ready" << VAR(m_width) << VAR(m_height);
+                notify_mumu_input_status(MumuInputNotify::Ready);
+                return true;
+            }
+            LogWarn << "MuMu display size mismatches adb screen size" << VAR(mumu_width) << VAR(mumu_height)
+                    << VAR(m_width) << VAR(m_height);
+        }
     }
 
     LogInfo << "MuMu extras input is not available, fallback to minitouch";
 
-    // 通知 GUI：MuMu 触控增强未生效（版本不支持或路径错误等），已降级
-    json::value input_info = json::object {
-        { "uuid", m_uuid },
-        { "what", "MuMuExtrasInputStatus" },
-        { "details", json::object { { "available", false } } },
-    };
-    callback(AsstMsg::ConnectionInfo, input_info);
+    // 通知 GUI：触控增强未生效。deferred 场景（游戏尚未渲染）输入入口仍会自动重试，
+    // GUI 不得据此判定触控不可用而停止任务
+    notify_mumu_input_status(deferred ? MumuInputNotify::Deferred : MumuInputNotify::Unavailable);
 
     m_minitouch_available = probe_minitouch();
     if (!m_minitouch_available) {
+        if (deferred) {
+            // 游戏渲染后 MuMu 输入仍可能就绪，不因过渡期的 minitouch 探测失败而断开
+            LogWarn << "minitouch probe failed while MuMu input check is deferred";
+            return true;
+        }
         json::value info = json::object {
             { "uuid", m_uuid },
             { "details",
@@ -85,9 +89,54 @@ bool MumuController::connect(const std::string& adb_path, const std::string& add
     return true;
 }
 
+bool MumuController::try_enable_mumu_input()
+{
+    if (m_mumu_input_ready) {
+        return true;
+    }
+    if (!m_mumu_extras.input_available() || !m_mumu_extras.has_target_display()) {
+        return false;
+    }
+    auto [mumu_width, mumu_height] = m_mumu_extras.get_display_size();
+    if (mumu_width != m_width || mumu_height != m_height) {
+        // 游戏已渲染但坐标系不一致，挂起到此为止：这是确认不可用，不再是"尚未判定"，
+        // 通知 GUI 终态（保活场景下 GUI 会据此停止任务）
+        notify_mumu_input_status(MumuInputNotify::Unavailable);
+        return false;
+    }
+
+    // 游戏已开始渲染且坐标系一致（典型场景：连接时游戏未启动，由任务拉起后），
+    // 此前降级的 minitouch 不再需要
+    m_mumu_input_ready = true;
+    release_minitouch();
+    LogInfo << "MuMu extras input is ready (deferred)" << VAR(m_width) << VAR(m_height);
+    notify_mumu_input_status(MumuInputNotify::Ready);
+    return true;
+}
+
+void MumuController::notify_mumu_input_status(MumuInputNotify status)
+{
+    if (status == m_mumu_input_notify) {
+        return;
+    }
+    m_mumu_input_notify = status;
+
+    // 通知 GUI：MuMu 触控增强的实际生效状态；deferred 表示尚未判定、等待游戏渲染后自动重试
+    json::value input_info = json::object {
+        { "uuid", m_uuid },
+        { "what", "MuMuExtrasInputStatus" },
+        { "details",
+          json::object {
+              { "available", status == MumuInputNotify::Ready },
+              { "deferred", status == MumuInputNotify::Deferred },
+          } },
+    };
+    callback(AsstMsg::ConnectionInfo, input_info);
+}
+
 bool MumuController::click(const Point& p)
 {
-    if (!use_mumu_input()) {
+    if (!try_enable_mumu_input()) {
         return MinitouchController::click(p);
     }
 
@@ -117,7 +166,7 @@ bool MumuController::swipe(
     double slope_out,
     bool with_pause)
 {
-    if (!use_mumu_input()) {
+    if (!try_enable_mumu_input()) {
         return MinitouchController::swipe(p1, p2, duration, extra_swipe, slope_in, slope_out, with_pause);
     }
 
@@ -213,7 +262,7 @@ bool MumuController::swipe(
 
 bool MumuController::inject_input_event(const InputEvent& event)
 {
-    if (!use_mumu_input()) {
+    if (!try_enable_mumu_input()) {
         return MinitouchController::inject_input_event(event);
     }
 
@@ -244,7 +293,7 @@ bool MumuController::inject_input_event(const InputEvent& event)
 
 bool MumuController::input(const std::string& text)
 {
-    if (!use_mumu_input()) {
+    if (!try_enable_mumu_input()) {
         return MinitouchController::input(text);
     }
 
@@ -253,7 +302,7 @@ bool MumuController::input(const std::string& text)
 
 bool MumuController::press_esc()
 {
-    if (!use_mumu_input()) {
+    if (!try_enable_mumu_input()) {
         return MinitouchController::press_esc();
     }
 
@@ -278,8 +327,9 @@ std::optional<std::string> MumuController::reconnect(const std::string& cmd, int
         return MinitouchController::reconnect(cmd, timeout, recv_by_socket);
     }
 
-    // 走 MuMu 触控时没有探测过 minitouch，跳过基类的 minitouch 重新拉起，
-    // 否则会拿着空命令去起交互式 shell。nemu 的连接由 MumuExtras 自己维护。
+    // 走 MuMu 触控时输入不经过 minitouch（即使降级过渡期探测过，恢复时也已释放），
+    // 跳过基类的 minitouch 重新拉起，否则会拿着空命令去起交互式 shell。
+    // nemu 的连接由 MumuExtras 自己维护
     return AdbController::reconnect(cmd, timeout, recv_by_socket);
 }
 
@@ -287,6 +337,7 @@ void MumuController::clear_info() noexcept
 {
     MinitouchController::clear_info();
     m_mumu_input_ready = false;
+    m_mumu_input_notify = MumuInputNotify::None;
 }
 } // namespace asst
 

--- a/src/MaaCore/Controller/MumuController.h
+++ b/src/MaaCore/Controller/MumuController.h
@@ -54,7 +54,23 @@ private:
     // MuMu 触控是否就绪。未就绪时全部操作降级到 MinitouchController
     bool use_mumu_input() const noexcept { return m_mumu_input_ready; }
 
+    // 输入入口在未就绪时重试启用：连接时游戏可能尚未开始渲染，display 是 fallback 的
+    // 桌面，无法判定尺寸是否匹配；等包名命中且尺寸一致后再启用，启用后不再回退
+    bool try_enable_mumu_input();
+
+    enum class MumuInputNotify
+    {
+        None,
+        Ready, // 触控增强已生效
+        Deferred, // 游戏未渲染，判定挂起，等待输入入口自动重试
+        Unavailable, // 确认不可用（版本不支持、路径错误、尺寸不匹配等）
+    };
+
+    // 通知 GUI 触控状态；与上次相同的状态不重发，避免输入入口的重试刷回调
+    void notify_mumu_input_status(MumuInputNotify status);
+
     bool m_mumu_input_ready = false;
+    MumuInputNotify m_mumu_input_notify = MumuInputNotify::None;
 };
 } // namespace asst
 

--- a/src/MaaCore/Controller/MumuExtras.h
+++ b/src/MaaCore/Controller/MumuExtras.h
@@ -36,6 +36,13 @@ public:
 
     std::pair<int, int> get_display_size() const { return { display_width_, display_height_ }; }
 
+    // 当前 display 是否为包名命中的缓存结果（而非 fallback）。fallback 时游戏未在渲染，
+    // 拿到的 display 及其尺寸都与目标游戏无关，不能用于判断触控坐标系是否一致
+    bool has_target_display() const
+    {
+        return display_id_cache_.load(std::memory_order_relaxed) != kInvalidDisplayId;
+    }
+
     // contact 为 0 起始，内部转换为 mumu 的 1 起始 finger_id
     bool touch_down(int contact, int x, int y);
     bool touch_move(int contact, int x, int y);

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -835,6 +835,12 @@ public class AsstProxy
     /// </summary>
     private bool _mumuExtrasInputAvailable;
 
+    /// <summary>
+    /// 连接时游戏尚未渲染、core 挂起了触控判定（等待游戏启动后自动恢复），
+    /// 此时触控增强只是尚未生效，不能当作不可用处理。
+    /// </summary>
+    private bool _mumuExtrasInputDeferred;
+
     private void ProcConnectInfo(JObject details)
     {
         var what = details["what"]?.ToString() ?? string.Empty;
@@ -874,8 +880,44 @@ public class AsstProxy
                 break;
 
             case "MuMuExtrasInputStatus":
-                // core 连接后报告 MuMu 触控增强是否实际生效
+                // core 报告 MuMu 触控增强状态；deferred 表示尚未判定（连接时游戏未渲染），
+                // 会在游戏开始渲染后自动转为就绪或确认不可用
+                bool wasDeferred = _mumuExtrasInputDeferred;
                 _mumuExtrasInputAvailable = details["details"]?["available"]?.ToObject<bool>() ?? false;
+                _mumuExtrasInputDeferred = !_mumuExtrasInputAvailable
+                    && details["details"]?["deferred"]?.ToObject<bool>() == true;
+
+                // 从挂起恢复就绪（Deferred → Ready）时不会再有 FastestWayToScreencap 回调，就绪提示在这里补上
+                if (_mumuExtrasInputAvailable && wasDeferred)
+                {
+                    Instances.TaskQueueViewModel.AddLog(
+                        LocalizationHelper.GetString("MuMuEmulator12FullExtrasReady"),
+                        UiLogColor.Rainbow);
+                    Instances.CopilotViewModel.AddLog(
+                        LocalizationHelper.GetString("MuMuEmulator12FullExtrasReady"),
+                        UiLogColor.Rainbow,
+                        showTime: false);
+                }
+
+                // 保活开启但触控确认不可用 → 后台保活下无法操作，直接停止。
+                // 触发点跟着状态回调走而不是只在连接时检测一次：挂起（deferred）的终态
+                // 可能出现在任务执行中，此时也要停止
+                if (!_mumuExtrasInputAvailable && !_mumuExtrasInputDeferred
+                    && EmulatorHelper.CheckMuMuKeepAlive())
+                {
+                    Instances.TaskQueueViewModel.AddLog(
+                        LocalizationHelper.GetString("MuMuEmulator12KeepAliveOn"),
+                        UiLogColor.Error);
+                    Instances.CopilotViewModel.AddLog(
+                        LocalizationHelper.GetString("MuMuEmulator12KeepAliveOn"),
+                        UiLogColor.Error, showTime: false);
+                    Execute.OnUIThreadAsync(async () => {
+                        Connected = false;
+                        await Instances.TaskQueueViewModel.Stop();
+                        Instances.TaskQueueViewModel.SetStopped();
+                    });
+                }
+
                 break;
 
             case "ResolutionError":
@@ -959,19 +1001,7 @@ public class AsstProxy
                     {
                         case ConnectConfig.MuMuEmulator12:
 
-                            // 保活开启但触控未生效 → 后台保活下无法操作，直接停止
-                            if (!_mumuExtrasInputAvailable && EmulatorHelper.CheckMuMuKeepAlive())
-                            {
-                                Instances.TaskQueueViewModel.AddLog(
-                                    LocalizationHelper.GetString("MuMuEmulator12KeepAliveOn"),
-                                    UiLogColor.Error);
-                                Instances.CopilotViewModel.AddLog(
-                                    LocalizationHelper.GetString("MuMuEmulator12KeepAliveOn"),
-                                    UiLogColor.Error, showTime: false);
-                                needToStop = true;
-                            }
-
-                            // 以下是截图增强相关逻辑
+                            // 保活的触控检测在 MuMuExtrasInputStatus 回调中处理，这里只查截图增强
                             if (SettingsViewModel.ConnectSettings.ExtraConfig is not MuMu12Extra muMu12 || !muMu12.Enable)
                             {
                                 break;


### PR DESCRIPTION
在连接阶段，目标应用可能尚未开始渲染；此时显示的画面为回退状态（即桌面视图），其尺寸与触控坐标系无关。因此，应跳过此时的不匹配判定，改为在游戏实际开始渲染时由 `try_enable_mumu_input` 重新评估——即在坐标系匹配后，将输入方式从 minitouch 升级为 MuMu 输入。GUI 状态回调现包含一个“延迟”标志，以便区分“尚未判定”与“确认不可用”这两种状态

## Sourcery 摘要

将 MuMu 扩展输入检查推迟到目标游戏开始渲染后，并在坐标系匹配时自动切换输入方式。

新功能：
- 在游戏开始渲染后重新评估并自动启用 MuMu 扩展输入。

错误修复：
- 避免在游戏尚未渲染时误判显示尺寸不匹配，并修正过渡期间 MuMu 输入状态及保活任务的处理。

改进：
- 区分触控增强尚未判定与确认不可用的状态，并在状态变化时通知 GUI。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

将 MuMu 扩展输入检查推迟到目标游戏开始渲染后，并在坐标系匹配时自动切换输入方式。

New Features:
- 在游戏开始渲染后重新评估并自动启用 MuMu 扩展输入。

Bug Fixes:
- 避免在游戏尚未渲染时误判显示尺寸不匹配，并修正过渡期间 MuMu 输入状态及保活任务的处理。

Enhancements:
- 区分触控增强尚未判定与确认不可用的状态，并在状态变化时通知 GUI。

</details>