### PR TITLE
docs(mac): 添加 Mac GUI 过渡公告

### DIFF
--- a/docs/zh-cn/mac.md
+++ b/docs/zh-cn/mac.md
@@ -1,0 +1,89 @@
+---
+title: MAA Mac GUI 公告
+comments: false
+editLink: false
+readingTime: false
+---
+
+::: note 过渡期说明
+在 Mac GUI 内置公告功能完成前，版本动态、重要提醒和临时解决方案将在本页发布。
+:::
+
+<!--
+维护约定：
+1. 当前公告按重要程度排列，不要把更新日志完整复制到这里。
+2. 需要用户立即处理的内容使用 danger，影响部分用户的内容使用 warning，一般消息使用 tip。
+3. 每条公告注明发布日期和适用版本；失效后移入“历史公告”。
+4. 安装、连接等长期有效的说明应更新到用户手册，本页只保留链接。
+-->
+
+## 当前公告
+
+::: warning 2026 年 8 月 26 日资源更新异常
+2026 年 8 月 26 日凌晨发布的资源更新存在异常，可能导致 Mac GUI 报告“初始化失败”。
+
+如遇此错误，请更新至 `v6.17.0-beta.6` 或更高版本。你可以在 Mac GUI 的更新设置中开启“**接收开发版更新**”后使用内置更新，也可以参考下方的 [更新与下载](#更新与下载) 手动下载。
+:::
+
+<!-- 公告模板
+::: warning 公告标题
+**发布日期：** YYYY-MM-DD
+**适用版本：** vX.Y.Z（如不限制版本，可写“全部版本”）
+
+用一两句话说明发生了什么、影响哪些用户。
+
+**你需要做什么：**
+
+1. 给出最短、明确的处理步骤。
+2. 如有详细说明，链接到用户手册或对应 Issue。
+:::
+-->
+
+## 更新与下载
+
+- 建议优先使用 Mac GUI 和 PlayCover 各自内置的“检查更新”功能。若无法正常更新，可分别前往 [MAA Releases](https://github.com/MaaAssistantArknights/MaaAssistantArknights/releases) 和 [PlayCover Releases](https://github.com/hguandl/PlayCover/releases) 手动下载。
+- Releases 中的 Mac GUI 安装包命名格式为 `MAA-<版本号>-macos-universal.dmg`。
+
+::: tip 推荐使用 Beta 版 Mac GUI
+Mac GUI 的开发进度可能滞后于 Windows GUI。建议在 Releases 页面选择标记为 **Pre-release** 的 Beta 版，或在 Mac GUI 的更新设置中开启“**接收开发版更新**”，以便及时获取 Mac 端的最新修复。
+:::
+
+## 已知问题与临时解决方案
+
+### “连接失败”不一定是连接问题
+
+Mac GUI 目前可能会将部分配置错误也显示为“连接失败”。遇到该提示时，除检查设备连接外，也请确认任务配置和资源是否正确。常见原因包括关卡名称填写错误，或资源未及时更新、缺少对应关卡的数据文件。
+
+### 其他连接与设备兼容问题
+
+遇到其他常规连接或设备兼容问题时，请先查阅 [Mac 模拟器支持](./manual/device/macos.md)。
+
+<!-- 已知问题模板
+### 问题简述
+
+- **影响范围：** 版本、系统或设备范围
+- **现象：** 用户能够观察到的表现
+- **临时方案：** 可立即执行的规避步骤
+- **跟踪进度：** 对应 Issue 或 PR 链接
+-->
+
+## 问题反馈
+
+如果公告和文档均未覆盖你遇到的问题，请前往 [GitHub Issues](https://github.com/MaaAssistantArknights/MaaAssistantArknights/issues) 反馈。提交前请准备：
+
+- Mac GUI 版本与 macOS 版本
+- 使用的模拟器或 PlayCover 版本
+- 问题发生前后的操作步骤
+- 日志、报错信息和必要的截图
+
+## 历史公告
+
+<!--
+旧公告按时间倒序放入 details 容器，避免拉长页面。例如：
+
+::: details YYYY-MM-DD · 公告标题
+公告正文或处理结果。
+:::
+-->
+
+暂无历史公告。


### PR DESCRIPTION
在 Mac GUI 内置公告功能完成前，新增独立的过渡公告页面，用于发布版本动态、重要提醒和临时解决方案。
预计链接为 https://docs.maa.plus/zh-cn/mac.html

## Sourcery 摘要

为 Mac GUI 发布版本、重要通知和临时解决方案添加多语言过渡公告页面。

新功能：
- 添加英语、日语、韩语、简体中文和繁体中文的 Mac GUI 公告页面。
- 为 Mac GUI 用户提供版本发布指南、下载链接、已知问题解决方法和问题报告说明。

改进：
- 建立过渡公告结构，用于发布当前通知并保留公告历史记录，直到 Mac GUI 支持公告功能。

文档：
- 记录可能导致初始化失败的资源更新问题，并建议更新到 v6.17.0-beta.6 或更高版本。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

添加多语言过渡公告页面，以便及时向 Mac GUI 用户提供版本发布、重要通知和临时解决方案等信息。

新功能：
- 添加支持英语、日语、韩语、简体中文和繁体中文的多语言 Mac GUI 公告页面。
- 为用户提供版本发布指南、下载链接、已知问题解决方法以及问题报告说明。

增强功能：
- 建立过渡公告结构，包含当前通知和历史公告部分，直到 Mac GUI 支持公告功能。

文档：
- 记录可能导致初始化失败的资源更新问题，并建议升级到 v6.17.0-beta.6 或更高版本。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

新增一个支持多语言的 Mac GUI 过渡公告页面，用于发布版本更新、重要通知和临时解决方案。

新功能：
- 新增 Mac GUI 过渡公告页面，为版本发布、下载、已知问题、临时解决方法和问题报告提供指导。

增强功能：
- 在内置公告支持不可用期间，建立当前和历史 Mac GUI 公告的结构。

文档：
- 记录可能导致初始化失败的资源更新问题，并建议升级到 v6.17.0-beta.6 或更高版本。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

添加一个临时的 Mac GUI 公告页面，以便及时向用户提供版本发布、重要通知和解决方法等信息。

新功能：
- 添加一个多语言 Mac GUI 迁移公告页面，涵盖版本发布、下载、已知问题、解决方法和问题报告。

增强功能：
- 建立用于发布当前及历史 Mac GUI 公告的结构，直至内置公告支持可用。

文档：
- 记录可能导致初始化失败的资源更新问题，并建议升级到 v6.17.0-beta.6 或更高版本。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

提供一个临时的 Mac GUI 公告页面，用于及时发布版本更新、重要通知和用户解决方法。

新功能：
- 添加多语言 Mac GUI 迁移公告页面，涵盖版本发布、下载、已知问题、临时解决方法和问题报告。

增强功能：
- 建立当前及历史 Mac GUI 公告的发布结构，直到内置公告支持可用。

文档：
- 记录一个可能导致初始化失败的资源更新问题，并建议升级到 v6.17.0-beta.6 或更高版本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Provide a temporary Mac GUI announcements page for timely release updates, important notices, and user workarounds.

New Features:
- Add a multilingual Mac GUI transition announcements page covering releases, downloads, known issues, temporary workarounds, and issue reporting.

Enhancements:
- Establish a structure for publishing current and historical Mac GUI announcements until built-in announcement support is available.

Documentation:
- Document a resource-update issue that may cause initialization failures and recommend upgrading to v6.17.0-beta.6 or later.

</details>

</details>

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

添加一个临时的 Mac GUI 公告页面，以便及时向用户提供版本发布、重要通知和解决方法等信息。

新功能：
- 添加一个多语言 Mac GUI 迁移公告页面，涵盖版本发布、下载、已知问题、解决方法和问题报告。

增强功能：
- 建立用于发布当前及历史 Mac GUI 公告的结构，直至内置公告支持可用。

文档：
- 记录可能导致初始化失败的资源更新问题，并建议升级到 v6.17.0-beta.6 或更高版本。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

提供一个临时的 Mac GUI 公告页面，用于及时发布版本更新、重要通知和用户解决方法。

新功能：
- 添加多语言 Mac GUI 迁移公告页面，涵盖版本发布、下载、已知问题、临时解决方法和问题报告。

增强功能：
- 建立当前及历史 Mac GUI 公告的发布结构，直到内置公告支持可用。

文档：
- 记录一个可能导致初始化失败的资源更新问题，并建议升级到 v6.17.0-beta.6 或更高版本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Provide a temporary Mac GUI announcements page for timely release updates, important notices, and user workarounds.

New Features:
- Add a multilingual Mac GUI transition announcements page covering releases, downloads, known issues, temporary workarounds, and issue reporting.

Enhancements:
- Establish a structure for publishing current and historical Mac GUI announcements until built-in announcement support is available.

Documentation:
- Document a resource-update issue that may cause initialization failures and recommend upgrading to v6.17.0-beta.6 or later.

</details>

</details>

</details>

</details>

</details>

</details>