### PR TITLE
refactor(wpf): 连接设置Extras拆分

### DIFF
--- a/src/MaaWpfGui/Configuration/Single/Settings/ConnectSettings.cs
+++ b/src/MaaWpfGui/Configuration/Single/Settings/ConnectSettings.cs
@@ -12,9 +12,10 @@
 // </copyright>
 #nullable enable
 using System.Collections.Generic;
+using System.Text.Json.Serialization;
+using MaaWpfGui.Configuration.Single.Settings.ConnectionExtra;
 using MaaWpfGui.Constants.Enums;
 using MaaWpfGui.Models;
-using MaaWpfGui.Models.EmulatorConnectionExtra;
 using static MaaWpfGui.Configuration.Factory.ConfigFactory;
 
 namespace MaaWpfGui.Configuration.Single.Settings;
@@ -30,7 +31,7 @@ public partial class ConnectSettings : NotifyPropertyChangedWithValue
     {
         _bindingPrefix = key;
         PropertyChanged += Handler.OnPropertyChangedFactory(_bindingPrefix + nameof(ConnectSettings) + ".");
-        Extras.MuMuEmulator12.PropertyChanged += Handler.OnPropertyChangedFactory(_bindingPrefix + nameof(ConnectSettings) + "." + nameof(ExtraConfigs) + "." + nameof(Extras.MuMuEmulator12) + ".");
+        Extras.Mumu12.PropertyChanged += Handler.OnPropertyChangedFactory(_bindingPrefix + nameof(ConnectSettings) + "." + nameof(ExtraConfigs) + "." + nameof(Extras.Mumu12) + ".");
         Extras.LDPlayer.PropertyChanged += Handler.OnPropertyChangedFactory(_bindingPrefix + nameof(ConnectSettings) + "." + nameof(ExtraConfigs) + "." + nameof(Extras.LDPlayer) + ".");
         Extras.Win32Extra.PropertyChanged += Handler.OnPropertyChangedFactory(_bindingPrefix + nameof(ConnectSettings) + "." + nameof(ExtraConfigs) + "." + nameof(Extras.Win32Extra) + ".");
     }
