### PR TITLE
feat: 新增本地图片离线识别评估工具

### DIFF
--- a/.agents/skills/core-image-eval/SKILL.md
+++ b/.agents/skills/core-image-eval/SKILL.md
@@ -10,7 +10,8 @@ description: 用 MaaCore 本体对本地图片（用户日志反馈包截图、�
 ## 前置条件
 
 - MaaCore Debug 构建：默认取 `build/bin/Debug/MaaCore.dll`，没有则 `cmake --build build --target MaaCore --config Debug`。
-- 资源根默认仓库根（`AsstLoadResource` 语义：其下找 `resource/`）；国际服 `--global YoStarJP`（分服 OCR 模型随之加载）。
+- 资源根默认仓库根（`AsstLoadResource` 语义：其下找 `resource/`）；外服加 `--global YoStarJP` / `YoStarEN` / `YoStarKR` / `txwy` —— 分服的 OCR 模型、模板与任务定义随资源叠加切换，识别即切到对应服。
+- `depot` 模式的模板涂黑处理依赖 Pillow（`pip install pillow`）。
 - Debug 构建日志会镜像 stdout，过滤干扰行用 `grep -v "^\[2026"`；完整日志在 user_dir 的 `debug/asst.log`。
 
 ## CLI 用法（人工快速验证）
@@ -36,7 +37,7 @@ python tools/maa_core_eval.py --mode depot [--templates "2001,..."] 图.png
 import sys; sys.path.insert(0, "tools")
 from maa_core_eval import CoreEval
 
-ev = CoreEval(global_client="YoStarJP")   # 国服默认 CoreEval()
+ev = CoreEval(global_client="YoStarJP")   # 默认国服用 CoreEval()，本例为日服
 ev.report(images=["1.png"], tasks=["TaskA"])
 ev.pipeline(images=["1.png"], tasks=["A", "B"])   # 返回含 next，可自行驱动链
 ev.ocr(images=["1.png"], roi=[100, 200, 300, 50])

--- a/.agents/skills/core-image-eval/SKILL.md
+++ b/.agents/skills/core-image-eval/SKILL.md
@@ -12,7 +12,7 @@ description: 用 MaaCore 本体对本地图片（用户日志反馈包截图、�
 - MaaCore Debug 构建：默认取 `build/bin/Debug/MaaCore.dll`，没有则 `cmake --build build --target MaaCore --config Debug`。
 - 资源根默认仓库根（`AsstLoadResource` 语义：其下找 `resource/`）；外服加 `--global YoStarJP` / `YoStarEN` / `YoStarKR` / `txwy` —— 分服的 OCR 模型、模板与任务定义随资源叠加切换，识别即切到对应服。
 - `depot` 模式的模板涂黑处理依赖 Pillow（`pip install pillow`）。
-- Debug 构建日志会镜像 stdout，过滤干扰行用 `grep -v "^\[2026"`；完整日志在 user_dir 的 `debug/asst.log`。
+- Debug 构建日志会镜像 stdout，过滤干扰行用 `grep -v '^\[[0-9]\{4\}-'`；完整日志在 user_dir 的 `debug/asst.log`。
 
 ## CLI 用法（人工快速验证）
 
@@ -50,11 +50,13 @@ ev.close()
 
 ## 关键语义
 
-- **report**：JustReturn 任务恒命中（`score=0`、`rect=[0,0,0,0]` 是其特征不是 bug）；未命中的任务只报 miss，最高分等细节看 `asst.log` 的 `match_templ` trace。
-- **templ**：内部阈值放开，恒报最佳得分，hit 由 `threshold` 判定；`task` 参数让 Matcher 的 maskRange/colorScales/method 取自该任务（复刻线上自定义识别器的关键），`resize` 在 core 侧 INTER_AREA 缩放（数值敏感预处理别在 python 做）。
-- **depot**：`depot_items` 的复刻要点是模板右下 80x50 涂黑 + `resize` 到 `DepotMatchData` 的 roi + `task="DepotMatchData"`（其 maskRange 排除数量角标）；数量识别不在复刻内。
-- 图片自动 INTER_AREA 归一到 1280x720（与线上截图缩放一致），识别不受历史 rect 缓存污染。
+- **report**：JustReturn 任务恒命中，结果的 `algorithm` 字段标注了任务算法（JustReturn 时 score=0、rect=[0,0,0,0]，不是 bug）；未命中的任务只报 miss，最高分等细节看 `asst.log` 的 `match_templ` trace。
+- **templ**：内部阈值放开，恒报最佳得分，hit 由 `threshold` 判定（缺省取 `task` 任务的阈值）；`task` 参数让 Matcher 的 maskRange/colorScales/method 取自该任务（复刻线上自定义识别器的关键），`resize` 在 core 侧 INTER_AREA 缩放（数值敏感预处理别在 python 做）；返回 error 表示输入问题（模板缺失/模板大于 roi 等），不存在正常的 ｢无结果｣。
+- **depot**：`depot_items` 复刻的是｢单个模板的匹配行为｣，不是线上完整的选物逻辑 —— 线上 DepotImageAnalyzer 逐格匹配、按颜色筛候选并受材料顺序约束，本工具是整张图对全部 MATERIAL 候选各取全图最佳；所以它适合验证 ｢某模板在某图上的分数｣，不能直接等同线上会认出的物品清单。复刻要点：模板右下 80x50 涂黑 + `resize` 到 `DepotMatchData` 的 roi + `task="DepotMatchData"`（其 maskRange 排除数量角标）；数量识别不在复刻内。
+- 评估不带实例，`cache: true` 的任务不会命中 rect 缓存，结果相当于线上 ｢第一次识别｣；线上后续识别被限制在缓存 rect 内，若怀疑缓存导致的线上偏差，注意这一差异。
+- 图片自动 INTER_AREA 归一到 1280x720（与线上截图缩放一致；非 16:9 的图会被拉伸并打 warn，结果与该分辨率的线上行为不可比），识别不受历史 rect 缓存污染。
 - 连着模拟器要在线验证任务流（含点击 action）用 Custom 任务，本工具只做离线图片评估。
+- 仅支持 Windows（`ctypes.WinDLL` + `MaaCore.dll`）；`AsstLoadResource` 是进程级的 —— 同一进程先建日服 `CoreEval` 再建国服的，日服资源叠加不会撤掉，需要分服独立评估请分开进程跑。
 
 ## 排查套路
 

--- a/.agents/skills/core-image-eval/SKILL.md
+++ b/.agents/skills/core-image-eval/SKILL.md
@@ -26,7 +26,7 @@ python tools/maa_core_eval.py --mode pipeline --tasks "TaskA" 图.png
 # 图片序列按 next 链推进（纯识别，不执行 action）
 python tools/maa_core_eval.py --mode replay --tasks "TaskA" 1.png 2.png 3.png
 # 裸模板匹配（物品图标等非任务模板；支持目录全量）
