### PR TITLE
fix(Core): 对截图、OCR、OpenCV 图像处理增加捕获，避免直接触发 Core 崩溃

### DIFF
--- a/src/MaaCore/Assistant.cpp
+++ b/src/MaaCore/Assistant.cpp
@@ -2,6 +2,7 @@
 
 #include "MaaUtils/NoWarningCV.hpp"
 #include <meojson/json.hpp>
+#include <new>
 #include <ranges>
 
 #include "Config/GeneralConfig.h"
@@ -34,6 +35,44 @@
 #endif
 
 using namespace asst;
+
+namespace
+{
+enum class TaskExceptionKind
+{
+    None,
+    OpenCV,
+    OutOfMemory,
+    Standard,
+    Unknown,
+};
+
+const char* task_exception_name(TaskExceptionKind kind) noexcept
+{
+    switch (kind) {
+    case TaskExceptionKind::OpenCV:
+        return "OpenCVException";
+    case TaskExceptionKind::OutOfMemory:
+        return "OutOfMemory";
+    case TaskExceptionKind::Standard:
+        return "UnhandledException";
+    case TaskExceptionKind::Unknown:
+        return "UnknownException";
+    default:
+        return "";
+    }
+}
+
+template <typename Function>
+void best_effort(Function&& function) noexcept
+{
+    try {
+        function();
+    }
+    catch (...) {
+    }
+}
+}
 
 bool ::AsstExtAPI::set_static_option(StaticOptionKey key, const std::string& value)
 {
@@ -512,66 +551,147 @@ void Assistant::working_proc()
 
     std::vector<TaskId> finished_tasks;
     while (true) {
-        std::unique_lock<std::mutex> lock(m_mutex);
-        if (m_thread_exit) {
-            m_running = false;
-            return;
-        }
+        try {
+            std::unique_lock<std::mutex> lock(m_mutex);
+            if (m_thread_exit) {
+                m_running = false;
+                return;
+            }
 
-        if (m_thread_idle || m_tasks_list.empty()) {
-            finished_tasks.clear();
+            if (m_thread_idle || m_tasks_list.empty()) {
+                finished_tasks.clear();
+                m_thread_idle = true;
+                m_running = false;
+                Log.flush();
+#ifdef _WIN32
+                m_ctrler->restore_window_position();
+#endif
+                m_condvar.wait(lock);
+                continue;
+            }
+
+            m_running = true;
+            const auto [id, task_ptr] = m_tasks_list.front();
+            lock.unlock();
+            // only one instance of working_proc running, unlock here to allow set_task_param to the running task
+
+            json::value callback_json = json::object {
+                { "taskchain", std::string(task_ptr->get_task_chain()) },
+                { "taskid", id },
+            };
+            append_callback(AsstMsg::TaskChainStart, callback_json);
+
+            bool ret = false;
+            TaskExceptionKind exception_kind = TaskExceptionKind::None;
+            try {
+                ret = task_ptr->run();
+            }
+            catch (const cv::Exception& e) {
+                if (e.code == cv::Error::StsNoMem) {
+                    exception_kind = TaskExceptionKind::OutOfMemory;
+                }
+                else {
+                    exception_kind = TaskExceptionKind::OpenCV;
+                    best_effort([&] {
+                        Log.error(
+                            "Unhandled OpenCV exception in task thread",
+                            e.what(),
+                            "code",
+                            e.code,
+                            "file",
+                            e.file,
+                            "line",
+                            e.line);
+                    });
+                }
+            }
+            catch (const std::bad_alloc&) {
+                exception_kind = TaskExceptionKind::OutOfMemory;
+            }
+            catch (const std::exception& e) {
+                exception_kind = TaskExceptionKind::Standard;
+                best_effort([&] { Log.error("Unhandled exception in task thread", e.what()); });
+            }
+            catch (...) {
+                exception_kind = TaskExceptionKind::Unknown;
+                best_effort([&] { Log.error("Unknown exception in task thread"); });
+            }
+
+            lock.lock();
+            if (!m_tasks_list.empty()) {
+                m_tasks_list.pop_front();
+            }
+            lock.unlock();
+
+            if (exception_kind != TaskExceptionKind::OutOfMemory) {
+                finished_tasks.emplace_back(id);
+            }
+
+            if (exception_kind != TaskExceptionKind::None) {
+                if (exception_kind == TaskExceptionKind::OutOfMemory) {
+                    lock.lock();
+                    m_thread_idle = true;
+                    m_tasks_list.clear();
+                    lock.unlock();
+                    best_effort([&] { Log.error("Unhandled out of memory in task thread"); });
+                }
+
+                const auto append_error = [&] {
+                    callback_json["details"] = json::object {
+                        { "error", task_exception_name(exception_kind) },
+                    };
+                    append_callback(AsstMsg::TaskChainError, callback_json);
+                };
+                if (exception_kind == TaskExceptionKind::OutOfMemory) {
+                    best_effort(append_error);
+                }
+                else {
+                    append_error();
+                }
+            }
+            else {
+                auto msg = m_thread_idle ? AsstMsg::TaskChainStopped
+                                         : (ret ? AsstMsg::TaskChainCompleted : AsstMsg::TaskChainError);
+                append_callback(msg, callback_json);
+            }
+
+            if (m_thread_idle) {
+                finished_tasks.clear();
+                if (exception_kind != TaskExceptionKind::None) {
+                    if (exception_kind == TaskExceptionKind::OutOfMemory) {
+                        best_effort([&] { clear_cache(); });
+                        best_effort([&] { append_callback(AsstMsg::TaskChainStopped, callback_json); });
+                    }
+                    else {
+                        clear_cache();
+                        append_callback(AsstMsg::TaskChainStopped, callback_json);
+                    }
+                }
+                continue;
+            }
+
+            if (m_tasks_list.empty()) {
+                callback_json["finished_tasks"] = json::array(finished_tasks);
+                append_callback(AsstMsg::AllTasksCompleted, callback_json);
+                finished_tasks.clear();
+                clear_cache();
+            }
+
+            const int delay = Config.get_options().task_delay;
+            lock.lock();
+            m_condvar.wait_for(lock, std::chrono::milliseconds(delay), [&]() -> bool { return m_thread_idle; });
+
+            if (m_thread_idle) {
+                append_callback(AsstMsg::TaskChainStopped, callback_json);
+            }
+        }
+        catch (...) {
             m_thread_idle = true;
             m_running = false;
-            Log.flush();
-#ifdef _WIN32
-            m_ctrler->restore_window_position();
-#endif
-            m_condvar.wait(lock);
-            continue;
-        }
-
-        m_running = true;
-        const auto [id, task_ptr] = m_tasks_list.front();
-        lock.unlock();
-        // only one instance of working_proc running, unlock here to allow set_task_param to the running task
-
-        json::value callback_json = json::object {
-            { "taskchain", std::string(task_ptr->get_task_chain()) },
-            { "taskid", id },
-        };
-        append_callback(AsstMsg::TaskChainStart, callback_json);
-
-        bool ret = task_ptr->run();
-        finished_tasks.emplace_back(id);
-
-        lock.lock();
-        if (!m_tasks_list.empty()) {
-            m_tasks_list.pop_front();
-        }
-        lock.unlock();
-
-        auto msg =
-            m_thread_idle ? AsstMsg::TaskChainStopped : (ret ? AsstMsg::TaskChainCompleted : AsstMsg::TaskChainError);
-        append_callback(msg, callback_json);
-
-        if (m_thread_idle) {
-            finished_tasks.clear();
-            continue;
-        }
-
-        if (m_tasks_list.empty()) {
-            callback_json["finished_tasks"] = json::array(finished_tasks);
-            append_callback(AsstMsg::AllTasksCompleted, callback_json);
-            finished_tasks.clear();
-            clear_cache();
-        }
-
-        const int delay = Config.get_options().task_delay;
-        lock.lock();
-        m_condvar.wait_for(lock, std::chrono::milliseconds(delay), [&]() -> bool { return m_thread_idle; });
-
-        if (m_thread_idle) {
-            append_callback(AsstMsg::TaskChainStopped, callback_json);
+            best_effort([&] {
+                std::unique_lock<std::mutex> recovery_lock(m_mutex);
+                m_tasks_list.clear();
+            });
         }
     }
 }
@@ -595,8 +715,14 @@ void Assistant::msg_proc()
         m_msg_queue.pop();
         lock.unlock();
 
-        if (m_callback) {
-            m_callback(static_cast<AsstMsgId>(msg), detail.to_string().c_str(), m_callback_arg);
+        try {
+            if (m_callback) {
+                auto detail_string = detail.to_string();
+                m_callback(static_cast<AsstMsgId>(msg), detail_string.c_str(), m_callback_arg);
+            }
+        }
+        catch (...) {
+            best_effort([&] { Log.error("Unhandled exception in callback message thread"); });
         }
     }
 }
