### PR TITLE
fix: 襁褓羽蛇与三头犬改为进入第三层后结算

### DIFF
--- a/resource/roguelike/BlackFlow/node_execution.json
+++ b/resource/roguelike/BlackFlow/node_execution.json
@@ -272,8 +272,7 @@
                     "kind": "capture_integer",
                     "fact": "cultivated_animals",
                     "source": "details.result.text",
-                    "minimum": 0,
-                    "maximum": 3
+                    "minimum": 0
                 }
             ],
             "result_kind": "intermediate"

--- a/resource/roguelike/BlackFlow/strategy.json
+++ b/resource/roguelike/BlackFlow/strategy.json
@@ -140,6 +140,11 @@
             "scope": "run"
         },
         {
+            "name": "cultivation_target_obtained",
+            "type": "bool",
+            "scope": "run"
+        },
+        {
             "name": "sandtable_a",
             "type": "bool",
             "scope": "run"
@@ -1129,6 +1134,11 @@
                                 "value": 2
                             },
                             {
+                                "fact": "cultivation_target_obtained",
+                                "op": "eq",
+                                "value": false
+                            },
+                            {
                                 "fact": "floor_development_exhausted",
                                 "op": "eq",
                                 "value": false
@@ -1164,26 +1174,39 @@
                                 "value": 2
                             },
                             {
-                                "fact": "scrap_shop_available",
-                                "op": "eq",
-                                "value": false
-                            },
-                            {
                                 "any": [
                                     {
-                                        "fact": "floor_development_exhausted",
+                                        "fact": "cultivation_target_obtained",
                                         "op": "eq",
                                         "value": true
                                     },
                                     {
-                                        "fact": "safety_margin_low",
-                                        "op": "eq",
-                                        "value": true
-                                    },
-                                    {
-                                        "fact": "force_exit",
-                                        "op": "eq",
-                                        "value": true
+                                        "all": [
+                                            {
+                                                "fact": "scrap_shop_available",
+                                                "op": "eq",
+                                                "value": false
+                                            },
+                                            {
+                                                "any": [
+                                                    {
+                                                        "fact": "floor_development_exhausted",
+                                                        "op": "eq",
+                                                        "value": true
+                                                    },
+                                                    {
+                                                        "fact": "safety_margin_low",
+                                                        "op": "eq",
+                                                        "value": true
+                                                    },
+                                                    {
+                                                        "fact": "force_exit",
+                                                        "op": "eq",
+                                                        "value": true
+                                                    }
+                                                ]
+                                            }
+                                        ]
                                     }
                                 ]
                             }
