### PR TITLE
feat: 新增运行时长上限，到达后自动停止任务

### DIFF
--- a/src/MaaWpfGui/Configuration/Single/Settings/RuntimeSettings.cs
+++ b/src/MaaWpfGui/Configuration/Single/Settings/RuntimeSettings.cs
@@ -58,9 +58,19 @@ public partial class RuntimeSettings : NotifyPropertyChangedWithValue, IJsonOnDe
 
     public int StallTimeoutMinutes { get; set; } = 30;
 
+    /// <summary>
+    /// 运行时长上限，从开始任务起计时，到时停止任务
+    /// </summary>
+    public bool EnableRunDurationLimit { get; set; }
+
+    public int RunDurationLimitMinutes { get; set; } = 240;
+
+    public bool RunDurationLimitExecutePostActions { get; set; } = true;
+
     public void OnDeserialized()
     {
         StallTimeoutMinutes = Math.Clamp(StallTimeoutMinutes, 0, GameSettingsUserControlModel.TimeoutMaxMinutes);
         StallTimeoutReminderIntervalMinutes = Math.Clamp(StallTimeoutReminderIntervalMinutes, 1, GameSettingsUserControlModel.TimeoutMaxMinutes);
+        RunDurationLimitMinutes = Math.Clamp(RunDurationLimitMinutes, 1, GameSettingsUserControlModel.TimeoutMaxMinutes);
     }
 }

--- a/src/MaaWpfGui/Configuration/Single/Settings/RuntimeSettings.cs
+++ b/src/MaaWpfGui/Configuration/Single/Settings/RuntimeSettings.cs
@@ -59,9 +59,9 @@ public partial class RuntimeSettings : NotifyPropertyChangedWithValue, IJsonOnDe
     public int StallTimeoutMinutes { get; set; } = 30;
 
     /// <summary>
-    /// 运行时长上限，从开始任务起计时，到时停止任务
+    /// 运行时长上限，从开始任务起计时，到时停止任务；null 为右键半选，仅生效一次
     /// </summary>
-    public bool EnableRunDurationLimit { get; set; }
+    public bool? EnableRunDurationLimit { get; set; } = false;
 
     public int RunDurationLimitMinutes { get; set; } = 240;
 

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -2033,7 +2033,8 @@ These directories are not suitable places to keep MAA; files there can be easily
     <system:String x:Key="TaskStallWarning">Task log output has not been updated for {0} minutes (currently stalled for {1} minutes). Please check whether the task is still running; if so, you can ignore this warning. If the task is unresponsive, manual intervention may be required.</system:String>
     <system:String x:Key="RunDurationLimitEnabled">Limit run duration</system:String>
     <system:String x:Key="RunDurationLimitMinutes">Run duration limit (min)</system:String>
-    <system:String x:Key="RunDurationLimitTip">Timed from ｢{key=LinkStart}｣. Tasks are stopped automatically once the limit is reached; the option below controls whether actions in ｢{key=PostActionsSettings}｣ (e.g. exiting the game, closing the emulator, shutting down) are executed afterwards.</system:String>
+    <system:String x:Key="RunDurationLimitTip" xml:space="preserve">Timed from ｢{key=LinkStart}｣. Tasks are stopped automatically once the limit is reached; the option below controls whether actions in ｢{key=PostActionsSettings}｣ (e.g. exiting the game, closing the emulator, shutting down) are executed afterwards.
+{key=CheckBoxesNotSavedAsNull}.</system:String>
     <system:String x:Key="RunDurationLimitExecutePostActions">Run actions in ｢{key=PostActionsSettings}｣ after stopping</system:String>
     <system:String x:Key="RunDurationLimitReached">Run duration limit ({0} min) reached, stopping tasks</system:String>
     <!--  !TimeOutTimer  -->

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -2031,6 +2031,11 @@ These directories are not suitable places to keep MAA; files there can be easily
     <system:String x:Key="StallTimeoutMinutes">Log output stall timeout (min)</system:String>
     <system:String x:Key="StallTimeoutEnabled">Enable stall detection</system:String>
     <system:String x:Key="TaskStallWarning">Task log output has not been updated for {0} minutes (currently stalled for {1} minutes). Please check whether the task is still running; if so, you can ignore this warning. If the task is unresponsive, manual intervention may be required.</system:String>
+    <system:String x:Key="RunDurationLimitEnabled">Limit run duration</system:String>
+    <system:String x:Key="RunDurationLimitMinutes">Run duration limit (min)</system:String>
+    <system:String x:Key="RunDurationLimitTip">Timed from ｢{key=LinkStart}｣. Tasks are stopped automatically once the limit is reached; the option below controls whether actions in ｢{key=PostActionsSettings}｣ (e.g. exiting the game, closing the emulator, shutting down) are executed afterwards.</system:String>
+    <system:String x:Key="RunDurationLimitExecutePostActions">Run actions in ｢{key=PostActionsSettings}｣ after stopping</system:String>
+    <system:String x:Key="RunDurationLimitReached">Run duration limit ({0} min) reached, stopping tasks</system:String>
     <!--  !TimeOutTimer  -->
     <!--  Achievement  -->
     <system:String x:Key="AchievementCelebrate">🎉 Achievement Unlocked</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -2034,6 +2034,11 @@ MAA を複数開くには、新しい MAA を他のフォルダにコピーし�
     <system:String x:Key="StallTimeoutMinutes">ログ出力停滞タイムアウト（分）</system:String>
     <system:String x:Key="StallTimeoutEnabled">停滞検出を有効にする</system:String>
     <system:String x:Key="TaskStallWarning">タスクログ出力が {0} 分間更新されていません（現在 {1} 分間停滞）。タスクが正常に実行中か確認してください。正常であればこの警告は無視できます。応答がない場合は、手動での操作が必要になる可能性があります。</system:String>
