### PR TITLE
fix: 修复 StageDropsConfig 与 TilePack 热重载时的旧数据残留

### DIFF
--- a/src/MaaCore/Config/Miscellaneous/StageDropsConfig.cpp
+++ b/src/MaaCore/Config/Miscellaneous/StageDropsConfig.cpp
@@ -8,6 +8,12 @@ bool asst::StageDropsConfig::parse(const json::value& json)
 {
     LogTraceFunction;
 
+    // 热重载或加载 _custom.json 时，旧数据必须先清空，
+    // 否则已删除的关卡/物品会残留（参考 InfrastConfig 的处理方式）
+    m_all_stage_code.clear();
+    m_all_item_id.clear();
+    m_stage_info.clear();
+
     for (const json::value& stage_json : json.as_array()) {
         auto drop_infos_opt = stage_json.find<json::array>("dropInfos");
         if (!drop_infos_opt) { // 这种一般是以前的活动关，现在已经关闭了的

--- a/src/MaaCore/Config/Miscellaneous/TilePack.cpp
+++ b/src/MaaCore/Config/Miscellaneous/TilePack.cpp
@@ -25,6 +25,11 @@ bool asst::TilePack::parse(const json::value& json)
 {
     LogTraceFunction;
 
+    // 热重载或加载 _custom.json 时，旧索引必须先清空，
+    // 否则 m_summarize 会累积重复/已删除关卡的条目，且 find() 会命中失效的旧文件路径
+    // （参考 InfrastConfig 的处理方式）
+    m_summarize.clear();
+
     auto dir = m_path.parent_path();
     for (const auto& [_, summary] : json.as_object()) {
         LevelKey level_key {


### PR DESCRIPTION
## 问题

`StageDropsConfig` 和 `TilePack` 的 `parse()` 都是增量写入、从不清理旧数据。而 `ResourceLoader` 对同一个单例可能连续 load 多次（热重载，或者加载 `_custom.json` 覆盖文件），二次 load 之后：

- StageDropsConfig：已删除的关卡/掉落物继续残留，`get_stage_info()` 还能查到旧 stage_id 进上报数据，残留 item 会参与掉落识别的模板匹配兜底
- TilePack：`m_summarize` 累积重复条目，`find()` 取第一个命中，可能拿到指向已失效文件的旧记录，导致战斗地图计算失败

## 修复

和 InfrastConfig 的处理一致（348b3178），在 `parse()` 开头清空成员容器。

`_custom.json` 本来就是「复制官方 json 改一份」的全量替换语义（#12382），所以清空对 custom 二次加载同样是正确行为；正常首次加载不受影响。

## 验证

写了独立小程序复现两个类的 parse 逻辑，模拟连续加载新旧两版资源：现状版热重载后 AP-5 已删关卡仍可查到、TilePack 记录翻倍且 find 命中已删关卡；加 clear 后数据与单次加载一致。两个改动文件 clang++ -std=c++20 编译通过。

## Sourcery 总结

确保重复解析资源时完全替换 StageDropsConfig 和 TilePack 数据，而不是保留过时的条目。

Bug 修复：
- 在解析前清除 StageDropsConfig 数据，防止热重载或完整替换自定义资源后，已删除的关卡和物品仍然存在。
- 在解析前清除 TilePack 索引，防止重复和过时的关卡记录导致查找结果解析到无效文件。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure repeated resource parsing fully replaces StageDropsConfig and TilePack data instead of retaining stale entries.

Bug Fixes:
- Clear StageDropsConfig data before parsing to prevent deleted stages and items from remaining after hot reloads or full custom-resource replacements.
- Clear TilePack indexes before parsing to prevent duplicate and stale level records from causing lookups to resolve to invalid files.

</details>