### PR TITLE
docs: add RIIC.Autos links to all languages

### DIFF
--- a/docs/en-us/protocol/base-scheduling-schema.md
+++ b/docs/en-us/protocol/base-scheduling-schema.md
@@ -13,6 +13,8 @@ Please note that JSON files do not support comments. The comments in this docume
 
 [Visual Schedule Generator Tool](https://ark.yituliu.cn/tools/scheduleV3)
 
+[Automatic RIIC Schedule Generator](https://riic.autos/)
+
 ## Complete Field Reference
 
 ```json

--- a/docs/ja-jp/protocol/base-scheduling-schema.md
+++ b/docs/ja-jp/protocol/base-scheduling-schema.md
@@ -15,6 +15,8 @@ JSONファイルはコメントをサポートしていません。テキスト�
 
 [ビジュアルスケジューリング生成ツール](https://ark.yituliu.cn/tools/scheduleV3)
 
+[基地スケジュール自動生成ツール](https://riic.autos/)
+
 ## 完全なフィールドの一覧
 
 ```json

--- a/docs/ko-kr/protocol/base-scheduling-schema.md
+++ b/docs/ko-kr/protocol/base-scheduling-schema.md
@@ -13,6 +13,8 @@ JSON 파일은 주석을 지원하지 않으므로, 텍스트 내의 주석은 �
 
 [기반시설 스케줄링 생성 도구](https://ark.yituliu.cn/tools/scheduleV3)
 
+[기반시설 스케줄 자동 생성 도구](https://riic.autos/)
+
 ## 전체 필드 목록
 
 ```json

--- a/docs/zh-cn/protocol/base-scheduling-schema.md
+++ b/docs/zh-cn/protocol/base-scheduling-schema.md
@@ -13,6 +13,8 @@ icon: material-symbols:view-quilt-rounded
 
 [可视化排班生成工具](https://ark.yituliu.cn/tools/scheduleV3)
 
+[自动生成基建排班表工具](https://riic.autos/)
+
 ## 完整字段一览
 
 ```json

--- a/docs/zh-tw/protocol/base-scheduling-schema.md
+++ b/docs/zh-tw/protocol/base-scheduling-schema.md
@@ -13,6 +13,8 @@ icon: material-symbols:view-quilt-rounded
 
 [視覺化排班產生工具](https://ark.yituliu.cn/tools/scheduleV3)
 
+[自動產生基建排班表工具](https://riic.autos/)
+
 ## 完整欄位一覽
 
 ```json


### PR DESCRIPTION
在“基建排班协议”文档的五种语言页面中新增 RIIC.Autos 自动生成基建排班表工具链接。

- 简体中文：自动生成基建排班表工具
- 繁體中文：自動產生基建排班表工具
- English：Automatic RIIC Schedule Generator
- 日本語：基地スケジュール自動生成ツール
- 한국어：기반시설 스케줄 자동 생성 도구
- 保留现有的可视化排班生成工具链接
- 仅修改文档链接，不涉及 MAA 核心代码或协议内容

## Sourcery 总结

在基建排班协议文档中添加 RIIC.Autos 自动排班生成器链接。

新功能：
- 在所有本地化的基建排班协议页面中，将 RIIC.Autos 自动基建排班生成器链接与现有的可视化生成器并列添加。

文档：
- 在英文、日文、韩文、简体中文和繁体中文基建排班协议文档中更新新的工具链接。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add the RIIC.Autos automatic schedule generator link to the base-scheduling protocol documentation.

New Features:
- Add the RIIC.Autos automatic base-scheduling generator link alongside the existing visual generator across all localized base-scheduling protocol pages.

Documentation:
- Update English, Japanese, Korean, Simplified Chinese, and Traditional Chinese base-scheduling protocol documentation with the new tool link.

</details>