+    <system:String x:Key="RunDurationLimitEnabled">1回の実行時間を制限する</system:String>
+    <system:String x:Key="RunDurationLimitMinutes">実行時間の上限（分）</system:String>
+    <system:String x:Key="RunDurationLimitTip">｢{key=LinkStart}｣ をクリックした時点から計測し、上限に達するとタスクを自動停止します。停止後に ｢{key=PostActionsSettings}｣ の動作（ゲーム終了、エミュレーター終了、シャットダウンなど）を実行するかは下のオプションで設定できます。</system:String>
+    <system:String x:Key="RunDurationLimitExecutePostActions">停止後に ｢{key=PostActionsSettings}｣ の動作を実行する</system:String>
+    <system:String x:Key="RunDurationLimitReached">実行時間の上限（{0} 分）に達したため、タスクを停止します</system:String>
     <!--  !TimeOutTimer  -->
     <!--  Achievement  -->
     <system:String x:Key="AchievementCelebrate">🎉 実績を獲得した</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -2036,7 +2036,8 @@ MAA を複数開くには、新しい MAA を他のフォルダにコピーし�
     <system:String x:Key="TaskStallWarning">タスクログ出力が {0} 分間更新されていません（現在 {1} 分間停滞）。タスクが正常に実行中か確認してください。正常であればこの警告は無視できます。応答がない場合は、手動での操作が必要になる可能性があります。</system:String>
     <system:String x:Key="RunDurationLimitEnabled">1回の実行時間を制限する</system:String>
     <system:String x:Key="RunDurationLimitMinutes">実行時間の上限（分）</system:String>
-    <system:String x:Key="RunDurationLimitTip">｢{key=LinkStart}｣ をクリックした時点から計測し、上限に達するとタスクを自動停止します。停止後に ｢{key=PostActionsSettings}｣ の動作（ゲーム終了、エミュレーター終了、シャットダウンなど）を実行するかは下のオプションで設定できます。</system:String>
+    <system:String x:Key="RunDurationLimitTip" xml:space="preserve">｢{key=LinkStart}｣ をクリックした時点から計測し、上限に達するとタスクを自動停止します。停止後に ｢{key=PostActionsSettings}｣ の動作（ゲーム終了、エミュレーター終了、シャットダウンなど）を実行するかは下のオプションで設定できます。
+{key=CheckBoxesNotSavedAsNull}。</system:String>
     <system:String x:Key="RunDurationLimitExecutePostActions">停止後に ｢{key=PostActionsSettings}｣ の動作を実行する</system:String>
     <system:String x:Key="RunDurationLimitReached">実行時間の上限（{0} 分）に達したため、タスクを停止します</system:String>
     <!--  !TimeOutTimer  -->

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -2034,7 +2034,8 @@ MAA를 독립된 새 폴더에 압축 해제하거나, MAA에 속하지 않는 D
     <system:String x:Key="TaskStallWarning">작업 로그 출력이 {0}분 동안 업데이트되지 않았습니다(현재 {1}분 정지). 작업이 정상적으로 실행 중인지 확인하세요. 정상이라면 이 경고를 무시해도 됩니다. 응답이 없으면 수동 개입이 필요할 수 있습니다.</system:String>
     <system:String x:Key="RunDurationLimitEnabled">1회 실행 시간 제한</system:String>
     <system:String x:Key="RunDurationLimitMinutes">실행 시간 상한 (분)</system:String>
-    <system:String x:Key="RunDurationLimitTip">｢{key=LinkStart}｣ 클릭 시점부터 시간을 측정하며, 상한에 도달하면 작업을 자동으로 중지합니다. 중지 후 ｢{key=PostActionsSettings}｣의 동작(게임 종료, 에뮬레이터 종료, 시스템 종료 등) 실행 여부는 아래 옵션으로 설정할 수 있습니다.</system:String>
+    <system:String x:Key="RunDurationLimitTip" xml:space="preserve">｢{key=LinkStart}｣ 클릭 시점부터 시간을 측정하며, 상한에 도달하면 작업을 자동으로 중지합니다. 중지 후 ｢{key=PostActionsSettings}｣의 동작(게임 종료, 에뮬레이터 종료, 시스템 종료 등) 실행 여부는 아래 옵션으로 설정할 수 있습니다.
+{key=CheckBoxesNotSavedAsNull}.</system:String>
     <system:String x:Key="RunDurationLimitExecutePostActions">중지 후 ｢{key=PostActionsSettings}｣의 동작 실행</system:String>
     <system:String x:Key="RunDurationLimitReached">실행 시간 상한({0}분)에 도달하여 작업을 중지합니다</system:String>
     <!--  !TimeOutTimer  -->

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -2032,6 +2032,11 @@ MAA를 독립된 새 폴더에 압축 해제하거나, MAA에 속하지 않는 D
     <system:String x:Key="StallTimeoutMinutes">로그 출력 정지 타임아웃 (분)</system:String>
     <system:String x:Key="StallTimeoutEnabled">정지 감지 활성화</system:String>
     <system:String x:Key="TaskStallWarning">작업 로그 출력이 {0}분 동안 업데이트되지 않았습니다(현재 {1}분 정지). 작업이 정상적으로 실행 중인지 확인하세요. 정상이라면 이 경고를 무시해도 됩니다. 응답이 없으면 수동 개입이 필요할 수 있습니다.</system:String>
+    <system:String x:Key="RunDurationLimitEnabled">1회 실행 시간 제한</system:String>
+    <system:String x:Key="RunDurationLimitMinutes">실행 시간 상한 (분)</system:String>
+    <system:String x:Key="RunDurationLimitTip">｢{key=LinkStart}｣ 클릭 시점부터 시간을 측정하며, 상한에 도달하면 작업을 자동으로 중지합니다. 중지 후 ｢{key=PostActionsSettings}｣의 동작(게임 종료, 에뮬레이터 종료, 시스템 종료 등) 실행 여부는 아래 옵션으로 설정할 수 있습니다.</system:String>
+    <system:String x:Key="RunDurationLimitExecutePostActions">중지 후 ｢{key=PostActionsSettings}｣의 동작 실행</system:String>
+    <system:String x:Key="RunDurationLimitReached">실행 시간 상한({0}분)에 도달하여 작업을 중지합니다</system:String>
     <!--  !TimeOutTimer  -->
     <!--  Achievement  -->
     <system:String x:Key="AchievementCelebrate">🎉 도전과제 달성</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -2030,6 +2030,11 @@ DEBUG 目录下保存的图片有数量限制，超出后会自动清理旧图�
     <system:String x:Key="StallTimeoutMinutes">日志输出停滞超时时间（分钟）</system:String>
     <system:String x:Key="StallTimeoutEnabled">启用停滞检测</system:String>
     <system:String x:Key="TaskStallWarning">任务日志输出已超过 {0} 分钟无更新（当前已停滞 {1} 分钟）。请确认任务是否正常运行，若任务正常可忽略此提示，若无响应则可能需要手动干预。</system:String>
