### PR TITLE
chore: 更新 MaaFramework 依赖至 v5.13.0，支持独立公告 WebView 窗口截图

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
         uses: robinraju/release-downloader@v1
         with:
           repository: MaaXYZ/MaaFramework
-          tag: v5.9.2
+          tag: v5.13.0
           fileName: ${{ matrix.arch == 'arm64' && '*win-aarch64*.zip' || '*win-x86_64*.zip' }}
           extract: true
           out-file-path: MaaFramework-temp

--- a/.github/workflows/release-nightly-ota.yml
+++ b/.github/workflows/release-nightly-ota.yml
@@ -198,7 +198,7 @@ jobs:
         uses: robinraju/release-downloader@v1
         with:
           repository: MaaXYZ/MaaFramework
-          tag: v5.9.2
+          tag: v5.13.0
           fileName: ${{ matrix.arch == 'arm64' && '*win-aarch64*.zip' || '*win-x86_64*.zip' }}
           extract: true
           out-file-path: MaaFramework-temp

--- a/src/MaaCore/Controller/MaaFwAdbController.h
+++ b/src/MaaCore/Controller/MaaFwAdbController.h
@@ -69,7 +69,7 @@ private:
     AsstCallback m_callback = nullptr;
     void callback(AsstMsg msg, const json::value& details);
 
-    // MaaFramework/source/include/ControlUnit/AdbControlUnitAPI.h
+    // MaaFramework/include/MaaControlUnit/AdbControlUnitAPI.h
     using GetVersionFunc = const char*();
     using CreateFunc = MaaFwAdbControlUnitAPI*(const char*, const char*, uint64_t, uint64_t, const char*, const char*);
     using DestroyFunc = void(MaaFwAdbControlUnitAPI*);

--- a/src/MaaCore/Controller/MaaFwAndroidNativeController.h
+++ b/src/MaaCore/Controller/MaaFwAndroidNativeController.h
@@ -73,7 +73,7 @@ private:
     AsstCallback m_callback = nullptr;
     void callback(AsstMsg msg, const json::value& details) const;
 
-    // MaaFramework/source/include/MaaControlUnit/AndroidNativeControlUnitAPI.h
+    // MaaFramework/include/MaaControlUnit/AndroidNativeControlUnitAPI.h
     using GetVersionFunc = const char*();
     using CreateFunc = MaaFwAndroidNativeControlUnitAPI*(const char*);
     using DestroyFunc = void(MaaFwAndroidNativeControlUnitAPI*);

--- a/src/MaaCore/Controller/MaaFwControlUnitInterface.h
+++ b/src/MaaCore/Controller/MaaFwControlUnitInterface.h
@@ -45,16 +45,23 @@ public:
     virtual void* get_info() const = 0;
 };
 
