### PR TITLE
fix(roguelike): refresh Mizuki trader after investment

### DIFF
--- a/resource/tasks/Roguelike/Mizuki.json
+++ b/resource/tasks/Roguelike/Mizuki.json
@@ -413,6 +413,73 @@
         "templThreshold": 0.95
     },
     "Mizuki@Roguelike@StageTraderEnter": {},
+    "Mizuki@Roguelike@StageTraderInvestCancel": {
+        "baseTask": "Roguelike@StageTraderInvestCancel",
+        "template": "Roguelike@StageTraderInvestCancel.png",
+        "exceededNext": ["Mizuki@Roguelike@StageTraderInvestCancelForRefresh"]
+    },
+    "Mizuki@Roguelike@StageTraderInvestCancelForRefresh": {
+        "baseTask": "Roguelike@StageTraderInvestCancel",
+        "template": "Roguelike@StageTraderInvestCancel.png",
+        "next": [
+            "Mizuki@Roguelike@StageTraderInvestSystemLeaveForRefresh",
+            "Mizuki@Roguelike@StageTraderInvestCancelForRefresh"
+        ]
+    },
+    "Mizuki@Roguelike@StageTraderInvestSystemLeaveForRefresh": {
+        "baseTask": "Roguelike@StageTraderInvestSystemLeave",
+        "template": "Roguelike@StageTraderInvestSystemLeave.png",
+        "next": [
+            "Mizuki@Roguelike@StageTraderRefreshWithDice",
+            "Mizuki@Roguelike@StageTraderInvestSystemLeaveForRefresh"
+        ]
+    },
+    "Mizuki@Roguelike@StageTraderRefreshWithDice": {
+        "baseTask": "Roguelike@StageTraderRefreshWithDice",
+        "template": "Roguelike@StageTraderRefresh.png",
+        "next": [
+            "Mizuki@Roguelike@StageTraderRefreshWithDiceConfirm",
+            "Mizuki@Roguelike@StageTraderRefreshWithDiceNotAvaiable",
+            "Mizuki@Roguelike@ExitThenAbandon"
+        ],
+        "exceededNext": ["Mizuki@Roguelike@ExitThenAbandon"]
+    },
+    "Mizuki@Roguelike@StageTraderRefreshWithDiceDoubleConfirm": {
+        "baseTask": "Roguelike@StageTraderRefreshWithDiceDoubleConfirm",
+        "next": [
+            "Mizuki@Roguelike@StageTraderSpecialShoppingAfterRefresh",
+            "Mizuki@Roguelike@StageTraderRefreshWithDice",
+            "Mizuki@Roguelike@ExitThenAbandon"
+        ]
+    },
+    "Mizuki@Roguelike@StageTraderRefreshWithDiceNotAvaiable": {
+        "baseTask": "Roguelike@StageTraderRefreshWithDiceNotAvaiable",
+        "next": ["Mizuki@Roguelike@ExitThenAbandon"]
+    },
+    "Mizuki@Roguelike@StageTraderSpecialShoppingAfterRefresh": {
+        "baseTask": "Roguelike@StageTraderSpecialShoppingAfterRefresh",
+        "next": [
+            "Mizuki@Roguelike@StageTraderSpecialShoppingAfterRefreshConfirm",
+            "Mizuki@Roguelike@StageTraderSpecialShoppingAfterRefreshCancel",
+            "Mizuki@Roguelike@ExitThenAbandon"
+        ]
+    },
+    "Mizuki@Roguelike@StageTraderSpecialShoppingAfterRefreshConfirm": {
+        "baseTask": "Roguelike@TraderRandomShoppingConfirm",
+        "template": "Roguelike@TraderRandomShoppingConfirm.png",
+        "next": [
+            "Mizuki@Roguelike@ExitThenAbandon",
+            "Mizuki@Roguelike@StageTraderSpecialShoppingAfterRefreshConfirm"
+        ]
+    },
+    "Mizuki@Roguelike@StageTraderSpecialShoppingAfterRefreshCancel": {
+        "baseTask": "Roguelike@TraderRandomShoppingCancel",
+        "template": "Roguelike@StageTraderInvestCancel.png",
+        "next": [
+            "Mizuki@Roguelike@ExitThenAbandon",
+            "Mizuki@Roguelike@StageTraderSpecialShoppingAfterRefreshCancel"
+        ]
+    },
     "Mizuki@Roguelike@StageTraderLeaveConfirm": {
         "template": "Roguelike@StageTraderLeaveConfirm.png",
         "exceededNext": ["Mizuki@Roguelike@DiceConfirmThenAbandon", "Mizuki@Roguelike@ExitThenAbandon"]


### PR DESCRIPTION
Close the investment error dialog and leave the investment screen before refreshing the trader with dice.

Continue searching for and purchasing 指路鳞 after the refresh, then abandon the current exploration.

Refs: #16768

## Sourcery 摘要

错误修复：
- 完成投资尝试后刷新 Mizuki 商人，以便任务可以继续正确搜索并购买指路鳞。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Refresh the Mizuki trader after completing an investment attempt so the task can continue searching for and purchasing 指路鳞 correctly.

</details>