@@ -1270,6 +1293,104 @@
                     "completion": "condition"
                 },
                 {
+                    "id": "baby_explore_hidden",
+                    "description": "尚未发现秘境行商时，按路线计数尽量多开未知的诡秘",
+                    "kind": "preferred",
+                    "floor_window": [2, 3],
+                    "rank": 0,
+                    "count": 99,
+                    "weight": 4,
+                    "active_if": {
+                        "all": [
+                            {
+                                "fact": "scrap_shop_available",
+                                "op": "eq",
+                                "value": false
+                            },
+                            {
+                                "fact": "cultivation_completed",
+                                "op": "eq",
+                                "value": false
+                            },
+                            {
+                                "fact": "cultivation_target_obtained",
+                                "op": "eq",
+                                "value": false
+                            }
+                        ]
+                    },
+                    "selector": {
+                        "node_types": ["hide_invisible"]
+                    }
+                },
+                {
+                    "id": "baby_visit_incident",
+                    "kind": "preferred",
+                    "floor_window": [2, 3],
+                    "rank": 0,
+                    "count": 99,
+                    "weight": 3,
+                    "active_if": {
+                        "all": [
+                            {
+                                "fact": "scrap_shop_available",
+                                "op": "eq",
+                                "value": false
+                            },
+                            {
+                                "fact": "cultivation_target_obtained",
+                                "op": "eq",
+                                "value": false
+                            }
+                        ]
+                    },
+                    "selector": {
+                        "node_types": ["incident"]
+                    }
+                },
+                {
+                    "id": "baby_floor2_shops",
+                    "description": "第二层经过普通商店时继续优先获取种子",
+                    "kind": "preferred",
+                    "floor_window": [2, 2],
+                    "rank": 0,
+                    "count": 99,
+                    "weight": 2,
+                    "active_if": {
+                        "fact": "cultivation_target_obtained",
+                        "op": "eq",
+                        "value": false
+                    },
+                    "selector": {
+                        "node_types": ["shop"]
+                    },
+                    "page_intent": "shop.seed_priority"
+                },
+                {
+                    "id": "baby_floor3_shops",
+                    "description": "第三层经过普通商店时卖货、刷新并尽量购买种子",
+                    "kind": "preferred",
+                    "floor_window": [3, 3],
+                    "rank": 0,
+                    "count": 99,
+                    "weight": 2,
+                    "active_if": {
+                        "fact": "cultivation_target_obtained",
+                        "op": "eq",
+                        "value": false
+                    },
+                    "selector": {
+                        "node_types": ["shop"]
+                    },
+                    "page_intent": "shop.seed_priority_floor3"
+                }
+            ]
+        },
+        {
+            "id": "baby_cultivate_direct",
+            "description": "培育出目标即收工的秘境行商目标，用于猫和狗",
+            "milestones": [
+                {
                     "id": "baby_cultivate_scrap_shop",
                     "floor_window": [1, 3],
                     "rank": 0,
@@ -1303,80 +1424,57 @@
                     },
                     "page_intent": "scrap_shop.cultivate",
                     "completion": "condition"
-                },
+                }
+            ]
+        },
+        {
+            "id": "baby_cultivate_gated",
+            "description": "培育出目标之后仍须进入第三层的秘境行商目标，用于羽蛇和三头犬",
+            "milestones": [
                 {
-                    "id": "baby_explore_hidden",
-                    "description": "尚未发现秘境行商时，按路线计数尽量多开未知的诡秘",
-                    "kind": "preferred",
-                    "floor_window": [2, 3],
+                    "id": "baby_cultivate_scrap_shop_transit",
+                    "description": "前两层的秘境行商是必达目标，但仍须保住走到险路尽头的能力",
+                    "floor_window": [1, 2],
                     "rank": 0,
-                    "count": 99,
-                    "weight": 4,
                     "active_if": {
-                        "all": [
-                            {
-                                "fact": "scrap_shop_available",
-                                "op": "eq",
-                                "value": false
-                            },
-                            {
-                                "fact": "cultivation_completed",
-                                "op": "eq",
-                                "value": false
-                            }
-                        ]
+                        "fact": "scrap_shop_available",
+                        "op": "eq",
+                        "value": true
                     },
-                    "selector": {
-                        "node_types": ["hide_invisible"]
-                    }
-                },
-                {
-                    "id": "baby_visit_incident",
-                    "kind": "preferred",
-                    "floor_window": [2, 3],
-                    "rank": 0,
-                    "count": 99,
-                    "weight": 3,
-                    "selector": {
-                        "node_types": ["incident"]
-                    }
-                },
-                {
-                    "id": "baby_visit_light",
-                    "kind": "preferred",
-                    "floor_window": [2, 3],
-                    "rank": 0,
-                    "count": 99,
-                    "weight": 2,
-                    "selector": {
-                        "node_types": ["light"]
-                    }
-                },
-                {
-                    "id": "baby_floor2_shops",
-                    "description": "第二层经过普通商店时继续优先获取种子",
-                    "kind": "preferred",
-                    "floor_window": [2, 2],
-                    "rank": 0,
-                    "count": 99,
-                    "weight": 2,
-                    "selector": {
-                        "node_types": ["shop"]
+                    "complete_if": {
+                        "fact": "cultivation_completed",
+                        "op": "eq",
+                        "value": true
                     },
-                    "page_intent": "shop.seed_priority"
+                    "reserves": ["baby_keep_cultivation_movement"],
+                    "enforcement": "feasible_hard",
+                    "selector": {
+                        "node_types": ["scrap_shop"]
+                    },
+                    "page_intent": "scrap_shop.cultivate",
+                    "completion": "condition"
                 },
                 {
-                    "id": "baby_floor3_shops",
-                    "description": "第三层经过普通商店时卖货、刷新并尽量购买种子",
-                    "kind": "preferred",
+                    "id": "baby_cultivate_scrap_shop_final",
+                    "description": "第三层的秘境行商是本局终点，允许耗尽行动力抵达",
                     "floor_window": [3, 3],
                     "rank": 0,
-                    "count": 99,
-                    "weight": 2,
-                    "selector": {
-                        "node_types": ["shop"]
+                    "complete_if": {
+                        "fact": "cultivation_completed",
+                        "op": "eq",
+                        "value": true
                     },
-                    "page_intent": "shop.seed_priority_floor3"
+                    "reserves": ["baby_keep_cultivation_movement"],
+                    "enforcement": "feasible_hard",
+                    "terminality": "is_terminal",
+                    "on_miss": "terminate",
+                    "miss_outcome": "baby_cultivation_unfinished",
+                    "miss_reason": "scrap_shop_never_reached",
+                    "selector": {
+                        "node_types": ["scrap_shop"]
+                    },
+                    "page_intent": "scrap_shop.cultivate",
+                    "completion": "condition"
                 }
             ]
         },
@@ -1635,7 +1733,7 @@
         {
             "id": "baby_animal",
             "description": "第一层检查普通商店，第二、三层探索并进入秘境行商培育种子",
-            "modules": ["common_navigation", "baby_animal_route"],
+            "modules": ["common_navigation", "baby_animal_route", "baby_cultivate_direct"],
             "terminal_rules": [
                 {
                     "id": "baby_cultivation_completed",
@@ -1643,6 +1741,82 @@
                         "fact": "cultivation_completed",
                         "op": "eq",
                         "value": true
+                    },
+                    "outcome": "baby_cultivation_completed",
+                    "reason": "cultivation_result_reported",
+                    "succeeded": true
+                },
+                {
+                    "id": "baby_third_floor_action_points_exhausted",
+                    "when": {
+                        "all": [
+                            {
+                                "fact": "current_floor",
+                                "op": "eq",
+                                "value": 3
+                            },
+                            {
+                                "fact": "action_points",
+                                "op": "le",
+                                "value": 0
+                            },
+                            {
+                                "fact": "cultivation_completed",
+                                "op": "eq",
+                                "value": false
+                            }
+                        ]
+                    },
+                    "outcome": "baby_cultivation_unfinished",
+                    "reason": "third_floor_action_points_exhausted",
+                    "succeeded": false
+                }
+            ],
+            "failure_action": "restart_current_run",
+            "no_AP_is_terminal": {
+                "floors": [3]
+            }
+        },
+        {
+            "id": "baby_animal_floor3",
+            "description": "培育目标须通过两个区域才生效，因此培育出目标后仍要进入第三层才收工",
+            "modules": ["common_navigation", "baby_animal_route", "baby_cultivate_gated"],
+            "terminal_rules": [
+                {
+                    "id": "baby_cultivation_completed",
+                    "when": {
+                        "all": [
+                            {
+                                "fact": "cultivation_target_obtained",
+                                "op": "eq",
+                                "value": true
+                            },
+                            {
+                                "fact": "current_floor",
+                                "op": "ge",
+                                "value": 3
+                            }
+                        ]
+                    },
+                    "outcome": "baby_cultivation_completed",
+                    "reason": "cultivation_result_reported",
+                    "succeeded": true
+                },
+                {
+                    "id": "baby_cultivation_target_missed",
+                    "when": {
+                        "all": [
+                            {
+                                "fact": "cultivation_completed",
+                                "op": "eq",
+                                "value": true
+                            },
+                            {
+                                "fact": "cultivation_target_obtained",
+                                "op": "eq",
+                                "value": false
+                            }
+                        ]
                     },
                     "outcome": "baby_cultivation_completed",
                     "reason": "cultivation_result_reported",

--- a/resource/tasks/Roguelike/BlackFlow.json
+++ b/resource/tasks/Roguelike/BlackFlow.json
@@ -296,6 +296,30 @@
         ],
         "fullMatch": true
     },
+    "BlackFlow@Roguelike@CultivateSellItemsKeepMovement": {
+        "algorithm": "OcrDetect",
+        "roi": [395, 159, 857, 290],
+        "text": [
+            "血蕈",
+            "雾滚草",
+            "回声玉米",
+            "浪花",
+            "霜晶树",
+            "多生苔藓",
+            "枯苔藓球",
+            "板藤",
+            "恋家果",
+            "光彩松露",
+            "笼控器",
+            "白模鸟",
+            "白模狗",
+            "白模鱼",
+            "涂装黎博利",
+            "涂装佩洛",
+            "涂装阿戈尔"
+        ],
+        "fullMatch": true
+    },
     "BlackFlow@Roguelike@CultivateSellingFlag": {
         "template": "BlackFlow@Roguelike@CultivateBulkSell.png",
         "roi": [729, 103, 216, 66],

--- a/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowCultivationTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowCultivationTaskPlugin.cpp
@@ -21,6 +21,8 @@ constexpr std::string_view EnterTask = "BlackFlow@Roguelike@CultivateEnter";
 constexpr std::string_view SellDecisionTask = "BlackFlow@Roguelike@CultivateSellDecision";
 constexpr std::string_view SellAction = "BlackFlow@Roguelike@CultivateSellAction";
 constexpr std::string_view SellItemsTask = "BlackFlow@Roguelike@CultivateSellItems";
+constexpr std::string_view SellItemsKeepMovementTask = "BlackFlow@Roguelike@CultivateSellItemsKeepMovement";
+constexpr int LastFloor = 3;
 constexpr std::string_view SellConfirmEntry = "BlackFlow@Roguelike@CultivateSellConfirm-Enter";
 constexpr std::string_view ToggleToBuyTask = "BlackFlow@Roguelike@CultivateToggleToBuy";
 constexpr std::string_view BuyDecisionTask = "BlackFlow@Roguelike@CultivateBuyDecision";
@@ -134,7 +136,7 @@ bool BlackFlowCultivationTaskPlugin::_run()
 
     if (work == PendingWork::SellDecision) {
         Task.set_task_base(std::string(SellAction), std::string(ToggleToBuyTask));
-        const auto items = recognize(ctrler()->get_image(), std::string(SellItemsTask));
+        const auto items = recognize(ctrler()->get_image(), sell_items_task());
         if (!items.empty()) {
             ctrler()->click(items.front().rect);
             Task.set_task_base(std::string(SellAction), std::string(SellConfirmEntry));
@@ -220,6 +222,14 @@ bool BlackFlowCultivationTaskPlugin::_run()
         return true;
     }
     return true;
+}
+
+// 加工品在最后一层已经没有残值，卖掉换来的源石锭还能再买几颗种子；在此之前它们是走到
+// 秘境行商本身所依赖的移动能力，卖掉会把留给培育的那次长距离移动一起卖出去。
+std::string BlackFlowCultivationTaskPlugin::sell_items_task() const
+{
+    const int floor = m_session == nullptr ? 0 : m_session->current_floor().value_or(0);
+    return std::string(floor >= LastFloor ? SellItemsTask : SellItemsKeepMovementTask);
 }
 
 std::vector<TextRect> BlackFlowCultivationTaskPlugin::recognize(const cv::Mat& image, const std::string& task) const

--- a/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowCultivationTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowCultivationTaskPlugin.h
@@ -34,6 +34,7 @@ private:
         ApplyCultivationResult,
     };
 
+    [[nodiscard]] std::string sell_items_task() const;
     [[nodiscard]] std::vector<TextRect> recognize(const cv::Mat& image, const std::string& task) const;
     [[nodiscard]] int read_number(const cv::Mat& image, const std::string& task) const;
     void bind_completion(const std::string& task) const;

--- a/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowLifecycleTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowLifecycleTaskPlugin.cpp
@@ -39,8 +39,7 @@ bool BlackFlowLifecycleTaskPlugin::load_params(const json::value& params)
             profile = params.get("investment_enabled", true) ? "burn_with_investment" : "burn";
         }
     }
