### PR TITLE
fix: 在技能3的支持条件中允许阿米娅

### DIFF
--- a/src/MaaCore/Config/Miscellaneous/CopilotConfig.cpp
+++ b/src/MaaCore/Config/Miscellaneous/CopilotConfig.cpp
@@ -57,10 +57,12 @@ std::optional<asst::battle::OperUsage> asst::CopilotConfig::parse_oper_usage(con
     oper.name = json.at("name").as_string();
     oper.skill = json.get("skill", 0);
     oper.skill_usage = static_cast<battle::SkillUsage>(json.get("skill_usage", 0));
-    oper.skill_times = json.get("skill_times", 1);                       // 使用技能的次数，默认为 1，兼容曾经的作业
+    oper.skill_times = json.get("skill_times", 1); // 使用技能的次数，默认为 1，兼容曾经的作业
 
-    int rarity = BattleDataConfig::get_instance().get_rarity(oper.name); // 兼容古早旧作业中非法的技能选择
-    if (oper.skill == 3 && rarity < 6) {
+    const auto& oper_props = BattleDataConfig::get_instance().find_oper(oper.role, oper.name);
+    int rarity = oper_props ? oper_props->rarity : 0;
+    std::string id = oper_props ? oper_props->id : std::string();
+    if (oper.skill == 3 && rarity < 6 && id != "char_002_amiya") {
         LogError << __FUNCTION__ << "| Oper " << oper.name << " with rarity " << rarity
                  << " cannot use skill index 3, set to 0.";
         oper.skill = 0;

--- a/src/MaaCore/Config/Miscellaneous/CopilotConfig.cpp
+++ b/src/MaaCore/Config/Miscellaneous/CopilotConfig.cpp
@@ -57,12 +57,16 @@ std::optional<asst::battle::OperUsage> asst::CopilotConfig::parse_oper_usage(con
     oper.name = json.at("name").as_string();
     oper.skill = json.get("skill", 0);
     oper.skill_usage = static_cast<battle::SkillUsage>(json.get("skill_usage", 0));
-    oper.skill_times = json.get("skill_times", 1);                       // 使用技能的次数，默认为 1，兼容曾经的作业
+    oper.skill_times = json.get("skill_times", 1); // 使用技能的次数，默认为 1，兼容曾经的作业
 
-    const auto& oper_props = BattleDataConfig::get_instance().find_oper(oper.role, oper.name);
-    int rarity = oper_props ? oper_props->rarity : 0;
-    std::string id = oper_props ? oper_props->id : std::string();
-    if (oper.skill == 3 && rarity < 6 && id != "char_002_amiya") {
+    // 兼容古早旧作业中非法的技能选择
+    const auto& oper_props_opt = BattleData.find_oper(oper.role, oper.name);
+    if (!oper_props_opt) {
+        LogError << __FUNCTION__ << "| Oper" << oper.name << "with role" << enum_to_string(oper.role)
+                 << "not found in BattleData.";
+    }
+    int rarity =  oper_props_opt->rarity ;
+    if (oper.skill == 3 && rarity < 6 && oper_props_opt->id != "char_002_amiya") {
         LogError << __FUNCTION__ << "| Oper " << oper.name << " with rarity " << rarity
                  << " cannot use skill index 3, set to 0.";
         oper.skill = 0;

--- a/src/MaaCore/Config/Miscellaneous/CopilotConfig.cpp
+++ b/src/MaaCore/Config/Miscellaneous/CopilotConfig.cpp
@@ -57,7 +57,7 @@ std::optional<asst::battle::OperUsage> asst::CopilotConfig::parse_oper_usage(con
     oper.name = json.at("name").as_string();
     oper.skill = json.get("skill", 0);
     oper.skill_usage = static_cast<battle::SkillUsage>(json.get("skill_usage", 0));
-    oper.skill_times = json.get("skill_times", 1); // 使用技能的次数，默认为 1，兼容曾经的作业
+    oper.skill_times = json.get("skill_times", 1);                       // 使用技能的次数，默认为 1，兼容曾经的作业
 
     const auto& oper_props = BattleDataConfig::get_instance().find_oper(oper.role, oper.name);
     int rarity = oper_props ? oper_props->rarity : 0;

--- a/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
@@ -1163,8 +1163,9 @@ public partial class CopilotViewModel : Screen
         var list = copilot.Opers.Concat(copilot.Groups.SelectMany(g => g.Opers)).ToList();
         foreach (var oper in list)
         {
-            int rarity = DataHelper.GetCharacterByNameOrAlias(oper.Name)?.Rarity ?? -1;
-            string id = DataHelper.GetCharacterByNameOrAlias(oper.Name)?.Id ?? string.Empty;
+            var character = DataHelper.GetCharacterByNameOrAlias(oper.Name);
+            int rarity = character?.Rarity ?? -1;
+            string id = character?.Id ?? string.Empty;
             switch (oper.Skill)
             {
                 case 3 when rarity < 6 && id != "char_002_amiya":

--- a/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
@@ -1164,9 +1164,10 @@ public partial class CopilotViewModel : Screen
         foreach (var oper in list)
         {
             int rarity = DataHelper.GetCharacterByNameOrAlias(oper.Name)?.Rarity ?? -1;
+            string id = DataHelper.GetCharacterByNameOrAlias(oper.Name)?.Id ?? string.Empty;
             switch (oper.Skill)
             {
-                case 3 when rarity < 6:
+                case 3 when rarity < 6 && id != "char_002_amiya":
                 case 2 when rarity < 4:
                 case 1 when rarity < 3:
                     AddLog(LocalizationHelper.GetStringFormat("Copilot.UnsupportedSkill", DataHelper.GetLocalizedCharacterName(oper.Name) ?? oper.Name, oper.Skill), UiLogColor.Warning, showTime: false);


### PR DESCRIPTION
## Sourcery 摘要

错误修复：
- 在 Copilot 支持条件验证中，允许阿米娅使用技能 3，不受通常的稀有度限制。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

错误修复：
- 在 Copilot 支持验证中，允许阿米娅使用技能 3，不受通常稀有度限制的影响。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

错误修复：
- 尽管 Amiya 的稀有度有限，仍允许她在 Copilot 支持验证中使用技能 3。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

错误修复：
- 尽管阿米娅的稀有度低于标准要求，但仍允许她在 Copilot 验证中使用技能 3。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

错误修复：
- 尽管阿米娅的稀有度较低，仍允许她在 Copilot 验证期间使用技能 3。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Allow Amiya to use skill 3 during Copilot validation despite her lower rarity.

</details>

</details>

</details>

</details>

</details>