-class MaaFwAdbControlUnitAPI : public MaaFwControlUnitAPI
+class MaaFwShellableUnitAPI
+{
+public:
+    virtual ~MaaFwShellableUnitAPI() = default;
+
+    virtual bool shell(
+        const std::string& cmd,
+        std::string& output,
+        std::chrono::milliseconds timeout = std::chrono::milliseconds(20'000)) = 0;
+};
+
+class MaaFwAdbControlUnitAPI : public MaaFwControlUnitAPI, public MaaFwShellableUnitAPI
 {
 public:
     virtual ~MaaFwAdbControlUnitAPI() = default;
 
     virtual bool find_device(std::vector<std::string>& devices) = 0;
-    virtual bool shell(
-        const std::string& cmd,
-        std::string& output,
-        std::chrono::milliseconds timeout = std::chrono::milliseconds(20'000)) = 0;
 };
 
 class MaaFwAndroidNativeControlUnitAPI : public MaaFwControlUnitAPI
@@ -67,8 +74,8 @@ public:
 namespace MaaFeature
 {
 constexpr uint64_t None = 0;
-constexpr uint64_t UseMouseDownAndUpInsteadOfClick = 1ULL << 1;
-constexpr uint64_t UseKeyboardDownAndUpInsteadOfClick = 1ULL << 2;
+constexpr uint64_t UseMouseDownAndUpInsteadOfClick = 1ULL;
+constexpr uint64_t UseKeyboardDownAndUpInsteadOfClick = 1ULL << 1;
 } // namespace MaaFeature
 
 // 与 MaaFramework 的 MaaAdbScreencapMethod 兼容的常量

--- a/tools/maafw-control-unit-download.py
+++ b/tools/maafw-control-unit-download.py
@@ -14,7 +14,7 @@ unit binaries (MaaWin32ControlUnit.dll, MaaAdbControlUnit.dll, ...) out of its
 expected control units are already present unless ``--force`` is given.
 
 Usage:
-    python tools/maafw-control-unit-download.py [--tag v5.9.2] [--output-dir DIR] [--force]
+    python tools/maafw-control-unit-download.py [--tag v5.13.0] [--output-dir DIR] [--force]
 
 Note: these are Release builds of MaaFramework. They are ABI-compatible with
 Release/RelWithDebInfo builds of MAA, but NOT with Debug builds of MAA (MSVC
@@ -42,7 +42,7 @@ from pathlib import Path
 
 REPO = "MaaXYZ/MaaFramework"
 # Keep in sync with the pin used in .github/workflows/ci.yml
-DEFAULT_TAG = "v5.9.2"
+DEFAULT_TAG = "v5.13.0"
 
 ROOT = Path(__file__).resolve().parent.parent
 


### PR DESCRIPTION
## 变更内容

- 将 Windows CI 构建使用的 MaaFramework 从 `v5.9.2` 更新至 `v5.13.0`
- 将 Nightly OTA 构建使用的 MaaFramework 更新至 `v5.13.0`
- 同步 `MaaUtils` 子模块至 MaaFramework `v5.13.0` 对应版本
- 适配 MaaFramework `v5.13.0` 的 `ShellableUnit` ABI 变化
- 更新控制单元下载工具的默认 MaaFramework 版本
- 使用新版 MaaWin32ControlUnit，为独立公告 WebView 窗口截图提供运行时支持
- 保持现有 Win32 控制方式和 MAA 对外调用接口不变

## 修改范围

- 仅修改 Windows 构建流程
- Linux、Android、macOS 构建流程保持不变
- 发布流程下载并打包 `v5.13.0` 对应的 MaaWin32ControlUnit 和 MaaAdbControlUnit
- `MaaUtils.dll` 由更新后的 `MaaUtils` 子模块重新编译生成

## 测试情况

- `git diff --check` 通过
- Windows `MaaCore` Release 构建通过
- 已确认构建产物正常生成：
  - `MaaCore.dll`
  - `MaaUtils.dll`

## 测试情况

- 已使用 MaaFramework v5.13.0 构建并运行 Windows 版本
- 已验证公告窗口存在时的截图流程
- 已验证公告窗口关闭后的主窗口截图流程
- 已验证普通任务截图和输入功能未受影响

## Sourcery 总结

将 Windows 构建与发布依赖升级至 MaaFramework v5.13.0，并支持公告窗口截图。

新功能：
- 为 Windows 版本提供独立公告 WebView 窗口截图支持。

增强：
- 适配 MaaFramework v5.13.0 的控制单元接口变化，同时保持现有 Win32 控制方式和对外调用接口兼容。

构建：
- 将 Windows CI、Nightly OTA 及控制单元下载工具使用的 MaaFramework 版本升级至 v5.13.0，并同步 MaaUtils 子模块。

部署：
- 更新发布流程以使用 MaaFramework v5.13.0 对应的 Windows 控制单元。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

升级 Windows 端 MaaFramework 依赖至 v5.13.0，并支持独立公告窗口截图。

新功能：
- 支持 Windows 独立公告 WebView 窗口的截图。

增强：
- 适配 MaaFramework v5.13.0 的控制单元接口变化，同时保持现有控制方式和对外接口兼容。

构建：
- 将 Windows CI、Nightly OTA 及控制单元下载工具使用的 MaaFramework 版本升级至 v5.13.0，并同步 MaaUtils。

部署：
- 更新发布流程以使用 MaaFramework v5.13.0 对应的 Windows 控制单元。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

将 Windows MaaFramework 依赖升级至 v5.13.0，并启用独立公告窗口的截图功能。

新功能：
- 支持从 Windows 上独立的公告 WebView 窗口中捕获截图。

改进：
- 适配 MaaFramework v5.13.0 的 Windows 控制单元接口和功能标志，同时保持现有控制器和公共 API 的兼容性。

构建：
- 将 Windows CI、每夜 OTA 构建以及控制单元下载默认版本升级至 MaaFramework v5.13.0，并同步 MaaUtils 子模块。

部署：
- 更新发布打包配置，以使用 MaaFramework v5.13.0 的 Windows 控制单元。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Upgrade Windows MaaFramework dependencies to v5.13.0 and enable screenshots of standalone announcement windows.

New Features:
- Support capturing screenshots from the standalone announcement WebView window on Windows.

Enhancements:
- Adapt Windows control-unit interfaces and feature flags for MaaFramework v5.13.0 while preserving existing controller and public API compatibility.

Build:
- Upgrade the Windows CI, nightly OTA builds, and control-unit download defaults to MaaFramework v5.13.0 and synchronize the MaaUtils submodule.

Deployment:
- Update release packaging to use the MaaFramework v5.13.0 Windows control units.

</details>

</details>

</details>