-    const std::string selected_profile = profile;
-    if (selected_profile == "baby_animal") {
+    if (is_baby_animal_profile(profile)) {
         const std::string target_text = params.get("blackflow_cultivation_target", std::string("swaddled_cat"));
         const auto target = parse_cultivated_animal_type(target_text);
         if (!target.has_value()) {
@@ -48,7 +47,10 @@ bool BlackFlowLifecycleTaskPlugin::load_params(const json::value& params)
             return false;
         }
         m_session->set_cultivation_target(*target);
+        // 界面只传「刷襁褓动物」这一个模式，收工条件随目标动物变化，所以在这里分流到对应策略。
+        profile = baby_animal_profile_for(*target);
     }
+    const std::string selected_profile = profile;
 
     // 三项都直接读 params：分队要等真正在选择界面点中才会写回 RoguelikeConfig，此刻取不到。
     // 必须先于 initialize()，事实是在它末尾写入的。

--- a/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowPolicy.cpp
+++ b/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowPolicy.cpp
@@ -531,6 +531,53 @@ bool milestone_is_complete(const Milestone& milestone, const FactStore& facts)
     return milestone.complete_if.evaluate(facts);
 }
 
+StrategyGoals strategy_goals_for(
+    const ResolvedPolicy& policy,
+    const MissionState& mission,
+    const FactStore& facts,
+    const MapSnapshot& map,
+    int floor)
+{
+    StrategyGoals result;
+    std::vector<const Milestone*> candidates;
+    for (const Milestone& milestone : policy.milestones) {
+        if (!milestone_is_active(milestone, floor, facts, mission)) {
+            continue;
+        }
+        bool has_matching_node = false;
+        for (const auto& [id, node] : map.nodes()) {
+            if (node.progress == NodeProgress::Removed || !milestone_matches_node(milestone, node)) {
+                continue;
+            }
+            has_matching_node = true;
+            if (milestone.terminality == MilestoneTerminality::IsTerminal) {
+                result.terminal_nodes.emplace(id);
+            }
+        }
+        if (!milestone.binding_candidate() || mission.progress(milestone.id) >= milestone.required_count) {
+            continue;
+        }
+        // 目标在本层地图上没有任何匹配节点时，可行性求解一定得出无解。可行则必达的目标直接跳过，
+        // 省掉一次白跑的安全求解；无条件必达的目标仍然送进去，让它按声明把本层判成无解。
+        if (milestone.enforcement == MilestoneEnforcement::FeasibleHard && !has_matching_node) {
+            continue;
+        }
+        candidates.emplace_back(&milestone);
+    }
+    std::ranges::sort(candidates, [](const Milestone* lhs, const Milestone* rhs) {
+        if (lhs->enforcement != rhs->enforcement) {
+            // Hard 排在 FeasibleHard 之前，阶梯从末尾开始降级，因此永远不会降到 Hard。
+            return lhs->enforcement > rhs->enforcement;
+        }
+        return std::tie(lhs->rank, lhs->id) < std::tie(rhs->rank, rhs->id);
+    });
+    for (const Milestone* milestone : candidates) {
+        result.binding_candidates.emplace_back(milestone->id);
+        result.undemotable_count += milestone->enforcement == MilestoneEnforcement::Hard ? 1 : 0;
+    }
+    return result;
+}
+
 PolicyDecision PolicyExecutor::choose(
     const ResolvedPolicy& policy,
     const FactStore& facts,

--- a/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowPolicy.h
+++ b/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowPolicy.h
@@ -439,6 +439,24 @@ public:
     const MissionState& mission_state);
 [[nodiscard]] bool milestone_is_complete(const Milestone& milestone, const FactStore& facts);
 
