### PR TITLE
fix: retry Sami exploration entry after recruitment

### DIFF
--- a/resource/tasks/Roguelike/Sami.json
+++ b/resource/tasks/Roguelike/Sami.json
@@ -275,7 +275,7 @@
         "baseTask": "Sami@Roguelike@DropsFlag_default"
     },
     "Sami@Roguelike@EnterAfterRecruit": {
-        "next": ["Sami@Roguelike@NextLevel", "Sami@Roguelike@FoldartalGainNextLevel"]
+        "next": ["#self", "Sami@Roguelike@NextLevel", "Sami@Roguelike@FoldartalGainNextLevel"]
     },
     "Sami@Roguelike@ExitThenAbandon": {
         "template": "Roguelike@ExitThenAbandon.png",


### PR DESCRIPTION
萨米初始招募结束后，如果第一次点击“探索冰原”没有生效，`Sami@Roguelike@EnterAfterRecruit` 只识别下一层和密文板界面，无法再次点击仍然显示的入口，最终耗尽识别重试次数并报错。补回 `next` 中的 `#self`，恢复基类及其他主题已有的入口重试行为。

#18143 的日志在 `11:48:30.487` 至 `11:48:33.488` 明确执行了 3000ms 等待，因此无需重复配置 `postDelay`。`11:20:18`、`11:34:34`、`11:48:45` 三张故障截图都仍停在初始招募界面，“探索冰原”模板的离线匹配分数均为 `0.997668`。问题发生在进入探索的状态切换处，不需要改变术师招募优先级。

验证：
- 对上述三张原始截图，用 OpenCV `TM_CCOEFF_NORMED` 和现有模板、ROI 做真实匹配，再进行离线后继任务选择检查：修复前没有可匹配后继，修复后均选择入口的 `ClickSelf`。
- 下一层、密文板两种成功状态的模拟识别输入仍进入原有后继。
- 回滚后重现三个失败，恢复文件的 SHA-256 与原版一致。
- JSON 格式和 `git diff --check` 检查通过。

尚未进行游戏实机多轮验证；上述状态流转检查是离线回归，不是完整 MaaCore 执行。

Fixes #18143

## Sourcery 摘要

恢复招募后的萨米探索入口重试机制，以防止首次点击无效且入口仍然可见时发生失败。

错误修复：
- 恢复萨米肉鸽探索入口在首次招募后的重试处理，以应对首次点击未生效的情况。

测试：
- 根据报告中的截图验证修正后的状态转换，并确认现有的下一层和密码板流程保持不变。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore Sami exploration-entry retries after recruitment to prevent failures when the entry remains visible after an ineffective first click.

Bug Fixes:
- Restore retry handling for the Sami roguelike exploration entry after initial recruitment when the first click does not take effect.

Tests:
- Validate the corrected state transitions against the reported screenshots and confirm existing next-floor and cipher-board flows remain unchanged.

</details>