### PR TITLE
build: 修复Unix平台上构建MaaWpfGui报错

### DIFF
--- a/src/MaaWpfGui/MaaWpfGui.csproj
+++ b/src/MaaWpfGui/MaaWpfGui.csproj
@@ -28,10 +28,15 @@
     <BeautyUsePatch Condition="'$(RuntimeIdentifier)' != ''">true</BeautyUsePatch>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <AppendRuntimeIdentifierToOutputPath>false</AppendRuntimeIdentifierToOutputPath>
-    <PostBuildEvent>
+    <PostBuildEvent Condition="'$(OS)' == 'Windows_NT'">
       echo Creating resource directory link...
       if exist "$(OutputPath)resource" rmdir "$(OutputPath)resource"
       mklink /J "$(OutputPath)resource" "$(SolutionDir)\..\resource"
+      echo Resource directory link created successfully
+    </PostBuildEvent>
+    <PostBuildEvent Condition="'$(OS)' != 'Windows_NT'">
+      echo Creating resource directory link...
+      ln -sfT "$(SolutionDir)/../resource" "$(OutputPath)resource"
       echo Resource directory link created successfully
     </PostBuildEvent>
   </PropertyGroup>

--- a/src/MaaWpfGui/MaaWpfGui.csproj
+++ b/src/MaaWpfGui/MaaWpfGui.csproj
@@ -36,7 +36,7 @@
     </PostBuildEvent>
     <PostBuildEvent Condition="'$(OS)' != 'Windows_NT'">
       echo Creating resource directory link...
-      ln -sfT "$(SolutionDir)/../resource" "$(OutputPath)resource"
+      ln -sfn "$([MSBuild]::NormalizeDirectory($(SolutionDir), ".."))resource" "$(OutputPath)resource"
       echo Resource directory link created successfully
     </PostBuildEvent>
   </PropertyGroup>


### PR DESCRIPTION
自 #8960 以来，非Windows平台应该也能构建MaaWpfGui，但是后来 #14077 加了个基于cmd的PostBuildEvent，就坏了。这里补上sh的版本，即可正常通过`dotnet build -p:Platform=x64`构建。

## Sourcery 总结

修复 MaaWpfGui 在 Unix 平台上的构建兼容性。

错误修复：
- 修复在 Unix 平台构建 MaaWpfGui 时，因基于 cmd 的构建后事件导致的构建失败。

构建：
- 为 Unix 平台补充兼容的构建后事件，使 MaaWpfGui 可以通过 dotnet build 正常构建。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

支持 MaaWpfGui 在 Unix 平台上的正常构建。

Bug Fixes:
- 修复 MaaWpfGui 在 Unix 平台构建时因 Windows 专用构建后事件导致的失败。

Build:
- 为 Unix 平台提供兼容的构建后事件，使 MaaWpfGui 支持通过 dotnet build 正常构建。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

支持 MaaWpfGui 在 Unix 平台上的正常构建。

Bug Fixes:
- 修复 MaaWpfGui 在 Unix 平台构建时因 Windows 专用构建后事件导致的失败。

Build:
- 为 Unix 平台提供兼容的构建后事件，使 MaaWpfGui 支持通过 dotnet build 正常构建。

</details>

</details>