### PR TITLE
fix: 修复规划器单拍gap

### DIFF
--- a/resource/roguelike/BlackFlow/strategy.json
+++ b/resource/roguelike/BlackFlow/strategy.json
@@ -30,8 +30,12 @@
             "description": "可跨层保留的全图移动加工品"
         },
         {
-            "id": "persistent_long_range_movement",
-            "description": "可跨层保留的长距离移动加工品"
+            "id": "persistent_reach_scrap_shop",
+            "description": "可跨层保留、且能落到秘境行商上的全图移动加工品"
+        },
+        {
+            "id": "persistent_reach_battle_boss",
+            "description": "可跨层保留、且能落到险路恶敌上的全图移动加工品"
         },
         {
             "id": "rogue_6_scrap_M_11",
@@ -75,7 +79,12 @@
             "scope": "run"
         },
         {
-            "name": "persistent_long_range_count",
+            "name": "persistent_reach_scrap_shop_count",
+            "type": "int",
+            "scope": "run"
+        },
+        {
+            "name": "persistent_reach_battle_boss_count",
             "type": "int",
             "scope": "run"
         },
@@ -456,8 +465,56 @@
             "id": "ending_development",
             "reserves": [
                 {
+                    "id": "keep_processing_move_for_boss",
+                    "description": "第三、五层持有白模鸟或涂装黎博利时，留一次能落到险路恶敌上的全图移动",
+                    "resource": "persistent_reach_battle_boss",
+                    "minimum": 1,
+                    "active_if": {
+                        "all": [
+                            {
+                                "any": [
+                                    {
+                                        "fact": "current_floor",
+                                        "op": "eq",
+                                        "value": 3
+                                    },
+                                    {
+                                        "fact": "current_floor",
+                                        "op": "eq",
+                                        "value": 5
+                                    }
+                                ]
+                            },
+                            {
+                                "any": [
+                                    {
+                                        "fact": "white_model_bird_count",
+                                        "op": "gt",
+                                        "value": 0
+                                    },
+                                    {
+                                        "fact": "painted_liberi_owned",
+                                        "op": "eq",
+                                        "value": true
+                                    }
+                                ]
+                            },
+                            {
+                                "fact": "persistent_reach_battle_boss_count",
+                                "op": "ge",
+                                "value": 1
+                            }
+                        ]
+                    },
+                    "release_if": {
+                        "fact": "candidate.node_type",
+                        "op": "eq",
+                        "value": "battle_boss"
+                    }
+                },
+                {
                     "id": "keep_full_map_before_floor4",
-                    "description": "前三层保留一次全图移动，留给第四、五层的远端节点",
+                    "description": "前三层保留一次全图移动，留给第四、五层的远端节点；花在险路恶敌上不算违背",
                     "resource": "persistent_full_map_movement",
                     "minimum": 1,
                     "active_if": {
@@ -473,6 +530,11 @@
                                 "value": 1
                             }
                         ]
+                    },
+                    "release_if": {
+                        "fact": "candidate.node_type",
+                        "op": "eq",
+                        "value": "battle_boss"
                     }
                 }
             ],
@@ -1220,7 +1282,7 @@
             "reserves": [
                 {
                     "id": "baby_keep_cultivation_movement",
-                    "resource": "persistent_long_range_movement",
+                    "resource": "persistent_reach_scrap_shop",
                     "minimum": 1,
                     "active_if": {
                         "all": [
@@ -1230,25 +1292,16 @@
                                 "value": false
                             },
                             {
-                                "fact": "persistent_long_range_count",
+                                "fact": "persistent_reach_scrap_shop_count",
                                 "op": "ge",
                                 "value": 1
                             }
                         ]
                     },
                     "release_if": {
-                        "any": [
-                            {
-                                "fact": "candidate.node_type",
-                                "op": "eq",
-                                "value": "scrap_shop"
-                            },
-                            {
-                                "fact": "candidate.guaranteed_route_node_types",
-                                "op": "contains",
-                                "value": "scrap_shop"
-                            }
-                        ]
+                        "fact": "candidate.node_type",
+                        "op": "eq",
+                        "value": "scrap_shop"
                     }
                 }
             ],

