### PR TITLE
feat: ProcessTask新增单实例next覆盖

### DIFF
--- a/src/MaaCore/Task/ProcessTask.cpp
+++ b/src/MaaCore/Task/ProcessTask.cpp
@@ -115,6 +115,10 @@ ProcessTask& ProcessTask::set_reusable_image(const cv::Mat& reusable)
 
 bool asst::ProcessTask::override_next(const std::string& name, const std::vector<std::string>& next_tasks)
 {
+    if (Task.get(name) == nullptr) {
+        LogError << __FUNCTION__ << "task not found:" << name;
+        return false;
+    }
     for (const auto& task_name : next_tasks) {
         if (Task.get(task_name) == nullptr) {
             LogError << __FUNCTION__ << "task not found:" << task_name;

--- a/src/MaaCore/Task/ProcessTask.cpp
+++ b/src/MaaCore/Task/ProcessTask.cpp
@@ -113,6 +113,18 @@ ProcessTask& ProcessTask::set_reusable_image(const cv::Mat& reusable)
     return *this;
 }
 
+bool asst::ProcessTask::override_next(const std::string& name, const std::vector<std::string>& next_tasks)
+{
+    for (const auto& task_name : next_tasks) {
+        if (Task.get(task_name) == nullptr) {
+            LogError << __FUNCTION__ << "task not found:" << task_name;
+            return false;
+        }
+    }
+    m_next_override.insert_or_assign(name, next_tasks);
+    return true;
+}
+
 bool ProcessTask::run()
 {
     LogTraceFunction;
@@ -150,7 +162,13 @@ bool ProcessTask::run()
             break;
         case NodeStatus::Success:
             // 成功匹配且执行成功，下一个匹配列表是 next
-            to_be_recognized = next_task_ptr->next;
+            if (auto it = m_next_override.find(next_task_ptr->name); it != m_next_override.end()) {
+                LogTrace << "found in override" << next_task_ptr->name << ", next:" << it->second;
+                to_be_recognized = it->second;
+            }
+            else {
+                to_be_recognized = next_task_ptr->next;
+            }
             break;
         case NodeStatus::Interrupted:
             // need_exit() or Stop action

--- a/src/MaaCore/Task/ProcessTask.cpp
+++ b/src/MaaCore/Task/ProcessTask.cpp
@@ -121,9 +121,8 @@ ProcessTask& asst::ProcessTask::set_override_next(std::unordered_map<std::string
 
 bool asst::ProcessTask::override_next(std::string_view name, std::vector<std::string> next_tasks)
 {
-    std::string parent_task(name);
-    if (Task.get(parent_task) == nullptr) {
-        LogError << __FUNCTION__ << "task not found:" << parent_task;
+    if (Task.get(name) == nullptr) {
+        LogError << __FUNCTION__ << "task not found:" << name;
         return false;
     }
     for (const auto& task_name : next_tasks) {
@@ -132,19 +131,18 @@ bool asst::ProcessTask::override_next(std::string_view name, std::vector<std::st
             return false;
         }
     }
-    LogInfo << __FUNCTION__ << "override next for task" << parent_task << "to" << next_tasks;
-    m_next_override.insert_or_assign(std::move(parent_task), std::move(next_tasks));
+    LogInfo << __FUNCTION__ << "override next for task" << name << "to" << next_tasks;
+    m_next_override.insert_or_assign(std::string(name), std::move(next_tasks));
     return true;
 }
 
-bool asst::ProcessTask::reset_override_next(std::string_view name)
+bool asst::ProcessTask::remove_override_next(std::string_view name)
 {
-    std::string parent_task(name);
-    if (Task.get(parent_task) == nullptr) {
-        LogError << __FUNCTION__ << "task not found:" << parent_task;
+    if (Task.get(name) == nullptr) {
+        LogError << __FUNCTION__ << "task not found:" << name;
         return false;
     }
-    m_next_override.erase(parent_task);
+    m_next_override.erase(std::string(name));
     return true;
 }
 

--- a/src/MaaCore/Task/ProcessTask.cpp
+++ b/src/MaaCore/Task/ProcessTask.cpp
@@ -20,15 +20,15 @@ using namespace asst;
 
 namespace
 {
-// 需要在主界面进行识别的任务，用于PC端
-constexpr std::array<std::string_view, 9> MainScreenEntryPrefixes = {
-    "Friends", "Task", "Terminal", "Mall", "Infrast", "Recruit", "Depot", "OperBox", "Gacha",
-};
-
 // 主界面入口按钮，用于提取当前主题
 // 资源重载后 ResourceLoader 会生成新的 uuid，这里通过比对 uuid 判断是否需要重新缓存
 const std::unordered_set<std::string>& get_main_screen_entry_tasks()
 {
+    // 需要在主界面进行识别的任务，用于PC端
+    constexpr std::array<std::string_view, 9> MainScreenEntryPrefixes = {
+        "Friends", "Task", "Terminal", "Mall", "Infrast", "Recruit", "Depot", "OperBox", "Gacha",
+    };
+
     static std::unordered_set<std::string> tasks;
     static std::string cached_uuid;
 
@@ -113,10 +113,17 @@ ProcessTask& ProcessTask::set_reusable_image(const cv::Mat& reusable)
     return *this;
 }
 
-bool asst::ProcessTask::override_next(const std::string& name, const std::vector<std::string>& next_tasks)
+ProcessTask& asst::ProcessTask::set_override_next(std::unordered_map<std::string, TaskList> next_override)
 {
-    if (Task.get(name) == nullptr) {
-        LogError << __FUNCTION__ << "task not found:" << name;
+    m_next_override = std::move(next_override);
+    return *this;
+}
+
+bool asst::ProcessTask::override_next(std::string_view name, std::vector<std::string> next_tasks)
+{
+    std::string parent_task(name);
+    if (Task.get(parent_task) == nullptr) {
+        LogError << __FUNCTION__ << "task not found:" << parent_task;
         return false;
     }
     for (const auto& task_name : next_tasks) {
@@ -125,8 +132,19 @@ bool asst::ProcessTask::override_next(const std::string& name, const std::vector
             return false;
         }
     }
-    m_next_override.insert_or_assign(name, next_tasks);
-    LogInfo << __FUNCTION__ << "override next for task" << name << "to" << next_tasks;
+    LogInfo << __FUNCTION__ << "override next for task" << parent_task << "to" << next_tasks;
+    m_next_override.insert_or_assign(std::move(parent_task), std::move(next_tasks));
+    return true;
+}
+
+bool asst::ProcessTask::reset_override_next(std::string_view name)
+{
+    std::string parent_task(name);
+    if (Task.get(parent_task) == nullptr) {
+        LogError << __FUNCTION__ << "task not found:" << parent_task;
+        return false;
+    }
+    m_next_override.erase(parent_task);
     return true;
 }
 
@@ -386,7 +404,7 @@ ProcessTask::NodeStatus ProcessTask::run_task(const HitDetail& hits)
 
     for (const std::string& sub : task->sub) {
         LogTraceScope("Sub: " + sub);
-        bool sub_ret = ProcessTask(*this, { sub }).run();
+        bool sub_ret = ProcessTask(*this, { sub }).set_override_next(m_next_override).run();
         if (!sub_ret && !task->sub_error_ignored) {
             Log.error("Sub error and not ignored", sub);
             // 感觉应该把 run 改成 NodeStatus 类型，这样可以知道 sub 的具体执行结果

--- a/src/MaaCore/Task/ProcessTask.cpp
+++ b/src/MaaCore/Task/ProcessTask.cpp
@@ -122,6 +122,7 @@ bool asst::ProcessTask::override_next(const std::string& name, const std::vector
         }
     }
     m_next_override.insert_or_assign(name, next_tasks);
+    LogInfo << __FUNCTION__ << "override next for task" << name << "to" << next_tasks;
     return true;
 }
 

--- a/src/MaaCore/Task/ProcessTask.h
+++ b/src/MaaCore/Task/ProcessTask.h
@@ -37,9 +37,10 @@ public:
     ProcessTask& set_times_limit(std::string name, int limit, TimesLimitType type = TimesLimitType::Pre);
     ProcessTask& set_post_delay(std::string name, int delay);
     ProcessTask& set_reusable_image(const cv::Mat& reusable);
-    ProcessTask& set_override_next(std::unordered_map<std::string, TaskList> next_override);
+    // 设定某个任务的 next 列表, 返回值表示是否成功覆盖; 任务名需要为实际执行任务名, 不支持@, #next 等语法
     bool override_next(std::string_view name, std::vector<std::string> next_tasks);
-    bool reset_override_next(std::string_view name);
+    // 移除某个任务的 next 列表覆盖, 返回值表示是否成功移除; 任务名需要为实际执行任务名, 不支持@, #next 等语法
+    bool remove_override_next(std::string_view name);
 
     const std::string& get_last_task_name() const noexcept { return m_last_task_name; }
 
@@ -70,6 +71,8 @@ protected:
     NodeStatus run_action(const HitDetail& hits) const;
     NodeStatus run_task(const HitDetail& hits);
     std::pair<NodeStatus, TaskConstPtr> find_and_run_task(const TaskList& list);
+    // for fast init only, not for runtime use
+    ProcessTask& set_override_next(std::unordered_map<std::string, TaskList> next_override);
 
     TimesLimitData calc_time_limit(TaskConstPtr task) const;
     int calc_post_delay(TaskConstPtr task) const;

--- a/src/MaaCore/Task/ProcessTask.h
+++ b/src/MaaCore/Task/ProcessTask.h
@@ -1,9 +1,10 @@
 #pragma once
 
+#include <unordered_map>
+
 #include "AbstractTask.h"
 #include "Common/AsstTypes.h"
 #include "MaaUtils/NoWarningCVMat.hpp"
-#include <unordered_map>
 
 namespace asst
 {

--- a/src/MaaCore/Task/ProcessTask.h
+++ b/src/MaaCore/Task/ProcessTask.h
@@ -36,6 +36,7 @@ public:
     ProcessTask& set_times_limit(std::string name, int limit, TimesLimitType type = TimesLimitType::Pre);
     ProcessTask& set_post_delay(std::string name, int delay);
     ProcessTask& set_reusable_image(const cv::Mat& reusable);
+    bool override_next(const std::string& name, const std::vector<std::string>& next_tasks);
 
     const std::string& get_last_task_name() const noexcept { return m_last_task_name; }
 
@@ -92,5 +93,6 @@ protected:
     int m_task_delay = TaskDelayUnsetted;
     cv::Mat m_reusable;
     std::shared_ptr<HitDetail> m_last_hit_detail = nullptr;
+    std::unordered_map<std::string, TaskList> m_next_override;
 };
 }

--- a/src/MaaCore/Task/ProcessTask.h
+++ b/src/MaaCore/Task/ProcessTask.h
@@ -3,6 +3,7 @@
 #include "AbstractTask.h"
 #include "Common/AsstTypes.h"
 #include "MaaUtils/NoWarningCVMat.hpp"
+#include <unordered_map>
 
 namespace asst
 {
@@ -36,7 +37,9 @@ public:
     ProcessTask& set_times_limit(std::string name, int limit, TimesLimitType type = TimesLimitType::Pre);
     ProcessTask& set_post_delay(std::string name, int delay);
     ProcessTask& set_reusable_image(const cv::Mat& reusable);
-    bool override_next(const std::string& name, const std::vector<std::string>& next_tasks);
+    ProcessTask& set_override_next(std::unordered_map<std::string, TaskList> next_override);
+    bool override_next(std::string_view name, std::vector<std::string> next_tasks);
+    bool reset_override_next(std::string_view name);
 
     const std::string& get_last_task_name() const noexcept { return m_last_task_name; }
 


### PR DESCRIPTION
## Sourcery 总结

支持为单个 ProcessTask 实例覆盖后续任务。

新功能：
- 为 ProcessTask 添加按实例设置的后续任务覆盖，并验证所有替换任务是否存在。

增强：
- 成功执行后选择后续任务时，使用为每个任务配置的覆盖项；在其他情况下继续使用默认任务图。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

支持按 ProcessTask 实例覆盖任务成功后的后续任务流程。

新功能：
- 为单个 ProcessTask 实例提供后续任务覆盖配置，并校验目标任务是否存在。

改进：
- 任务成功执行后优先使用实例级后续任务配置，未配置时继续沿用默认任务图。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

支持 ProcessTask 实例在任务成功执行后自定义后续任务流程。

新功能：
- 为单个 ProcessTask 任务添加实例级 API，以覆盖或移除下一任务列表，并验证所引用的任务。

增强功能：
- 在任务成功执行后使用实例级下一任务覆盖配置；未配置覆盖时，保留默认任务图。
- 将下一任务覆盖配置传递给嵌套子任务。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

支持 ProcessTask 实例自定义成功执行后所选的任务。

新功能：
- 添加实例级 API，可为单个 ProcessTask 执行覆盖或移除下一个任务列表，并验证所引用的任务。

增强：
- 成功执行后使用实例级的下一个任务覆盖设置；未配置覆盖时，保留默认任务图。
- 将下一个任务的覆盖设置传递给嵌套子任务。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable ProcessTask instances to customize the tasks selected after successful execution.

New Features:
- Add per-instance APIs to override or remove the next-task list for individual ProcessTask executions, with validation of referenced tasks.

Enhancements:
- Use instance-level next-task overrides after successful execution while preserving the default task graph when no override is configured.
- Propagate next-task override settings to nested subtasks.

</details>

</details>

<details>
<summary>Original summary in English</summary>



</details>

</details>

<details>
<summary>Original summary in English</summary>



</details>

</details>