### PR TITLE
fix: Windows 下连接局域网设备时 RawByNc 不可用

### DIFF
--- a/src/MaaCore/Controller/Platform/Win32IO.cpp
+++ b/src/MaaCore/Controller/Platform/Win32IO.cpp
@@ -401,30 +401,45 @@ std::optional<unsigned short> asst::Win32IO::init_socket(const std::string& loca
     if (err == SOCKET_ERROR) {
         err = WSAGetLastError();
         Log.error("failed to resolve AcceptEx, err:", err);
-        ::closesocket(m_server_sock);
+        close_socket();
         return std::nullopt;
     }
+
+    m_server_sock_addr = {};
     m_server_sock_addr.sin_family = PF_INET;
-    ::inet_pton(AF_INET, local_address.c_str(), &m_server_sock_addr.sin_addr);
+    if (::inet_pton(AF_INET, local_address.c_str(), &m_server_sock_addr.sin_addr) != 1) {
+        m_server_sock_addr.sin_addr.s_addr = ::htonl(INADDR_ANY);
+    }
 
     bool server_start = false;
     uint16_t port_result = 0;
 
     m_server_sock_addr.sin_port = ::htons(0);
     int bind_ret = ::bind(m_server_sock, reinterpret_cast<SOCKADDR*>(&m_server_sock_addr), sizeof(SOCKADDR));
+    if (bind_ret != 0 && m_server_sock_addr.sin_addr.s_addr != ::htonl(INADDR_ANY)) {
+        // local_address is not on this machine (e.g. a device connected over LAN), listen on all interfaces instead
+        err = WSAGetLastError();
+        Log.warn("failed to bind", local_address, ", err:", err, ", fallback to INADDR_ANY");
+        close_socket();
+        return init_socket("0.0.0.0");
+    }
     int addrlen = sizeof(m_server_sock_addr);
     int getname_ret = ::getsockname(m_server_sock, reinterpret_cast<sockaddr*>(&m_server_sock_addr), &addrlen);
     int listen_ret = ::listen(m_server_sock, 3);
     server_start = bind_ret == 0 && getname_ret == 0 && listen_ret == 0;
 
     if (!server_start) {
-        Log.info("not supports socket");
+        err = WSAGetLastError();
+        Log.info("not supports socket, err:", err);
+        close_socket();
         return std::nullopt;
     }
 
     port_result = ::ntohs(m_server_sock_addr.sin_port);
 
-    Log.info("command server start", local_address, port_result);
+    char bound_address[INET_ADDRSTRLEN] = {};
+    ::inet_ntop(AF_INET, &m_server_sock_addr.sin_addr, bound_address, sizeof(bound_address));
+    Log.info("command server start", bound_address, port_result);
     return port_result;
 }
 

--- a/src/MaaCore/Controller/Platform/Win32IO.cpp
+++ b/src/MaaCore/Controller/Platform/Win32IO.cpp
@@ -411,12 +411,19 @@ std::optional<unsigned short> asst::Win32IO::init_socket(const std::string& loca
         m_server_sock_addr.sin_addr.s_addr = ::htonl(INADDR_ANY);
     }
 
-    bool server_start = false;
-    uint16_t port_result = 0;
+    // capture the error right after the failed call, before logging may overwrite it
+    auto socket_failed = [&](const char* step) -> std::optional<unsigned short> {
+        int last_err = WSAGetLastError();
+        Log.info("not supports socket,", step, "failed, err:", last_err);
+        close_socket();
+        return std::nullopt;
+    };
 
     m_server_sock_addr.sin_port = ::htons(0);
-    int bind_ret = ::bind(m_server_sock, reinterpret_cast<SOCKADDR*>(&m_server_sock_addr), sizeof(SOCKADDR));
-    if (bind_ret != 0 && m_server_sock_addr.sin_addr.s_addr != ::htonl(INADDR_ANY)) {
+    if (::bind(m_server_sock, reinterpret_cast<SOCKADDR*>(&m_server_sock_addr), sizeof(SOCKADDR)) != 0) {
+        if (m_server_sock_addr.sin_addr.s_addr == ::htonl(INADDR_ANY)) {
+            return socket_failed("bind");
+        }
         // local_address is not on this machine (e.g. a device connected over LAN), listen on all interfaces instead
         err = WSAGetLastError();
         Log.warn("failed to bind", local_address, ", err:", err, ", fallback to INADDR_ANY");
@@ -424,18 +431,14 @@ std::optional<unsigned short> asst::Win32IO::init_socket(const std::string& loca
         return init_socket("0.0.0.0");
     }
     int addrlen = sizeof(m_server_sock_addr);
-    int getname_ret = ::getsockname(m_server_sock, reinterpret_cast<sockaddr*>(&m_server_sock_addr), &addrlen);
-    int listen_ret = ::listen(m_server_sock, 3);
-    server_start = bind_ret == 0 && getname_ret == 0 && listen_ret == 0;
-
-    if (!server_start) {
-        err = WSAGetLastError();
-        Log.info("not supports socket, err:", err);
-        close_socket();
-        return std::nullopt;
+    if (::getsockname(m_server_sock, reinterpret_cast<sockaddr*>(&m_server_sock_addr), &addrlen) != 0) {
+        return socket_failed("getsockname");
+    }
+    if (::listen(m_server_sock, 3) != 0) {
+        return socket_failed("listen");
     }
 
-    port_result = ::ntohs(m_server_sock_addr.sin_port);
+    uint16_t port_result = ::ntohs(m_server_sock_addr.sin_port);
 
     char bound_address[INET_ADDRSTRLEN] = {};
     ::inet_ntop(AF_INET, &m_server_sock_addr.sin_addr, bound_address, sizeof(bound_address));


### PR DESCRIPTION
close #17150

Windows 下 ADB 连接局域网设备（非本机模拟器）时，`AdbController` 把 ADB 地址的 host 当作 socket server 的 bind 地址`Win32IO::init_socket` 去 bind 远端设备 IP 直接就失败了，RawByNc 被直接判为不支持，`PosixIO` 直接 bind `INADDR_ANY` 没这个问题

## Sourcery 摘要

通过在设备主机地址无法在本地使用时使用有效的本地监听地址，为远程 ADB 设备启用 Windows RawByNc 连接。

错误修复：
- 修复 Windows ADB 连接对可通过局域网访问的设备的 RawByNc 支持：当无法绑定远程设备地址时，改为监听所有本地接口。

增强功能：
- 改进 Windows 套接字初始化清理、错误报告和启动日志记录。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

为局域网连接的 ADB 设备启用可靠的 Windows RawByNc 连接。

错误修复：
- 当设备地址无法在本地绑定时，通过回退到监听所有本地接口，为远程 ADB 设备启用 Windows RawByNc 连接。

改进：
- 改进 Windows 套接字初始化清理、失败报告以及命令服务器启动日志记录。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable reliable Windows RawByNc connectivity for LAN-connected ADB devices.

Bug Fixes:
- Enable Windows RawByNc connections for remote ADB devices by falling back to listening on all local interfaces when the device address cannot be bound locally.

Enhancements:
- Improve Windows socket initialization cleanup, failure reporting, and command-server startup logging.

</details>

</details>