@@ -63,9 +64,10 @@ public partial class ConnectSettings : NotifyPropertyChangedWithValue
 
     public record class ExtraConfigs
     {
-        public LDPlayerExtra LDPlayer { get; set; } = new();
+        public LdPlayerExtra LDPlayer { get; set; } = new();
 
-        public MuMu12Extra MuMuEmulator12 { get; set; } = new();
+        [JsonPropertyName("MuMuEmulator12")]
+        public Mumu12Extra Mumu12 { get; set; } = new();
 
         public Win32Extra Win32Extra { get; set; } = new();
 

--- a/src/MaaWpfGui/Configuration/Single/Settings/ConnectionExtra/BaseExtra.cs
+++ b/src/MaaWpfGui/Configuration/Single/Settings/ConnectionExtra/BaseExtra.cs
@@ -1,4 +1,4 @@
-// <copyright file="ExtraConfig.cs" company="MaaAssistantArknights">
+// <copyright file="BaseExtra.cs" company="MaaAssistantArknights">
 // Part of the MaaWpfGui project, maintained by the MaaAssistantArknights team (Maa Team)
 // Copyright (C) 2021-2025 MaaAssistantArknights Contributors
 //
@@ -10,12 +10,16 @@
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY
 // </copyright>
-#nullable enable
+
 using System.Text.Json.Serialization;
-using Stylet;
+using MaaWpfGui.Models;
+using MaaWpfGui.Models.EmulatorConnectionExtra;
 
-namespace MaaWpfGui.Models.EmulatorConnectionExtra;
+namespace MaaWpfGui.Configuration.Single.Settings.ConnectionExtra;
 
-public class ExtraConfig : PropertyChangedBase
+[JsonDerivedType(typeof(Mumu12Extra), typeDiscriminator: nameof(Mumu12Extra))]
+[JsonDerivedType(typeof(LdPlayerExtra), typeDiscriminator: nameof(LdPlayerExtra))]
+[JsonDerivedType(typeof(Win32Extra), typeDiscriminator: nameof(Win32Extra))]
+public class BaseExtra : NotifyPropertyChangedWithValue
 {
 }

--- a/src/MaaWpfGui/Configuration/Single/Settings/ConnectionExtra/LdPlayerExtra.cs
+++ b/src/MaaWpfGui/Configuration/Single/Settings/ConnectionExtra/LdPlayerExtra.cs
@@ -1,4 +1,4 @@
-// <copyright file="ExtraConfig.cs" company="MaaAssistantArknights">
+// <copyright file="LdPlayerExtra.cs" company="MaaAssistantArknights">
 // Part of the MaaWpfGui project, maintained by the MaaAssistantArknights team (Maa Team)
 // Copyright (C) 2021-2025 MaaAssistantArknights Contributors
 //
@@ -11,11 +11,15 @@
 // but WITHOUT ANY WARRANTY
 // </copyright>
 #nullable enable
-using System.Text.Json.Serialization;
-using Stylet;
+namespace MaaWpfGui.Configuration.Single.Settings.ConnectionExtra;
 
-namespace MaaWpfGui.Models.EmulatorConnectionExtra;
-
-public class ExtraConfig : PropertyChangedBase
+public class LdPlayerExtra : BaseExtra
 {
+    public bool IsEnabled { get; set; }
+
+    public string EmulatorPath { get; set; } = string.Empty;
+
+    public bool ManualSetIndex { get; set; }
+
+    public int InstanceIndex { get; set; }
 }

--- a/src/MaaWpfGui/Configuration/Single/Settings/ConnectionExtra/Mumu12Extra.cs
+++ b/src/MaaWpfGui/Configuration/Single/Settings/ConnectionExtra/Mumu12Extra.cs
@@ -1,4 +1,4 @@
-// <copyright file="ExtraConfig.cs" company="MaaAssistantArknights">
+// <copyright file="Mumu12Extra.cs" company="MaaAssistantArknights">
 // Part of the MaaWpfGui project, maintained by the MaaAssistantArknights team (Maa Team)
 // Copyright (C) 2021-2025 MaaAssistantArknights Contributors
 //
@@ -11,11 +11,17 @@
 // but WITHOUT ANY WARRANTY
 // </copyright>
 #nullable enable
-using System.Text.Json.Serialization;
-using Stylet;
+namespace MaaWpfGui.Configuration.Single.Settings.ConnectionExtra;
 
-namespace MaaWpfGui.Models.EmulatorConnectionExtra;
-
-public class ExtraConfig : PropertyChangedBase
+public class Mumu12Extra : BaseExtra
 {
+    public bool IsEnabled { get; set; }
+
+    public string EmulatorPath { get; set; } = string.Empty;
+
+    public bool EnableBridgeConnection { get; set; }
+
+    public bool EnableTouch { get; set; }
+
+    public int InstanceIndex { get; set; }
 }

--- a/src/MaaWpfGui/Configuration/Single/Settings/ConnectionExtra/Win32Extra.cs
+++ b/src/MaaWpfGui/Configuration/Single/Settings/ConnectionExtra/Win32Extra.cs
@@ -1,4 +1,4 @@
-// <copyright file="ExtraConfig.cs" company="MaaAssistantArknights">
+// <copyright file="Win32Extra.cs" company="MaaAssistantArknights">
 // Part of the MaaWpfGui project, maintained by the MaaAssistantArknights team (Maa Team)
 // Copyright (C) 2021-2025 MaaAssistantArknights Contributors
 //
@@ -11,11 +11,15 @@
 // but WITHOUT ANY WARRANTY
 // </copyright>
 #nullable enable
-using System.Text.Json.Serialization;
-using Stylet;
+using MaaWpfGui.Constants.Enums.Core;
 
-namespace MaaWpfGui.Models.EmulatorConnectionExtra;
+namespace MaaWpfGui.Configuration.Single.Settings.ConnectionExtra;
 
-public class ExtraConfig : PropertyChangedBase
+public class Win32Extra : BaseExtra
 {
+    public AsstWin32ScreencapMethod ScreencapMethod { get; set; } = AsstWin32ScreencapMethod.FramePool;
+
+    public AsstWin32InputMethod MouseMethod { get; set; } = AsstWin32InputMethod.SendMessageWithCursorPos;
+
+    public AsstWin32KeyboardInputMethod KeyboardMethod { get; set; } = AsstWin32KeyboardInputMethod.SendMessage;
 }

--- a/src/MaaWpfGui/Constants/Enums/Core/AsstWin32InputMethod.cs
+++ b/src/MaaWpfGui/Constants/Enums/Core/AsstWin32InputMethod.cs
@@ -1,4 +1,4 @@
-// <copyright file="ExtraConfig.cs" company="MaaAssistantArknights">
+// <copyright file="AsstWin32InputMethod.cs" company="MaaAssistantArknights">
 // Part of the MaaWpfGui project, maintained by the MaaAssistantArknights team (Maa Team)
 // Copyright (C) 2021-2025 MaaAssistantArknights Contributors
 //
@@ -10,12 +10,15 @@
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY
 // </copyright>
-#nullable enable
-using System.Text.Json.Serialization;
-using Stylet;
 
-namespace MaaWpfGui.Models.EmulatorConnectionExtra;
+namespace MaaWpfGui.Constants.Enums.Core;
 
-public class ExtraConfig : PropertyChangedBase
+#pragma warning disable SA1602 // Enumeration items should be documented
+// 遵循 AsstCaller.h 中的定义，确保与 AsstCaller.h 中的枚举值对应
+public enum AsstWin32InputMethod
 {
+    Seize = 1,
+    SendMessageWithCursorPos = 32,
+    SendMessageWithWindowPos = 128,
 }
+#pragma warning restore SA1602 // Enumeration items should be documented

--- a/src/MaaWpfGui/Constants/Enums/Core/AsstWin32KeyboardInputMethod.cs
+++ b/src/MaaWpfGui/Constants/Enums/Core/AsstWin32KeyboardInputMethod.cs
@@ -1,4 +1,4 @@
-// <copyright file="ExtraConfig.cs" company="MaaAssistantArknights">
+// <copyright file="AsstWin32KeyboardInputMethod.cs" company="MaaAssistantArknights">
 // Part of the MaaWpfGui project, maintained by the MaaAssistantArknights team (Maa Team)
 // Copyright (C) 2021-2025 MaaAssistantArknights Contributors
 //
@@ -10,12 +10,16 @@
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY
 // </copyright>
-#nullable enable
-using System.Text.Json.Serialization;
-using Stylet;
 
-namespace MaaWpfGui.Models.EmulatorConnectionExtra;
+namespace MaaWpfGui.Constants.Enums.Core;
 
-public class ExtraConfig : PropertyChangedBase
+#pragma warning disable SA1602 // Enumeration items should be documented
+// 遵循 AsstCaller.h 中的定义，确保与 AsstCaller.h 中的枚举值对应
+public enum AsstWin32KeyboardInputMethod
 {
+    Seize = 1,
+    SendMessage = 2,
+    PostMessage = 4,
 }
+#pragma warning restore SA1602 // Enumeration items should be documented
+

--- a/src/MaaWpfGui/Constants/Enums/Core/AsstWin32ScreencapMethod.cs
+++ b/src/MaaWpfGui/Constants/Enums/Core/AsstWin32ScreencapMethod.cs
@@ -1,4 +1,4 @@
-// <copyright file="ExtraConfig.cs" company="MaaAssistantArknights">
+// <copyright file="AsstWin32ScreencapMethod.cs" company="MaaAssistantArknights">
 // Part of the MaaWpfGui project, maintained by the MaaAssistantArknights team (Maa Team)
 // Copyright (C) 2021-2025 MaaAssistantArknights Contributors
 //
@@ -10,12 +10,16 @@
 // This program is distributed in the hope that it will be useful,
 // but WITHOUT ANY WARRANTY
 // </copyright>
-#nullable enable
-using System.Text.Json.Serialization;
-using Stylet;
 
-namespace MaaWpfGui.Models.EmulatorConnectionExtra;
+namespace MaaWpfGui.Constants.Enums.Core;
 
-public class ExtraConfig : PropertyChangedBase
+#pragma warning disable SA1602 // Enumeration items should be documented
+// 遵循 AsstCaller.h 中的定义，确保与 AsstCaller.h 中的枚举值对应
+public enum AsstWin32ScreencapMethod
 {
+    FramePool = 2,
+    PrintWindow = 16,
+    ScreenDC = 32,
+    DesktopDupWindow = 8,
 }
+#pragma warning restore SA1602 // Enumeration items should be documented

--- a/src/MaaWpfGui/Helper/ConfigConverter.cs
+++ b/src/MaaWpfGui/Helper/ConfigConverter.cs
@@ -21,11 +21,12 @@ using System.Windows.Media;
 using MaaWpfGui.Configuration.Factory;
 using MaaWpfGui.Configuration.Global;
 using MaaWpfGui.Configuration.Single.MaaTask;
+using MaaWpfGui.Configuration.Single.Settings.ConnectionExtra;
 using MaaWpfGui.Constants;
 using MaaWpfGui.Constants.Enums;
+using MaaWpfGui.Constants.Enums.Core;
 using MaaWpfGui.Extensions;
 using MaaWpfGui.Models;
-using MaaWpfGui.Models.EmulatorConnectionExtra;
 using MaaWpfGui.Services.HotKeys;
 using MaaWpfGui.ViewModels.Items;
 using MaaWpfGui.ViewModels.UserControl.Settings;
@@ -36,7 +37,6 @@ using Serilog;
 using static MaaWpfGui.Configuration.Global.Gui;
 using static MaaWpfGui.Configuration.Single.Settings.ExternalNotification;
 using static MaaWpfGui.Models.AsstTasks.AsstCopilotTask;
-using static MaaWpfGui.Models.EmulatorConnectionExtra.Win32Extra;
 using static MaaWpfGui.Models.PostActionSetting;
 using static MaaWpfGui.ViewModels.UI.CopilotViewModel;
 using static MaaWpfGui.ViewModels.UI.OverlayViewModel;
@@ -818,26 +818,29 @@ public class ConfigConverter
                 ConfigurationHelper.DeleteValue(ConfigurationKeys.AdbLiteEnabled);
                 ConfigurationHelper.DeleteValue(ConfigurationKeys.KillAdbOnExit);
                 {
-                    var extra = new MuMu12Extra(
-                        ConfigurationHelper.GetValue(ConfigurationKeys.MuMu12ExtrasEnabled, false),
-                        ConfigurationHelper.GetValue(ConfigurationKeys.MuMu12EmulatorPath, string.Empty),
-                        ConfigurationHelper.GetValue(ConfigurationKeys.MumuBridgeConnection, false),
-                        ConfigurationHelper.GetValue(ConfigurationKeys.MuMu12Index, 0));
-                    ConfigFactory.CurrentConfig.Gui.ConnectSettings.Extras.MuMuEmulator12 = extra;
+                    var extra = new Mumu12Extra {
+                        IsEnabled = ConfigurationHelper.GetValue(ConfigurationKeys.MuMu12ExtrasEnabled, false),
+                        EmulatorPath = ConfigurationHelper.GetValue(ConfigurationKeys.MuMu12EmulatorPath, string.Empty),
+                        EnableBridgeConnection = ConfigurationHelper.GetValue(ConfigurationKeys.MumuBridgeConnection, false),
+                        InstanceIndex = ConfigurationHelper.GetValue(ConfigurationKeys.MuMu12Index, 0),
+                    };
+                    ConfigFactory.CurrentConfig.Gui.ConnectSettings.Extras.Mumu12 = extra;
                 }
                 {
-                    var extra = new LDPlayerExtra(
-                        ConfigurationHelper.GetValue(ConfigurationKeys.LdPlayerExtrasEnabled, false),
-                        ConfigurationHelper.GetValue(ConfigurationKeys.LdPlayerEmulatorPath, string.Empty),
-                        ConfigurationHelper.GetValue(ConfigurationKeys.LdPlayerManualSetIndex, false),
-                        ConfigurationHelper.GetValue(ConfigurationKeys.LdPlayerIndex, 0));
+                    var extra = new LdPlayerExtra {
+                        IsEnabled = ConfigurationHelper.GetValue(ConfigurationKeys.LdPlayerExtrasEnabled, false),
+                        EmulatorPath = ConfigurationHelper.GetValue(ConfigurationKeys.LdPlayerEmulatorPath, string.Empty),
+                        ManualSetIndex = ConfigurationHelper.GetValue(ConfigurationKeys.LdPlayerManualSetIndex, false),
+                        InstanceIndex = ConfigurationHelper.GetValue(ConfigurationKeys.LdPlayerIndex, 0),
+                    };
                     ConfigFactory.CurrentConfig.Gui.ConnectSettings.Extras.LDPlayer = extra;
                 }
                 {
-                    var extra = new Win32Extra(
-                         ConfigurationHelper.GetValue(ConfigurationKeys.AttachWindowScreencapMethod, AsstWin32ScreencapMethod.FramePool),
-                         ConfigurationHelper.GetValue(ConfigurationKeys.AttachWindowMouseMethod, AsstWin32InputMethod.SendMessageWithCursorPos),
-                         ConfigurationHelper.GetValue(ConfigurationKeys.AttachWindowKeyboardMethod, AsstWin32KeyboardInputMethod.SendMessage));
+                    var extra = new Win32Extra {
+                        ScreencapMethod = ConfigurationHelper.GetValue(ConfigurationKeys.AttachWindowScreencapMethod, AsstWin32ScreencapMethod.FramePool),
+                        MouseMethod = ConfigurationHelper.GetValue(ConfigurationKeys.AttachWindowMouseMethod, AsstWin32InputMethod.SendMessageWithCursorPos),
+                        KeyboardMethod = ConfigurationHelper.GetValue(ConfigurationKeys.AttachWindowKeyboardMethod, AsstWin32KeyboardInputMethod.SendMessage),
+                    };
                     ConfigFactory.CurrentConfig.Gui.ConnectSettings.Extras.Win32Extra = extra;
                 }
                 ConfigurationHelper.DeleteValue(ConfigurationKeys.MuMu12ExtrasEnabled);

--- a/src/MaaWpfGui/Models/EmulatorConnectionExtra/LDPlayerExtra.cs
+++ b/src/MaaWpfGui/Models/EmulatorConnectionExtra/LDPlayerExtra.cs
@@ -16,7 +16,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Text.Json.Serialization;
+using MaaWpfGui.Configuration.Factory;
 using MaaWpfGui.Helper;
 using MaaWpfGui.ViewModels.UI;
 using MaaWpfGui.ViewModels.UserControl.Settings;
@@ -26,38 +26,18 @@ using Serilog;
 
 namespace MaaWpfGui.Models.EmulatorConnectionExtra;
 
-public class LDPlayerExtra() : ExtraConfig, IJsonOnDeserialized
+public class LDPlayerExtra() : ExtraConfig
 {
     private static readonly ILogger _logger = Log.ForContext<LDPlayerExtra>();
 
-    public LDPlayerExtra(bool isEnabled, string emulatorPath, bool manualSetIndex, int instanceIndex)
-        : this()
-    {
-        _isEnabled = isEnabled;
-        _emulatorPath = emulatorPath;
-        _manualSetIndex = manualSetIndex;
-        _instanceIndex = instanceIndex;
-    }
-
-    public void OnDeserialized()
-    {
-        _emulatorPath = Directory.Exists(_emulatorPath) ? _emulatorPath : string.Empty;
-    }
-
-    [JsonInclude]
-    [JsonPropertyName("IsEnabled")]
-    private bool _isEnabled;
-
-    [JsonIgnore]
     public bool Enable
     {
-        get => _isEnabled;
-        set {
-            if (!SetAndNotify(ref _isEnabled, value))
+        get; set {
+            if (!SetAndNotify(ref field, value))
             {
                 return;
             }
-
+            ConfigFactory.CurrentConfig.Gui.ConnectSettings.Extras.LDPlayer.IsEnabled = value;
             if (value)
             {
                 AutoDetectEmulatorPath();
@@ -65,7 +45,7 @@ public class LDPlayerExtra() : ExtraConfig, IJsonOnDeserialized
 
             Instances.AsstProxy.Connected = false;
         }
-    }
+    } = ConfigFactory.CurrentConfig.Gui.ConnectSettings.Extras.LDPlayer.IsEnabled;
 
     private void AutoDetectEmulatorPath()
     {
@@ -136,19 +116,13 @@ public class LDPlayerExtra() : ExtraConfig, IJsonOnDeserialized
         }
     }
 
-    [JsonInclude]
-    [JsonPropertyName("EmulatorPath")]
-    private string _emulatorPath = string.Empty;
-
     /// <summary>
     /// Gets or sets a value indicating the path of the emulator.
     /// </summary>
-    [JsonIgnore]
     public string EmulatorPath
     {
-        get => _emulatorPath;
-        set {
-            if (_isEnabled && !string.IsNullOrEmpty(value) && !Directory.Exists(value))
+        get; set {
+            if (Enable && !string.IsNullOrEmpty(value) && !Directory.Exists(value))
             {
                 MessageBoxHelper.Show(LocalizationHelper.GetString("LdPlayerEmulatorPathNotFound"));
                 MessageBoxHelper.Show(LocalizationHelper.GetString("LdExtrasEnabledTip"));
@@ -168,20 +142,15 @@ public class LDPlayerExtra() : ExtraConfig, IJsonOnDeserialized
             }
 
             Instances.AsstProxy.Connected = false;
-            SetAndNotify(ref _emulatorPath, value);
+            SetAndNotify(ref field, value);
+            ConfigFactory.CurrentConfig.Gui.ConnectSettings.Extras.LDPlayer.EmulatorPath = value;
         }
-    }
+    } = Directory.Exists(ConfigFactory.CurrentConfig.Gui.ConnectSettings.Extras.LDPlayer.EmulatorPath) ? ConfigFactory.CurrentConfig.Gui.ConnectSettings.Extras.LDPlayer.EmulatorPath : string.Empty;
 
-    [JsonInclude]
-    [JsonPropertyName("ManualSetIndex")]
-    private bool _manualSetIndex;
-
-    [JsonIgnore]
     public bool ManualSetIndex
     {
-        get => _manualSetIndex;
-        set {
-            if (_manualSetIndex == value)
+        get; set {
+            if (field == value)
             {
                 return;
             }
@@ -191,27 +160,23 @@ public class LDPlayerExtra() : ExtraConfig, IJsonOnDeserialized
                 InstanceIndex = GetEmulatorIndex(SettingsViewModel.ConnectSettings.ConnectAddress);
             }
 
-            SetAndNotify(ref _manualSetIndex, value);
+            SetAndNotify(ref field, value);
             Instances.AsstProxy.Connected = false;
+            ConfigFactory.CurrentConfig.Gui.ConnectSettings.Extras.LDPlayer.ManualSetIndex = value;
         }
-    }
-
-    [JsonInclude]
-    [JsonPropertyName("InstanceIndex")]
-    private int _instanceIndex;
+    } = ConfigFactory.CurrentConfig.Gui.ConnectSettings.Extras.LDPlayer.ManualSetIndex;
 
     /// <summary>
     /// Gets or sets the index of the emulator.
     /// </summary>
-    [JsonIgnore]
     public int InstanceIndex
     {
-        get => _instanceIndex;
-        set {
+        get; set {
             Instances.AsstProxy.Connected = false;
-            SetAndNotify(ref _instanceIndex, value);
+            SetAndNotify(ref field, value);
+            ConfigFactory.CurrentConfig.Gui.ConnectSettings.Extras.LDPlayer.InstanceIndex = value;
         }
-    }
+    } = ConfigFactory.CurrentConfig.Gui.ConnectSettings.Extras.LDPlayer.InstanceIndex;
 
     private int GetEmulatorPid(int index)
     {
@@ -287,7 +252,6 @@ public class LDPlayerExtra() : ExtraConfig, IJsonOnDeserialized
         return index;
     }
 
-    [JsonIgnore]
     public string Config
     {
         get {

--- a/src/MaaWpfGui/Models/EmulatorConnectionExtra/MuMu12Extra.cs
+++ b/src/MaaWpfGui/Models/EmulatorConnectionExtra/MuMu12Extra.cs
@@ -15,9 +15,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using System.Windows;
+using MaaWpfGui.Configuration.Factory;
 using MaaWpfGui.Constants.Enums;
 using MaaWpfGui.Extensions;
 using MaaWpfGui.Helper;
@@ -29,49 +29,31 @@ using Serilog;
 
 namespace MaaWpfGui.Models.EmulatorConnectionExtra;
 
-public class MuMu12Extra() : ExtraConfig, IJsonOnDeserialized
+public class MuMu12Extra() : ExtraConfig
 {
     private static readonly ILogger _logger = Log.ForContext<MuMu12Extra>();
 
-    public MuMu12Extra(bool isEnabled, string emulatorPath, bool enableBridgeConnection, int instanceIndex, bool enableTouch = false)
-        : this()
-    {
-        _enable = isEnabled;
-        _emulatorPath = emulatorPath;
-        _enableBridgeConnection = enableBridgeConnection;
-        _instanceIndex = instanceIndex;
-        _enableTouch = enableTouch;
-    }
-
-    public void OnDeserialized()
-    {
-        _emulatorPath = Directory.Exists(_emulatorPath) ? _emulatorPath : string.Empty;
-    }
-
-    [JsonInclude]
-    [JsonPropertyName("IsEnabled")]
-    private bool _enable;
-
-    [JsonIgnore]
     public bool Enable
     {
-        get => _enable;
-        set {
-            if (!SetAndNotify(ref _enable, value))
+        get; set {
+            if (!SetAndNotify(ref field, value))
             {
                 return;
             }
+            ConfigFactory.CurrentConfig.Gui.ConnectSettings.Extras.Mumu12.IsEnabled = value;
 
             if (value)
             {
+                string path = EmulatorPath;
                 AutoDetectEmulatorPath();
+                EmulatorPath = path;
             }
 
             // 通知 ConnectSettings 动态增删触控模式下拉项并自动切换
             ConnectSettingsUserControlModel.Instance.OnMuMuExtrasEnableChanged(value);
             Instances.AsstProxy.Connected = false;
         }
-    }
+    } = ConfigFactory.CurrentConfig.Gui.ConnectSettings.Extras.Mumu12.IsEnabled;
 
     private void AutoDetectEmulatorPath()
     {
@@ -157,18 +139,12 @@ public class MuMu12Extra() : ExtraConfig, IJsonOnDeserialized
         }
     }
 
-    [JsonInclude]
-    [JsonPropertyName("EmulatorPath")]
-    private string _emulatorPath = string.Empty;
-
     /// <summary>
     /// Gets or sets a value indicating the path of the emulator.
     /// </summary>
-    [JsonIgnore]
     public string EmulatorPath
     {
-        get => _emulatorPath;
-        set {
+        get; set {
             if (Enable && !string.IsNullOrEmpty(value) && !Directory.Exists(value))
             {
                 MessageBoxHelper.Show(LocalizationHelper.GetString("MuMuEmulatorPathNotFound"));
@@ -196,20 +172,15 @@ public class MuMu12Extra() : ExtraConfig, IJsonOnDeserialized
             }
 
             Instances.AsstProxy.Connected = false;
-            SetAndNotify(ref _emulatorPath, value);
+            ConfigFactory.CurrentConfig.Gui.ConnectSettings.Extras.Mumu12.EmulatorPath = value;
+            SetAndNotify(ref field, value);
         }
-    }
+    } = Directory.Exists(ConfigFactory.CurrentConfig.Gui.ConnectSettings.Extras.Mumu12.EmulatorPath) ? ConfigFactory.CurrentConfig.Gui.ConnectSettings.Extras.Mumu12.EmulatorPath : string.Empty;
 
-    [JsonInclude]
-    [JsonPropertyName("EnableBridgeConnection")]
-    private bool _enableBridgeConnection;
-
-    [JsonIgnore]
     public bool EnableBridgeConnection
     {
-        get => _enableBridgeConnection;
-        set {
-            if (_enableBridgeConnection == value)
+        get; set {
+            if (field == value)
             {
                 return;
             }
@@ -228,25 +199,20 @@ public class MuMu12Extra() : ExtraConfig, IJsonOnDeserialized
                 }
             }
 
-            SetAndNotify(ref _enableBridgeConnection, value);
+            ConfigFactory.CurrentConfig.Gui.ConnectSettings.Extras.Mumu12.EnableBridgeConnection = value;
+            SetAndNotify(ref field, value);
             Instances.AsstProxy.Connected = false;
         }
-    }
-
-    [JsonInclude]
-    [JsonPropertyName("EnableTouch")]
-    private bool _enableTouch;
+    } = ConfigFactory.CurrentConfig.Gui.ConnectSettings.Extras.Mumu12.EnableBridgeConnection;
 
     /// <summary>
     /// Gets or sets a value indicating whether MuMu extras is also used for touch input, not just screencap.
     /// 勾选时自动切换触控模式为 MuMu 触控，取消勾选时回到默认 Minitouch。
     /// </summary>
-    [JsonIgnore]
     public bool EnableTouch
     {
-        get => _enableTouch;
-        set {
-            if (!SetAndNotify(ref _enableTouch, value))
+        get; set {
+            if (!SetAndNotify(ref field, value))
             {
                 return;
             }
@@ -261,27 +227,22 @@ public class MuMu12Extra() : ExtraConfig, IJsonOnDeserialized
                 // 避免用户主动切换到其他触控模式时被覆盖
                 ConnectSettingsUserControlModel.Instance.TouchMode = TouchMode.MiniTouch;
             }
+            ConfigFactory.CurrentConfig.Gui.ConnectSettings.Extras.Mumu12.EnableTouch = value;
         }
-    }
-
-    [JsonInclude]
-    [JsonPropertyName("InstanceIndex")]
-    private int _instanceIndex;
+    } = ConfigFactory.CurrentConfig.Gui.ConnectSettings.Extras.Mumu12.EnableTouch;
 
     /// <summary>
     /// Gets or sets the index of the emulator.
     /// </summary>
