### PR TITLE
fix(wpf): 完善消息队列耗尽恢复并防止任务队列锁泄漏

### DIFF
--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -927,8 +927,10 @@ public class AsstProxy
                         UiLogColor.Error, showTime: false);
                     Execute.OnUIThreadAsync(async () => {
                         Connected = false;
-                        await Instances.TaskQueueViewModel.Stop();
-                        Instances.TaskQueueViewModel.SetStopped();
+                        if (await Instances.TaskQueueViewModel.Stop())
+                        {
+                            Instances.TaskQueueViewModel.SetStopped();
+                        }
                     });
                 }
 
@@ -1079,8 +1081,10 @@ public class AsstProxy
                     {
                         Execute.OnUIThreadAsync(async () => {
                             Connected = false;
-                            await Instances.TaskQueueViewModel.Stop();
-                            Instances.TaskQueueViewModel.SetStopped();
+                            if (await Instances.TaskQueueViewModel.Stop())
+                            {
+                                Instances.TaskQueueViewModel.SetStopped();
+                            }
                         });
                     }
                 }

--- a/src/MaaWpfGui/Main/Bootstrapper.cs
+++ b/src/MaaWpfGui/Main/Bootstrapper.cs
@@ -61,6 +61,9 @@ namespace MaaWpfGui.Main;
 public class Bootstrapper : Bootstrapper<RootViewModel>
 {
     private const int ErrorNotEnoughQuota = 1816;
+    private const int WpfMessageQueueShutdownGracePeriodMilliseconds = 5000;
+    private const int RecoveryParentExitWaitMilliseconds = 30000;
+    private const string WaitForProcessExitArg = "--wait-for-process-exit";
 
     private static ILogger _logger = Logger.None;
 
@@ -427,6 +430,10 @@ public class Bootstrapper : Bootstrapper<RootViewModel>
     protected override void OnStart()
     {
         Directory.SetCurrentDirectory(AppContext.BaseDirectory);
+        var args = Environment.GetCommandLineArgs();
+
+        // Recovery children must wait before opening the shared log files or acquiring the single-instance mutex.
+        WaitForProcessExitIfRequested(args);
         if (!Directory.Exists("debug"))
         {
             Directory.CreateDirectory("debug");
@@ -459,7 +466,6 @@ public class Bootstrapper : Bootstrapper<RootViewModel>
         var maaEnv = Environment.GetEnvironmentVariable("MAA_ENVIRONMENT") == "Debug"
             ? "Debug"
             : "Production";
-        var args = Environment.GetCommandLineArgs();
         var withDebugFile = File.Exists("DEBUG") || File.Exists("DEBUG.txt");
         loggerConfiguration = (maaEnv == "Debug" || withDebugFile)
             ? loggerConfiguration.MinimumLevel.Verbose()
@@ -1218,6 +1224,7 @@ public class Bootstrapper : Bootstrapper<RootViewModel>
             if (Interlocked.Exchange(ref _wpfMessageQueueRecoveryStarted, 1) == 0)
             {
                 _logger.Fatal("WPF window message queue quota was exhausted. Restarting MAA to recover.");
+                StartWpfMessageQueueRecoveryWatchdog();
                 ShutdownAndRestartWithoutArgs();
             }
 
@@ -1243,6 +1250,72 @@ public class Bootstrapper : Bootstrapper<RootViewModel>
         }
 
         return false;
+    }
+
+    private static void StartWpfMessageQueueRecoveryWatchdog()
+    {
+        var processPath = Environment.ProcessPath;
+        var currentProcessId = Environment.ProcessId;
+        var workingDirectory = AppDomain.CurrentDomain.BaseDirectory;
+        var watchdog = new Thread(() => {
+            Thread.Sleep(WpfMessageQueueShutdownGracePeriodMilliseconds);
+
+            try
+            {
+                if (processPath is not null)
+                {
+                    var startInfo = new ProcessStartInfo {
+                        FileName = processPath,
+                        WorkingDirectory = workingDirectory,
+                        UseShellExecute = false,
+                    };
+                    startInfo.ArgumentList.Add(WaitForProcessExitArg);
+                    startInfo.ArgumentList.Add(currentProcessId.ToString());
+                    Process.Start(startInfo);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.Fatal(ex, "Failed to launch the WPF message queue recovery process.");
+            }
+            finally
+            {
+                Environment.FailFast("WPF message queue recovery watchdog forced process termination.");
+            }
+        }) {
+            IsBackground = true,
+            Name = "WPF message queue recovery watchdog",
+        };
+        watchdog.Start();
+    }
+
+    private static void WaitForProcessExitIfRequested(string[] args)
+    {
+        var parsedArgs = ParseArgs(args, WaitForProcessExitArg);
+        if (!parsedArgs.TryGetValue(WaitForProcessExitArg, out var processIdText) ||
+            !int.TryParse(processIdText, out var processId) ||
+            processId <= 0 ||
+            processId == Environment.ProcessId)
+        {
+            return;
+        }
+
+        try
+        {
+            using var process = Process.GetProcessById(processId);
+            if (!process.WaitForExit(RecoveryParentExitWaitMilliseconds))
+            {
+                Debug.WriteLine($"Timed out waiting for recovery parent process {processId} to exit.");
+            }
+        }
+        catch (ArgumentException)
+        {
+            // The parent process has already exited.
+        }
+        catch (Exception ex)
+        {
+            Debug.WriteLine($"Failed while waiting for recovery parent process {processId} to exit: {ex}");
+        }
     }
 
     private static void LogUnhandledException(Exception exception)

--- a/src/MaaWpfGui/Main/Bootstrapper.cs
+++ b/src/MaaWpfGui/Main/Bootstrapper.cs
@@ -1319,10 +1319,6 @@ public class Bootstrapper : Bootstrapper<RootViewModel>
         {
             // The parent process has already exited.
         }
-        catch (Exception ex)
-        {
-            Debug.WriteLine($"Failed while waiting for recovery parent process {processId} to exit: {ex}");
-        }
     }
 
     private static void LogUnhandledException(Exception exception)

--- a/src/MaaWpfGui/Main/Bootstrapper.cs
+++ b/src/MaaWpfGui/Main/Bootstrapper.cs
@@ -13,6 +13,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -59,7 +60,11 @@ namespace MaaWpfGui.Main;
 /// </summary>
 public class Bootstrapper : Bootstrapper<RootViewModel>
 {
+    private const int ErrorNotEnoughQuota = 1816;
+
     private static ILogger _logger = Logger.None;
+
+    private static int _wpfMessageQueueRecoveryStarted;
 
     private static Mutex _mutex;
     private static bool _hasMutex;
@@ -1205,8 +1210,39 @@ public class Bootstrapper : Bootstrapper<RootViewModel>
     protected override void OnUnhandledException(DispatcherUnhandledExceptionEventArgs e)
     {
         LogUnhandledException(e.Exception);
+
+        if (IsWpfMessageQueueQuotaException(e.Exception))
+        {
+            e.Handled = true;
+
+            if (Interlocked.Exchange(ref _wpfMessageQueueRecoveryStarted, 1) == 0)
+            {
+                _logger.Fatal("WPF window message queue quota was exhausted. Restarting MAA to recover.");
+                ShutdownAndRestartWithoutArgs();
+            }
+
+            return;
+        }
+
         ShowErrorDialog(e.Exception);
         e.Handled = true;
+    }
+
+    private static bool IsWpfMessageQueueQuotaException(Exception exception)
+    {
+        for (Exception current = exception; current is not null; current = current.InnerException)
+        {
+            if (current is not Win32Exception { NativeErrorCode: ErrorNotEnoughQuota })
+            {
+                continue;
+            }
+
+            var details = current.ToString();
+            return details.Contains("System.Windows.Interop.HwndTarget", StringComparison.Ordinal) ||
+                   details.Contains("MS.Win32.UnsafeNativeMethods.PostMessage", StringComparison.Ordinal);
+        }
+
+        return false;
     }
 
     private static void LogUnhandledException(Exception exception)

--- a/src/MaaWpfGui/Main/Bootstrapper.cs
+++ b/src/MaaWpfGui/Main/Bootstrapper.cs
@@ -62,7 +62,6 @@ public class Bootstrapper : Bootstrapper<RootViewModel>
 {
     private const int ErrorNotEnoughQuota = 1816;
     private const int WpfMessageQueueShutdownGracePeriodMilliseconds = 5000;
-    private const int RecoveryParentExitWaitMilliseconds = 30000;
     private const string WaitForProcessExitArg = "--wait-for-process-exit";
 
     private static ILogger _logger = Logger.None;
@@ -1303,10 +1302,9 @@ public class Bootstrapper : Bootstrapper<RootViewModel>
         try
         {
             using var process = Process.GetProcessById(processId);
-            if (!process.WaitForExit(RecoveryParentExitWaitMilliseconds))
-            {
-                Debug.WriteLine($"Timed out waiting for recovery parent process {processId} to exit.");
-            }
+
+            // WER may keep the failed parent alive while writing a dump. Shared startup must not continue until it exits.
+            process.WaitForExit();
         }
         catch (ArgumentException)
         {

--- a/src/MaaWpfGui/Main/Bootstrapper.cs
+++ b/src/MaaWpfGui/Main/Bootstrapper.cs
@@ -1216,22 +1216,31 @@ public class Bootstrapper : Bootstrapper<RootViewModel>
     {
         LogUnhandledException(e.Exception);
 
-        if (IsWpfMessageQueueQuotaException(e.Exception))
+        if (TryStartWpfMessageQueueRecovery(e.Exception))
         {
             e.Handled = true;
-
-            if (Interlocked.Exchange(ref _wpfMessageQueueRecoveryStarted, 1) == 0)
-            {
-                _logger.Fatal("WPF window message queue quota was exhausted. Restarting MAA to recover.");
-                StartWpfMessageQueueRecoveryWatchdog();
-                ShutdownAndRestartWithoutArgs();
-            }
-
             return;
         }
 
         ShowErrorDialog(e.Exception);
         e.Handled = true;
+    }
+
+    internal static bool TryStartWpfMessageQueueRecovery(Exception exception)
+    {
+        if (!IsWpfMessageQueueQuotaException(exception))
+        {
+            return false;
+        }
+
+        if (Interlocked.Exchange(ref _wpfMessageQueueRecoveryStarted, 1) == 0)
+        {
+            _logger.Fatal("WPF window message queue quota was exhausted. Restarting MAA to recover.");
+            StartWpfMessageQueueRecoveryWatchdog();
+            ShutdownAndRestartWithoutArgs();
+        }
+
+        return true;
     }
 
     private static bool IsWpfMessageQueueQuotaException(Exception exception)

--- a/src/MaaWpfGui/Services/RemoteControl/RemoteControlService.cs
+++ b/src/MaaWpfGui/Services/RemoteControl/RemoteControlService.cs
@@ -308,14 +308,14 @@ public class RemoteControlService
                 case "LinkStart":
                     {
                         // 一键长草特殊任务
-                        await _runningState.UntilIdleAsync();
                         var startLogStr = LocalizationHelper.GetStringFormat("RemoteControlReceivedTask", type, id);
 
                         Instances.TaskQueueViewModel.AddLog(startLogStr);
-                        await Execute.OnUIThreadAsync(() => {
-                            _ = Instances.TaskQueueViewModel.LinkStart();
-                        });
-                        await _runningState.UntilIdleAsync();
+                        if (!await LinkStartAllTasks())
+                        {
+                            status = "FAILED";
+                            break;
+                        }
 
                         var stopLogStr = LocalizationHelper.GetStringFormat("RemoteControlCompletedTask", type, id);
                         Instances.TaskQueueViewModel.AddLog(stopLogStr);
@@ -331,7 +331,11 @@ public class RemoteControlService
                 case "LinkStart-AutoRoguelike":
                 case "LinkStart-Reclamation":
                     {
-                        await LinkStart([type.Split('-')[1]]);
+                        if (!await LinkStart([type.Split('-')[1]]))
+                        {
+                            status = "FAILED";
+                        }
+
                         break;
                     }
 
@@ -525,68 +529,115 @@ public class RemoteControlService
     /// <para>任务的连接、序列化、状态恢复和并发控制统一由 <see cref="TaskQueueViewModel"/> 处理。</para>
     /// </remarks>
     /// <param name="originalNames">指定的任务列表。</param>
-    /// <returns>异步任务，无返回结果。</returns>
-    private async Task LinkStart(IEnumerable<string> originalNames)
+    /// <returns>是否实际启动并完成了指定任务。</returns>
+    private async Task<bool> LinkStart(IEnumerable<string> originalNames)
     {
-        await _runningState.UntilIdleAsync();
+        while (true)
+        {
+            await _runningState.UntilIdleAsync();
 
-        await Execute.OnUIThreadAsync(async () => {
-            List<BaseTask> tasks = [];
-            foreach (var originalName in originalNames)
-            {
-                BaseTask task;
-                switch (originalName)
+            var startResult = TaskQueueStartResult.Failed;
+            await Execute.OnUIThreadAsync(async () => {
+                List<BaseTask> tasks = [];
+                foreach (var originalName in originalNames)
                 {
-                    case "Base":
-                        task = GetSingleTask<InfrastTask>();
-                        break;
-                    case "WakeUp":
-                        task = GetSingleTask<StartUpTask>();
-                        break;
-                    case "Combat":
-                        task = GetSingleTask<FightTask>();
-                        break;
-                    case "Recruiting":
-                        task = GetSingleTask<RecruitTask>();
-                        break;
-                    case "Mall":
-                        task = GetSingleTask<MallTask>();
-                        break;
-                    case "Mission":
-                        task = GetSingleTask<AwardTask>();
-                        break;
-                    case "AutoRoguelike":
-                        task = GetSingleTask<RoguelikeTask>();
-                        break;
-                    case "Reclamation":
-                        task = GetSingleTask<ReclamationTask>();
-                        break;
-                    default:
+                    BaseTask task;
+                    switch (originalName)
+                    {
+                        case "Base":
+                            task = GetSingleTask<InfrastTask>();
+                            break;
+                        case "WakeUp":
+                            task = GetSingleTask<StartUpTask>();
+                            break;
+                        case "Combat":
+                            task = GetSingleTask<FightTask>();
+                            break;
+                        case "Recruiting":
+                            task = GetSingleTask<RecruitTask>();
+                            break;
+                        case "Mall":
+                            task = GetSingleTask<MallTask>();
+                            break;
+                        case "Mission":
+                            task = GetSingleTask<AwardTask>();
+                            break;
+                        case "AutoRoguelike":
+                            task = GetSingleTask<RoguelikeTask>();
+                            break;
+                        case "Reclamation":
+                            task = GetSingleTask<ReclamationTask>();
+                            break;
+                        default:
+                            continue;
+                    }
+
+                    if (task is null)
+                    {
+                        Instances.TaskQueueViewModel.AddLog(originalName + "Error", UiLogColor.Error);
                         continue;
+                    }
+
+                    tasks.Add(task);
                 }
 
-                if (task is null)
-                {
-                    Instances.TaskQueueViewModel.AddLog(originalName + "Error", UiLogColor.Error);
-                    continue;
-                }
+                startResult = await Instances.TaskQueueViewModel.LinkStartWithTasks(
+                    tasks,
+                    runStartScript: false,
+                    forceEnableTasks: true);
+            });
 
-                tasks.Add(task);
+            if (startResult == TaskQueueStartResult.Busy)
+            {
+                Log.Logger.Information("Remote task startup lost the idle-state race; waiting to retry.");
+                continue;
             }
 
-            await Instances.TaskQueueViewModel.LinkStartWithTasks(
-                tasks,
-                runStartScript: false,
-                forceEnableTasks: true);
-        });
+            if (startResult != TaskQueueStartResult.Started)
+            {
+                return false;
+            }
 
-        await _runningState.UntilIdleAsync();
+            await _runningState.UntilIdleAsync();
+            return true;
+        }
 
         static T GetSingleTask<T>()
             where T : BaseTask
         {
             var matches = ConfigFactory.CurrentConfig.TaskQueue.OfType<T>().Take(2).ToList();
             return matches.Count == 1 ? matches[0] : null;
+        }
+    }
+
+    /// <summary>
+    /// 启动完整任务队列；若等待空闲后被其他入口抢先启动，则在其结束后重试。
+    /// </summary>
+    /// <returns>是否实际启动并完成了任务队列。</returns>
+    private async Task<bool> LinkStartAllTasks()
+    {
+        while (true)
+        {
+            await _runningState.UntilIdleAsync();
+
+            var startResult = TaskQueueStartResult.Failed;
+            await Execute.OnUIThreadAsync(async () => {
+                startResult = await Instances.TaskQueueViewModel.LinkStartWithTasks(ConfigFactory.CurrentConfig.TaskQueue);
+            });
+
+            if (startResult == TaskQueueStartResult.Busy)
+            {
+                Log.Logger.Information("Remote full task queue startup lost the idle-state race; waiting to retry.");
+                continue;
+            }
+
+            if (startResult != TaskQueueStartResult.Started)
+            {
+                return false;
+            }
+
+            await _runningState.UntilIdleAsync();
+            return true;
         }
     }
 

--- a/src/MaaWpfGui/Services/RemoteControl/RemoteControlService.cs
+++ b/src/MaaWpfGui/Services/RemoteControl/RemoteControlService.cs
@@ -28,7 +28,6 @@ using MaaWpfGui.Helper;
 using MaaWpfGui.States;
 using MaaWpfGui.ViewModels.UI;
 using MaaWpfGui.ViewModels.UserControl.Settings;
-using MaaWpfGui.ViewModels.UserControl.TaskQueue;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Serilog;
@@ -199,27 +198,6 @@ public class RemoteControlService
         }
 
         return (T)methodInfo.Invoke(instance, null);
-    }
-
-    private static async Task<T> InvokeInstanceAsyncFunction<T>(object instance, string methodName)
-    {
-        ArgumentNullException.ThrowIfNull(instance);
-
-        if (string.IsNullOrEmpty(methodName))
-        {
-            throw new ArgumentNullException(nameof(methodName));
-        }
-
-        Type type = instance.GetType();
-        MethodInfo methodInfo = type.GetMethod(methodName, BindingFlags.NonPublic | BindingFlags.Instance) ?? throw new ArgumentException($"Method '{methodName}' not found in type '{type.FullName}'.");
-
-        // 检查方法是否是异步方法 (返回Task或Task<T>)
-        if (!typeof(Task).IsAssignableFrom(methodInfo.ReturnType))
-        {
-            throw new ArgumentException($"Method '{methodName}' is not asynchronous.");
-        }
-
-        return await (Task<T>)methodInfo.Invoke(instance, null);
     }
 
     private static TResult InvokeStaticFunction<TResult>(Type staticType, string methodName)
@@ -540,209 +518,76 @@ public class RemoteControlService
     #endregion
 
     /// <summary>
-    /// 根据"一键长草"功能进行修改的方法。
+    /// 使用统一的任务队列启动入口执行远程指定任务。
     /// </summary>
     /// <remarks>
-    /// <para>注意以下特点:</para>
-    /// <para>- 可以在非UI线程执行。</para>
-    /// <para>- 不调用StartScript。</para>
-    /// <para>- 不使用Model里的列表。</para>
-    /// <para>- 在结尾添加对RunningStatus的等待。</para>
-    /// <para>若"一键长草"功能在未来有更新，此方法也应进行相应的同步更新，但需确保上述特点保持不变。</para>
+    /// <para>不调用启动前脚本，并在任务结束前保持等待。</para>
+    /// <para>任务的连接、序列化、状态恢复和并发控制统一由 <see cref="TaskQueueViewModel"/> 处理。</para>
     /// </remarks>
     /// <param name="originalNames">指定的任务列表。</param>
     /// <returns>异步任务，无返回结果。</returns>
-    // 这个是不是可以直接做到 TaskQueueViewModel 里面去？
     private async Task LinkStart(IEnumerable<string> originalNames)
     {
         await _runningState.UntilIdleAsync();
 
-        _runningState.SetIdle(false);
-
         await Execute.OnUIThreadAsync(async () => {
-            // 虽然更改时已经保存过了，不过保险起见还是在点击开始之后再保存一次(任务及基建列表)
-            // Instances.TaskQueueViewModel.TaskItemSelectionChanged();
-            // TaskQueueViewModel.InfrastTask.InfrastOrderSelectionChanged();
-            Instances.TaskQueueViewModel.ClearLog();
-
-            /*await Task.Run(() => Instances.SettingsViewModel.RunScript("StartsWithScript"));*/
-
-            Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("ConnectingToEmulator"));
-
-            // 一般是点了“停止”按钮了
-            if (_runningState.GetStopping())
+            List<BaseTask> tasks = [];
+            foreach (var originalName in originalNames)
             {
-                Instances.TaskQueueViewModel.SetStopped();
-                return;
-            }
-
-            if (!await InvokeInstanceAsyncFunction<bool>(Instances.TaskQueueViewModel, "ConnectToEmulator"))
-            {
-                return;
-            }
-
-            // 一般是点了“停止”按钮了
-            if (_runningState.GetStopping())
-            {
-                Instances.TaskQueueViewModel.SetStopped();
-                return;
-            }
-
-            bool taskRet = true;
-
-            // 直接遍历TaskItemViewModels里面的内容，是排序后的
-            // 20260112 status102: 先做兼容处理
-            int count = 0;
-            foreach (var item in originalNames)
-            {
-                ++count;
-                switch (item)
+                BaseTask task;
+                switch (originalName)
                 {
                     case "Base":
-                        {
-                            var tasks = ConfigFactory.CurrentConfig.TaskQueue.OfType<InfrastTask>().ToList();
-                            if (tasks.Count == 1)
-                            {
-                                taskRet &= InfrastSettingsUserControlModel.Instance.SerializeTask(tasks[0]).IsSuccess ?? false;
-                                break;
-                            }
-
-                            taskRet = false;
-                            break;
-                        }
-
-                    case "WakeUp":
-                        {
-                            var tasks = ConfigFactory.CurrentConfig.TaskQueue.OfType<StartUpTask>().ToList();
-                            if (tasks.Count == 1)
-                            {
-                                taskRet &= StartUpSettingsUserControlModel.Instance.SerializeTask(tasks[0]).IsSuccess ?? false;
-                                break;
-                            }
-
-                            taskRet = false;
-                            break;
-                        }
-
-                    case "Combat":
-                        {
-                            var tasks = ConfigFactory.CurrentConfig.TaskQueue.OfType<FightTask>().ToList();
-                            if (tasks.Count == 1)
-                            {
-                                taskRet &= FightSettingsUserControlModel.Instance.SerializeTask(tasks[0]).IsSuccess ?? false;
-                                break;
-                            }
-
-                            taskRet = false;
-                            break;
-                        }
-
-                    case "Recruiting":
-                        {
-                            var tasks = ConfigFactory.CurrentConfig.TaskQueue.OfType<RecruitTask>().ToList();
-                            if (tasks.Count == 1)
-                            {
-                                taskRet &= RecruitSettingsUserControlModel.Instance.SerializeTask(tasks[0]).IsSuccess ?? false;
-                                break;
-                            }
-
-                            taskRet = false;
-                            break;
-                        }
-
-                    case "Mall":
-                        {
-                            var tasks = ConfigFactory.CurrentConfig.TaskQueue.OfType<MallTask>().ToList();
-                            if (tasks.Count == 1)
-                            {
-                                taskRet &= MallSettingsUserControlModel.Instance.SerializeTask(tasks[0]).IsSuccess ?? false;
-                                break;
-                            }
-
-                            taskRet = false;
-                            break;
-                        }
-
-                    case "Mission":
-                        {
-                            var tasks = ConfigFactory.CurrentConfig.TaskQueue.OfType<AwardTask>().ToList();
-                            if (tasks.Count == 1)
-                            {
-                                taskRet &= AwardSettingsUserControlModel.Instance.SerializeTask(tasks[0]).IsSuccess ?? false;
-                                break;
-                            }
-
-                            taskRet = false;
-                            break;
-                        }
-
-                    case "AutoRoguelike":
-                        {
-                            var tasks = ConfigFactory.CurrentConfig.TaskQueue.OfType<RoguelikeTask>().ToList();
-                            if (tasks.Count == 1)
-                            {
-                                taskRet &= RoguelikeSettingsUserControlModel.Instance.SerializeTask(tasks[0]).IsSuccess ?? false;
-                                break;
-                            }
-
-                            taskRet = false;
-                            break;
-                        }
-
-                    case "Reclamation":
-                        {
-                            var tasks = ConfigFactory.CurrentConfig.TaskQueue.OfType<ReclamationTask>().ToList();
-                            if (tasks.Count == 1)
-                            {
-                                taskRet &= ReclamationSettingsUserControlModel.Instance.SerializeTask(tasks[0]).IsSuccess ?? false;
-                                break;
-                            }
-
-                            taskRet = false;
-                            break;
-                        }
-
-                    default:
-                        --count;
-
-                        // Instances.TaskQueueViewModel._logger.Error("Unknown task: " + item);
+                        task = GetSingleTask<InfrastTask>();
                         break;
+                    case "WakeUp":
+                        task = GetSingleTask<StartUpTask>();
+                        break;
+                    case "Combat":
+                        task = GetSingleTask<FightTask>();
+                        break;
+                    case "Recruiting":
+                        task = GetSingleTask<RecruitTask>();
+                        break;
+                    case "Mall":
+                        task = GetSingleTask<MallTask>();
+                        break;
+                    case "Mission":
+                        task = GetSingleTask<AwardTask>();
+                        break;
+                    case "AutoRoguelike":
+                        task = GetSingleTask<RoguelikeTask>();
+                        break;
+                    case "Reclamation":
+                        task = GetSingleTask<ReclamationTask>();
+                        break;
+                    default:
+                        continue;
                 }
 
-                if (taskRet)
+                if (task is null)
                 {
+                    Instances.TaskQueueViewModel.AddLog(originalName + "Error", UiLogColor.Error);
                     continue;
                 }
 
-                Instances.TaskQueueViewModel.AddLog(item + "Error", UiLogColor.Error);
-                taskRet = true;
-                --count;
+                tasks.Add(task);
             }
 
-            if (count == 0)
-            {
-                Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("UnselectedTask"));
-                _runningState.SetIdle(true);
-                Instances.TaskQueueViewModel.SetStopped();
-                return;
-            }
-
-            taskRet &= Instances.AsstProxy.AsstStart();
-
-            if (taskRet)
-            {
-                Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("Running"));
-                Instances.AsstProxy.StartTaskTime = DateTimeOffset.Now;
-            }
-            else
-            {
-                Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("UnknownErrorOccurs"));
-                await Instances.TaskQueueViewModel.Stop();
-                Instances.TaskQueueViewModel.SetStopped();
-            }
+            await Instances.TaskQueueViewModel.LinkStartWithTasks(
+                tasks,
+                runStartScript: false,
+                forceEnableTasks: true);
         });
 
         await _runningState.UntilIdleAsync();
+
+        static T GetSingleTask<T>()
+            where T : BaseTask
+        {
+            var matches = ConfigFactory.CurrentConfig.TaskQueue.OfType<T>().Take(2).ToList();
+            return matches.Count == 1 ? matches[0] : null;
+        }
     }
 
     public static async Task ConnectionTest()

