### PR TITLE
fix: 修复更换主题在非调试模式下不可见

### DIFF
--- a/src/MaaWpfGui/Views/UI/TaskQueueView.xaml
+++ b/src/MaaWpfGui/Views/UI/TaskQueueView.xaml
@@ -377,7 +377,11 @@
                                             <MenuItem
                                                 Command="{s:Action AddTaskQueueTask}"
                                                 CommandParameter="{Binding TaskTypeList[10].Value}"
-                                                Header="{Binding TaskTypeList[10].Display}"
+                                                Header="{Binding TaskTypeList[10].Display}" />
+                                            <MenuItem
+                                                Command="{s:Action AddTaskQueueTask}"
+                                                CommandParameter="{Binding TaskTypeList[11].Value}"
+                                                Header="{Binding TaskTypeList[11].Display}"
                                                 Visibility="{c:Binding ShowDebugTask}" />
                                         </Menu>
                                     </Border>


### PR DESCRIPTION
新增「更换主题」任务后，TaskTypeList 中「自定义任务」的索引由 10 移至 11，但添加任务菜单未同步更新，导致「更换主题」被仅调试可见的条件隐藏，同时「自定义任务」入口缺失

补齐菜单项，使「更换主题」正常显示

## Sourcery 总结

错误修复：
- 恢复任务菜单项，使“更改主题”任务在调试模式之外可见，并保留“自定义任务”条目。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Restore the task menu entries so the Change Theme task is visible outside debug mode and the Custom Task entry remains available.

</details>