-python tools/maa_core_eval.py --mode templ --templates "2001,items/xxx.png,items" 图.png
+python tools/maa_core_eval.py --mode templ [--task 任务名] [--resize w,h] --templates "2001,items/xxx.png,items" 图.png
 # 仓库物品匹配（复刻线上 DepotImageAnalyzer 预处理）
 python tools/maa_core_eval.py --mode depot [--templates "2001,..."] 图.png
 ```
@@ -51,7 +51,8 @@ ev.close()
 ## 关键语义
 
 - **report**：JustReturn 任务恒命中，结果的 `algorithm` 字段标注了任务算法（JustReturn 时 score=0、rect=[0,0,0,0]，不是 bug）；未命中的任务只报 miss，最高分等细节看 `asst.log` 的 `match_templ` trace。
-- **templ**：内部阈值放开，恒报最佳得分，hit 由 `threshold` 判定（缺省取 `task` 任务的阈值）；`task` 参数让 Matcher 的 maskRange/colorScales/method 取自该任务（复刻线上自定义识别器的关键），`resize` 在 core 侧 INTER_AREA 缩放（数值敏感预处理别在 python 做）；返回 error 表示输入问题（模板缺失/模板大于 roi 等），不存在正常的 ｢无结果｣。
+- **pipeline**：命中详情在 `result` 字段（`task` 为完整任务名含 `@` 前缀），`next` 为命中任务的 next 列表；replay 即靠 `next` 逐图推进。
+- **templ**：内部阈值放开，恒报最佳得分，hit 由 `threshold` 判定（缺省取 `task` 任务的阈值，无 `task` 时 0.8）；`task` 参数让 Matcher 的 maskRange/colorScales/method 取自该任务，任务的 roi 同样生效（不传 `roi` 时识别区域即任务 roi；复刻线上自定义识别器的关键），`resize` 在 core 侧先归一 1280x720 再 INTER_AREA 缩放（两级与线上截图缩放链一致，数值敏感预处理别在 python 做）；返回 error 表示输入问题（模板缺失/模板大于 roi 等），不存在正常的 ｢无结果｣。
 - **depot**：`depot_items` 复刻的是｢单个模板的匹配行为｣，不是线上完整的选物逻辑 —— 线上 DepotImageAnalyzer 逐格匹配、按颜色筛候选并受材料顺序约束，本工具是整张图对全部 MATERIAL 候选各取全图最佳；所以它适合验证 ｢某模板在某图上的分数｣，不能直接等同线上会认出的物品清单。复刻要点：模板右下 80x50 涂黑 + `resize` 到 `DepotMatchData` 的 roi + `task="DepotMatchData"`（其 maskRange 排除数量角标）；数量识别不在复刻内。
 - 评估不带实例，`cache: true` 的任务不会命中 rect 缓存，结果相当于线上 ｢第一次识别｣；线上后续识别被限制在缓存 rect 内，若怀疑缓存导致的线上偏差，注意这一差异。
 - 图片自动 INTER_AREA 归一到 1280x720（与线上截图缩放一致；非 16:9 的图会被拉伸并打 warn，结果与该分辨率的线上行为不可比），识别不受历史 rect 缓存污染。

--- a/.agents/skills/core-image-eval/SKILL.md
+++ b/.agents/skills/core-image-eval/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: core-image-eval
+description: 用 MaaCore 本体对本地图片（用户日志反馈包截图、自己截的图）离线验证识别结果：pipeline 任务为什么没命中、模板匹配得分多少、OCR 认出了什么、物品模板匹配情况。用户提到 ｢验证识别｣｢为什么没识别/没命中｣｢模板分数/得分｣｢OCR 结果对不对｣｢排查反馈包截图｣或给了截图要复现 core 行为时使用。与外部脚本（python 直调 ppocr/OpenCV）的区别：本工具走 core 完整链路（前处理、ocrReplace、mask、各服 OCR 模型），结果与运行时一致。
+---
+
+# MaaCore 本地图片离线评估
+
+工具是 `tools/maa_core_eval.py`（自包含 ctypes 模块，可 import 也可 CLI）。core 侧入口为 `DebugTask` 参数化（`AsstAppendTask(handle, "Debug", params)`），仅 **Debug 构建** 的 MaaCore.dll 可用。
+
+## 前置条件
+
+- MaaCore Debug 构建：默认取 `build/bin/Debug/MaaCore.dll`，没有则 `cmake --build build --target MaaCore --config Debug`。
+- 资源根默认仓库根（`AsstLoadResource` 语义：其下找 `resource/`）；国际服 `--global YoStarJP`（分服 OCR 模型随之加载）。
+- Debug 构建日志会镜像 stdout，过滤干扰行用 `grep -v "^\[2026"`；完整日志在 user_dir 的 `debug/asst.log`。
+
+## CLI 用法（人工快速验证）
+
+```bash
+# 任务命中评估（hit/score/box/OCR 文本）
+python tools/maa_core_eval.py --mode report --tasks "TaskA,TaskB" 图.png
+# OCR 原始识别文本（不套 ocrReplace/expected）
+python tools/maa_core_eval.py --mode ocr [--roi x,y,w,h] 图.png
+# 首命中 + next 列表（线上 find_first 同款）
+python tools/maa_core_eval.py --mode pipeline --tasks "TaskA" 图.png
+# 图片序列按 next 链推进（纯识别，不执行 action）
+python tools/maa_core_eval.py --mode replay --tasks "TaskA" 1.png 2.png 3.png
+# 裸模板匹配（物品图标等非任务模板；支持目录全量）
+python tools/maa_core_eval.py --mode templ --templates "2001,items/xxx.png,items" 图.png
+# 仓库物品匹配（复刻线上 DepotImageAnalyzer 预处理）
+python tools/maa_core_eval.py --mode depot [--templates "2001,..."] 图.png
+```
+
+## Agent 编程用法（写脚本组合调用）
+
+```python
+import sys; sys.path.insert(0, "tools")
+from maa_core_eval import CoreEval
+
+ev = CoreEval(global_client="YoStarJP")   # 国服默认 CoreEval()
+ev.report(images=["1.png"], tasks=["TaskA"])
+ev.pipeline(images=["1.png"], tasks=["A", "B"])   # 返回含 next，可自行驱动链
+ev.ocr(images=["1.png"], roi=[100, 200, 300, 50])
+ev.templ(images=["1.png"], templates=["2001"], task="DepotMatchData", resize=[1066, 599])
+ev.replay(images=["1.png", "2.png"], tasks=["A"])
+ev.close()
+```
+
+返回均为 list[dict]，字段见各方法 docstring。
+
+## 关键语义
+
+- **report**：JustReturn 任务恒命中（`score=0`、`rect=[0,0,0,0]` 是其特征不是 bug）；未命中的任务只报 miss，最高分等细节看 `asst.log` 的 `match_templ` trace。
+- **templ**：内部阈值放开，恒报最佳得分，hit 由 `threshold` 判定；`task` 参数让 Matcher 的 maskRange/colorScales/method 取自该任务（复刻线上自定义识别器的关键），`resize` 在 core 侧 INTER_AREA 缩放（数值敏感预处理别在 python 做）。
+- **depot**：`depot_items` 的复刻要点是模板右下 80x50 涂黑 + `resize` 到 `DepotMatchData` 的 roi + `task="DepotMatchData"`（其 maskRange 排除数量角标）；数量识别不在复刻内。
+- 图片自动 INTER_AREA 归一到 1280x720（与线上截图缩放一致），识别不受历史 rect 缓存污染。
+- 连着模拟器要在线验证任务流（含点击 action）用 Custom 任务，本工具只做离线图片评估。
+
+## 排查套路
+
+1. ｢任务为什么没命中｣：report 该任务 → miss 时看 `asst.log` 里该模板的 `match_templ` 行（score 距阈值差多少）。
+2. ｢OCR 为什么没匹配 expected｣：`ocr` 看引擎原文，`report` 看经过 ocrReplace/expected 过滤后的结果，两者对比定位是识别问题还是替换表问题。
+3. ｢物品图标认成别的｣：`depot`（或 templ 指定多个候选物品）看各候选的分数差。

--- a/src/MaaCore/Common/AsstTypes.h
+++ b/src/MaaCore/Common/AsstTypes.h
@@ -437,6 +437,28 @@ struct FeatureMatchRect : public AnalyzerResult
 };
 } // namespace asst
 
+namespace json::ext
+{
+template <>
+class jsonization<asst::Rect>
+{
+public:
+    json::value to_json(const asst::Rect& t) const { return json::array { t.x, t.y, t.width, t.height }; }
+
+    bool check_json(const json::value& j) const { return j.is<std::array<int, 4>>(); }
+
+    bool from_json(const json::value& j, asst::Rect& out) const
+    {
+        const auto& arr = j.as<std::array<int, 4>>();
+        out.x = arr[0];
+        out.y = arr[1];
+        out.width = arr[2];
+        out.height = arr[3];
+        return true;
+    }
+};
+}
+
 namespace std
 {
 template <>

--- a/src/MaaCore/Common/AsstTypes.h
+++ b/src/MaaCore/Common/AsstTypes.h
@@ -457,7 +457,7 @@ public:
         return true;
     }
 };
-}
+} // namespace json::ext
 
 namespace std
 {

--- a/src/MaaCore/Task/Interface/DebugTask.cpp
+++ b/src/MaaCore/Task/Interface/DebugTask.cpp
@@ -77,6 +77,11 @@ std::optional<cv::Mat> resize_eval_image(cv::Mat image, int width, int height)
     return image;
 }
 
+json::array to_json_rect(const asst::Rect& rect)
+{
+    return json::array { rect.x, rect.y, rect.width, rect.height };
+}
+
 json::object to_result_json(const std::string& task_name, const asst::PipelineAnalyzer::ResultOpt& result_opt)
 {
     json::object result { { "task", task_name } };
@@ -103,7 +108,8 @@ json::object to_result_json(const std::string& task_name, const asst::PipelineAn
         const auto& r = std::get<asst::FeatureMatcher::Result>(result_var);
         result["count"] = r.count;
     }
-    result["rect"] = (json::value)result_opt->rect;
+    // Rect 没有 json 转换（AnalyzerResult 上的 operator 不覆盖独立的 Rect），用辅助函数展开
+    result["rect"] = to_json_rect(result_opt->rect);
     return result;
 }
 }
@@ -367,7 +373,7 @@ bool asst::DebugTask::image_test_ocr()
             if (results_opt) {
                 for (const auto& res : *results_opt) {
                     results.emplace_back(
-                        json::object { { "text", res.text }, { "score", res.score }, { "rect", (json::value)res.rect } });
+                        json::object { { "text", res.text }, { "score", res.score }, { "rect", to_json_rect(res.rect) } });
                 }
             }
             LogInfo << __FUNCTION__ << image_path << "ocr" << json::value(results).dumps();
@@ -442,7 +448,7 @@ bool asst::DebugTask::image_test_templ()
                 auto result_opt = analyzer.analyze();
                 if (result_opt) {
                     result["score"] = result_opt->score;
-                    result["rect"] = (json::value)result_opt->rect;
+                    result["rect"] = to_json_rect(result_opt->rect);
                     result["hit"] = result_opt->score >= m_eval_threshold;
                 }
                 else {

--- a/src/MaaCore/Task/Interface/DebugTask.cpp
+++ b/src/MaaCore/Task/Interface/DebugTask.cpp
@@ -31,10 +31,8 @@ asst::DebugTask::DebugTask(const AsstCallback& callback, Assistant* inst) :
 
 bool asst::DebugTask::run()
 {
-    std::string test = "[1,2,3,4]";
-    json::value test_json = json::parse(test);
-    LogInfo << "DebugTask run() called, test_json:" << test_json;
-    LogInfo << "DebugTask run() called, test_json:" << test_json.is<asst::Rect>();
+    // PackageTask::run 被覆盖，运行标记须自行置位，set_params 据此拒绝运行中更新
+    m_running = true;
 
     if (m_image_test_mode == "report") {
         return image_test_report();
@@ -53,9 +51,9 @@ bool asst::DebugTask::run()
 
 namespace
 {
-// 读取本地图片；normalize 为 true 时缩放到 1280x720（INTER_AREA），
-// 与线上 Controller::get_resized_image_cache 一致，调用方已自行预处理尺寸时传 false
-std::optional<cv::Mat> load_eval_image(const std::string& utf8_path, bool normalize)
+// 读取本地图片并缩放到 1280x720（INTER_AREA），与线上 Controller::get_resized_image_cache 一致；
+// 需要其他评估尺寸（如仓库识别的 1066x599）的先经此归一，再用 resize_eval_image 二级缩放
+std::optional<cv::Mat> load_eval_image(const std::string& utf8_path)
 {
     cv::Mat image = MAA_NS::imread(asst::utils::path(utf8_path));
     if (image.empty()) {
@@ -67,14 +65,14 @@ std::optional<cv::Mat> load_eval_image(const std::string& utf8_path, bool normal
         // 但结果与该分辨率的线上行为没有可比性
         LogWarn << __FUNCTION__ << "image is not 16:9, will be stretched to 1280x720:" << utf8_path;
     }
-    if (normalize && (image.cols != 1280 || image.rows != 720)) {
+    if (image.cols != 1280 || image.rows != 720) {
         cv::resize(image, image, { 1280, 720 }, 0, 0, cv::INTER_AREA);
     }
     return image;
 }
 
-// 可选的评估前缩放（INTER_AREA），供调用方复刻线上各识别器的尺度预处理
-std::optional<cv::Mat> resize_eval_image(cv::Mat image, int width, int height)
+// 归一后的二级缩放（INTER_AREA），复刻线上各识别器在 720p 截图基础上的尺度预处理
+cv::Mat resize_eval_image(cv::Mat image, int width, int height)
 {
     if (image.cols != width || image.rows != height) {
         cv::resize(image, image, { width, height }, 0, 0, cv::INTER_AREA);
@@ -118,10 +116,10 @@ json::object to_result_json(const std::string& task_name, const asst::PipelineAn
 // { "mode": "report" | "pipeline" | "ocr" | "templ", "images": [图片路径], "tasks": [任务名],
 //   "templates": [模板名], "task": "任务名", "roi": [x, y, w, h], "threshold": 0.8, "resize": [w, h] }
 // images/tasks/templates 为 UTF-8 路径与名字（模板名也接受绝对路径图片文件）；roi 仅 ocr/templ
-// 模式使用，缺省全图；task 仅 templ 模式使用（mask/method 等 Matcher 配置取自该任务，复刻线上
-// 自定义识别器的用法，未显式给 threshold 时 hit 判定也取该任务阈值）；threshold/resize 仅 templ
-// 模式使用（内部匹配放开阈值恒报最佳得分；resize 为评估前 INTER_AREA 缩放尺寸，替代默认的
-// 1280x720 归一）
+// 模式使用，缺省全图；task 仅 templ 模式使用（mask/method/roi 等 Matcher 配置取自该任务，
+// 显式传 roi 可覆盖任务 roi；未显式给 threshold 时 hit 判定也取该任务阈值）；threshold/resize
+// 仅 templ 模式使用（内部匹配放开阈值恒报最佳得分；resize 为 1280x720 归一后的二级 INTER_AREA
+// 缩放尺寸，复刻线上识别器的尺度预处理）
 bool asst::DebugTask::set_params(const json::value& params)
 {
     LogTraceFunction;
@@ -144,30 +142,28 @@ bool asst::DebugTask::set_params(const json::value& params)
 
 bool asst::DebugTask::set_params_impl(const json::value& params)
 {
-    m_image_test_mode = params.get("mode", "");
-    if (m_image_test_mode.empty()) {
+    auto mode = params.get("mode", "");
+    if (mode.empty()) {
         return true; // 无 mode 的 Debug 任务保持 run() 空跑的旧行为
     }
 
-    // AsstSetTaskParams 会对同一任务重复调用 set_params，先清空上次状态避免累积
-    m_eval_images.clear();
-    m_eval_tasks.clear();
-    m_eval_templates.clear();
-    m_eval_templ_task.clear();
-    m_eval_roi = Rect();
-    m_eval_threshold = 0.8;
-    m_eval_resize.reset();
+    // 全部解析校验通过后才写成员，AsstSetTaskParams 更新失败时任务保持原有完整参数
+    std::vector<std::string> images;
+    std::vector<std::string> tasks;
+    std::vector<std::string> templates;
+    std::string templ_task;
+    Rect roi;
+    double threshold = TemplThresholdDefault;
+    std::optional<std::pair<int, int>> resize;
 
     auto images_opt = params.find<std::vector<std::string>>("images");
     if (!images_opt || images_opt->empty()) {
         LogError << __FUNCTION__ << "failed, images not found";
         return false;
     }
-    for (auto& image : *images_opt) {
-        m_eval_images.emplace_back(std::move(image));
-    }
+    images = std::move(*images_opt);
 
-    if (m_image_test_mode == "report" || m_image_test_mode == "pipeline") {
+    if (mode == "report" || mode == "pipeline") {
         auto tasks_opt = params.find<std::vector<std::string>>("tasks");
         if (!tasks_opt || tasks_opt->empty()) {
             LogError << __FUNCTION__ << "failed, tasks not found";
@@ -178,54 +174,69 @@ bool asst::DebugTask::set_params_impl(const json::value& params)
                 LogError << __FUNCTION__ << "failed, task not found:" << task;
                 return false;
             }
-            m_eval_tasks.emplace_back(std::move(task));
+            tasks.emplace_back(std::move(task));
         }
     }
-    else if (m_image_test_mode == "ocr" || m_image_test_mode == "templ") {
-        if (auto roi_opt = params.find<asst::Rect>("roi"); roi_opt) {
-            m_eval_roi = *roi_opt;
+    else if (mode == "ocr" || mode == "templ") {
+        if (params.contains("roi")) {
+            // 畸形 roi（如只给了三个数）不能静默退化成全图，诊断工具须显式报错
+            auto roi_opt = params.find<asst::Rect>("roi");
+            if (!roi_opt) {
+                LogError << __FUNCTION__ << "failed, invalid roi";
+                return false;
+            }
+            roi = *roi_opt;
         }
-        if (m_image_test_mode == "templ") {
+        if (mode == "templ") {
             auto templates_opt = params.find<std::vector<std::string>>("templates");
             if (!templates_opt || templates_opt->empty()) {
                 LogError << __FUNCTION__ << "failed, templates not found";
                 return false;
             }
             for (const auto& templ : *templates_opt) {
-                m_eval_templates.emplace_back(templ);
+                templates.emplace_back(templ);
             }
             if (auto task_opt = params.find<std::string>("task"); task_opt) {
                 // Matcher 配置只能取自模板类任务；Task.get<MatchTaskInfo> 对非 MatchTaskInfo
                 // 任务返回空，后续 set_task_info 会对其解引用，必须在入口拒绝
                 auto match_ptr = Task.get<MatchTaskInfo>(*task_opt);
                 if (match_ptr == nullptr) {
-                    LogError << "set_params failed, task not found or not a match task:" << *task_opt;
+                    LogError << __FUNCTION__ << "failed, task not found or not a match task:" << *task_opt;
                     return false;
                 }
-                m_eval_templ_task = *task_opt;
-                double default_threshold =
-                    !match_ptr->templ_thresholds.empty() ? match_ptr->templ_thresholds.front() : 0.8;
-                m_eval_threshold = params.get("threshold", default_threshold);
+                templ_task = *task_opt;
+                double default_threshold = !match_ptr->templ_thresholds.empty() ?
+                                               match_ptr->templ_thresholds.front() :
+                                               TemplThresholdDefault;
+                threshold = params.get("threshold", default_threshold);
             }
             else {
-                m_eval_threshold = params.get("threshold", 0.8);
+                threshold = params.get("threshold", TemplThresholdDefault);
             }
             if (auto resize_opt = params.find<std::array<int, 2>>("resize"); resize_opt) {
                 int resize_w = (*resize_opt)[0];
                 int resize_h = (*resize_opt)[1];
                 if (resize_w <= 0 || resize_h <= 0) {
-                    LogError << "set_params failed, invalid resize:" << resize_w << resize_h;
+                    LogError << __FUNCTION__ << "failed, invalid resize:" << resize_w << resize_h;
                     return false;
                 }
-                m_eval_resize = std::make_pair(resize_w, resize_h);
+                resize = std::make_pair(resize_w, resize_h);
             }
         }
     }
     else {
-        LogError << "set_params failed, unknown mode:" << m_image_test_mode;
+        LogError << __FUNCTION__ << "failed, unknown mode:" << mode;
         return false;
     }
 
+    m_image_test_mode = std::move(mode);
+    m_eval_images = std::move(images);
+    m_eval_tasks = std::move(tasks);
+    m_eval_templates = std::move(templates);
+    m_eval_templ_task = std::move(templ_task);
+    m_eval_roi = roi;
+    m_eval_threshold = threshold;
+    m_eval_resize = resize;
     return true;
 }
 
@@ -243,7 +254,7 @@ bool asst::DebugTask::image_test_report()
     bool all_ok = true;
     for (const auto& image_path : m_eval_images) {
         try {
-            auto image_opt = load_eval_image(image_path, true);
+            auto image_opt = load_eval_image(image_path);
             if (!image_opt) {
                 all_ok = false;
                 emit_eval_error("report", image_path, "failed to load image");
@@ -252,7 +263,7 @@ bool asst::DebugTask::image_test_report()
 
             json::array results;
             for (const auto& task_name : m_eval_tasks) {
-                PipelineAnalyzer analyzer(*image_opt, Rect(0, 0, 1280, 720), nullptr);
+                PipelineAnalyzer analyzer(*image_opt, Rect(), nullptr);
                 analyzer.set_tasks({ task_name });
                 auto result_opt = analyzer.analyze();
 
@@ -283,28 +294,28 @@ bool asst::DebugTask::image_test_pipeline()
     bool all_ok = true;
     for (const auto& image_path : m_eval_images) {
         try {
-            auto image_opt = load_eval_image(image_path, true);
+            auto image_opt = load_eval_image(image_path);
             if (!image_opt) {
                 all_ok = false;
                 emit_eval_error("pipeline", image_path, "failed to load image");
                 continue;
             }
 
-            PipelineAnalyzer analyzer(*image_opt, Rect(0, 0, 1280, 720), nullptr);
+            PipelineAnalyzer analyzer(*image_opt, Rect(), nullptr);
             analyzer.set_tasks(m_eval_tasks);
             auto result_opt = analyzer.analyze();
 
             json::object detail { { "mode", "pipeline" }, { "image", image_path } };
             json::array next;
             if (result_opt) {
-                const auto hit = to_result_json(result_opt->task_ptr->name, result_opt);
-                for (const auto& [key, value] : hit) {
-                    detail[key] = value;
-                }
+                // 任务名须嵌在 result 内上报：平铺到 details.task 会被 AbstractTask::callback 按 @ 截断
+                const auto result = to_result_json(result_opt->task_ptr->name, result_opt);
+                detail["hit"] = true;
+                detail["result"] = result;
                 for (const auto& next_task : result_opt->task_ptr->next) {
                     next.emplace_back(next_task);
                 }
-                LogInfo << __FUNCTION__ << image_path << "hit" << hit.dumps();
+                LogInfo << __FUNCTION__ << image_path << "hit" << result.dumps();
             }
             else {
                 detail["hit"] = false;
@@ -329,7 +340,7 @@ bool asst::DebugTask::image_test_ocr()
     bool all_ok = true;
     for (const auto& image_path : m_eval_images) {
         try {
-            auto image_opt = load_eval_image(image_path, true);
+            auto image_opt = load_eval_image(image_path);
             if (!image_opt) {
                 all_ok = false;
                 emit_eval_error("ocr", image_path, "failed to load image");
@@ -338,8 +349,7 @@ bool asst::DebugTask::image_test_ocr()
 
             // 不 set_task_info：默认参数下 required 为空即不做 expected 过滤、不做 ocrReplace，
             // 返回 OCR 引擎的原始识别结果；带任务配置的评估用 report 模式
-            Rect roi = m_eval_roi.empty() ? Rect(0, 0, 1280, 720) : m_eval_roi;
-            OCRer analyzer(*image_opt, roi);
+            OCRer analyzer(*image_opt, m_eval_roi); // 空 roi 由 VisionHelper 展开为全图
             auto results_opt = analyzer.analyze();
 
             json::array results;
@@ -374,9 +384,9 @@ bool asst::DebugTask::image_test_templ()
     bool all_ok = true;
     for (const auto& image_path : m_eval_images) {
         try {
-            auto image_opt = load_eval_image(image_path, !m_eval_resize.has_value());
+            auto image_opt = load_eval_image(image_path);
             if (image_opt && m_eval_resize) {
-                image_opt = resize_eval_image(std::move(*image_opt), m_eval_resize->first, m_eval_resize->second);
+                *image_opt = resize_eval_image(std::move(*image_opt), m_eval_resize->first, m_eval_resize->second);
             }
             if (!image_opt) {
                 all_ok = false;
@@ -389,7 +399,7 @@ bool asst::DebugTask::image_test_templ()
                 // 模板名与 core 各处 get_templ 一致：物品 ID（如 "2001"）或相对
                 // resource/template 的路径（如 "items/2001.png"）；也接受绝对路径的
                 // 图片文件（调用方自行预处理过的模板）
-                Matcher analyzer(*image_opt, Rect(0, 0, image_opt->cols, image_opt->rows), nullptr);
+                Matcher analyzer(*image_opt, Rect(), nullptr);
 
                 if (!m_eval_templ_task.empty()) {
                     // mask/method 等 Matcher 配置取自该任务；须在 set_templ 之前调用，

--- a/src/MaaCore/Task/Interface/DebugTask.cpp
+++ b/src/MaaCore/Task/Interface/DebugTask.cpp
@@ -111,7 +111,7 @@ json::object to_result_json(const std::string& task_name, const asst::PipelineAn
 // 离线图片评估的参数协议（AsstAppendTask 的 params，type 固定为 "Debug"）。
 // 日常用配套的 python 驱动 tools/maa_core_eval.py 调用，无需手拼 json：
 // { "mode": "report" | "pipeline" | "ocr" | "templ", "images": [图片路径], "tasks": [任务名],
-//   "templates": [模板名], "task": "任务名", "roi": [x, y, w, h], "threshold": 0.7, "resize": [w, h] }
+//   "templates": [模板名], "task": "任务名", "roi": [x, y, w, h], "threshold": 0.8, "resize": [w, h] }
 // images/tasks/templates 为 UTF-8 路径与名字（模板名也接受绝对路径图片文件）；roi 仅 ocr/templ
 // 模式使用，缺省全图；task 仅 templ 模式使用（mask/method 等 Matcher 配置取自该任务，复刻线上
 // 自定义识别器的用法，未显式给 threshold 时 hit 判定也取该任务阈值）；threshold/resize 仅 templ
@@ -150,7 +150,7 @@ bool asst::DebugTask::set_params_impl(const json::value& params)
     m_eval_templates.clear();
     m_eval_templ_task.clear();
     m_eval_roi = Rect();
-    m_eval_threshold = 0.7;
+    m_eval_threshold = 0.8;
     m_eval_resize.reset();
 
     auto images_opt = params.find<json::array>("images");
@@ -220,11 +220,11 @@ bool asst::DebugTask::set_params_impl(const json::value& params)
                 }
                 m_eval_templ_task = *task_opt;
                 double default_threshold =
-                    !match_ptr->templ_thresholds.empty() ? match_ptr->templ_thresholds.front() : 0.7;
+                    !match_ptr->templ_thresholds.empty() ? match_ptr->templ_thresholds.front() : 0.8;
                 m_eval_threshold = params.get("threshold", default_threshold);
             }
             else {
-                m_eval_threshold = params.get("threshold", 0.7);
+                m_eval_threshold = params.get("threshold", 0.8);
             }
             if (auto resize_opt = params.find<json::array>("resize"); resize_opt) {
                 if (resize_opt->size() != 2 ||
@@ -279,7 +279,6 @@ bool asst::DebugTask::image_test_report()
 
                 json::object result = to_result_json(task_name, result_opt);
                 LogInfo << __FUNCTION__ << image_path << task_name << (result_opt ? "hit" : "miss") << result.dumps();
-                        << result.dumps();
                 results.emplace_back(std::move(result));
             }
 

--- a/src/MaaCore/Task/Interface/DebugTask.cpp
+++ b/src/MaaCore/Task/Interface/DebugTask.cpp
@@ -192,7 +192,8 @@ bool asst::DebugTask::set_params_impl(const json::value& params)
     }
     else if (m_image_test_mode == "ocr" || m_image_test_mode == "templ") {
         if (auto roi_opt = params.find<json::array>("roi"); roi_opt) {
-            if (roi_opt->size() != 4 || std::ranges::any_of(*roi_opt, [](const json::value& v) { return !v.is_number(); })) {
+            if (roi_opt->size() != 4 ||
+                std::ranges::any_of(*roi_opt, [](const json::value& v) { return !v.is_number(); })) {
                 LogError << "set_params failed, roi must be 4 numbers";
                 return false;
             }
@@ -224,7 +225,8 @@ bool asst::DebugTask::set_params_impl(const json::value& params)
                     return false;
                 }
                 m_eval_templ_task = *task_opt;
-                double default_threshold = !match_ptr->templ_thresholds.empty() ? match_ptr->templ_thresholds.front() : 0.7;
+                double default_threshold =
+                    !match_ptr->templ_thresholds.empty() ? match_ptr->templ_thresholds.front() : 0.7;
                 m_eval_threshold = params.get("threshold", default_threshold);
             }
             else {
@@ -283,23 +285,23 @@ bool asst::DebugTask::image_test_report()
 
                 json::object result = to_result_json(task_name, result_opt);
                 LogInfo << __FUNCTION__ << image_path << task_name << (result_opt ? "hit" : "miss")
-                        << json::value(result).dumps();
+                        << result.dumps();
                 results.emplace_back(std::move(result));
             }
 
             callback(
                 AsstMsg::SubTaskExtraInfo,
                 json::object { { "what", "DebugImageTest" },
-                               { "details", json::object { { "mode", "report" },
-                                                            { "image", image_path },
-                                                            { "results", std::move(results) } } } });
+                               { "details",
+                                 json::object { { "mode", "report" },
+                                                { "image", image_path },
+                                                { "results", std::move(results) } } } });
         }
         catch (const std::exception& e) {
             // ASST_DEBUG 下模板缺失/为空等会 throw，逐图兜住避免后续图静默缺结果
             all_ok = false;
             emit_eval_error("report", image_path, e.what());
         }
-
     }
     return all_ok;
 }
@@ -330,7 +332,7 @@ bool asst::DebugTask::image_test_pipeline()
                 for (const auto& next_task : result_opt->task_ptr->next) {
                     next.emplace_back(next_task);
                 }
-                LogInfo << __FUNCTION__ << image_path << "hit" << json::value(hit).dumps();
+                LogInfo << __FUNCTION__ << image_path << "hit" << hit.dumps();
             }
             else {
                 detail["hit"] = false;
@@ -346,7 +348,6 @@ bool asst::DebugTask::image_test_pipeline()
             all_ok = false;
             emit_eval_error("pipeline", image_path, e.what());
         }
-
     }
     return all_ok;
 }
@@ -373,17 +374,20 @@ bool asst::DebugTask::image_test_ocr()
             if (results_opt) {
                 for (const auto& res : *results_opt) {
                     results.emplace_back(
-                        json::object { { "text", res.text }, { "score", res.score }, { "rect", to_json_rect(res.rect) } });
+                        json::object { { "text", res.text },
+                                       { "score", res.score },
+                                       { "rect", to_json_rect(res.rect) } });
                 }
             }
-            LogInfo << __FUNCTION__ << image_path << "ocr" << json::value(results).dumps();
+            LogInfo << __FUNCTION__ << image_path << "ocr" << results.dumps();
 
             callback(
                 AsstMsg::SubTaskExtraInfo,
                 json::object { { "what", "DebugImageTest" },
-                               { "details", json::object { { "mode", "ocr" },
-                                                            { "image", image_path },
-                                                            { "results", std::move(results) } } } });
+                               { "details",
+                                 json::object { { "mode", "ocr" },
+                                                { "image", image_path },
+                                                { "results", std::move(results) } } } });
         }
         catch (const std::exception& e) {
             all_ok = false;
@@ -408,73 +412,74 @@ bool asst::DebugTask::image_test_templ()
                 continue;
             }
 
-        json::array results;
-        for (const auto& templ_name : m_eval_templates) {
-            // 模板名与 core 各处 get_templ 一致：物品 ID（如 "2001"）或相对
-            // resource/template 的路径（如 "items/2001.png"）；也接受绝对路径的
-            // 图片文件（调用方自行预处理过的模板）
-            Matcher analyzer(*image_opt, Rect(0, 0, image_opt->cols, image_opt->rows), nullptr);
+            json::array results;
+            for (const auto& templ_name : m_eval_templates) {
+                // 模板名与 core 各处 get_templ 一致：物品 ID（如 "2001"）或相对
+                // resource/template 的路径（如 "items/2001.png"）；也接受绝对路径的
+                // 图片文件（调用方自行预处理过的模板）
+                Matcher analyzer(*image_opt, Rect(0, 0, image_opt->cols, image_opt->rows), nullptr);
 
-            if (!m_eval_templ_task.empty()) {
-                // mask/method 等 Matcher 配置取自该任务；须在 set_templ 之前调用，
-                // 否则 set_task_info 会把模板重置为任务自带的
-                analyzer.set_task_info(m_eval_templ_task);
-            }
-            if (!m_eval_roi.empty()) {
-                // set_task_info 会用任务自身的 roi 覆盖构造时的 roi，显式传入的 roi 在其后重设
-                analyzer.set_roi(m_eval_roi);
-            }
-
-            json::object result { { "template", templ_name } };
-            std::filesystem::path templ_file = asst::utils::path(templ_name);
-            if (templ_file.is_absolute() && std::filesystem::exists(templ_file)) {
-                cv::Mat templ = MAA_NS::imread(templ_file);
-                if (templ.empty()) {
-                    result["hit"] = false;
-                    result["error"] = "failed to load templ file";
-                    LogError << __FUNCTION__ << "failed to load templ:" << templ_name;
-                    all_ok = false;
-                    results.emplace_back(std::move(result));
-                    continue;
+                if (!m_eval_templ_task.empty()) {
+                    // mask/method 等 Matcher 配置取自该任务；须在 set_templ 之前调用，
+                    // 否则 set_task_info 会把模板重置为任务自带的
+                    analyzer.set_task_info(m_eval_templ_task);
                 }
-                analyzer.set_templ(std::move(templ));
-            }
-            else {
-                analyzer.set_templ(templ_name);
-            }
-            analyzer.set_threshold(-1.0); // 放开阈值恒报最佳得分，hit 由 threshold 字段判定
+                if (!m_eval_roi.empty()) {
+                    // set_task_info 会用任务自身的 roi 覆盖构造时的 roi，显式传入的 roi 在其后重设
+                    analyzer.set_roi(m_eval_roi);
+                }
 
-            try {
-                auto result_opt = analyzer.analyze();
-                if (result_opt) {
-                    result["score"] = result_opt->score;
-                    result["rect"] = to_json_rect(result_opt->rect);
-                    result["hit"] = result_opt->score >= m_eval_threshold;
+                json::object result { { "template", templ_name } };
+                std::filesystem::path templ_file = asst::utils::path(templ_name);
+                if (templ_file.is_absolute() && std::filesystem::exists(templ_file)) {
+                    cv::Mat templ = MAA_NS::imread(templ_file);
+                    if (templ.empty()) {
+                        result["hit"] = false;
+                        result["error"] = "failed to load templ file";
+                        LogError << __FUNCTION__ << "failed to load templ:" << templ_name;
+                        all_ok = false;
+                        results.emplace_back(std::move(result));
+                        continue;
+                    }
+                    analyzer.set_templ(std::move(templ));
                 }
                 else {
-                    // 阈值已放开仍无结果，只剩 roi 为空或模板大于 roi 等输入问题，不存在正常 miss
+                    analyzer.set_templ(templ_name);
+                }
+                analyzer.set_threshold(-1.0); // 放开阈值恒报最佳得分，hit 由 threshold 字段判定
+
+                try {
+                    auto result_opt = analyzer.analyze();
+                    if (result_opt) {
+                        result["score"] = result_opt->score;
+                        result["rect"] = to_json_rect(result_opt->rect);
+                        result["hit"] = result_opt->score >= m_eval_threshold;
+                    }
+                    else {
+                        // 阈值已放开仍无结果，只剩 roi 为空或模板大于 roi 等输入问题，不存在正常 miss
+                        result["hit"] = false;
+                        result["error"] = "no match result (check roi / template size)";
+                        all_ok = false;
+                    }
+                }
+                catch (const std::exception& e) {
+                    // ASST_DEBUG 下模板不存在/加载失败会 throw，报错后继续评估其余模板
                     result["hit"] = false;
-                    result["error"] = "no match result (check roi / template size)";
+                    result["error"] = e.what();
                     all_ok = false;
                 }
+                LogInfo << __FUNCTION__ << image_path << templ_name << (result["hit"].as_boolean() ? "hit" : "miss")
+                        << result.dumps();
+                results.emplace_back(std::move(result));
             }
-            catch (const std::exception& e) {
-                // ASST_DEBUG 下模板不存在/加载失败会 throw，报错后继续评估其余模板
-                result["hit"] = false;
-                result["error"] = e.what();
-                all_ok = false;
-            }
-            LogInfo << __FUNCTION__ << image_path << templ_name << (result["hit"].as_boolean() ? "hit" : "miss")
-                    << json::value(result).dumps();
-            results.emplace_back(std::move(result));
-        }
 
-        callback(
-            AsstMsg::SubTaskExtraInfo,
-            json::object { { "what", "DebugImageTest" },
-                           { "details", json::object { { "mode", "templ" },
-                                                        { "image", image_path },
-                                                        { "results", std::move(results) } } } });
+            callback(
+                AsstMsg::SubTaskExtraInfo,
+                json::object { { "what", "DebugImageTest" },
+                               { "details",
+                                 json::object { { "mode", "templ" },
+                                                { "image", image_path },
+                                                { "results", std::move(results) } } } });
         }
         catch (const std::exception& e) {
             all_ok = false;

--- a/src/MaaCore/Task/Interface/DebugTask.cpp
+++ b/src/MaaCore/Task/Interface/DebugTask.cpp
@@ -210,7 +210,7 @@ bool asst::DebugTask::set_params_impl(const json::value& params)
             else {
                 m_eval_threshold = params.get("threshold", 0.8);
             }
-            if (auto resize_opt = params.find<std::array<int,2>>("resize"); resize_opt) {
+            if (auto resize_opt = params.find<std::array<int, 2>>("resize"); resize_opt) {
                 int resize_w = (*resize_opt)[0];
                 int resize_h = (*resize_opt)[1];
                 if (resize_w <= 0 || resize_h <= 0) {

--- a/src/MaaCore/Task/Interface/DebugTask.cpp
+++ b/src/MaaCore/Task/Interface/DebugTask.cpp
@@ -54,7 +54,7 @@ std::optional<cv::Mat> load_eval_image(const std::string& utf8_path, bool normal
 {
     cv::Mat image = MAA_NS::imread(asst::utils::path(utf8_path));
     if (image.empty()) {
-        Log.error("image_test | failed to load image:", utf8_path);
+        LogError << __FUNCTION__ << "failed to load image:" << utf8_path;
         return std::nullopt;
     }
     if (normalize && (image.cols != 1280 || image.rows != 720)) {
@@ -130,12 +130,12 @@ bool asst::DebugTask::set_params(const json::value& params)
 
     auto images_opt = params.find<json::array>("images");
     if (!images_opt || images_opt->empty()) {
-        Log.error("set_params failed, images not found");
+        LogError << "set_params failed, images not found";
         return false;
     }
     for (const auto& image : *images_opt) {
         if (!image.is_string()) {
-            Log.error("set_params failed, image is not string");
+            LogError << "set_params failed, image is not string";
             return false;
         }
         m_eval_images.emplace_back(image.as_string());
@@ -144,16 +144,16 @@ bool asst::DebugTask::set_params(const json::value& params)
     if (m_image_test_mode == "report" || m_image_test_mode == "pipeline") {
         auto tasks_opt = params.find<json::array>("tasks");
         if (!tasks_opt || tasks_opt->empty()) {
-            Log.error("set_params failed, tasks not found");
+            LogError << "set_params failed, tasks not found";
             return false;
         }
         for (const auto& task : *tasks_opt) {
             if (!task.is_string()) {
-                Log.error("set_params failed, task is not string");
+                LogError << "set_params failed, task is not string";
                 return false;
             }
             if (Task.get(task.as_string()) == nullptr) {
-                Log.error("set_params failed, task not found:", task.as_string());
+                LogError << "set_params failed, task not found:" << task.as_string();
                 return false;
             }
             m_eval_tasks.emplace_back(task.as_string());
@@ -170,12 +170,12 @@ bool asst::DebugTask::set_params(const json::value& params)
         if (m_image_test_mode == "templ") {
             auto templates_opt = params.find<json::array>("templates");
             if (!templates_opt || templates_opt->empty()) {
-                Log.error("set_params failed, templates not found");
+                LogError << "set_params failed, templates not found";
                 return false;
             }
             for (const auto& templ : *templates_opt) {
                 if (!templ.is_string()) {
-                    Log.error("set_params failed, template is not string");
+                    LogError << "set_params failed, template is not string";
                     return false;
                 }
                 m_eval_templates.emplace_back(templ.as_string());
@@ -183,7 +183,7 @@ bool asst::DebugTask::set_params(const json::value& params)
             if (auto task_opt = params.find<std::string>("task"); task_opt) {
                 auto task_ptr = Task.get(*task_opt);
                 if (task_ptr == nullptr) {
-                    Log.error("set_params failed, task not found:", *task_opt);
+                    LogError << "set_params failed, task not found:" << *task_opt;
                     return false;
                 }
                 m_eval_templ_task = *task_opt;
@@ -199,7 +199,7 @@ bool asst::DebugTask::set_params(const json::value& params)
                 int resize_w = (*resize_opt)[0].as_integer();
                 int resize_h = (*resize_opt)[1].as_integer();
                 if (resize_w <= 0 || resize_h <= 0) {
-                    Log.error("set_params failed, invalid resize:", resize_w, resize_h);
+                    LogError << "set_params failed, invalid resize:" << resize_w << resize_h;
                     return false;
                 }
                 m_eval_resize = std::make_pair(resize_w, resize_h);
@@ -207,7 +207,7 @@ bool asst::DebugTask::set_params(const json::value& params)
         }
     }
     else {
-        Log.error("set_params failed, unknown mode:", m_image_test_mode);
+        LogError << "set_params failed, unknown mode:" << m_image_test_mode;
         return false;
     }
 
@@ -216,7 +216,7 @@ bool asst::DebugTask::set_params(const json::value& params)
 
 void asst::DebugTask::emit_eval_error(const std::string& mode, const std::string& image_path, const std::string& error)
 {
-    Log.error("image_test |", image_path, error);
+    LogError << __FUNCTION__ << image_path << error;
     callback(
         AsstMsg::SubTaskExtraInfo,
         json::object { { "what", "DebugImageTest" },
@@ -241,21 +241,18 @@ bool asst::DebugTask::image_test_report()
             auto result_opt = analyzer.analyze();
 
             json::object result = to_result_json(task_name, result_opt);
-            Log.info(
-                "image_test |",
-                image_path,
-                task_name,
-                result_opt ? "hit" : "miss",
-                json::value(result).dumps());
+            LogInfo << __FUNCTION__ << image_path << task_name << (result_opt ? "hit" : "miss")
+                    << json::value(result).dumps();
             results.emplace_back(std::move(result));
         }
 
         callback(
             AsstMsg::SubTaskExtraInfo,
             json::object { { "what", "DebugImageTest" },
-                           { "details", json::object { { "mode", "report" },
-                                                        { "image", image_path },
-                                                        { "results", std::move(results) } } } });
+                           { "details",
+                             json::object { { "mode", "report" },
+                                            { "image", image_path },
+                                            { "results", std::move(results) } } } });
     }
     return all_ok;
 }
@@ -285,11 +282,11 @@ bool asst::DebugTask::image_test_pipeline()
             for (const auto& next_task : result_opt->task_ptr->next) {
                 next.emplace_back(next_task);
             }
-            Log.info("image_test |", image_path, "hit", json::value(hit).dumps());
+            LogInfo << __FUNCTION__ << image_path << "hit" << json::value(hit).dumps();
         }
         else {
             detail["hit"] = false;
-            Log.info("image_test |", image_path, "miss");
+            LogInfo << __FUNCTION__ << image_path << "miss";
         }
         detail["next"] = std::move(next);
 
@@ -324,14 +321,14 @@ bool asst::DebugTask::image_test_ocr()
                     json::object { { "text", res.text }, { "score", res.score }, { "rect", (json::value)res.rect } });
             }
         }
-        Log.info("image_test |", image_path, "ocr", json::value(results).dumps());
+        LogInfo << __FUNCTION__ << image_path << "ocr" << json::value(results).dumps();
 
         callback(
             AsstMsg::SubTaskExtraInfo,
-            json::object { { "what", "DebugImageTest" },
-                           { "details", json::object { { "mode", "ocr" },
-                                                        { "image", image_path },
-                                                        { "results", std::move(results) } } } });
+            json::object {
+                { "what", "DebugImageTest" },
+                { "details",
+                  json::object { { "mode", "ocr" }, { "image", image_path }, { "results", std::move(results) } } } });
     }
     return all_ok;
 }
@@ -371,7 +368,7 @@ bool asst::DebugTask::image_test_templ()
             if (templ_file.is_absolute() && std::filesystem::exists(templ_file)) {
                 cv::Mat templ = MAA_NS::imread(templ_file);
                 if (templ.empty()) {
-                    Log.error("image_test | failed to load templ:", templ_name);
+                    LogError << __FUNCTION__ << "failed to load templ:" << templ_name;
                     all_ok = false;
                     continue;
                 }
@@ -387,7 +384,7 @@ bool asst::DebugTask::image_test_templ()
                 auto result_opt = analyzer.analyze();
                 if (result_opt) {
                     result["score"] = result_opt->score;
-                    result["rect"] = to_json_rect(result_opt->rect);
+                    result["rect"] = (json::value)result_opt->rect;
                     result["hit"] = result_opt->score >= m_eval_threshold;
                 }
                 else {
@@ -400,21 +397,17 @@ bool asst::DebugTask::image_test_templ()
                 result["error"] = e.what();
                 all_ok = false;
             }
-            Log.info(
-                "image_test |",
-                image_path,
-                templ_name,
-                result["hit"].as_boolean() ? "hit" : "miss",
-                json::value(result).dumps());
+            LogInfo << __FUNCTION__ << image_path << templ_name << (result["hit"].as_boolean() ? "hit" : "miss")
+                    << json::value(result).dumps();
             results.emplace_back(std::move(result));
         }
 
         callback(
             AsstMsg::SubTaskExtraInfo,
-            json::object { { "what", "DebugImageTest" },
-                           { "details", json::object { { "mode", "templ" },
-                                                        { "image", image_path },
-                                                        { "results", std::move(results) } } } });
+            json::object {
+                { "what", "DebugImageTest" },
+                { "details",
+                  json::object { { "mode", "templ" }, { "image", image_path }, { "results", std::move(results) } } } });
     }
     return all_ok;
 }

--- a/src/MaaCore/Task/Interface/DebugTask.cpp
+++ b/src/MaaCore/Task/Interface/DebugTask.cpp
@@ -153,17 +153,13 @@ bool asst::DebugTask::set_params_impl(const json::value& params)
     m_eval_threshold = 0.8;
     m_eval_resize.reset();
 
-    auto images_opt = params.find<json::array>("images");
+    auto images_opt = params.find<std::vector<std::string>>("images");
     if (!images_opt || images_opt->empty()) {
         LogError << "set_params failed, images not found";
         return false;
     }
-    for (const auto& image : *images_opt) {
-        if (!image.is_string()) {
-            LogError << "set_params failed, image is not string";
-            return false;
-        }
-        m_eval_images.emplace_back(image.as_string());
+    for (auto& image : *images_opt) {
+        m_eval_images.emplace_back(std::move(image));
     }
 
     if (m_image_test_mode == "report" || m_image_test_mode == "pipeline") {

--- a/src/MaaCore/Task/Interface/DebugTask.cpp
+++ b/src/MaaCore/Task/Interface/DebugTask.cpp
@@ -210,14 +210,9 @@ bool asst::DebugTask::set_params_impl(const json::value& params)
             else {
                 m_eval_threshold = params.get("threshold", 0.8);
             }
-            if (auto resize_opt = params.find<json::array>("resize"); resize_opt) {
-                if (resize_opt->size() != 2 ||
-                    std::ranges::any_of(*resize_opt, [](const json::value& v) { return !v.is_number(); })) {
-                    LogError << "set_params failed, resize must be 2 numbers";
-                    return false;
-                }
-                int resize_w = (*resize_opt)[0].as_integer();
-                int resize_h = (*resize_opt)[1].as_integer();
+            if (auto resize_opt = params.find<std::array<int,2>>("resize"); resize_opt) {
+                int resize_w = (*resize_opt)[0];
+                int resize_h = (*resize_opt)[1];
                 if (resize_w <= 0 || resize_h <= 0) {
                     LogError << "set_params failed, invalid resize:" << resize_w << resize_h;
                     return false;

--- a/src/MaaCore/Task/Interface/DebugTask.cpp
+++ b/src/MaaCore/Task/Interface/DebugTask.cpp
@@ -24,6 +24,28 @@
 #include "Vision/OCRer.h"
 #include "Vision/RegionOCRer.h"
 
+asst::DebugTask::DebugTask(const AsstCallback& callback, Assistant* inst) :
+    InterfaceTask(callback, inst, TaskType)
+{
+}
+
+bool asst::DebugTask::run()
+{
+    if (m_image_test_mode == "report") {
+        return image_test_report();
+    }
+    if (m_image_test_mode == "pipeline") {
+        return image_test_pipeline();
+    }
+    if (m_image_test_mode == "ocr") {
+        return image_test_ocr();
+    }
+    if (m_image_test_mode == "templ") {
+        return image_test_templ();
+    }
+    return true;
+}
+
 namespace
 {
 // 读取本地图片；normalize 为 true 时缩放到 1280x720（INTER_AREA），
@@ -82,28 +104,6 @@ json::object to_result_json(const std::string& task_name, const asst::PipelineAn
     result["rect"] = to_json_rect(result_opt->rect);
     return result;
 }
-}
-
-asst::DebugTask::DebugTask(const AsstCallback& callback, Assistant* inst) :
-    InterfaceTask(callback, inst, TaskType)
-{
-}
-
-bool asst::DebugTask::run()
-{
-    if (m_image_test_mode == "report") {
-        return image_test_report();
-    }
-    if (m_image_test_mode == "pipeline") {
-        return image_test_pipeline();
-    }
-    if (m_image_test_mode == "ocr") {
-        return image_test_ocr();
-    }
-    if (m_image_test_mode == "templ") {
-        return image_test_templ();
-    }
-    return true;
 }
 
 // 离线图片评估的参数协议（AsstAppendTask 的 params，type 固定为 "Debug"）。

--- a/src/MaaCore/Task/Interface/DebugTask.cpp
+++ b/src/MaaCore/Task/Interface/DebugTask.cpp
@@ -77,11 +77,6 @@ std::optional<cv::Mat> resize_eval_image(cv::Mat image, int width, int height)
     return image;
 }
 
-json::array to_json_rect(const asst::Rect& rect)
-{
-    return json::array { rect.x, rect.y, rect.width, rect.height };
-}
-
 json::object to_result_json(const std::string& task_name, const asst::PipelineAnalyzer::ResultOpt& result_opt)
 {
     json::object result { { "task", task_name } };
@@ -108,8 +103,7 @@ json::object to_result_json(const std::string& task_name, const asst::PipelineAn
         const auto& r = std::get<asst::FeatureMatcher::Result>(result_var);
         result["count"] = r.count;
     }
-    // Rect 没有 json 转换（AnalyzerResult 上的 operator 不覆盖独立的 Rect），用辅助函数展开
-    result["rect"] = to_json_rect(result_opt->rect);
+    result["rect"] = (json::value)result_opt->rect;
     return result;
 }
 }
@@ -284,7 +278,7 @@ bool asst::DebugTask::image_test_report()
                 auto result_opt = analyzer.analyze();
 
                 json::object result = to_result_json(task_name, result_opt);
-                LogInfo << __FUNCTION__ << image_path << task_name << (result_opt ? "hit" : "miss")
+                LogInfo << __FUNCTION__ << image_path << task_name << (result_opt ? "hit" : "miss") << result.dumps();
                         << result.dumps();
                 results.emplace_back(std::move(result));
             }

--- a/src/MaaCore/Task/Interface/DebugTask.cpp
+++ b/src/MaaCore/Task/Interface/DebugTask.cpp
@@ -72,11 +72,6 @@ std::optional<cv::Mat> resize_eval_image(cv::Mat image, int width, int height)
     return image;
 }
 
-json::array to_json_rect(const asst::Rect& rect)
-{
-    return json::array { rect.x, rect.y, rect.width, rect.height };
-}
-
 json::object to_result_json(const std::string& task_name, const asst::PipelineAnalyzer::ResultOpt& result_opt)
 {
     json::object result { { "task", task_name } };
@@ -101,7 +96,7 @@ json::object to_result_json(const std::string& task_name, const asst::PipelineAn
         const auto& r = std::get<asst::FeatureMatcher::Result>(result_var);
         result["count"] = r.count;
     }
-    result["rect"] = to_json_rect(result_opt->rect);
+    result["rect"] = (json::value)result_opt->rect;
     return result;
 }
 }
@@ -326,7 +321,7 @@ bool asst::DebugTask::image_test_ocr()
         if (results_opt) {
             for (const auto& res : *results_opt) {
                 results.emplace_back(
-                    json::object { { "text", res.text }, { "score", res.score }, { "rect", to_json_rect(res.rect) } });
+                    json::object { { "text", res.text }, { "score", res.score }, { "rect", (json::value)res.rect } });
             }
         }
         Log.info("image_test |", image_path, "ocr", json::value(results).dumps());

--- a/src/MaaCore/Task/Interface/DebugTask.cpp
+++ b/src/MaaCore/Task/Interface/DebugTask.cpp
@@ -167,21 +167,17 @@ bool asst::DebugTask::set_params_impl(const json::value& params)
     }
 
     if (m_image_test_mode == "report" || m_image_test_mode == "pipeline") {
-        auto tasks_opt = params.find<json::array>("tasks");
+        auto tasks_opt = params.find<std::vector<std::string>>("tasks");
         if (!tasks_opt || tasks_opt->empty()) {
             LogError << "set_params failed, tasks not found";
             return false;
         }
-        for (const auto& task : *tasks_opt) {
-            if (!task.is_string()) {
-                LogError << "set_params failed, task is not string";
+        for (auto& task : *tasks_opt) {
+            if (Task.get(task) == nullptr) {
+                LogError << "set_params failed, task not found:" << task;
                 return false;
             }
-            if (Task.get(task.as_string()) == nullptr) {
-                LogError << "set_params failed, task not found:" << task.as_string();
-                return false;
-            }
-            m_eval_tasks.emplace_back(task.as_string());
+            m_eval_tasks.emplace_back(std::move(task));
         }
     }
     else if (m_image_test_mode == "ocr" || m_image_test_mode == "templ") {

--- a/src/MaaCore/Task/Interface/DebugTask.cpp
+++ b/src/MaaCore/Task/Interface/DebugTask.cpp
@@ -124,6 +124,15 @@ bool asst::DebugTask::set_params(const json::value& params)
         return true; // 无 mode 的 Debug 任务保持 run() 空跑的旧行为
     }
 
+    // AsstSetTaskParams 会对同一任务重复调用 set_params，先清空上次状态避免累积
+    m_eval_images.clear();
+    m_eval_tasks.clear();
+    m_eval_templates.clear();
+    m_eval_templ_task.clear();
+    m_eval_roi = Rect();
+    m_eval_threshold = 0.7;
+    m_eval_resize.reset();
+
     auto images_opt = params.find<json::array>("images");
     if (!images_opt || images_opt->empty()) {
         Log.error("set_params failed, images not found");
@@ -192,7 +201,13 @@ bool asst::DebugTask::set_params(const json::value& params)
                 m_eval_threshold = params.get("threshold", 0.7);
             }
             if (auto resize_opt = params.find<json::array>("resize"); resize_opt && resize_opt->size() == 2) {
-                m_eval_resize = std::make_pair((*resize_opt)[0].as_integer(), (*resize_opt)[1].as_integer());
+                int resize_w = (*resize_opt)[0].as_integer();
+                int resize_h = (*resize_opt)[1].as_integer();
+                if (resize_w <= 0 || resize_h <= 0) {
+                    Log.error("set_params failed, invalid resize:", resize_w, resize_h);
+                    return false;
+                }
+                m_eval_resize = std::make_pair(resize_w, resize_h);
             }
         }
     }
@@ -204,6 +219,15 @@ bool asst::DebugTask::set_params(const json::value& params)
     return true;
 }
 
+void asst::DebugTask::emit_eval_error(const std::string& mode, const std::string& image_path, const std::string& error)
+{
+    Log.error("image_test |", image_path, error);
+    callback(
+        AsstMsg::SubTaskExtraInfo,
+        json::object { { "what", "DebugImageTest" },
+                       { "details", json::object { { "mode", mode }, { "image", image_path }, { "error", error } } } });
+}
+
 bool asst::DebugTask::image_test_report()
 {
     bool all_ok = true;
@@ -211,6 +235,7 @@ bool asst::DebugTask::image_test_report()
         auto image_opt = load_eval_image(image_path, true);
         if (!image_opt) {
             all_ok = false;
+            emit_eval_error("report", image_path, "failed to load image");
             continue;
         }
 
@@ -247,6 +272,7 @@ bool asst::DebugTask::image_test_pipeline()
         auto image_opt = load_eval_image(image_path, true);
         if (!image_opt) {
             all_ok = false;
+            emit_eval_error("pipeline", image_path, "failed to load image");
             continue;
         }
 
@@ -286,6 +312,7 @@ bool asst::DebugTask::image_test_ocr()
         auto image_opt = load_eval_image(image_path, true);
         if (!image_opt) {
             all_ok = false;
+            emit_eval_error("ocr", image_path, "failed to load image");
             continue;
         }
 
@@ -324,6 +351,7 @@ bool asst::DebugTask::image_test_templ()
         }
         if (!image_opt) {
             all_ok = false;
+            emit_eval_error("templ", image_path, "failed to load image");
             continue;
         }
 
@@ -332,12 +360,16 @@ bool asst::DebugTask::image_test_templ()
             // 模板名与 core 各处 get_templ 一致：物品 ID（如 "2001"）或相对
             // resource/template 的路径（如 "items/2001.png"）；也接受绝对路径的
             // 图片文件（调用方自行预处理过的模板）
-            Matcher analyzer(*image_opt, m_eval_roi.empty() ? Rect(0, 0, image_opt->cols, image_opt->rows) : m_eval_roi, nullptr);
+            Matcher analyzer(*image_opt, Rect(0, 0, image_opt->cols, image_opt->rows), nullptr);
 
             if (!m_eval_templ_task.empty()) {
                 // mask/method 等 Matcher 配置取自该任务；须在 set_templ 之前调用，
                 // 否则 set_task_info 会把模板重置为任务自带的
                 analyzer.set_task_info(m_eval_templ_task);
+            }
+            if (!m_eval_roi.empty()) {
+                // set_task_info 会用任务自身的 roi 覆盖构造时的 roi，显式传入的 roi 在其后重设
+                analyzer.set_roi(m_eval_roi);
             }
 
             std::filesystem::path templ_file = asst::utils::path(templ_name);

--- a/src/MaaCore/Task/Interface/DebugTask.cpp
+++ b/src/MaaCore/Task/Interface/DebugTask.cpp
@@ -31,6 +31,11 @@ asst::DebugTask::DebugTask(const AsstCallback& callback, Assistant* inst) :
 
 bool asst::DebugTask::run()
 {
+    std::string test = "[1,2,3,4]";
+    json::value test_json = json::parse(test);
+    LogInfo << "DebugTask run() called, test_json:" << test_json;
+    LogInfo << "DebugTask run() called, test_json:" << test_json.is<asst::Rect>();
+
     if (m_image_test_mode == "report") {
         return image_test_report();
     }
@@ -123,7 +128,7 @@ bool asst::DebugTask::set_params(const json::value& params)
 
     // AsstSetTaskParams 在任务运行中调用会与 run() 遍历 m_eval_* 产生数据竞争，运行中拒绝更新
     if (m_running) {
-        LogError << "set_params failed, task is running";
+        LogError << __FUNCTION__ << "failed, task is running";
         return false;
     }
 
@@ -132,7 +137,7 @@ bool asst::DebugTask::set_params(const json::value& params)
         return set_params_impl(params);
     }
     catch (const std::exception& e) {
-        LogError << "set_params failed, invalid params:" << e.what();
+        LogError << __FUNCTION__ << "failed, invalid params:" << e.what();
         return false;
     }
 }
@@ -155,7 +160,7 @@ bool asst::DebugTask::set_params_impl(const json::value& params)
 
     auto images_opt = params.find<std::vector<std::string>>("images");
     if (!images_opt || images_opt->empty()) {
-        LogError << "set_params failed, images not found";
+        LogError << __FUNCTION__ << "failed, images not found";
         return false;
     }
     for (auto& image : *images_opt) {
@@ -165,42 +170,29 @@ bool asst::DebugTask::set_params_impl(const json::value& params)
     if (m_image_test_mode == "report" || m_image_test_mode == "pipeline") {
         auto tasks_opt = params.find<std::vector<std::string>>("tasks");
         if (!tasks_opt || tasks_opt->empty()) {
-            LogError << "set_params failed, tasks not found";
+            LogError << __FUNCTION__ << "failed, tasks not found";
             return false;
         }
         for (auto& task : *tasks_opt) {
             if (Task.get(task) == nullptr) {
-                LogError << "set_params failed, task not found:" << task;
+                LogError << __FUNCTION__ << "failed, task not found:" << task;
                 return false;
             }
             m_eval_tasks.emplace_back(std::move(task));
         }
     }
     else if (m_image_test_mode == "ocr" || m_image_test_mode == "templ") {
-        if (auto roi_opt = params.find<json::array>("roi"); roi_opt) {
-            if (roi_opt->size() != 4 ||
-                std::ranges::any_of(*roi_opt, [](const json::value& v) { return !v.is_number(); })) {
-                LogError << "set_params failed, roi must be 4 numbers";
-                return false;
-            }
-            m_eval_roi = Rect(
-                (*roi_opt)[0].as_integer(),
-                (*roi_opt)[1].as_integer(),
-                (*roi_opt)[2].as_integer(),
-                (*roi_opt)[3].as_integer());
+        if (auto roi_opt = params.find<asst::Rect>("roi"); roi_opt) {
+            m_eval_roi = *roi_opt;
         }
         if (m_image_test_mode == "templ") {
-            auto templates_opt = params.find<json::array>("templates");
+            auto templates_opt = params.find<std::vector<std::string>>("templates");
             if (!templates_opt || templates_opt->empty()) {
-                LogError << "set_params failed, templates not found";
+                LogError << __FUNCTION__ << "failed, templates not found";
                 return false;
             }
             for (const auto& templ : *templates_opt) {
-                if (!templ.is_string()) {
-                    LogError << "set_params failed, template is not string";
-                    return false;
-                }
-                m_eval_templates.emplace_back(templ.as_string());
+                m_eval_templates.emplace_back(templ);
             }
             if (auto task_opt = params.find<std::string>("task"); task_opt) {
                 // Matcher 配置只能取自模板类任务；Task.get<MatchTaskInfo> 对非 MatchTaskInfo
@@ -361,7 +353,7 @@ bool asst::DebugTask::image_test_ocr()
                     results.emplace_back(
                         json::object { { "text", res.text },
                                        { "score", res.score },
-                                       { "rect", to_json_rect(res.rect) } });
+                                       { "rect", (json::value)(res.rect) } });
                 }
             }
             LogInfo << __FUNCTION__ << image_path << "ocr" << results.dumps();
@@ -437,7 +429,7 @@ bool asst::DebugTask::image_test_templ()
                     auto result_opt = analyzer.analyze();
                     if (result_opt) {
                         result["score"] = result_opt->score;
-                        result["rect"] = to_json_rect(result_opt->rect);
+                        result["rect"] = (json::value)(result_opt->rect);
                         result["hit"] = result_opt->score >= m_eval_threshold;
                     }
                     else {

--- a/src/MaaCore/Task/Interface/DebugTask.cpp
+++ b/src/MaaCore/Task/Interface/DebugTask.cpp
@@ -5,6 +5,7 @@
 #include <filesystem>
 #include <shared_mutex>
 
+#include "Common/AsstMsg.h"
 #include "Common/AsstTypes.h"
 #include "Config/TaskData.h"
 #include "Config/TemplResource.h"
@@ -17,10 +18,71 @@
 #include "Vision/FeatureMatcher.h"
 #include "Vision/Matcher.h"
 #include "Vision/Miscellaneous/DepotImageAnalyzer.h"
+#include "Vision/Miscellaneous/PipelineAnalyzer.h"
 #include "Vision/Miscellaneous/StageDropsImageAnalyzer.h"
 #include "Vision/MultiMatcher.h"
 #include "Vision/OCRer.h"
 #include "Vision/RegionOCRer.h"
+
+namespace
+{
+// 读取本地图片；normalize 为 true 时缩放到 1280x720（INTER_AREA），
+// 与线上 Controller::get_resized_image_cache 一致，调用方已自行预处理尺寸时传 false
+std::optional<cv::Mat> load_eval_image(const std::string& utf8_path, bool normalize)
+{
+    cv::Mat image = MAA_NS::imread(asst::utils::path(utf8_path));
+    if (image.empty()) {
+        Log.error("image_test | failed to load image:", utf8_path);
+        return std::nullopt;
+    }
+    if (normalize && (image.cols != 1280 || image.rows != 720)) {
+        cv::resize(image, image, { 1280, 720 }, 0, 0, cv::INTER_AREA);
+    }
+    return image;
+}
+
+// 可选的评估前缩放（INTER_AREA），供调用方复刻线上各识别器的尺度预处理
+std::optional<cv::Mat> resize_eval_image(cv::Mat image, int width, int height)
+{
+    if (image.cols != width || image.rows != height) {
+        cv::resize(image, image, { width, height }, 0, 0, cv::INTER_AREA);
+    }
+    return image;
+}
+
+json::array to_json_rect(const asst::Rect& rect)
+{
+    return json::array { rect.x, rect.y, rect.width, rect.height };
+}
+
+json::object to_result_json(const std::string& task_name, const asst::PipelineAnalyzer::ResultOpt& result_opt)
+{
+    json::object result { { "task", task_name } };
+    if (!result_opt) {
+        result["hit"] = false;
+        return result;
+    }
+    result["hit"] = true;
+    const auto& result_var = result_opt->result;
+    if (std::holds_alternative<asst::Matcher::Result>(result_var)) {
+        const auto& r = std::get<asst::Matcher::Result>(result_var);
+        result["score"] = r.score;
+        result["templ"] = r.templ_name;
+    }
+    else if (std::holds_alternative<asst::OCRer::Result>(result_var)) {
+        const auto& r = std::get<asst::OCRer::Result>(result_var);
+        result["score"] = r.score;
+        result["text"] = r.text;
+    }
+    else if (std::holds_alternative<asst::FeatureMatcher::Result>(result_var)) {
+        // FeatureMatch 的判据是特征点数而非相似度分数
+        const auto& r = std::get<asst::FeatureMatcher::Result>(result_var);
+        result["count"] = r.count;
+    }
+    result["rect"] = to_json_rect(result_opt->rect);
+    return result;
+}
+}
 
 asst::DebugTask::DebugTask(const AsstCallback& callback, Assistant* inst) :
     InterfaceTask(callback, inst, TaskType)
@@ -29,7 +91,305 @@ asst::DebugTask::DebugTask(const AsstCallback& callback, Assistant* inst) :
 
 bool asst::DebugTask::run()
 {
+    if (m_image_test_mode == "report") {
+        return image_test_report();
+    }
+    if (m_image_test_mode == "pipeline") {
+        return image_test_pipeline();
+    }
+    if (m_image_test_mode == "ocr") {
+        return image_test_ocr();
+    }
+    if (m_image_test_mode == "templ") {
+        return image_test_templ();
+    }
     return true;
+}
+
+// 离线图片评估的参数协议（AsstAppendTask 的 params，type 固定为 "Debug"）。
+// 日常用配套的 python 驱动 tools/maa_core_eval.py 调用，无需手拼 json：
+// { "mode": "report" | "pipeline" | "ocr" | "templ", "images": [图片路径], "tasks": [任务名],
+//   "templates": [模板名], "task": "任务名", "roi": [x, y, w, h], "threshold": 0.7, "resize": [w, h] }
+// images/tasks/templates 为 UTF-8 路径与名字（模板名也接受绝对路径图片文件）；roi 仅 ocr/templ
+// 模式使用，缺省全图；task 仅 templ 模式使用（mask/method 等 Matcher 配置取自该任务，复刻线上
+// 自定义识别器的用法，未显式给 threshold 时 hit 判定也取该任务阈值）；threshold/resize 仅 templ
+// 模式使用（内部匹配放开阈值恒报最佳得分；resize 为评估前 INTER_AREA 缩放尺寸，替代默认的
+// 1280x720 归一）
+bool asst::DebugTask::set_params(const json::value& params)
+{
+    LogTraceFunction;
+
+    m_image_test_mode = params.get("mode", "");
+    if (m_image_test_mode.empty()) {
+        return true; // 无 mode 的 Debug 任务保持 run() 空跑的旧行为
+    }
+
+    auto images_opt = params.find<json::array>("images");
+    if (!images_opt || images_opt->empty()) {
+        Log.error("set_params failed, images not found");
+        return false;
+    }
+    for (const auto& image : *images_opt) {
+        if (!image.is_string()) {
+            Log.error("set_params failed, image is not string");
+            return false;
+        }
+        m_eval_images.emplace_back(image.as_string());
+    }
+
+    if (m_image_test_mode == "report" || m_image_test_mode == "pipeline") {
+        auto tasks_opt = params.find<json::array>("tasks");
+        if (!tasks_opt || tasks_opt->empty()) {
+            Log.error("set_params failed, tasks not found");
+            return false;
+        }
+        for (const auto& task : *tasks_opt) {
+            if (!task.is_string()) {
+                Log.error("set_params failed, task is not string");
+                return false;
+            }
+            if (Task.get(task.as_string()) == nullptr) {
+                Log.error("set_params failed, task not found:", task.as_string());
+                return false;
+            }
+            m_eval_tasks.emplace_back(task.as_string());
+        }
+    }
+    else if (m_image_test_mode == "ocr" || m_image_test_mode == "templ") {
+        if (auto roi_opt = params.find<json::array>("roi"); roi_opt && roi_opt->size() == 4) {
+            m_eval_roi = Rect(
+                (*roi_opt)[0].as_integer(),
+                (*roi_opt)[1].as_integer(),
+                (*roi_opt)[2].as_integer(),
+                (*roi_opt)[3].as_integer());
+        }
+        if (m_image_test_mode == "templ") {
+            auto templates_opt = params.find<json::array>("templates");
+            if (!templates_opt || templates_opt->empty()) {
+                Log.error("set_params failed, templates not found");
+                return false;
+            }
+            for (const auto& templ : *templates_opt) {
+                if (!templ.is_string()) {
+                    Log.error("set_params failed, template is not string");
+                    return false;
+                }
+                m_eval_templates.emplace_back(templ.as_string());
+            }
+            if (auto task_opt = params.find<std::string>("task"); task_opt) {
+                auto task_ptr = Task.get(*task_opt);
+                if (task_ptr == nullptr) {
+                    Log.error("set_params failed, task not found:", *task_opt);
+                    return false;
+                }
+                m_eval_templ_task = *task_opt;
+                auto match_ptr = std::dynamic_pointer_cast<MatchTaskInfo>(task_ptr);
+                double default_threshold =
+                    match_ptr && !match_ptr->templ_thresholds.empty() ? match_ptr->templ_thresholds.front() : 0.7;
+                m_eval_threshold = params.get("threshold", default_threshold);
+            }
+            else {
+                m_eval_threshold = params.get("threshold", 0.7);
+            }
+            if (auto resize_opt = params.find<json::array>("resize"); resize_opt && resize_opt->size() == 2) {
+                m_eval_resize = std::make_pair((*resize_opt)[0].as_integer(), (*resize_opt)[1].as_integer());
+            }
+        }
+    }
+    else {
+        Log.error("set_params failed, unknown mode:", m_image_test_mode);
+        return false;
+    }
+
+    return true;
+}
+
+bool asst::DebugTask::image_test_report()
+{
+    bool all_ok = true;
+    for (const auto& image_path : m_eval_images) {
+        auto image_opt = load_eval_image(image_path, true);
+        if (!image_opt) {
+            all_ok = false;
+            continue;
+        }
+
+        json::array results;
+        for (const auto& task_name : m_eval_tasks) {
+            PipelineAnalyzer analyzer(*image_opt, Rect(0, 0, 1280, 720), nullptr);
+            analyzer.set_tasks({ task_name });
+            auto result_opt = analyzer.analyze();
+
+            json::object result = to_result_json(task_name, result_opt);
+            Log.info(
+                "image_test |",
+                image_path,
+                task_name,
+                result_opt ? "hit" : "miss",
+                json::value(result).dumps());
+            results.emplace_back(std::move(result));
+        }
+
+        callback(
+            AsstMsg::SubTaskExtraInfo,
+            json::object { { "what", "DebugImageTest" },
+                           { "details", json::object { { "mode", "report" },
+                                                        { "image", image_path },
+                                                        { "results", std::move(results) } } } });
+    }
+    return all_ok;
+}
+
+bool asst::DebugTask::image_test_pipeline()
+{
+    bool all_ok = true;
+    for (const auto& image_path : m_eval_images) {
+        auto image_opt = load_eval_image(image_path, true);
+        if (!image_opt) {
+            all_ok = false;
+            continue;
+        }
+
+        PipelineAnalyzer analyzer(*image_opt, Rect(0, 0, 1280, 720), nullptr);
+        analyzer.set_tasks(m_eval_tasks);
+        auto result_opt = analyzer.analyze();
+
+        json::object detail { { "mode", "pipeline" }, { "image", image_path } };
+        json::array next;
+        if (result_opt) {
+            const auto hit = to_result_json(result_opt->task_ptr->name, result_opt);
+            for (const auto& [key, value] : hit) {
+                detail[key] = value;
+            }
+            for (const auto& next_task : result_opt->task_ptr->next) {
+                next.emplace_back(next_task);
+            }
+            Log.info("image_test |", image_path, "hit", json::value(hit).dumps());
+        }
+        else {
+            detail["hit"] = false;
+            Log.info("image_test |", image_path, "miss");
+        }
+        detail["next"] = std::move(next);
+
+        callback(
+            AsstMsg::SubTaskExtraInfo,
+            json::object { { "what", "DebugImageTest" }, { "details", std::move(detail) } });
+    }
+    return all_ok;
+}
+
+bool asst::DebugTask::image_test_ocr()
+{
+    bool all_ok = true;
+    for (const auto& image_path : m_eval_images) {
+        auto image_opt = load_eval_image(image_path, true);
+        if (!image_opt) {
+            all_ok = false;
+            continue;
+        }
+
+        // 不 set_task_info：默认参数下 required 为空即不做 expected 过滤、不做 ocrReplace，
+        // 返回 OCR 引擎的原始识别结果；带任务配置的评估用 report 模式
+        Rect roi = m_eval_roi.empty() ? Rect(0, 0, 1280, 720) : m_eval_roi;
+        OCRer analyzer(*image_opt, roi);
+        auto results_opt = analyzer.analyze();
+
+        json::array results;
+        if (results_opt) {
+            for (const auto& res : *results_opt) {
+                results.emplace_back(
+                    json::object { { "text", res.text }, { "score", res.score }, { "rect", to_json_rect(res.rect) } });
+            }
+        }
+        Log.info("image_test |", image_path, "ocr", json::value(results).dumps());
+
+        callback(
+            AsstMsg::SubTaskExtraInfo,
+            json::object { { "what", "DebugImageTest" },
+                           { "details", json::object { { "mode", "ocr" },
+                                                        { "image", image_path },
+                                                        { "results", std::move(results) } } } });
+    }
+    return all_ok;
+}
+
+bool asst::DebugTask::image_test_templ()
+{
+    bool all_ok = true;
+    for (const auto& image_path : m_eval_images) {
+        auto image_opt = load_eval_image(image_path, !m_eval_resize.has_value());
+        if (image_opt && m_eval_resize) {
+            image_opt = resize_eval_image(std::move(*image_opt), m_eval_resize->first, m_eval_resize->second);
+        }
+        if (!image_opt) {
+            all_ok = false;
+            continue;
+        }
+
+        json::array results;
+        for (const auto& templ_name : m_eval_templates) {
+            // 模板名与 core 各处 get_templ 一致：物品 ID（如 "2001"）或相对
+            // resource/template 的路径（如 "items/2001.png"）；也接受绝对路径的
+            // 图片文件（调用方自行预处理过的模板）
+            Matcher analyzer(*image_opt, m_eval_roi.empty() ? Rect(0, 0, image_opt->cols, image_opt->rows) : m_eval_roi, nullptr);
+
+            if (!m_eval_templ_task.empty()) {
+                // mask/method 等 Matcher 配置取自该任务；须在 set_templ 之前调用，
+                // 否则 set_task_info 会把模板重置为任务自带的
+                analyzer.set_task_info(m_eval_templ_task);
+            }
+
+            std::filesystem::path templ_file = asst::utils::path(templ_name);
+            if (templ_file.is_absolute() && std::filesystem::exists(templ_file)) {
+                cv::Mat templ = MAA_NS::imread(templ_file);
+                if (templ.empty()) {
+                    Log.error("image_test | failed to load templ:", templ_name);
+                    all_ok = false;
+                    continue;
+                }
+                analyzer.set_templ(std::move(templ));
+            }
+            else {
+                analyzer.set_templ(templ_name);
+            }
+            analyzer.set_threshold(-1.0); // 放开阈值恒报最佳得分，hit 由 threshold 字段判定
+
+            json::object result { { "template", templ_name } };
+            try {
+                auto result_opt = analyzer.analyze();
+                if (result_opt) {
+                    result["score"] = result_opt->score;
+                    result["rect"] = to_json_rect(result_opt->rect);
+                    result["hit"] = result_opt->score >= m_eval_threshold;
+                }
+                else {
+                    result["hit"] = false;
+                }
+            }
+            catch (const std::exception& e) {
+                // ASST_DEBUG 下模板不存在/加载失败会 throw，报错后继续评估其余模板
+                result["hit"] = false;
+                result["error"] = e.what();
+                all_ok = false;
+            }
+            Log.info(
+                "image_test |",
+                image_path,
+                templ_name,
+                result["hit"].as_boolean() ? "hit" : "miss",
+                json::value(result).dumps());
+            results.emplace_back(std::move(result));
+        }
+
+        callback(
+            AsstMsg::SubTaskExtraInfo,
+            json::object { { "what", "DebugImageTest" },
+                           { "details", json::object { { "mode", "templ" },
+                                                        { "image", image_path },
+                                                        { "results", std::move(results) } } } });
+    }
+    return all_ok;
 }
 
 void asst::DebugTask::test_drops()

--- a/src/MaaCore/Task/Interface/DebugTask.cpp
+++ b/src/MaaCore/Task/Interface/DebugTask.cpp
@@ -57,6 +57,11 @@ std::optional<cv::Mat> load_eval_image(const std::string& utf8_path, bool normal
         LogError << __FUNCTION__ << "failed to load image:" << utf8_path;
         return std::nullopt;
     }
+    if (image.cols * 9 != image.rows * 16) {
+        // 线上遇到非 16:9 截图会直接报 Unsupported resolution，这里拉伸后仍可评估，
+        // 但结果与该分辨率的线上行为没有可比性
+        LogWarn << __FUNCTION__ << "image is not 16:9, will be stretched to 1280x720:" << utf8_path;
+    }
     if (normalize && (image.cols != 1280 || image.rows != 720)) {
         cv::resize(image, image, { 1280, 720 }, 0, 0, cv::INTER_AREA);
     }
@@ -80,6 +85,8 @@ json::object to_result_json(const std::string& task_name, const asst::PipelineAn
         return result;
     }
     result["hit"] = true;
+    // JustReturn 任务无识别结果（variant 默认构造的 Matcher::Result），带上算法类型供调用方区分
+    result["algorithm"] = asst::enum_to_string(result_opt->task_ptr->algorithm);
     const auto& result_var = result_opt->result;
     if (std::holds_alternative<asst::Matcher::Result>(result_var)) {
         const auto& r = std::get<asst::Matcher::Result>(result_var);
@@ -114,6 +121,24 @@ bool asst::DebugTask::set_params(const json::value& params)
 {
     LogTraceFunction;
 
+    // AsstSetTaskParams 在任务运行中调用会与 run() 遍历 m_eval_* 产生数据竞争，运行中拒绝更新
+    if (m_running) {
+        LogError << "set_params failed, task is running";
+        return false;
+    }
+
+    // 畸形参数（如 roi/resize 数组里有非数字）会让 as_integer 抛异常，不能让它穿过 C 接口
+    try {
+        return set_params_impl(params);
+    }
+    catch (const std::exception& e) {
+        LogError << "set_params failed, invalid params:" << e.what();
+        return false;
+    }
+}
+
+bool asst::DebugTask::set_params_impl(const json::value& params)
+{
     m_image_test_mode = params.get("mode", "");
     if (m_image_test_mode.empty()) {
         return true; // 无 mode 的 Debug 任务保持 run() 空跑的旧行为
@@ -160,7 +185,11 @@ bool asst::DebugTask::set_params(const json::value& params)
         }
     }
     else if (m_image_test_mode == "ocr" || m_image_test_mode == "templ") {
-        if (auto roi_opt = params.find<json::array>("roi"); roi_opt && roi_opt->size() == 4) {
+        if (auto roi_opt = params.find<json::array>("roi"); roi_opt) {
+            if (roi_opt->size() != 4 || std::ranges::any_of(*roi_opt, [](const json::value& v) { return !v.is_number(); })) {
+                LogError << "set_params failed, roi must be 4 numbers";
+                return false;
+            }
             m_eval_roi = Rect(
                 (*roi_opt)[0].as_integer(),
                 (*roi_opt)[1].as_integer(),
@@ -181,21 +210,26 @@ bool asst::DebugTask::set_params(const json::value& params)
                 m_eval_templates.emplace_back(templ.as_string());
             }
             if (auto task_opt = params.find<std::string>("task"); task_opt) {
-                auto task_ptr = Task.get(*task_opt);
-                if (task_ptr == nullptr) {
-                    LogError << "set_params failed, task not found:" << *task_opt;
+                // Matcher 配置只能取自模板类任务；Task.get<MatchTaskInfo> 对非 MatchTaskInfo
+                // 任务返回空，后续 set_task_info 会对其解引用，必须在入口拒绝
+                auto match_ptr = Task.get<MatchTaskInfo>(*task_opt);
+                if (match_ptr == nullptr) {
+                    LogError << "set_params failed, task not found or not a match task:" << *task_opt;
                     return false;
                 }
                 m_eval_templ_task = *task_opt;
-                auto match_ptr = std::dynamic_pointer_cast<MatchTaskInfo>(task_ptr);
-                double default_threshold =
-                    match_ptr && !match_ptr->templ_thresholds.empty() ? match_ptr->templ_thresholds.front() : 0.7;
+                double default_threshold = !match_ptr->templ_thresholds.empty() ? match_ptr->templ_thresholds.front() : 0.7;
                 m_eval_threshold = params.get("threshold", default_threshold);
             }
             else {
                 m_eval_threshold = params.get("threshold", 0.7);
             }
-            if (auto resize_opt = params.find<json::array>("resize"); resize_opt && resize_opt->size() == 2) {
+            if (auto resize_opt = params.find<json::array>("resize"); resize_opt) {
+                if (resize_opt->size() != 2 ||
+                    std::ranges::any_of(*resize_opt, [](const json::value& v) { return !v.is_number(); })) {
+                    LogError << "set_params failed, resize must be 2 numbers";
+                    return false;
+                }
                 int resize_w = (*resize_opt)[0].as_integer();
                 int resize_h = (*resize_opt)[1].as_integer();
                 if (resize_w <= 0 || resize_h <= 0) {
@@ -227,32 +261,39 @@ bool asst::DebugTask::image_test_report()
 {
     bool all_ok = true;
     for (const auto& image_path : m_eval_images) {
-        auto image_opt = load_eval_image(image_path, true);
-        if (!image_opt) {
+        try {
+            auto image_opt = load_eval_image(image_path, true);
+            if (!image_opt) {
+                all_ok = false;
+                emit_eval_error("report", image_path, "failed to load image");
+                continue;
+            }
+
+            json::array results;
+            for (const auto& task_name : m_eval_tasks) {
+                PipelineAnalyzer analyzer(*image_opt, Rect(0, 0, 1280, 720), nullptr);
+                analyzer.set_tasks({ task_name });
+                auto result_opt = analyzer.analyze();
+
+                json::object result = to_result_json(task_name, result_opt);
+                LogInfo << __FUNCTION__ << image_path << task_name << (result_opt ? "hit" : "miss")
+                        << json::value(result).dumps();
+                results.emplace_back(std::move(result));
+            }
+
+            callback(
+                AsstMsg::SubTaskExtraInfo,
+                json::object { { "what", "DebugImageTest" },
+                               { "details", json::object { { "mode", "report" },
+                                                            { "image", image_path },
+                                                            { "results", std::move(results) } } } });
+        }
+        catch (const std::exception& e) {
+            // ASST_DEBUG 下模板缺失/为空等会 throw，逐图兜住避免后续图静默缺结果
             all_ok = false;
-            emit_eval_error("report", image_path, "failed to load image");
-            continue;
+            emit_eval_error("report", image_path, e.what());
         }
 
-        json::array results;
-        for (const auto& task_name : m_eval_tasks) {
-            PipelineAnalyzer analyzer(*image_opt, Rect(0, 0, 1280, 720), nullptr);
-            analyzer.set_tasks({ task_name });
-            auto result_opt = analyzer.analyze();
-
-            json::object result = to_result_json(task_name, result_opt);
-            LogInfo << __FUNCTION__ << image_path << task_name << (result_opt ? "hit" : "miss")
-                    << json::value(result).dumps();
-            results.emplace_back(std::move(result));
-        }
-
-        callback(
-            AsstMsg::SubTaskExtraInfo,
-            json::object { { "what", "DebugImageTest" },
-                           { "details",
-                             json::object { { "mode", "report" },
-                                            { "image", image_path },
-                                            { "results", std::move(results) } } } });
     }
     return all_ok;
 }
@@ -261,38 +302,45 @@ bool asst::DebugTask::image_test_pipeline()
 {
     bool all_ok = true;
     for (const auto& image_path : m_eval_images) {
-        auto image_opt = load_eval_image(image_path, true);
-        if (!image_opt) {
+        try {
+            auto image_opt = load_eval_image(image_path, true);
+            if (!image_opt) {
+                all_ok = false;
+                emit_eval_error("pipeline", image_path, "failed to load image");
+                continue;
+            }
+
+            PipelineAnalyzer analyzer(*image_opt, Rect(0, 0, 1280, 720), nullptr);
+            analyzer.set_tasks(m_eval_tasks);
+            auto result_opt = analyzer.analyze();
+
+            json::object detail { { "mode", "pipeline" }, { "image", image_path } };
+            json::array next;
+            if (result_opt) {
+                const auto hit = to_result_json(result_opt->task_ptr->name, result_opt);
+                for (const auto& [key, value] : hit) {
+                    detail[key] = value;
+                }
+                for (const auto& next_task : result_opt->task_ptr->next) {
+                    next.emplace_back(next_task);
+                }
+                LogInfo << __FUNCTION__ << image_path << "hit" << json::value(hit).dumps();
+            }
+            else {
+                detail["hit"] = false;
+                LogInfo << __FUNCTION__ << image_path << "miss";
+            }
+            detail["next"] = std::move(next);
+
+            callback(
+                AsstMsg::SubTaskExtraInfo,
+                json::object { { "what", "DebugImageTest" }, { "details", std::move(detail) } });
+        }
+        catch (const std::exception& e) {
             all_ok = false;
-            emit_eval_error("pipeline", image_path, "failed to load image");
-            continue;
+            emit_eval_error("pipeline", image_path, e.what());
         }
 
-        PipelineAnalyzer analyzer(*image_opt, Rect(0, 0, 1280, 720), nullptr);
-        analyzer.set_tasks(m_eval_tasks);
-        auto result_opt = analyzer.analyze();
-
-        json::object detail { { "mode", "pipeline" }, { "image", image_path } };
-        json::array next;
-        if (result_opt) {
-            const auto hit = to_result_json(result_opt->task_ptr->name, result_opt);
-            for (const auto& [key, value] : hit) {
-                detail[key] = value;
-            }
-            for (const auto& next_task : result_opt->task_ptr->next) {
-                next.emplace_back(next_task);
-            }
-            LogInfo << __FUNCTION__ << image_path << "hit" << json::value(hit).dumps();
-        }
-        else {
-            detail["hit"] = false;
-            LogInfo << __FUNCTION__ << image_path << "miss";
-        }
-        detail["next"] = std::move(next);
-
-        callback(
-            AsstMsg::SubTaskExtraInfo,
-            json::object { { "what", "DebugImageTest" }, { "details", std::move(detail) } });
     }
     return all_ok;
 }
@@ -301,34 +349,40 @@ bool asst::DebugTask::image_test_ocr()
 {
     bool all_ok = true;
     for (const auto& image_path : m_eval_images) {
-        auto image_opt = load_eval_image(image_path, true);
-        if (!image_opt) {
-            all_ok = false;
-            emit_eval_error("ocr", image_path, "failed to load image");
-            continue;
-        }
-
-        // 不 set_task_info：默认参数下 required 为空即不做 expected 过滤、不做 ocrReplace，
-        // 返回 OCR 引擎的原始识别结果；带任务配置的评估用 report 模式
-        Rect roi = m_eval_roi.empty() ? Rect(0, 0, 1280, 720) : m_eval_roi;
-        OCRer analyzer(*image_opt, roi);
-        auto results_opt = analyzer.analyze();
-
-        json::array results;
-        if (results_opt) {
-            for (const auto& res : *results_opt) {
-                results.emplace_back(
-                    json::object { { "text", res.text }, { "score", res.score }, { "rect", (json::value)res.rect } });
+        try {
+            auto image_opt = load_eval_image(image_path, true);
+            if (!image_opt) {
+                all_ok = false;
+                emit_eval_error("ocr", image_path, "failed to load image");
+                continue;
             }
-        }
-        LogInfo << __FUNCTION__ << image_path << "ocr" << json::value(results).dumps();
 
-        callback(
-            AsstMsg::SubTaskExtraInfo,
-            json::object {
-                { "what", "DebugImageTest" },
-                { "details",
-                  json::object { { "mode", "ocr" }, { "image", image_path }, { "results", std::move(results) } } } });
+            // 不 set_task_info：默认参数下 required 为空即不做 expected 过滤、不做 ocrReplace，
+            // 返回 OCR 引擎的原始识别结果；带任务配置的评估用 report 模式
+            Rect roi = m_eval_roi.empty() ? Rect(0, 0, 1280, 720) : m_eval_roi;
+            OCRer analyzer(*image_opt, roi);
+            auto results_opt = analyzer.analyze();
+
+            json::array results;
+            if (results_opt) {
+                for (const auto& res : *results_opt) {
+                    results.emplace_back(
+                        json::object { { "text", res.text }, { "score", res.score }, { "rect", (json::value)res.rect } });
+                }
+            }
+            LogInfo << __FUNCTION__ << image_path << "ocr" << json::value(results).dumps();
+
+            callback(
+                AsstMsg::SubTaskExtraInfo,
+                json::object { { "what", "DebugImageTest" },
+                               { "details", json::object { { "mode", "ocr" },
+                                                            { "image", image_path },
+                                                            { "results", std::move(results) } } } });
+        }
+        catch (const std::exception& e) {
+            all_ok = false;
+            emit_eval_error("ocr", image_path, e.what());
+        }
     }
     return all_ok;
 }
@@ -337,15 +391,16 @@ bool asst::DebugTask::image_test_templ()
 {
     bool all_ok = true;
     for (const auto& image_path : m_eval_images) {
-        auto image_opt = load_eval_image(image_path, !m_eval_resize.has_value());
-        if (image_opt && m_eval_resize) {
-            image_opt = resize_eval_image(std::move(*image_opt), m_eval_resize->first, m_eval_resize->second);
-        }
-        if (!image_opt) {
-            all_ok = false;
-            emit_eval_error("templ", image_path, "failed to load image");
-            continue;
-        }
+        try {
+            auto image_opt = load_eval_image(image_path, !m_eval_resize.has_value());
+            if (image_opt && m_eval_resize) {
+                image_opt = resize_eval_image(std::move(*image_opt), m_eval_resize->first, m_eval_resize->second);
+            }
+            if (!image_opt) {
+                all_ok = false;
+                emit_eval_error("templ", image_path, "failed to load image");
+                continue;
+            }
 
         json::array results;
         for (const auto& templ_name : m_eval_templates) {
@@ -364,12 +419,16 @@ bool asst::DebugTask::image_test_templ()
                 analyzer.set_roi(m_eval_roi);
             }
 
+            json::object result { { "template", templ_name } };
             std::filesystem::path templ_file = asst::utils::path(templ_name);
             if (templ_file.is_absolute() && std::filesystem::exists(templ_file)) {
                 cv::Mat templ = MAA_NS::imread(templ_file);
                 if (templ.empty()) {
+                    result["hit"] = false;
+                    result["error"] = "failed to load templ file";
                     LogError << __FUNCTION__ << "failed to load templ:" << templ_name;
                     all_ok = false;
+                    results.emplace_back(std::move(result));
                     continue;
                 }
                 analyzer.set_templ(std::move(templ));
@@ -379,7 +438,6 @@ bool asst::DebugTask::image_test_templ()
             }
             analyzer.set_threshold(-1.0); // 放开阈值恒报最佳得分，hit 由 threshold 字段判定
 
-            json::object result { { "template", templ_name } };
             try {
                 auto result_opt = analyzer.analyze();
                 if (result_opt) {
@@ -388,7 +446,10 @@ bool asst::DebugTask::image_test_templ()
                     result["hit"] = result_opt->score >= m_eval_threshold;
                 }
                 else {
+                    // 阈值已放开仍无结果，只剩 roi 为空或模板大于 roi 等输入问题，不存在正常 miss
                     result["hit"] = false;
+                    result["error"] = "no match result (check roi / template size)";
+                    all_ok = false;
                 }
             }
             catch (const std::exception& e) {
@@ -404,10 +465,15 @@ bool asst::DebugTask::image_test_templ()
 
         callback(
             AsstMsg::SubTaskExtraInfo,
-            json::object {
-                { "what", "DebugImageTest" },
-                { "details",
-                  json::object { { "mode", "templ" }, { "image", image_path }, { "results", std::move(results) } } } });
+            json::object { { "what", "DebugImageTest" },
+                           { "details", json::object { { "mode", "templ" },
+                                                        { "image", image_path },
+                                                        { "results", std::move(results) } } } });
+        }
+        catch (const std::exception& e) {
+            all_ok = false;
+            emit_eval_error("templ", image_path, e.what());
+        }
     }
     return all_ok;
 }

--- a/src/MaaCore/Task/Interface/DebugTask.h
+++ b/src/MaaCore/Task/Interface/DebugTask.h
@@ -37,5 +37,8 @@ private:
     Rect m_eval_roi;
     double m_eval_threshold = 0.7;
     std::optional<std::pair<int, int>> m_eval_resize; // 评估前把图缩放到该尺寸（templ 模式）
+
+    // 读图失败等单图错误也要发对应的结果条目，否则调用方按图取结果会缺项
+    void emit_eval_error(const std::string& mode, const std::string& image_path, const std::string& error);
 };
 }

--- a/src/MaaCore/Task/Interface/DebugTask.h
+++ b/src/MaaCore/Task/Interface/DebugTask.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "Common/AsstTypes.h"
 #include "Task/InterfaceTask.h"
 
 namespace asst
@@ -12,11 +13,29 @@ public:
     virtual ~DebugTask() override = default;
 
     virtual bool run() override;
+    virtual bool set_params(const json::value& params) override;
 
 private:
     void test_drops();
     void test_skill_ready();
     void test_battle_image();
     void test_match_template();
+
+    // 以下为离线图片评估入口：不连设备，对本地图片跑与线上一致的识别链路，
+    // 结果通过 SubTaskExtraInfo 回调（what = "DebugImageTest"）与日志输出。
+    // 配套 python 驱动 tools/maa_core_eval.py（可 import 或 CLI），测试本地图片用它即可
+    bool image_test_report();    // 每张图 × 每个任务独立评估命中情况
+    bool image_test_pipeline();  // 每张图按任务列表跑一次首命中，附带命中任务的 next 列表
+    bool image_test_ocr();       // 返回 OCR 原始识别文本（不套任务的 ocrReplace 与 expected 过滤）
+    bool image_test_templ();     // 每张图 × 裸模板文件匹配（物品图标等非任务模板），报最佳得分
+
+    std::string m_image_test_mode; // 空 = 未启用（run 空跑，保持旧行为）；report / pipeline / ocr / templ
+    std::vector<std::string> m_eval_images;
+    std::vector<std::string> m_eval_tasks;
+    std::vector<std::string> m_eval_templates;
+    std::string m_eval_templ_task; // templ 模式的 Matcher 配置来源任务名（mask/method 等取自它）
+    Rect m_eval_roi;
+    double m_eval_threshold = 0.7;
+    std::optional<std::pair<int, int>> m_eval_resize; // 评估前把图缩放到该尺寸（templ 模式）
 };
 }

--- a/src/MaaCore/Task/Interface/DebugTask.h
+++ b/src/MaaCore/Task/Interface/DebugTask.h
@@ -34,10 +34,10 @@ private:
     std::vector<std::string> m_eval_images;
     std::vector<std::string> m_eval_tasks;
     std::vector<std::string> m_eval_templates;
-    std::string m_eval_templ_task; // templ 模式的 Matcher 配置来源任务名（mask/method 等取自它）
+    std::string m_eval_templ_task; // templ 模式的 Matcher 配置来源任务名（mask/method/roi 等取自它）
     Rect m_eval_roi;
-    double m_eval_threshold = 0.7;
-    std::optional<std::pair<int, int>> m_eval_resize; // 评估前把图缩放到该尺寸（templ 模式）
+    double m_eval_threshold = TemplThresholdDefault;
+    std::optional<std::pair<int, int>> m_eval_resize; // 1280x720 归一后的二级缩放尺寸（templ 模式）
 
     // 读图失败等单图错误也要发对应的结果条目，否则调用方按图取结果会缺项
     void emit_eval_error(const std::string& mode, const std::string& image_path, const std::string& error);

--- a/src/MaaCore/Task/Interface/DebugTask.h
+++ b/src/MaaCore/Task/Interface/DebugTask.h
@@ -16,6 +16,7 @@ public:
     virtual bool set_params(const json::value& params) override;
 
 private:
+    bool set_params_impl(const json::value& params);
     void test_drops();
     void test_skill_ready();
     void test_battle_image();

--- a/tools/maa_core_eval.py
+++ b/tools/maa_core_eval.py
@@ -98,7 +98,7 @@ class CoreEval:
         lib.AsstDestroy.argtypes = [ctypes.c_void_p]
         lib.AsstDestroy.restype = None
         lib.AsstAppendTask.argtypes = [ctypes.c_void_p, c, c]
-        lib.AsstAppendTask.restype = ctypes.c_int64
+        lib.AsstAppendTask.restype = ctypes.c_int  # AsstTaskId 为 int32，与 AsstCaller.h 一致
         lib.AsstStart.argtypes, lib.AsstStart.restype = [ctypes.c_void_p], ctypes.c_bool
         lib.AsstRunning.argtypes, lib.AsstRunning.restype = [ctypes.c_void_p], ctypes.c_bool
 
@@ -205,9 +205,12 @@ class CoreEval:
         线上的自定义处理在此复刻：模板右下 80x50 涂黑（数量角标）、图 INTER_AREA 缩放
         到 DepotMatchData 的 roi 尺寸、maskRange/阈值等 Matcher 配置取自 DepotMatchData
         任务 —— 尺寸、mask、阈值直接读 tasks.json，与 core 运行时同源；缩放和匹配仍由
-        core 执行。数量识别等其余链路不在此复刻，只做模板匹配评估。
+        core 执行。需要 Pillow。数量识别等其余链路不在此复刻，只做模板匹配评估。
 
-        :param item_ids: 物品 ID / 模板路径 / 目录列表，默认 "items" 全部材料模板
+        :param item_ids: 物品 ID / 模板路径 / 目录列表；缺省为 item_index.json 里
+                         classifyType 为 MATERIAL 的物品（与线上
+                         ItemData.get_ordered_material_item_id 的候选集一致），
+                         显式传目录时才展开全部模板
         :return: 同 templ
         """
         from PIL import Image
@@ -219,13 +222,15 @@ class CoreEval:
         names = []
         tmpdir = pathlib.Path(tempfile.mkdtemp(prefix="maa-eval-templ-"))
         try:
-            for name in (item_ids or ["items"]):
+            for name in (item_ids or self._default_depot_candidates()):
                 path = templ_root / name
                 # 纯物品 ID（如 "2001"）落到 items/<id>.png，与 core get_templ 的查找一致
                 if not path.exists() and not pathlib.Path(name).suffix:
                     candidate = templ_root / "items" / f"{name}.png"
                     if candidate.exists():
                         path = candidate
+                if not path.is_dir() and not path.exists():
+                    continue # 候选缺模板（如分服活动进度差异），跳过
                 files = sorted(path.rglob("*.png")) if path.is_dir() else [path]
                 for src in files:
                     templ = Image.open(src).convert("RGB")
@@ -246,6 +251,16 @@ class CoreEval:
             import shutil
 
             shutil.rmtree(tmpdir, ignore_errors=True)
+
+    def _default_depot_candidates(self):
+        # 与线上 ItemData.get_ordered_material_item_id 对齐：classifyType 为 MATERIAL 的物品
+        items_file = self._resource / "resource" / "item_index.json"
+        with open(items_file, encoding="utf-8") as f:
+            items = json.load(f)
+        return sorted(
+            (item for item, v in items.items() if v.get("classifyType") == "MATERIAL"),
+            key=lambda i: items[i].get("sortId", 0),
+        )
 
     def _read_task_def(self, task_name):
         tasks_file = self._resource / "resource" / "tasks" / "tasks.json"
@@ -284,7 +299,11 @@ class CoreEval:
 
 def _print_report(result):
     for entry in result:
-        print(f"{pathlib.Path(entry['image']).name}:")
+        name = pathlib.Path(entry["image"]).name
+        if "error" in entry:
+            print(f"{name}: ERROR {entry['error']}")
+            continue
+        print(f"{name}:")
         for r in entry["results"]:
             fields = " ".join(f"{k}={r[k]}" for k in ("score", "count", "templ", "text", "rect") if k in r)
             print(f"  {'hit ' if r['hit'] else 'MISS'} {r['task']} {fields}")
@@ -296,6 +315,7 @@ def main():
     parser.add_argument("--mode", choices=["report", "pipeline", "ocr", "templ", "depot", "replay"], default="report")
     parser.add_argument("--tasks", help="逗号分隔的任务名列表")
     parser.add_argument("--templates", help="逗号分隔的模板名（物品 ID / items/xxx.png / 目录），templ 模式用")
+    parser.add_argument("--task", help="templ 模式的 Matcher 配置来源任务名（maskRange/method 等）")
     parser.add_argument("--threshold", type=float, default=None, help="templ/depot 模式的 hit 判定阈值，默认取任务阈值或 0.7")
     parser.add_argument("--roi", help="ocr/templ 模式的识别区域 x,y,w,h")
     parser.add_argument("--dll-dir", default=str(REPO_ROOT / "build" / "bin" / "Debug"))
@@ -323,9 +343,9 @@ def main():
         elif args.mode == "pipeline":
             tasks = [t.strip() for t in args.tasks.split(",") if t.strip()]
             for r in ev.pipeline(args.images, tasks):
-                hit = "hit " if r["hit"] else "MISS"
+                hit = "hit " if r.get("hit") else "MISS"
                 extras = " ".join(f"{k}={r[k]}" for k in ("score", "count", "text", "rect") if k in r)
-                print(f"{pathlib.Path(r['image']).name}: {hit} {r.get('task', '')} {extras} next={r['next']}")
+                print(f"{pathlib.Path(r['image']).name}: {hit} {r.get('task', '')} {extras} next={r.get('next', [])}")
         elif args.mode == "ocr":
             roi = [int(v) for v in args.roi.split(",")] if args.roi else None
             for entry in ev.ocr(args.images, roi):
@@ -335,9 +355,9 @@ def main():
         elif args.mode == "templ":
             roi = [int(v) for v in args.roi.split(",")] if args.roi else None
             templates = [t.strip() for t in args.templates.split(",") if t.strip()]
-            for entry in ev.templ(args.images, templates, threshold=args.threshold, roi=roi):
+            for entry in ev.templ(args.images, templates, threshold=args.threshold, roi=roi, task=args.task):
                 print(f"{pathlib.Path(entry['image']).name}:")
-                for r in entry["results"]:
+                for r in entry.get("results", []):
                     if "error" in r:
                         print(f"  ERR  {r['template']} {r['error']}")
                     else:
@@ -347,7 +367,7 @@ def main():
             item_ids = [t.strip() for t in args.templates.split(",")] if args.templates else None
             for entry in ev.depot_items(args.images, item_ids=item_ids, threshold=args.threshold):
                 print(f"{pathlib.Path(entry['image']).name}:")
-                for r in sorted(entry["results"], key=lambda x: -x.get("score", 0)):
+                for r in sorted(entry.get("results", []), key=lambda x: -x.get("score", 0)):
                     name = pathlib.Path(r["template"]).stem
                     if "error" in r:
                         print(f"  ERR  {name} {r['error']}")
@@ -356,9 +376,12 @@ def main():
         else:
             tasks = [t.strip() for t in args.tasks.split(",") if t.strip()]
             for s in ev.replay(args.images, tasks):
-                hit = "hit " if s["hit"] else "MISS"
+                if "error" in s:
+                    print(f"step{s['step']} {pathlib.Path(s['image']).name}: ERROR {s['error']}")
+                    continue
+                hit = "hit " if s.get("hit") else "MISS"
                 extras = " ".join(f"{k}={s[k]}" for k in ("score", "count", "text", "rect") if k in s)
-                print(f"step{s['step']} {pathlib.Path(s['image']).name}: {hit} {s.get('task', '')} {extras} next={s['next']}")
+                print(f"step{s['step']} {pathlib.Path(s['image']).name}: {hit} {s.get('task', '')} {extras} next={s.get('next', [])}")
     finally:
         ev.close()
 

--- a/tools/maa_core_eval.py
+++ b/tools/maa_core_eval.py
@@ -1,0 +1,369 @@
+# -*- coding: utf-8 -*-
+"""通过 MaaCore.dll 对本地图片跑与线上一致的识别与匹配，用于离线验证 pipeline 任务。
+
+典型场景：拿手动截图或用户日志压缩包里的截图，验证某个任务在 core 眼里是否命中、
+得分多少、OCR 认出了什么文本 —— 识别走的是 core 本体（模板、前处理、ocrReplace、
+各服 OCR 模型均与运行时一致），避免用外部脚本近似复现导致结论偏差。
+
+仅 Debug 构建的 MaaCore.dll 可用（Debug 任务只在 ASST_DEBUG 下注册）。
+连着模拟器在线验证任务流请用 Custom 任务，本模块只做离线图片评估。
+
+用法一（作为模块，供脚本组合调用）::
+
+    import sys; sys.path.insert(0, "tools")
+    from maa_core_eval import CoreEval
+
+    ev = CoreEval()                                   # 默认 build/bin/Debug + 仓库 resource
+    ev = CoreEval(global_client="YoStarJP")           # 国际服资源与 OCR 模型
+    ev.report(images=["1.png"], tasks=["xxx@Roguelike@StageEnter"])
+    ev.pipeline(images=["1.png"], tasks=["A", "B"])   # 首命中 + 命中任务的 next 列表
+    ev.ocr(images=["1.png"], roi=[100, 200, 300, 50]) # OCR 原始识别文本
+    ev.replay(images=["1.png", "2.png"], tasks=["A"]) # 按 next 链逐图推进
+
+用法二（命令行）::
+
+    python tools/maa_core_eval.py --mode report --tasks "A,B" 1.png 2.png
+    python tools/maa_core_eval.py --mode ocr --roi 100,200,300,50 1.png
+    python tools/maa_core_eval.py --mode replay --tasks "A" 1.png 2.png 3.png
+"""
+
+import argparse
+import ctypes
+import json
+import os
+import pathlib
+import sys
+import tempfile
+import threading
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+MSG_ALL_TASKS_COMPLETED = 3
+
+
+class CoreEval:
+    """MaaCore 离线图片评估的 python 封装。
+
+    :param dll_dir:   MaaCore.dll 所在目录（须为 Debug 构建），默认 build/bin/Debug
+    :param resource:  资源根目录（AsstLoadResource 语义：其下应有 resource/ 子目录），默认仓库根
+    :param global_client: 国际服名（YoStarJP / YoStarEN / YoStarKR / txwy），
+                          加载主资源后再叠加对应分服资源与 OCR 模型
+    :param user_dir:  core 日志（debug/asst.log）写入目录，默认临时目录
+    :param verbose:   额外打印 core 回调的其余消息
+    """
+
+    def __init__(
+        self,
+        dll_dir=REPO_ROOT / "build" / "bin" / "Debug",
+        resource=REPO_ROOT,
+        global_client=None,
+        user_dir=None,
+        verbose=False,
+    ):
+        self._verbose = verbose
+        self._resource = pathlib.Path(resource)
+        self._user_dir = pathlib.Path(user_dir) if user_dir else pathlib.Path(tempfile.mkdtemp(prefix="maa-eval-"))
+        self._user_dir.mkdir(parents=True, exist_ok=True)
+
+        dll_dir = pathlib.Path(dll_dir)
+        os.environ["PATH"] = str(dll_dir) + os.pathsep + os.environ.get("PATH", "")
+        self._lib = ctypes.WinDLL(str(dll_dir / "MaaCore.dll"))
+        self._declare_functions()
+
+        def on_callback(msg, details, arg):
+            self._on_callback(msg, details)
+
+        # 持有回调引用，实例存活期间不被 GC
+        self._callback = ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.c_char_p, ctypes.c_void_p)(on_callback)
+        self._completed = threading.Event()
+        self._results = []
+
+        self._lib.AsstSetUserDir(str(self._user_dir).encode("utf-8"))
+        if not self._lib.AsstLoadResource(str(self._resource).encode("utf-8")):
+            raise RuntimeError(f"load resource failed: {resource}")
+        if global_client:
+            global_path = self._resource / "resource" / "global" / global_client
+            if not self._lib.AsstLoadResource(str(global_path).encode("utf-8")):
+                raise RuntimeError(f"load global resource failed: {global_path}")
+
+        self._handle = self._lib.AsstCreateEx(self._callback, None)
+        if not self._handle:
+            raise RuntimeError("AsstCreateEx failed")
+
+    def _declare_functions(self):
+        lib = self._lib
+        c = ctypes.c_char_p
+        lib.AsstSetUserDir.argtypes, lib.AsstSetUserDir.restype = [c], ctypes.c_bool
+        lib.AsstLoadResource.argtypes, lib.AsstLoadResource.restype = [c], ctypes.c_bool
+        lib.AsstCreateEx.restype = ctypes.c_void_p
+        lib.AsstDestroy.argtypes = [ctypes.c_void_p]
+        lib.AsstDestroy.restype = None
+        lib.AsstAppendTask.argtypes = [ctypes.c_void_p, c, c]
+        lib.AsstAppendTask.restype = ctypes.c_int64
+        lib.AsstStart.argtypes, lib.AsstStart.restype = [ctypes.c_void_p], ctypes.c_bool
+        lib.AsstRunning.argtypes, lib.AsstRunning.restype = [ctypes.c_void_p], ctypes.c_bool
+
+    def _on_callback(self, msg, details):
+        try:
+            detail = json.loads(details.decode("utf-8")) if details else {}
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return
+        if detail.get("what") == "DebugImageTest":
+            self._results.append(detail.get("details", {}))
+        elif msg == MSG_ALL_TASKS_COMPLETED:
+            self._completed.set()
+        elif self._verbose:
+            print(f"[core] msg={msg} {json.dumps(detail, ensure_ascii=False)}")
+
+    def _run_task(self, params, timeout=600):
+        """append 一个 Debug 任务并同步等待完成，返回所有 DebugImageTest 结果。"""
+        self._results.clear()
+        self._completed.clear()
+        task_id = self._lib.AsstAppendTask(
+            self._handle, b"Debug", json.dumps(params, ensure_ascii=False).encode("utf-8")
+        )
+        if not task_id:
+            raise RuntimeError(f'append Debug task failed: {json.dumps(params, ensure_ascii=False)}')
+        if not self._lib.AsstStart(self._handle):
+            raise RuntimeError("AsstStart failed")
+        if not self._completed.wait(timeout):
+            raise TimeoutError(f"Debug task not completed in {timeout}s")
+        # 等工作线程回到 idle，否则下一次 append+start 会被拒绝
+        for _ in range(100):
+            if not self._lib.AsstRunning(self._handle):
+                break
+            threading.Event().wait(0.02)
+        return list(self._results)
+
+    @staticmethod
+    def _abs_images(images):
+        return [str(pathlib.Path(p).resolve()) for p in images]
+
+    def report(self, images, tasks):
+        """每张图 × 每个任务独立评估：[{image, results: [{task, hit, score, rect, ...}]}]。
+
+        命中结果按任务算法携带 score+templ（模板）、score+text（OCR）、count（特征匹配）。
+        """
+        return self._run_task(
+            {"mode": "report", "images": self._abs_images(images), "tasks": list(tasks)}
+        )
+
+    def pipeline(self, images, tasks):
+        """每张图按任务列表跑一次线上同款首命中匹配：[{image, hit, task, next, ...}]。
+
+        返回的 next 是命中任务的 next 任务列表，可用于自行驱动任务链回放。
+        """
+        return self._run_task(
+            {"mode": "pipeline", "images": self._abs_images(images), "tasks": list(tasks)}
+        )
+
+    def ocr(self, images, roi=None):
+        """OCR 引擎对该图（或指定 roi）的原始识别结果：[{image, results: [{text, score, rect}]}]。
+
+        不套任务的 ocrReplace 与 expected 过滤；要看任务配置过滤后的效果用 report。
+        """
+        params = {"mode": "ocr", "images": self._abs_images(images)}
+        if roi:
+            params["roi"] = list(roi)
+        return self._run_task(params)
+
+    def templ(self, images, templates, threshold=0.7, roi=None, resize=None, task=None):
+        """每张图 × 裸模板文件匹配（物品图标等非任务模板）。
+
+        :param templates: 模板名列表，与 core 的 get_templ 一致：物品 ID（如 "2001"）、
+                          相对 resource/template 的路径（如 "items/2001.png"）、
+                          或 resource/template 下的目录（自动展开其中全部模板）
+        :param threshold: hit 判定阈值；匹配恒报最佳得分，排查 ｢为什么没认出｣ 时可调低
+        :param resize:    评估前把图 INTER_AREA 缩放到 [w, h]（core 侧执行），
+                          复刻线上各识别器的尺度预处理时使用
+        :param task:      Matcher 配置来源任务名（maskRange / colorScales / method 等取自
+                          该任务，threshold 缺省时也取任务阈值），复刻线上自定义识别器
+                          的 Matcher 用法时使用
+        :return: [{image, results: [{template, hit, score, rect, error?}]}]
+        """
+        names = []
+        templ_root = self._resource / "resource" / "template"
+        for name in templates:
+            path = templ_root / name
+            if path.is_dir():
+                names.extend(sorted(str(p.relative_to(templ_root)).replace("\\", "/") for p in path.rglob("*.png")))
+            else:
+                names.append(name)
+        params = {"mode": "templ", "images": self._abs_images(images), "templates": names}
+        if threshold is not None:
+            params["threshold"] = threshold
+        if roi:
+            params["roi"] = list(roi)
+        if resize:
+            params["resize"] = list(resize)
+        if task:
+            params["task"] = task
+        return self._run_task(params)
+
+    def depot_items(self, images, item_ids=None, threshold=None):
+        """复刻线上 DepotImageAnalyzer 的仓库物品匹配（python 侧做自定义预处理）。
+
+        线上的自定义处理在此复刻：模板右下 80x50 涂黑（数量角标）、图 INTER_AREA 缩放
+        到 DepotMatchData 的 roi 尺寸、maskRange/阈值等 Matcher 配置取自 DepotMatchData
+        任务 —— 尺寸、mask、阈值直接读 tasks.json，与 core 运行时同源；缩放和匹配仍由
+        core 执行。数量识别等其余链路不在此复刻，只做模板匹配评估。
+
+        :param item_ids: 物品 ID / 模板路径 / 目录列表，默认 "items" 全部材料模板
+        :return: 同 templ
+        """
+        from PIL import Image
+
+        task = self._read_task_def("DepotMatchData")
+        roi = task.get("roi", [0, 0, 1066, 599])
+
+        templ_root = self._resource / "resource" / "template"
+        names = []
+        tmpdir = pathlib.Path(tempfile.mkdtemp(prefix="maa-eval-templ-"))
+        try:
+            for name in (item_ids or ["items"]):
+                path = templ_root / name
+                # 纯物品 ID（如 "2001"）落到 items/<id>.png，与 core get_templ 的查找一致
+                if not path.exists() and not pathlib.Path(name).suffix:
+                    candidate = templ_root / "items" / f"{name}.png"
+                    if candidate.exists():
+                        path = candidate
+                files = sorted(path.rglob("*.png")) if path.is_dir() else [path]
+                for src in files:
+                    templ = Image.open(src).convert("RGB")
+                    w, h = templ.size
+                    if w > 80 and h > 50:
+                        templ.paste((0, 0, 0), (w - 80, h - 50, w, h))
+                    dst = tmpdir / src.name
+                    templ.save(dst)
+                    names.append(str(dst))
+            return self.templ(
+                images,
+                names,
+                threshold=threshold,
+                resize=[roi[2], roi[3]],
+                task="DepotMatchData",
+            )
+        finally:
+            import shutil
+
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    def _read_task_def(self, task_name):
+        tasks_file = self._resource / "resource" / "tasks" / "tasks.json"
+        with open(tasks_file, encoding="utf-8") as f:
+            return json.load(f).get(task_name, {})
+
+    def replay(self, images, tasks):
+        """图片序列按 next 链逐图推进（纯识别，不执行点击等 action）。
+
+        返回 [{step, image, hit, task, next, ...}]；链在未命中、next 为空或图耗尽处停止。
+        """
+        steps = []
+        current = list(tasks)
+        for i, image in enumerate(self._abs_images(images)):
+            result = self.pipeline([image], current)[0]
+            result["step"] = i
+            steps.append(result)
+            if not result.get("hit"):
+                break
+            current = result.get("next", [])
+            if not current:
+                break
+        return steps
+
+    def close(self):
+        if getattr(self, "_handle", None):
+            self._lib.AsstDestroy(self._handle)
+            self._handle = None
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            pass
+
+
+def _print_report(result):
+    for entry in result:
+        print(f"{pathlib.Path(entry['image']).name}:")
+        for r in entry["results"]:
+            fields = " ".join(f"{k}={r[k]}" for k in ("score", "count", "templ", "text", "rect") if k in r)
+            print(f"  {'hit ' if r['hit'] else 'MISS'} {r['task']} {fields}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("images", nargs="+", help="图片路径（可多张）")
+    parser.add_argument("--mode", choices=["report", "pipeline", "ocr", "templ", "depot", "replay"], default="report")
+    parser.add_argument("--tasks", help="逗号分隔的任务名列表")
+    parser.add_argument("--templates", help="逗号分隔的模板名（物品 ID / items/xxx.png / 目录），templ 模式用")
+    parser.add_argument("--threshold", type=float, default=None, help="templ/depot 模式的 hit 判定阈值，默认取任务阈值或 0.7")
+    parser.add_argument("--roi", help="ocr/templ 模式的识别区域 x,y,w,h")
+    parser.add_argument("--dll-dir", default=str(REPO_ROOT / "build" / "bin" / "Debug"))
+    parser.add_argument("--resource", default=str(REPO_ROOT), help="资源根目录（其下应有 resource/ 子目录）")
+    parser.add_argument("--global", dest="global_client", help="国际服名，如 YoStarJP")
+    parser.add_argument("--user-dir", help="core 日志写入目录")
+    parser.add_argument("--verbose", action="store_true", help="打印 core 其余回调消息")
+    args = parser.parse_args()
+
+    if args.mode in ("report", "pipeline", "replay") and not args.tasks:
+        parser.error(f"--mode {args.mode} 需要 --tasks")
+    if args.mode == "templ" and not args.templates:
+        parser.error("--mode templ 需要 --templates")
+    ev = CoreEval(
+        dll_dir=args.dll_dir,
+        resource=args.resource,
+        global_client=args.global_client,
+        user_dir=args.user_dir,
+        verbose=args.verbose,
+    )
+    try:
+        if args.mode == "report":
+            tasks = [t.strip() for t in args.tasks.split(",") if t.strip()]
+            _print_report(ev.report(args.images, tasks))
+        elif args.mode == "pipeline":
+            tasks = [t.strip() for t in args.tasks.split(",") if t.strip()]
+            for r in ev.pipeline(args.images, tasks):
+                hit = "hit " if r["hit"] else "MISS"
+                extras = " ".join(f"{k}={r[k]}" for k in ("score", "count", "text", "rect") if k in r)
+                print(f"{pathlib.Path(r['image']).name}: {hit} {r.get('task', '')} {extras} next={r['next']}")
+        elif args.mode == "ocr":
+            roi = [int(v) for v in args.roi.split(",")] if args.roi else None
+            for entry in ev.ocr(args.images, roi):
+                print(f"{pathlib.Path(entry['image']).name}:")
+                for r in entry["results"]:
+                    print(f"  {r['score']:.4f} {r['text']} {r['rect']}")
+        elif args.mode == "templ":
+            roi = [int(v) for v in args.roi.split(",")] if args.roi else None
+            templates = [t.strip() for t in args.templates.split(",") if t.strip()]
+            for entry in ev.templ(args.images, templates, threshold=args.threshold, roi=roi):
+                print(f"{pathlib.Path(entry['image']).name}:")
+                for r in entry["results"]:
+                    if "error" in r:
+                        print(f"  ERR  {r['template']} {r['error']}")
+                    else:
+                        mark = "hit " if r["hit"] else "MISS"
+                        print(f"  {mark} {r['template']} score={r.get('score', 0):.4f} {r.get('rect', '')}")
+        elif args.mode == "depot":
+            item_ids = [t.strip() for t in args.templates.split(",")] if args.templates else None
+            for entry in ev.depot_items(args.images, item_ids=item_ids, threshold=args.threshold):
+                print(f"{pathlib.Path(entry['image']).name}:")
+                for r in sorted(entry["results"], key=lambda x: -x.get("score", 0)):
+                    name = pathlib.Path(r["template"]).stem
+                    if "error" in r:
+                        print(f"  ERR  {name} {r['error']}")
+                    elif r["hit"]:
+                        print(f"  hit  {name} score={r.get('score', 0):.4f} {r.get('rect', '')}")
+        else:
+            tasks = [t.strip() for t in args.tasks.split(",") if t.strip()]
+            for s in ev.replay(args.images, tasks):
+                hit = "hit " if s["hit"] else "MISS"
+                extras = " ".join(f"{k}={s[k]}" for k in ("score", "count", "text", "rect") if k in s)
+                print(f"step{s['step']} {pathlib.Path(s['image']).name}: {hit} {s.get('task', '')} {extras} next={s['next']}")
+    finally:
+        ev.close()
+
+
+if __name__ == "__main__":
+    if hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    main()

--- a/tools/maa_core_eval.py
+++ b/tools/maa_core_eval.py
@@ -154,7 +154,12 @@ class CoreEval:
                 break
             time.sleep(0.02)
         else:
-            raise RuntimeError("core did not return to idle after Debug task")
+            # AsstRunning 晚于 AllTasksCompleted 转 false（间隔 taskDelay，默认 500ms、可配置更大），
+            # 走到这里结果已完整，超时只警告不丢弃；真异常由下一次 AsstStart failed 暴露
+            print(
+                "WARN: core still running 2s after Debug task completed",
+                file=sys.stderr,
+            )
         return list(self._results)
 
     @staticmethod

--- a/tools/maa_core_eval.py
+++ b/tools/maa_core_eval.py
@@ -5,7 +5,8 @@
 得分多少、OCR 认出了什么文本 —— 识别走的是 core 本体（模板、前处理、ocrReplace、
 各服 OCR 模型均与运行时一致），避免用外部脚本近似复现导致结论偏差。
 
-仅 Debug 构建的 MaaCore.dll 可用（Debug 任务只在 ASST_DEBUG 下注册）。
+仅 Debug 构建的 MaaCore.dll 可用（Debug 任务只在 ASST_DEBUG 下注册），
+且仅限 Windows（ctypes.WinDLL 加载 MaaCore.dll）。
 连着模拟器在线验证任务流请用 Custom 任务，本模块只做离线图片评估。
 
 用法一（作为模块，供脚本组合调用）::
@@ -35,6 +36,7 @@ import pathlib
 import sys
 import tempfile
 import threading
+import time
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 MSG_ALL_TASKS_COMPLETED = 3
@@ -150,7 +152,9 @@ class CoreEval:
         for _ in range(100):
             if not self._lib.AsstRunning(self._handle):
                 break
-            threading.Event().wait(0.02)
+            time.sleep(0.02)
+        else:
+            raise RuntimeError("core did not return to idle after Debug task")
         return list(self._results)
 
     @staticmethod
@@ -167,9 +171,10 @@ class CoreEval:
         )
 
     def pipeline(self, images, tasks):
-        """每张图按任务列表跑一次线上同款首命中匹配：[{image, hit, task, next, ...}]。
+        """每张图按任务列表跑一次线上同款首命中匹配：[{image, hit, result, next}]。
 
-        返回的 next 是命中任务的 next 任务列表，可用于自行驱动任务链回放。
+        命中详情在 result 字段（task 为完整任务名含 @ 前缀、score、rect 等），next 为命中
+        任务的 next 任务列表，可用于自行驱动任务链回放。
         """
         return self._run_task(
             {
@@ -197,13 +202,13 @@ class CoreEval:
         :param templates: 模板名列表，与 core 的 get_templ 一致：物品 ID（如 "2001"）、
                           相对 resource/template 的路径（如 "items/2001.png"）、
                           或 resource/template 下的目录（自动展开其中全部模板）
-        :param threshold: hit 判定阈值，缺省取 task 任务的阈值（无 task 时 0.7）；
+        :param threshold: hit 判定阈值，缺省取 task 任务的阈值（无 task 时 0.8）；
                           匹配恒报最佳得分，排查 ｢为什么没认出｣ 时可调低
-        :param resize:    评估前把图 INTER_AREA 缩放到 [w, h]（core 侧执行），
-                          复刻线上各识别器的尺度预处理时使用
-        :param task:      Matcher 配置来源任务名（maskRange / colorScales / method 等取自
-                          该任务，threshold 缺省时也取任务阈值），复刻线上自定义识别器
-                          的 Matcher 用法时使用
+        :param resize:    先归一到 1280x720 再 INTER_AREA 缩放到 [w, h]（core 侧两级
+                          执行，与线上截图缩放链一致），复刻线上各识别器的尺度预处理时使用
+        :param task:      Matcher 配置来源任务名（maskRange / colorScales / method / roi
+                          等取自该任务，threshold 缺省时也取任务阈值），复刻线上自定义识别器
+                          的 Matcher 用法时使用；不传 roi 时识别区域即任务 roi
         :return: [{image, results: [{template, hit, score, rect, error?}]}]
         """
         names = []
@@ -237,10 +242,10 @@ class CoreEval:
     def depot_items(self, images, item_ids=None, threshold=None):
         """复刻线上 DepotImageAnalyzer 的仓库物品匹配（python 侧做自定义预处理）。
 
-        线上的自定义处理在此复刻：模板右下 80x50 涂黑（数量角标）、图 INTER_AREA 缩放
-        到 DepotMatchData 的 roi 尺寸、maskRange/阈值等 Matcher 配置取自 DepotMatchData
-        任务 —— 尺寸、mask、阈值直接读 tasks.json，与 core 运行时同源；缩放和匹配仍由
-        core 执行。需要 Pillow。数量识别等其余链路不在此复刻，只做模板匹配评估。
+        线上的自定义处理在此复刻：模板右下 80x50 涂黑（数量角标）、图先归一 1280x720 再
+        INTER_AREA 缩放到 DepotMatchData 的 roi 尺寸、maskRange/阈值等 Matcher 配置取自
+        DepotMatchData 任务 —— 尺寸、mask、阈值直接读 tasks.json，与 core 运行时同源；缩放
+        和匹配仍由 core 执行。需要 Pillow。数量识别等其余链路不在此复刻，只做模板匹配评估。
 
         :param item_ids: 物品 ID / 模板路径 / 目录列表；缺省为 item_index.json 里
                          classifyType 为 MATERIAL 的物品（与线上
@@ -315,7 +320,7 @@ class CoreEval:
     def replay(self, images, tasks):
         """图片序列按 next 链逐图推进（纯识别，不执行点击等 action）。
 
-        返回 [{step, image, hit, task, next, ...}]；链在未命中、next 为空或图耗尽处停止。
+        返回 [{step, image, hit, result, next}]；链在未命中、next 为空或图耗尽处停止。
         """
         steps = []
         current = list(tasks)
@@ -387,9 +392,13 @@ def main():
         "--threshold",
         type=float,
         default=None,
-        help="templ/depot 模式的 hit 判定阈值，默认取任务阈值或 0.7",
+        help="templ/depot 模式的 hit 判定阈值，默认取任务阈值或 0.8",
     )
     parser.add_argument("--roi", help="ocr/templ 模式的识别区域 x,y,w,h")
+    parser.add_argument(
+        "--resize",
+        help="templ 模式的评估前缩放尺寸 w,h（先归一 1280x720 再缩放，与线上两级缩放一致）",
+    )
     parser.add_argument("--dll-dir", default=str(REPO_ROOT / "build" / "bin" / "Debug"))
     parser.add_argument(
         "--resource",
@@ -431,11 +440,14 @@ def _run_cli(ev, args):
             if _print_entry_error(r):
                 continue
             hit = "hit " if r.get("hit") else "MISS"
+            result = r.get("result", {})
             extras = " ".join(
-                f"{k}={r[k]}" for k in ("score", "count", "text", "rect") if k in r
+                f"{k}={result[k]}"
+                for k in ("score", "count", "text", "rect")
+                if k in result
             )
             print(
-                f"{pathlib.Path(r['image']).name}: {hit} {r.get('task', '')} {extras} next={r.get('next', [])}"
+                f"{pathlib.Path(r['image']).name}: {hit} {result.get('task', '')} {extras} next={r.get('next', [])}"
             )
     elif args.mode == "ocr":
         roi = [int(v) for v in args.roi.split(",")] if args.roi else None
@@ -447,12 +459,14 @@ def _run_cli(ev, args):
                 print(f"  {r['score']:.4f} {r['text']} {r['rect']}")
     elif args.mode == "templ":
         roi = [int(v) for v in args.roi.split(",")] if args.roi else None
+        resize = [int(v) for v in args.resize.split(",")] if args.resize else None
         templates = [t.strip() for t in args.templates.split(",") if t.strip()]
         for entry in ev.templ(
             args.images,
             templates,
             threshold=args.threshold,
             roi=roi,
+            resize=resize,
             task=args.task,
         ):
             if _print_entry_error(entry):
@@ -490,11 +504,14 @@ def _run_cli(ev, args):
             if _print_entry_error(s):
                 continue
             hit = "hit " if s.get("hit") else "MISS"
+            result = s.get("result", {})
             extras = " ".join(
-                f"{k}={s[k]}" for k in ("score", "count", "text", "rect") if k in s
+                f"{k}={result[k]}"
+                for k in ("score", "count", "text", "rect")
+                if k in result
             )
             print(
-                f"step{s['step']} {pathlib.Path(s['image']).name}: {hit} {s.get('task', '')} {extras} next={s.get('next', [])}"
+                f"step{s['step']} {pathlib.Path(s['image']).name}: {hit} {result.get('task', '')} {extras} next={s.get('next', [])}"
             )
 
 

--- a/tools/maa_core_eval.py
+++ b/tools/maa_core_eval.py
@@ -13,8 +13,8 @@
     import sys; sys.path.insert(0, "tools")
     from maa_core_eval import CoreEval
 
-    ev = CoreEval()                                   # 默认 build/bin/Debug + 仓库 resource
-    ev = CoreEval(global_client="YoStarJP")           # 国际服资源与 OCR 模型
+    ev = CoreEval()                                   # 默认国服资源
+    ev = CoreEval(global_client="YoStarJP")           # 日服等分服资源与 OCR 模型（YoStarEN/YoStarKR/txwy 同理）
     ev.report(images=["1.png"], tasks=["xxx@Roguelike@StageEnter"])
     ev.pipeline(images=["1.png"], tasks=["A", "B"])   # 首命中 + 命中任务的 next 列表
     ev.ocr(images=["1.png"], roi=[100, 200, 300, 50]) # OCR 原始识别文本
@@ -61,7 +61,11 @@ class CoreEval:
     ):
         self._verbose = verbose
         self._resource = pathlib.Path(resource)
-        self._user_dir = pathlib.Path(user_dir) if user_dir else pathlib.Path(tempfile.mkdtemp(prefix="maa-eval-"))
+        self._user_dir = (
+            pathlib.Path(user_dir)
+            if user_dir
+            else pathlib.Path(tempfile.mkdtemp(prefix="maa-eval-"))
+        )
         self._user_dir.mkdir(parents=True, exist_ok=True)
 
         dll_dir = pathlib.Path(dll_dir)
@@ -73,17 +77,23 @@ class CoreEval:
             self._on_callback(msg, details)
 
         # 持有回调引用，实例存活期间不被 GC
-        self._callback = ctypes.CFUNCTYPE(None, ctypes.c_int, ctypes.c_char_p, ctypes.c_void_p)(on_callback)
+        self._callback = ctypes.CFUNCTYPE(
+            None, ctypes.c_int, ctypes.c_char_p, ctypes.c_void_p
+        )(on_callback)
         self._completed = threading.Event()
         self._results = []
 
         self._lib.AsstSetUserDir(str(self._user_dir).encode("utf-8"))
         if not self._lib.AsstLoadResource(str(self._resource).encode("utf-8")):
             raise RuntimeError(f"load resource failed: {resource}")
+        self._global_resource = None
         if global_client:
-            global_path = self._resource / "resource" / "global" / global_client
-            if not self._lib.AsstLoadResource(str(global_path).encode("utf-8")):
-                raise RuntimeError(f"load global resource failed: {global_path}")
+            global_path = (
+                self._resource / "resource" / "global" / global_client / "resource"
+            )
+            if not self._lib.AsstLoadResource(str(global_path.parent).encode("utf-8")):
+                raise RuntimeError(f"load global resource failed: {global_path.parent}")
+            self._global_resource = global_path
 
         self._handle = self._lib.AsstCreateEx(self._callback, None)
         if not self._handle:
@@ -98,9 +108,14 @@ class CoreEval:
         lib.AsstDestroy.argtypes = [ctypes.c_void_p]
         lib.AsstDestroy.restype = None
         lib.AsstAppendTask.argtypes = [ctypes.c_void_p, c, c]
-        lib.AsstAppendTask.restype = ctypes.c_int  # AsstTaskId 为 int32，与 AsstCaller.h 一致
+        lib.AsstAppendTask.restype = (
+            ctypes.c_int
+        )  # AsstTaskId 为 int32，与 AsstCaller.h 一致
         lib.AsstStart.argtypes, lib.AsstStart.restype = [ctypes.c_void_p], ctypes.c_bool
-        lib.AsstRunning.argtypes, lib.AsstRunning.restype = [ctypes.c_void_p], ctypes.c_bool
+        lib.AsstRunning.argtypes, lib.AsstRunning.restype = (
+            [ctypes.c_void_p],
+            ctypes.c_bool,
+        )
 
     def _on_callback(self, msg, details):
         try:
@@ -119,10 +134,14 @@ class CoreEval:
         self._results.clear()
         self._completed.clear()
         task_id = self._lib.AsstAppendTask(
-            self._handle, b"Debug", json.dumps(params, ensure_ascii=False).encode("utf-8")
+            self._handle,
+            b"Debug",
+            json.dumps(params, ensure_ascii=False).encode("utf-8"),
         )
         if not task_id:
-            raise RuntimeError(f'append Debug task failed: {json.dumps(params, ensure_ascii=False)}')
+            raise RuntimeError(
+                f"append Debug task failed: {json.dumps(params, ensure_ascii=False)}"
+            )
         if not self._lib.AsstStart(self._handle):
             raise RuntimeError("AsstStart failed")
         if not self._completed.wait(timeout):
@@ -153,7 +172,11 @@ class CoreEval:
         返回的 next 是命中任务的 next 任务列表，可用于自行驱动任务链回放。
         """
         return self._run_task(
-            {"mode": "pipeline", "images": self._abs_images(images), "tasks": list(tasks)}
+            {
+                "mode": "pipeline",
+                "images": self._abs_images(images),
+                "tasks": list(tasks),
+            }
         )
 
     def ocr(self, images, roi=None):
@@ -166,13 +189,16 @@ class CoreEval:
             params["roi"] = list(roi)
         return self._run_task(params)
 
-    def templ(self, images, templates, threshold=0.7, roi=None, resize=None, task=None):
+    def templ(
+        self, images, templates, threshold=None, roi=None, resize=None, task=None
+    ):
         """每张图 × 裸模板文件匹配（物品图标等非任务模板）。
 
         :param templates: 模板名列表，与 core 的 get_templ 一致：物品 ID（如 "2001"）、
                           相对 resource/template 的路径（如 "items/2001.png"）、
                           或 resource/template 下的目录（自动展开其中全部模板）
-        :param threshold: hit 判定阈值；匹配恒报最佳得分，排查 ｢为什么没认出｣ 时可调低
+        :param threshold: hit 判定阈值，缺省取 task 任务的阈值（无 task 时 0.7）；
+                          匹配恒报最佳得分，排查 ｢为什么没认出｣ 时可调低
         :param resize:    评估前把图 INTER_AREA 缩放到 [w, h]（core 侧执行），
                           复刻线上各识别器的尺度预处理时使用
         :param task:      Matcher 配置来源任务名（maskRange / colorScales / method 等取自
@@ -185,10 +211,19 @@ class CoreEval:
         for name in templates:
             path = templ_root / name
             if path.is_dir():
-                names.extend(sorted(str(p.relative_to(templ_root)).replace("\\", "/") for p in path.rglob("*.png")))
+                names.extend(
+                    sorted(
+                        str(p.relative_to(templ_root)).replace("\\", "/")
+                        for p in path.rglob("*.png")
+                    )
+                )
             else:
                 names.append(name)
-        params = {"mode": "templ", "images": self._abs_images(images), "templates": names}
+        params = {
+            "mode": "templ",
+            "images": self._abs_images(images),
+            "templates": names,
+        }
         if threshold is not None:
             params["threshold"] = threshold
         if roi:
@@ -222,7 +257,7 @@ class CoreEval:
         names = []
         tmpdir = pathlib.Path(tempfile.mkdtemp(prefix="maa-eval-templ-"))
         try:
-            for name in (item_ids or self._default_depot_candidates()):
+            for name in item_ids or self._default_depot_candidates():
                 path = templ_root / name
                 # 纯物品 ID（如 "2001"）落到 items/<id>.png，与 core get_templ 的查找一致
                 if not path.exists() and not pathlib.Path(name).suffix:
@@ -230,14 +265,16 @@ class CoreEval:
                     if candidate.exists():
                         path = candidate
                 if not path.is_dir() and not path.exists():
-                    continue # 候选缺模板（如分服活动进度差异），跳过
+                    continue  # 候选缺模板（如分服活动进度差异），跳过
                 files = sorted(path.rglob("*.png")) if path.is_dir() else [path]
                 for src in files:
                     templ = Image.open(src).convert("RGB")
                     w, h = templ.size
                     if w > 80 and h > 50:
                         templ.paste((0, 0, 0), (w - 80, h - 50, w, h))
-                    dst = tmpdir / src.name
+                    # 保留相对 template 根的目录结构，展开带子目录的目录时同名文件不会互相覆盖
+                    dst = tmpdir / src.relative_to(templ_root)
+                    dst.parent.mkdir(parents=True, exist_ok=True)
                     templ.save(dst)
                     names.append(str(dst))
             return self.templ(
@@ -252,9 +289,17 @@ class CoreEval:
 
             shutil.rmtree(tmpdir, ignore_errors=True)
 
+    def _resource_overridden(self, *relative):
+        """按 resource 目录内的相对路径取配置文件，分服存在覆盖文件时优先（与叠加加载后生效的一致）。"""
+        if self._global_resource:
+            overridden = self._global_resource.joinpath(*relative)
+            if overridden.exists():
+                return overridden
+        return self._resource.joinpath("resource", *relative)
+
     def _default_depot_candidates(self):
         # 与线上 ItemData.get_ordered_material_item_id 对齐：classifyType 为 MATERIAL 的物品
-        items_file = self._resource / "resource" / "item_index.json"
+        items_file = self._resource_overridden("item_index.json")
         with open(items_file, encoding="utf-8") as f:
             items = json.load(f)
         return sorted(
@@ -263,7 +308,7 @@ class CoreEval:
         )
 
     def _read_task_def(self, task_name):
-        tasks_file = self._resource / "resource" / "tasks" / "tasks.json"
+        tasks_file = self._resource_overridden("tasks", "tasks.json")
         with open(tasks_file, encoding="utf-8") as f:
             return json.load(f).get(task_name, {})
 
@@ -297,29 +342,60 @@ class CoreEval:
             pass
 
 
+def _print_entry_error(entry):
+    """逐图错误条目（读图失败/识别抛异常等）统一打印，避免静默缺行。"""
+    if "error" in entry:
+        print(f"{pathlib.Path(entry['image']).name}: ERROR {entry['error']}")
+        return True
+    return False
+
+
 def _print_report(result):
     for entry in result:
-        name = pathlib.Path(entry["image"]).name
-        if "error" in entry:
-            print(f"{name}: ERROR {entry['error']}")
+        if _print_entry_error(entry):
             continue
+        name = pathlib.Path(entry["image"]).name
         print(f"{name}:")
         for r in entry["results"]:
-            fields = " ".join(f"{k}={r[k]}" for k in ("score", "count", "templ", "text", "rect") if k in r)
+            fields = " ".join(
+                f"{k}={r[k]}"
+                for k in ("score", "count", "templ", "text", "rect", "algorithm")
+                if k in r
+            )
             print(f"  {'hit ' if r['hit'] else 'MISS'} {r['task']} {fields}")
 
 
 def main():
-    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
     parser.add_argument("images", nargs="+", help="图片路径（可多张）")
-    parser.add_argument("--mode", choices=["report", "pipeline", "ocr", "templ", "depot", "replay"], default="report")
+    parser.add_argument(
+        "--mode",
+        choices=["report", "pipeline", "ocr", "templ", "depot", "replay"],
+        default="report",
+    )
     parser.add_argument("--tasks", help="逗号分隔的任务名列表")
-    parser.add_argument("--templates", help="逗号分隔的模板名（物品 ID / items/xxx.png / 目录），templ 模式用")
-    parser.add_argument("--task", help="templ 模式的 Matcher 配置来源任务名（maskRange/method 等）")
-    parser.add_argument("--threshold", type=float, default=None, help="templ/depot 模式的 hit 判定阈值，默认取任务阈值或 0.7")
+    parser.add_argument(
+        "--templates",
+        help="逗号分隔的模板名（物品 ID / items/xxx.png / 目录），templ 模式用",
+    )
+    parser.add_argument(
+        "--task", help="templ 模式的 Matcher 配置来源任务名（maskRange/method 等）"
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=None,
+        help="templ/depot 模式的 hit 判定阈值，默认取任务阈值或 0.7",
+    )
     parser.add_argument("--roi", help="ocr/templ 模式的识别区域 x,y,w,h")
     parser.add_argument("--dll-dir", default=str(REPO_ROOT / "build" / "bin" / "Debug"))
-    parser.add_argument("--resource", default=str(REPO_ROOT), help="资源根目录（其下应有 resource/ 子目录）")
+    parser.add_argument(
+        "--resource",
+        default=str(REPO_ROOT),
+        help="资源根目录（其下应有 resource/ 子目录）",
+    )
     parser.add_argument("--global", dest="global_client", help="国际服名，如 YoStarJP")
     parser.add_argument("--user-dir", help="core 日志写入目录")
     parser.add_argument("--verbose", action="store_true", help="打印 core 其余回调消息")
@@ -337,53 +413,89 @@ def main():
         verbose=args.verbose,
     )
     try:
-        if args.mode == "report":
-            tasks = [t.strip() for t in args.tasks.split(",") if t.strip()]
-            _print_report(ev.report(args.images, tasks))
-        elif args.mode == "pipeline":
-            tasks = [t.strip() for t in args.tasks.split(",") if t.strip()]
-            for r in ev.pipeline(args.images, tasks):
-                hit = "hit " if r.get("hit") else "MISS"
-                extras = " ".join(f"{k}={r[k]}" for k in ("score", "count", "text", "rect") if k in r)
-                print(f"{pathlib.Path(r['image']).name}: {hit} {r.get('task', '')} {extras} next={r.get('next', [])}")
-        elif args.mode == "ocr":
-            roi = [int(v) for v in args.roi.split(",")] if args.roi else None
-            for entry in ev.ocr(args.images, roi):
-                print(f"{pathlib.Path(entry['image']).name}:")
-                for r in entry["results"]:
-                    print(f"  {r['score']:.4f} {r['text']} {r['rect']}")
-        elif args.mode == "templ":
-            roi = [int(v) for v in args.roi.split(",")] if args.roi else None
-            templates = [t.strip() for t in args.templates.split(",") if t.strip()]
-            for entry in ev.templ(args.images, templates, threshold=args.threshold, roi=roi, task=args.task):
-                print(f"{pathlib.Path(entry['image']).name}:")
-                for r in entry.get("results", []):
-                    if "error" in r:
-                        print(f"  ERR  {r['template']} {r['error']}")
-                    else:
-                        mark = "hit " if r["hit"] else "MISS"
-                        print(f"  {mark} {r['template']} score={r.get('score', 0):.4f} {r.get('rect', '')}")
-        elif args.mode == "depot":
-            item_ids = [t.strip() for t in args.templates.split(",")] if args.templates else None
-            for entry in ev.depot_items(args.images, item_ids=item_ids, threshold=args.threshold):
-                print(f"{pathlib.Path(entry['image']).name}:")
-                for r in sorted(entry.get("results", []), key=lambda x: -x.get("score", 0)):
-                    name = pathlib.Path(r["template"]).stem
-                    if "error" in r:
-                        print(f"  ERR  {name} {r['error']}")
-                    elif r["hit"]:
-                        print(f"  hit  {name} score={r.get('score', 0):.4f} {r.get('rect', '')}")
-        else:
-            tasks = [t.strip() for t in args.tasks.split(",") if t.strip()]
-            for s in ev.replay(args.images, tasks):
-                if "error" in s:
-                    print(f"step{s['step']} {pathlib.Path(s['image']).name}: ERROR {s['error']}")
-                    continue
-                hit = "hit " if s.get("hit") else "MISS"
-                extras = " ".join(f"{k}={s[k]}" for k in ("score", "count", "text", "rect") if k in s)
-                print(f"step{s['step']} {pathlib.Path(s['image']).name}: {hit} {s.get('task', '')} {extras} next={s.get('next', [])}")
+        _run_cli(ev, args)
+    except (RuntimeError, TimeoutError, ValueError) as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        sys.exit(1)
     finally:
         ev.close()
+
+
+def _run_cli(ev, args):
+    if args.mode == "report":
+        tasks = [t.strip() for t in args.tasks.split(",") if t.strip()]
+        _print_report(ev.report(args.images, tasks))
+    elif args.mode == "pipeline":
+        tasks = [t.strip() for t in args.tasks.split(",") if t.strip()]
+        for r in ev.pipeline(args.images, tasks):
+            if _print_entry_error(r):
+                continue
+            hit = "hit " if r.get("hit") else "MISS"
+            extras = " ".join(
+                f"{k}={r[k]}" for k in ("score", "count", "text", "rect") if k in r
+            )
+            print(
+                f"{pathlib.Path(r['image']).name}: {hit} {r.get('task', '')} {extras} next={r.get('next', [])}"
+            )
+    elif args.mode == "ocr":
+        roi = [int(v) for v in args.roi.split(",")] if args.roi else None
+        for entry in ev.ocr(args.images, roi):
+            if _print_entry_error(entry):
+                continue
+            print(f"{pathlib.Path(entry['image']).name}:")
+            for r in entry["results"]:
+                print(f"  {r['score']:.4f} {r['text']} {r['rect']}")
+    elif args.mode == "templ":
+        roi = [int(v) for v in args.roi.split(",")] if args.roi else None
+        templates = [t.strip() for t in args.templates.split(",") if t.strip()]
+        for entry in ev.templ(
+            args.images,
+            templates,
+            threshold=args.threshold,
+            roi=roi,
+            task=args.task,
+        ):
+            if _print_entry_error(entry):
+                continue
+            print(f"{pathlib.Path(entry['image']).name}:")
+            for r in entry.get("results", []):
+                if "error" in r:
+                    print(f"  ERR  {r['template']} {r['error']}")
+                else:
+                    mark = "hit " if r["hit"] else "MISS"
+                    print(
+                        f"  {mark} {r['template']} score={r.get('score', 0):.4f} {r.get('rect', '')}"
+                    )
+    elif args.mode == "depot":
+        item_ids = (
+            [t.strip() for t in args.templates.split(",")] if args.templates else None
+        )
+        for entry in ev.depot_items(
+            args.images, item_ids=item_ids, threshold=args.threshold
+        ):
+            if _print_entry_error(entry):
+                continue
+            print(f"{pathlib.Path(entry['image']).name}:")
+            for r in sorted(entry.get("results", []), key=lambda x: -x.get("score", 0)):
+                name = pathlib.Path(r["template"]).stem
+                if "error" in r:
+                    print(f"  ERR  {name} {r['error']}")
+                elif r["hit"]:
+                    print(
+                        f"  hit  {name} score={r.get('score', 0):.4f} {r.get('rect', '')}"
+                    )
+    else:
+        tasks = [t.strip() for t in args.tasks.split(",") if t.strip()]
+        for s in ev.replay(args.images, tasks):
+            if _print_entry_error(s):
+                continue
+            hit = "hit " if s.get("hit") else "MISS"
+            extras = " ".join(
+                f"{k}={s[k]}" for k in ("score", "count", "text", "rect") if k in s
+            )
+            print(
+                f"step{s['step']} {pathlib.Path(s['image']).name}: {hit} {s.get('task', '')} {extras} next={s.get('next', [])}"
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 动机

排查用户反馈时经常需要回答 ｢core 对这张截图到底识别出了什么｣。外部脚本（python 直调 ppocr / OpenCV）与 core 行为对不上：前处理、ocrReplace、mask、各服 OCR 模型各有差异，近似复现容易得出错误结论。本 PR 让 core 本体直接对本地图片（反馈包截图、手动截图）跑与运行时一致的识别链路。

## 用法

配套 python 驱动 `tools/maa_core_eval.py`（可 import 亦可 CLI），经 `AsstAppendTask(handle, "Debug", params)` 驱动，无需连接设备：

| 原语 | 说明 |
|---|---|
| `report` | 每张图 × 每个任务独立评估，报 hit / score / box / OCR 文本 |
| `pipeline` | 按任务列表跑一次线上同款首命中，返回命中任务及其 next 列表 |
| `ocr` | OCR 引擎原始识别文本（不套 ocrReplace / expected） |
| `templ` | 裸模板文件匹配（物品图标等非任务模板），恒报最佳得分；`task` 参数可让 maskRange / colorScales / method 等 Matcher 配置取自指定任务，用于复刻线上自定义识别器 |
| `replay`（python 层） | 图片序列按命中任务的 next 链逐步推进 |

另附 agent 技能 `.agents/skills/core-image-eval/SKILL.md`，方便 AI 辅助排查时自动发现与调用。

## 说明

- 仅 Debug 构建可用（Debug 任务在 ASST_DEBUG 下注册），无参数的 Debug 任务保持原空跑行为。
- 图片统一 INTER_AREA 缩放到 1280x720，与线上 `Controller::get_resized_image_cache` 一致；识别不带实例，不受历史 rect 缓存污染。
- 结果双通道输出：SubTaskExtraInfo 回调（what 为 DebugImageTest）+ asst.log。
- 既有 test_* 方法保持不动。

## 测试

- OCR 任务：StartButton1 于开始行动界面 hit 0.99999（干员列表界面正确 miss）。
- 模板任务：BlackFlow@Roguelike@StartExplore hit 0.996；主界面 Delicious 皮肤入口 0.97+ 且 Default 变体互斥 miss。
- 物品模板：经 maskRange 配置后 0.84-0.93 命中，坐标与线上 DepotImageAnalyzer 识别结果一致。
- replay：next 链推进与断链报告正确。

## Sourcery 摘要

启用 Debug 构建，以便通过 MaaCore 的生产环境识别流水线评估本地截图，无需连接设备。

新功能：
- 通过 Debug 任务添加离线本地图像评估，支持与运行时等效的任务识别、OCR、流水线匹配和模板匹配。
- 提供 Python CLI 和可导入的封装，用于运行评估，包括 next-chain 重放和仓库物品匹配。
- 添加代理技能，说明如何发现和使用核心图像评估工作流。

增强功能：
- 通过回调和日志返回结构化评估结果，包括命中状态、分数、文本、模板、坐标和后续任务。
- 对评估图像进行标准化，并支持针对任务配置匹配器、感兴趣区域、阈值和缩放。

文档：
- 记录 CLI、Python API、前置条件、模式、结果语义，以及离线图像识别评估的故障排除工作流。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

支持 Debug 构建通过 MaaCore 的生产级图像识别流程评估本地截图，无需连接设备。

新功能：
- 新增仅限 Debug 的离线图像评估功能，可在未连接设备的情况下执行与运行时等效的任务识别、OCR、流程匹配和模板匹配。
- 提供用于图像评估的 Python CLI 和可导入 API，包括 next-chain 回放和仓库物品匹配。
- 新增 Agent skill，说明如何发现并使用核心图像评估流程。

增强功能：
- 通过回调和日志返回结构化评估结果，包括命中状态、分数、OCR 文本、模板、坐标和后续任务。
- 统一评估图像缩放方式，并支持按任务配置匹配器、感兴趣区域、阈值和预处理尺寸。

文档：
- 补充 CLI、Python API、前置条件、评估模式、结果语义以及离线图像识别故障排查流程的文档。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

支持 Debug 构建通过 MaaCore 的生产级图像识别流水线评估本地截图，无需连接设备。

新功能：
- 新增仅限 Debug 的离线图像评估工作流：无需连接设备，即可通过 MaaCore 的运行时识别路径执行报告、流水线、OCR 和模板匹配。
- 提供用于本地图像评估的 Python CLI 和可导入 API，包括 next-chain 重放和仓库项目匹配。

增强功能：
- 通过回调和日志返回结构化评估结果，包括命中状态、分数、OCR 文本、模板、坐标和后续任务。
- 统一评估图像缩放，并支持针对任务配置匹配器、感兴趣区域、阈值和预处理尺寸。

文档：
- 记录离线图像评估工作流、前置条件、CLI 和 Python API、评估模式、结果语义以及故障排查指南。
- 新增用于发现和使用核心图像评估工作流的代理技能。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

支持 Debug 构建通过 MaaCore 的生产级图像识别流水线评估本地截图，无需连接设备。

新功能：
- 新增仅限 Debug 的离线图像评估流程，可使用 MaaCore 运行时等效的任务识别、OCR、流水线和模板匹配功能处理本地截图。
- 提供用于图像评估的 Python CLI 和可导入 API，包括 next-chain 重放和仓库物品模板匹配。

增强功能：
- 通过回调和日志返回结构化评估结果，包括命中状态、分数、OCR 文本、模板、坐标和后续任务。
- 统一评估图像尺寸，并支持针对任务配置匹配器、感兴趣区域、阈值和预处理尺寸。

文档：
- 记录离线图像评估的前置条件、CLI 和 Python API、运行模式、结果语义及故障排查流程。
- 新增用于发现和使用核心图像评估流程的 agent skill。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

启用 Debug 构建中的本地图片离线识别评估，以便无需连接设备即可复现 MaaCore 的运行时识别结果。

新功能：
- 新增仅限 Debug 构建的本地图片离线评估能力，支持按运行时识别链路执行任务报告、首命中流水线、原始 OCR 和模板匹配。
- 提供可导入的 Python API 与 CLI，支持多图片评估、next 链 replay 以及仓库物品模板匹配。

增强功能：
- 通过回调和日志输出结构化评估结果，涵盖命中状态、分数、文本、模板、坐标及后续任务。
- 统一评估图片的线上等效缩放，并支持复用指定任务的 Matcher 配置进行模板评估。

文档：
- 新增 Agent 技能，记录离线图片评估的使用方法、结果语义和常见排查流程。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

使 Debug 构建能够通过 MaaCore 的生产环境识别流水线评估本地截图，而无需连接设备。

新功能：
- 新增仅限 Debug 的离线图像评估工作流，可在无设备连接的情况下，将本地截图通过与运行时等效的任务、流水线、OCR 和模板识别路径进行处理。
- 提供 Python CLI 和可导入 API，支持生成图像报告、重放流水线 next-chain、检查原始 OCR、进行模板匹配以及仓库项匹配。
- 新增代理技能文档，说明如何发现并使用核心图像评估工作流。

增强功能：
- 通过回调和日志返回结构化评估结果，包括命中状态、分数、OCR 文本、模板、坐标、错误和后续任务。
- 统一评估图像尺寸，并支持复用特定任务的匹配器配置、区域、阈值和预处理尺寸。

文档：
- 记录前置条件、CLI 和 Python API 的使用方法、评估模式、结果语义以及故障排查工作流。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

支持 Debug 构建通过 MaaCore 的生产级图像识别流程评估本地截图，无需连接设备。

新功能：
- 新增仅限 Debug 的离线图像评估功能，可在未连接设备的情况下生成与运行时等效的任务报告、进行流程匹配、执行原始 OCR 和模板匹配。
- 提供用于图像评估的 Python CLI 和可导入 API，包括流程 next-chain 重放和仓库物品模板匹配。
- 新增 Agent 技能文档，介绍如何使用核心图像评估工作流。

增强功能：
- 通过回调和日志返回结构化的评估结果与错误，包括命中状态、分数、文本、模板、坐标和后续任务。
- 统一评估图像缩放方式，并允许模板检查复用任务专属的匹配器配置、区域、阈值和预处理尺寸。

文档：
- 补充离线图像评估的前置条件、CLI 和 Python API、模式、结果语义及故障排除指南。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable Debug builds to evaluate local screenshots through MaaCore’s production image-recognition pipeline without connecting a device.

New Features:
- Add Debug-only offline image evaluation for runtime-equivalent task reports, pipeline matching, raw OCR, and template matching without a connected device.
- Provide a Python CLI and importable API for image evaluation, including pipeline next-chain replay and depot item template matching.
- Add an agent skill documenting how to use the core image evaluation workflow.

Enhancements:
- Return structured evaluation results and errors through callbacks and logs, including hit status, scores, text, templates, coordinates, and next tasks.
- Standardize evaluation image scaling and allow template checks to reuse task-specific matcher configuration, regions, thresholds, and preprocessing sizes.

Documentation:
- Document offline image evaluation prerequisites, CLI and Python APIs, modes, result semantics, and troubleshooting guidance.

</details>

</details>

</details>

</details>

</details>

</details>

</details>