### PR TITLE
rft: 彻底移除升变阿米娅的职业后缀

### DIFF
--- a/resource/battle_data.json
+++ b/resource/battle_data.json
@@ -66,11 +66,11 @@
             "subProfessionId": "centurion"
         },
         "char_1001_amiya2": {
-            "name": "阿米娅-WARRIOR",
-            "name_en": "Amiya-WARRIOR",
-            "name_jp": "アーミヤ-WARRIOR",
-            "name_kr": "아미야-WARRIOR",
-            "name_tw": "阿米婭-WARRIOR",
+            "name": "阿米娅",
+            "name_en": "Amiya",
+            "name_jp": "アーミヤ",
+            "name_kr": "아미야",
+            "name_tw": "阿米婭",
             "position": "MELEE",
             "profession": "WARRIOR",
             "rangeId": ["1-1", "1-1", "1-1"],
@@ -414,11 +414,11 @@
             "subProfessionId": "charger"
         },
         "char_1037_amiya3": {
-            "name": "阿米娅-MEDIC",
-            "name_en": "Amiya-MEDIC",
-            "name_jp": "アーミヤ-MEDIC",
-            "name_kr": "아미야-MEDIC",
-            "name_tw": "阿米婭-MEDIC",
+            "name": "阿米娅",
+            "name_en": "Amiya",
+            "name_jp": "アーミヤ",
+            "name_kr": "아미야",
+            "name_tw": "阿米婭",
             "position": "RANGED",
             "profession": "MEDIC",
             "rangeId": ["3-1", "3-3", "3-3"],

--- a/resource/roguelike/BlackFlow/recruitment.json
+++ b/resource/roguelike/BlackFlow/recruitment.json
@@ -3600,7 +3600,8 @@
                     "name": "濯尘芙蓉"
                 },
                 {
-                    "name": "阿米娅-MEDIC"
+                    "role": "MEDIC",
+                    "name": "阿米娅"
                 },
                 {
                     "name": "苏苏洛"
@@ -3911,7 +3912,8 @@
                     "skill": 2
                 },
                 {
-                    "name": "阿米娅-MEDIC"
+                    "role": "MEDIC",
+                    "name": "阿米娅"
                 },
                 {
                     "name": "至简",

--- a/resource/roguelike/JieGarden/recruitment.json
+++ b/resource/roguelike/JieGarden/recruitment.json
@@ -3635,7 +3635,8 @@
                     "name": "濯尘芙蓉"
                 },
                 {
-                    "name": "阿米娅-MEDIC"
+                    "role": "MEDIC",
+                    "name": "阿米娅"
                 },
                 {
                     "name": "苏苏洛"
@@ -3946,7 +3947,8 @@
                     "skill": 2
                 },
                 {
-                    "name": "阿米娅-MEDIC"
+                    "role": "MEDIC",
+                    "name": "阿米娅"
                 },
                 {
                     "name": "至简",

--- a/resource/roguelike/Mizuki/recruitment.json
+++ b/resource/roguelike/Mizuki/recruitment.json
@@ -3092,7 +3092,8 @@
                     "name": "濯尘芙蓉"
                 },
                 {
-                    "name": "阿米娅-MEDIC"
+                    "role": "MEDIC",
+                    "name": "阿米娅"
                 },
                 {
                     "name": "苏苏洛"
@@ -3375,7 +3376,8 @@
                     "skill": 2
                 },
                 {
-                    "name": "阿米娅-MEDIC"
+                    "role": "MEDIC",
+                    "name": "阿米娅"
                 },
                 {
                     "name": "至简",

--- a/resource/roguelike/Mizuki/recruitment.json
+++ b/resource/roguelike/Mizuki/recruitment.json
@@ -907,7 +907,8 @@
                     "recruit_priority": 318
                 },
                 {
-                    "name": "阿米娅-WARRIOR",
+                    "role": "WARRIOR",
+                    "name": "阿米娅",
                     "skill": 1,
                     "is_start": true,
                     "recruit_priority": 478,

--- a/resource/roguelike/Phantom/recruitment.json
+++ b/resource/roguelike/Phantom/recruitment.json
@@ -1816,7 +1816,8 @@
                     "name": "濯尘芙蓉"
                 },
                 {
-                    "name": "阿米娅-MEDIC"
+                    "role": "MEDIC",
+                    "name": "阿米娅"
                 },
                 {
                     "name": "苏苏洛"
@@ -3516,7 +3517,8 @@
                     "skill": 2
                 },
                 {
-                    "name": "阿米娅-MEDIC"
+                    "role": "MEDIC",
+                    "name": "阿米娅"
                 },
                 {
                     "name": "至简",

--- a/resource/roguelike/Sami/recruitment.json
+++ b/resource/roguelike/Sami/recruitment.json
@@ -3278,7 +3278,8 @@
                     "name": "濯尘芙蓉"
                 },
                 {
-                    "name": "阿米娅-MEDIC"
+                    "role": "MEDIC",
+                    "name": "阿米娅"
                 },
                 {
                     "name": "苏苏洛"
@@ -3571,7 +3572,8 @@
                     "skill": 2
                 },
                 {
-                    "name": "阿米娅-MEDIC"
+                    "role": "MEDIC",
+                    "name": "阿米娅"
                 },
                 {
                     "name": "至简",

--- a/resource/roguelike/Sarkaz/recruitment.json
+++ b/resource/roguelike/Sarkaz/recruitment.json
@@ -3622,7 +3622,8 @@
                     "name": "濯尘芙蓉"
                 },
                 {
-                    "name": "阿米娅-MEDIC"
+                    "role": "MEDIC",
+                    "name": "阿米娅"
                 },
                 {
                     "name": "苏苏洛"
@@ -3929,7 +3930,8 @@
                     "skill": 2
                 },
                 {
-                    "name": "阿米娅-MEDIC"
+                    "role": "MEDIC",
+                    "name": "阿米娅"
                 },
                 {
                     "name": "至简",

--- a/src/MaaCore/Common/AsstBattleDef.h
+++ b/src/MaaCore/Common/AsstBattleDef.h
@@ -401,6 +401,8 @@ struct SupportUnit
 {
     cv::Mat templ;
 
+    battle::Role role = battle::Role::Unknown;
+
     /// <summary>
     /// 助战干员名称。
     /// </summary>
@@ -435,26 +437,6 @@ struct SupportUnit
     // int elite_after_promotion = 0; // 进阶后精英化阶段，仅在集成战略中有效，
     // int level_after_promotion = 0; // 进阶后等级，仅在集成战略中有效，
 };
-
-/// <summary>
-/// 根据 <c>role</c> 对干员名 <c>literal_name</c> 进行消歧义，目前仅用于区分不同升变形态下的阿米娅。
-/// </summary>
-inline static std::string canonical_oper_name(battle::Role role, const std::string& literal_name)
-{
-    using battle::Role;
-    static const std::unordered_map<std::pair<Role, std::string>, std::string, std::pair_hash<Role, std::string>>
-        CanonicalOperNameDict {
-            { { Role::Caster, "阿米娅" }, "阿米娅" },
-            { { Role::Warrior, "阿米娅" }, "阿米娅-WARRIOR" },
-            { { Role::Medic, "阿米娅" }, "阿米娅-MEDIC" },
-        };
-
-    if (const auto iter = CanonicalOperNameDict.find({ role, literal_name }); iter != CanonicalOperNameDict.end()) {
-        return iter->second;
-    }
-
-    return literal_name;
-}
 
 // ————————————————————————————————————————————————————————————————
 

--- a/src/MaaCore/Config/Roguelike/RoguelikeRecruitConfig.cpp
+++ b/src/MaaCore/Config/Roguelike/RoguelikeRecruitConfig.cpp
@@ -33,7 +33,10 @@ const asst::RoguelikeOperInfo&
     if (opers.contains(oper_tag)) {
         return opers.at(oper_tag);
     }
-    const auto& it = std::ranges::find_if(opers, [&](const auto& pair) { return pair.first.name == oper_tag.name; });
+    const auto& it = std::ranges::find_if(opers, [&](const auto& pair) {
+        return (pair.first.role == battle::Role::Unknown || pair.first.role == oper_tag.role) &&
+               pair.first.name == oper_tag.name;
+    }); // 配置中要求的为 unk 或者与实际干员职业相等
     if (it != opers.end()) {
         return it->second;
     }

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -1063,7 +1063,7 @@ std::optional<std::string> asst::BattleFormationTask::add_support_unit_from_supp
 
     for (const RequiredOper& required_oper : required_opers) {
         auto it = std::ranges::find_if(support_units, [friendship, &required_oper](const SupportUnit& support_unit) {
-            return support_unit.name == battle::canonical_oper_name(required_oper.role, required_oper.name) &&
+            return support_unit.name == required_oper.name &&
                    (support_unit.elite > required_oper.elite ||
                     (support_unit.elite == required_oper.elite && support_unit.level >= required_oper.level)) &&
                    support_unit.potential >= required_oper.potential &&

--- a/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
+++ b/src/MaaCore/Task/Miscellaneous/BattleFormationTask.cpp
@@ -1063,7 +1063,7 @@ std::optional<std::string> asst::BattleFormationTask::add_support_unit_from_supp
 
     for (const RequiredOper& required_oper : required_opers) {
         auto it = std::ranges::find_if(support_units, [friendship, &required_oper](const SupportUnit& support_unit) {
-            return support_unit.name == required_oper.name &&
+            return support_unit.role == required_oper.role && support_unit.name == required_oper.name &&
                    (support_unit.elite > required_oper.elite ||
                     (support_unit.elite == required_oper.elite && support_unit.level >= required_oper.level)) &&
                    support_unit.potential >= required_oper.potential &&

--- a/src/MaaCore/Task/Roguelike/RoguelikeBattleTaskPlugin.cpp
+++ b/src/MaaCore/Task/Roguelike/RoguelikeBattleTaskPlugin.cpp
@@ -109,19 +109,6 @@ void asst::RoguelikeBattleTaskPlugin::wait_until_start_button_clicked()
         .run();
 }
 
-std::string asst::RoguelikeBattleTaskPlugin::oper_name_in_config(const battle::DeploymentOper& oper) const
-{
-    if (oper.role == Role::Warrior && oper.name == "阿米娅") {
-        return "阿米娅-WARRIOR"; // 在 BattleData.json 中有
-    }
-    else if (oper.role == Role::Medic && oper.name == "阿米娅") {
-        return "阿米娅-MEDIC"; // 在 BattleData.json 中有
-    }
-    else {
-        return oper.name;
-    }
-}
-
 bool asst::RoguelikeBattleTaskPlugin::calc_stage_info()
 {
     LogTraceFunction;
@@ -249,12 +236,6 @@ bool asst::RoguelikeBattleTaskPlugin::calc_stage_info()
     return true;
 }
 
-asst::battle::LocationType
-    asst::RoguelikeBattleTaskPlugin::get_oper_location_type(const battle::DeploymentOper& oper) const
-{
-    return BattleData.get_location_type(oper.role, oper_name_in_config(oper));
-}
-
 asst::battle::OperPosition asst::RoguelikeBattleTaskPlugin::get_role_position(const battle::Role& role) const
 {
     switch (role) {
@@ -316,7 +297,7 @@ void asst::RoguelikeBattleTaskPlugin::set_position_full(const Point& loc, bool f
 
 void asst::RoguelikeBattleTaskPlugin::set_position_full(const battle::DeploymentOper& oper, bool full)
 {
-    set_position_full(get_oper_location_type(oper), full);
+    set_position_full(BattleData.get_location_type(oper.role, oper.name), full);
 }
 
 bool asst::RoguelikeBattleTaskPlugin::get_position_full(battle::LocationType loc_type) const
@@ -341,7 +322,7 @@ bool asst::RoguelikeBattleTaskPlugin::get_position_full(battle::LocationType loc
 
 bool asst::RoguelikeBattleTaskPlugin::get_position_full(const battle::DeploymentOper& oper) const
 {
-    return get_position_full(get_oper_location_type(oper));
+    return get_position_full(BattleData.get_location_type(oper.role, oper.name));
 }
 
 bool asst::RoguelikeBattleTaskPlugin::do_best_deploy()
@@ -373,9 +354,7 @@ bool asst::RoguelikeBattleTaskPlugin::do_best_deploy()
             continue;
         }
 
-        const battle::OperNameTag oper_tag { oper.role,
-                                             oper_name_in_config(
-                                                 oper) }; // 临时使用阿米娅-WARRIOR/阿米娅-MEDIC来获取招募信息
+        const battle::OperNameTag oper_tag { oper.role, oper.name };
         // 获取招募信息
         const auto& recruit_info = RoguelikeRecruit.get_oper_info(m_config->get_theme(), oper_tag);
         // 获取会用到该干员的干员组[干员组1序号,干员组2序号,...]
@@ -859,7 +838,7 @@ void asst::RoguelikeBattleTaskPlugin::clear()
 
 std::vector<asst::Point> asst::RoguelikeBattleTaskPlugin::available_locations(const DeploymentOper& oper) const
 {
-    auto type = get_oper_location_type(oper);
+    auto type = BattleData.get_location_type(oper.role, oper.name);
     if (type == LocationType::Invalid || type == LocationType::None) {
         return available_locations(get_role_usual_location(oper.role));
     }
@@ -890,7 +869,7 @@ asst::battle::AttackRange asst::RoguelikeBattleTaskPlugin::get_attack_range(
     if (m_oper_elite.contains(oper.name)) {
         elite = m_oper_elite.at(oper.name);
     }
-    battle::AttackRange right_attack_range = BattleData.get_range(oper_name_in_config(oper), elite);
+    battle::AttackRange right_attack_range = BattleData.get_range(oper.role, oper.name, elite);
 
     if (right_attack_range == BattleDataConfig::EmptyRange) {
         switch (oper.role) {

--- a/src/MaaCore/Task/Roguelike/RoguelikeBattleTaskPlugin.h
+++ b/src/MaaCore/Task/Roguelike/RoguelikeBattleTaskPlugin.h
@@ -94,8 +94,6 @@ protected:
     void check_drone_tiles();
     void wait_until_start_button_clicked();
 
-    std::string oper_name_in_config(const battle::DeploymentOper& oper) const;
-    battle::LocationType get_oper_location_type(const battle::DeploymentOper& oper) const;
     std::vector<Point> available_locations(const battle::DeploymentOper& oper) const;
     std::vector<Point> available_locations(battle::LocationType type) const;
     bool get_position_full(const battle::DeploymentOper& oper) const;

--- a/src/MaaCore/Vision/Battle/SupportListAnalyzer.cpp
+++ b/src/MaaCore/Vision/Battle/SupportListAnalyzer.cpp
@@ -185,6 +185,7 @@ bool asst::SupportListAnalyzer::analyze(const battle::Role role)
         templ_rect.x = rect.x;
 
         SupportUnit support_unit { .templ = make_roi(m_image, templ_rect),
+                                   .role = role,
                                    .name = name_analyzer.get_result().text,
                                    .elite = elite,
                                    .level = level,

--- a/src/MaaCore/Vision/Battle/SupportListAnalyzer.cpp
+++ b/src/MaaCore/Vision/Battle/SupportListAnalyzer.cpp
@@ -62,9 +62,6 @@ bool asst::SupportListAnalyzer::analyze(const battle::Role role)
             continue;
         }
 
-        // canonical_oper_name 函数根据 role 对干员名进行消歧义，目前仅用于区分不同升变形态下的阿米娅
-        const std::string name = canonical_oper_name(role, name_analyzer.get_result().text);
-
         // ————————————————————————————————————————————————————————————————
         // Elite
         // ————————————————————————————————————————————————————————————————
@@ -188,7 +185,7 @@ bool asst::SupportListAnalyzer::analyze(const battle::Role role)
         templ_rect.x = rect.x;
 
         SupportUnit support_unit { .templ = make_roi(m_image, templ_rect),
-                                   .name = name,
+                                   .name = name_analyzer.get_result().text,
                                    .elite = elite,
                                    .level = level,
                                    .potential = potential,

--- a/tools/ResourceUpdater/main.cpp
+++ b/tools/ResourceUpdater/main.cpp
@@ -1400,16 +1400,16 @@ bool update_battle_chars_info(const fs::path& official_dir, const fs::path& over
 
     const auto& patch_json = chars_patch_opt.value()["patchChars"].as_object();
     json::value Amiya_data;
-    Amiya_data["name"] = "阿米娅-WARRIOR";
-    Amiya_data["name_en"] = "Amiya-WARRIOR";
-    Amiya_data["name_jp"] = "アーミヤ-WARRIOR";
-    Amiya_data["name_kr"] = "아미야-WARRIOR";
-    Amiya_data["name_tw"] = "阿米婭-WARRIOR";
+    Amiya_data["name"] = "阿米娅";
+    Amiya_data["name_en"] = "Amiya";
+    Amiya_data["name_jp"] = "アーミヤ";
+    Amiya_data["name_kr"] = "아미야";
+    Amiya_data["name_tw"] = "阿米婭";
     if (auto amiya2_opt = patch_json.find<json::object>("char_1001_amiya2")) {
         Amiya_data["profession"] = amiya2_opt->at("profession");
         Amiya_data["rarity"] = static_cast<int>(amiya2_opt->at("rarity")) + 1;
         Amiya_data["position"] = amiya2_opt->at("position");
-        Amiya_data["sortIndex"] = amiya2_opt->at("sortIndex");
+        Amiya_data["sortIndex"] = 17; // yj 给升变的 sortIndex 设了0，暂时使用主角色的 sortIndex
         Amiya_data["subProfessionId"] = amiya2_opt->at("subProfessionId");
         const std::string& default_range = amiya2_opt->get("phases", 0, "rangeId", "0-1");
         Amiya_data["rangeId"] = json::array {
@@ -1421,16 +1421,16 @@ bool update_battle_chars_info(const fs::path& official_dir, const fs::path& over
     chars.emplace("char_1001_amiya2", std::move(Amiya_data));
 
     json::value Amiya_data3;
-    Amiya_data3["name"] = "阿米娅-MEDIC";
-    Amiya_data3["name_en"] = "Amiya-MEDIC";
-    Amiya_data3["name_jp"] = "アーミヤ-MEDIC";
-    Amiya_data3["name_kr"] = "아미야-MEDIC";
-    Amiya_data3["name_tw"] = "阿米婭-MEDIC";
+    Amiya_data3["name"] = "阿米娅";
+    Amiya_data3["name_en"] = "Amiya";
+    Amiya_data3["name_jp"] = "アーミヤ";
+    Amiya_data3["name_kr"] = "아미야";
+    Amiya_data3["name_tw"] = "阿米婭";
     if (auto amiya3_opt = patch_json.find<json::object>("char_1037_amiya3")) {
         Amiya_data3["profession"] = amiya3_opt->at("profession");
         Amiya_data3["rarity"] = static_cast<int>(amiya3_opt->at("rarity")) + 1;
         Amiya_data3["position"] = amiya3_opt->at("position");
-        Amiya_data3["sortIndex"] = amiya3_opt->at("sortIndex");
+        Amiya_data3["sortIndex"] = 17;
         Amiya_data3["subProfessionId"] = amiya3_opt->at("subProfessionId");
         const std::string& default_range = amiya3_opt->get("phases", 0, "rangeId", "0-1");
         Amiya_data3["rangeId"] = json::array {


### PR DESCRIPTION
## Sourcery 摘要

在资源生成、支援识别和肉鸽战斗处理的各个环节中，统一使用标准干员名称来表示升级后的阿米娅。

肉鸽中尚未完全支持阿米娅，RoguelikeRecruitImageAnalyzer、RoguelikeSkillSelectionImageAnalyzer 等待添加职业识别

Bug 修复：
- 移除肉鸽招募资源和支援单位识别中阿米娅名称的职业后缀。
- 确保阿米娅两种升级形态生成的角色元数据使用统一名称和稳定的排序位置。

功能增强：
- 更新肉鸽战斗、招募、定位和攻击范围处理逻辑，通过角色区分干员，而不是将职业后缀嵌入名称。
- 移除阿米娅的特殊名称转换逻辑，简化干员查找。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Unify upgraded Amiya under the standard operator name throughout resource generation, support recognition, and roguelike battle handling.

Bug Fixes:
- Remove profession suffixes from Amiya names across roguelike recruitment resources and support-unit recognition.
- Ensure Amiya's generated character metadata uses the shared name and stable sorting position for both upgraded forms.

Enhancements:
- Update roguelike battle, recruitment, positioning, and attack-range handling to distinguish operators by role without embedding profession suffixes in names.
- Simplify operator lookup by eliminating the special-case name conversion logic for Amiya.

</details>