### PR TITLE
fix: 修复基建配置热重载时旧数据残留导致的崩溃

### DIFF
--- a/src/MaaCore/Config/Miscellaneous/InfrastConfig.cpp
+++ b/src/MaaCore/Config/Miscellaneous/InfrastConfig.cpp
@@ -8,6 +8,8 @@ bool asst::InfrastConfig::parse(const json::value& json)
 {
     LogTraceFunction;
 
+    clear();
+
     for (const json::value& facility : json.at("roomType").as_array()) {
         std::string facility_name = facility.as_string();
         const json::value& facility_json = json.at(facility_name);
@@ -212,4 +214,14 @@ bool asst::InfrastConfig::parse(const json::value& json)
         m_facilities_info.emplace(facility_name, std::move(fac_info));
     }
     return true;
+}
+
+void asst::InfrastConfig::clear()
+{
+    LogTraceFunction;
+
+    m_skills.clear();
+    m_skills_groups.clear();
+    m_facilities_info.clear();
+    m_templ_required.clear();
 }

--- a/src/MaaCore/Config/Miscellaneous/InfrastConfig.h
+++ b/src/MaaCore/Config/Miscellaneous/InfrastConfig.h
@@ -41,6 +41,8 @@ public:
 protected:
     virtual bool parse(const json::value& json) override;
 
+    void clear();
+
     // 所有基建技能，key：设施名，value：map<技能id，技能>
     std::unordered_map<std::string, std::unordered_map<std::string, infrast::Skill>> m_skills;
     // 所有设施信息，key：设施名，value：信息


### PR DESCRIPTION
同进程内二次 AsstLoadResource 时（资源更新后重载），InfrastConfig 单例的 m_skills 等 map 未清理，emplace 对已有 key 不覆盖，新表被静默丢弃（沟槽的emplace ），
若新版 infrast.json 的 skillsGroup 引用了改名后的技能 ID（如 #17835 将 bskill_tra_Lappland1 改为小写），m_skills.at() 抛出
unordered_map::at: key not found，资源加载整体失败

后面那个@就出现问题了，拿着旧的数据@了新的技能
```
m_skills.at(facility_name).at(skill_json.as_string());
```

## Sourcery 总结

错误修复：
- 在解析资源之前清除缓存的基础设施配置数据，以防止过时的技能和设施条目导致重新加载失败。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Clear cached infrastructure configuration data before parsing resources to prevent stale skills and facility entries from causing reload failures.

</details>