### PR TITLE
fix: 基建布局识别失败时继续缩小视图重试

### DIFF
--- a/src/MaaCore/Task/Infrast/InfrastInfoTask.cpp
+++ b/src/MaaCore/Task/Infrast/InfrastInfoTask.cpp
@@ -414,6 +414,23 @@ bool asst::InfrastInfoTask::_run()
     Log.info("InfrastInfoTask | zoom gesture", zoom_sent ? "sent" : "unsupported");
 
     constexpr int MaxAttempts = 3;
+    const auto prepare_retry = [&](int attempt) {
+        // A pinch may advance only one zoom level. When the first gesture leaves
+        // the overview at an intermediate scale, waiting cannot make the fixed-size
+        // normal or mini templates match; pinch again before retrying.
+        if (zoom_sent && attempt < MaxAttempts) {
+            const bool retry_zoom_sent = try_zoom_out();
+            Log.info(
+                "InfrastInfoTask | retry zoom gesture",
+                retry_zoom_sent ? "sent" : "unsupported",
+                "after attempt",
+                attempt);
+            if (retry_zoom_sent) {
+                return;
+            }
+        }
+        sleep(300);
+    };
     std::optional<FacilityLayoutCounts> partial_layout_candidate;
     for (int attempt = 1; attempt <= MaxAttempts; ++attempt) {
         if (need_exit()) {
@@ -427,7 +444,7 @@ bool asst::InfrastInfoTask::_run()
         if (!analyzer.analyze()) {
             partial_layout_candidate.reset();
             Log.warn("InfrastInfoTask | no facility matched, attempt", attempt);
-            sleep(300);
+            prepare_retry(attempt);
             continue;
         }
 
@@ -461,7 +478,7 @@ bool asst::InfrastInfoTask::_run()
                 attempt,
                 "view",
                 static_cast<int>(analyzer.get_view_type()));
-            sleep(300);
+            prepare_retry(attempt);
             continue;
         }
 


### PR DESCRIPTION
## 变更内容

- 基建常规模式识别设施布局失败时，再次执行缩小视图后重试
- 设施完全未命中或布局结果不一致时均应用该逻辑
- 保留原有的 3 次识别上限，不会无限缩小或重试

## 问题原因

在 MuMu 12 上，单次双指捏合可能只缩小一个档位。

当基建以较大的视图进入时，首次捏合会停在中间缩放档。现有设施模板仅覆盖正常视图和最小视图，无法匹配中间档，因此会触发 `FacilityLayoutRecognitionFailed`。

原有重试逻辑只等待 300 ms，没有继续改变缩放状态，所以后续识别仍会失败。任务失败后再次运行时，由于画面保留在中间档，第二次捏合能够进入最小视图，因此表现为偶发成功，或失败与成功交替出现。

## 修复方式

首次缩小后，如果设施未命中或识别出的布局不可用，则在下一次识别前再次执行缩小手势。

单次任务最多执行 3 次缩小和 3 次识别；到达最小缩放档后，游戏自身会限制缩放比例。

## 测试

- [x] Windows x64 `RelWithDebInfo` 构建通过
- [x] Clang-Format 检查通过
- [x] 确认识别重试及缩小次数均受 `MaxAttempts` 限制
- [ ] 更多模拟器环境验证

## Sourcery 总结

当当前视图无法识别时，继续缩小视图，然后再重试基础设施布局识别。

错误修复：
- 当没有匹配的设施或检测到的布局不一致时，在进一步缩小视图后重试设施布局识别，从而改善对中间缩放级别的识别效果。

增强功能：
- 在协调缩放手势和识别重试的同时，保留现有的三次尝试限制。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Continue zooming out before retrying infrastructure facility layout recognition when the current view cannot be recognized.

Bug Fixes:
- Retry facility layout recognition after an additional zoom-out when no facility matches or the detected layout is inconsistent, improving recognition on intermediate zoom levels.

Enhancements:
- Preserve the existing three-attempt limit while coordinating zoom gestures and recognition retries.

</details>

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

当当前视图无法识别时，继续缩小视图，然后再重试基础设施布局识别。

错误修复：
- 当没有匹配的设施或检测到的布局不一致时，在进一步缩小视图后重试设施布局识别，从而改善对中间缩放级别的识别效果。

增强功能：
- 在协调缩放手势和识别重试的同时，保留现有的三次尝试限制。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Continue zooming out before retrying infrastructure facility layout recognition when the current view cannot be recognized.

Bug Fixes:
- Retry facility layout recognition after an additional zoom-out when no facility matches or the detected layout is inconsistent, improving recognition on intermediate zoom levels.

Enhancements:
- Preserve the existing three-attempt limit while coordinating zoom gestures and recognition retries.

</details>

</details>