### PR TITLE
fix: 肉鸽开局招募的Swipe参数未除以10

### DIFF
--- a/src/MaaCore/Task/Roguelike/RoguelikeRecruitTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeRecruitTaskPlugin.cpp
@@ -740,7 +740,7 @@ void asst::RoguelikeRecruitTaskPlugin::slowly_swipe(bool to_left, int swipe_dist
         { StartPoint.x + swipe_dist - StartPoint.width, StartPoint.y, StartPoint.width, StartPoint.height },
         swipe_task->special_params.empty() ? 0 : swipe_task->special_params.at(0),
         (swipe_task->special_params.size() < 2) ? false : swipe_task->special_params.at(1),
-        (swipe_task->special_params.size() < 3) ? 1 : swipe_task->special_params.at(2),
-        (swipe_task->special_params.size() < 4) ? 1 : swipe_task->special_params.at(3));
+        (swipe_task->special_params.size() < 3) ? 1 : swipe_task->special_params.at(2) / 10.0,
+        (swipe_task->special_params.size() < 4) ? 1 : swipe_task->special_params.at(3) / 10.0);
     sleep(swipe_task->post_delay);
 }


### PR DESCRIPTION
#18112 将 Swipe specialParams[2]/[3] 改为十倍整数存储，但 `RoguelikeRecruitTaskPlugin::slowly_swipe` 的 PRECISE_SWIPE 分支仍直接传值，导致肉鸽开局招募滑动失效

补齐了两个遗漏的 /10.0

## Summary by Sourcery

Bug Fixes:
- 修复肉鸽开局招募精准滑动参数未按新的十倍整数存储格式缩放，导致滑动失效的问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- 修复肉鸽开局招募精准滑动参数未按新的十倍整数存储格式缩放，导致滑动失效的问题。

</details>