+// 本层的策略目标：哪些节点算「达成即收工」，以及哪些强制目标要送进可行性阶梯去锁定。
+// 只依赖地图、任务进度和事实，不依赖会话状态，因此放在策略层。
+struct StrategyGoals
+{
+    // 声明「达成即收工」的目标节点。它与物理出口取并集，所以端点集合恒非空。
+    std::unordered_set<NodeId> terminal_nodes;
+    // 待锁定的强制目标，按优先级从高到低。前 undemotable_count 条是无条件必达的，阶梯不会降级它们。
+    std::vector<std::string> binding_candidates;
+    std::size_t undemotable_count = 0;
+};
+
+[[nodiscard]] StrategyGoals strategy_goals_for(
+    const ResolvedPolicy& policy,
+    const MissionState& mission,
+    const FactStore& facts,
+    const MapSnapshot& map,
+    int floor);
+
 [[nodiscard]] std::string_view to_string(RuleKind kind) noexcept;
 [[nodiscard]] std::string_view to_string(PolicyTier tier) noexcept;
 [[nodiscard]] std::string_view to_string(MilestoneStatus status) noexcept;

--- a/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowSession.cpp
+++ b/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowSession.cpp
@@ -45,6 +45,24 @@ std::optional<CultivatedAnimalType> parse_cultivated_animal_type(std::string_vie
     return std::nullopt;
 }
 