--- a/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
@@ -2097,7 +2097,8 @@ public partial class CopilotViewModel : Screen
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     public async Task Stop()
     {
-        // 等待 Core 实际停止；回调或超时自动 SetStopped（脚本由 proxy 回调按 CopilotWithScript 设置判断）
+        // 等待 Core 实际停止；正常停止后由回调 SetStopped，超时则保持占用状态并提示重启。
+        // 结束脚本由 proxy 回调按 CopilotWithScript 设置判断。
         AddLog(LocalizationHelper.GetString("Stopping"));
         await Instances.TaskQueueViewModel.Stop();
         if (_runningState.GetIdle() && !_runningState.GetStopping())

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -2129,7 +2129,7 @@ public class TaskQueueViewModel : Screen
         }
 
         _logger.Information(
-            "All enabled tasks were serialized. Count {Count}, AppendSucceeded {AppendSucceeded}. Entering core start.",
+            "All enabled tasks were serialized. Count {Count}, AppendSucceeded {AppendSucceeded}.",
             count,
             taskRet);
 
@@ -2144,6 +2144,10 @@ public class TaskQueueViewModel : Screen
 
         AchievementTrackerHelper.Instance.SetProgress(AchievementIds.TaskChainKing, count);
 
+        _logger.Information(
+            "Entering core start. Count {Count}, AppendSucceeded {AppendSucceeded}.",
+            count,
+            taskRet);
         var coreStartStopwatch = Stopwatch.StartNew();
         var coreStartSucceeded = Instances.AsstProxy.AsstStart();
         coreStartStopwatch.Stop();

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -1925,8 +1925,16 @@ public class TaskQueueViewModel : Screen
 
         using var log = new LogScope(_logger);
         await TaskQueueSerializingLock.WaitAsync();
