### PR TITLE
fix: 忽略仅由屏幕方向切换引起的分辨率变化

### DIFF
--- a/src/MaaCore/Controller/AdbController.cpp
+++ b/src/MaaCore/Controller/AdbController.cpp
@@ -684,21 +684,21 @@ bool asst::AdbController::screencap(cv::Mat& image_payload, bool allow_reconnect
                      static_cast<uint32_t>(static_cast<unsigned char>(data[5])) << 8 |
                      static_cast<uint32_t>(static_cast<unsigned char>(data[6])) << 16 |
                      static_cast<uint32_t>(static_cast<unsigned char>(data[7])) << 24;
-        if (int(w) != m_width || int(h) != m_height) {
+        if ((std::max)(int(w), int(h)) != m_width || (std::min)(int(w), int(h)) != m_height) {
             // 截图头与已知分辨率不符，通常为运行中模拟器分辨率被外部修改。
             // 分辨率变化后触控倍率等整套映射全部过期，原地修补无法覆盖所有层，
             // 标记连接失效并通知上层走整体重连，本帧按失败处理
             invalidate_connection("Size from image header", w, h);
             return false;
         }
-        size_t std_size = 4ULL * m_width * m_height;
+        size_t std_size = 4ULL * w * h;
         if (data.size() < std_size) {
             return false;
         }
         const size_t header_size = data.size() - std_size; // 12 or 16. ref:
         // https://android.googlesource.com/platform/frameworks/base/+/26a2b97dbe48ee45e9ae70110714048f2f360f97%5E%21/cmds/screencap/screencap.cpp
         auto img_data_beg = data.cbegin() + header_size;
-        cv::Mat temp(m_height, m_width, CV_8UC4, const_cast<char*>(&*img_data_beg));
+        cv::Mat temp(int(h), int(w), CV_8UC4, const_cast<char*>(&*img_data_beg));
         if (temp.empty()) {
             return false;
         }
@@ -949,8 +949,11 @@ bool asst::AdbController::screencap(cv::Mat& image_payload, bool allow_reconnect
         // 每 1 分钟检测一次模拟器帧率
         check_fps();
 
-        if (screencap_ret &&
-            (image_payload.cols != m_last_screencap_size.first || image_payload.rows != m_last_screencap_size.second)) {
+        const std::pair<int, int> current_screencap_size {
+            (std::max)(image_payload.cols, image_payload.rows),
+            (std::min)(image_payload.cols, image_payload.rows),
+        };
+        if (screencap_ret && current_screencap_size != m_last_screencap_size) {
             // 截图尺寸发生帧间变化：模拟器分辨率可能被外部修改（MumuExtras/LDExtras
             // 输出原生分辨率且无协议头校验点，Encode 路径同理，统一在此检测）。
             // 以图像自身历史尺寸为基准，连接初期 fallback 桌面等持续性差异不会误触发；
@@ -959,7 +962,7 @@ bool asst::AdbController::screencap(cv::Mat& image_payload, bool allow_reconnect
             if (m_last_screencap_size.first != 0) {
                 invalidate_connection("Screencap size changed", image_payload.cols, image_payload.rows);
             }
-            m_last_screencap_size = { image_payload.cols, image_payload.rows };
+            m_last_screencap_size = current_screencap_size;
         }
 
         return screencap_ret;


### PR DESCRIPTION
## 变更说明

- 将截图尺寸按长边和短边规范化后再进行比较
- 忽略 `720 × 1280` 与 `1280 × 720` 这类仅由屏幕方向切换产生的变化
- Raw 截图仍按照协议头中的实际宽高构造图像，避免纵向截图被错误解析
- 实际分辨率发生变化时仍会使连接失效并中断任务

## 问题原因

连接时获取的屏幕尺寸已经通过 `max / min` 规范化为横屏尺寸，但运行中的截图尺寸检查仍按宽高顺序严格比较。

模拟器在游戏启动前可能处于竖屏状态，截图尺寸会从 `720 × 1280` 切换为 `1280 × 720`。虽然实际分辨率没有变化，仍会被误判为分辨率改变，导致开始唤醒任务中断。

本次修改参考连接探测中已有的尺寸规范化方式，以较大值作为宽、较小值作为高，使连接阶段与运行时截图检查的判断逻辑保持一致。

~~把 Startup 是否正在执行从任务层一路泄漏到 Controller 容易爆炸不值得所以不如都改了~~

## 测试

- [x] `cmake --preset windows-x64`
- [x] `cmake --build build --target MaaCore --config RelWithDebInfo --parallel`
- [x] `cmake --build build --target MaaWpfGui --config RelWithDebInfo --parallel`
- [x] MuMu 模拟器竖屏启动后进入游戏的实际场景测试

~~我相信用户不会在开游戏后顶着诱发颈椎病的风险旋转模拟器视奸MAA~~
~~不会真的有人竖屏玩吧~~

Fix #17932

## Sourcery 总结

忽略仅由屏幕方向切换导致的截图尺寸变化，同时保留对实际分辨率变化的检测。

Bug 修复：
- 防止仅由屏幕方向变化导致的截图尺寸变化被误判为分辨率变化，从而不必要地使连接失效或中断任务。
- 构建原始图像时保留截图协议标头中的实际宽度和高度，防止纵向截图被错误解析。

增强功能：
- 使运行时截图尺寸检查与连接时的分辨率规范化保持一致，同时继续针对真正的分辨率变化使连接失效。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ignore screenshot dimension changes caused solely by screen orientation switches while retaining detection of actual resolution changes.

Bug Fixes:
- Prevent screen-orientation-only screenshot size changes from being mistaken for resolution changes and unnecessarily invalidating connections or interrupting tasks.
- Preserve the actual width and height from screenshot protocol headers when constructing raw images, preventing portrait screenshots from being parsed incorrectly.

Enhancements:
- Align runtime screenshot dimension checks with connection-time resolution normalization while continuing to invalidate connections for genuine resolution changes.

</details>