--- a/src/MaaCore/Config/Roguelike/BlackFlow/BlackFlowStrategyConfig.cpp
+++ b/src/MaaCore/Config/Roguelike/BlackFlow/BlackFlowStrategyConfig.cpp
@@ -714,15 +714,28 @@ PolicyProfile parse_profile(const json::value& value)
     return result;
 }
 
+// 整条投影路线算出来的候选事实。它们回答的是「按本拍的计划，以后会经过什么」，而计划逐拍
+// 从零重算、从不提交，因此只能当转向依据，不能当许可依据。
+bool is_route_projection_fact(const std::string& name)
+{
+    static const std::unordered_set<std::string> Projection = {
+        "candidate.route_node_types",          "candidate.guaranteed_route_node_types",
+        "candidate.route_has_badged",          "candidate.guaranteed_route_has_badged",
+        "candidate.route_has_badged_incident", "candidate.guaranteed_route_has_badged_incident",
+    };
+    return Projection.contains(name);
+}
+
 void validate_condition(
     const Condition& condition,
     const std::unordered_map<std::string, FactDefinition>& facts,
-    bool allow_candidate)
+    bool allow_candidate,
+    bool allow_route_projection = true)
 {
     if (condition.kind == ConditionKind::All || condition.kind == ConditionKind::Any ||
         condition.kind == ConditionKind::Not) {
         for (const auto& child : condition.children) {
-            validate_condition(child, facts, allow_candidate);
+            validate_condition(child, facts, allow_candidate, allow_route_projection);
         }
         return;
     }
@@ -735,6 +748,12 @@ void validate_condition(
     }
     if (!allow_candidate && definition->second.scope == FactScope::Candidate) {
         invalid_config("non-candidate condition references candidate fact: " + condition.fact);
+    }
+    // 资源预留一旦释放，那一份资源当拍就被花掉，收不回来。拿「以后会经过」去授权一次不可逆的
+    // 消耗，等于把单拍的计划当成了承诺；实测过的后果是留给秘境行商的最后一次长距离移动被用来
+    // 飞别处。释放条件只能看这一步本身。
+    if (!allow_route_projection && is_route_projection_fact(condition.fact)) {
+        invalid_config("resource reserve release condition references a route projection fact: " + condition.fact);
     }
     if (condition.compare == CompareOperator::Exists || condition.compare == CompareOperator::NotExists) {
         return;
@@ -781,7 +800,7 @@ void validate_module(
             invalid_config("resource reserve references unknown resource: " + reserve.resource);
         }
         validate_condition(reserve.active_if, facts, false);
-        validate_condition(reserve.release_if, facts, true);
+        validate_condition(reserve.release_if, facts, true, false);
     }
     for (const auto& milestone : module.milestones) {
         if (!ids.emplace("milestone:" + milestone.id).second) {

--- a/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowModel.cpp
+++ b/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowModel.cpp
@@ -646,6 +646,11 @@ bool node_type_allowed(const MovementSpec& movement, NodeType type) noexcept
     return std::ranges::find(movement.target_types, type) != movement.target_types.end();
 }
 
+const std::vector<NodeType>& all_target_node_types() noexcept
+{
+    return AllTargetTypes;
+}
+
 const std::vector<MovementSpec>& movement_specs()
 {
     static const std::vector<MovementSpec> Specs = {

--- a/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowModel.h
+++ b/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowModel.h
@@ -307,6 +307,10 @@ struct MovementSpec
 
 [[nodiscard]] bool node_type_allowed(const MovementSpec& movement, NodeType type) noexcept;
 
+// 加工品移动可以作为落点的全部节点类型。按落点能力划分资源时需要逐个遍历，取用同一份表
+// 可以保证资源定义与候选生成用的白名单不会分叉。
+[[nodiscard]] const std::vector<NodeType>& all_target_node_types() noexcept;
+
 struct DynamicCostModel
 {
     int walk_cost_per_edge = 1;

--- a/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowPolicy.cpp
+++ b/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowPolicy.cpp
@@ -419,26 +419,21 @@ ResourceRegistry::ResourceRegistry()
     register_resource("sellable_scraps", [](const RunState& state) { return state.resources.sellable_scraps; });
     register_resource("white_model_bird", [](const RunState& state) { return state.resources.white_model_birds; });
     register_resource("painted_liberi", [](const RunState& state) { return state.resources.painted_liberi ? 1 : 0; });
-    register_resource("persistent_full_map_movement", [](const RunState& state) {
-        std::int64_t total = 0;
-        for (const auto& spec : movement_specs()) {
-            if (spec.range == MovementRange::FullMap && !spec.expires_on_floor_end) {
-                total += movement_count(state, spec.kind);
-            }
-        }
-        return total;
+    // 跨层保留的全图移动。它服务的是「留给后面的楼层」这类目标，与落点无关，因此不筛目标类型。
+    register_movement_group("persistent_full_map_movement", [](const MovementSpec& spec) {
+        return spec.range == MovementRange::FullMap && !spec.expires_on_floor_end;
     });
-    register_resource("persistent_long_range_movement", [](const RunState& state) {
-        std::int64_t total = 0;
-        for (const auto& spec : movement_specs()) {
-            const bool long_range =
-                spec.range == MovementRange::FullMap || spec.range == MovementRange::OrthogonalThree;
-            if (long_range && !spec.expires_on_floor_end) {
-                total += movement_count(state, spec.kind);
-            }
-        }
-        return total;
-    });
+
+    // 「留一次移动给某类节点」是策略矩阵里反复出现的形状：襁褓动物留给秘境行商、结局策略留给
+    // 险路恶敌，将来还会有留给误入奇境和险路尽头的。真正要留住的性质是「从任何位置都能落到那类
+    // 节点上」，而不是射程本身——射程够远但落点白名单不含目标的加工品（老妈妈的融雪落不了战斗、
+    // 坎诺特的触须只落行商）留下来也够不着。因此按落点能力逐个节点类型登记，策略各取所需。
+    for (const NodeType type : all_target_node_types()) {
+        register_movement_group("persistent_reach_" + std::string(to_string(type)), [type](const MovementSpec& spec) {
+            return spec.range == MovementRange::FullMap && !spec.expires_on_floor_end && node_type_allowed(spec, type);
+        });
+    }
+
     for (const auto& spec : movement_specs()) {
         if (spec.kind == MovementKind::Walk) {
             continue;
@@ -446,6 +441,29 @@ ResourceRegistry::ResourceRegistry()
         const MovementKind kind = spec.kind;
         register_resource(std::string(spec.id), [kind](const RunState& state) { return movement_count(state, kind); });
     }
+}
+
+// 组合资源的成员表只算一次，读数与「走完这一步还剩几次」共用同一份，两边不会漂移。
+bool ResourceRegistry::register_movement_group(std::string id, const std::function<bool(const MovementSpec&)>& member)
+{
+    std::unordered_set<MovementKind> members;
+    for (const auto& spec : movement_specs()) {
+        if (spec.kind != MovementKind::Walk && member(spec)) {
+            members.emplace(spec.kind);
+        }
+    }
+    const auto inserted = m_movement_groups.emplace(id, std::move(members));
+    if (!inserted.second) {
+        return false;
+    }
+    std::unordered_set<MovementKind> kinds = inserted.first->second;
+    return register_resource(std::move(id), [kinds = std::move(kinds)](const RunState& state) {
+        std::int64_t total = 0;
+        for (const MovementKind kind : kinds) {
+            total += movement_count(state, kind);
+        }
+        return total;
+    });
 }
 
 bool ResourceRegistry::register_resource(std::string id, Reader reader)
@@ -480,21 +498,12 @@ std::optional<std::int64_t>
     }
     if (candidate.movement != MovementKind::Walk) {
         const MovementSpec* movement = find_movement_spec(candidate.movement);
-        if (movement != nullptr) {
-            if (id == movement->id) {
-                --after;
-            }
-            const bool persistent_full_map =
-                movement->range == MovementRange::FullMap && !movement->expires_on_floor_end;
-            const bool persistent_long_range =
-                (movement->range == MovementRange::FullMap || movement->range == MovementRange::OrthogonalThree) &&
-                !movement->expires_on_floor_end;
-            if (id == "persistent_full_map_movement" && persistent_full_map) {
-                --after;
-            }
-            if (id == "persistent_long_range_movement" && persistent_long_range) {
-                --after;
-            }
+        if (movement != nullptr && id == movement->id) {
+            --after;
+        }
+        if (const auto group = m_movement_groups.find(std::string(id));
+            group != m_movement_groups.end() && group->second.contains(candidate.movement)) {
+            --after;
         }
     }
     return after;

--- a/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowPolicy.h
+++ b/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowPolicy.h
@@ -346,6 +346,9 @@ public:
 
     ResourceRegistry();
     bool register_resource(std::string id, Reader reader);
+    // 登记一个由若干移动方式合起来构成的资源。成员表存下来供 read_after 判断这一步扣不扣，
+    // 因此读数与扣减用的是同一份定义。
+    bool register_movement_group(std::string id, const std::function<bool(const MovementSpec&)>& member);
     [[nodiscard]] bool contains(std::string_view id) const noexcept;
     [[nodiscard]] std::optional<std::int64_t> read(std::string_view id, const RunState& state) const;
     [[nodiscard]] std::optional<std::int64_t>
@@ -353,6 +356,7 @@ public:
 
 private:
     std::unordered_map<std::string, Reader> m_readers;
+    std::unordered_map<std::string, std::unordered_set<MovementKind>> m_movement_groups;
 };
 
 struct PlannedRouteStep

--- a/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowSession.cpp
+++ b/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowSession.cpp
@@ -325,8 +325,9 @@ bool BlackFlowSession::synchronize_resource_facts(std::string* error)
         { "sellable_scraps", m_run.resources.sellable_scraps },
         { "white_model_bird_count", m_run.resources.white_model_birds },
         { "painted_liberi_owned", m_run.resources.painted_liberi ? 1 : 0 },
-        { "persistent_long_range_count", m_resources.read("persistent_long_range_movement", m_run).value_or(0) },
         { "persistent_full_map_count", m_resources.read("persistent_full_map_movement", m_run).value_or(0) },
+        { "persistent_reach_scrap_shop_count", m_resources.read("persistent_reach_scrap_shop", m_run).value_or(0) },
+        { "persistent_reach_battle_boss_count", m_resources.read("persistent_reach_battle_boss", m_run).value_or(0) },
     };
     for (const auto& [name, value] : values) {
         if (name == "painted_liberi_owned") {


### PR DESCRIPTION
## Sourcery 摘要

通过基于即时可达性进行移动资源预留，并防止预测路线释放受保护的资源，修正单步间隙规划。

错误修复：
- 防止路线预测事实在单步规划期间授权释放不可逆的资源预留。
- 按持久移动资源实际可到达的节点类型对其进行跟踪，确保预留的移动资源仍可用于其预定目的地。

改进：
- 统一移动组资源核算与移动后的扣减逻辑，确保资源可用性保持一致。
- 暴露完整的移动目标节点类型集合，用于资源注册和候选项生成。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Correct single-step gap planning by basing movement reservations on immediate reachability and preventing projected routes from releasing protected resources.

Bug Fixes:
- Prevent route-projection facts from authorizing irreversible resource reservation releases during single-step planning.
- Track persistent movement resources by the node types they can actually reach, ensuring reserved movements remain usable for their intended destinations.

Enhancements:
- Unify movement-group resource accounting and post-move deductions so resource availability stays consistent.
- Expose the complete set of movement target node types for resource registration and candidate generation.

</details>