### PR TITLE
fix: 干员超负荷图像会在不同分辨率下变换大小

### DIFF
--- a/resource/global/YoStarEN/resource/tasks/MiniGame/MaterialSynthesis.json
+++ b/resource/global/YoStarEN/resource/tasks/MiniGame/MaterialSynthesis.json
@@ -1,0 +1,5 @@
+{
+    "MiniGame@MaterialSynthesis@LowMood": {
+        "text": ["overworked"]
+    }
+}

--- a/resource/global/YoStarJP/resource/tasks/MiniGame/MaterialSynthesis.json
+++ b/resource/global/YoStarJP/resource/tasks/MiniGame/MaterialSynthesis.json
@@ -1,0 +1,5 @@
+{
+    "MiniGame@MaterialSynthesis@LowMood": {
+        "text": ["過負荷作業"]
+    }
+}

--- a/resource/global/YoStarKR/resource/tasks/MiniGame/MaterialSynthesis.json
+++ b/resource/global/YoStarKR/resource/tasks/MiniGame/MaterialSynthesis.json
@@ -1,0 +1,5 @@
+{
+    "MiniGame@MaterialSynthesis@LowMood": {
+        "text": ["과부하 가공"]
+    }
+}

--- a/resource/global/txwy/resource/tasks/MiniGame/MaterialSynthesis.json
+++ b/resource/global/txwy/resource/tasks/MiniGame/MaterialSynthesis.json
@@ -1,0 +1,5 @@
+{
+    "MiniGame@MaterialSynthesis@LowMood": {
+        "text": ["超負荷加工"]
+    }
+}

--- a/resource/tasks/MiniGame/MaterialSynthesis.json
+++ b/resource/tasks/MiniGame/MaterialSynthesis.json
@@ -77,7 +77,8 @@
         "postDelay": 900
     },
     "MiniGame@MaterialSynthesis@LowMood": {
-        "template": "ProcessingOperatorLowMood.png",
+        "algorithm": "OcrDetect",
+        "text": ["超负荷加工"],
         "roi": [649, 308, 362, 155]
     },
     "MiniGame@MaterialSynthesis@OpenOperatorList": {


### PR DESCRIPTION
~~不知道什么原因新版本的超负荷加工变大了，所以重新截取模板~~
~~因为这个图像在不同分辨率下好像会变大小，所以换成纯色识别~~
换成OCR了

## Sourcery 摘要

错误修复：
- 通过改用基于颜色的识别，防止在不同屏幕分辨率下错误识别运算符重载图像。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

修复不同分辨率下干员超负荷图像识别不一致的问题，并补充各服材料合成任务配置。

Bug 修复：
- 改用纯色识别处理干员超负荷图像，避免因屏幕分辨率变化导致识别结果不一致。

杂项：
- 为英文、日文、韩文及繁中服新增材料合成任务配置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

修复不同分辨率下干员超负荷图像识别不一致的问题，并补充各服材料合成任务配置。

Bug Fixes:
- 改用纯色识别处理干员超负荷图像，避免因屏幕分辨率变化导致识别结果不一致。

Chores:
- 为英文、日文、韩文及繁中服新增材料合成任务配置。

</details>

<details>
<summary>Original summary in English</summary>



</details>

</details>