### PR TITLE
fix: 修复 MuMu 未使用触控增强时漏检应用保活

### DIFF
--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -1050,7 +1050,20 @@ public class AsstProxy
                     {
                         case ConnectConfig.MuMuEmulator12:
 
-                            // 保活的触控检测在 MuMuExtrasInputStatus 回调中处理，这里只查截图增强
+                            // 非 MuMu 触控不会上报 MuMuExtrasInputStatus，在此补查保活
+                            // MuMu 触控增强仍由状态回调判定
+                            if (SettingsViewModel.ConnectSettings.TouchMode != TouchMode.MumuExtras
+                                && EmulatorHelper.CheckMuMuKeepAlive())
+                            {
+                                Instances.TaskQueueViewModel.AddLog(
+                                    LocalizationHelper.GetString("MuMuEmulator12KeepAliveOn"),
+                                    UiLogColor.Error);
+                                Instances.CopilotViewModel.AddLog(
+                                    LocalizationHelper.GetString("MuMuEmulator12KeepAliveOn"),
+                                    UiLogColor.Error, showTime: false);
+                                needToStop = true;
+                            }
+
                             if (SettingsViewModel.ConnectSettings.ExtraConfig is not MuMu12Extra muMu12 || !muMu12.Enable)
                             {
                                 break;
@@ -1109,7 +1122,7 @@ public class AsstProxy
                     Instances.TaskQueueViewModel.AddLog(fastestScreencapString, color, toolTip: screencapAlternatives.CreateScreencapTooltip());
                     Instances.CopilotViewModel.AddLog(fastestScreencapString, color, showTime: false);
 
-                    // 截图增强未生效禁止启动
+                    // 保活与触控不兼容或截图增强未生效时停止任务
                     if (needToStop)
                     {
                         Execute.OnUIThreadAsync(async () => {


### PR DESCRIPTION
MuMu 未使用触控增强时，即使模拟器开启了应用保活，MAA 也不会执行保活检测或提示停止任务。

#17855 将保活检测移至 MuMuExtrasInputStatus 回调，以避免游戏尚未渲染时误判触控不可用，并在延迟判定结束后及时停止任务。但其他触控模式不会发送该回调，导致原有检测入口丢失。

参照以前的写法补回了保活检查（~~但我总觉得这个判断有点抽象，不知道还有没有更好的方式~~）

## Sourcery 摘要

恢复对不报告输入状态的触摸模式的 MuMu 保活检查，避免漏检和意外执行任务。

错误修复：
- 恢复对非增强触摸模式下 MuMu 应用的保活检测，以便在启用保活功能时停止任务并通知用户。

功能增强：
- 明确检测到 MuMu 保活不兼容或截图增强失败时的任务停止处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore MuMu keep-alive checks for touch modes that do not report input status, preventing missed detections and unintended task execution.

Bug Fixes:
- Restore MuMu application keep-alive detection for non-enhanced touch modes so tasks are stopped and users are notified when keep-alive is enabled.

Enhancements:
- Clarify task-stop handling when MuMu keep-alive incompatibility or screenshot enhancement failure is detected.

</details>