### PR TITLE
fix: respect dorm stationed filter during preparation

### DIFF
--- a/src/MaaCore/Task/Infrast/InfrastDormTask.cpp
+++ b/src/MaaCore/Task/Infrast/InfrastDormTask.cpp
@@ -312,8 +312,8 @@ bool asst::InfrastDormTask::fill_dorm_slots(bool low_mood_only)
                         .operator_id = oper.operator_id,
                         .mood_ratio = oper.mood_ratio,
                         .selected = oper.selected,
-                        // 第一轮的目的就是把其他设施中的低心情干员换进宿舍。
-                        .available = true,
+                        // 第一轮默认允许跨设施换班；启用“不将已进驻干员放入宿舍”时排除在岗干员。
+                        .available = !m_notstationed_filter_enabled || oper.doing != infrast::Doing::Working,
                     });
             }
             const auto indices = infrast::find_low_mood_candidates(
@@ -555,8 +555,8 @@ asst::InfrastDormTask::FiammettaSelectionResult asst::InfrastDormTask::try_selec
             .operator_id = oper.operator_id,
             .mood_ratio = oper.mood_ratio,
             .selected = oper.selected,
-            // 菲亚梅塔目标可能正在其他设施工作，第一轮仍应允许将其换入宿舍。
-            .available = true,
+            // 菲亚梅塔目标可能正在其他设施工作；启用“不将已进驻干员放入宿舍”时保留该约束。
+            .available = !m_notstationed_filter_enabled || oper.doing != infrast::Doing::Working,
         };
         if (!candidate.selected && candidate.available && candidate.mood_ratio < m_mood_threshold) {
             RegionOCRer name_analyzer(oper.name_img);
@@ -609,8 +609,8 @@ asst::InfrastDormTask::FiammettaSelectionResult asst::InfrastDormTask::try_selec
                 .operator_id = oper.operator_id,
                 .mood_ratio = oper.mood_ratio,
                 .selected = oper.selected,
-                // 第一轮保持“全部”筛选，满心情菲亚梅塔也可能正在其他设施工作。
-                .available = true,
+                // 第一轮保持“全部”筛选；启用“不将已进驻干员放入宿舍”时排除在岗的菲亚梅塔。
+                .available = !m_notstationed_filter_enabled || oper.doing != infrast::Doing::Working,
             });
     }
     const auto fiammetta_index = infrast::find_full_mood_fiammetta(fiammetta_candidates);


### PR DESCRIPTION
## 问题\n\n最近的默认基建换班重写新增了宿舍前置阶段。该阶段为了支持跨设施换班，保持全部干员筛选并把当前页的低心情干员全部标记为可选，导致开启‘不将已进驻干员放入宿舍’时，训练室、制造站等仍可能被移入宿舍。\n\nIssue #17934 的报告包确认了配置已正确下发，问题出在 DormPrepare 绕过了这个筛选。\n\n## 修改\n\n在宿舍前置阶段的低心情候选、菲亚梅塔目标和满心情菲亚梅塔候选中，复用 dorm_notstationed_enabled 约束：开启时排除 Doing::Working 的干员，关闭时继续保留跨设施换班行为。后置阶段和自定义模式不受影响。\n\n这是候选层的最小修复，不恢复旧版整体流程，也不改变游戏界面筛选状态。\n\nFixes #17934\n\n## 验证\n\n- git diff --check 通过\n- 本地无法运行完整 C++ 构建：当前环境的 MinGW 缺少 <format>，且没有可用的 Visual Studio/CMake 工具链\n- 已检查默认模式、后置阶段、自定义模式和菲亚梅塔分支的调用路径\n

## Sourcery 总结

错误修复：
- 在准备期间遵循宿舍干员筛选条件，以便在启用“不要将驻站干员安排在宿舍中”选项时排除当前工作的干员。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Respect the dormitory staffing filter during preparation so active operators are excluded when the “do not place stationed operators in dormitories” option is enabled.

</details>