### PR TITLE
perf: 机械师基建技能“我睡过了”效率值优化

### DIFF
--- a/resource/infrast.json
+++ b/resource/infrast.json
@@ -2037,6 +2037,9 @@
             },
             "bskill_man_spd_mechanist": {
                 "desc": ["进驻制造站时，若单次工作时长达到12小时，生产力+10%"],
+                "efficient": {
+                    "all": 4.9
+                },
                 "name": ["“我睡过了”"],
                 "operatorIds": ["char_4230_mcnist"],
                 "template": "Bskill_man_spd_mechanist.png"


### PR DESCRIPTION
假设按照30%阈值把24精力用到7，那应该会连续工作(17/.65)小时，这种情况下的等效效率是((17/0.65)-12)/(17/0.65)*10 = 5.41

考虑到这东西没有真的35好用（可能被MAA自作主张换干员中断计时），但还是比没有好，先给个4.9试试？

## Sourcery 摘要

增强功能：
- 调整基础设施数据，以考虑“我睡过头了”这一情况，并将效率值估算为 4.9%。
<img width="1862" height="180" alt="image" src="https://github.com/user-attachments/assets/e86a22e8-4653-43d2-85d7-e09c4f99288b" />

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enhancements:
- Adjust the infrastructure data to account for the “I overslept” condition with an estimated 4.9% efficiency value.

</details>