### PR TITLE
feat(pc): PC端连接方式默认隐藏，仅可通过配置 AllowPCClient 启用

### DIFF
--- a/src/MaaWpfGui/Configuration/Global/Gui.cs
+++ b/src/MaaWpfGui/Configuration/Global/Gui.cs
@@ -45,6 +45,12 @@ public class Gui : NotifyPropertyChangedWithValue
 
     public bool HideCloseButton { get; set; }
 
+    /// <summary>
+    /// 是否在连接设置中显示"明日方舟 PC 端（社区维护）"连接方式。
+    /// 默认隐藏，仅可通过修改配置文件（gui.new.json 的 Gui 节点）启用。
+    /// </summary>
+    public bool AllowPCClient { get; set; }
+
     public string WindowTitleSelectShowList { get; set; } = "2 3 4";
 
     public bool WindowTitleScrollable { get; set; }

--- a/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/SettingsViewModel.cs
@@ -331,6 +331,26 @@ public class SettingsViewModel : Screen
         ConnectSettings.ConnectAddressHistory.CollectionChanged += (_, _) => {
             ConfigFactory.CurrentConfig.Gui.ConnectSettings.AddressHistory = [.. ConnectSettings.ConnectAddressHistory];
         };
+
+        // 明日方舟 PC 端连接方式默认隐藏（AllowPCClient 默认 false，仅改配置文件启用）。
+        // 未显式启用时，凡已选用 PC 连接方式的配置一律静默回退到 General；ADB 路径/地址与 Win32 附加设置保留，便于改配置后恢复。
+        if (!ConfigFactory.Root.Gui.AllowPCClient)
+        {
+            var anyPcConfig = false;
+            foreach (var kv in ConfigFactory.Root.Configurations)
+            {
+                if (kv.Value.Gui.ConnectSettings.Config == ConnectConfig.PC)
+                {
+                    kv.Value.Gui.ConnectSettings.Config = ConnectConfig.General;
+                    anyPcConfig = true;
+                }
+            }
+
+            if (anyPcConfig && ConnectSettings.ConnectConfig == ConnectConfig.PC)
+            {
+                ConnectSettings.ConnectConfig = ConnectConfig.General;
+            }
+        }
     }
 
     private void InitVersionUpdate()

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/ConnectSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/ConnectSettingsUserControlModel.cs
@@ -88,7 +88,7 @@ public class ConnectSettingsUserControlModel : PropertyChangedBase
     /// <summary>
     /// Gets the list of the configuration of connection.
     /// </summary>
-    public LocalizedObservableList<ConnectConfig> ConnectConfigList { get; } = new(
+    public LocalizedObservableList<ConnectConfig> AllConnectConfigList { get; } = new(
         (ConnectConfig.General, "General"),
         (ConnectConfig.BlueStacks, "BlueStacks"),
         (ConnectConfig.MuMuEmulator12, "MuMuEmulator12"),
@@ -102,6 +102,24 @@ public class ConnectSettingsUserControlModel : PropertyChangedBase
         (ConnectConfig.Compatible, "Compatible"),
         (ConnectConfig.SecondResolution, "SecondResolution"),
         (ConnectConfig.GeneralWithoutScreencapErr, "GeneralWithoutScreencapErr"));
+
+    /// <summary>
+    /// Gets the list of the configuration of connection, 过滤掉默认隐藏的"明日方舟 PC 端（社区维护）"。
+    /// </summary>
+    public List<GenericCombinedData<ConnectConfig>> ConnectConfigList =>
+        [.. AllConnectConfigList.Items.Where(v => AllowPCClient || v.Value != ConnectConfig.PC)];
+
+    /// <summary>
+    /// Gets or sets a value indicating whether to show the PC client connection option in the connection settings.
+    /// 默认隐藏，仅可通过修改配置文件（gui.new.json 的 Gui 节点）启用。
+    /// </summary>
+    public bool AllowPCClient
+    {
+        get; set {
+            SetAndNotify(ref field, value);
+            ConfigFactory.Root.Gui.AllowPCClient = value;
+        }
+    } = ConfigFactory.Root.Gui.AllowPCClient;
 
     public static string TouchModeVideoPath => Path.Combine(PathsHelper.BaseDir, "Res", "Video", "TouchMode.mp4");
 
@@ -241,7 +259,14 @@ public class ConnectSettingsUserControlModel : PropertyChangedBase
             Instances.AsstProxy.Connected = false;
             SetAndNotify(ref field, value);
             ConfigFactory.CurrentConfig.Gui.ConnectSettings.Config = value;
-            Instances.SettingsViewModel.UpdateWindowTitle(); // 每次修改客户端时更新WindowTitle
+
+            // 仅在运行期同步窗口标题；构造阶段（SettingsViewModel 构造函数内的启动回退）时
+            // Instances.SettingsViewModel 尚未赋值且未挂载 RootViewModel，需跳过，
+            // 挂载后由 RootViewModel.InitViewModels 统一刷新标题。
+            if (Instances.SettingsViewModel is { } settingsViewModel)
+            {
+                settingsViewModel.UpdateWindowTitle(); // 每次修改客户端时更新WindowTitle
+            }
 
             // 切换连接配置时，若不再使用 MuMu 截图增强，需移除 MuMu 触控选项
             var mumuEnabled = ExtraConfig is MuMu12Extra { Enable: true };
@@ -876,7 +901,8 @@ public class ConnectSettingsUserControlModel : PropertyChangedBase
     /// </summary>
     private void RefreshLocalization()
     {
-        ConnectConfigList.RefreshLocalization();
+        AllConnectConfigList.RefreshLocalization();
+        OnPropertyChanged(nameof(ConnectConfigList));
         TouchModeList.RefreshLocalization();
     }
 }


### PR DESCRIPTION
### 改动

- 新增根配置 `Gui.AllowPCClient`（位于 `gui.new.json` 的 `Gui` 节点，默认 `false`）
- 未启用时，连接设置下拉框过滤掉 `ConnectConfig.PC` 项（连接设置 / 启动设置 / 新手引导三处入口）
- 未启用时，存量已选用 PC 连接的配置启动时静默回退到 `General`（通用连接），保留 ADB 路径/地址与 Win32 附加设置，便于开启后恢复

### 测试

- [x] 默认隐藏：未启用时下拉框无 PC 项
- [x] 存量回退：`Config = "PC"` 且未启用时，启动不崩溃，配置自动回退 `General`，ADB/Win32 设置保留
- [x] 配置启用：`AllowPCClient = true` 时 PC 项出现且不被回退

## Sourcery 摘要

默认隐藏 PC 客户端连接方式，并允许通过配置启用。

新功能：
- 添加 `Gui.AllowPCClient` 设置，用于控制 PC 客户端连接选项的可见性。

错误修复：
- 默认隐藏 PC 客户端连接选项，并自动将现有的 PC 配置回退为“通用”，同时保留相关连接设置。

增强功能：
- 在连接设置中统一应用 PC 连接筛选，并安全处理启动时的回退，避免初始化错误。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Hide the PC client connection method by default and allow it to be enabled through configuration.

New Features:
- Add the Gui.AllowPCClient setting to control visibility of the PC client connection option.

Bug Fixes:
- Hide the PC client connection option by default and automatically fall back existing PC configurations to General while preserving related connection settings.

Enhancements:
- Apply PC connection filtering consistently across connection settings and safely handle startup fallback without initialization errors.

</details>