@@ -646,75 +772,159 @@ void asst::Assistant::call_proc()
     LogTraceFunction;
 
     while (true) {
-        std::unique_lock<std::mutex> lock(m_call_mutex);
-        if (m_thread_exit) {
-            break;
-        }
+        AsyncCallId current_call_id = 0;
+        try {
+            std::unique_lock<std::mutex> lock(m_call_mutex);
+            if (m_thread_exit) {
+                break;
+            }
 
-        if (m_call_queue.empty()) {
-            m_call_condvar.wait(lock);
-            continue;
-        }
+            if (m_call_queue.empty()) {
+                m_call_condvar.wait(lock);
+                continue;
+            }
 
-        auto call_item = std::move(m_call_queue.front());
-        m_call_queue.pop();
-        lock.unlock();
+            auto call_item = std::move(m_call_queue.front());
+            m_call_queue.pop();
+            current_call_id = call_item.id;
+            lock.unlock();
 
-        auto start = std::chrono::steady_clock::now();
-        bool ret = false;
-        std::string what;
+            auto start = std::chrono::steady_clock::now();
+            bool ret = false;
+            const char* what = "Unknown";
+            TaskExceptionKind exception_kind = TaskExceptionKind::None;
 
-        switch (call_item.type) {
-        case AsyncCallItem::Type::Connect: {
-            what = "Connect";
-            const auto& [adb_path, address, config] = std::get<AsyncCallItem::ConnectParams>(call_item.params);
-            ret = ctrl_connect(adb_path, address, config);
-        } break;
+            try {
+                switch (call_item.type) {
+                case AsyncCallItem::Type::Connect: {
+                    what = "Connect";
+                    const auto& [adb_path, address, config] = std::get<AsyncCallItem::ConnectParams>(call_item.params);
+                    ret = ctrl_connect(adb_path, address, config);
+                } break;
 #ifdef _WIN32
-        case AsyncCallItem::Type::AttachWindow: {
-            what = "AttachWindow";
-            const auto& [hwnd, screencap_method, mouse_method, keyboard_method] =
-                std::get<AsyncCallItem::AttachWindowParams>(call_item.params);
-            ret = ctrl_attach_window(hwnd, screencap_method, mouse_method, keyboard_method);
-        } break;
+                case AsyncCallItem::Type::AttachWindow: {
+                    what = "AttachWindow";
+                    const auto& [hwnd, screencap_method, mouse_method, keyboard_method] =
+                        std::get<AsyncCallItem::AttachWindowParams>(call_item.params);
+                    ret = ctrl_attach_window(hwnd, screencap_method, mouse_method, keyboard_method);
+                } break;
 #endif
-        case AsyncCallItem::Type::Click: {
-            what = "Click";
-            const auto& [x, y] = std::get<AsyncCallItem::ClickParams>(call_item.params);
-            ret = ctrl_click(x, y);
-        } break;
-        case AsyncCallItem::Type::Screencap: {
-            what = "Screencap";
-            std::ignore = std::get<AsyncCallItem::ScreencapParams>(call_item.params);
-            ret = ctrl_screencap();
-        } break;
-        default:
-            what = "Unknown";
-            ret = false;
-            break;
-        }
+                case AsyncCallItem::Type::Click: {
+                    what = "Click";
+                    const auto& [x, y] = std::get<AsyncCallItem::ClickParams>(call_item.params);
+                    ret = ctrl_click(x, y);
+                } break;
+                case AsyncCallItem::Type::Screencap: {
+                    what = "Screencap";
+                    std::ignore = std::get<AsyncCallItem::ScreencapParams>(call_item.params);
+                    ret = ctrl_screencap();
+                } break;
+                default:
+                    what = "Unknown";
+                    ret = false;
+                    break;
+                }
+            }
+            catch (const cv::Exception& e) {
+                if (e.code == cv::Error::StsNoMem) {
+                    exception_kind = TaskExceptionKind::OutOfMemory;
+                }
+                else {
+                    exception_kind = TaskExceptionKind::OpenCV;
+                    best_effort([&] {
+                        Log.error(
+                            "Unhandled OpenCV exception in async call thread",
+                            e.what(),
+                            "code",
+                            e.code,
+                            "file",
+                            e.file,
+                            "line",
+                            e.line);
+                    });
+                }
+            }
+            catch (const std::bad_alloc&) {
+                exception_kind = TaskExceptionKind::OutOfMemory;
+            }
+            catch (const std::exception& e) {
+                exception_kind = TaskExceptionKind::Standard;
+                best_effort([&] { Log.error("Unhandled exception in async call thread", e.what()); });
+            }
+            catch (...) {
+                exception_kind = TaskExceptionKind::Unknown;
+                best_effort([&] { Log.error("Unknown exception in async call thread"); });
+            }
 
-        {
-            std::unique_lock<std::mutex> completed_call_lock(m_completed_call_mutex);
-            m_completed_call = call_item.id;
-            m_completed_call_condvar.notify_all();
-        }
-
-        auto cost =
-            std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start).count();
-        json::value cb_info = json::object {
-            { "uuid", m_uuid },
-            { "what", what },
-            { "async_call_id", call_item.id },
             {
-                "details",
-                json::object {
-                    { "ret", ret },
-                    { "cost", cost },
-                },
-            },
-        };
-        append_callback(AsstMsg::AsyncCallInfo, cb_info);
+                std::unique_lock<std::mutex> completed_call_lock(m_completed_call_mutex);
+                m_completed_call = call_item.id;
+                m_completed_call_condvar.notify_all();
+            }
+
+            if (exception_kind == TaskExceptionKind::OutOfMemory) {
+                {
+                    std::unique_lock<std::mutex> task_lock(m_mutex);
+                    m_thread_idle = true;
+                    m_tasks_list.clear();
+                }
+                best_effort([&] { Log.error("Unhandled out of memory in async call thread"); });
+            }
+
+            auto cost =
+                std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start).count();
+            const auto append_call_info = [&] {
+                json::value cb_info = json::object {
+                    { "uuid", m_uuid },
+                    { "what", what },
+                    { "async_call_id", call_item.id },
+                    {
+                        "details",
+                        json::object {
+                            { "ret", ret },
+                            { "cost", cost },
+                        },
+                    },
+                };
+                if (exception_kind != TaskExceptionKind::None) {
+                    cb_info["details"]["error"] = task_exception_name(exception_kind);
+                }
+                append_callback(AsstMsg::AsyncCallInfo, cb_info);
+            };
+            if (exception_kind == TaskExceptionKind::OutOfMemory) {
+                best_effort(append_call_info);
+            }
+            else {
+                append_call_info();
+            }
+        }
+        catch (...) {
+            m_thread_idle = true;
+            best_effort([&] {
+                std::unique_lock<std::mutex> recovery_lock(m_mutex);
+                m_tasks_list.clear();
+            });
+            AsyncCallId discarded_max_id = current_call_id;
+            best_effort([&] {
+                std::unique_lock<std::mutex> recovery_lock(m_call_mutex);
+                while (!m_call_queue.empty()) {
+                    if (discarded_max_id < m_call_queue.front().id) {
+                        discarded_max_id = m_call_queue.front().id;
+                    }
+                    m_call_queue.pop();
+                }
+            });
+            best_effort([&] {
+                if (discarded_max_id == 0) {
+                    return;
+                }
+                std::unique_lock<std::mutex> completed_call_lock(m_completed_call_mutex);
+                if (m_completed_call < discarded_max_id) {
+                    m_completed_call = discarded_max_id;
+                }
+                m_completed_call_condvar.notify_all();
+            });
+        }
     }
 }
 

