### PR TITLE
fix: retry BlackFlow investment entry clicks

### DIFF
--- a/resource/tasks/Roguelike/BlackFlow.json
+++ b/resource/tasks/Roguelike/BlackFlow.json
@@ -1433,6 +1433,16 @@
     "BlackFlow@Roguelike@StageTraderInvest-Wallet": {
         "roi": [1136, 15, 124, 43]
     },
+    "BlackFlow@Roguelike@StageTraderInvestSystem": {
+        "baseTask": "Roguelike@StageTraderInvestSystem",
+        "maxTimes": 3,
+        "next": [
+            "BlackFlow@Roguelike@StageTraderInvestSystemEnter",
+            "BlackFlow@Roguelike@StageTraderInvestSystem",
+            "BlackFlow@Roguelike@StageTraderLeave"
+        ],
+        "exceededNext": ["BlackFlow@Roguelike@StageTraderLeave"]
+    },
     "BlackFlow@Roguelike@StageTraderInvestCancel": {
         "baseTask": "Roguelike@StageTraderInvestCancel",
         "template": "Roguelike@StageTraderInvestCancel.png",
@@ -1456,7 +1466,8 @@
             "BlackFlow@Roguelike@StageTraderInvestCancel",
             "#self"
         ],
-        "maxTimes": 3
+        "maxTimes": 3,
+        "reduceOtherTimes": ["BlackFlow@Roguelike@StageTraderInvestSystem*3"]
     },
     "BlackFlow@Roguelike@StageTraderInvestSystemError": {
         "baseTask": "Roguelike@StageTraderInvestSystemError",
@@ -1490,7 +1501,10 @@
     },
     "BlackFlow@Roguelike@StageTraderLeaveConfirmCompleted": {
         "algorithm": "JustReturn",
-        "reduceOtherTimes": ["BlackFlow@Roguelike@StageTraderLeaveConfirm*3"],
+        "reduceOtherTimes": [
+            "BlackFlow@Roguelike@StageTraderLeaveConfirm*3",
+            "BlackFlow@Roguelike@StageTraderInvestSystem*3"
+        ],
         "next": ["BlackFlow@Roguelike@Stages"]
     },
     "BlackFlow@Roguelike@Stages": {


### PR DESCRIPTION
## 变更内容

黑流树海投资模式进入投资页时，点击被模拟器吞掉后，当前任务会直接匹配“离开商店”，导致本轮没有存款就重开。

为黑流投资入口增加最多 3 次的同页重试：如果投资页入口仍然存在，就再次点击；成功进入投资页或正常离开商店后会重置重试计数，不会影响下一次商店。

## 关联 Issue

Fixes #17922

## 验证

- 已对照 Issue 报告中的 asst.log 确认失败路径：投资入口点击后匹配到离开商店
- 已用当前资源任务文件解析并检查重试上限及计数重置
- 已通过 git diff --check

## Sourcery 总结

错误修复：
- 当第一次点击未生效时，最多重试三次点击 BlackFlow 投资入口，避免任务未存款就错误地离开商店。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Retry BlackFlow investment entry clicks up to three times when the first click is lost, preventing the task from incorrectly leaving the shop without making a deposit.

</details>