### PR TITLE
fix: 肉鸽战斗记录同步失败弹窗处理，避免误触发 ReturnConfirm 卡死

### DIFF
--- a/resource/tasks/Roguelike/base.json
+++ b/resource/tasks/Roguelike/base.json
@@ -1665,6 +1665,7 @@
             "Roguelike@GamePassTheEndConfirm",
             "Roguelike@GamePass",
             "Roguelike@StartAction@LoadingText",
+            "Roguelike@StageSyncRetryConfirm",
             "Roguelike@StartAction@LoadingIcon",
             "Roguelike@NextLevel",
             "Roguelike@NextLevel#next",
@@ -1676,6 +1677,18 @@
         "postDelay": 5000,
         "maxTimes": 20,
         "next": ["Roguelike@StartAction#next"]
+    },
+    "Roguelike@StageSyncRetryConfirm": {
+        "Doc": "战斗记录同步神经网络失败弹窗：识别“是否重试”并点重试按钮重新同步。防止弹窗残留被 ReturnConfirm(PopupConfirm) 误吃导致 ReturnConfirm@LoadingIcon 卡死整链报错",
+        "algorithm": "OcrDetect",
+        "text": ["是否重试"],
+        "roi": [574, 306, 126, 35],
+        "action": "ClickRect",
+        "specificRect": [917, 464, 80, 60],
+        "postDelay": 10000,
+        "maxTimes": 10,
+        "next": ["Roguelike@StartAction#next"],
+        "exceededNext": ["Roguelike@ExitThenAbandon"]
     },
     "Roguelike@StartExplore": {
         "Doc": "base_task",


### PR DESCRIPTION
## 问题

肉鸽战斗结算后，游戏会"把战斗记录同步到神经网络"（即 OCR 识别的 `LoadingText`「正在提交/反馈至神经」）。同步失败时游戏弹出 **「战斗记录未能成功同步到神经网络 / 是否重试？ / (错误号:0)」** 弹窗（底部两按钮：左黑底×取消、右红底√重试）。

此前 MAA 无该弹窗的专属处理任务。弹窗残留时，其「重试」红按钮被通用 `PopupConfirm.png`（`ReturnConfirm` 任务）误识别，引发整链卡死报错。

## 故障链（实测日志 asst.log taskid:87）

1. taskid:86（上一局）以 `StartActionReCheck` 达 `maxTimes` 正常结束，但结束时画面残留「是否重试?」弹窗（OCR `是否重试?` score 0.999970）。
2. taskid:87 从 `Mizuki@Roguelike@Begin` 启动，弹窗「重试」按钮被 `PopupConfirm.png` 以 **0.976** 误识别为 `ReturnConfirm`（22:25:01、22:25:13 两次命中，rect `[640,457,625,72]` 正是重试按钮区）。
3. 误点后进入加载，`ReturnConfirm@LoadingIcon` 命中 2 次后画面停在战斗结算界面（debug 截图印证）。
4. `ReturnConfirm.next` 的 14 项候选无一口中，重试 21 次耗尽（`retry_times=20`）。
5. `ReturnConfirm@LoadingIcon` 无 `on_error_next` 兜底 → `SubTaskError` → `TaskChainError`，整链失败。

> 实测：结算界面左上角红色返回按钮能被 `Roguelike@ExitThenAbandon.png` 以 0.9945 匹配（与 taskid:88 正常退出时命中 score 0.994489 一致），说明画面上存在可识别的出口，只是 `ReturnConfirm.next` 候选不含它。

## 修复

新增 `Roguelike@StageSyncRetryConfirm` 任务（OCR 识别「是否重试」弹窗 → ClickRect 点「重试」按钮让游戏重新同步），挂在 `Roguelike@StartAction.next` 的 `LoadingText` 之后。

```json
"Roguelike@StageSyncRetryConfirm": {
    "algorithm": "OcrDetect",
    "text": ["是否重试"],
    "roi": [574, 306, 126, 35],
    "action": "ClickRect",
    "specificRect": [917, 464, 80, 60],
    "postDelay": 10000,
    "maxTimes": 10,
    "next": ["Roguelike@StartAction#next"],
    "exceededNext": ["Roguelike@ExitThenAbandon"]
}
```

**治本逻辑**：弹窗被识别并点重试后消失，不再残留，就不会被 `PopupConfirm.png` 误识别为 `ReturnConfirm`，从源头消除卡死。

- 点「重试」让游戏重新同步，流程最自然；`maxTimes` 上限 + `exceededNext` 退到 `Roguelike@ExitThenAbandon`（点左上角返回放弃本局），避免网络持续故障时死循环。
- 坐标基于弹窗截图实测（1280×720 坐标系）：「是否重试?」文字区 `(574,306)-(700,341)`；重试按钮 `(644,459)-(1271,529)` 中心 `(957,494)`。
- 仅肉鸽生效（挂在 `Roguelike@StartAction.next`，各主题经继承自动生效），不影响 Fight/SSS/Copilot 与全局任务。

## 验证

- [x] JSON 语法校验通过（`python -m json.tool`）
- [x] 实际肉鸽运行复现回归（断网制造同步失败弹窗，确认被识别点重试后流程继续，不再误触发 ReturnConfirm / 卡死）
- [x] 网络持续故障场景：确认重试达 maxTimes 后走 `ExitThenAbandon` 放弃本局，不无限循环
- [x] 正常网络下：确认 `StageSyncRetryConfirm` 不误命中正常结算画面

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Sourcery 摘要

显式处理 roguelike 同步失败对话框，使运行可以安全地重试或放弃，而不会触发卡住的返回确认流程。

新功能：
- 为 roguelike 战斗记录同步重试对话框添加专门的处理逻辑。

错误修复：
- 防止将同步重试对话框误识别为通用返回确认对话框，从而导致任务链死锁。
- 限制重复同步重试次数，并在同步持续失败时放弃本次运行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Handle roguelike synchronization failure dialogs explicitly so runs can retry safely or abandon without triggering a stuck return-confirmation flow.

New Features:
- Add dedicated handling for roguelike battle-record synchronization retry dialogs.

Bug Fixes:
- Prevent synchronization retry dialogs from being misidentified as generic return confirmations and causing task-chain deadlocks.
- Bound repeated synchronization retries and abandon the run when synchronization continues to fail.

</details>