### PR TITLE
feat: 增加一个自定义github镜像代理的更新源

### DIFF
--- a/src/MaaWpfGui/Configuration/Global/Update.cs
+++ b/src/MaaWpfGui/Configuration/Global/Update.cs
@@ -40,6 +40,8 @@ public partial class Update : NotifyPropertyChangedWithValue
 
     public bool ForceGithubGlobalSource { get; set; }
 
+    public string GithubMirrorUrl { get; set; } = string.Empty;
+
     public string MirrorChyanCdk { get; set; } = string.Empty;
 
     public long MirrorChyanCdkExpiredTime { get; set; }

--- a/src/MaaWpfGui/Constants/Enums/UpdateSource.cs
+++ b/src/MaaWpfGui/Constants/Enums/UpdateSource.cs
@@ -26,6 +26,11 @@ public enum UpdateSource
     GitHub,
 
     /// <summary>
+    /// GitHub 镜像（使用自定义镜像站前缀加速 GitHub 下载）
+    /// </summary>
+    GitHubMirror,
+
+    /// <summary>
     /// Mirror酱
     /// </summary>
     MirrorChyan,

--- a/src/MaaWpfGui/Helper/GithubMirrorHelper.cs
+++ b/src/MaaWpfGui/Helper/GithubMirrorHelper.cs
@@ -1,0 +1,86 @@
+// <copyright file="GithubMirrorHelper.cs" company="MaaAssistantArknights">
+// Part of the MaaWpfGui project, maintained by the MaaAssistantArknights team (Maa Team)
+// Copyright (C) 2021-2025 MaaAssistantArknights Contributors
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License v3.0 only as published by
+// the Free Software Foundation, either version 3 of the License, or
+// any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY
+// </copyright>
+
+#nullable enable
+
+using System;
+using MaaWpfGui.Constants.Enums;
+using MaaWpfGui.ViewModels.UserControl.Settings;
+
+namespace MaaWpfGui.Helper;
+
+/// <summary>
+/// GitHub 镜像站加速：为 GitHub 相关的下载链接添加用户配置的镜像前缀
+/// </summary>
+public static class GithubMirrorHelper
+{
+    /// <summary>
+    /// 若当前更新源为 ｢GitHub 镜像｣ 且链接指向 GitHub 相关域名，则为其添加镜像站前缀。
+    /// <para>例如前缀为 <c>https://gh-proxy.org/</c> 时，<c>https://github.com/a/b/file.zip</c> 会变为
+    /// <c>https://gh-proxy.org/https://github.com/a/b/file.zip</c></para>
+    /// </summary>
+    /// <param name="url">原始下载链接</param>
+    /// <returns>镜像化后的链接；未启用镜像或非 GitHub 链接时原样返回</returns>
+    public static string ApplyMirrorIfNeeded(string url)
+    {
+        var settings = VersionUpdateSettingsUserControlModel.Instance;
+        if (settings.UpdateSource != UpdateSource.GitHubMirror)
+        {
+            return url;
+        }
+
+        return ApplyMirror(settings.GithubMirrorUrl, url);
+    }
+
+    /// <summary>
+    /// 为 GitHub 相关域名（github.com、*.githubusercontent.com 等）的链接添加镜像前缀
+    /// </summary>
+    /// <param name="mirrorUrl">镜像站前缀地址</param>
+    /// <param name="url">原始下载链接</param>
+    /// <returns>镜像化后的链接；前缀为空或非 GitHub 链接时原样返回</returns>
+    public static string ApplyMirror(string mirrorUrl, string url)
+    {
+        mirrorUrl = mirrorUrl?.Trim() ?? string.Empty;
+        if (mirrorUrl.Length == 0 || string.IsNullOrEmpty(url))
+        {
+            return url;
+        }
+
+        // 前缀必须是合法的绝对 HTTP(S) 地址，无效配置直接回退原链接，避免把错误配置拼进下载链接
+        if (!Uri.TryCreate(mirrorUrl, UriKind.Absolute, out var mirrorUri)
+            || (mirrorUri.Scheme != Uri.UriSchemeHttps && mirrorUri.Scheme != Uri.UriSchemeHttp))
+        {
+            return url;
+        }
+
+        try
+        {
+            var host = new Uri(url).Host;
+            if (host.Equals("github.com", StringComparison.OrdinalIgnoreCase)
+                || host.EndsWith(".githubusercontent.com", StringComparison.OrdinalIgnoreCase)
+                || host.Equals("githubusercontent.com", StringComparison.OrdinalIgnoreCase))
+            {
+                var mirrored = mirrorUrl.TrimEnd('/') + "/" + url;
+
+                // 拼接结果同样要求是合法的绝对地址，否则回退原链接，防止后续探测 new Uri 时抛异常导致更新检测崩溃
+                return Uri.TryCreate(mirrored, UriKind.Absolute, out _) ? mirrored : url;
+            }
+        }
+        catch (UriFormatException)
+        {
+            // 非法链接，原样返回
+        }
+
+        return url;
+    }
+}

