### PR TITLE
fix: 修复黑流树海出发前往流程

### DIFF
--- a/resource/tasks/Roguelike/BlackFlow.json
+++ b/resource/tasks/Roguelike/BlackFlow.json
@@ -792,33 +792,38 @@
     },
     "BlackFlow@Roguelike@MovePreviewConfirm": {
         "Doc": [
-            "点击“出发前往”后，分别在约 500、1000、1500 和 2000 毫秒观察按钮；按钮提前消失即确认成功，持续存在两秒才允许再次点击。",
-            "本任务的 maxTimes 只统计真实点击，观察节点不会消耗点击次数。"
+            "点击“出发前往”后，每隔一个 taskDelay=500ms 观察是否依旧存在；任一观察点未识别到按钮即确认成功，按钮持续存在四次=2000ms 才允许再次点击。",
+            "Confirm 的 maxTimes 只统计真实点击；每次点击将 Observe 的两次执行计数恢复为零，使下一轮重新完整观察。",
+            "显式设置 reduceOtherTimes 会覆盖 baseTask 的同名字段，因此这里同时保留 MovePreviewWait 的既有复位。"
         ],
         "baseTask": "BlackFlow@Roguelike@MovePreviewEnter",
         "template": "BlackFlow@Roguelike@MovePreviewEnter.png",
         "action": "ClickSelf",
-        "next": ["BlackFlow@Roguelike@MovePreviewConfirmObserve1", "BlackFlow@Roguelike@MovePreviewConfirmSucceeded"],
+        "next": [
+            "BlackFlow@Roguelike@MovePreviewConfirmObserve",
+            "BlackFlow@Roguelike@MovePreviewConfirmSucceeded"
+        ],
         "maxTimes": 4,
-        "exceededNext": ["BlackFlow@Roguelike@MovePreviewConfirmExceeded"]
+        "exceededNext": ["BlackFlow@Roguelike@MovePreviewConfirmExceeded"],
+        "reduceOtherTimes": [
+            "BlackFlow@Roguelike@MovePreviewWait*3",
+            "BlackFlow@Roguelike@MovePreviewConfirmObserve*2"
+        ]
     },