--- a/src/MaaCore/Assistant.cpp
+++ b/src/MaaCore/Assistant.cpp
@@ -589,6 +589,9 @@ void Assistant::working_proc()
             catch (const cv::Exception& e) {
                 if (e.code == cv::Error::StsNoMem) {
                     exception_kind = TaskExceptionKind::OutOfMemory;
+                    best_effort([&] {
+                        Log.error("OpenCV out of memory in task thread", e.what(), "code", e.code, "file", e.file, "line", e.line);
+                    });
                 }
                 else {
                     exception_kind = TaskExceptionKind::OpenCV;
@@ -831,6 +834,9 @@ void asst::Assistant::call_proc()
             catch (const cv::Exception& e) {
                 if (e.code == cv::Error::StsNoMem) {
                     exception_kind = TaskExceptionKind::OutOfMemory;
+                    best_effort([&] {
+                        Log.error("OpenCV out of memory in async call thread", e.what(), "code", e.code, "file", e.file, "line", e.line);
+                    });
                 }
                 else {
                     exception_kind = TaskExceptionKind::OpenCV;

--- a/src/MaaCore/Assistant.cpp
+++ b/src/MaaCore/Assistant.cpp
@@ -693,6 +693,8 @@ void Assistant::working_proc()
                 std::unique_lock<std::mutex> recovery_lock(m_mutex);
                 m_tasks_list.clear();
             });
+            // 任务链可能在 TaskChainStart 后中断于此，补发停止消息，避免上层等待链终结回调悬挂
+            best_effort([&] { append_callback(AsstMsg::TaskChainStopped, json::object {}); });
         }
     }
 }