+    <system:String x:Key="RunDurationLimitEnabled">限制单次运行时长</system:String>
+    <system:String x:Key="RunDurationLimitMinutes">运行时长上限（分钟）</system:String>
+    <system:String x:Key="RunDurationLimitTip">从点击 ｢{key=LinkStart}｣ 开始计时，到达上限后自动停止任务，并按下方选项决定是否执行 ｢{key=PostActionsSettings}｣ 中的动作（如退出游戏、关闭模拟器、关机）。</system:String>
+    <system:String x:Key="RunDurationLimitExecutePostActions">停止后执行 ｢{key=PostActionsSettings}｣ 中的动作</system:String>
+    <system:String x:Key="RunDurationLimitReached">已达到运行时长上限（{0} 分钟），停止任务</system:String>
     <!--  !TimeOutTimer  -->
     <!--  Achievement  -->
     <system:String x:Key="AchievementCelebrate">🎉 达成成就</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -2032,7 +2032,8 @@ DEBUG 目录下保存的图片有数量限制，超出后会自动清理旧图�
     <system:String x:Key="TaskStallWarning">任务日志输出已超过 {0} 分钟无更新（当前已停滞 {1} 分钟）。请确认任务是否正常运行，若任务正常可忽略此提示，若无响应则可能需要手动干预。</system:String>
     <system:String x:Key="RunDurationLimitEnabled">限制单次运行时长</system:String>
     <system:String x:Key="RunDurationLimitMinutes">运行时长上限（分钟）</system:String>
-    <system:String x:Key="RunDurationLimitTip">从点击 ｢{key=LinkStart}｣ 开始计时，到达上限后自动停止任务，并按下方选项决定是否执行 ｢{key=PostActionsSettings}｣ 中的动作（如退出游戏、关闭模拟器、关机）。</system:String>
+    <system:String x:Key="RunDurationLimitTip" xml:space="preserve">从点击 ｢{key=LinkStart}｣ 开始计时，到达上限后自动停止任务，并按下方选项决定是否执行 ｢{key=PostActionsSettings}｣ 中的动作（如退出游戏、关闭模拟器、关机）。
+{key=CheckBoxesNotSavedAsNull}。</system:String>
     <system:String x:Key="RunDurationLimitExecutePostActions">停止后执行 ｢{key=PostActionsSettings}｣ 中的动作</system:String>
     <system:String x:Key="RunDurationLimitReached">已达到运行时长上限（{0} 分钟），停止任务</system:String>
     <!--  !TimeOutTimer  -->

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -2034,7 +2034,8 @@ DEBUG 目錄下儲存的圖片有數量限制，超出後會自動清理舊圖�
     <system:String x:Key="TaskStallWarning">任務日誌輸出已超過 {0} 分鐘無更新（當前已停滯 {1} 分鐘）。請確認任務是否正常運行，若任務正常可忽略此提示，若無回應則可能需要手動干預。</system:String>
     <system:String x:Key="RunDurationLimitEnabled">限制單次運行時長</system:String>
     <system:String x:Key="RunDurationLimitMinutes">運行時長上限（分鐘）</system:String>
-    <system:String x:Key="RunDurationLimitTip">從點擊 ｢{key=LinkStart}｣ 開始計時，到達上限後自動停止任務，並依下方選項決定是否執行 ｢{key=PostActionsSettings}｣ 中的動作（如退出遊戲、關閉模擬器、關機）。</system:String>
+    <system:String x:Key="RunDurationLimitTip" xml:space="preserve">從點擊 ｢{key=LinkStart}｣ 開始計時，到達上限後自動停止任務，並依下方選項決定是否執行 ｢{key=PostActionsSettings}｣ 中的動作（如退出遊戲、關閉模擬器、關機）。
+{key=CheckBoxesNotSavedAsNull}。</system:String>
     <system:String x:Key="RunDurationLimitExecutePostActions">停止後執行 ｢{key=PostActionsSettings}｣ 中的動作</system:String>
     <system:String x:Key="RunDurationLimitReached">已達到運行時長上限（{0} 分鐘），停止任務</system:String>
     <!--  !TimeOutTimer  -->

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -2032,6 +2032,11 @@ DEBUG 目錄下儲存的圖片有數量限制，超出後會自動清理舊圖�
     <system:String x:Key="StallTimeoutMinutes">日誌輸出停滯超時時間（分鐘）</system:String>
     <system:String x:Key="StallTimeoutEnabled">啟用停滯偵測</system:String>
     <system:String x:Key="TaskStallWarning">任務日誌輸出已超過 {0} 分鐘無更新（當前已停滯 {1} 分鐘）。請確認任務是否正常運行，若任務正常可忽略此提示，若無回應則可能需要手動干預。</system:String>
+    <system:String x:Key="RunDurationLimitEnabled">限制單次運行時長</system:String>
+    <system:String x:Key="RunDurationLimitMinutes">運行時長上限（分鐘）</system:String>
+    <system:String x:Key="RunDurationLimitTip">從點擊 ｢{key=LinkStart}｣ 開始計時，到達上限後自動停止任務，並依下方選項決定是否執行 ｢{key=PostActionsSettings}｣ 中的動作（如退出遊戲、關閉模擬器、關機）。</system:String>
+    <system:String x:Key="RunDurationLimitExecutePostActions">停止後執行 ｢{key=PostActionsSettings}｣ 中的動作</system:String>
+    <system:String x:Key="RunDurationLimitReached">已達到運行時長上限（{0} 分鐘），停止任務</system:String>
     <!--  !TimeOutTimer  -->
     <!--  Achievement  -->
     <system:String x:Key="AchievementCelebrate">🎉 達成成就</system:String>

--- a/src/MaaWpfGui/Services/RemoteControl/RemoteControlService.cs
+++ b/src/MaaWpfGui/Services/RemoteControl/RemoteControlService.cs
@@ -733,6 +733,7 @@ public class RemoteControlService
             {
                 Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("Running"));
                 Instances.AsstProxy.StartTaskTime = DateTimeOffset.Now;