-    [JsonIgnore]
     public int InstanceIndex
     {
-        get => _instanceIndex;
-        set {
+        get; set {
             Instances.AsstProxy.Connected = false;
-            SetAndNotify(ref _instanceIndex, value);
+            ConfigFactory.CurrentConfig.Gui.ConnectSettings.Extras.Mumu12.InstanceIndex = value;
+            SetAndNotify(ref field, value);
         }
-    }
+    } = ConfigFactory.CurrentConfig.Gui.ConnectSettings.Extras.Mumu12.InstanceIndex;
 
-    [JsonIgnore]
     public string Config
     {
         get {

--- a/src/MaaWpfGui/Models/EmulatorConnectionExtra/MuMu12Extra.cs
+++ b/src/MaaWpfGui/Models/EmulatorConnectionExtra/MuMu12Extra.cs
@@ -44,9 +44,7 @@ public class MuMu12Extra() : ExtraConfig
 
             if (value)
             {
-                string path = EmulatorPath;
                 AutoDetectEmulatorPath();
-                EmulatorPath = path;
             }
 
             // 通知 ConnectSettings 动态增删触控模式下拉项并自动切换

--- a/src/MaaWpfGui/Models/EmulatorConnectionExtra/Win32Extra.cs
+++ b/src/MaaWpfGui/Models/EmulatorConnectionExtra/Win32Extra.cs
@@ -12,50 +12,22 @@
 // </copyright>
 #nullable enable
 using System.Collections.Generic;
-using System.Text.Json.Serialization;
+using MaaWpfGui.Configuration.Factory;
+using MaaWpfGui.Constants.Enums.Core;
 using MaaWpfGui.Helper;
 using MaaWpfGui.Utilities.ValueType;
-using Serilog;
 
 namespace MaaWpfGui.Models.EmulatorConnectionExtra;
 
-public class Win32Extra() : ExtraConfig
+public class Win32Extra : ExtraConfig
 {
-    private static readonly ILogger _logger = Log.ForContext<Win32Extra>();
-
-    #region Enums
-#pragma warning disable SA1602 // Enumeration items should be documented
-    // 遵循 AsstCaller.h 中的定义，确保与 AsstCaller.h 中的枚举值对应
-    public enum AsstWin32ScreencapMethod
+    public Win32Extra()
+        : base()
     {
-        FramePool = 2,
-        PrintWindow = 16,
-        ScreenDC = 32,
-        DesktopDupWindow = 8,
-    }
-
-    public enum AsstWin32InputMethod
-    {
-        Seize = 1,
-        SendMessageWithCursorPos = 32,
-        SendMessageWithWindowPos = 128,
-    }
-
-    public enum AsstWin32KeyboardInputMethod
-    {
-        Seize = 1,
-        SendMessage = 2,
-        PostMessage = 4,
-    }
-#pragma warning restore SA1602 // Enumeration items should be documented
-    #endregion Enums
-
-    public Win32Extra(AsstWin32ScreencapMethod screencapMethod, AsstWin32InputMethod inputMethod, AsstWin32KeyboardInputMethod keyboardInputMethod)
-        : this()
-    {
-        _screencapMethod = screencapMethod;
-        _mouseMethod = inputMethod;
-        _KeyboardMethod = keyboardInputMethod;
+        if (MouseMethod == AsstWin32InputMethod.SendMessageWithWindowPos)
+        {
+            ScreencapMethod = AsstWin32ScreencapMethod.PrintWindow;
+        }
     }
 
     /// <summary>
@@ -69,59 +41,46 @@ public class Win32Extra() : ExtraConfig
         new(LocalizationHelper.GetString("AttachWindowScreencapDesktopDupWindow"),  AsstWin32ScreencapMethod.DesktopDupWindow),
     ];
 
-    [JsonIgnore]
     public List<SelectableGenericCombinedData<AsstWin32ScreencapMethod>> ScreencapMethodList => _screencapMethodList;
-
-    [JsonInclude]
-    [JsonPropertyName("ScreencapMethod")]
-    private AsstWin32ScreencapMethod _screencapMethod = AsstWin32ScreencapMethod.FramePool; // 默认 FramePool
 
     /// <summary>
     /// Gets or sets the screencap method for AttachWindow mode.
     /// </summary>
-    [JsonIgnore]
     public AsstWin32ScreencapMethod ScreencapMethod
     {
-        get => _mouseMethod == AsstWin32InputMethod.SendMessageWithWindowPos ? AsstWin32ScreencapMethod.PrintWindow : _screencapMethod;
-        set {
+        get; set {
             // 鼠标输入方式为 SendMessageWithWindowPos 时，截图方式仅支持 PrintWindow
-            if (_mouseMethod == AsstWin32InputMethod.SendMessageWithWindowPos)
+            if (MouseMethod == AsstWin32InputMethod.SendMessageWithWindowPos)
             {
                 value = AsstWin32ScreencapMethod.PrintWindow;
             }
 
             Instances.AsstProxy.Connected = false;
-            SetAndNotify(ref _screencapMethod, value);
+            SetAndNotify(ref field, value);
+            ConfigFactory.CurrentConfig.Gui.ConnectSettings.Extras.Win32Extra.ScreencapMethod = value;
         }
-    }
+    } = ConfigFactory.CurrentConfig.Gui.ConnectSettings.Extras.Win32Extra.ScreencapMethod;
 
     /// <summary>
     /// Win32 鼠标输入方式枚举（与 AsstCaller.h 中 AsstWin32InputMethodEnum 对应）
     /// </summary>
     private static readonly List<GenericCombinedData<AsstWin32InputMethod>> _mouseMethodList =
     [
-        new(LocalizationHelper.GetString("AttachWindowInputSeize"),  AsstWin32InputMethod.Seize),
-        new(LocalizationHelper.GetString("AttachWindowInputSendWithCursor"),  AsstWin32InputMethod.SendMessageWithCursorPos),
-        new(LocalizationHelper.GetString("AttachWindowInputSendWithWindowPos"),  AsstWin32InputMethod.SendMessageWithWindowPos),
+        new(LocalizationHelper.GetString("AttachWindowInputSeize"), AsstWin32InputMethod.Seize),
+        new(LocalizationHelper.GetString("AttachWindowInputSendWithCursor"), AsstWin32InputMethod.SendMessageWithCursorPos),
+        new(LocalizationHelper.GetString("AttachWindowInputSendWithWindowPos"), AsstWin32InputMethod.SendMessageWithWindowPos),
     ];
 
-    [JsonIgnore]
     public List<GenericCombinedData<AsstWin32InputMethod>> MouseMethodList => _mouseMethodList;
-
-    [JsonInclude]
-    [JsonPropertyName("MouseMethod")]
-    private AsstWin32InputMethod _mouseMethod = AsstWin32InputMethod.SendMessageWithCursorPos; // 默认 SendMessageWithCursor
 
     /// <summary>
     /// Gets or sets the mouse input method for AttachWindow mode.
     /// </summary>
-    [JsonIgnore]
     public AsstWin32InputMethod MouseMethod
     {
-        get => _mouseMethod;
-        set {
+        get; set {
             Instances.AsstProxy.Connected = false;
-            SetAndNotify(ref _mouseMethod, value);
+            SetAndNotify(ref field, value);
 
             // 鼠标输入方式为 SendMessageWithWindowPos 时，截图方式仅支持 PrintWindow
             if (value == AsstWin32InputMethod.SendMessageWithWindowPos)
@@ -130,8 +89,9 @@ public class Win32Extra() : ExtraConfig
             }
 
             UpdateScreencapMethodAvailability();
+            ConfigFactory.CurrentConfig.Gui.ConnectSettings.Extras.Win32Extra.MouseMethod = value;
         }
-    }
+    } = ConfigFactory.CurrentConfig.Gui.ConnectSettings.Extras.Win32Extra.MouseMethod;
 
     /// <summary>
     /// 根据当前鼠标输入方式刷新截图方式选项的可用状态
@@ -140,7 +100,7 @@ public class Win32Extra() : ExtraConfig
     {
         foreach (var item in _screencapMethodList)
         {
-            item.IsEnabled = _mouseMethod != AsstWin32InputMethod.SendMessageWithWindowPos || item.Value == AsstWin32ScreencapMethod.PrintWindow;
+            item.IsEnabled = MouseMethod != AsstWin32InputMethod.SendMessageWithWindowPos || item.Value == AsstWin32ScreencapMethod.PrintWindow;
         }
     }
 
@@ -154,23 +114,17 @@ public class Win32Extra() : ExtraConfig
         new(LocalizationHelper.GetString("AttachWindowInputPostMsg"),  AsstWin32KeyboardInputMethod.PostMessage),
     ];
 