+std::string_view baby_animal_profile_for(CultivatedAnimalType target) noexcept
+{
+    switch (target) {
+    case CultivatedAnimalType::FeatheredSerpent:
+    case CultivatedAnimalType::Cerberus:
+        return "baby_animal_floor3";
+    case CultivatedAnimalType::Cat:
+    case CultivatedAnimalType::Dog:
+        break;
+    }
+    return "baby_animal";
+}
+
+bool is_baby_animal_profile(std::string_view profile) noexcept
+{
+    return profile == "baby_animal" || profile == "baby_animal_floor3";
+}
+
 std::optional<CultivatedAnimalType> cultivated_animal_type_from_name(std::string_view name) noexcept
 {
     if (name == "襁褓中的猫") {
@@ -102,63 +120,6 @@ bool has_node_type(const MapSnapshot& map, NodeType type)
         return pair.second.type == type && pair.second.progress != NodeProgress::Removed;
     });
 }
-
-struct StrategyGoals
-{
-    // 声明「达成即收工」的目标节点。它与物理出口取并集，所以端点集合恒非空。
-    std::unordered_set<NodeId> terminal_nodes;
-    // 待锁定的强制目标，按优先级从高到低。前 undemotable_count 条是无条件必达的，阶梯不会降级它们。
-    std::vector<std::string> binding_candidates;
-    std::size_t undemotable_count = 0;
-};
-
-StrategyGoals strategy_goals_for(
-    const ResolvedPolicy& policy,
-    const MissionState& mission,
-    const FactStore& facts,
-    const MapSnapshot& map,
-    int floor)
-{
-    StrategyGoals result;
-    std::vector<const Milestone*> candidates;
-    for (const Milestone& milestone : policy.milestones) {
-        if (!milestone_is_active(milestone, floor, facts, mission)) {
-            continue;
-        }
-        bool has_matching_node = false;
-        for (const auto& [id, node] : map.nodes()) {
-            if (node.progress == NodeProgress::Removed || !milestone_matches_node(milestone, node)) {
-                continue;
-            }
-            has_matching_node = true;
-            if (milestone.terminality == MilestoneTerminality::IsTerminal) {
-                result.terminal_nodes.emplace(id);
-            }
-        }
-        if (!milestone.binding_candidate() || mission.progress(milestone.id) >= milestone.required_count) {
-            continue;
-        }
-        // 目标在本层地图上没有任何匹配节点时，可行性求解一定得出无解。可行则必达的目标直接跳过，
-        // 省掉一次白跑的安全求解；无条件必达的目标仍然送进去，让它按声明把本层判成无解。
-        if (milestone.enforcement == MilestoneEnforcement::FeasibleHard && !has_matching_node) {
-            continue;
-        }
-        candidates.emplace_back(&milestone);
-    }
-    std::ranges::sort(candidates, [](const Milestone* lhs, const Milestone* rhs) {
-        if (lhs->enforcement != rhs->enforcement) {
-            // Hard 排在 FeasibleHard 之前，阶梯从末尾开始降级，因此永远不会降到 Hard。
-            return lhs->enforcement > rhs->enforcement;
-        }
-        return std::tie(lhs->rank, lhs->id) < std::tie(rhs->rank, rhs->id);
-    });
-    for (const Milestone* milestone : candidates) {
-        result.binding_candidates.emplace_back(milestone->id);
-        result.undemotable_count += milestone->enforcement == MilestoneEnforcement::Hard ? 1 : 0;
-    }
-    return result;
-}
-
 } // namespace
 
 json::object BlackFlowStrategyResult::to_json() const