+                Instances.TaskQueueViewModel.SetRunDeadlineFromSettings();
             }
             else
             {

--- a/src/MaaWpfGui/States/RunningState.cs
+++ b/src/MaaWpfGui/States/RunningState.cs
@@ -154,6 +154,52 @@ public class RunningState
         _taskStartTime = DateTime.Now;
     }
 
+    // 运行时长上限相关字段，仅由主任务队列开始时设置，空闲时清除
+    private readonly Lock _runDeadlineLock = new();
+    private DateTime? _runDeadline;
+    private int _runDurationLimitMinutes;
+    private bool _runDurationLimitExecutePostActions;
+
+    public void SetRunDeadline(int limitMinutes, bool executePostActions)
+    {
+        lock (_runDeadlineLock)
+        {
+            _runDurationLimitMinutes = limitMinutes;
+            _runDurationLimitExecutePostActions = executePostActions;
+            _runDeadline = DateTime.UtcNow.AddMinutes(limitMinutes);
+        }
+    }
+
+    public void ClearRunDeadline()
+    {
+        lock (_runDeadlineLock)
+        {
+            _runDeadline = null;
+        }
+    }
+
+    /// <summary>
+    /// 若已到达运行截止时间，则清除截止时间并返回 true，保证每轮运行只触发一次。
+    /// </summary>
+    /// <param name="limitMinutes">设置的运行时长上限（分钟）。</param>
+    /// <param name="executePostActions">停止后是否执行完成后动作。</param>
+    /// <returns>是否已到达截止时间。</returns>
+    public bool TryConsumeRunDeadline(out int limitMinutes, out bool executePostActions)
+    {
+        lock (_runDeadlineLock)
+        {
+            limitMinutes = _runDurationLimitMinutes;
+            executePostActions = _runDurationLimitExecutePostActions;
+            if (_runDeadline is not { } deadline || DateTime.UtcNow < deadline)
+            {
+                return false;
+            }
+
+            _runDeadline = null;
+            return true;
+        }
+    }
+
     // 超时计时器回调
     private void TimeoutReminderTimer_Elapsed(object? sender, System.Timers.ElapsedEventArgs? e)
     {
@@ -208,6 +254,7 @@ public class RunningState
             if (value)
             {
                 StopTimeoutTimer();
+                ClearRunDeadline();
                 SleepManagement.AllowSleep();
             }
             else

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -470,13 +470,18 @@ public class TaskQueueViewModel : Screen
     /// <summary>
     /// Checks after completion.
     /// </summary>
+    /// <param name="runEndsWithScript">是否执行结束脚本，调用方已执行过时传 false 避免重复执行</param>
     /// <returns>Task</returns>
-    public async Task CheckAfterCompleted()
+    public async Task CheckAfterCompleted(bool runEndsWithScript = true)
     {
         RunningState.Instance.LockInterrupt();
         try
         {
-            await Task.Run(() => SettingsViewModel.GameSettings.RunScript("EndsWithScript"));
+            if (runEndsWithScript)
+            {
+                await Task.Run(() => SettingsViewModel.GameSettings.RunScript("EndsWithScript"));
+            }
+
             var actions = PostActionSetting;
             _logger.Information("Post actions: " + actions.ActionDescription);
 
@@ -803,11 +808,75 @@ public class TaskQueueViewModel : Screen
 
             InfrastTask.RefreshInfrastTimeRotationDisplay();
 
+            HandleRunDurationLimit();
+
             await HandleTimerLogic(currentTime);
         }
         catch
         {
             // ignored
+        }
+    }
+
+    private void HandleRunDurationLimit()
+    {
+        if (!_runningState.TryConsumeRunDeadline(out var limitMinutes, out var executePostActions))
+        {
+            return;
+        }
+
+        // 不在定时器里等待停止完成，避免错过同一时刻的定时启动
+        _ = StopByRunDurationLimitAsync(limitMinutes, executePostActions);
+    }
+
+    private async Task StopByRunDurationLimitAsync(int limitMinutes, bool executePostActions)
+    {
+        try
+        {
+            if (Stopping || _runningState.GetIdle())
+            {
+                return;
+            }
+
+            // 用于识别等待期间本轮是否已结束，并由定时执行开始了新一轮
+            var startTaskTime = Instances.AsstProxy.StartTaskTime;
+
+            _logger.Information("Run duration limit reached: {LimitMinutes} min, stopping", limitMinutes);
+            var message = LocalizationHelper.GetStringFormat("RunDurationLimitReached", limitMinutes);
+            AddLog(message, UiLogColor.Warning);
+            ToastNotification.ShowDirect(message);
+
+            if (RoguelikeTask.RoguelikeDelayAbortUntilCombatComplete && RoguelikeInCombatAndShowWait)
+            {
+                Waiting = true;
+                AddLog(LocalizationHelper.GetString("Waiting"));
+                await WaitUntilRoguelikeCombatComplete();
+            }
+
+            if (Instances.AsstProxy.StartTaskTime != startTaskTime)
+            {
+                _logger.Information("A new run started while waiting, skip stopping by run duration limit");
+                return;
+            }
+
+            // 本轮已自然结束或已在停止中时交由原流程处理，避免重复执行完成后动作
+            if (!Instances.AsstProxy.AsstRunning() || _runningState.GetStopping())
+            {
+                return;
+            }
+
+            await Stop();
+            SetStopped();
+
+            if (executePostActions)
+            {
+                // 开启手动停止执行脚本时，SetStopped 已执行过结束脚本
+                await CheckAfterCompleted(runEndsWithScript: !SettingsViewModel.GameSettings.ManualStopWithScript);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.Error(ex, "Failed to stop by run duration limit");
         }
     }
 
@@ -2137,6 +2206,12 @@ public class TaskQueueViewModel : Screen
         {
             AddLog(LocalizationHelper.GetString("Running"));
             Instances.AsstProxy.StartTaskTime = DateTimeOffset.Now;
+
+            var runtimeSettings = ConfigFactory.CurrentConfig.Gui.RuntimeSettings;
+            if (runtimeSettings.EnableRunDurationLimit)
+            {
+                _runningState.SetRunDeadline(runtimeSettings.RunDurationLimitMinutes, runtimeSettings.RunDurationLimitExecutePostActions);
+            }
         }
         else
         {

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -889,6 +889,21 @@ public class TaskQueueViewModel : Screen
         }
     }
 
+    /// <summary>
+    /// 按当前设置设置运行时长截止时间，各启动路径在 <c>AsstStart</c> 成功后调用。
+    /// </summary>
+    public void SetRunDeadlineFromSettings()
+    {
+        var runtimeSettings = ConfigFactory.CurrentConfig.Gui.RuntimeSettings;
+        if (runtimeSettings.EnableRunDurationLimit != false)
+        {
+            _runningState.SetRunDeadline(runtimeSettings.RunDurationLimitMinutes, runtimeSettings.RunDurationLimitExecutePostActions);
+
+            // 右键半选仅生效一次，本轮开始计时后恢复为未勾选
+            SettingsViewModel.GameSettings.EnableRunDurationLimit ??= false;
+        }
+    }
+
     private static int CalculateRandomDelay()
     {
         Random random = new Random();
@@ -2215,15 +2230,7 @@ public class TaskQueueViewModel : Screen
         {
             AddLog(LocalizationHelper.GetString("Running"));
             Instances.AsstProxy.StartTaskTime = DateTimeOffset.Now;
-
-            var runtimeSettings = ConfigFactory.CurrentConfig.Gui.RuntimeSettings;
-            if (runtimeSettings.EnableRunDurationLimit != false)
-            {
-                _runningState.SetRunDeadline(runtimeSettings.RunDurationLimitMinutes, runtimeSettings.RunDurationLimitExecutePostActions);
-
-                // 右键半选仅生效一次，本轮开始计时后恢复为未勾选
-                SettingsViewModel.GameSettings.EnableRunDurationLimit ??= false;
-            }
+            SetRunDeadlineFromSettings();
         }
         else
         {

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -808,9 +808,9 @@ public class TaskQueueViewModel : Screen
 
             InfrastTask.RefreshInfrastTimeRotationDisplay();
 
-            HandleRunDurationLimit();
-
             await HandleTimerLogic(currentTime);
+
+            await HandleRunDurationLimit();
         }
         catch
         {
@@ -818,15 +818,14 @@ public class TaskQueueViewModel : Screen
         }
     }
 
-    private void HandleRunDurationLimit()
+    private async Task HandleRunDurationLimit()
     {
         if (!_runningState.TryConsumeRunDeadline(out var limitMinutes, out var executePostActions))
         {
             return;
         }
 
-        // 不在定时器里等待停止完成，避免错过同一时刻的定时启动
-        _ = StopByRunDurationLimitAsync(limitMinutes, executePostActions);
+        await StopByRunDurationLimitAsync(limitMinutes, executePostActions);
     }
 
     private async Task StopByRunDurationLimitAsync(int limitMinutes, bool executePostActions)
@@ -846,21 +845,30 @@ public class TaskQueueViewModel : Screen
             AddLog(message, UiLogColor.Warning);
             ToastNotification.ShowDirect(message);
 
+            var waited = false;
             if (RoguelikeTask.RoguelikeDelayAbortUntilCombatComplete && RoguelikeInCombatAndShowWait)
             {
                 Waiting = true;
+                waited = true;
                 AddLog(LocalizationHelper.GetString("Waiting"));
                 await WaitUntilRoguelikeCombatComplete();
             }
 
-            if (Instances.AsstProxy.StartTaskTime != startTaskTime)
+            // 等待期间本轮已自然结束或定时执行已开始新一轮时不再停止，交由原流程处理完成后动作；
+            // 这两种情况不会经过 SetStopped，需自行恢复等待状态
+            if (Instances.AsstProxy.StartTaskTime != startTaskTime || !Instances.AsstProxy.AsstRunning())
             {
-                _logger.Information("A new run started while waiting, skip stopping by run duration limit");
+                if (waited)
+                {
+                    Waiting = false;
+                }
+
+                _logger.Information("Run already ended or a new run started, skip stopping by run duration limit");
                 return;
             }
 
-            // 本轮已自然结束或已在停止中时交由原流程处理，避免重复执行完成后动作
-            if (!Instances.AsstProxy.AsstRunning() || _runningState.GetStopping())
+            // 已在停止中时交由原流程处理，避免重复执行完成后动作
+            if (_runningState.GetStopping())
             {
                 return;
             }
@@ -868,11 +876,12 @@ public class TaskQueueViewModel : Screen
             await Stop();
             SetStopped();
 
-            if (executePostActions)
+            if (!executePostActions)
             {
-                // 开启手动停止执行脚本时，SetStopped 已执行过结束脚本
-                await CheckAfterCompleted(runEndsWithScript: !SettingsViewModel.GameSettings.ManualStopWithScript);
+                return;
             }
+
+            await CheckAfterCompleted(runEndsWithScript: !SettingsViewModel.GameSettings.ManualStopWithScript);
         }
         catch (Exception ex)
         {

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -651,6 +651,12 @@ public class TaskQueueViewModel : Screen
             {
                 Instances.Data.ClearCache();
             }
+
+            if (e.NewState.Idle && _runDurationLimitOnce)
+            {
+                _runDurationLimitOnce = false;
+                SettingsViewModel.GameSettings.EnableRunDurationLimit ??= false;
+            }
         };
         _runningState.StallOccurred += RunningState_Stalled;
 