--- a/src/MaaWpfGui/Models/ResourceUpdater.cs
+++ b/src/MaaWpfGui/Models/ResourceUpdater.cs
@@ -673,6 +673,7 @@ public static class ResourceUpdater
 
     private static async Task<bool> DownloadFullPackageAsync(string url, string saveTo, bool globalSource)
     {
+        url = GithubMirrorHelper.ApplyMirrorIfNeeded(url);
         try
         {
             return await Instances.HttpService.DownloadFileAsync(new(url), saveTo, "application/zip");

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -464,6 +464,9 @@ You can cancel this popup by clicking the ｢{key=Settings} - {key=IssueReport}�
     <system:String x:Key="GlobalSource">Global Source</system:String>
     <system:String x:Key="ForceGithubGlobalSource">Force using GitHub</system:String>
     <system:String x:Key="ForceGithubGlobalSourceTip">When updates are detected, force download update packages from GitHub</system:String>
+        <system:String x:Key="GithubMirror">GitHub Mirror</system:String>
+    <system:String x:Key="GithubMirrorUrl">Mirror prefix URL</system:String>
+    <system:String x:Key="GithubMirrorUrlTip">When a download link points to GitHub (including githubusercontent etc.), this prefix is prepended to the link as the mirror address, e.g. https://gh-proxy.org/</system:String>
     <system:String x:Key="MirrorChyan">MirrorChyan</system:String>
     <system:String x:Key="MirrorChyanSelectedButNoCdk">Please go to ｢{key=Settings} - {key=UpdateSettings}｣ to configure MirrorChyan CDK or switch to Global Source.</system:String>
     <system:String x:Key="MirrorChyanResourceUpdateTip">Resource update {0} detected. Please go to ｢{key=Settings} - {key=UpdateSettings} - {key=ResourceUpdate}｣ to update manually, or fill in MirrorChyan CDK to update automatically.</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -464,6 +464,9 @@
     <system:String x:Key="GlobalSource">グローバルソース</system:String>
     <system:String x:Key="ForceGithubGlobalSource">GitHub を強制使用</system:String>
     <system:String x:Key="ForceGithubGlobalSourceTip">更新を検出後、Githubから強制的に更新パッケージをダウンロード</system:String>
+        <system:String x:Key="GithubMirror">GitHub ミラー</system:String>
+    <system:String x:Key="GithubMirrorUrl">ミラー接頭辞 URL</system:String>
+    <system:String x:Key="GithubMirrorUrlTip">ダウンロードリンクが GitHub（githubusercontent などを含む）を指す場合、この接頭辞をリンクの前に付けてミラーとして使用します。例: https://gh-proxy.org/</system:String>
     <system:String x:Key="MirrorChyan">MirrorChyan</system:String>
     <system:String x:Key="MirrorChyanSelectedButNoCdk">｢{key=Settings} - {key=UpdateSettings}｣ に移動して MirrorChyan CDK を設定するか、グローバル ソースに切り替えてください。</system:String>
     <system:String x:Key="MirrorChyanResourceUpdateTip">リソース更新 {0} が検出されました。 ｢{key=Settings} - {key=UpdateSettings} - {key=ResourceUpdate}｣ に移動して手動で更新するか、MirrorChyan CDK を入力して自動的に更新してください。</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -464,6 +464,9 @@
     <system:String x:Key="GlobalSource">글로벌 소스</system:String>
     <system:String x:Key="ForceGithubGlobalSource">GitHub 강제 사용</system:String>
     <system:String x:Key="ForceGithubGlobalSourceTip">업데이트 감지 후, Github에서 강제로 업데이트 패키지 다운로드</system:String>
+        <system:String x:Key="GithubMirror">GitHub 미러</system:String>
+    <system:String x:Key="GithubMirrorUrl">미러 접두사 URL</system:String>
+    <system:String x:Key="GithubMirrorUrlTip">다운로드 링크가 GitHub(githubusercontent 등 포함)를 가리킬 때, 해당 링크 앞에 이 접두사를 붙여 미러 주소로 사용합니다. 예: https://gh-proxy.org/</system:String>
     <system:String x:Key="MirrorChyan">MirrorChyan</system:String>
     <system:String x:Key="MirrorChyanSelectedButNoCdk">｢{key=Settings} - {key=UpdateSettings}｣ 으로 이동하여 MirrorChyan CDK를 구성하거나 글로벌 소스로 전환하세요.</system:String>
     <system:String x:Key="MirrorChyanResourceUpdateTip">리소스 업데이트 {0}이 감지되었습니다. ｢{key=Settings} - {key=UpdateSettings} - {key=ResourceUpdate}｣ 로 이동하여 수동으로 업데이트하거나, MirrorChyan CDK를 입력하여 자동으로 업데이트하세요.</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -463,6 +463,9 @@
     <system:String x:Key="GlobalSource">海外源</system:String>
     <system:String x:Key="ForceGithubGlobalSource">强制使用 GitHub</system:String>
     <system:String x:Key="ForceGithubGlobalSourceTip">检测到更新后，强制从 GitHub 下载更新包</system:String>
+        <system:String x:Key="GithubMirror">GitHub 镜像</system:String>
+    <system:String x:Key="GithubMirrorUrl">镜像站前缀地址</system:String>
+    <system:String x:Key="GithubMirrorUrlTip">更新时若下载链接指向 GitHub（含 githubusercontent 等域名），则在该链接前拼接此前缀作为镜像站地址，例如 https://gh-proxy.org/</system:String>
     <system:String x:Key="MirrorChyan">Mirror酱</system:String>
     <system:String x:Key="MirrorChyanSelectedButNoCdk">请前往 ｢{key=Settings} - {key=UpdateSettings}｣ 配置 Mirror酱 CDK 或切换海外源。</system:String>
     <system:String x:Key="MirrorChyanResourceUpdateTip">检测到资源更新: {0}。请前往 ｢{key=Settings} - {key=UpdateSettings} - {key=ResourceUpdate}｣ 手动更新，或配置 Mirror酱 CDK 以自动更新。</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -464,6 +464,9 @@
     <system:String x:Key="GlobalSource">全域來源</system:String>
     <system:String x:Key="ForceGithubGlobalSource">強制使用 GitHub</system:String>
     <system:String x:Key="ForceGithubGlobalSourceTip">偵測到更新後，強制從 GitHub 下載更新壓縮檔</system:String>
+        <system:String x:Key="GithubMirror">GitHub 鏡像</system:String>
+    <system:String x:Key="GithubMirrorUrl">鏡像站前綴位址</system:String>
+    <system:String x:Key="GithubMirrorUrlTip">更新時若下載連結指向 GitHub（含 githubusercontent 等網域），則在該連結前拼接此前綴作為鏡像站位址，例如 https://gh-proxy.org/</system:String>
     <system:String x:Key="MirrorChyan">MirrorChyan</system:String>
     <system:String x:Key="MirrorChyanSelectedButNoCdk">請前往 ｢{key=Settings} - {key=UpdateSettings}｣ 設定 MirrorChyan CDK 或切換到全域來源。</system:String>
     <system:String x:Key="MirrorChyanResourceUpdateTip">偵測到資源更新: {0}。請前往 ｢{key=Settings} - {key=UpdateSettings} - {key=ResourceUpdate}｣ 手動更新，或設定 MirrorChyan CDK 以自動更新。</system:String>

--- a/src/MaaWpfGui/ViewModels/Dialogs/VersionUpdateDialogViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/Dialogs/VersionUpdateDialogViewModel.cs
@@ -508,7 +508,7 @@ public class VersionUpdateDialogViewModel : Screen
         string? rawUrl = _assetsObject["browser_download_url"]?.ToString();
         var urls = new List<string>();
 
-        if (SettingsViewModel.VersionUpdateSettings.UpdateSource == UpdateSource.GitHub && !SettingsViewModel.VersionUpdateSettings.ForceGithubGlobalSource)
+        if (SettingsViewModel.VersionUpdateSettings.UpdateSource is UpdateSource.GitHub or UpdateSource.GitHubMirror && !SettingsViewModel.VersionUpdateSettings.ForceGithubGlobalSource)
         {
             var mirrors = _assetsObject["mirrors"]?.ToObject<List<string>>();
 
@@ -523,7 +523,7 @@ public class VersionUpdateDialogViewModel : Screen
         // urls = urls.OrderBy(_ => rand.Next()).ToList();
         if (rawUrl != null)
         {
-            urls.Add(rawUrl);
+            urls.Add(GithubMirrorHelper.ApplyMirrorIfNeeded(rawUrl));
         }
 
         _logger.Information("Start test legacy download urls");
@@ -810,7 +810,7 @@ public class VersionUpdateDialogViewModel : Screen
             OutputDownloadProgress(LocalizationHelper.GetString("ResourceIntegrityRepairDownloading"), downloading: true, globalSource: true);
             foreach (string url in maaApiPackage.DownloadUrls)
             {
-                if (await DownloadGithubAssets(url, maaApiPackage.Asset))
+                if (await DownloadGithubAssets(GithubMirrorHelper.ApplyMirrorIfNeeded(url), maaApiPackage.Asset))
                 {
                     packagePath = GetPlannedUpdatePackagePath(maaApiPackage.PackageName);
                     break;

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/VersionUpdateSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/VersionUpdateSettingsUserControlModel.cs
@@ -250,6 +250,7 @@ public class VersionUpdateSettingsUserControlModel : PropertyChangedBase
 
     public LocalizedObservableList<UpdateSource> UpdateSourceList { get; } = new(
         (UpdateSource.GitHub, "GlobalSource"),
+        (UpdateSource.GitHubMirror, "GithubMirror"),
         (UpdateSource.MirrorChyan, "MirrorChyan"));
 
     /// <summary>
@@ -270,6 +271,17 @@ public class VersionUpdateSettingsUserControlModel : PropertyChangedBase
             ConfigFactory.Root.Update.ForceGithubGlobalSource = value;
         }
     } = ConfigFactory.Root.Update.ForceGithubGlobalSource;
+
+    /// <summary>
+    /// Gets or sets the GitHub mirror prefix, e.g. <c>https://gh-proxy.org/</c>.
+    /// </summary>
+    public string GithubMirrorUrl
+    {
+        get; set {
+            SetAndNotify(ref field, value);
+            ConfigFactory.Root.Update.GithubMirrorUrl = value;
+        }
+    } = ConfigFactory.Root.Update.GithubMirrorUrl;
 
     public string MirrorChyanCdk
     {
@@ -573,7 +585,7 @@ public class VersionUpdateSettingsUserControlModel : PropertyChangedBase
         }
 
         bool success = UpdateSource switch {
-            UpdateSource.GitHub => await ResourceUpdater.UpdateFromGithubAsync(),
+            UpdateSource.GitHub or UpdateSource.GitHubMirror => await ResourceUpdater.UpdateFromGithubAsync(),
             UpdateSource.MirrorChyan => (ret == VersionUpdateDialogViewModel.CheckUpdateRetT.OK) && await ResourceUpdater.DownloadFromMirrorChyanAsync(uri, releaseNote),
             _ => await ResourceUpdater.UpdateFromGithubAsync(),
         };

--- a/src/MaaWpfGui/Views/UserControl/Settings/VersionUpdateSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/Settings/VersionUpdateSettingsUserControl.xaml
@@ -133,6 +133,24 @@
                             ItemsSource="{Binding UpdateSourceList}"
                             SelectedValue="{Binding UpdateSource}"
                             SelectedValuePath="Value" />
+                        <StackPanel
+                            Margin="0,5,0,0"
+                            HorizontalAlignment="Left"
+                            Visibility="{c:Binding 'UpdateSource == enums:UpdateSource.GitHubMirror'}">
+                            <StackPanel Margin="0,0,0,5" Orientation="Horizontal">
+                                <controls:TextBlock
+                                    Margin="8,0,0,0"
+                                    HorizontalAlignment="Left"
+                                    Text="{DynamicResource GithubMirrorUrl}" />
+                                <controls:TooltipBlock TooltipText="{DynamicResource GithubMirrorUrlTip}" />
+                            </StackPanel>
+                            <hc:TextBox
+                                Width="150"
+                                HorizontalAlignment="Left"
+                                VerticalAlignment="Center"
+                                hc:InfoElement.Placeholder="https://gh-proxy.org/"
+                                Text="{Binding GithubMirrorUrl}" />
+                        </StackPanel>
                     </StackPanel>
                     <StackPanel
                         Margin="8"


### PR DESCRIPTION
在更新源下拉框增加了一个“github镜像”的选项，可以自行设置github镜像前缀下载更新数据。

镜像站拼接方式用的是 “镜像站地址/原始github地址”，
如：`https://gh-proxy.org/https://github.com/MaaAssistantArknights/MaaAssistantArknights.git`

<img width="798" height="540" alt="image" src="https://github.com/user-attachments/assets/88f1f773-a651-4ff3-aa56-a7cad4c28606" />

## Sourcery 总结

支持通过用户配置的 GitHub 镜像下载更新。

新功能：
- 添加可配置的 GitHub 镜像更新源，支持用户提供镜像前缀。
- 在更新和完整性修复期间，将配置的镜像应用于 GitHub 和 GitHubusercontent 下载 URL。

增强功能：
- 扩展更新源设置和本地化界面，以支持配置和选择 GitHub 镜像。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

支持用户通过自定义 GitHub 镜像下载更新。

新功能：
- 添加可配置的 GitHub 镜像更新源，允许用户为下载提供自定义镜像前缀。

增强功能：
- 在更新和完整性修复期间，将配置的镜像应用于 GitHub 和 GitHubusercontent URL；对于无效配置或非 GitHub 链接，安全地回退。
- 扩展更新源设置和本地化 UI，以支持选择和配置 GitHub 镜像。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

支持通过用户配置的 GitHub 镜像下载更新。

新功能：
- 添加可配置的 GitHub 镜像更新源，将用户提供的前缀应用于 GitHub 下载。

改进：
- 在更新和完整性修复期间，将配置的镜像应用于 GitHub 和 GitHubusercontent URL；对于无效或不受支持的 URL，则安全地回退。
- 扩展更新设置和本地化 UI，支持选择 GitHub 镜像和配置前缀。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable downloading updates through a user-configured GitHub mirror.

New Features:
- Add a configurable GitHub mirror update source that applies a user-provided prefix to GitHub downloads.

Enhancements:
- Apply the configured mirror to GitHub and GitHubusercontent URLs during updates and integrity repairs, while safely falling back for invalid or unsupported URLs.
- Extend update settings and localized UI with GitHub mirror selection and prefix configuration.

</details>

</details>

</details>