### PR TITLE
fix: 修复自动战斗跳过剧情后误判离开战斗

### DIFF
--- a/src/MaaCore/Task/BattleHelper.cpp
+++ b/src/MaaCore/Task/BattleHelper.cpp
@@ -683,14 +683,18 @@ bool asst::BattleHelper::check_in_battle(const cv::Mat& reusable, bool weak)
     if (weak) {
         BattlefieldMatcher analyzer(image);
         auto result = analyzer.analyze();
-        m_in_battle = result.has_value();
-        if (m_in_battle && !result->pause_button) {
+        if (result && result->pause_button) {
+            m_in_battle = true;
+        }
+        else {
             if (check_skip_plot_button(image)) {
+                m_in_battle = true;
                 if (m_in_speedup && !check_in_speedup()) {
                     speed_up(); // 跳过剧情会退出2倍速
                 }
             }
             else if (check_avatar_dialog(image)) {
+                m_in_battle = true;
                 if (m_in_speedup && !check_in_speedup()) {
                     speed_up(); // 跳过剧情会退出2倍速
                     m_inst_helper.sleep(Config.get_options().task_delay);
@@ -702,11 +706,21 @@ bool asst::BattleHelper::check_in_battle(const cv::Mat& reusable, bool weak)
                     }
                 }
             }
+            else {
+                m_in_battle = result.has_value();
+            }
         }
     }
     else {
-        check_skip_plot_button(image);
-        m_in_battle = check_pause_button(image);
+        if (check_skip_plot_button(image) || check_avatar_dialog(image)) {
+            m_in_battle = true;
+            if (m_in_speedup && !check_in_speedup()) {
+                speed_up();
+            }
+        }
+        else {
+            m_in_battle = check_pause_button(image);
+        }
     }
     return m_in_battle;
 }


### PR DESCRIPTION
## 说明

关卡内剧情和头像对话会隐藏暂停按钮。此前强校验路径即使成功识别并处理了剧情，随后仍会用暂停按钮识别结果覆盖战斗状态，从而误判尚未进入战斗；弱校验路径也只有在 BattlefieldMatcher 成功时才会继续检查剧情状态。

本 PR：

- 在暂停按钮不可见时继续检查关卡内剧情和头像对话
- 命中剧情状态后保持 m_in_battle，避免跳过剧情后提前结束等待
- 统一 weak / non-weak 两条战斗状态检测路径，并保留剧情结束后的倍速恢复行为

## 测试

- macOS arm64 Release：cmake --build build --config Release --target MaaCore --parallel 8
- MaaCore 完整编译通过
- 未进行游戏内手动回归；建议使用 RS-5、MT 系列带开场剧情关卡验证

Closes #11394
Closes #12508

## Summary by Sourcery

保持剧情与头像对话期间的战斗状态识别，避免自动战斗跳过剧情后提前结束等待。

Bug Fixes:
- 修复战斗开场剧情或头像对话隐藏暂停按钮时被误判为未进入战斗的问题。

Enhancements:
- 统一弱校验与常规校验下的战斗状态检测，并在剧情期间保持战斗状态及必要的倍速恢复行为。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

保持剧情与头像对话期间的战斗状态识别，避免自动战斗跳过剧情后提前结束等待。

Bug Fixes:
- 修复战斗开场剧情或头像对话隐藏暂停按钮时被误判为未进入战斗的问题。

Enhancements:
- 统一弱校验与常规校验下的战斗状态检测，并在剧情期间保持战斗状态及必要的倍速恢复行为。

</details>