-    [JsonIgnore]
     public List<GenericCombinedData<AsstWin32KeyboardInputMethod>> KeyboardMethodList => _KeyboardMethodList;
-
-    [JsonInclude]
-    [JsonPropertyName("KeyboardMethod")]
-    private AsstWin32KeyboardInputMethod _KeyboardMethod = AsstWin32KeyboardInputMethod.SendMessage; // 默认 SendMessage
 
     /// <summary>
     /// Gets or sets the keyboard input method for AttachWindow mode.
     /// </summary>
-    [JsonIgnore]
     public AsstWin32KeyboardInputMethod KeyboardMethod
     {
-        get => _KeyboardMethod;
-        set {
+        get; set {
             Instances.AsstProxy.Connected = false;
-            SetAndNotify(ref _KeyboardMethod, value);
+            SetAndNotify(ref field, value);
+            ConfigFactory.CurrentConfig.Gui.ConnectSettings.Extras.Win32Extra.KeyboardMethod = value;
         }
-    }
+    } = ConfigFactory.CurrentConfig.Gui.ConnectSettings.Extras.Win32Extra.KeyboardMethod;
 }

--- a/src/MaaWpfGui/Utilities/ValueType/SelectableGenericCombinedData.cs
+++ b/src/MaaWpfGui/Utilities/ValueType/SelectableGenericCombinedData.cs
@@ -23,9 +23,10 @@ public class SelectableGenericCombinedData<TValueType> : GenericCombinedData<TVa
     {
     }
 