@@ -284,6 +245,17 @@ void BlackFlowSession::set_cultivated_animal_types(std::vector<CultivatedAnimalT
             m_cultivated_animal_types.end()) {
             m_cultivated_animal_types.emplace_back(type);
         }
+    }
+
+    // 是否拿到目标动物必须在这里落成事实：培育插件先调本函数、再提交页面结果，而终止规则
+    // 在页面结果提交的末尾求值，此刻写入才赶得上同一拍的结算。进店没能下种时收获为空，
+    // 事实置假，正好落进「培育已了结但没拿到目标」那一条终止规则。
+    const bool obtained =
+        std::find(m_cultivated_animal_types.begin(), m_cultivated_animal_types.end(), m_cultivation_target) !=
+        m_cultivated_animal_types.end();
+    std::string error;
+    if (!set_fact("cultivation_target_obtained", obtained, &error)) {
+        Log.error("BlackFlow cultivation target fact update failed", error);
     }
 }
 
@@ -459,14 +431,14 @@ void BlackFlowSession::evaluate_terminal_rules()
         if (!rule.when.evaluate(facts)) {
             continue;
         }
-        const int cultivated =
-            static_cast<int>(std::clamp<std::int64_t>(integer_fact(facts, "cultivated_animals"), 0, 3));
+        const int cultivated = static_cast<int>(
+            std::clamp<std::int64_t>(integer_fact(facts, "cultivated_animals"), 0, std::numeric_limits<int>::max()));
         BlackFlowStrategyResult result {
             m_profile, rule.outcome, rule.reason, cultivated, rule.succeeded,
         };
         result.next_action =
             rule.next_action.empty() ? (rule.succeeded ? "stop_run" : m_policy->failure_action) : rule.next_action;