-        await LinkStartWithTasks(ConfigFactory.CurrentConfig.TaskQueue);
-        TaskQueueSerializingLock.Release();
+        try
+        {
+            _logger.Information("Task queue startup acquired the serialization lock.");
+            await LinkStartWithTasks(ConfigFactory.CurrentConfig.TaskQueue);
+        }
+        finally
+        {
+            TaskQueueSerializingLock.Release();
+            _logger.Information("Task queue startup released the serialization lock.");
+        }
     }
 
 #if DEBUG
@@ -2080,12 +2088,26 @@ public class TaskQueueViewModel : Screen
 
             try
             {
+                var serializationStopwatch = Stopwatch.StartNew();
                 var (isSuccess, taskIds) = SerializeTask(item);
+                serializationStopwatch.Stop();
+                _logger.Information(
+                    "Task serialization returned. Index {Index}, Type {TaskType}, Success {Success}, Elapsed {ElapsedMilliseconds} ms",
+                    index,
+                    item.TaskType,
+                    isSuccess,
+                    serializationStopwatch.ElapsedMilliseconds);
                 switch (isSuccess)
                 {
                     case true:
                         ++count;
-                        Instances.TaskQueueViewModel.TaskItemViewModels.ElementAtOrDefault(index)?.SetTaskIds(taskIds);
+                        var taskItemViewModel = Instances.TaskQueueViewModel.TaskItemViewModels.ElementAtOrDefault(index);
+                        taskItemViewModel?.SetTaskIds(taskIds);
+                        _logger.Information(
+                            "Task IDs stored. Index {Index}, Type {TaskType}, TaskIdCount {TaskIdCount}",
+                            index,
+                            item.TaskType,
+                            taskItemViewModel?.TaskIds.Count ?? 0);
                         break;
                     case false:
                         taskRet = false;
@@ -2101,9 +2123,15 @@ public class TaskQueueViewModel : Screen
             catch (Exception ex)
             {
                 taskRet = false;
+                _logger.Error(ex, "Failed to serialize task. Index {Index}, Type {TaskType}", index, item.TaskType);
                 AddLog(LocalizationHelper.GetStringFormat("TaskAppend.Error", LocalizationHelper.GetString(item.TaskType.ToString()), item.NameOrTaskType) + "\n" + ex.Message, UiLogColor.Error);
             }
         }
+
+        _logger.Information(
+            "All enabled tasks were serialized. Count {Count}, AppendSucceeded {AppendSucceeded}. Entering core start.",
+            count,
+            taskRet);
 
         if (count == 0)
         {
@@ -2116,7 +2144,14 @@ public class TaskQueueViewModel : Screen
 
         AchievementTrackerHelper.Instance.SetProgress(AchievementIds.TaskChainKing, count);
 
-        taskRet &= Instances.AsstProxy.AsstStart();
+        var coreStartStopwatch = Stopwatch.StartNew();
+        var coreStartSucceeded = Instances.AsstProxy.AsstStart();
+        coreStartStopwatch.Stop();
+        _logger.Information(
+            "Core start returned. Success {Success}, Elapsed {ElapsedMilliseconds} ms",
+            coreStartSucceeded,
+            coreStartStopwatch.ElapsedMilliseconds);
+        taskRet &= coreStartSucceeded;
 
         if (taskRet)
         {

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -821,13 +821,12 @@ public class TaskQueueViewModel : Screen
 
             await HandleTimerLogic(currentTime);
         }
+        catch (Exception ex) when (Bootstrapper.TryStartWpfMessageQueueRecovery(ex))
+        {
+            // 消息队列已无法可靠投递，由独立恢复流程接管。
+        }
         catch (Exception ex)
         {
-            if (Bootstrapper.TryStartWpfMessageQueueRecovery(ex))
-            {
-                return;
-            }
-
             _logger.Error(ex, "Task queue timer callback failed.");
         }
     }
@@ -2014,6 +2013,7 @@ public class TaskQueueViewModel : Screen
         }
         catch (Exception ex)
         {
+            // 这里只回滚尚未交给 Core 的运行状态；异常必须继续向上传递，不能降级成普通启动失败。
             _logger.Error(
                 ex,
                 "Task queue startup failed unexpectedly. CoreStartSucceeded {CoreStartSucceeded}",
@@ -2145,45 +2145,36 @@ public class TaskQueueViewModel : Screen
                 continue;
             }
 
-            try
+            var serializationStopwatch = Stopwatch.StartNew();
+            var (isSuccess, taskIds) = SerializeTask(item);
+            serializationStopwatch.Stop();
+            _logger.Information(
+                "Task serialization returned. Index {Index}, Type {TaskType}, Success {Success}, Elapsed {ElapsedMilliseconds} ms",
+                index,
+                item.TaskType,
+                isSuccess,
+                serializationStopwatch.ElapsedMilliseconds);
+            switch (isSuccess)
             {
-                var serializationStopwatch = Stopwatch.StartNew();
-                var (isSuccess, taskIds) = SerializeTask(item);
-                serializationStopwatch.Stop();
-                _logger.Information(
-                    "Task serialization returned. Index {Index}, Type {TaskType}, Success {Success}, Elapsed {ElapsedMilliseconds} ms",
-                    index,
-                    item.TaskType,
-                    isSuccess,
-                    serializationStopwatch.ElapsedMilliseconds);
-                switch (isSuccess)
-                {
-                    case true:
-                        ++count;
-                        var taskItemViewModel = Instances.TaskQueueViewModel.TaskItemViewModels.ElementAtOrDefault(index);
-                        taskItemViewModel?.SetTaskIds(taskIds);
-                        _logger.Information(
-                            "Task IDs stored. Index {Index}, Type {TaskType}, TaskIdCount {TaskIdCount}",
-                            index,
-                            item.TaskType,
-                            taskItemViewModel?.TaskIds.Count ?? 0);
-                        break;
-                    case false:
-                        taskRet = false;
-                        AddLog(LocalizationHelper.GetStringFormat("TaskAppend.Error", LocalizationHelper.GetString(item.TaskType.ToString()), item.NameOrTaskType), UiLogColor.Error);
-                        SetTaskStatus(index, TaskItemStatus.Error);
-                        break;
-                    case null:
-                        AddLog(LocalizationHelper.GetStringFormat("TaskAppend.Skip", LocalizationHelper.GetString(item.TaskType.ToString()), item.NameOrTaskType), UiLogColor.Info);
-                        SetTaskStatus(index, TaskItemStatus.Skipped);
-                        break;
-                }
-            }
-            catch (Exception ex)
-            {
-                taskRet = false;
-                _logger.Error(ex, "Failed to serialize task. Index {Index}, Type {TaskType}", index, item.TaskType);
-                AddLog(LocalizationHelper.GetStringFormat("TaskAppend.Error", LocalizationHelper.GetString(item.TaskType.ToString()), item.NameOrTaskType) + "\n" + ex.Message, UiLogColor.Error);
+                case true:
+                    ++count;
+                    var taskItemViewModel = Instances.TaskQueueViewModel.TaskItemViewModels.ElementAtOrDefault(index);
+                    taskItemViewModel?.SetTaskIds(taskIds);
+                    _logger.Information(
+                        "Task IDs stored. Index {Index}, Type {TaskType}, TaskIdCount {TaskIdCount}",
+                        index,
+                        item.TaskType,
+                        taskItemViewModel?.TaskIds.Count ?? 0);
+                    break;
+                case false:
+                    taskRet = false;
+                    AddLog(LocalizationHelper.GetStringFormat("TaskAppend.Error", LocalizationHelper.GetString(item.TaskType.ToString()), item.NameOrTaskType), UiLogColor.Error);
+                    SetTaskStatus(index, TaskItemStatus.Error);
+                    break;
+                case null:
+                    AddLog(LocalizationHelper.GetStringFormat("TaskAppend.Skip", LocalizationHelper.GetString(item.TaskType.ToString()), item.NameOrTaskType), UiLogColor.Info);
+                    SetTaskStatus(index, TaskItemStatus.Skipped);
+                    break;
             }
         }
 

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -800,9 +800,14 @@ public class TaskQueueViewModel : Screen
 
             await HandleTimerLogic(currentTime);
         }
