### PR TITLE
fix: wait for loading after visiting a friend

### DIFF
--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -2212,7 +2212,7 @@
             ]
         ],
         "roi": [1080, 570, 200, 130],
-        "next": ["VisitLimited", "VisitNext", "VisitNextBlack", "VisitNextOcr"]
+        "next": ["VisitNext@LoadingText", "VisitLimited", "VisitNext", "VisitNextBlack", "VisitNextOcr"]
     },
     "VisitNextBlack": {
         "method": "HSVCount",
@@ -2230,7 +2230,7 @@
         "text": ["访问下位"],
         "action": "ClickSelf",
         "roi": [1080, 570, 200, 130],
-        "next": ["VisitLimited", "VisitNext", "VisitNextBlack", "VisitNextOcr"]
+        "next": ["VisitNext@LoadingText", "VisitLimited", "VisitNext", "VisitNextBlack", "VisitNextOcr"]
     },
     "MallBegin": {
         "algorithm": "JustReturn",


### PR DESCRIPTION
## 变更内容

访问好友时，点击“访问下位”后优先检查加载提示，再继续识别下一位好友或结束访问。这样可以避免模拟器或虚拟机加载较慢时，把加载界面上的残留按钮误判为可操作目标。

## 关联 Issue

Fixes #17923

## 验证

- 已用当前资源任务文件解析并检查任务顺序
- 已通过 git diff --check

## Sourcery 总结

错误修复：
- 确保在选择下一位好友后，好友访问会等待加载指示器消失，从而避免在运行缓慢的模拟器或虚拟机上将过时的控件误认为可操作目标。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure friend visits wait for the loading indicator to clear after selecting the next friend, preventing stale controls from being mistaken for actionable targets on slow emulators or virtual machines.

</details>