-    public SelectableGenericCombinedData(string name, TValueType value)
+    public SelectableGenericCombinedData(string name, TValueType value, bool isEnabled = true)
         : base(name, value)
     {
+        IsEnabled = isEnabled;
     }
 
     /// <summary>

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/ConnectSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/ConnectSettingsUserControlModel.cs
@@ -26,6 +26,7 @@ using JetBrains.Annotations;
 using MaaWpfGui.Configuration.Factory;
 using MaaWpfGui.Constants;
 using MaaWpfGui.Constants.Enums;
+using MaaWpfGui.Constants.Enums.Core;
 using MaaWpfGui.Extensions;
 using MaaWpfGui.Helper;
 using MaaWpfGui.Main;
@@ -58,19 +59,15 @@ public class ConnectSettingsUserControlModel : PropertyChangedBase
     {
         PropertyDependsOnUtility.InitializePropertyDependencies(this);
 
-        // 鼠标输入方式变化时刷新窗口恢复按钮的可见性
-        if (ConfigFactory.CurrentConfig.Gui.ConnectSettings.Extras.Win32Extra is { } win32Extra)
-        {
-            // 从配置恢复时，刷新截图方式选项的可用状态
-            win32Extra.UpdateScreencapMethodAvailability();
+        // 刷新截图方式选项的可用状态
+        Extras.Win32.UpdateScreencapMethodAvailability();
 
-            win32Extra.PropertyChanged += (_, e) => {
-                if (e.PropertyName == nameof(Win32Extra.MouseMethod))
-                {
-                    NotifyOfPropertyChange(nameof(ShowWindowRestoreButton));
-                }
-            };
-        }
+        Extras.Win32.PropertyChanged += (_, e) => {
+            if (e.PropertyName == nameof(Win32Extra.MouseMethod))
+            {
+                NotifyOfPropertyChange(nameof(ShowWindowRestoreButton));
+            }
+        };
 
         // 从配置恢复时，若 MuMu 截图增强已启用，需将 MuMu 触控加入下拉列表
         if (ExtraConfig is MuMu12Extra { Enable: true })
@@ -254,11 +251,31 @@ public class ConnectSettingsUserControlModel : PropertyChangedBase
 
     [PropertyDependsOn(nameof(ConnectConfig))]
     public ExtraConfig? ExtraConfig => ConnectConfig switch {
-        ConnectConfig.LDPlayer => ConfigFactory.CurrentConfig.Gui.ConnectSettings.Extras.LDPlayer,
-        ConnectConfig.MuMuEmulator12 => ConfigFactory.CurrentConfig.Gui.ConnectSettings.Extras.MuMuEmulator12,
-        ConnectConfig.PC => ConfigFactory.CurrentConfig.Gui.ConnectSettings.Extras.Win32Extra,
+        ConnectConfig.LDPlayer => Extras.LdPlayer,
+        ConnectConfig.MuMuEmulator12 => Extras.Mumu12,
+        ConnectConfig.PC => Extras.Win32,
         _ => null,
     };
+
+    private readonly ExtraConfigs Extras = new();
+
+    private class ExtraConfigs
+    {
+        public LDPlayerExtra LdPlayer { get; set; } = new();
+
+        public MuMu12Extra Mumu12 { get; set; } = new();
+
+        public Models.EmulatorConnectionExtra.Win32Extra Win32 { get; set; } = new();
+
+        public Bluestacks BluestacksExtra { get; set; } = new();
+
+        public record class Bluestacks
+        {
+            public string ConfigKeyword { get; set; } = string.Empty;
+
+            public string ConfigPath { get; set; } = string.Empty;
+        }
+    }
 
     public string ScreencapMethod { get; set; } = string.Empty;
 
@@ -742,8 +759,7 @@ public class ConnectSettingsUserControlModel : PropertyChangedBase
     /// <param name="mumuExtrasEnabled">MuMu 截图增强是否已启用。</param>
     public void OnMuMuExtrasEnableChanged(bool mumuExtrasEnabled)
     {
-        Execute.OnUIThread(() =>
-        {
+        Execute.OnUIThread(() => {
             var hasMumu = TouchModeList.Items.Any(item => item.Value == TouchMode.MumuExtras);
             if (mumuExtrasEnabled && !hasMumu)
             {
@@ -849,7 +865,7 @@ public class ConnectSettingsUserControlModel : PropertyChangedBase
     /// </summary>
     [PropertyDependsOn(nameof(ConnectConfig))]
     public bool ShowWindowRestoreButton =>
-        IsPCConnectConfig && ExtraConfig is Win32Extra { MouseMethod: Win32Extra.AsstWin32InputMethod.SendMessageWithWindowPos };
+        IsPCConnectConfig && ExtraConfig is Models.EmulatorConnectionExtra.Win32Extra { MouseMethod: AsstWin32InputMethod.SendMessageWithWindowPos };
 
     public bool IsPCConnectConfig => ConnectConfig == ConnectConfig.PC;
 


### PR DESCRIPTION
## Sourcery 摘要

将连接额外设置重构为专用配置模型，同时保持与现有序列化设置的兼容性。

增强功能：
- 将连接额外设置拆分为专用配置模型，并支持共享的多态序列化。
- 在持久化配置与运行时视图模型之间同步模拟器和 Win32 连接设置。
- 将 Win32 连接输入和屏幕捕获方法枚举提取为共享核心常量。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

将连接额外设置重构为专用配置模型，同时保持序列化兼容性，并确保运行时设置同步。

增强功能：
- 将连接额外设置拆分为专用的持久化配置模型，采用共享的多态序列化机制，并保留现有的 MuMu12 配置属性名称以确保兼容性。
- 在持久化配置与运行时视图模型之间同步模拟器和 Win32 连接设置。
- 将 Win32 输入和屏幕捕获方法枚举移至共享核心常量中，并支持在可选设置中禁用屏幕捕获选项。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor connection extra settings into dedicated configuration models while preserving serialization compatibility and keeping runtime settings synchronized.

Enhancements:
- Split connection extra settings into dedicated persistent configuration models with shared polymorphic serialization and preserve the existing MuMu12 configuration property name for compatibility.
- Synchronize emulator and Win32 connection settings between persisted configuration and runtime view models.
- Move Win32 input and screen-capture method enums into shared core constants and support disabled screen-capture options in selectable settings.

</details>

</details>