### PR TITLE
feat: ResourceUpdater 新增干员养成需求表转换

### DIFF
--- a/tools/ResourceUpdater/main.cpp
+++ b/tools/ResourceUpdater/main.cpp
@@ -468,7 +468,7 @@ bool run_parallel_tasks(
             return;
         }
         std::cout << "------- Update raise demand data for Official -------" << '\n';
-        if (!update_raise_demand_data(official_data_dir, resource_dir)) {
+        if (!update_raise_demand_data(official_data_dir / "gamedata" / "excel", resource_dir)) {
             std::cerr << "update_raise_demand_data failed" << '\n';
             error_occurred.store(true);
         }
@@ -659,7 +659,7 @@ bool update_items_data(const fs::path& input_dir, const fs::path& output_dir, bo
 
 bool update_raise_demand_data(const fs::path& input_dir, const fs::path& output_dir)
 {
-    const auto input_json_path = input_dir / "gamedata" / "excel" / "character_table.json";
+    const auto input_json_path = input_dir / "character_table.json";
 
     auto parse_ret = json::open(input_json_path);
     if (!parse_ret) {
@@ -671,14 +671,16 @@ bool update_raise_demand_data(const fs::path& input_dir, const fs::path& output_
 
     // Consumption entries of one cost field -> [[item_id, count], ...].
     // A cost field that is absent, null or empty yields an empty array, nullopt means the data is invalid.
-    const auto collect_costs = [](const json::value& owner, const std::string& cost_key) -> std::optional<json::value> {
+    const auto collect_costs = [](const json::value& owner,
+                                  const std::string& char_id,
+                                  const std::string& cost_key) -> std::optional<json::value> {
         json::array costs;
         if (const auto cost_list_opt = owner.find<json::array>(cost_key)) {
             for (const auto& cost : cost_list_opt.value()) {
                 const std::string item_id = cost.get("id", std::string());
                 const int count = cost.get("count", 0);
                 if (item_id.empty() || count <= 0) {
-                    std::cerr << "Invalid raise demand cost: " << cost_key << ' ' << item_id << '\n';
+                    std::cerr << "Invalid raise demand cost: " << char_id << ' ' << cost_key << ' ' << item_id << '\n';
                     return std::nullopt;
                 }
                 costs.emplace_back(json::array { item_id, count });
@@ -709,7 +711,7 @@ bool update_raise_demand_data(const fs::path& input_dir, const fs::path& output_
         json::array elite_costs;
         if (const auto phases_opt = char_data.find<json::array>("phases")) {
             for (size_t phase_index = 1; phase_index < phases_opt->size(); ++phase_index) {
-                auto costs_opt = collect_costs(phases_opt->at(phase_index), "evolveCost");
+                auto costs_opt = collect_costs(phases_opt->at(phase_index), char_id, "evolveCost");
                 if (!costs_opt) {
                     return false;
                 }
@@ -721,7 +723,7 @@ bool update_raise_demand_data(const fs::path& input_dir, const fs::path& output_
         json::array skill_level_costs;
         if (const auto lvlup_opt = char_data.find<json::array>("allSkillLvlup")) {
             for (const auto& lvlup : lvlup_opt.value()) {
-                auto costs_opt = collect_costs(lvlup, "lvlUpCost");
+                auto costs_opt = collect_costs(lvlup, char_id, "lvlUpCost");
                 if (!costs_opt) {
                     return false;
                 }
@@ -742,7 +744,7 @@ bool update_raise_demand_data(const fs::path& input_dir, const fs::path& output_
                 }
                 json::array mastery_by_level;
                 for (const auto& condition : condition_opt.value()) {
-                    auto costs_opt = collect_costs(condition, "levelUpCost");
+                    auto costs_opt = collect_costs(condition, char_id, "levelUpCost");
                     if (!costs_opt) {
                         return false;
                     }

--- a/tools/ResourceUpdater/main.cpp
+++ b/tools/ResourceUpdater/main.cpp
@@ -763,8 +763,16 @@ bool update_raise_demand_data(const fs::path& input_dir, const fs::path& output_
 
     auto output_json_path = output_dir / "raise_demand_index.json";
     std::ofstream ofs(output_json_path, std::ios::out);
+    if (!ofs.is_open()) {
+        std::cerr << output_json_path << " open error" << '\n';
+        return false;
+    }
     ofs << output_json.format();
     ofs.close();
+    if (!ofs.good()) {
+        std::cerr << output_json_path << " write error" << '\n';
+        return false;
+    }
 
     return true;
 }

--- a/tools/ResourceUpdater/main.cpp
+++ b/tools/ResourceUpdater/main.cpp
@@ -164,6 +164,7 @@ bool run_parallel_tasks(
     const std::unordered_map<std::string, std::string>& global_dirs);
 
 bool update_items_data(const fs::path& input_dir, const fs::path& output_dir, bool with_imgs = true);
+bool update_raise_demand_data(const fs::path& input_dir, const fs::path& output_dir);
 bool cvt_single_item_template(const fs::path& input, const fs::path& output);
 bool update_infrast_data(const fs::path& input_dir, const fs::path& output_dir);
 bool update_stages_data(const fs::path& input_dir, const fs::path& output_dir);
@@ -189,6 +190,9 @@ int main([[maybe_unused]] int argc, char** argv)
     }
     if (argc == 4 && std::string_view(argv[1]) == "--items-data") {
         return update_items_data(fs::path(argv[2]), fs::path(argv[3]), false) ? 0 : 1;
+    }
+    if (argc == 4 && std::string_view(argv[1]) == "--raise-demand-data") {
+        return update_raise_demand_data(fs::path(argv[2]), fs::path(argv[3])) ? 0 : 1;
     }
 
     // ---- PATH DECLARATION ----
@@ -459,6 +463,20 @@ bool run_parallel_tasks(
         }
     });
 
+    std::thread raise_demand_thread([&]() {
+        if (error_occurred.load()) {
+            return;
+        }
+        std::cout << "------- Update raise demand data for Official -------" << '\n';
+        if (!update_raise_demand_data(official_data_dir, resource_dir)) {
+            std::cerr << "update_raise_demand_data failed" << '\n';
+            error_occurred.store(true);
+        }
+        else {
+            std::cout << ">Done raise demand for Official" << '\n';
+        }
+    });
+
     stages_thread.join();
     levels_thread.join();
     infrast_data_thread.join();
@@ -468,6 +486,7 @@ bool run_parallel_tasks(
     check_roguelike_thread.join();
     recruit_thread.join();
     items_data_thread.join();
+    raise_demand_thread.join();
 
     if (!error_occurred.load() &&
         !validate_infrast_resources(resource_dir, official_data_dir / "gamedata" / "excel" / "building_data.json")) {
@@ -631,6 +650,118 @@ bool update_items_data(const fs::path& input_dir, const fs::path& output_dir, bo
         }
     }
     auto output_json_path = output_dir / "item_index.json";
+    std::ofstream ofs(output_json_path, std::ios::out);
+    ofs << output_json.format();
+    ofs.close();
+
+    return true;
+}
+
+bool update_raise_demand_data(const fs::path& input_dir, const fs::path& output_dir)
+{
+    const auto input_json_path = input_dir / "gamedata" / "excel" / "character_table.json";
+
+    auto parse_ret = json::open(input_json_path);
+    if (!parse_ret) {
+        std::cerr << input_json_path << " parse error" << '\n';
+        return false;
+    }
+
+    auto& input_json = parse_ret.value();
+
+    // Consumption entries of one cost field -> [[item_id, count], ...].
+    // A cost field that is absent, null or empty yields an empty array, nullopt means the data is invalid.
+    const auto collect_costs = [](const json::value& owner, const std::string& cost_key) -> std::optional<json::value> {
+        json::array costs;
+        if (const auto cost_list_opt = owner.find<json::array>(cost_key)) {
+            for (const auto& cost : cost_list_opt.value()) {
+                const std::string item_id = cost.get("id", std::string());
+                const int count = cost.get("count", 0);
+                if (item_id.empty() || count <= 0) {
+                    std::cerr << "Invalid raise demand cost: " << cost_key << ' ' << item_id << '\n';
+                    return std::nullopt;
+                }
+                costs.emplace_back(json::array { item_id, count });
+            }
+        }
+        return json::value(std::move(costs));
+    };
+
+    // A dimension that never consumes any material is null, so that consumers can tell it from an empty cost list
+    const auto has_any_costs = [](const json::array& costs) {
+        return std::ranges::any_of(costs, [](const json::value& cost) { return !cost.as_array().empty(); });
+    };
+
+    json::value output_json;
+    for (const auto& [char_id, char_data] : input_json.as_object()) {
+        if (!char_id.starts_with("char_") || char_data.get("isNotObtainable", false)) {
+            continue;
+        }
+
+        const auto name_opt = char_data.find<std::string>("name");
+        if (!name_opt) {
+            std::cerr << "Character without name: " << char_id << '\n';
+            return false;
+        }
+
+        // Elite promotion: phases[1..].evolveCost, index i is the (i + 1)-th promotion.
+        // Phase 0 is the initial phase, so it is skipped.
+        json::array elite_costs;
+        if (const auto phases_opt = char_data.find<json::array>("phases")) {
+            for (size_t phase_index = 1; phase_index < phases_opt->size(); ++phase_index) {
+                auto costs_opt = collect_costs(phases_opt->at(phase_index), "evolveCost");
+                if (!costs_opt) {
+                    return false;
+                }
+                elite_costs.emplace_back(std::move(costs_opt).value());
+            }
+        }
+
+        // Skill level up: allSkillLvlup[j].lvlUpCost, index j is the skill level j + 1 -> j + 2.
+        json::array skill_level_costs;
+        if (const auto lvlup_opt = char_data.find<json::array>("allSkillLvlup")) {
+            for (const auto& lvlup : lvlup_opt.value()) {
+                auto costs_opt = collect_costs(lvlup, "lvlUpCost");
+                if (!costs_opt) {
+                    return false;
+                }
+                skill_level_costs.emplace_back(std::move(costs_opt).value());
+            }
+        }
+
+        // Mastery: skills[k].levelUpCostCond[m].levelUpCost, index k is the k-th skill, m is its m-th mastery.
+        // A skill without any mastery condition stays null while the other skills keep their own index.
+        json::value mastery_costs;
+        if (const auto skills_opt = char_data.find<json::array>("skills"); skills_opt && !skills_opt->empty()) {
+            json::array mastery_by_skill;
+            for (const auto& skill : skills_opt.value()) {
+                const auto condition_opt = skill.find<json::array>("levelUpCostCond");
+                if (!condition_opt || condition_opt->empty()) {
+                    mastery_by_skill.emplace_back(nullptr);
+                    continue;
+                }
+                json::array mastery_by_level;
+                for (const auto& condition : condition_opt.value()) {
+                    auto costs_opt = collect_costs(condition, "levelUpCost");
+                    if (!costs_opt) {
+                        return false;
+                    }
+                    mastery_by_level.emplace_back(std::move(costs_opt).value());
+                }
+                mastery_by_skill.emplace_back(std::move(mastery_by_level));
+            }
+            mastery_costs = std::move(mastery_by_skill);
+        }
+
+        auto& output = output_json[char_id];
+        output["name"] = name_opt.value();
+        output["elite"] = has_any_costs(elite_costs) ? json::value(std::move(elite_costs)) : json::value(nullptr);
+        output["skills"] =
+            has_any_costs(skill_level_costs) ? json::value(std::move(skill_level_costs)) : json::value(nullptr);
+        output["mastery"] = std::move(mastery_costs);
+    }
+
+    auto output_json_path = output_dir / "raise_demand_index.json";
     std::ofstream ofs(output_json_path, std::ios::out);
     ofs << output_json.format();
     ofs.close();


### PR DESCRIPTION
## 这是什么

一本 MAA 世界里此前不存在的「干员养成百科全书」：429 个干员，每人一段，把这个干员精英化 / 技能升级 / 专精**每一级每一档需要什么材料**记全，产出一个 `resource/raise_demand_index.json`（约 1.8MB）。真实条目长这样（阿米娅，节选）：

```json
"char_002_amiya": {
  "name": "阿米娅",
  "elite":   [[["30011",5], ["30021",4]],        // 精一：源岩×5、代糖×4…
             [["30032",4], ["30042",4]]],        // 精二：聚酸酯×4、异铁×4…
  "skills":  [[["3301",4]],                       // 技能 1→2 级：卷1×4
             [["3301",2], ["30021",1]], ...],    // 2→3 级…
  "mastery": [[["3302",8], ["30043",4]], ...]     // 技能1专一：卷2×8、异铁组×4…
}
```

原料是 `character_table` 的 `evolveCost` / `lvlUpCost` / `levelUpCostCond` 字段——数据一直都在解包仓库里，只是从未被任何管线转换。本 PR 把它接入现有 `res-update-game` CI：**游戏出新干员，20 分钟内新书页自动印好**，与 `item_index.json` 同源同机制，零新增维护负担。

## 为什么需要它

任何「算养成」的功能都绕不开这份数据。以 #18137 的干员培养为例：因为拿不到这本书，目前只能执行时把游戏开到目标界面识别屏幕红字——费时，且一次只能看到下一档的消耗，总需求引导用户去外部工具（Arknights Toolbox）查。有了这张表，「银灰专三总共要什么」就是一次毫秒级的文件查询，游戏都不用开。

数据先于消费者半步是基础设施的自然顺序：表先进管线，规划类功能（Mac 预览、WPF 预览、外部工具）随取随用。

## 内容

- `ResourceUpdater` 新增 `update_raise_demand_data`，产出 `resource/raise_demand_index.json`
- 键 = char id，条目含 `name` / `elite` / `skills` / `mastery`，消耗为**逐级增量** `["物品id", 数量]`（数组对保序），目标档需求 = 前缀累加
- 过滤：`char_` 前缀 + 排除 `isNotObtainable`
- 严格校验：消耗条目缺 id / count≤0 / 缺 name → 报错（含 char id 定位）中止，风格与 `update_items_data` 一致

## 数据口径

- **仅材料**：只含 `type == "MATERIAL"` 的消耗。龙门币与经验不在 `character_table` 消耗字段中，本表同样不含，消费端展示总花费应另行计算。
- **null 语义**：`elite` / `skills` 维度整体无数据为 null；`mastery` 按技能保索引（无专精数据的技能槽为 null，存在 `[null]` 形态）。如实映射原始数据，未做额外归一化。
- **服务器边界**：仅出 Official 主表（官服解包为唯一源）。海外服未实装干员会包含在内，消费端按需过滤；海外分表可后续跟进 `item_index` 的多服先例。

## 验证

- 429 名可获得干员全量产出，与一份独立实现的 Python 转换器（同口径）**全量语义比对一致**（0 差异）
- 错误路径实测：非法消耗条目 → 报错退出且不写出文件；输出目录不可用 → 报错退出
- CI 路径核对：`res-update-game.yml` 的 sparse-checkout 已含 `character_table.json`；新线程与 items/infrast 线程同构，失败传播一致
- CLI 单跑分支入参语义与 `--items-data` / `--infrast-data` 一致（excel 目录）
