### PR TITLE
docs: 将更换主题移至更新数据之后

### DIFF
--- a/docs/en-us/manual/introduction/copilot.md
+++ b/docs/en-us/manual/introduction/copilot.md
@@ -1,5 +1,5 @@
 ---
-order: 11
+order: 12
 icon: ph:sword-bold
 ---
 

--- a/docs/en-us/manual/introduction/others.md
+++ b/docs/en-us/manual/introduction/others.md
@@ -1,5 +1,5 @@
 ---
-order: 13
+order: 14
 icon: icon-park-solid:other
 ---
 

--- a/docs/en-us/manual/introduction/switch-theme.md
+++ b/docs/en-us/manual/introduction/switch-theme.md
@@ -1,5 +1,5 @@
 ---
-order: 14
+order: 11
 icon: mdi:theme-light-dark
 ---
 

--- a/docs/en-us/manual/introduction/tools.md
+++ b/docs/en-us/manual/introduction/tools.md
@@ -1,5 +1,5 @@
 ---
-order: 12
+order: 13
 icon: octicon:tools-16
 ---
 

--- a/docs/ja-jp/manual/introduction/copilot.md
+++ b/docs/ja-jp/manual/introduction/copilot.md
@@ -1,5 +1,5 @@
 ---
-order: 11
+order: 12
 icon: ph:sword-bold
 ---
 

--- a/docs/ja-jp/manual/introduction/others.md
+++ b/docs/ja-jp/manual/introduction/others.md
@@ -1,5 +1,5 @@
 ---
-order: 13
+order: 14
 icon: icon-park-solid:other
 ---
 

--- a/docs/ja-jp/manual/introduction/switch-theme.md
+++ b/docs/ja-jp/manual/introduction/switch-theme.md
@@ -1,5 +1,5 @@
 ---
-order: 14
+order: 11
 icon: mdi:theme-light-dark
 ---
 

--- a/docs/ja-jp/manual/introduction/tools.md
+++ b/docs/ja-jp/manual/introduction/tools.md
@@ -1,5 +1,5 @@
 ---
-order: 12
+order: 13
 icon: octicon:tools-16
 ---
 

--- a/docs/ko-kr/manual/introduction/copilot.md
+++ b/docs/ko-kr/manual/introduction/copilot.md
@@ -1,5 +1,5 @@
 ---
-order: 11
+order: 12
 icon: ph:sword-bold
 ---
 

--- a/docs/ko-kr/manual/introduction/others.md
+++ b/docs/ko-kr/manual/introduction/others.md
@@ -1,5 +1,5 @@
 ---
-order: 13
+order: 14
 icon: icon-park-solid:other
 ---
 

--- a/docs/ko-kr/manual/introduction/switch-theme.md
+++ b/docs/ko-kr/manual/introduction/switch-theme.md
@@ -1,5 +1,5 @@
 ---
-order: 14
+order: 11
 icon: mdi:theme-light-dark
 ---
 

--- a/docs/ko-kr/manual/introduction/tools.md
+++ b/docs/ko-kr/manual/introduction/tools.md
@@ -1,5 +1,5 @@
 ---
-order: 12
+order: 13
 icon: octicon:tools-16
 ---
 

--- a/docs/zh-cn/manual/introduction/copilot.md
+++ b/docs/zh-cn/manual/introduction/copilot.md
@@ -1,5 +1,5 @@
 ---
-order: 11
+order: 12
 icon: ph:sword-bold
 ---
 

--- a/docs/zh-cn/manual/introduction/others.md
+++ b/docs/zh-cn/manual/introduction/others.md
@@ -1,5 +1,5 @@
 ---
-order: 13
+order: 14
 icon: icon-park-solid:other
 ---
 

--- a/docs/zh-cn/manual/introduction/switch-theme.md
+++ b/docs/zh-cn/manual/introduction/switch-theme.md
@@ -1,5 +1,5 @@
 ---
-order: 14
+order: 11
 icon: mdi:theme-light-dark
 ---
 

--- a/docs/zh-cn/manual/introduction/tools.md
+++ b/docs/zh-cn/manual/introduction/tools.md
@@ -1,5 +1,5 @@
 ---
-order: 12
+order: 13
 icon: octicon:tools-16
 ---
 

--- a/docs/zh-tw/manual/introduction/copilot.md
+++ b/docs/zh-tw/manual/introduction/copilot.md
@@ -1,5 +1,5 @@
 ---
-order: 11
+order: 12
 icon: ph:sword-bold
 ---
 

--- a/docs/zh-tw/manual/introduction/others.md
+++ b/docs/zh-tw/manual/introduction/others.md
@@ -1,5 +1,5 @@
 ---
-order: 13
+order: 14
 icon: icon-park-solid:other
 ---
 

--- a/docs/zh-tw/manual/introduction/switch-theme.md
+++ b/docs/zh-tw/manual/introduction/switch-theme.md
@@ -1,5 +1,5 @@
 ---
-order: 14
+order: 11
 icon: mdi:theme-light-dark
 ---
 

--- a/docs/zh-tw/manual/introduction/tools.md
+++ b/docs/zh-tw/manual/introduction/tools.md
@@ -1,5 +1,5 @@
 ---
-order: 12
+order: 13
 icon: octicon:tools-16
 ---
 


### PR DESCRIPTION
~~真的没人觉得这更换主题放在其他下面很诡异么~~

| 修改前 | 修改后 |
| --- | --- |
| <img width="240" alt="修改前" src="https://github.com/user-attachments/assets/7f74a635-2b8f-4fc8-b7de-40bd837ae1e7" /> | <img width="240" alt="修改后" src="https://github.com/user-attachments/assets/b398b843-8467-4afe-8f55-528a9edee282" /> |

## Sourcery 摘要

将主题切换指南移到其他入门主题之前，以改善文档导航。

增强功能：
- 重新排列入门文档页面的顺序，使主题切换指南在所有受支持的语言中都位于Copilot、工具和其他主题之前。

文档：
- 在英文、日文、韩文、简体中文和繁体中文文档中，统一更新本地化入门指南的导航顺序。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Move the theme-switching guide ahead of the other introductory topics to improve documentation navigation.

Enhancements:
- Reorder the introductory documentation pages so the theme-switching guide appears before the Copilot, tools, and other topics across all supported languages.

Documentation:
- Update the navigation order of localized introduction guides consistently across English, Japanese, Korean, Simplified Chinese, and Traditional Chinese documentation.

</details>