### PR TITLE
Release v6.17.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -625,9 +625,9 @@ jobs:
       - name: Build MAA
         run: |
           if ${{ startsWith(github.ref, 'refs/tags/v') }}; then
-            xcodebuild -scheme MAA archive -archivePath MAA.xcarchive
+            xcodebuild -skipMacroValidation -scheme MAA archive -archivePath MAA.xcarchive
           else
-            xcodebuild CODE_SIGNING_ALLOWED=NO -scheme MAA archive -archivePath MAA.xcarchive
+            xcodebuild -skipMacroValidation CODE_SIGNING_ALLOWED=NO -scheme MAA archive -archivePath MAA.xcarchive
           fi
         working-directory: src/MaaMacGui
 

--- a/src/MaaCore/Task/Roguelike/JieGarden/RoguelikeCoppersTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/JieGarden/RoguelikeCoppersTaskPlugin.cpp
@@ -424,9 +424,9 @@ bool asst::RoguelikeCoppersTaskPlugin::swipe_copper_list(int times, bool to_left
                     cur_point,
                     origin_point,
                     swipe_task->special_params.empty() ? 0 : swipe_task->special_params.at(0),
-                    (swipe_task->special_params.size() < 2) ?
-                        SwipeExtraDirection::None :
-                        to_swipe_extra_direction(swipe_task->special_params.at(1)),
+                    (swipe_task->special_params.size() < 2)
+                        ? SwipeExtraDirection::None
+                        : to_swipe_extra_direction(swipe_task->special_params.at(1)),
                     (swipe_task->special_params.size() < 3) ? 1 : swipe_task->special_params.at(2) / 10.0,
                     (swipe_task->special_params.size() < 4) ? 1 : swipe_task->special_params.at(3) / 10.0);
                 Log.debug(

--- a/src/MaaCore/Task/Roguelike/RoguelikeRecruitTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeRecruitTaskPlugin.cpp
@@ -449,7 +449,7 @@ bool asst::RoguelikeRecruitTaskPlugin::_run()
 
     // 选择优先级最高的干员
     auto selected_oper =
-        std::ranges::max_element(recruit_list, std::less { }, std::mem_fn(&RoguelikeRecruitInfo::priority));
+        std::ranges::max_element(recruit_list, std::less {}, std::mem_fn(&RoguelikeRecruitInfo::priority));
     if (selected_oper == recruit_list.cend()) {
         Log.trace(__FUNCTION__, "| No opers in recruit list.");
         return false;

--- a/src/MaaCore/Task/Roguelike/Sami/RoguelikeFoldartalUseTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/Sami/RoguelikeFoldartalUseTaskPlugin.cpp
@@ -313,8 +313,8 @@ void asst::RoguelikeFoldartalUseTaskPlugin::slowly_swipe(const bool direction, i
         start_point,
         { start_point.x + swipe_dist - start_point.width, start_point.y, start_point.width, start_point.height },
         swipe_task->special_params.empty() ? 0 : swipe_task->special_params.at(0),
-        (swipe_task->special_params.size() < 2) ? SwipeExtraDirection::None :
-                                                  to_swipe_extra_direction(swipe_task->special_params.at(1)),
+        (swipe_task->special_params.size() < 2) ? SwipeExtraDirection::None
+                                                : to_swipe_extra_direction(swipe_task->special_params.at(1)),
         (swipe_task->special_params.size() < 3) ? 1 : swipe_task->special_params.at(2) / 10.0,
         (swipe_task->special_params.size() < 4) ? 1 : swipe_task->special_params.at(3) / 10.0);
     sleep(swipe_task->post_delay);


### PR DESCRIPTION
重新发布 v6.17.5：mac GUI 构建因 JBird 新增 Swift Macro 触发 CI 宏信任校验失败（#18159 首次发布时 mac 包未产出），在 Release Pipeline 的 xcodebuild archive 加 `-skipMacroValidation` 修复。已删除旧 tag v6.17.5，合并后重新打 tag 触发发布。

## Sourcery 摘要

通过在归档构建期间绕过 Swift 宏验证，恢复成功的 macOS 发布打包。

Bug 修复：
- 通过在 xcodebuild 中跳过 Swift 宏验证，修复 macOS 发布归档构建因宏信任验证失败的问题。

构建：
- 更新 macOS 归档命令，使带标签和不带标签的构建均跳过宏验证。

杂项：
- 对 Roguelike 任务代码应用仅格式化更新。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Restore successful macOS release packaging by bypassing Swift macro validation during archive builds.

Bug Fixes:
- Fix macOS release archive builds failing macro trust validation by skipping Swift macro validation in xcodebuild.

Build:
- Update macOS archive commands to skip macro validation for both tagged and non-tagged builds.

Chores:
- Apply formatting-only updates to Roguelike task code.

</details>