@@ -889,6 +895,9 @@ public class TaskQueueViewModel : Screen
         }
     }
 
+    // 本轮时长上限来自右键半选（仅生效一次），本轮结束后恢复为未勾选
+    private bool _runDurationLimitOnce;
+
     /// <summary>
     /// 按当前设置设置运行时长截止时间，各启动路径在 <c>AsstStart</c> 成功后调用。
     /// </summary>
@@ -898,9 +907,7 @@ public class TaskQueueViewModel : Screen
         if (runtimeSettings.EnableRunDurationLimit != false)
         {
             _runningState.SetRunDeadline(runtimeSettings.RunDurationLimitMinutes, runtimeSettings.RunDurationLimitExecutePostActions);
-
-            // 右键半选仅生效一次，本轮开始计时后恢复为未勾选
-            SettingsViewModel.GameSettings.EnableRunDurationLimit ??= false;
+            _runDurationLimitOnce = runtimeSettings.EnableRunDurationLimit == null;
         }
     }
 

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -470,7 +470,7 @@ public class TaskQueueViewModel : Screen
     /// <summary>
     /// Checks after completion.
     /// </summary>
-    /// <param name="runEndsWithScript">是否执行结束脚本，调用方已执行过时传 false 避免重复执行</param>
+    /// <param name="runEndsWithScript">是否执行结束脚本；为 false 时等待 SetStopped 中已启动的结束脚本执行完毕</param>
     /// <returns>Task</returns>
     public async Task CheckAfterCompleted(bool runEndsWithScript = true)
     {
@@ -480,6 +480,10 @@ public class TaskQueueViewModel : Screen
             if (runEndsWithScript)
             {
                 await Task.Run(() => SettingsViewModel.GameSettings.RunScript("EndsWithScript"));
+            }
+            else
+            {
+                await _stopScriptTask;
             }
 
             var actions = PostActionSetting;
@@ -2365,6 +2369,9 @@ public class TaskQueueViewModel : Screen
 
     public bool RoguelikeInCombatAndShowWait { get => field; set => SetAndNotify(ref field, value); }
 
+    // SetStopped 中启动的结束脚本，供完成后动作等待其执行完毕
+    private Task _stopScriptTask = Task.CompletedTask;
+
     /// <summary>
     /// 重置 UI 状态为已停止。
     /// </summary>
@@ -2382,7 +2389,7 @@ public class TaskQueueViewModel : Screen
         SleepManagement.AllowSleep();
         if (runStopScript && SettingsViewModel.GameSettings.ManualStopWithScript)
         {
-            Task.Run(() => SettingsViewModel.GameSettings.RunScript("EndsWithScript"));
+            _stopScriptTask = Task.Run(() => SettingsViewModel.GameSettings.RunScript("EndsWithScript"));
         }
 
         if (!_runningState.GetIdle() || _runningState.GetStopping())

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -2208,9 +2208,12 @@ public class TaskQueueViewModel : Screen
             Instances.AsstProxy.StartTaskTime = DateTimeOffset.Now;
 
             var runtimeSettings = ConfigFactory.CurrentConfig.Gui.RuntimeSettings;
-            if (runtimeSettings.EnableRunDurationLimit)
+            if (runtimeSettings.EnableRunDurationLimit != false)
             {
                 _runningState.SetRunDeadline(runtimeSettings.RunDurationLimitMinutes, runtimeSettings.RunDurationLimitExecutePostActions);
+
+                // 右键半选仅生效一次，本轮开始计时后恢复为未勾选
+                SettingsViewModel.GameSettings.EnableRunDurationLimit ??= false;
             }
         }
         else

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -470,7 +470,7 @@ public class TaskQueueViewModel : Screen
     /// <summary>
     /// Checks after completion.
     /// </summary>
