### PR TITLE
docs: add RIIC.Autos infrastructure scheduling links

### DIFF
--- a/docs/en-us/manual/introduction/infrastructure.md
+++ b/docs/en-us/manual/introduction/infrastructure.md
@@ -45,4 +45,5 @@ In Normal Mode, the shift order is planned automatically by the algorithm (Dormi
 ## Custom Base Mode
 
 - The [Schedule Generator](https://ark.yituliu.cn/tools/scheduleV3) created by community experts can help you create custom schedules. Refer to the [Base Facility Protocol Documentation](../../protocol/base-scheduling-schema.md) for usage.
+- [Automatic RIIC Schedule Generator](https://riic.autos/): Generate an efficient base schedule for the current version based on your operator roster.
 - The MAA folder `/resource/custom_infrast/` contains built-in theoretically maximum-efficiency presets. Not recommended for direct use due to their extreme operator and elite/skill level requirements.

--- a/docs/ja-jp/manual/introduction/infrastructure.md
+++ b/docs/ja-jp/manual/introduction/infrastructure.md
@@ -45,4 +45,5 @@ icon: material-symbols:view-quilt-rounded
 ## 基地シフトのカスタマイズ
 
 - ワンシート攻略の有志の方々が作成した [シフト生成ツール](https://ark.yituliu.cn/tools/scheduleV3) があり、[基地スケジューリング仕様書](../../protocol/base-scheduling-schema.md) を参考に利用できます。
+- [基地スケジュール自動生成ツール](https://riic.autos/)：オペレーターの所持状況に基づいて、現在の環境に適した効率的な基地シフトを生成できます。
 - MAA フォルダー配下の `/resource/custom_infrast/` には、理論上の最大効率を目指したいくつかのシフトプランが同梱されています。参考用としてお使いください。オペレーターおよび育成度の要件が非常に高いため、直接の使用は推奨しません。

--- a/docs/ko-kr/manual/introduction/infrastructure.md
+++ b/docs/ko-kr/manual/introduction/infrastructure.md
@@ -45,4 +45,5 @@ icon: material-symbols:view-quilt-rounded
 ## 커스텀 기반시설
 
 - Yituliu의 [기반시설 JSON 생성기](https://ark.yituliu.cn/tools/scheduleV3)를 참고해서 작성하세요. [기반시설 프로토콜 문서](../../protocol/base-scheduling-schema.md)도 참조할 수 있습니다.
+- [기반시설 스케줄 자동 생성 도구](https://riic.autos/): 오퍼레이터 보유 목록을 바탕으로 현재 환경에 맞는 효율적인 기반시설 스케줄을 생성합니다.
 - MAA 폴더의 `/resource/custom_infrast/`에는 이론적 최대 효율의 작업 몇 개가 내장되어 있습니다. 오퍼레이터 인원 수 및 육성의 요구 사항이 매우 높기 때문에 직접 사용하는 것은 권장하지 않습니다.

--- a/docs/zh-cn/manual/introduction/infrastructure.md
+++ b/docs/zh-cn/manual/introduction/infrastructure.md
@@ -45,4 +45,5 @@ icon: material-symbols:view-quilt-rounded
 ## 自定义基建换班
 
 - 一图流的大佬们帮忙写了一个 [排班生成器](https://ark.yituliu.cn/tools/scheduleV3)，可参考 [基建协议文档](../../protocol/base-scheduling-schema.md) 使用。
+- [自动生成基建排班表工具](https://riic.autos/)：根据干员Box 生成当前的高效基建排班表。
 - MAA 文件夹下 `/resource/custom_infrast/` 中内置了几套理论极限效率的作业，可用作参考。由于其对干员及练度的需求极高，不推荐直接使用。

--- a/docs/zh-cn/manual/introduction/infrastructure.md
+++ b/docs/zh-cn/manual/introduction/infrastructure.md
@@ -45,5 +45,5 @@ icon: material-symbols:view-quilt-rounded
 ## 自定义基建换班
 
 - 一图流的大佬们帮忙写了一个 [排班生成器](https://ark.yituliu.cn/tools/scheduleV3)，可参考 [基建协议文档](../../protocol/base-scheduling-schema.md) 使用。
-- [自动生成基建排班表工具](https://riic.autos/)：根据干员Box 生成当前的高效基建排班表。
+- [自动生成基建排班表工具](https://riic.autos/)：根据干员 Box 生成当前的高效基建排班表。
 - MAA 文件夹下 `/resource/custom_infrast/` 中内置了几套理论极限效率的作业，可用作参考。由于其对干员及练度的需求极高，不推荐直接使用。

--- a/docs/zh-tw/manual/introduction/infrastructure.md
+++ b/docs/zh-tw/manual/introduction/infrastructure.md
@@ -45,4 +45,5 @@ icon: material-symbols:view-quilt-rounded
 ## 自訂基建換班
 
 - 一圖流的大佬們幫忙寫了一個 [排班產生器](https://ark.yituliu.cn/tools/scheduleV3)，可參閱 [基建協定文件](../../protocol/base-scheduling-schema.md) 使用。
+- [自動產生基建排班表工具](https://riic.autos/)：根據幹員 Box 產生目前的高效基建排班表。
 - MAA 資料夾下 `/resource/custom_infrast/` 中內建了幾套理論極限效率的作業，可用作參考。由於其對幹員及練度的需求極高，不推薦直接使用。


### PR DESCRIPTION
在 MAA“自定义基建换班”文档的五种语言页面中新增 RIIC.Autos 工具链接。

新增文案说明该工具可根据干员 Box 生成当前的高效基建排班表。

修改文件：
- docs/zh-cn/manual/introduction/infrastructure.md
- docs/zh-tw/manual/introduction/infrastructure.md
- docs/en-us/manual/introduction/infrastructure.md
- docs/ja-jp/manual/introduction/infrastructure.md
- docs/ko-kr/manual/introduction/infrastructure.md

保留原有排班生成器链接及基建协议文档链接。

## Sourcery 总结

文档：
- 在中文、繁体中文、英文、日文和韩文版本的自定义基准排程文档中，添加本地化的 RIIC.Autos 链接，介绍基于排班表的高效排程生成，同时保留现有资源。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

在自定义基建文档中添加本地化的 RIIC.Autos 排班链接。

新功能：
- 在中文、繁体中文、英语、日语和韩语的自定义基建排班文档中添加本地化的 RIIC.Autos 链接。
- 将 RIIC.Autos 描述为根据用户的干员阵容生成当前版本高效基建排班的工具。

文档：
- 更新全部五种本地化的基建文档页面，同时保留现有的排班生成器和协议引用。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

文档：
- 在中文、繁体中文、英文、日文和韩文版本的自定义基础设施调度文档中添加本地化的 RIIC.Autos 链接，介绍基于排班表的高效日程生成，同时保留现有引用。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Add localized RIIC.Autos links to the custom infrastructure scheduling documentation in Chinese, Traditional Chinese, English, Japanese, and Korean, describing roster-based efficient schedule generation while retaining existing references.

</details>

</details>

</details>