### PR TITLE
fix: 公招未勾选自动确认 3/4 星时仍会确认

### DIFF
--- a/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/AutoRecruitTask.cpp
@@ -688,15 +688,13 @@ asst::AutoRecruitTask::calc_task_result_type asst::AutoRecruitTask::recruit_calc
         if (!is_calc_only_task()) {
             if (!(has_skip_tag || has_special_tag)) {
                 // do not confirm 3 star, force skip
-                if (!is_confirm_level_valid(3) && final_combination.min_level == 3 &&
-                    !is_select_level_valid(final_combination.min_level)) {
+                if (!is_confirm_level_valid(3) && final_combination.min_level == 3) {
                     calc_task_result_type result(calc_task_result::force_skip);
                     return result;
                 }
             }
             // do not confirm 4 star
-            if (!is_confirm_level_valid(4) && final_combination.min_level == 4 &&
-                !is_select_level_valid(final_combination.min_level)) {
+            if (!is_confirm_level_valid(4) && final_combination.min_level == 4) {
                 calc_task_result_type result(calc_task_result::force_skip);
                 return result;
             }


### PR DESCRIPTION
#18087  日志中的任务参数为 `"select":[4,5], "confirm":[3]`，识别到 4★ 词条后仍点击了 `RecruitConfirm`
confirm 只有 [3] 的情况还会去确认4星的不符合语义

close #18087

## 影响范围

- WPF：4星 的 `select` / `confirm` 始终一致，3星 从不进入 `select`，旧条件中的 `select` 判断恒为真，行为不变
- Mac：未勾选「自动确认 4 星」时，保底 4星 的槽位会被跳过，不计入招募次数
- 小工具公招识别 `confirm:[-1]` 不经过该逻辑，不受影响
- 直接调用接口的客户端：`select` 含某星级而 `confirm` 不含时不再确认，与文档一致

## Sourcery 总结

错误修复：
- 当未启用相应的确认等级时，禁止对 3 星或 4 星结果进行招募确认。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Prevent recruitment confirmation for 3- or 4-star results when the corresponding confirmation level is not enabled.

</details>