-    /// <param name="runEndsWithScript">是否执行结束脚本；为 false 时等待 SetStopped 中已启动的结束脚本执行完毕</param>
+    /// <param name="runEndsWithScript">是否执行结束脚本；为 false 时等待本次停止中 SetStopped 启动的结束脚本执行完毕</param>
     /// <returns>Task</returns>
     public async Task CheckAfterCompleted(bool runEndsWithScript = true)
     {
@@ -483,7 +483,7 @@ public class TaskQueueViewModel : Screen
             }
             else
             {
-                await _stopScriptTask;
+                await (Volatile.Read(ref _stopHandling)?.Task ?? Task.CompletedTask);
             }
 
             var actions = PostActionSetting;
@@ -654,6 +654,12 @@ public class TaskQueueViewModel : Screen
             if (!e.NewState.Idle)
             {
                 Instances.Data.ClearCache();
+            }
+
+            // 进入运行或停止中时重置停止处理权
+            if ((e.OldState.Idle && !e.NewState.Idle) || (!e.OldState.Stopping && e.NewState.Stopping))
+            {
+                Interlocked.Exchange(ref _stopHandling, null);
             }
 
             if (e.NewState.Idle && _runDurationLimitOnce)
@@ -2369,8 +2375,8 @@ public class TaskQueueViewModel : Screen
 
     public bool RoguelikeInCombatAndShowWait { get => field; set => SetAndNotify(ref field, value); }
 
-    // SetStopped 中启动的结束脚本，供完成后动作等待其执行完毕
-    private Task _stopScriptTask = Task.CompletedTask;
+    // 本次停止的处理权，进入运行或停止中时重置为 null；其 Task 在 SetStopped 启动的结束脚本执行完毕后完成
+    private TaskCompletionSource? _stopHandling;
 
     /// <summary>
     /// 重置 UI 状态为已停止。
@@ -2386,10 +2392,30 @@ public class TaskQueueViewModel : Screen
             return false;
         }
 
+        // 回调与到点停止等可能并发调用，CAS 抢占处理权，保证只处理一次
+        var handling = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        if (Interlocked.CompareExchange(ref _stopHandling, handling, null) is not null)
+        {
+            return false;
+        }
+
         SleepManagement.AllowSleep();
         if (runStopScript && SettingsViewModel.GameSettings.ManualStopWithScript)
         {
-            _stopScriptTask = Task.Run(() => SettingsViewModel.GameSettings.RunScript("EndsWithScript"));
+            Task.Run(() => {
+                try
+                {
+                    SettingsViewModel.GameSettings.RunScript("EndsWithScript");
+                }
+                finally
+                {
+                    handling.TrySetResult();
+                }
+            });
+        }
+        else
+        {
+            handling.TrySetResult();
         }
 
         if (!_runningState.GetIdle() || _runningState.GetStopping())

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/GameSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/GameSettingsUserControlModel.cs
@@ -341,15 +341,21 @@ public class GameSettingsUserControlModel : PropertyChangedBase
     } = ConfigFactory.CurrentConfig.Gui.RuntimeSettings.StallTimeoutReminderIntervalMinutes;
 
     /// <summary>
-    /// Gets or sets a value indicating whether 是否启用运行时长上限
+    /// Gets or sets a value indicating whether 是否启用运行时长上限，null 为右键半选，仅生效一次
     /// </summary>
-    public bool EnableRunDurationLimit
+    public bool? EnableRunDurationLimit
     {
         get; set {
             SetAndNotify(ref field, value);
+            NotifyOfPropertyChange(nameof(RunDurationLimitActive));
             ConfigFactory.CurrentConfig.Gui.RuntimeSettings.EnableRunDurationLimit = value;
         }
     } = ConfigFactory.CurrentConfig.Gui.RuntimeSettings.EnableRunDurationLimit;
