### PR TITLE
docs: 更新仓库分支名（dev → dev-v2），修复“编辑此页”链接404

### DIFF
--- a/docs/.vuepress/config.ts
+++ b/docs/.vuepress/config.ts
@@ -57,7 +57,7 @@ export default defineUserConfig({
 
     docsRepo: 'MaaAssistantArknights/MaaAssistantArknights',
     docsDir: '/docs',
-    docsBranch: 'dev',
+    docsBranch: 'dev-v2',
 
     editLink: true,
     lastUpdated: false,


### PR DESCRIPTION
## Summary by Sourcery

更新文档分支配置以确保“编辑此页”链接指向正确的仓库分支。

Bug Fixes:
- 修复文档“编辑此页”链接因分支配置不正确而返回 404 的问题。

Documentation:
- 将文档仓库分支配置从 `dev` 更新为 `dev-v2`。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

更新文档分支配置以确保“编辑此页”链接指向正确的仓库分支。

Bug Fixes:
- 修复文档“编辑此页”链接因分支配置不正确而返回 404 的问题。

Documentation:
- 将文档仓库分支配置从 `dev` 更新为 `dev-v2`。

</details>