-        if (m_profile == "baby_animal" && result.outcome == "baby_cultivation_completed") {
+        if (is_baby_animal_profile(m_profile) && result.outcome == "baby_cultivation_completed") {
             result.cultivation_target = std::string(to_string(m_cultivation_target));
             result.cultivated_animal_types.reserve(m_cultivated_animal_types.size());
             for (const CultivatedAnimalType type : m_cultivated_animal_types) {

--- a/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowSession.h
+++ b/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowSession.h
@@ -33,6 +33,12 @@ enum class CultivatedAnimalType
 [[nodiscard]] std::optional<CultivatedAnimalType> parse_cultivated_animal_type(std::string_view value) noexcept;
 [[nodiscard]] std::optional<CultivatedAnimalType> cultivated_animal_type_from_name(std::string_view name) noexcept;
 
+// 襁褓羽蛇与襁褓三头犬要求本次探索通过至少两个区域才在下一局生效，因此它们走的策略
+// 与猫、狗不同：培育出目标之后还要进入第三层才收工。两条策略共用同一份路线模块，
+// 差别只在秘境行商目标的终点语义与终止规则，所以在这里按目标选 profile。
+[[nodiscard]] std::string_view baby_animal_profile_for(CultivatedAnimalType target) noexcept;
+[[nodiscard]] bool is_baby_animal_profile(std::string_view profile) noexcept;
+
 struct BlackFlowStrategyResult
 {
     std::string profile;

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -1530,9 +1530,10 @@ Right-click to clear inactive jobs</system:String>
     <system:String x:Key="BlackFlowMilestoneBurnFloor2Final">Reach the final node on floor 2</system:String>
     <system:String x:Key="BlackFlowMilestoneBabyCheckSeedShop">Check the floor 1 shop for seeds</system:String>
     <system:String x:Key="BlackFlowMilestoneBabyCultivateScrapShop">Enter a scrap trader on floors 1-3 to cultivate seeds</system:String>
+    <system:String x:Key="BlackFlowMilestoneBabyCultivateScrapShopTransit">Enter a scrap trader on floors 1-2 to cultivate seeds, then head for the exit</system:String>
+    <system:String x:Key="BlackFlowMilestoneBabyCultivateScrapShopFinal">Enter the scrap trader on floor 3 to cultivate seeds</system:String>
     <system:String x:Key="BlackFlowMilestoneBabyExploreHidden">Reveal as many unknown nodes as possible until a scrap trader is found</system:String>
     <system:String x:Key="BlackFlowMilestoneBabyVisitIncident">Visit an encounter along the way</system:String>
-    <system:String x:Key="BlackFlowMilestoneBabyVisitLight">Visit a vantage point along the way</system:String>
     <system:String x:Key="BlackFlowMilestoneBabyFloor2Shops">Continue collecting seeds when visiting a normal shop on floor 2</system:String>
     <system:String x:Key="BlackFlowMilestoneBabyFloor3Shops">Sell items, refresh stock, and collect seeds when visiting a normal shop on floor 3</system:String>
     <system:String x:Key="BlackFlowMilestoneEnding2SandtableA">Obtain Sandtable A</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -1532,9 +1532,10 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="BlackFlowMilestoneBurnFloor2Final">第2層の険路の果てに到達</system:String>
     <system:String x:Key="BlackFlowMilestoneBabyCheckSeedShop">第1層の商店で種子を確認</system:String>
     <system:String x:Key="BlackFlowMilestoneBabyCultivateScrapShop">第1〜3層で秘境の行商人に入り種子を育成</system:String>
+    <system:String x:Key="BlackFlowMilestoneBabyCultivateScrapShopTransit">第1〜2層で秘境の行商人に入り種子を育成してから層の出口へ</system:String>
+    <system:String x:Key="BlackFlowMilestoneBabyCultivateScrapShopFinal">第3層で秘境の行商人に入り種子を育成</system:String>
     <system:String x:Key="BlackFlowMilestoneBabyExploreHidden">秘境の行商人が見つかるまで未知の怪奇をできるだけ開拓</system:String>
     <system:String x:Key="BlackFlowMilestoneBabyVisitIncident">道中で不意の遭遇に入る</system:String>
-    <system:String x:Key="BlackFlowMilestoneBabyVisitLight">道中で羽瞰点に入る</system:String>
     <system:String x:Key="BlackFlowMilestoneBabyFloor2Shops">第2層は通常商店に立ち寄って種子を入手し続ける</system:String>
     <system:String x:Key="BlackFlowMilestoneBabyFloor3Shops">第3層は通常商店で売却・品揃え更新を行い種子をできるだけ購入</system:String>
     <system:String x:Key="BlackFlowMilestoneEnding2SandtableA">砂盤Aを入手</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -1533,9 +1533,10 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="BlackFlowMilestoneBurnFloor2Final">2구역 험로의 끝 도달</system:String>
     <system:String x:Key="BlackFlowMilestoneBabyCheckSeedShop">1구역 상점에서 종자 확인</system:String>
     <system:String x:Key="BlackFlowMilestoneBabyCultivateScrapShop">1~3구역 신비한 상인에 들어가 종자 육성</system:String>
+    <system:String x:Key="BlackFlowMilestoneBabyCultivateScrapShopTransit">1~2구역 신비한 상인에서 종자를 육성한 뒤 출구로 이동</system:String>
+    <system:String x:Key="BlackFlowMilestoneBabyCultivateScrapShopFinal">3구역 신비한 상인에 들어가 종자 육성</system:String>
     <system:String x:Key="BlackFlowMilestoneBabyExploreHidden">신비한 상인을 발견할 때까지 미지의 괴이를 최대한 개척</system:String>
     <system:String x:Key="BlackFlowMilestoneBabyVisitIncident">가는 길에 우연한 만남 진입</system:String>
-    <system:String x:Key="BlackFlowMilestoneBabyVisitLight">가는 길에 깃털 조망점 진입</system:String>
     <system:String x:Key="BlackFlowMilestoneBabyFloor2Shops">2구역은 교활한 상인 경유 시 종자 계속 획득</system:String>
     <system:String x:Key="BlackFlowMilestoneBabyFloor3Shops">3구역은 교활한 상인 경유 시 판매·진열 갱신 후 종자 최대한 구매</system:String>
     <system:String x:Key="BlackFlowMilestoneEnding2SandtableA">사판 A 획득</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -1530,9 +1530,10 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="BlackFlowMilestoneBurnFloor2Final">第二层抵达险路尽头</system:String>
     <system:String x:Key="BlackFlowMilestoneBabyCheckSeedShop">第一层检查商店中的种子</system:String>
     <system:String x:Key="BlackFlowMilestoneBabyCultivateScrapShop">第一至三层进入秘境行商培育种子</system:String>
+    <system:String x:Key="BlackFlowMilestoneBabyCultivateScrapShopTransit">第一、二层进入秘境行商培育种子后前往层出口</system:String>
+    <system:String x:Key="BlackFlowMilestoneBabyCultivateScrapShopFinal">第三层进入秘境行商培育种子</system:String>
     <system:String x:Key="BlackFlowMilestoneBabyExploreHidden">尚未发现秘境行商时尽量多开未知的诡秘</system:String>
     <system:String x:Key="BlackFlowMilestoneBabyVisitIncident">顺路进入不期而遇</system:String>
-    <system:String x:Key="BlackFlowMilestoneBabyVisitLight">顺路进入羽瞰点</system:String>
     <system:String x:Key="BlackFlowMilestoneBabyFloor2Shops">第二层经过普通商店时继续获取种子</system:String>
     <system:String x:Key="BlackFlowMilestoneBabyFloor3Shops">第三层经过普通商店时卖货、刷新并尽量购买种子</system:String>
     <system:String x:Key="BlackFlowMilestoneEnding2SandtableA">获得沙盘 A</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -1531,9 +1531,10 @@ C:\\leidian\\LDPlayer9
     <system:String x:Key="BlackFlowMilestoneBurnFloor2Final">第二層抵達險路盡頭</system:String>
     <system:String x:Key="BlackFlowMilestoneBabyCheckSeedShop">第一層檢查商店中的種子</system:String>
     <system:String x:Key="BlackFlowMilestoneBabyCultivateScrapShop">第一至三層進入秘境行商培育種子</system:String>
+    <system:String x:Key="BlackFlowMilestoneBabyCultivateScrapShopTransit">第一、二層進入秘境行商培育種子後前往層出口</system:String>
+    <system:String x:Key="BlackFlowMilestoneBabyCultivateScrapShopFinal">第三層進入秘境行商培育種子</system:String>
     <system:String x:Key="BlackFlowMilestoneBabyExploreHidden">尚未發現秘境行商時盡量多開未知的詭秘</system:String>
     <system:String x:Key="BlackFlowMilestoneBabyVisitIncident">順路進入不期而遇</system:String>
-    <system:String x:Key="BlackFlowMilestoneBabyVisitLight">順路進入羽瞰點</system:String>
     <system:String x:Key="BlackFlowMilestoneBabyFloor2Shops">第二層經過普通商店時繼續獲取種子</system:String>
     <system:String x:Key="BlackFlowMilestoneBabyFloor3Shops">第三層經過普通商店時賣貨、刷新並盡量購買種子</system:String>
     <system:String x:Key="BlackFlowMilestoneEnding2SandtableA">獲得沙盤 A</system:String>

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/RoguelikeSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/RoguelikeSettingsUserControlModel.cs
@@ -908,7 +908,7 @@ public class RoguelikeSettingsUserControlModel : TaskSettingsViewModel, Roguelik
     {
         "investment" => LocalizationHelper.GetString("RoguelikeStrategyBlackFlowInvestment"),
         "burn" or "burn_with_investment" => LocalizationHelper.GetString("RoguelikeStrategyBlackFlowExp"),
-        "baby_animal" => LocalizationHelper.GetString("RoguelikeStrategyBlackFlowBabyAnimal"),
+        "baby_animal" or "baby_animal_floor3" => LocalizationHelper.GetString("RoguelikeStrategyBlackFlowBabyAnimal"),
         _ => LocalizationHelper.GetString("BlackFlowStrategyUnknown"),
     };
 


### PR DESCRIPTION
- 两类目标改为进入第三层后结算
- 第一、二层保留加工品，第三层统一出售
- 放宽培育数量记录范围
- 羽瞰点仅在顺路时经过