+
+    /// <summary>
+    /// Gets a value indicating whether 运行时长上限生效（勾选或右键半选）
+    /// </summary>
+    public bool RunDurationLimitActive => EnableRunDurationLimit != false;
 
     public int RunDurationLimitMinutes
     {

--- a/src/MaaWpfGui/ViewModels/UserControl/Settings/GameSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/Settings/GameSettingsUserControlModel.cs
@@ -340,6 +340,37 @@ public class GameSettingsUserControlModel : PropertyChangedBase
         }
     } = ConfigFactory.CurrentConfig.Gui.RuntimeSettings.StallTimeoutReminderIntervalMinutes;
 
+    /// <summary>
+    /// Gets or sets a value indicating whether 是否启用运行时长上限
+    /// </summary>
+    public bool EnableRunDurationLimit
+    {
+        get; set {
+            SetAndNotify(ref field, value);
+            ConfigFactory.CurrentConfig.Gui.RuntimeSettings.EnableRunDurationLimit = value;
+        }
+    } = ConfigFactory.CurrentConfig.Gui.RuntimeSettings.EnableRunDurationLimit;
+
+    public int RunDurationLimitMinutes
+    {
+        get; set {
+            value = value.Clamp(1, TimeoutMaxMinutes);
+            SetAndNotify(ref field, value);
+            ConfigFactory.CurrentConfig.Gui.RuntimeSettings.RunDurationLimitMinutes = value;
+        }
+    } = ConfigFactory.CurrentConfig.Gui.RuntimeSettings.RunDurationLimitMinutes;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether 到达运行时长上限停止后是否执行完成后动作
+    /// </summary>
+    public bool RunDurationLimitExecutePostActions
+    {
+        get; set {
+            SetAndNotify(ref field, value);
+            ConfigFactory.CurrentConfig.Gui.RuntimeSettings.RunDurationLimitExecutePostActions = value;
+        }
+    } = ConfigFactory.CurrentConfig.Gui.RuntimeSettings.RunDurationLimitExecutePostActions;
+
     #endregion 任务超时
 
     /// <summary>

--- a/src/MaaWpfGui/Views/UserControl/Settings/GameSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/Settings/GameSettingsUserControl.xaml
@@ -247,6 +247,7 @@
                 VerticalAlignment="Center"
                 Content="{DynamicResource RunDurationLimitEnabled}"
                 IsChecked="{Binding EnableRunDurationLimit}"
+                IsEnabled="{Binding Idle, Source={x:Static ui_vms:TaskQueueViewModel.TaskSettingDataContext}}"
                 MouseRightButtonUp="{s:Action ToggleCheckBoxNullOnRightClick,
                                               Target={x:Type helper:CheckBoxHelper}}"
                 ToolTip="{DynamicResource CheckBoxesNotSavedAsNull}" />
@@ -264,6 +265,7 @@
                 hc:InfoElement.Title="{DynamicResource RunDurationLimitMinutes}"
                 hc:TitleElement.TitlePlacement="Left"
                 InputMethod.IsInputMethodEnabled="False"
+                IsEnabled="{Binding Idle, Source={x:Static ui_vms:TaskQueueViewModel.TaskSettingDataContext}}"
                 Maximum="11451"
                 Minimum="1"
                 Value="{Binding RunDurationLimitMinutes}" />
@@ -273,6 +275,7 @@
             HorizontalAlignment="Center"
             Content="{DynamicResource RunDurationLimitExecutePostActions}"
             IsChecked="{Binding RunDurationLimitExecutePostActions}"
+            IsEnabled="{Binding Idle, Source={x:Static ui_vms:TaskQueueViewModel.TaskSettingDataContext}}"
             Visibility="{c:Binding RunDurationLimitActive}" />
     </StackPanel>
 </UserControl>

--- a/src/MaaWpfGui/Views/UserControl/Settings/GameSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/Settings/GameSettingsUserControl.xaml
@@ -237,5 +237,38 @@
                 Minimum="1"
                 Value="{Binding ReminderIntervalMinutes}" />
         </StackPanel>
+        <StackPanel
+            HorizontalAlignment="Center"
+            VerticalAlignment="Center"
+            Orientation="Horizontal">
+            <CheckBox
+                Margin="20,10,0,10"
+                VerticalAlignment="Center"
+                Content="{DynamicResource RunDurationLimitEnabled}"
+                IsChecked="{Binding EnableRunDurationLimit}" />
+            <controls:TooltipBlock
+                Margin="0,10"
+                VerticalAlignment="Center"
+                TooltipText="{DynamicResource RunDurationLimitTip}" />
+        </StackPanel>
+        <StackPanel
+            HorizontalAlignment="Center"
+            Orientation="Horizontal"
+            Visibility="{c:Binding EnableRunDurationLimit}">
+            <hc:NumericUpDown
+                Margin="5"
+                hc:InfoElement.Title="{DynamicResource RunDurationLimitMinutes}"
+                hc:TitleElement.TitlePlacement="Left"
+                InputMethod.IsInputMethodEnabled="False"
+                Maximum="11451"
+                Minimum="1"
+                Value="{Binding RunDurationLimitMinutes}" />
+        </StackPanel>
+        <CheckBox
+            Margin="10"
+            HorizontalAlignment="Center"
+            Content="{DynamicResource RunDurationLimitExecutePostActions}"
+            IsChecked="{Binding RunDurationLimitExecutePostActions}"
+            Visibility="{c:Binding EnableRunDurationLimit}" />
     </StackPanel>
 </UserControl>

--- a/src/MaaWpfGui/Views/UserControl/Settings/GameSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/Settings/GameSettingsUserControl.xaml
@@ -9,6 +9,7 @@
     xmlns:dd="urn:gong-wpf-dragdrop"
     xmlns:enums="clr-namespace:MaaWpfGui.Constants.Enums"
     xmlns:hc="https://handyorg.github.io/handycontrol"
+    xmlns:helper="clr-namespace:MaaWpfGui.Helper"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:s="https://github.com/canton7/Stylet"
     xmlns:settings_vms="clr-namespace:MaaWpfGui.ViewModels.UserControl.Settings"
@@ -245,7 +246,10 @@
                 Margin="20,10,0,10"
                 VerticalAlignment="Center"
                 Content="{DynamicResource RunDurationLimitEnabled}"
