### PR TITLE
fix: 降低黑流树海事件选项确认阈值

### DIFF
--- a/resource/tasks/Roguelike/BlackFlow.json
+++ b/resource/tasks/Roguelike/BlackFlow.json
@@ -1360,6 +1360,7 @@
     "BlackFlow@Roguelike@StageEncounterLeaveConfirm": {
         "baseTask": "Roguelike@StageEncounterLeaveConfirm",
         "template": "BlackFlow@Roguelike@StageEncounterLeaveConfirm.png",
+        "templThreshold": 0.7,
         "next": [
             "BlackFlow@Roguelike@StageEncounterLeaveConfirm",
             "BlackFlow@Roguelike@StageEncounterLeaveConfirmCompleted"

--- a/resource/tasks/Roguelike/BlackFlow.json
+++ b/resource/tasks/Roguelike/BlackFlow.json
@@ -1358,8 +1358,6 @@
         "next": ["BlackFlow@Roguelike@StageEncounterResult"]
     },
     "BlackFlow@Roguelike@StageEncounterLeaveConfirm": {
-        "baseTask": "Roguelike@StageEncounterLeaveConfirm",
-        "template": "BlackFlow@Roguelike@StageEncounterLeaveConfirm.png",
         "templThreshold": 0.7,
         "next": [
             "BlackFlow@Roguelike@StageEncounterLeaveConfirm",


### PR DESCRIPTION
fix: #18064

## Sourcery 总结

错误修复：
- 降低 BlackFlow Roguelike 树中事件选择的确认阈值。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Lower the confirmation threshold for event choices in the BlackFlow roguelike tree.

</details>

<details>
<summary>Original summary in English</summary>



</details>