-        catch
+        catch (Exception ex)
         {
-            // ignored
+            if (Bootstrapper.TryStartWpfMessageQueueRecovery(ex))
+            {
+                return;
+            }
+
+            _logger.Error(ex, "Task queue timer callback failed.");
         }
     }
 
@@ -1544,18 +1549,9 @@ public class TaskQueueViewModel : Screen
         }
 
         var task = ConfigFactory.CurrentConfig.TaskQueue[taskItem.Index];
-        var originalIsEnable = task.IsEnable;
 
-        try
-        {
-            // 单次运行应只受当前右键操作影响，不改变任务的持久启用状态。
-            task.IsEnable = true;
-            await LinkStartWithTasks([task]);
-        }
-        finally
-        {
-            task.IsEnable = originalIsEnable;
-        }
+        // 单次运行应只受当前右键操作影响，不改变任务的持久启用状态。
+        await LinkStartWithTasks([task], forceEnableTasks: true);
     }
 
     /// <summary>
@@ -1908,6 +1904,13 @@ public class TaskQueueViewModel : Screen
 
     private DateTime? _taskStartTime;
 
+    private sealed class TaskQueueStartupContext
+    {
+        public bool OwnsRunningState { get; set; }
+
+        public bool CoreStartSucceeded { get; set; }
+    }
+
     /// <summary>
     /// Starts.
     /// </summary>
