### PR TITLE
fix(roguelike): 修复日服界园交换通宝弹窗卡死问题

### DIFF
--- a/resource/global/YoStarJP/resource/tasks/Roguelike/JieGarden.json
+++ b/resource/global/YoStarJP/resource/tasks/Roguelike/JieGarden.json
@@ -1,4 +1,25 @@
 {
+    "JieGarden@Roguelike@CoppersTakeFlag": {
+        "next": [
+            "JieGarden@Roguelike@CoppersExchangeRewardClose_JP",
+            "JieGarden@Roguelike@CoppersAbandonExchange",
+            "JieGarden@Roguelike@DropsFlag",
+            "JieGarden@Roguelike@CloseEvent",
+            "#self"
+        ]
+    },
+    "JieGarden@Roguelike@CoppersExchangeRewardClose_JP": {
+        "Doc": "日服关闭交换通宝后的获得弹窗",
+        "algorithm": "OcrDetect",
+        "text": ["交換しました"],
+        "action": "ClickRect",
+        "specificRect": [620, 60, 40, 40],
+        "postDelay": 800,
+        "next": [
+            "JieGarden@Roguelike@DropsFlag",
+            "JieGarden@Roguelike@CloseEvent"
+        ]
+    },
     "JieGarden@Roguelike@CheckLevel": {
         "text": ["来園記念", "来園", "記念"]
     },


### PR DESCRIPTION
### 描述 / Description
修复日服界园肉鸽在交换/获得通宝后，停留在展示弹窗导致任务识别超时卡死的问题。

### 问题原因 / Problem
在日服界园肉鸽中交换通宝后，会弹出“大炎通宝を xxx と交換しました”的获得弹窗。由于原配置中 `CoppersTakeFlag` 的 `next` 未包含该弹窗的关闭逻辑，且日服字体与遮罩影响导致无法误触穿透，MAA 最终因重试 20 次超时而报错卡死：
`match_templ | JieGarden@Roguelike@CoppersTakeFlag.png score: 0.613767`

### 解决方式 / Solution
在日服界园配置文件中：
1. 为 `JieGarden@Roguelike@CoppersTakeFlag` 的 `next` 前置添加关闭任务 `JieGarden@Roguelike@CoppersExchangeRewardClose_JP`。
2. 新增该任务节点，使用 OCR 检测文本 `交換しました`，并点击顶部安全空白区域 `[620, 60, 40, 40]` 关闭弹窗继续流程。

### 测试情况 / Verification
- [x] 在日服客户端实测，成功识别弹窗并点击空白处关闭，后续肉鸽流程正常流转。
<img width="1280" height="720" alt="2026 09 06-20 25 13 487_raw" src="https://github.com/user-attachments/assets/bf9f1452-e363-41a0-95c5-120208f78683" />

## Sourcery 摘要

错误修复：
- 通过自动关闭对话框并继续任务识别，防止 Japanese Jie Garden 肉鸽流程在铜币兑换奖励弹窗处卡住。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent the Japanese Jie Garden roguelike flow from hanging on Copper exchange reward pop-ups by automatically closing the dialog and continuing task recognition.

</details>