### PR TITLE
Release v6.17.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,22 @@ A new "Switch Theme" task switches in-game themes by name; multiple candidate th
 以下是详细内容：
 
 <details open>
+<summary><b>v6.17.4 (2026-09-08)</b></summary>
+
+### 修复 | Fix
+
+* 沃日弱智 AI 把更换主题入口隐藏了 @ABA2396
+* 修复如果第一次点击“探索冰原”没有生效只识别下一层和密文板界面，无法再次点击仍然显示的入口的问题 @Koileo
+
+### MaaMacGui
+
+#### 改进 | Improved
+
+* MacSCK 线程同步优化 @hguandl
+
+</details>
+
+<details>
 <summary><b>v6.17.3 (2026-09-08)</b></summary>
 
 ### 新增 | New

--- a/resource/tasks/Roguelike/Sami.json
+++ b/resource/tasks/Roguelike/Sami.json
@@ -275,7 +275,7 @@
         "baseTask": "Sami@Roguelike@DropsFlag_default"
     },
     "Sami@Roguelike@EnterAfterRecruit": {
-        "next": ["Sami@Roguelike@NextLevel", "Sami@Roguelike@FoldartalGainNextLevel"]
+        "next": ["#self", "Sami@Roguelike@NextLevel", "Sami@Roguelike@FoldartalGainNextLevel"]
     },
     "Sami@Roguelike@ExitThenAbandon": {
         "template": "Roguelike@ExitThenAbandon.png",

--- a/src/MaaCore/Controller/MacSCKHelper.mm
+++ b/src/MaaCore/Controller/MacSCKHelper.mm
@@ -8,8 +8,7 @@
 
 #include "Utils/Logger.hpp"
 
-@interface MacSCKOutput : NSObject <SCStreamDelegate, SCStreamOutput> {
-}
+@interface MacSCKOutput : NSObject <SCStreamDelegate, SCStreamOutput>
 
 @property (nonatomic, readonly) CVImageBufferRef buffer;
 
@@ -17,7 +16,18 @@
 
 @end
 
-@implementation MacSCKOutput
+@implementation MacSCKOutput {
+    std::atomic_bool _initialized;
+}
+
+- (instancetype)init
+{
+    self = [super init];
+    if (self) {
+        _initialized.store(false, std::memory_order_relaxed);
+    }
+    return self;
+}
 
 - (void)stream:(SCStream*)stream didStopWithError:(NSError*)error
 {
@@ -27,11 +37,37 @@
         Log.trace(__FUNCTION__, "| Stream stopped without error");
     }
     self.running = NO;
+    _initialized.store(true, std::memory_order_release);
+    _initialized.notify_all();
 }
 
 - (void)stream:(SCStream*)stream didOutputSampleBuffer:(CMSampleBufferRef)sampleBuffer ofType:(SCStreamOutputType)type
 {
-    if (type != SCStreamOutputTypeScreen) {
+    if (type != SCStreamOutputTypeScreen || !CMSampleBufferIsValid(sampleBuffer)) {
+        return;
+    }
+
+    auto attachments = CMSampleBufferGetSampleAttachmentsArray(sampleBuffer, NO);
+    if (!attachments || CFArrayGetCount(attachments) == 0) {
+        return;
+    }
+    bool complete = false;
+    if (auto frameInfo = CFArrayGetValueAtIndex(attachments, 0)) {
+        if (auto value = CFDictionaryGetValue((CFDictionaryRef)frameInfo, SCStreamFrameInfoStatus)) {
+            SCFrameStatus status;
+            if (CFNumberGetValue((CFNumberRef)value, kCFNumberNSIntegerType, &status)) {
+                switch (status) {
+                case SCFrameStatusComplete:
+                case SCFrameStatusStarted:
+                    complete = true;
+                    break;
+                default:
+                    break;
+                }
+            }
+        }
+    }
+    if (!complete) {
         return;
     }
 
@@ -43,7 +79,17 @@
             CFRelease(_buffer);
         }
         _buffer = newBuffer;
+
+        if (!_initialized.load(std::memory_order::relaxed)) {
+            _initialized.store(true, std::memory_order_release);
+            _initialized.notify_all();
+        }
     }
+}
+
+- (void)waitForInitialized
+{
+    _initialized.wait(false, std::memory_order_acquire);
 }
 
 - (void)dealloc