@@ -1923,18 +1926,7 @@ public class TaskQueueViewModel : Screen
         }
 #endif
 
-        using var log = new LogScope(_logger);
-        await TaskQueueSerializingLock.WaitAsync();
-        try
-        {
-            _logger.Information("Task queue startup acquired the serialization lock.");
-            await LinkStartWithTasks(ConfigFactory.CurrentConfig.TaskQueue);
-        }
-        finally
-        {
-            TaskQueueSerializingLock.Release();
-            _logger.Information("Task queue startup released the serialization lock.");
-        }
+        await LinkStartWithTasks(ConfigFactory.CurrentConfig.TaskQueue);
     }
 
 #if DEBUG
@@ -1981,7 +1973,44 @@ public class TaskQueueViewModel : Screen
     }
 #endif
 
-    public async Task LinkStartWithTasks(IEnumerable<BaseTask> tasks)
+    public async Task LinkStartWithTasks(
+        IEnumerable<BaseTask> tasks,
+        bool runStartScript = true,
+        bool forceEnableTasks = false)
+    {
+        using var log = new LogScope(_logger);
+        await TaskQueueSerializingLock.WaitAsync();
+        var startupContext = new TaskQueueStartupContext();
+        try
+        {
+            _logger.Information("Task queue startup acquired the serialization lock.");
+            await LinkStartWithTasksCore(tasks, runStartScript, forceEnableTasks, startupContext);
+        }
+        catch (Exception ex)
+        {
+            _logger.Error(
+                ex,
+                "Task queue startup failed unexpectedly. CoreStartSucceeded {CoreStartSucceeded}",
+                startupContext.CoreStartSucceeded);
+            if (startupContext.OwnsRunningState && !startupContext.CoreStartSucceeded)
+            {
+                SetStopped(runStopScript: false);
+            }
+
+            throw;
+        }
+        finally
+        {
+            TaskQueueSerializingLock.Release();
+            _logger.Information("Task queue startup released the serialization lock.");
+        }
+    }
+
+    private async Task LinkStartWithTasksCore(
+        IEnumerable<BaseTask> tasks,
+        bool runStartScript,
+        bool forceEnableTasks,
+        TaskQueueStartupContext startupContext)
     {
         if (!_runningState.Idle)
         {
@@ -2031,13 +2060,17 @@ public class TaskQueueViewModel : Screen
         MainTasksCompletedCount = 0;
         ResetTaskItemStatuses();
 
-        // 所有提前 return 都要放在 _runningState.SetIdle(false) 之前，否则会导致无法再次点击开始
+        // Core 成功接管运行状态前发生异常时，由调用方负责恢复为空闲。
+        startupContext.OwnsRunningState = true;
         _runningState.SetIdle(false);
 
         // 虽然更改时已经保存过了，不过保险起见在点击开始之后再次保存任务和基建列表
         // TaskItemSelectionChanged();
         // InfrastTask.InfrastOrderSelectionChanged();
-        await Task.Run(() => SettingsViewModel.GameSettings.RunScript("StartsWithScript"));
+        if (runStartScript)
+        {
+            await Task.Run(() => SettingsViewModel.GameSettings.RunScript("StartsWithScript"));
+        }
 
         AddLog(LocalizationHelper.GetString("ConnectingToEmulator"));
 
@@ -2080,7 +2113,7 @@ public class TaskQueueViewModel : Screen
                 item.TaskType,
                 item.NameOrTaskType,
                 item.IsEnable);
-            if (!IsTaskEnable(item))
+            if (!forceEnableTasks && !IsTaskEnable(item))
             {
                 SetTaskStatus(index, TaskItemStatus.Skipped);
                 continue;
@@ -2149,13 +2182,13 @@ public class TaskQueueViewModel : Screen
             count,
             taskRet);
         var coreStartStopwatch = Stopwatch.StartNew();
-        var coreStartSucceeded = Instances.AsstProxy.AsstStart();
+        startupContext.CoreStartSucceeded = Instances.AsstProxy.AsstStart();
         coreStartStopwatch.Stop();
         _logger.Information(
             "Core start returned. Success {Success}, Elapsed {ElapsedMilliseconds} ms",
-            coreStartSucceeded,
+            startupContext.CoreStartSucceeded,
             coreStartStopwatch.ElapsedMilliseconds);
-        taskRet &= coreStartSucceeded;
+        taskRet &= startupContext.CoreStartSucceeded;
 
         if (taskRet)
         {
@@ -2308,14 +2341,17 @@ public class TaskQueueViewModel : Screen
             Task.Run(() => SettingsViewModel.GameSettings.RunScript("EndsWithScript"));
         }
 
-        if (!_runningState.GetIdle() || _runningState.GetStopping())
-        {
-            AddLog(LocalizationHelper.GetString("Stopped"), splitMode: LogCardSplitMode.Both);
-        }
+        bool shouldAddStoppedLog = !_runningState.GetIdle() || _runningState.GetStopping();
 
         Waiting = false;
         _runningState.SetStopping(false);
         _runningState.SetIdle(true);
+
+        // 先恢复运行状态，避免日志投递异常导致界面永久停留在“运行中”。
+        if (shouldAddStoppedLog)
+        {
+            AddLog(LocalizationHelper.GetString("Stopped"), splitMode: LogCardSplitMode.Both);
+        }
 
         // 只抑制“本轮任务期间”的自动开启；任务结束后应允许下一轮自动开启 LiveView。
         return true;

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -56,6 +56,27 @@ using Task = System.Threading.Tasks.Task;
 namespace MaaWpfGui.ViewModels.UI;
 
 /// <summary>
+/// 任务队列启动结果。
+/// </summary>
+public enum TaskQueueStartResult
+{
+    /// <summary>
+    /// 已成功启动。
+    /// </summary>
+    Started,
+
+    /// <summary>
+    /// 当前已有任务占用运行状态。
+    /// </summary>
+    Busy,
+
+    /// <summary>
+    /// 启动流程执行失败。
+    /// </summary>
+    Failed,
+}
+
+/// <summary>
 /// The view model of task queue.
 /// </summary>
 // 通过 container.Get<TaskQueueViewModel>(); 实例化或获取实例
@@ -978,7 +999,12 @@ public class TaskQueueViewModel : Screen
             if (!_runningState.GetIdle())
             {
                 _logger.Information("Not idle, Stop and CloseDown");
-                await Stop();
+                if (!await Stop())
+                {
+                    _logger.Warning("Core did not stop before the scheduled shutdown task started. Aborting the scheduled task.");
+                    return;
+                }
+
                 SetStopped();
             }
 
@@ -1973,7 +1999,7 @@ public class TaskQueueViewModel : Screen
     }
 #endif
 