-    "BlackFlow@Roguelike@MovePreviewConfirmObserve1": {
+    "BlackFlow@Roguelike@MovePreviewConfirmObserve": {
+        "Doc": "maxTimes 为 2 时，第三次匹配会进入 exceededNext；随后经过一个 taskDelay 在第四个观察点识别 Confirm，默认配置下两次点击间隔约为两秒。",
         "baseTask": "BlackFlow@Roguelike@MovePreviewEnter",
         "template": "BlackFlow@Roguelike@MovePreviewEnter.png",
         "action": "DoNothing",
-        "next": ["BlackFlow@Roguelike@MovePreviewConfirmObserve2", "BlackFlow@Roguelike@MovePreviewConfirmSucceeded"]
-    },
-    "BlackFlow@Roguelike@MovePreviewConfirmObserve2": {
-        "baseTask": "BlackFlow@Roguelike@MovePreviewEnter",
-        "template": "BlackFlow@Roguelike@MovePreviewEnter.png",
-        "action": "DoNothing",
-        "next": ["BlackFlow@Roguelike@MovePreviewConfirmObserve3", "BlackFlow@Roguelike@MovePreviewConfirmSucceeded"]
-    },
-    "BlackFlow@Roguelike@MovePreviewConfirmObserve3": {
-        "baseTask": "BlackFlow@Roguelike@MovePreviewEnter",
-        "template": "BlackFlow@Roguelike@MovePreviewEnter.png",
-        "action": "DoNothing",
-        "next": ["BlackFlow@Roguelike@MovePreviewConfirm", "BlackFlow@Roguelike@MovePreviewConfirmSucceeded"]
+        "next": [
+            "#self",
+            "BlackFlow@Roguelike@MovePreviewConfirmSucceeded"
+        ],
+        "maxTimes": 2,
+        "exceededNext": [
+            "BlackFlow@Roguelike@MovePreviewConfirm",
+            "BlackFlow@Roguelike@MovePreviewConfirmSucceeded"
+        ]
     },
     "BlackFlow@Roguelike@MovePreviewConfirmSucceeded": {
         "algorithm": "JustReturn"

--- a/resource/tasks/Roguelike/BlackFlow.json
+++ b/resource/tasks/Roguelike/BlackFlow.json
@@ -793,12 +793,11 @@
     "BlackFlow@Roguelike@MovePreviewConfirm": {
         "Doc": [
             "点击“出发前往”后，分别在约 500、1000、1500 和 2000 毫秒观察按钮；按钮提前消失即确认成功，持续存在两秒才允许再次点击。",
-            "本任务的 maxTimes 只统计真实点击。观察阶段由 C++ 以 taskDelay 0 执行，避免默认任务间隔叠加到观察时间。"
+            "本任务的 maxTimes 只统计真实点击，观察节点不会消耗点击次数。"
         ],
         "baseTask": "BlackFlow@Roguelike@MovePreviewEnter",
         "template": "BlackFlow@Roguelike@MovePreviewEnter.png",
         "action": "ClickSelf",
-        "postDelay": 500,
         "next": ["BlackFlow@Roguelike@MovePreviewConfirmObserve1", "BlackFlow@Roguelike@MovePreviewConfirmSucceeded"],
         "maxTimes": 4,
         "exceededNext": ["BlackFlow@Roguelike@MovePreviewConfirmExceeded"]
@@ -807,21 +806,18 @@
         "baseTask": "BlackFlow@Roguelike@MovePreviewEnter",
         "template": "BlackFlow@Roguelike@MovePreviewEnter.png",
         "action": "DoNothing",
-        "postDelay": 500,
         "next": ["BlackFlow@Roguelike@MovePreviewConfirmObserve2", "BlackFlow@Roguelike@MovePreviewConfirmSucceeded"]
     },
     "BlackFlow@Roguelike@MovePreviewConfirmObserve2": {
         "baseTask": "BlackFlow@Roguelike@MovePreviewEnter",
         "template": "BlackFlow@Roguelike@MovePreviewEnter.png",
         "action": "DoNothing",
-        "postDelay": 500,
         "next": ["BlackFlow@Roguelike@MovePreviewConfirmObserve3", "BlackFlow@Roguelike@MovePreviewConfirmSucceeded"]
     },
     "BlackFlow@Roguelike@MovePreviewConfirmObserve3": {
         "baseTask": "BlackFlow@Roguelike@MovePreviewEnter",
         "template": "BlackFlow@Roguelike@MovePreviewEnter.png",
         "action": "DoNothing",
-        "postDelay": 500,
         "next": ["BlackFlow@Roguelike@MovePreviewConfirm", "BlackFlow@Roguelike@MovePreviewConfirmSucceeded"]
     },
     "BlackFlow@Roguelike@MovePreviewConfirmSucceeded": {

--- a/resource/tasks/Roguelike/BlackFlow.json
+++ b/resource/tasks/Roguelike/BlackFlow.json
@@ -24,7 +24,7 @@
         "template": "BlackFlow@Roguelike@AbandonConfirm.png",
         "reduceOtherTimes": [
             "BlackFlow@Roguelike@MapPrepare-ZoomOut*3",
-            "BlackFlow@Roguelike@MovePreviewConfirm*3",
+            "BlackFlow@Roguelike@MovePreviewConfirm*4",
             "BlackFlow@Roguelike@MovePreviewWait*3",
             "BlackFlow@Roguelike@MovementInventoryClose*3",
             "BlackFlow@Roguelike@Page-Door-Wait*10",
@@ -791,16 +791,49 @@
         "reduceOtherTimes": ["BlackFlow@Roguelike@MovePreviewWait*3"]
     },
     "BlackFlow@Roguelike@MovePreviewConfirm": {
+        "Doc": [
+            "点击“出发前往”后，分别在约 500、1000、1500 和 2000 毫秒观察按钮；按钮提前消失即确认成功，持续存在两秒才允许再次点击。",
+            "本任务的 maxTimes 只统计真实点击。观察阶段由 C++ 以 taskDelay 0 执行，避免默认任务间隔叠加到观察时间。"
+        ],
         "baseTask": "BlackFlow@Roguelike@MovePreviewEnter",
         "template": "BlackFlow@Roguelike@MovePreviewEnter.png",
         "action": "ClickSelf",
-        "next": ["#self", "BlackFlow@Roguelike@MovePreviewConfirmCompleted"],
-        "maxTimes": 3
+        "postDelay": 500,
+        "next": ["BlackFlow@Roguelike@MovePreviewConfirmObserve1", "BlackFlow@Roguelike@MovePreviewConfirmSucceeded"],
+        "maxTimes": 4,
+        "exceededNext": ["BlackFlow@Roguelike@MovePreviewConfirmExceeded"]
+    },
+    "BlackFlow@Roguelike@MovePreviewConfirmObserve1": {
+        "baseTask": "BlackFlow@Roguelike@MovePreviewEnter",
+        "template": "BlackFlow@Roguelike@MovePreviewEnter.png",
+        "action": "DoNothing",
+        "postDelay": 500,
+        "next": ["BlackFlow@Roguelike@MovePreviewConfirmObserve2", "BlackFlow@Roguelike@MovePreviewConfirmSucceeded"]
+    },
+    "BlackFlow@Roguelike@MovePreviewConfirmObserve2": {
+        "baseTask": "BlackFlow@Roguelike@MovePreviewEnter",
+        "template": "BlackFlow@Roguelike@MovePreviewEnter.png",
+        "action": "DoNothing",
+        "postDelay": 500,
+        "next": ["BlackFlow@Roguelike@MovePreviewConfirmObserve3", "BlackFlow@Roguelike@MovePreviewConfirmSucceeded"]
+    },
+    "BlackFlow@Roguelike@MovePreviewConfirmObserve3": {
+        "baseTask": "BlackFlow@Roguelike@MovePreviewEnter",
+        "template": "BlackFlow@Roguelike@MovePreviewEnter.png",
+        "action": "DoNothing",
+        "postDelay": 500,
+        "next": ["BlackFlow@Roguelike@MovePreviewConfirm", "BlackFlow@Roguelike@MovePreviewConfirmSucceeded"]
+    },
+    "BlackFlow@Roguelike@MovePreviewConfirmSucceeded": {
+        "algorithm": "JustReturn"
+    },
+    "BlackFlow@Roguelike@MovePreviewConfirmExceeded": {
+        "algorithm": "JustReturn"
     },
     "BlackFlow@Roguelike@MovePreviewConfirmCompleted": {
         "algorithm": "JustReturn",
         "postDelay": 600,
-        "reduceOtherTimes": ["BlackFlow@Roguelike@MovePreviewConfirm*3"],
+        "reduceOtherTimes": ["BlackFlow@Roguelike@MovePreviewConfirm*4"],
         "next": [
             "BlackFlow@Roguelike@MovePreviewConfirmCompleted@(BlackFlow@Roguelike@CloseCollection)",
             "BlackFlow@Roguelike@MovePreviewConfirmCompletedDone"

--- a/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowRoutingLoop.h
+++ b/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowRoutingLoop.h
@@ -17,6 +17,7 @@ enum class RoutingCycleStatus
     MovementInventoryObservationRequired,
     ReplanRequired,
     PreviewNeedsDismiss,
+    ConfirmationNeedsDismiss,
     SessionTerminated,
     NeedsPageRecovery,
     Failed,
@@ -169,7 +170,12 @@ RoutingCycleOutcome execute_preview_cycle(Session& session, IBlackFlowTaskPort& 
         return { RoutingCycleStatus::PreviewNeedsDismiss, "move_confirmation_invalidated", std::move(error) };
     }
     EnteredPageObservation entered_page;
-    if (!port.confirm(*session.transaction(), entered_page, &error)) {
+    const MoveConfirmationStatus confirmation = port.confirm(*session.transaction(), entered_page, &error);
+    if (confirmation == MoveConfirmationStatus::NeedsDismiss) {
+        session.cancel_transaction();
+        return { RoutingCycleStatus::ConfirmationNeedsDismiss, "move_confirmation_exhausted", std::move(error) };
+    }
+    if (confirmation == MoveConfirmationStatus::Failed) {
         return { RoutingCycleStatus::Failed, "move_confirmation_failed", std::move(error) };
     }
     if (!session.commit(std::move(entered_page), &error)) {

--- a/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowRoutingTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowRoutingTaskPlugin.cpp
@@ -103,13 +103,9 @@ bool BlackFlowRoutingTaskPlugin::_run()
     if (cycle.status == RoutingCycleStatus::ConfirmationNeedsDismiss) {
         if (m_move_confirmation_dismiss_retries < MoveConfirmationDismissRetryLimit) {
             ++m_move_confirmation_dismiss_retries;
-            Log.info(
-                "BlackFlow move confirmation exhausted; dismissing preview before retry",
-                "attempt",
-                m_move_confirmation_dismiss_retries,
-                "of",
-                MoveConfirmationDismissRetryLimit,
-                cycle.error);
+            LogInfo << __FUNCTION__ << "BlackFlow move confirmation exhausted; dismissing preview before retry"
+                    << "attempt" << m_move_confirmation_dismiss_retries << "of" << MoveConfirmationDismissRetryLimit
+                    << cycle.error;
             Task.set_task_base("BlackFlow@Roguelike@RoutingAction", "BlackFlow@Roguelike@CancelNodeSelection");
         }
         else {

--- a/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowRoutingTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowRoutingTaskPlugin.cpp
@@ -7,6 +7,12 @@
 
 namespace asst::blackflow
 {
+namespace
+{
+// 首次完整确认耗尽时关闭预览面板并重新选择；再次耗尽时重开当前局。
+constexpr int MoveConfirmationDismissRetryLimit = 1;
+}
+
 bool BlackFlowRoutingTaskPlugin::verify(AsstMsg msg, const json::value& details) const
 {
     if (msg != AsstMsg::SubTaskStart || details.get("subtask", std::string()) != "ProcessTask") {
@@ -28,6 +34,7 @@ void BlackFlowRoutingTaskPlugin::reset_in_run_variables()
 {
     m_pending = PendingWork::None;
     m_page_recovery_attempted = false;
+    m_move_confirmation_dismiss_retries = 0;
 }
 
 bool BlackFlowRoutingTaskPlugin::_run()
@@ -93,12 +100,33 @@ bool BlackFlowRoutingTaskPlugin::_run()
         report_outputs();
         return true;
     }
+    if (cycle.status == RoutingCycleStatus::ConfirmationNeedsDismiss) {
+        if (m_move_confirmation_dismiss_retries < MoveConfirmationDismissRetryLimit) {
+            ++m_move_confirmation_dismiss_retries;
+            Log.info(
+                "BlackFlow move confirmation exhausted; dismissing preview before retry",
+                "attempt",
+                m_move_confirmation_dismiss_retries,
+                "of",
+                MoveConfirmationDismissRetryLimit,
+                cycle.error);
+            Task.set_task_base("BlackFlow@Roguelike@RoutingAction", "BlackFlow@Roguelike@CancelNodeSelection");
+        }
+        else {
+            m_session->fail(cycle.failure_code, cycle.error, FailureDisposition::RestartRun);
+            Task.set_task_base("BlackFlow@Roguelike@RoutingAction", "BlackFlow@Roguelike@StrategyTerminated-Enter");
+        }
+        report_outputs();
+        return true;
+    }
     if (cycle.status == RoutingCycleStatus::MoveCommittedToMap) {
+        m_move_confirmation_dismiss_retries = 0;
         Task.set_task_base("BlackFlow@Roguelike@RoutingAction", "BlackFlow@Roguelike@MapPrepare");
         report_outputs();
         return true;
     }
     if (cycle.status == RoutingCycleStatus::MoveCommitted) {
+        m_move_confirmation_dismiss_retries = 0;
         Task.set_task_base("BlackFlow@Roguelike@RoutingAction", "BlackFlow@Roguelike@NodeDispatch");
         report_outputs();
         return true;

--- a/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowRoutingTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowRoutingTaskPlugin.h
@@ -25,5 +25,6 @@ private:
 
     mutable PendingWork m_pending = PendingWork::None;
     bool m_page_recovery_attempted = false;
+    int m_move_confirmation_dismiss_retries = 0;
 };
 } // namespace asst::blackflow

--- a/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowTaskPort.cpp
+++ b/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowTaskPort.cpp
@@ -109,13 +109,9 @@ public:
         set_retry_times(0);
     }
 
-    bool execute(
-        std::vector<std::string> tasks,
-        std::string* error,
-        std::optional<int> task_delay_override = std::nullopt)
+    bool execute(std::vector<std::string> tasks, std::string* error)
     {
         m_tasks = std::move(tasks);
-        m_task_delay_override = task_delay_override;
         m_last_task.clear();
         m_last_image.reset();
         const bool succeeded = AbstractTask::run();
@@ -137,9 +133,6 @@ protected:
     bool _run() override
     {
         ProcessTask process(*this, m_tasks);
-        if (m_task_delay_override.has_value()) {
-            process.set_task_delay(*m_task_delay_override);
-        }
         const bool succeeded = process.run();
         m_last_task = process.get_last_task_name();
         if (const auto& hit = process.get_last_hit(); hit != nullptr && hit->image != nullptr) {
@@ -150,7 +143,6 @@ protected:
 
 private:
     std::vector<std::string> m_tasks;
-    std::optional<int> m_task_delay_override;
     std::string m_last_task;
     std::shared_ptr<cv::Mat> m_last_image;
 };
@@ -303,9 +295,7 @@ MoveConfirmationStatus BlackFlowTaskPort::confirm(
         set_error(error, "move confirmation requires a reachable previewed transaction");
         return MoveConfirmationStatus::Failed;
     }
-    // 观察任务已经通过 postDelay 定义点击后两秒内的检查时点。
-    // 此处关闭默认 taskDelay，避免每次状态切换额外叠加任务间隔。
-    if (!m_task_context->execute({ std::string(MovePreviewConfirmTask) }, error, 0)) {
+    if (!m_task_context->execute({ std::string(MovePreviewConfirmTask) }, error)) {
         return MoveConfirmationStatus::Failed;
     }
     const std::string& confirmation_task = m_task_context->last_task();

--- a/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowTaskPort.cpp
+++ b/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowTaskPort.cpp
@@ -32,6 +32,9 @@ constexpr std::string_view MovePreviewCannotEnterTask = "BlackFlow@Roguelike@Mov
 constexpr std::string_view MovePreviewCostTask = "BlackFlow@Roguelike@MovePreviewCost";
 constexpr std::string_view MovePreviewDisplayedNameTask = "BlackFlow@Roguelike@MovePreviewDisplayedName";
 constexpr std::string_view MovePreviewConfirmTask = "BlackFlow@Roguelike@MovePreviewConfirm";
+constexpr std::string_view MovePreviewConfirmSucceededTask = "BlackFlow@Roguelike@MovePreviewConfirmSucceeded";
+constexpr std::string_view MovePreviewConfirmExceededTask = "BlackFlow@Roguelike@MovePreviewConfirmExceeded";
+constexpr std::string_view MovePreviewConfirmCompletedTask = "BlackFlow@Roguelike@MovePreviewConfirmCompleted";
 constexpr std::string_view EnteredPageClassificationTask = "BlackFlow@Roguelike@EnteredPageClassification";
 constexpr std::string_view EnteredPageClassificationEncounterPrepareTask =
     "BlackFlow@Roguelike@EnteredPageClassificationEncounterPrepare";
@@ -106,9 +109,13 @@ public:
         set_retry_times(0);
     }
 
-    bool execute(std::vector<std::string> tasks, std::string* error)
+    bool execute(
+        std::vector<std::string> tasks,
+        std::string* error,
+        std::optional<int> task_delay_override = std::nullopt)
     {
         m_tasks = std::move(tasks);
+        m_task_delay_override = task_delay_override;
         m_last_task.clear();
         m_last_image.reset();
         const bool succeeded = AbstractTask::run();
@@ -130,6 +137,9 @@ protected:
     bool _run() override
     {
         ProcessTask process(*this, m_tasks);
+        if (m_task_delay_override.has_value()) {
+            process.set_task_delay(*m_task_delay_override);
+        }
         const bool succeeded = process.run();
         m_last_task = process.get_last_task_name();
         if (const auto& hit = process.get_last_hit(); hit != nullptr && hit->image != nullptr) {
@@ -140,6 +150,7 @@ protected:
 
 private:
     std::vector<std::string> m_tasks;
+    std::optional<int> m_task_delay_override;
     std::string m_last_task;
     std::shared_ptr<cv::Mat> m_last_image;
 };
@@ -282,7 +293,7 @@ bool BlackFlowTaskPort::preview(
     return true;
 }
 
-bool BlackFlowTaskPort::confirm(
+MoveConfirmationStatus BlackFlowTaskPort::confirm(
     const MoveTransaction& transaction,
     EnteredPageObservation& entered_page,
     std::string* error)
@@ -290,16 +301,33 @@ bool BlackFlowTaskPort::confirm(
     if (m_task_context == nullptr || transaction.stage() != MoveTransactionStage::Previewed ||
         !transaction.preview().has_value() || transaction.preview()->reachability != PreviewReachability::Reachable) {
         set_error(error, "move confirmation requires a reachable previewed transaction");
-        return false;
+        return MoveConfirmationStatus::Failed;
     }
-    if (!m_task_context->execute({ std::string(MovePreviewConfirmTask) }, error)) {
-        return false;
+    // 观察任务已经通过 postDelay 定义点击后两秒内的检查时点。
+    // 此处关闭默认 taskDelay，避免每次状态切换额外叠加任务间隔。
+    if (!m_task_context->execute({ std::string(MovePreviewConfirmTask) }, error, 0)) {
+        return MoveConfirmationStatus::Failed;
     }
+    const std::string& confirmation_task = m_task_context->last_task();
+    if (confirmation_task.ends_with(MovePreviewConfirmExceededTask)) {
+        set_error(error, "move preview confirmation remained visible after four attempts");
+        return MoveConfirmationStatus::NeedsDismiss;
+    }
+    if (!confirmation_task.ends_with(MovePreviewConfirmSucceededTask)) {
+        set_error(error, "move preview confirmation ended at an unexpected task: " + confirmation_task);
+        return MoveConfirmationStatus::Failed;
+    }
+    // 成功末端单独执行，继续保留默认任务间隔和既有的 600 毫秒页面稳定等待。
+    if (!m_task_context->execute({ std::string(MovePreviewConfirmCompletedTask) }, error)) {
+        return MoveConfirmationStatus::Failed;
+    }
+
     entered_page = {};
     if (transaction.preview()->identity_revealed) {
-        return true;
+        return MoveConfirmationStatus::Succeeded;
     }
-    return classify_entered_page(m_task_context->capture(), entered_page, error);
+    return classify_entered_page(m_task_context->capture(), entered_page, error) ? MoveConfirmationStatus::Succeeded
+                                                                                 : MoveConfirmationStatus::Failed;
 }
 
 void BlackFlowTaskPort::configure_diagnostics(const DiagnosticSettings& settings)

--- a/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowTaskPort.h
+++ b/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowTaskPort.h
@@ -96,6 +96,13 @@ struct EnteredPageObservation
     bool classification_conflict = false;
 };
 
+enum class MoveConfirmationStatus
+{
+    Succeeded,
+    NeedsDismiss,
+    Failed,
+};
+
 [[nodiscard]] EnteredPageObservation classify_entered_page_texts(std::vector<std::string> matched_texts);
 
 class IBlackFlowMapObservationSource
@@ -130,7 +137,7 @@ public:
         MovePreview& preview,
         bool& panel_open,
         std::string* error) = 0;
-    virtual bool
+    virtual MoveConfirmationStatus
         confirm(const MoveTransaction& transaction, EnteredPageObservation& entered_page, std::string* error) = 0;
 
     virtual void reset_run() {}
@@ -158,7 +165,8 @@ public:
         MovePreview& preview,
         bool& panel_open,
         std::string* error) override;
-    bool confirm(const MoveTransaction& transaction, EnteredPageObservation& entered_page, std::string* error) override;
+    MoveConfirmationStatus
+        confirm(const MoveTransaction& transaction, EnteredPageObservation& entered_page, std::string* error) override;
 
     void configure_diagnostics(const DiagnosticSettings& settings) override;
     bool persist_diagnostics(const DiagnosticArtifactRequest& request, std::string* error) override;


### PR DESCRIPTION
点击“出发前往”后，页面切换可能受到卡顿或延迟影响。下一张截图仍可能识别到旧的按钮，原有 `#self` 循环会立即发出第二次点击。

第二次点击真正落下时，界面可能已经进入商店。由于商店“离开”按钮与原确认按钮的位置重合，这次点击可能误触“离开”，并使界面进入“确认离开”状态，导致后续商店离开任务无法匹配预期页面。

原有 `maxTimes: 3` 还缺少 `exceededNext`。按钮在三次点击后仍能匹配时，`ProcessTask` 会进入空后继并返回成功，随后 C++ 继续提交尚未完成的移动状态。

每批确认流程现在会：
1. 点击一次“出发前往”。
2. 在 500、1000、1500 和 2000 ms检查确认按钮。
3. 按钮提前消失时立即确认成功，不再额外点击。
4. 按钮持续存在两秒时，才点下一次。
5. 最多执行四次点击；第四次点击后按钮仍持续存在两秒，则进入明确的次数耗尽状态。

观察状态机使用 taskDelay 0，防止默认任务间隔叠加到配置等待时间。截图获取和模板识别本身仍会占用时间，因此实际经过时间可能略长于两秒。

确认成功后，原有 MovePreviewConfirmCompleted 流程会单独执行，继续保留默认任务间隔和 600 毫秒页面稳定等待。
第一批确认耗尽时，当前移动事务取消，并关闭预览面板，流程随后回到地图准备并重新选择。第二批确认再次耗尽时，会通过现有的 FailureDisposition::RestartRun 路径重开当前局。

fix: #17865, #17850

## Sourcery 总结

使 Black Flow 移动确认能够稳健地处理延迟的 UI 更新，并在确认尝试次数耗尽时明确恢复。

错误修复：
- 防止重复或时机不当的 Black Flow 移动确认触发非预期的 UI 操作。
- 明确处理移动确认尝试次数耗尽的情况，避免错误地报告成功并继续执行不完整的移动。

增强功能：
- 将确认成功稳定处理与确认重试循环分离，并使用明确的确认结果。
- 在确认次数耗尽时，通过关闭预览并重试一次选择来进行恢复；如果确认仍然失败，则重新启动运行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make Black Flow movement confirmation robust against delayed UI updates and clearly recover when confirmation attempts are exhausted.

Bug Fixes:
- Prevent duplicate or mistimed Black Flow movement confirmations from triggering unintended UI actions.
- Handle exhausted movement confirmation attempts explicitly instead of reporting false success and continuing with an incomplete move.

Enhancements:
- Separate confirmation success stabilization from the confirmation retry loop and use explicit confirmation outcomes.
- Recover from exhausted confirmations by dismissing the preview and retrying selection once, then restarting the run if confirmation continues to fail.

</details>

## Sourcery 总结

增强 Black Flow 移动确认机制，以应对延迟的 UI 更新，并在确认尝试次数耗尽时添加明确的恢复机制。

Bug 修复：
- 防止重复或时机不当的 Black Flow 移动确认触发非预期的 UI 操作。
- 明确处理移动确认次数耗尽的情况，避免错误地报告成功并继续执行不完整的移动。

功能增强：
- 将确认成功稳定处理与重试逻辑分离，并提供明确的确认结果。
- 在确认次数耗尽时，通过关闭预览并重新尝试选择来恢复；如果确认再次失败，则重新启动运行。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

增强 Black Flow 移动确认机制，使其能够适应 UI 延迟更新，并在确认尝试次数耗尽时安全恢复。

错误修复：
- 防止延迟的 Black Flow 移动确认导致重复点击或触发非预期的 UI 操作。
- 显式处理移动确认次数耗尽的情况，避免将未完成的移动报告为成功。

增强功能：
- 将确认重试结果与确认后的页面稳定过程分离，并在确认失败时通过关闭预览、重试一次来进行恢复；如果再次确认失败，则重新启动运行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Make Black Flow movement confirmation resilient to delayed UI updates and recover safely when confirmation attempts are exhausted.

Bug Fixes:
- Prevent delayed Black Flow movement confirmations from issuing duplicate clicks or triggering unintended UI actions.
- Handle exhausted movement confirmations explicitly instead of reporting success for an incomplete move.

Enhancements:
- Separate confirmation retry outcomes from post-confirmation page stabilization and provide recovery by dismissing the preview, retrying once, and restarting the run if confirmation fails again.

</details>

</details>