### PR TITLE
docs: 调换更换主题与其他的文档顺序

### DIFF
--- a/docs/en-us/manual/introduction/others.md
+++ b/docs/en-us/manual/introduction/others.md
@@ -1,5 +1,5 @@
 ---
-order: 13
+order: 14
 icon: icon-park-solid:other
 ---
 

--- a/docs/en-us/manual/introduction/switch-theme.md
+++ b/docs/en-us/manual/introduction/switch-theme.md
@@ -1,5 +1,5 @@
 ---
-order: 14
+order: 13
 icon: mdi:theme-light-dark
 ---
 

--- a/docs/ja-jp/manual/introduction/others.md
+++ b/docs/ja-jp/manual/introduction/others.md
@@ -1,5 +1,5 @@
 ---
-order: 13
+order: 14
 icon: icon-park-solid:other
 ---
 

--- a/docs/ja-jp/manual/introduction/switch-theme.md
+++ b/docs/ja-jp/manual/introduction/switch-theme.md
@@ -1,5 +1,5 @@
 ---
-order: 14
+order: 13
 icon: mdi:theme-light-dark
 ---
 

--- a/docs/ko-kr/manual/introduction/others.md
+++ b/docs/ko-kr/manual/introduction/others.md
@@ -1,5 +1,5 @@
 ---
-order: 13
+order: 14
 icon: icon-park-solid:other
 ---
 

--- a/docs/ko-kr/manual/introduction/switch-theme.md
+++ b/docs/ko-kr/manual/introduction/switch-theme.md
@@ -1,5 +1,5 @@
 ---
-order: 14
+order: 13
 icon: mdi:theme-light-dark
 ---
 

--- a/docs/zh-cn/manual/introduction/others.md
+++ b/docs/zh-cn/manual/introduction/others.md
@@ -1,5 +1,5 @@
 ---
-order: 13
+order: 14
 icon: icon-park-solid:other
 ---
 

--- a/docs/zh-cn/manual/introduction/switch-theme.md
+++ b/docs/zh-cn/manual/introduction/switch-theme.md
@@ -1,5 +1,5 @@
 ---
-order: 14
+order: 13
 icon: mdi:theme-light-dark
 ---
 

--- a/docs/zh-tw/manual/introduction/others.md
+++ b/docs/zh-tw/manual/introduction/others.md
@@ -1,5 +1,5 @@
 ---
-order: 13
+order: 14
 icon: icon-park-solid:other
 ---
 

--- a/docs/zh-tw/manual/introduction/switch-theme.md
+++ b/docs/zh-tw/manual/introduction/switch-theme.md
@@ -1,5 +1,5 @@
 ---
-order: 14
+order: 13
 icon: mdi:theme-light-dark
 ---
 


### PR DESCRIPTION
~~这更换主题排在其他后面真的越看越变扭~~

## Sourcery 总结

文档：
- 在所有本地化手册中，将主题切换指南置于杂项指南之前。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Documentation:
- Prioritize the theme-switching guide before the miscellaneous guide across all localized manuals.

</details>