-    public async Task LinkStartWithTasks(
+    public async Task<TaskQueueStartResult> LinkStartWithTasks(
         IEnumerable<BaseTask> tasks,
         bool runStartScript = true,
         bool forceEnableTasks = false)
@@ -1984,7 +2010,7 @@ public class TaskQueueViewModel : Screen
         try
         {
             _logger.Information("Task queue startup acquired the serialization lock.");
-            await LinkStartWithTasksCore(tasks, runStartScript, forceEnableTasks, startupContext);
+            return await LinkStartWithTasksCore(tasks, runStartScript, forceEnableTasks, startupContext);
         }
         catch (Exception ex)
         {
@@ -2006,7 +2032,7 @@ public class TaskQueueViewModel : Screen
         }
     }
 
-    private async Task LinkStartWithTasksCore(
+    private async Task<TaskQueueStartResult> LinkStartWithTasksCore(
         IEnumerable<BaseTask> tasks,
         bool runStartScript,
         bool forceEnableTasks,
@@ -2015,7 +2041,7 @@ public class TaskQueueViewModel : Screen
         if (!_runningState.Idle)
         {
             _logger.Information("Not idle, return.");
-            return;
+            return TaskQueueStartResult.Busy;
         }
 
         _taskStartTime = DateTime.Now;
@@ -2044,7 +2070,7 @@ public class TaskQueueViewModel : Screen
         if (!Instances.VersionUpdateDialogViewModel.IsDebugVersion() && uiVersion != coreVersion)
         {
             AddLog(LocalizationHelper.GetStringFormat("VersionMismatch", uiVersion, coreVersion), UiLogColor.Error);
-            return;
+            return TaskQueueStartResult.Failed;
         }
 
         // 雷电模拟器 + maatouch 组合存在滑动异常缓慢的问题（滑动持续时间远大于预期），给出警告
@@ -2086,19 +2112,19 @@ public class TaskQueueViewModel : Screen
         if (_runningState.GetStopping())
         {
             SetStopped();
-            return;
+            return TaskQueueStartResult.Failed;
         }
 
         if (!await ConnectToEmulator())
         {
-            return;
+            return TaskQueueStartResult.Failed;
         }
 
         // 一般是点了“停止”按钮了
         if (_runningState.GetStopping())
         {
             SetStopped();
-            return;
+            return TaskQueueStartResult.Failed;
         }
 
         bool taskRet = true;
@@ -2172,7 +2198,7 @@ public class TaskQueueViewModel : Screen
             _runningState.SetIdle(true);
             Instances.AsstProxy.AsstStop();
             SetStopped();
-            return;
+            return TaskQueueStartResult.Failed;
         }
 
         AchievementTrackerHelper.Instance.SetProgress(AchievementIds.TaskChainKing, count);
@@ -2198,12 +2224,16 @@ public class TaskQueueViewModel : Screen
         else
         {
             AddLog(LocalizationHelper.GetString("UnknownErrorOccurs"));
-            await Stop();
-            SetStopped();
+            if (await Stop())
+            {
+                SetStopped();
+            }
         }
 
         AchievementTrackerHelper.Instance.MissionStartCountAdd();
         AchievementTrackerHelper.Instance.UseDailyAdd();
+
+        return taskRet ? TaskQueueStartResult.Started : TaskQueueStartResult.Failed;
 
         static void SetTaskStatus(int index, TaskItemStatus status)
         {
@@ -2250,19 +2280,19 @@ public class TaskQueueViewModel : Screen
     /// <summary>
     /// <para>通知 Core 停止当前任务并等待其完成。</para>
     /// <para>通常 Core 停止后会发送 <c>TaskChainStopped</c> 回调，由 <see cref="AsstProxy"/> 调用 <see cref="SetStopped"/> 恢复 UI 状态。</para>
-    /// <para>若未通过任务链调用 Core（如 Peep），则不会收到回调，需在调用 <see cref="Stop"/> 后手动调用 <see cref="SetStopped"/>。</para>
-    /// <para>超时后会自动调用 <see cref="SetStopped"/> 强制恢复 UI 状态。</para>
+    /// <para>若未通过任务链调用 Core（如 Peep），则不会收到回调，需在 <see cref="Stop"/> 返回 true 后手动调用 <see cref="SetStopped"/>。</para>
+    /// <para>超时后保持非空闲状态，避免旧任务的延迟回调终止随后启动的新任务。</para>
     /// <para>Notifies Core to stop the current task and waits for completion.</para>
     /// <para>Normally Core sends <c>TaskChainStopped</c> callback after stopping, and <see cref="AsstProxy"/> calls <see cref="SetStopped"/> to reset UI state.</para>
-    /// <para>If Core was not invoked via task chain (e.g. Peep), no callback will be received; caller must manually call <see cref="SetStopped"/> after <see cref="Stop"/>.</para>
-    /// <para>On timeout, <see cref="SetStopped"/> is called automatically to force-reset UI state.</para>
+    /// <para>If Core was not invoked via task chain (e.g. Peep), no callback will be received; caller must manually call <see cref="SetStopped"/> after <see cref="Stop"/> returns true.</para>
+    /// <para>On timeout, the non-idle state is preserved so a delayed callback from the old task cannot stop a newly started task.</para>
     /// </summary>
     /// <param name="timeout">Timeout millisecond</param>
-    /// <returns>A <see cref="Task"/>
-    /// <para>尝试等待 core 成功停止运行，默认超时时间一分钟</para>
-    /// <para>Try to wait for the core to stop running, the default timeout is one minute</para>
+    /// <returns>A <see cref="Task{TResult}"/> whose result indicates whether Core has stopped.
+    /// <para>尝试等待 core 成功停止运行，默认超时时间一分钟；成功停止返回 true，超时返回 false。</para>
+    /// <para>Try to wait for the core to stop running, the default timeout is one minute; returns true when stopped, otherwise false on timeout.</para>
     /// </returns>
-    public async Task Stop(int timeout = 60 * 1000)
+    public async Task<bool> Stop(int timeout = 60 * 1000)
     {
         _runningState.SetStopping(true);
         AddLog(LocalizationHelper.GetString("Stopping"), splitMode: LogCardSplitMode.Both);
@@ -2282,11 +2312,13 @@ public class TaskQueueViewModel : Screen
 
         if (Instances.AsstProxy.AsstRunning())
         {
-            // 超时：Core 未在超时内停止，强制恢复 UI 状态
-            _logger.Warning("Stop timeout, force resetting UI state");
+            // Core 仍可能稍后发送 TaskChainStopped。保持占用状态，禁止新任务在旧回调到达前启动。
+            _logger.Warning("Stop timeout, preserving non-idle state until Core reports that it has stopped");
             AddLog(LocalizationHelper.GetString("StopTimeout") + "\n" + LocalizationHelper.GetString("RestartRecommendation"), UiLogColor.Error);
-            SetStopped();
+            return false;
         }
+
+        return true;
     }
 
     // UI 绑定的方法
@@ -2328,8 +2360,7 @@ public class TaskQueueViewModel : Screen
     /// <returns>是否实际执行了状态重置（false 表示被幂等保护跳过）。</returns>
     public bool SetStopped(bool runStopScript = true)
     {
-        // 幂等保护：已经空闲且不在停止中，跳过
-        // 防止超时 SetStopped 后 Core 延迟回调再次触发导致打断新任务
+        // 幂等保护：已经空闲且不在停止中时，跳过同一轮任务的重复停止回调。
         if (_runningState.GetIdle() && !_runningState.GetStopping())
         {
             return false;

--- a/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
@@ -2217,8 +2217,10 @@ public class ToolboxViewModel : Screen
                 // 由 Peep() 方法启动的 Peep 也需要停止，Block 不会自动停止
                 if (IsGachaInProgress || IsPeepInProgress)
                 {
-                    await Instances.TaskQueueViewModel.Stop();
-                    Instances.TaskQueueViewModel.SetStopped();
+                    if (await Instances.TaskQueueViewModel.Stop())
+                    {
+                        Instances.TaskQueueViewModel.SetStopped();
+                    }
                 }
 
                 IsPeepInProgress = false;

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs
@@ -380,9 +380,14 @@ public class DepotMaintainTaskUserControlModel : TaskSettingsViewModel, DepotMai
         return Execute.OnUIThreadAsync(async () => {
             using var log = new LogScope(_logger);
             await TaskQueueViewModel.TaskQueueSerializingLock.WaitAsync();
-
-            RefreshStageList();
-            TaskQueueViewModel.TaskQueueSerializingLock.Release();
+            try
+            {
+                RefreshStageList();
+            }
+            finally
+            {
+                TaskQueueViewModel.TaskQueueSerializingLock.Release();
+            }
         });
     }
 

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/FightSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/FightSettingsUserControlModel.cs
@@ -1376,48 +1376,54 @@ public class FightSettingsUserControlModel : TaskSettingsViewModel, FightSetting
             using var log = new LogScope(_logger);
             var stageList = Instances.StageManager.GetStageList();
             await TaskQueueViewModel.TaskQueueSerializingLock.WaitAsync();
-            var time = DateTimeOffset.Now;
-            var activityList = Instances.StageManager.ActivityList.Where(ss => ss.Value.Info.StartTimeUtc <= time && time <= ss.Value.Info.ExpireTimeUtc);
-            if (activityList.Any())
+            try
             {
-                var activity = activityList.First();
-                var timeLeft = activity.Value.Info.ExpireTimeUtc - time;
-                var day = timeLeft.Days > 0 ? $"{timeLeft.Days}+" : LocalizationHelper.GetString("LessThanOneDay");
-                ActivityExpireIn2Days = timeLeft.Days < 2;
-                ActivityInfo = $"｢{activity.Value.Info.StageName}｣ {LocalizationHelper.GetString("DaysLeftOpen")}{day}";
-            }
-            else
-            {
-                ActivityInfo = LocalizationHelper.GetString("NoActivity");
-                ActivityExpireIn2Days = false;
-            }
-            using (var refresh = new UiRefreshingScope())
-            {
-                RefreshStageList();
-                foreach (var task in ConfigFactory.CurrentConfig.TaskQueue.OfType<FightTask>().Where(i => !i.IsStageManually))
+                var time = DateTimeOffset.Now;
+                var activityList = Instances.StageManager.ActivityList.Where(ss => ss.Value.Info.StartTimeUtc <= time && time <= ss.Value.Info.ExpireTimeUtc);
+                if (activityList.Any())
                 {
-                    var originalPlan = task.StagePlan.ToList();
-                    bool reset = false;
-                    for (int i = 0; i < task.StagePlan.Count; i++)
+                    var activity = activityList.First();
+                    var timeLeft = activity.Value.Info.ExpireTimeUtc - time;
+                    var day = timeLeft.Days > 0 ? $"{timeLeft.Days}+" : LocalizationHelper.GetString("LessThanOneDay");
+                    ActivityExpireIn2Days = timeLeft.Days < 2;
+                    ActivityInfo = $"｢{activity.Value.Info.StageName}｣ {LocalizationHelper.GetString("DaysLeftOpen")}{day}";
+                }
+                else
+                {
+                    ActivityInfo = LocalizationHelper.GetString("NoActivity");
+                    ActivityExpireIn2Days = false;
+                }
+                using (var refresh = new UiRefreshingScope())
+                {
+                    RefreshStageList();
+                    foreach (var task in ConfigFactory.CurrentConfig.TaskQueue.OfType<FightTask>().Where(i => !i.IsStageManually))
                     {
-                        var stage = task.StagePlan[i];
-                        if (!stageList.Any(p => p.Value == stage))
+                        var originalPlan = task.StagePlan.ToList();
+                        bool reset = false;
+                        for (int i = 0; i < task.StagePlan.Count; i++)
                         {
-                            reset = true;
-                            if (task.StageResetMode == FightStageResetMode.Current)
+                            var stage = task.StagePlan[i];
+                            if (!stageList.Any(p => p.Value == stage))
                             {
-                                task.StagePlan[i] = string.Empty;
+                                reset = true;
+                                if (task.StageResetMode == FightStageResetMode.Current)
+                                {
+                                    task.StagePlan[i] = string.Empty;
+                                }
                             }
                         }
+                        if (reset)
+                        {
+                            _logger.Information("Reset non-existing stage: {} to {}", string.Join(", ", originalPlan), string.Join(", ", task.StagePlan));
+                        }
                     }
-                    if (reset)
-                    {
-                        _logger.Information("Reset non-existing stage: {} to {}", string.Join(", ", originalPlan), string.Join(", ", task.StagePlan));
-                    }
+                    RefreshCurrentStagePlan();
                 }
-                RefreshCurrentStagePlan();
             }
-            TaskQueueViewModel.TaskQueueSerializingLock.Release();
+            finally
+            {
+                TaskQueueViewModel.TaskQueueSerializingLock.Release();
+            }
 
             foreach (var (item, index) in Instances.TaskQueueViewModel.TaskItemViewModels.Select((i, index) => (i, index)))
             {

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/StartUpSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/StartUpSettingsUserControlModel.cs
@@ -13,6 +13,7 @@
 
 #nullable enable
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using JetBrains.Annotations;
 using MaaWpfGui.Configuration.Single.MaaTask;
 using MaaWpfGui.Constants;
@@ -53,7 +54,7 @@ public class StartUpSettingsUserControlModel : TaskSettingsViewModel, StartUpSet
 
     // UI 绑定的方法
     [UsedImplicitly]
-    public async void AccountSwitchManualRun()
+    public async Task AccountSwitchManualRun()
     {
         if (TaskSettingVisibilityInfo.CurrentTask is not StartUpTask startUp)
         {


### PR DESCRIPTION
# fix(wpf): 修复消息队列配额耗尽导致的任务卡死并完善任务恢复

## 背景

Issue #17961 中，WPF 在更新窗口或向 Dispatcher 投递消息时可能抛出 Win32 错误 1816（配额不足，无法完成此操作）。

当异常发生在任务队列序列化锁持有期间时，原有代码无法保证释放 `TaskQueueSerializingLock`，后续手动启动、定时启动、单次运行和远程启动都会永久等待该锁，表现为点击开始后没有反应。

同时，WPF 消息队列已经耗尽时，普通的 `Application.Shutdown` 仍依赖 Dispatcher 投递关闭回调，无法保证正常退出和重启。因此需要提供不依赖 WPF 消息队列的恢复兜底。

相关 Issue：#17961

## 设计概要

- **保证任务队列锁释放**：所有 `TaskQueueSerializingLock` 使用点均通过 `try/finally` 释放，避免异常导致锁永久占用
- **统一任务启动入口**：完整任务队列、单次运行、账号切换和远程指定任务统一经过同一套连接、序列化和启动流程
- **完善启动异常恢复**：区分启动流程是否已经取得运行状态、Core 是否已经成功启动，仅在安全阶段恢复 Idle
- **增加关键边界日志**：记录锁获取与释放、任务序列化耗时、任务 ID 保存和 `AsstStart` 调用边界
- **识别消息队列配额异常**：仅匹配错误码 1816，且堆栈包含 `HwndTarget` 或 `PostMessage` 的异常
- **增加独立恢复 watchdog**：正常 WPF 关闭失败时，由独立线程启动恢复进程并强制结束当前进程
- **避免恢复进程提前启动**：恢复进程在打开日志、加载配置和检查单实例之前等待父进程真正退出
- **阻止旧回调中断新任务**：Core 停止超时后保持非 Idle，不允许下一轮任务在旧 `TaskChainStopped` 回调到达前启动
- **修复远程启动竞态**：启动入口返回明确结果；远程任务遇到 `Busy` 时等待并重试，未实际启动时上报 `FAILED`

### 修改文件（9 个）

| 文件 | 改动 |
| --- | --- |
| `src/MaaWpfGui/Main/Bootstrapper.cs` | 识别 WPF 消息队列配额异常；增加一次性恢复、独立 watchdog、恢复进程等待父进程退出逻辑 |
| `src/MaaWpfGui/Main/AsstProxy.cs` | 仅在确认 Core 已停止后手动恢复任务队列状态 |
| `src/MaaWpfGui/Services/RemoteControl/RemoteControlService.cs` | 远程任务改用统一启动入口；根据启动结果重试或上报失败 |
| `src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs` | 统一任务启动流程；完善锁、异常、日志、停止超时和启动结果处理 |
| `src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs` | 更新停止超时行为说明 |
| `src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs` | Peep 等非任务链调用仅在 Core 确认停止后恢复 Idle |
| `src/MaaWpfGui/ViewModels/UserControl/TaskQueue/DepotMaintainTaskUserControlModel.cs` | 使用 `try/finally` 保证刷新仓库关卡列表时释放序列化锁 |
| `src/MaaWpfGui/ViewModels/UserControl/TaskQueue/FightSettingsUserControlModel.cs` | 使用 `try/finally` 保证刷新作战关卡列表时释放序列化锁 |
| `src/MaaWpfGui/ViewModels/UserControl/TaskQueue/StartUpSettingsUserControlModel.cs` | 账号切换改用统一任务启动入口，并将 `async void` 调整为 `Task` |

## 消息队列恢复流程

1. 捕获未处理异常或任务队列定时器异常
2. 检查异常链中是否存在错误码 1816
3. 仅在堆栈包含 `System.Windows.Interop.HwndTarget` 或 `MS.Win32.UnsafeNativeMethods.PostMessage` 时进入恢复
4. 使用原子标记保证恢复流程只启动一次
5. 首先尝试正常关闭并重启
6. 独立 watchdog 等待 5 秒
7. 如果当前进程仍未退出，watchdog 启动恢复子进程并调用 `Environment.FailFast`
8. 恢复子进程在初始化日志、配置和单实例互斥量前等待父进程真正退出
9. 父进程退出后，恢复子进程继续正常启动

恢复子进程不设置固定等待超时，避免 Windows Error Reporting 或转储生成时间过长时提前进入单实例检查并自行退出。

## 任务队列启动流程

所有任务队列启动入口统一经过 `LinkStartWithTasks`：

1. 获取 `TaskQueueSerializingLock`
2. 检查当前是否空闲
3. 初始化任务运行状态
4. 连接模拟器
5. 按顺序序列化指定任务
6. 保存 Core 返回的任务 ID
7. 调用 `AsstStart`
8. 根据启动结果更新状态
9. 在 `finally` 中释放序列化锁

单次运行和远程指定任务通过 `forceEnableTasks` 仅影响本次启动，不修改任务的持久启用状态。

## 启动结果

`LinkStartWithTasks` 返回 `TaskQueueStartResult`：

| 返回值 | 含义 | 远程任务行为 |
| --- | --- | --- |
| `Started` | 任务已经实际追加并成功启动 | 等待本轮任务结束后上报成功 |
| `Busy` | 其他入口已经取得运行状态 | 等待当前任务结束并重新尝试 |
| `Failed` | 连接、序列化或 Core 启动失败 | 上报 `FAILED` |

远程完整任务队列和远程指定任务均使用该结果，避免“请求未实际启动，却等待其他任务结束后上报成功”的情况。

## 停止超时处理

`Stop` 调整为返回 `Task<bool>`：

| 返回值 | 含义 | 状态处理 |
| --- | --- | --- |
| `true` | Core 已确认停止 | 允许调用方手动恢复 Idle |
| `false` | 等待 Core 停止超时 | 保持 Stopping / 非 Idle，并提示用户重启 |

停止超时后不再强制恢复 Idle，避免出现以下竞态：

1. 旧任务停止超时
2. UI 被强制恢复为空闲
3. 用户启动新任务
4. 旧任务延迟发送 `TaskChainStopped`
5. 旧回调重置新任务状态并执行结束脚本

对于 Peep 等不会发送任务链停止回调的调用，仅在 `Stop` 返回 `true` 后手动调用 `SetStopped`。

## 日志补充

新增以下关键日志：

- 任务队列序列化锁获取与释放
- 每个任务的序列化结果和耗时
- 保存的任务 ID 数量
- 所有任务序列化完成
- 进入 Core 启动边界
- `AsstStart` 返回结果和耗时
- 启动流程异常时 Core 是否已经成功启动
- 远程任务因启动竞态等待重试
- Core 停止超时后保持非 Idle
- WPF 消息队列配额耗尽和恢复流程启动

`Entering core start` 仅在至少有一个任务成功追加后记录，避免没有任务启动时产生误导日志。

## 测试情况

- [x] Debug x64 本地编译通过，0 个警告，0 个错误
- [x] Release x64 本地编译通过，0 个警告，0 个错误
- [x] `dotnet format --verify-no-changes` 通过
- [x] `git diff --check` 通过
- [x] 3 个 `TaskQueueSerializingLock` 使用点均通过 `try/finally` 释放
- [x] 完整任务队列、单次运行、账号切换和远程任务均使用统一启动入口
- [x] 错误 1816 的匹配范围限制在 `HwndTarget` 和 `PostMessage` 调用链
- [x] 恢复进程在共享日志、配置和单实例逻辑之前等待父进程退出
- [x] Core 停止超时后不会开放下一轮任务启动
- [x] 远程启动未取得运行状态时不会上报成功
- [ ] 在真实消息队列配额耗尽环境中验证自动恢复
- [ ] 对远程启动与手动、定时启动的并发竞态进行集成测试

## 兼容性说明

- 未修改 Core、公共 C API 或外部配置格式
- 正常任务启动和停止流程保持不变
- `--wait-for-process-exit` 仅用于恢复子进程等待指定进程退出，不会终止参数指定的进程
- 恢复流程只处理错误码 1816 且堆栈匹配 WPF 消息投递路径的异常
- 其他未处理异常仍沿用原有错误日志和错误对话框流程
- 远程任务的协议和任务类型保持不变，仅修正未实际启动时的状态上报
- 停止超时后界面将保持停止中，用户需要等待 Core 回调或按照提示重启 MAA

## 已知局限

- watchdog 使用 `Environment.FailFast` 强制终止无法正常关闭的进程，Windows Error Reporting 可能生成转储
- 恢复子进程会一直等待父进程退出；如果父进程因系统组件异常长期无法结束，恢复进程也会持续等待
- 消息队列配额耗尽通常意味着当前 WPF Dispatcher 已不再可靠，恢复阶段不保证能够继续更新界面
- 本次修复阻止停止超时后的新任务启动，不尝试为现有 Core 回调协议增加任务 session 标识

## 检查项

- [x] 所有 Semaphore 获取均有对应的 `finally` 释放
- [x] 恢复流程使用原子标记避免重复启动
- [x] watchdog 不依赖 WPF Dispatcher 消息队列
- [x] 恢复进程不会提前访问共享日志和配置
- [x] 任务启动异常时不会遗留错误的运行状态
- [x] 没有成功追加任务时不会记录已经进入 Core 启动
- [x] 旧任务停止超时后无法启动新一轮任务
- [x] 远程任务能够区分成功启动、启动繁忙和启动失败
- [x] 未修改用户配置、远程控制协议和 Core 公共接口

## Sourcery 总结

增强 WPF 任务执行和恢复机制，以应对消息队列耗尽、启动竞争和关闭不完整等问题。

新功能：
- 增加 WPF 消息队列配额耗尽时的自动恢复机制，包括在正常关闭失败时通过看门狗重启进程。

错误修复：
- 防止任务队列序列化锁在发生异常后仍处于持有状态。
- 通过在停止超时后保留非空闲状态，防止延迟的停止回调中断新启动的任务。
- 修正远程任务状态报告，以及启动过程与其他正在运行的任务发生竞争时的重试行为。

增强功能：
- 通过统一的启动路径和明确的启动结果，整合手动、计划、一次性、账户切换和远程任务启动流程。
- 根据 Core 是否实际启动或停止，改进任务启动和关闭状态的恢复机制。
- 增加围绕任务序列化、Core 启动、锁所有权和恢复边界的诊断日志。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

增强 WPF 任务执行和进程恢复能力，以应对消息队列耗尽、启动竞争条件以及 Core 未能完整关闭等问题。

新功能：
- 增加 WPF 消息队列配额耗尽时的自动恢复机制，包括在正常关闭无法完成时通过 watchdog 协助重启。

Bug 修复：
- 防止在启动或任务列表刷新失败时，任务队列序列化锁泄漏。
- 防止停止超时后延迟执行的停止回调中断新启动的任务。
- 修正远程任务状态报告及重试行为，以处理启动操作与其他正在运行的任务发生竞争的情况。

增强：
- 通过共享的启动流程和明确的启动结果，统一手动、计划、一次性、账户切换和远程任务的执行方式。
- 根据 Core 实际启动或停止的情况改进任务状态恢复，并扩展任务序列化、启动和恢复边界相关的诊断日志。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden WPF task execution and process recovery against message-queue exhaustion, startup races, and incomplete Core shutdowns.

New Features:
- Add automatic recovery for WPF message-queue quota exhaustion, including watchdog-assisted restart when normal shutdown cannot complete.

Bug Fixes:
- Prevent task-queue serialization locks from leaking when startup or task-list refreshes fail.
- Prevent delayed stop callbacks from interrupting newly started tasks after a stop timeout.
- Correct remote task status reporting and retry behavior when startup races with another running task.

Enhancements:
- Unify manual, scheduled, one-time, account-switching, and remote task execution through a shared startup flow with explicit startup outcomes.
- Improve task state recovery based on whether Core actually started or stopped, and expand diagnostic logging around task serialization, startup, and recovery boundaries.

</details>

</details>