@@ -81,29 +127,31 @@ struct asst::MacSCKHelper::Impl {
 
 asst::MacSCKHelper::Impl::~Impl()
 {
-    if (m_stream) {
-        auto sem = dispatch_semaphore_create(0);
-        [m_stream stopCaptureWithCompletionHandler:^(NSError* _Nullable error) {
+    const auto stream = m_stream;
+    const auto output = m_output;
+    const auto queue = m_queue;
+
+    m_stream = nil;
+    m_output = nil;
+    m_queue = nil;
+
+    const auto cleanup = ^{
+        [stream release];
+        [output release];
+        if (queue) {
+            dispatch_release(queue);
+        }
+    };
+
+    if (stream) {
+        [stream stopCaptureWithCompletionHandler:^(NSError* _Nullable error) {
             if (error) {
                 Log.error("Error stopping capture:", error.localizedDescription.UTF8String);
             }
-            dispatch_semaphore_signal(sem);
+            cleanup();
         }];
-
-        dispatch_time_t timeout = dispatch_time(DISPATCH_TIME_NOW, 3 * NSEC_PER_SEC);
-        dispatch_semaphore_wait(sem, timeout);
-        dispatch_release(sem);
-
-        [m_stream release];
-        m_stream = nil;
-    }
-
-    [m_output release];
-    m_output = nil;
-
-    if (m_queue) {
-        dispatch_release(m_queue);
-        m_queue = nil;
+    } else {
+        cleanup();
     }
 }
 
@@ -226,6 +274,8 @@ bool asst::MacSCKHelper::Impl::capture(std::vector<uint8_t>& bgrData) const
         Log.error("Stream output is not initialized");
         return false;
     }
+
+    [m_output waitForInitialized];
 
     __block CVImageBufferRef buffer = nullptr;
     dispatch_sync(m_queue, ^{

--- a/src/MaaWpfGui/Views/UI/TaskQueueView.xaml
+++ b/src/MaaWpfGui/Views/UI/TaskQueueView.xaml
@@ -376,8 +376,12 @@
                                                 Header="{Binding TaskTypeList[9].Display}" />
                                             <MenuItem
                                                 Command="{s:Action AddTaskQueueTask}"
+                                                CommandParameter="{Binding TaskTypeList[9].Value}"
+                                                Header="{Binding TaskTypeList[10].Display}" />
+                                            <MenuItem
+                                                Command="{s:Action AddTaskQueueTask}"
                                                 CommandParameter="{Binding TaskTypeList[10].Value}"
-                                                Header="{Binding TaskTypeList[10].Display}"
+                                                Header="{Binding TaskTypeList[11].Display}"
                                                 Visibility="{c:Binding ShowDebugTask}" />
                                         </Menu>
                                     </Border>

--- a/tools/local-install.bat
+++ b/tools/local-install.bat
@@ -8,7 +8,7 @@ if exist ".\global.json" (
 	move /y ".\global.json" ".\global.json.local-install.bak" >nul || goto :error
 )
 
-> ".\global.json" echo {"sdk":{"version":"10.0.302","rollForward":"disable"}} || goto :error
+:: > ".\global.json" echo {"sdk":{"version":"10.0.302","rollForward":"disable"}} || goto :error
 
 set "netbeauty_bin=%NUGET_PACKAGES%\nulastudio.netbeauty\2.1.5\tools\win-x86\nbeauty2.exe"
 if "%NUGET_PACKAGES%"=="" set "netbeauty_bin=%USERPROFILE%\.nuget\packages\nulastudio.netbeauty\2.1.5\tools\win-x86\nbeauty2.exe"


### PR DESCRIPTION
## Sourcery 总结

改进屏幕捕获生命周期处理，并更新相关任务资源和 UI。

Bug 修复：
- 通过验证帧状态并在访问缓冲区之前同步捕获初始化，提高 macOS 屏幕捕获的可靠性。
- 确保 macOS 屏幕捕获资源在异步流关闭后安全释放。

杂项：
- 更新 Sami roguelike 任务资源和 WPF 任务队列 UI。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

强化 macOS 屏幕捕获生命周期处理，并刷新相关任务资源和用户界面更新。

Bug 修复：
- 通过仅接受有效的捕获帧，并在捕获初始化完成前同步访问，提高 macOS 屏幕捕获的可靠性。
- 在异步流关闭后安全释放 macOS 屏幕捕获资源。

增强功能：
- 更新 Sami roguelike 任务资源和 WPF 任务队列 UI。

文档：
- 在更新日志中添加 v6.17.4 版本说明。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

改进 macOS 屏幕捕获生命周期处理，并更新相关任务资源和用户界面。

错误修复：
- 通过仅接受有效且可用的帧，并在访问缓冲区前同步捕获初始化过程，提高 macOS 屏幕捕获的可靠性。
- 在异步流关闭后安全释放 macOS 屏幕捕获资源。

增强功能：
- 更新 Sami roguelike 任务资源，并刷新 WPF 任务队列界面。

构建：
- 调整本地安装脚本对 .NET SDK 配置的处理方式。

文档：
- 在变更日志中添加 v6.17.4 版本说明。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve macOS screen capture lifecycle handling and refresh related task resources and user interface updates.

Bug Fixes:
- Improve macOS screen capture reliability by accepting only valid, usable frames and synchronizing capture initialization before buffer access.
- Release macOS screen capture resources safely after asynchronous stream shutdown.

Enhancements:
- Update Sami roguelike task resources and refresh the WPF task queue UI.

Build:
- Adjust the local installation script's .NET SDK configuration handling.

Documentation:
- Add v6.17.4 release notes to the changelog.

</details>

</details>

</details>