--- a/src/MaaCore/Assistant.cpp
+++ b/src/MaaCore/Assistant.cpp
@@ -637,10 +637,11 @@ void Assistant::working_proc()
                 }
 
                 const auto append_error = [&] {
-                    callback_json["details"] = json::object {
+                    json::value error_json = callback_json;
+                    error_json["details"] = json::object {
                         { "error", task_exception_name(exception_kind) },
                     };
-                    append_callback(AsstMsg::TaskChainError, callback_json);
+                    append_callback(AsstMsg::TaskChainError, error_json);
                 };
                 if (exception_kind == TaskExceptionKind::OutOfMemory) {
                     best_effort(append_error);

--- a/src/MaaCore/Controller/AdbController.cpp
+++ b/src/MaaCore/Controller/AdbController.cpp
@@ -642,6 +642,7 @@ bool asst::AdbController::screencap(cv::Mat& image_payload, bool allow_reconnect
     image_payload = cv::Mat(); // 清空缓存
     if (m_adb.screencap_method == AdbProperty::ScreencapMethod::UnknownYet) {
         std::vector<std::pair<AdbProperty::ScreencapMethod, std::string>> all_methods_cost;
+        auto fastest_method = AdbProperty::ScreencapMethod::UnknownYet;
 
         Log.info("Try to find the fastest way to screencap");
         auto min_cost = milliseconds(LLONG_MAX);
@@ -649,10 +650,10 @@ bool asst::AdbController::screencap(cv::Mat& image_payload, bool allow_reconnect
 
         auto start_time = steady_clock::now();
         if (m_support_socket && m_server_started &&
-            screencap(m_adb.screencap_raw_by_nc, decode_raw, allow_reconnect, true, 5000)) {
+            screencap(m_adb.screencap_raw_by_nc, decode_raw, allow_reconnect, true, 5000) == ScreencapResult::Success) {
             auto duration = duration_cast<milliseconds>(steady_clock::now() - start_time);
             if (duration < min_cost) {
-                m_adb.screencap_method = AdbProperty::ScreencapMethod::RawByNc;
+                fastest_method = AdbProperty::ScreencapMethod::RawByNc;
                 m_inited = true;
                 min_cost = duration;
             }
@@ -666,10 +667,10 @@ bool asst::AdbController::screencap(cv::Mat& image_payload, bool allow_reconnect
         clear_lf_info();
 
         start_time = steady_clock::now();
-        if (screencap(m_adb.screencap_raw_with_gzip, decode_raw_with_gzip, allow_reconnect)) {
+        if (screencap(m_adb.screencap_raw_with_gzip, decode_raw_with_gzip, allow_reconnect) == ScreencapResult::Success) {
             auto duration = duration_cast<milliseconds>(steady_clock::now() - start_time);
             if (duration < min_cost) {
-                m_adb.screencap_method = AdbProperty::ScreencapMethod::RawWithGzip;
+                fastest_method = AdbProperty::ScreencapMethod::RawWithGzip;
                 m_inited = true;
                 min_cost = duration;
             }
@@ -683,10 +684,10 @@ bool asst::AdbController::screencap(cv::Mat& image_payload, bool allow_reconnect
         clear_lf_info();
 
         start_time = steady_clock::now();
-        if (screencap(m_adb.screencap_encode, decode_encode, allow_reconnect)) {
+        if (screencap(m_adb.screencap_encode, decode_encode, allow_reconnect) == ScreencapResult::Success) {
             auto duration = duration_cast<milliseconds>(steady_clock::now() - start_time);
             if (duration < min_cost) {
-                m_adb.screencap_method = AdbProperty::ScreencapMethod::Encode;
+                fastest_method = AdbProperty::ScreencapMethod::Encode;
                 m_inited = true;
                 min_cost = duration;
             }
@@ -704,7 +705,7 @@ bool asst::AdbController::screencap(cv::Mat& image_payload, bool allow_reconnect
             if (m_mumu_extras.screencap()) {
                 auto duration = duration_cast<milliseconds>(steady_clock::now() - start_time);
                 if (duration < min_cost) {
-                    m_adb.screencap_method = AdbProperty::ScreencapMethod::MumuExtras;
+                    fastest_method = AdbProperty::ScreencapMethod::MumuExtras;
                     m_inited = true;
                     min_cost = duration;
                 }
@@ -723,7 +724,7 @@ bool asst::AdbController::screencap(cv::Mat& image_payload, bool allow_reconnect
             if (m_ld_extras.screencap()) {
                 auto duration = duration_cast<milliseconds>(steady_clock::now() - start_time);
                 if (duration < min_cost) {
-                    m_adb.screencap_method = AdbProperty::ScreencapMethod::LDExtras;
+                    fastest_method = AdbProperty::ScreencapMethod::LDExtras;
                     m_inited = true;
                     min_cost = duration;
                 }
@@ -736,6 +737,8 @@ bool asst::AdbController::screencap(cv::Mat& image_payload, bool allow_reconnect
             }
         }
 #endif
+
+        m_adb.screencap_method = fastest_method;
 
         static const std::unordered_map<AdbProperty::ScreencapMethod, std::string> MethodName = {
             { AdbProperty::ScreencapMethod::UnknownYet, "UnknownYet" },
@@ -772,49 +775,53 @@ bool asst::AdbController::screencap(cv::Mat& image_payload, bool allow_reconnect
     }
     else {
         auto start_time = high_resolution_clock::now();
-        bool screencap_ret = false;
+        ScreencapResult screencap_result = ScreencapResult::Failed;
         switch (m_adb.screencap_method) {
         case AdbProperty::ScreencapMethod::RawByNc:
-            screencap_ret = screencap(m_adb.screencap_raw_by_nc, decode_raw, allow_reconnect, true);
+            screencap_result = screencap(m_adb.screencap_raw_by_nc, decode_raw, allow_reconnect, true);
             break;
         case AdbProperty::ScreencapMethod::RawWithGzip:
-            screencap_ret = screencap(m_adb.screencap_raw_with_gzip, decode_raw_with_gzip, allow_reconnect);
+            screencap_result = screencap(m_adb.screencap_raw_with_gzip, decode_raw_with_gzip, allow_reconnect);
             break;
         case AdbProperty::ScreencapMethod::Encode:
-            screencap_ret = screencap(m_adb.screencap_encode, decode_encode, allow_reconnect);
+            screencap_result = screencap(m_adb.screencap_encode, decode_encode, allow_reconnect);
             break;
 #if ASST_WITH_EMULATOR_EXTRAS
         case AdbProperty::ScreencapMethod::MumuExtras: {
             auto img_opt = m_mumu_extras.screencap();
-            screencap_ret = img_opt.has_value();
+            screencap_result = img_opt.has_value() ? ScreencapResult::Success : ScreencapResult::Reprobe;
 
-            if (!screencap_ret && allow_reconnect) {
+            if (screencap_result != ScreencapResult::Success && allow_reconnect) {
                 m_mumu_extras.reload();
                 img_opt = m_mumu_extras.screencap();
-                screencap_ret = img_opt.has_value();
+                screencap_result = img_opt.has_value() ? ScreencapResult::Success : ScreencapResult::Reprobe;
             }
 
-            if (screencap_ret) {
+            if (screencap_result == ScreencapResult::Success) {
                 image_payload = img_opt.value();
             }
         } break;
         case AdbProperty::ScreencapMethod::LDExtras: {
             auto img_opt = m_ld_extras.screencap();
-            screencap_ret = img_opt.has_value();
+            screencap_result = img_opt.has_value() ? ScreencapResult::Success : ScreencapResult::Reprobe;
 
-            if (!screencap_ret && allow_reconnect) {
+            if (screencap_result != ScreencapResult::Success && allow_reconnect) {
                 m_ld_extras.reload();
                 img_opt = m_ld_extras.screencap();
-                screencap_ret = img_opt.has_value();
+                screencap_result = img_opt.has_value() ? ScreencapResult::Success : ScreencapResult::Reprobe;
             }
 
-            if (screencap_ret) {
+            if (screencap_result == ScreencapResult::Success) {
                 image_payload = img_opt.value();
             }
         } break;
 #endif
         default:
             break;
+        }
+        const bool screencap_ret = screencap_result == ScreencapResult::Success;
+        if (screencap_result == ScreencapResult::Reprobe) {
+            m_adb.screencap_method = AdbProperty::ScreencapMethod::UnknownYet;
         }
         auto duration = duration_cast<milliseconds>(high_resolution_clock::now() - start_time);
         // 记录截图耗时，每10次截图回传一次最值+平均值
@@ -859,66 +866,80 @@ bool asst::AdbController::screencap(cv::Mat& image_payload, bool allow_reconnect
     }
 }
 
-bool asst::AdbController::screencap(
+asst::AdbController::ScreencapResult asst::AdbController::screencap(
     const std::string& cmd,
     const DecodeFunc& decode_func,
     bool allow_reconnect,
     bool by_socket,
     int timeout)
 {
-    if ((!m_support_socket || !m_server_started) && by_socket) [[unlikely]] {
-        return false;
-    }
-    auto ret = call_command(cmd, timeout, allow_reconnect, by_socket);
-
-    if (!ret || ret.value().empty()) [[unlikely]] {
-        Log.warn("data is empty!");
-        return false;
-    }
-    auto& data = ret.value();
-
-    bool tried_conversion = false;
-    if (m_adb.screencap_end_of_line == AdbProperty::ScreencapEndOfLine::CRLF) {
-        tried_conversion = true;
-        if (!convert_lf(data)) [[unlikely]] { // 没找到 "\r\n"
-            Log.info("screencap_end_of_line is set to CRLF but no `\\r\\n` found, set it to LF");
-            m_adb.screencap_end_of_line = AdbProperty::ScreencapEndOfLine::LF;
+    try {
+        if ((!m_support_socket || !m_server_started) && by_socket) [[unlikely]] {
+            return ScreencapResult::Failed;
         }
-    }
+        auto ret = call_command(cmd, timeout, allow_reconnect, by_socket);
 
-    if (decode_func(data)) [[likely]] {
-        if (m_adb.screencap_end_of_line == AdbProperty::ScreencapEndOfLine::UnknownYet) [[unlikely]] {
-            Log.info("screencap_end_of_line is LF");
-            m_adb.screencap_end_of_line = AdbProperty::ScreencapEndOfLine::LF;
+        if (!ret || ret.value().empty()) [[unlikely]] {
+            Log.warn("data is empty!");
+            return ScreencapResult::Failed;
         }
-    }
-    else {
-        Log.info("data is not empty, but image is empty");
+        auto& data = ret.value();
 
-        if (tried_conversion) { // 已经转换过行尾，再次转换 data 不会变化，不必重试
-            Log.error("skip retry decoding and decode failed!");
-            return false;
+        bool tried_conversion = false;
+        if (m_adb.screencap_end_of_line == AdbProperty::ScreencapEndOfLine::CRLF) {
+            tried_conversion = true;
+            if (!convert_lf(data)) [[unlikely]] { // 没找到 "\r\n"
+                Log.info("screencap_end_of_line is set to CRLF but no `\\r\\n` found, set it to LF");
+                m_adb.screencap_end_of_line = AdbProperty::ScreencapEndOfLine::LF;
+            }
         }
 
-        Log.info("try to cvt lf");
-        if (!convert_lf(data)) { // 没找到 "\r\n"，data 没有变化，不必重试
-            Log.error("no `\\r\\n` found, skip retry decode");
-            return false;
-        }
-        if (!decode_func(data)) {
-            Log.error("convert lf and retry decode failed!");
-            return false;
-        }
-
-        if (m_adb.screencap_end_of_line == AdbProperty::ScreencapEndOfLine::UnknownYet) {
-            Log.info("screencap_end_of_line is CRLF");
+        if (decode_func(data)) [[likely]] {
+            if (m_adb.screencap_end_of_line == AdbProperty::ScreencapEndOfLine::UnknownYet) [[unlikely]] {
+                Log.info("screencap_end_of_line is LF");
+                m_adb.screencap_end_of_line = AdbProperty::ScreencapEndOfLine::LF;
+            }
         }
         else {
-            Log.info("screencap_end_of_line is changed to CRLF");
+            Log.info("data is not empty, but image is empty");
+
+            if (tried_conversion) { // 已经转换过行尾，再次转换 data 不会变化，不必重试
+                Log.error("skip retry decoding and decode failed!");
+                return ScreencapResult::Reprobe;
+            }
+
+            Log.info("try to cvt lf");
+            if (!convert_lf(data)) { // 没找到 "\r\n"，data 没有变化，不必重试
+                Log.error("no `\\r\\n` found, skip retry decode");
+                return ScreencapResult::Reprobe;
+            }
+            if (!decode_func(data)) {
+                Log.error("convert lf and retry decode failed!");
+                return ScreencapResult::Reprobe;
+            }
+
+            if (m_adb.screencap_end_of_line == AdbProperty::ScreencapEndOfLine::UnknownYet) {
+                Log.info("screencap_end_of_line is CRLF");
+            }
+            else {
+                Log.info("screencap_end_of_line is changed to CRLF");
+            }
+            m_adb.screencap_end_of_line = AdbProperty::ScreencapEndOfLine::CRLF;
         }
-        m_adb.screencap_end_of_line = AdbProperty::ScreencapEndOfLine::CRLF;
+        return ScreencapResult::Success;
     }
-    return true;
+    catch (const cv::Exception& e) {
+        if (e.code == cv::Error::StsNoMem) {
+            throw;
+        }
+        try {
+            Log.error(
+                "ADB screencap decode OpenCV exception", e.what(), "code", e.code, "file", e.file, "line", e.line);
+        }
+        catch (...) {
+        }
+        return ScreencapResult::Reprobe;
+    }
 }
 
 bool asst::AdbController::connect(const std::string& adb_path, const std::string& address, const std::string& config)

--- a/src/MaaCore/Controller/AdbController.h
+++ b/src/MaaCore/Controller/AdbController.h
@@ -129,8 +129,15 @@ protected:
     void close_socket() noexcept;
     std::optional<unsigned short> init_socket(const std::string& local_address);
 
+    enum class ScreencapResult
+    {
+        Failed,
+        Success,
+        Reprobe,
+    };
+
     using DecodeFunc = std::function<bool(const std::string&)>;
-    bool screencap(
+    ScreencapResult screencap(
         const std::string& cmd,
         const DecodeFunc& decode_func,
         bool allow_reconnect = false,

--- a/src/MaaCore/Controller/LDExtras.cpp
+++ b/src/MaaCore/Controller/LDExtras.cpp
@@ -55,22 +55,36 @@ void LDExtras::uninit()
 
 std::optional<cv::Mat> LDExtras::screencap() const
 {
-    if (!screenshot_instance_) {
-        LogError << "screenshot_instance_ is null";
+    try {
+        if (!screenshot_instance_) {
+            LogError << "screenshot_instance_ is null";
+            return std::nullopt;
+        }
+
+        void* pixels = screenshot_instance_->cap();
+        if (!pixels) {
+            LogError << "Failed to capture screen";
+            return std::nullopt;
+        }
+
+        const cv::Mat raw(display_height_, display_width_, CV_8UC3, pixels);
+        cv::Mat dst;
+        cv::flip(raw, dst, 0);
+
+        return dst;
+    }
+    catch (const cv::Exception& e) {
+        if (e.code == cv::Error::StsNoMem) {
+            throw;
+        }
+        try {
+            LogError << "LDExtras screencap OpenCV exception:" << e.what() << VAR(e.code) << VAR(e.file)
+                     << VAR(e.line);
+        }
+        catch (...) {
+        }
         return std::nullopt;
     }
-
-    void* pixels = screenshot_instance_->cap();
-    if (!pixels) {
-        LogError << "Failed to capture screen";
-        return std::nullopt;
-    }
-
-    const cv::Mat raw(display_height_, display_width_, CV_8UC3, pixels);
-    cv::Mat dst;
-    cv::flip(raw, dst, 0);
-
-    return dst;
 }
 
 bool LDExtras::load_ld_library()

--- a/src/MaaCore/Controller/MumuExtras.cpp
+++ b/src/MaaCore/Controller/MumuExtras.cpp
@@ -75,59 +75,73 @@ void MumuExtras::uninit()
 
 std::optional<cv::Mat> MumuExtras::screencap()
 {
-    if (!capture_display_func_) {
-        LogError << "capture_display_func_ is null";
-        return std::nullopt;
-    }
-
-    auto display_id = get_display_id();
-    if (!display_id) {
-        LogError << "Failed to get display id";
-        return std::nullopt;
-    }
-
-    int ret = capture_display_func_(
-        mumu_handle_,
-        *display_id,
-        static_cast<int>(display_buffer_.size()),
-        &display_width_,
-        &display_height_,
-        display_buffer_.data());
-
-    if (ret) {
-        // Try reloading once before giving up.
-        if (!reload()) {
-            LogError << "Failed to capture display and failed to reload. " << VAR(ret) << VAR(mumu_handle_)
-                     << VAR(*display_id) << VAR(display_buffer_.size()) << VAR(display_width_) << VAR(display_height_);
+    try {
+        if (!capture_display_func_) {
+            LogError << "capture_display_func_ is null";
             return std::nullopt;
         }
-        // Reload 之后 display_id 可能变化，重新获取后再重试一次 capture。
-        display_id = get_display_id();
+
+        auto display_id = get_display_id();
         if (!display_id) {
-            LogError << "Failed to get display id after reload";
+            LogError << "Failed to get display id";
             return std::nullopt;
         }
-        ret = capture_display_func_(
+
+        int ret = capture_display_func_(
             mumu_handle_,
             *display_id,
             static_cast<int>(display_buffer_.size()),
             &display_width_,
             &display_height_,
             display_buffer_.data());
+
         if (ret) {
-            LogError << "Failed to capture display even after reload. " << VAR(ret) << VAR(mumu_handle_)
-                     << VAR(*display_id) << VAR(display_buffer_.size()) << VAR(display_width_) << VAR(display_height_);
-            return std::nullopt;
+            // Try reloading once before giving up.
+            if (!reload()) {
+                LogError << "Failed to capture display and failed to reload. " << VAR(ret) << VAR(mumu_handle_)
+                         << VAR(*display_id) << VAR(display_buffer_.size()) << VAR(display_width_) << VAR(display_height_);
+                return std::nullopt;
+            }
+            // Reload 之后 display_id 可能变化，重新获取后再重试一次 capture。
+            display_id = get_display_id();
+            if (!display_id) {
+                LogError << "Failed to get display id after reload";
+                return std::nullopt;
+            }
+            ret = capture_display_func_(
+                mumu_handle_,
+                *display_id,
+                static_cast<int>(display_buffer_.size()),
+                &display_width_,
+                &display_height_,
+                display_buffer_.data());
+            if (ret) {
+                LogError << "Failed to capture display even after reload. " << VAR(ret) << VAR(mumu_handle_)
+                         << VAR(*display_id) << VAR(display_buffer_.size()) << VAR(display_width_) << VAR(display_height_);
+                return std::nullopt;
+            }
         }
+
+        cv::Mat raw(display_height_, display_width_, CV_8UC4, display_buffer_.data());
+        cv::Mat bgr;
+        cv::cvtColor(raw, bgr, cv::COLOR_RGBA2BGR);
+        cv::Mat dst;
+        cv::flip(bgr, dst, 0);
+
+        return dst;
     }
-
-    cv::Mat raw(display_height_, display_width_, CV_8UC4, display_buffer_.data());
-    cv::Mat bgr;
-    cv::cvtColor(raw, bgr, cv::COLOR_RGBA2BGR);
-    cv::Mat dst;
-    cv::flip(bgr, dst, 0);
-
-    return dst;
+    catch (const cv::Exception& e) {
+        if (e.code == cv::Error::StsNoMem) {
+            throw;
+        }
+        try {
+            LogError << "MumuExtras screencap OpenCV exception:" << e.what() << VAR(e.code) << VAR(e.file)
+                     << VAR(e.line);
+        }
+        catch (...) {
+        }
+        return std::nullopt;
+    }
 }
 
 bool MumuExtras::touch_down(int contact, int x, int y)


### PR DESCRIPTION
# fix(Core): 对截图、OCR、OpenCV 图像处理增加捕获，避免直接触发 Core 崩溃

## 背景

Core 的任务执行、异步调用和消息回调线程原先缺少统一的未处理异常边界。截图解码、OCR 或其他 OpenCV 图像处理抛出异常时，异常可能直接越过线程入口，导致工作线程退出甚至触发 Core 崩溃，进而引发闪退；

此外，ADB 截图原先只区分成功和失败，无法判断截图命令普通失败与当前截图方式已经无法解码。已选方式出现解码异常后仍会被继续使用，不能自动回到截图方式探测流程。

相关 Issue：#17746、#17656、#17619

## 设计概要

- **在线程边界统一捕获异常**：任务线程、异步调用线程和回调消息线程分别增加异常保护，避免单次异常直接结束线程
- **使用稳定错误分类回调**：将异常归类为 `OpenCVException`、`OutOfMemory`、`UnhandledException`、`UnknownException`，通过原有回调的 `details.error` 返回
- **内存不足单独恢复**：检测 OpenCV `StsNoMem` 和 `std::bad_alloc`，停止当前任务链、清空待执行任务，并尽力清理缓存和发送回调
- **保证异步等待能够结束**：正常失败或已捕获异常均推进完成 id；最外层恢复失败时丢弃剩余异步调用，并推进至已丢弃调用中的最大 id
- **截图结果改为三态**：内部截图执行结果由 `bool` 改为 `Success`、`Failed`、`Reprobe`，仅在需要时废弃当前截图方式
- **截图方式自动重探测**：解码失败或 Extras 截图失效时将当前方式重置为 `UnknownYet`，下一次截图重新测速并选择可用方式
- **保持对外接口兼容**：公共截图接口仍返回 `bool`，公共 C API 和既有调用参数不变

### 修改文件（4 个）

| 文件 | 改动 |
| --- | --- |
| `src/MaaCore/Assistant.cpp` | 新增异常分类和 `best_effort`；保护任务、异步调用及回调消息线程；补充错误回调和队列恢复逻辑 |
| `src/MaaCore/Controller/AdbController.cpp` | 引入截图三态结果；区分普通失败与重探测；捕获 ADB 截图解码异常；延后写入最快截图方式 |
| `src/MaaCore/Controller/AdbController.h` | 新增 `ScreencapResult` 枚举，并调整内部 `screencap` 返回类型 |
| `src/MaaCore/Controller/MumuExtras.cpp` | 捕获 MuMu 截图颜色转换、翻转等阶段的 OpenCV 异常，内存不足继续向上抛出 |

### 修改参数

#### 错误分类

| 内部分类 | 回调值 | 触发条件 |
| --- | --- | --- |
| `TaskExceptionKind::OpenCV` | `OpenCVException` | 非内存不足的 `cv::Exception` |
| `TaskExceptionKind::OutOfMemory` | `OutOfMemory` | OpenCV `StsNoMem` 或 `std::bad_alloc` |
| `TaskExceptionKind::Standard` | `UnhandledException` | 其他 `std::exception` |
| `TaskExceptionKind::Unknown` | `UnknownException` | 非标准异常 |

#### 回调字段

| 回调 | 参数 | 修改前 | 修改后 |
| --- | --- | --- | --- |
| `TaskChainError` | `details.error` | 无 | 异常触发时新增可选 `string`，值为上述错误分类 |
| `AsyncCallInfo` | `details.error` | 无 | 异常触发时新增可选 `string`，值为上述错误分类 |

`AsyncCallInfo` 原有的 `details.ret`、`details.cost`、`async_call_id`、`what` 和 `uuid` 保持不变。

#### 截图返回值

| 返回值 | 含义 | 后续行为 |
| --- | --- | --- |
| `ScreencapResult::Success` | 截图并解码成功 | 对外转换为 `true`，保留当前截图方式 |
| `ScreencapResult::Failed` | Socket 不可用、命令失败或返回为空 | 对外转换为 `false`，保留当前截图方式 |
| `ScreencapResult::Reprobe` | 数据无法解码、非内存不足的 OpenCV 异常或 Extras 截图失效 | 对外转换为 `false`，将截图方式重置为 `UnknownYet` |

内部 `AdbController::screencap` 的输入参数及默认值没有修改：

| 参数 | 类型 | 默认值 |
| --- | --- | --- |
| `cmd` | `const std::string&` | 无 |
| `decode_func` | `const DecodeFunc&` | 无 |
| `allow_reconnect` | `bool` | `false` |
| `by_socket` | `bool` | `false` |
| `max_timeout` | `int` | `20000` ms |

## 测试情况

- [x] `MaaCore` Release 本地编译通过
- [x] `git diff --check` 通过
- [x] 内部 `screencap` 的 6 个调用点均已适配 `ScreencapResult`
- [x] MuMu模拟器实机截图回归
- [ ] 验证严格解析回调 JSON 的上层调用方对新增可选字段的兼容性

## 兼容性说明

- 公共 C API、C++ 公共截图接口及调用参数均未修改
- `TaskChainError.details.error` 和 `AsyncCallInfo.details.error` 均为可选字段，正常流程下不会出现
- 非内存不足异常只结束当前任务并上报错误，不影响后续任务继续执行
- 内存不足时优先停止任务链、清空队列和释放缓存，避免在资源不足状态下继续执行
- 截图发生 `Reprobe` 的当次调用仍返回失败，重新探测发生在下一次截图调用
- 普通 ADB 命令失败不会重置截图方式，避免瞬时连接波动触发频繁测速

## 已知局限

- 内存不足恢复采用 best-effort 策略，目标是释放资源并唤醒等待方，不保证当前任务能够继续
- 回调只提供稳定的错误分类，具体 OpenCV 错误、文件和行号仍需查看 Core 日志
- 截图方式重新探测会产生一次额外测速开销

## 检查项

- [x] 遵循现有代码风格和命名规范
- [x] `screencap_result` 与对外布尔值 `screencap_ret` 使用不同变量名
- [x] 所有内部截图调用点均区分 `Success`、`Failed` 和 `Reprobe`
- [x] 异步调用发生异常时仍会唤醒 `wait_async_id`
- [x] 公共 API 签名和默认参数保持不变

## Sourcery 摘要

增强 Core 执行和图像捕获路径的异常防护，同时支持可靠的截图方法恢复。

Bug 修复：
- 防止未处理的任务、异步调用、回调和截图处理异常终止 Core 工作线程或导致崩溃。
- 当图像解码或特定模拟器的捕获过程失败时，自动重置并重新探测所选的截图方法。

增强功能：
- 将任务和异步回调中捕获的失败分类为 OpenCVException、OutOfMemory、UnhandledException 或 UnknownException。
- 改进内存不足恢复机制：停止任务执行，尽最大努力清除排队中的工作和缓存，并确保异步等待能够完成。
- 在内部区分截图命令失败和解码失败，同时保留现有的公开布尔值截图 API。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

添加异常边界和弹性截图恢复机制，以确保图像处理或异步操作失败时 Core 执行仍能继续。

Bug 修复：
- 防止未处理的任务、异步调用、回调和图像处理异常终止 Core 工作线程或导致进程崩溃。
- 当图像解码或特定模拟器的截图处理变得不可用时，自动重置并重新检测所选的截图方法。

增强功能：
- 对任务和异步回调中的捕获失败进行分类，包括 OpenCV、内存不足、标准异常和未知异常。
- 改进内存不足时的恢复机制：停止任务执行，尽力清除待处理工作和缓存，并确保释放异步等待者。
- 在内部区分截图命令失败和解码失败，同时保留现有的公共布尔值截图接口。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add exception boundaries and resilient screenshot recovery to keep Core execution alive when image processing or asynchronous operations fail.

Bug Fixes:
- Prevent unhandled task, asynchronous-call, callback, and image-processing exceptions from terminating Core worker threads or crashing the process.
- Automatically reset and re-detect the selected screenshot method when image decoding or emulator-specific capture processing becomes unusable.

Enhancements:
- Classify captured failures in task and asynchronous callbacks, including OpenCV, out-of-memory, standard, and unknown exceptions.
- Improve out-of-memory recovery by stopping task execution, clearing pending work and caches on a best-effort basis, and ensuring asynchronous waiters are released.
- Distinguish screenshot command failures from decoding failures internally while preserving the existing public boolean screenshot interface.

</details>

</details>