-                IsChecked="{Binding EnableRunDurationLimit}" />
+                IsChecked="{Binding EnableRunDurationLimit}"
+                MouseRightButtonUp="{s:Action ToggleCheckBoxNullOnRightClick,
+                                              Target={x:Type helper:CheckBoxHelper}}"
+                ToolTip="{DynamicResource CheckBoxesNotSavedAsNull}" />
             <controls:TooltipBlock
                 Margin="0,10"
                 VerticalAlignment="Center"
@@ -254,7 +258,7 @@
         <StackPanel
             HorizontalAlignment="Center"
             Orientation="Horizontal"
-            Visibility="{c:Binding EnableRunDurationLimit}">
+            Visibility="{c:Binding RunDurationLimitActive}">
             <hc:NumericUpDown
                 Margin="5"
                 hc:InfoElement.Title="{DynamicResource RunDurationLimitMinutes}"
@@ -269,6 +273,6 @@
             HorizontalAlignment="Center"
             Content="{DynamicResource RunDurationLimitExecutePostActions}"
             IsChecked="{Binding RunDurationLimitExecutePostActions}"
-            Visibility="{c:Binding EnableRunDurationLimit}" />
+            Visibility="{c:Binding RunDurationLimitActive}" />
     </StackPanel>
 </UserControl>

--- a/src/MaaWpfGui/Views/UserControl/Settings/GameSettingsUserControl.xaml
+++ b/src/MaaWpfGui/Views/UserControl/Settings/GameSettingsUserControl.xaml
@@ -249,8 +249,7 @@
                 IsChecked="{Binding EnableRunDurationLimit}"
                 IsEnabled="{Binding Idle, Source={x:Static ui_vms:TaskQueueViewModel.TaskSettingDataContext}}"
                 MouseRightButtonUp="{s:Action ToggleCheckBoxNullOnRightClick,
-                                              Target={x:Type helper:CheckBoxHelper}}"
-                ToolTip="{DynamicResource CheckBoxesNotSavedAsNull}" />
+                                              Target={x:Type helper:CheckBoxHelper}}" />
             <controls:TooltipBlock
                 Margin="0,10"
                 VerticalAlignment="Center"


### PR DESCRIPTION
- 设置中新增「限制单次运行时长」，从 Link Start 开始计时，到达上限后停止任务
- 开启「战斗结束前延迟停止」时，等待肉鸽战斗结束后再停止
- 可选停止后执行「完成后动作设置」中的动作（默认开启），结束脚本只执行一次
- 单独肉鸽任务停止必须得改Core了，不然就是callback开始计时，ui做stop操作

close #3658

## Sourcery 摘要

添加可选的运行时长限制，自动停止任务，并协调延迟停止和完成操作。

新功能：
- 添加可配置的单次运行时长限制，支持自动停止任务以及可选的完成后操作。
- 在进行配置后，支持将时长限制触发的停止操作延迟到 roguelike 战斗结束。

增强功能：
- 确保时长限制处理会清除并使用每个截止时间一次，避免重复执行完成脚本，并在运行已结束或重新开始时跳过停止操作。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

添加可选的运行时长限制，以安全地停止任务，并协调延迟的 roguelike 停止与完成操作。

新功能：
- 添加可配置的单次运行时长限制，在达到所选时间后自动停止任务。
- 允许运行时长限制触发的停止操作等待当前 roguelike 战斗结束，并可选择执行完成后的操作。

错误修复：
- 防止在运行自然结束、手动停止，或延迟停止待处理期间开始新运行时，重复执行完成脚本和后续操作。

改进：
- 在游戏设置界面和支持的本地化语言中公开并验证运行时长限制设置。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

添加可选的单次运行时长限制并支持协调停止、肉鸽战斗延迟处理和完成后操作。

新功能：
- 添加可配置的单次运行时长限制，在达到所选时间后自动停止任务。
- 允许时长限制触发的停止操作等待当前肉鸽战斗结束，并可选择运行完成后操作。

错误修复：
- 防止运行自然结束、手动停止或在延迟停止期间发生变更时，重复执行完成脚本和完成后操作。

改进：
- 在游戏设置中显示并验证运行时长限制及相关选项，并提供本地化标签。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

新增可配置的运行时长限制，以安全地停止任务，并协调延迟停止 Roguelike 与完成操作。

新功能：
- 新增可配置的单次运行时长限制，在达到所选时间后自动停止任务。
- 支持选择是否等待 Roguelike 战斗结束后再停止，以及是否在完成后执行操作。

错误修复：
- 防止运行自然结束、手动停止或在延迟停止等待期间状态发生变化时，重复执行完成脚本和完成后操作。

增强功能：
- 在游戏设置界面中公开、验证、持久化并本地化运行时长限制设置。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

添加可配置的运行时长限制，以安全地停止任务，同时协调延迟的 roguelike 停止操作和完成操作。

新功能：
- 添加可配置的单次运行时长限制，自动停止任务，并可选择执行完成后的操作。
- 允许时长限制触发的停止操作等待当前 roguelike 战斗结束。

Bug 修复：
- 防止运行自然结束、手动停止，或在延迟停止待处理期间状态发生变化时，重复处理停止操作和完成操作。

增强功能：
- 在游戏设置界面中提供、验证、持久化并本地化新的运行时长设置。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

新增可配置的运行时长限制，并协调任务停止与完成处理。

新功能：
- 新增可配置的单次运行时长限制，可自动停止任务，并可选择执行完成后操作。
- 允许时长限制触发的停止操作等待当前 roguelike 战斗结束。

错误修复：
- 防止自动、手动或自然任务终止路径重叠时重复处理停止操作和完成操作。

增强功能：
- 在游戏设置界面中公开、验证、持久化并本地化新的运行时长设置。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add configurable runtime duration limits with coordinated task stopping and completion handling.

New Features:
- Add configurable per-run duration limits that automatically stop tasks and optionally execute post-completion actions.
- Allow duration-limit stops to wait until the current roguelike combat ends.

Bug Fixes:
- Prevent duplicate stop handling and completion actions when automatic, manual, or natural task termination paths overlap.

Enhancements:
- Expose, validate, persist, and localize the new runtime duration settings in the game settings UI.

</details>

</details>

</details>

</details>

</details>

</details>