### PR TITLE
refactor: 基建心情笑脸识别模块换用多模版任务

### DIFF
--- a/resource/platform_diff/iOS/resource/tasks.json
+++ b/resource/platform_diff/iOS/resource/tasks.json
@@ -23,13 +23,7 @@
     "InfrastOfficeMini": {
         "templThreshold": 0.9
     },
-    "InfrastSmileyOnRest": {
-        "templThreshold": 0.7
-    },
-    "InfrastSmileyOnWork": {
-        "templThreshold": 0.7
-    },
-    "InfrastSmileyOnDistract": {
+    "InfrastSmiley": {
         "templThreshold": 0.7
     },
     "BattleQuickFormationRole": {

--- a/resource/tasks/tasks.json
+++ b/resource/tasks/tasks.json
@@ -2977,18 +2977,8 @@
         "rectMove_Doc": "基于笑脸的位置移动",
         "rectMove": [0, -185, 113, 90]
     },
-    "InfrastSmileyOnRest": {
-        "template": "SmileyOnRest.png",
-        "maskRange": [100, 255],
-        "templThreshold": 0.8
-    },
-    "InfrastSmileyOnWork": {
-        "template": "SmileyOnWork.png",
-        "maskRange": [100, 255],
-        "templThreshold": 0.8
-    },
-    "InfrastSmileyOnDistract": {
-        "template": "SmileyOnDistract.png",
+    "InfrastSmiley": {
+        "template": ["SmileyOnRest.png", "SmileyOnWork.png", "SmileyOnDistract.png"],
         "maskRange": [100, 255],
         "templThreshold": 0.8
     },

--- a/src/MaaCore/Vision/Infrast/InfrastSmileyImageAnalyzer.cpp
+++ b/src/MaaCore/Vision/Infrast/InfrastSmileyImageAnalyzer.cpp
@@ -1,37 +1,33 @@
 #include "InfrastSmileyImageAnalyzer.h"
-
 #include "MaaUtils/NoWarningCV.hpp"
-
-#include "Utils/StringMisc.hpp"
 #include "Vision/MultiMatcher.h"
 
 bool asst::InfrastSmileyImageAnalyzer::analyze()
 {
-    const static std::unordered_map<infrast::SmileyType, std::string> smiley_map = {
-        { infrast::SmileyType::Rest, "InfrastSmileyOnRest" },
-        { infrast::SmileyType::Work, "InfrastSmileyOnWork" },
-        { infrast::SmileyType::Distract, "InfrastSmileyOnDistract" }
+    const static std::unordered_map<std::string, infrast::SmileyType> templ_name_to_smiley_type = {
+        { "SmileyOnRest.png", infrast::SmileyType::Rest },
+        { "SmileyOnWork.png", infrast::SmileyType::Work },
+        { "SmileyOnDistract.png", infrast::SmileyType::Distract }
     };
 
     m_result.clear();
 
-    MultiMatcher mm_analyzer(m_image);
+    MultiMatcher analyzer(m_image);
+    analyzer.set_task_info("InfrastSmiley");
+    analyzer.set_roi(m_roi);
 
-    decltype(m_result) temp_result;
-    for (const auto& [type, task_name] : smiley_map) {
-        mm_analyzer.set_task_info(task_name);
-        mm_analyzer.set_roi(m_roi);
-        if (!mm_analyzer.analyze()) {
-            continue;
-        }
-        auto& res = mm_analyzer.get_result();
-        for (const MatchRect& mr : res) {
-            temp_result.emplace_back(infrast::Smiley { type, mr.rect });
-#ifdef ASST_DEBUG
-            cv::rectangle(m_image_draw, make_rect<cv::Rect>(mr.rect), cv::Scalar(0, 0, 255), 2);
-#endif
-        }
+    if (!analyzer.analyze()) {
+        return false;
     }
-    m_result = std::move(temp_result);
+
+    std::vector<infrast::Smiley> result;
+    for (const auto& [rect, _, templ_name] : analyzer.get_result()) {
+        result.emplace_back(infrast::Smiley { templ_name_to_smiley_type.at(templ_name), rect });
+#ifdef ASST_DEBUG
+        cv::rectangle(m_image_draw, make_rect<cv::Rect>(rect), cv::Scalar(0, 0, 255), 2);
+#endif
+    }
+
+    m_result = std::move(result);
     return true;
 }


### PR DESCRIPTION
macOS 那边发现了一个神奇的现象，宿舍放了一个人就跑了。经过检查，由于同时匹配上了 `SmileyOnWork.png` 与 `SmileyOnDistract.png` 这两个模版，同一名干员被计算了两次，因而被点选了两下，负负得正了。
现换用多模版任务，利用 `MultiMatcher` 模块自带的去重功能来解决这个问题。

## Sourcery 总结

使用支持去重的多模板任务进行基础设施笑脸识别，以防止重复选择操作员。

Bug 修复：
- 防止重复的笑脸检测导致同一操作员被多次选中。

增强功能：
- 重构基础设施笑脸识别，使用内置去重功能的统一多模板匹配任务。
- 更新平台任务配置，以支持整合后的基础设施笑脸模板任务。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Use a deduplicating multi-template task for infrastructure smiley recognition to prevent duplicate operator selections.

Bug Fixes:
- Prevent duplicate smiley detections from causing the same operator to be selected multiple times.

Enhancements:
- Refactor infrastructure smiley recognition to use a unified multi-template matching task with built-in deduplication.
- Update platform task configurations to support the consolidated infrastructure smiley template task.

</details>