### PR TITLE
fix: 日服界园通宝交换结算页无法关闭导致任务出错

### DIFF
--- a/resource/global/YoStarJP/resource/tasks/Roguelike/JieGarden.json
+++ b/resource/global/YoStarJP/resource/tasks/Roguelike/JieGarden.json
@@ -12,7 +12,40 @@
     "JieGarden@Roguelike@CoppersExchangeFinish": {
         "Doc": "通宝交换完成后的交换按钮 (用于确认交换操作完成)",
         "text": ["交換"],
-        "roi": [575, 558, 240, 50]
+        "roi": [575, 558, 240, 50],
+        "next": [
+            "JieGarden@Roguelike@CoppersExchangeResult",
+            "JieGarden@Roguelike@CoppersTakeFlag",
+            "JieGarden@Roguelike@DropsFlag",
+            "JieGarden@Roguelike@CloseEvent"
+        ]
+    },
+    "JieGarden@Roguelike@CoppersExchangeResult": {
+        "Doc": "日服通宝交换成功结算页（「〜と交換しました」、无按钮，点文字关掉）",
+        "algorithm": "OcrDetect",
+        "action": "ClickSelf",
+        "text": ["交換しました"],
+        "roi": [250, 430, 780, 200],
+        "preDelay": 400,
+        "postDelay": 800,
+        "next": [
+            "JieGarden@Roguelike@DropsFlag",
+            "JieGarden@Roguelike@CloseEvent",
+            "JieGarden@Roguelike@Stages#next",
+            "JieGarden@Roguelike@NextLevel",
+            "JieGarden@Roguelike@RandomPickAfterNextLevel",
+            "#self"
+        ]
+    },
+    "JieGarden@Roguelike@CoppersTakeFlag": {
+        "Doc": "交换通宝界面拿取按钮后继：优先关掉日服结算页，避免 20 次重试后 TaskChainError",
+        "next": [
+            "JieGarden@Roguelike@CoppersExchangeResult",
+            "JieGarden@Roguelike@CoppersAbandonExchange",
+            "JieGarden@Roguelike@DropsFlag",
+            "JieGarden@Roguelike@CloseEvent",
+            "#self"
+        ]
     },
     "JieGarden@Roguelike@CoppersNameOcrReplace": {
         "Doc": "通宝名称 OCR 识别替换规则 no diff: 衡-苦寒 衡-霜雪 花-分久必合 入幻 引光 相合 易花 受引",


### PR DESCRIPTION
MAA挂界园经常会卡住，用天才程序员修正并测试无问题后也希望能帮到大家所以提了这个pr，
天才程序员帮我总结的说明如下：

问题
日服（YoStarJP）自动肉鸽·界园，通宝交换成功后会出现全屏结算页：

〜を 〜 と交換しました

没有按钮。CoppersTakeFlag 后继对不上这个画面，重试 20 次后 TaskChainError，GUI 报「任务出错: 自动肉鸽」。

国服点「交换」后能走下去；日服 CoppersExchangeFinish 只覆盖了 OCR「交換」，没有处理结算页。

改动
仅改 resource/global/YoStarJP/resource/tasks/Roguelike/JieGarden.json：

新增 CoppersExchangeResult：OCR「交換しました」后 ClickSelf
接到 CoppersExchangeFinish / CoppersTakeFlag 的 next 里

## Sourcery 总结

错误修复：
- 修复 YoStarJP JieGarden 自动化流程，使其能够关闭兑换后的结果页面，并在成功兑换铜币后继续执行。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix the YoStarJP JieGarden automation flow so it can dismiss the post-exchange result screen and continue after successful copper exchanges.

</details>