### PR TITLE
refactor: 手动停止链路收敛，结束脚本发射脱离 SetStopped

### DIFF
--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -1298,9 +1298,7 @@ public class AsstProxy
         {
             case AsstMsg.TaskChainStopped:
                 {
-                    // Copilot 场景下只有 CopilotWithScript 开启时才执行结束脚本，否则由 SetStopped 默认逻辑处理
-                    bool runScript = !isCopilotTaskChain || SettingsViewModel.GameSettings.CopilotWithScript;
-                    Instances.TaskQueueViewModel.SetStopped(runStopScript: runScript);
+                    Instances.TaskQueueViewModel.SetStopped();
                 }
 
                 // UpdateTaskStatus(taskId, TaskStatus.Completed);
@@ -1445,7 +1443,8 @@ public class AsstProxy
                 {
                     if (SettingsViewModel.GameSettings.CopilotWithScript)
                     {
-                        Task.Run(() => SettingsViewModel.GameSettings.RunScript("EndsWithScript", showLog: false));
+                        // 与手动停止入口共享发射权（copilot 日志走下方 AddLog，不进任务日志）
+                        _ = Instances.TaskQueueViewModel.RunStopScriptOnceAsync(showLog: false);
                         if (!string.IsNullOrWhiteSpace(SettingsViewModel.GameSettings.EndsWithScript))
                         {
                             Instances.CopilotViewModel.AddLog(LocalizationHelper.GetString("EndsWithScript"));

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -441,6 +441,13 @@ public class AsstProxy
     {
         _callback = CallbackFunction;
         _runningState = RunningState.Instance;
+        _runningState.StateChanged += (_, e) => {
+            // 轮次结束回到空闲时归零链信息，下一轮启动链路（core 尚无链信息）读到的即为干净的 false
+            if (!e.OldState.Idle && e.NewState.Idle)
+            {
+                _isCopilotTaskChainRunning = false;
+            }
+        };
         _tasksStatus.CollectionChanged += (in NotifyCollectionChangedEventArgs<KeyValuePair<AsstTaskId, (TaskType, TaskStatus)>> args) => {
             if (args.Action == NotifyCollectionChangedAction.Reset)
             {
@@ -1341,6 +1348,7 @@ public class AsstProxy
                     taskName += GetMultiChainTaskNameSuffix(task, taskChain, taskId);
                     Instances.TaskQueueViewModel.AddLogSection(LocalizationHelper.GetString("StartTask") + taskName, decoratePlainText: false);
                     _logger.Information("Start Task Chain: {TaskChain}, Task ID: {TaskId}", taskChain, taskId);
+                    _isCopilotTaskChainRunning = isCopilotTaskChain;
                     UpdateTaskStatus(taskId, TaskStatus.InProgress);
 
                     // LinkStart 按钮也会修改，但小工具中的日志源需要在这里修改
@@ -3311,6 +3319,17 @@ public class AsstProxy
     ];
 
     private readonly ObservableDictionary<AsstTaskId, (TaskType Type, TaskStatus Status)> _tasksStatus = [];
+
+    // 本轮 Core 任务链是否 copilot；链开始时置值，轮次结束回到空闲时归零。
+    // 归零挂在 StateChanged(→Idle) 而非 TaskChainStopped：自然完成不发 TaskChainStopped（只有停止
+    // 路径发），挂回调清会让残留的 true 被下一轮启动链路（连接、开始前脚本阶段）的手动停止读到
+    private volatile bool _isCopilotTaskChainRunning;
+
+    /// <summary>
+    /// 当前运行的任务链是否 copilot（Copilot / SSSCopilot）。
+    /// 链开始时置值；轮次结束（回到空闲）时归零，Core 未运行（启动链路中的连接、开始前脚本阶段）时无链信息，值为 false。
+    /// </summary>
+    public bool IsCopilotTaskChainRunning => _isCopilotTaskChainRunning;
 
     public IReadOnlyDictionary<AsstTaskId, (TaskType Type, TaskStatus Status)> TasksStatus => new Dictionary<AsstTaskId, (TaskType, TaskStatus)>(_tasksStatus);
 

--- a/src/MaaWpfGui/Main/Bootstrapper.cs
+++ b/src/MaaWpfGui/Main/Bootstrapper.cs
@@ -1199,7 +1199,7 @@ public class Bootstrapper : Bootstrapper<RootViewModel>
 
         _isWaitingToRestart = true;
 
-        await RunningState.Instance.UntilIdleAsync(60000);
+        await RunningState.Instance.UntilIdleAsync();
         if (args is { Length: > 0 })
         {
             ShutdownAndRestartWithArgs(args);

--- a/src/MaaWpfGui/Res/Localizations/en-us.xaml
+++ b/src/MaaWpfGui/Res/Localizations/en-us.xaml
@@ -2062,7 +2062,7 @@ These directories are not suitable places to keep MAA; files there can be easily
     <system:String x:Key="TaskStallWarning">Task log output has not been updated for {0} minutes (currently stalled for {1} minutes). Please check whether the task is still running; if so, you can ignore this warning. If the task is unresponsive, manual intervention may be required.</system:String>
     <system:String x:Key="RunDurationLimitEnabled">Limit run duration</system:String>
     <system:String x:Key="RunDurationLimitMinutes">Run duration limit (min)</system:String>
-    <system:String x:Key="RunDurationLimitTip" xml:space="preserve">Timed from ｢{key=LinkStart}｣. Tasks are stopped automatically once the limit is reached; the option below controls whether actions in ｢{key=PostActionsSettings}｣ (e.g. exiting the game, closing the emulator, shutting down) are executed afterwards.
+    <system:String x:Key="RunDurationLimitTip" xml:space="preserve">Timed from ｢{key=LinkStart}｣. A manual stop is triggered once the limit is reached.
 {key=CheckBoxesNotSavedAsNull}.</system:String>
     <system:String x:Key="RunDurationLimitExecutePostActions">Run actions in ｢{key=PostActionsSettings}｣ after stopping</system:String>
     <system:String x:Key="RunDurationLimitReached">Run duration limit ({0} min) reached, stopping tasks</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ja-jp.xaml
@@ -2065,7 +2065,7 @@ MAA を複数開くには、新しい MAA を他のフォルダにコピーし�
     <system:String x:Key="TaskStallWarning">タスクログ出力が {0} 分間更新されていません（現在 {1} 分間停滞）。タスクが正常に実行中か確認してください。正常であればこの警告は無視できます。応答がない場合は、手動での操作が必要になる可能性があります。</system:String>
     <system:String x:Key="RunDurationLimitEnabled">1回の実行時間を制限する</system:String>
     <system:String x:Key="RunDurationLimitMinutes">実行時間の上限（分）</system:String>
-    <system:String x:Key="RunDurationLimitTip" xml:space="preserve">｢{key=LinkStart}｣ をクリックした時点から計測し、上限に達するとタスクを自動停止します。停止後に ｢{key=PostActionsSettings}｣ の動作（ゲーム終了、エミュレーター終了、シャットダウンなど）を実行するかは下のオプションで設定できます。
+    <system:String x:Key="RunDurationLimitTip" xml:space="preserve">｢{key=LinkStart}｣ をクリックした時点から計測し、上限に達すると手動停止を一度だけ実行します。
 {key=CheckBoxesNotSavedAsNull}。</system:String>
     <system:String x:Key="RunDurationLimitExecutePostActions">停止後に ｢{key=PostActionsSettings}｣ の動作を実行する</system:String>
     <system:String x:Key="RunDurationLimitReached">実行時間の上限（{0} 分）に達したため、タスクを停止します</system:String>

--- a/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
+++ b/src/MaaWpfGui/Res/Localizations/ko-kr.xaml
@@ -2063,7 +2063,7 @@ MAA를 독립된 새 폴더에 압축 해제하거나, MAA에 속하지 않는 D
     <system:String x:Key="TaskStallWarning">작업 로그 출력이 {0}분 동안 업데이트되지 않았습니다(현재 {1}분 정지). 작업이 정상적으로 실행 중인지 확인하세요. 정상이라면 이 경고를 무시해도 됩니다. 응답이 없으면 수동 개입이 필요할 수 있습니다.</system:String>
     <system:String x:Key="RunDurationLimitEnabled">1회 실행 시간 제한</system:String>
     <system:String x:Key="RunDurationLimitMinutes">실행 시간 상한 (분)</system:String>
-    <system:String x:Key="RunDurationLimitTip" xml:space="preserve">｢{key=LinkStart}｣ 클릭 시점부터 시간을 측정하며, 상한에 도달하면 작업을 자동으로 중지합니다. 중지 후 ｢{key=PostActionsSettings}｣의 동작(게임 종료, 에뮬레이터 종료, 시스템 종료 등) 실행 여부는 아래 옵션으로 설정할 수 있습니다.
+    <system:String x:Key="RunDurationLimitTip" xml:space="preserve">｢{key=LinkStart}｣ 클릭 시점부터 시간을 측정하며, 상한에 도달하면 수동 중지를 한 번 실행합니다.
 {key=CheckBoxesNotSavedAsNull}.</system:String>
     <system:String x:Key="RunDurationLimitExecutePostActions">중지 후 ｢{key=PostActionsSettings}｣의 동작 실행</system:String>
     <system:String x:Key="RunDurationLimitReached">실행 시간 상한({0}분)에 도달하여 작업을 중지합니다</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-cn.xaml
@@ -595,7 +595,7 @@ D:\
     <system:String x:Key="EndsWithScript">结束后脚本</system:String>
     <system:String x:Key="EndsWithScriptPlaceholder">示例："C:\1.cmd" -noWindow</system:String>
     <system:String x:Key="CopilotWithScript">自动战斗时启用上述脚本</system:String>
-    <system:String x:Key="ManualStopWithScript">手动暂停时启用上述脚本</system:String>
+    <system:String x:Key="ManualStopWithScript">手动停止时启用上述脚本</system:String>
     <system:String x:Key="BlockSleep">运行任务时阻止休眠</system:String>
     <system:String x:Key="BlockSleepWithScreenOn">阻止休眠时保持屏幕常亮</system:String>
     <system:String x:Key="ScreencapCost">截图耗时 min/avg/max(ms): {0:#,#} / {1:#,#} / {2:#,#} ({3})</system:String>
@@ -2061,7 +2061,7 @@ DEBUG 目录下保存的图片有数量限制，超出后会自动清理旧图�
     <system:String x:Key="TaskStallWarning">任务日志输出已超过 {0} 分钟无更新（当前已停滞 {1} 分钟）。请确认任务是否正常运行，若任务正常可忽略此提示，若无响应则可能需要手动干预。</system:String>
     <system:String x:Key="RunDurationLimitEnabled">限制单次运行时长</system:String>
     <system:String x:Key="RunDurationLimitMinutes">运行时长上限（分钟）</system:String>
-    <system:String x:Key="RunDurationLimitTip" xml:space="preserve">从点击 ｢{key=LinkStart}｣ 开始计时，到达上限后自动停止任务，并按下方选项决定是否执行 ｢{key=PostActionsSettings}｣ 中的动作（如退出游戏、关闭模拟器、关机）。
+    <system:String x:Key="RunDurationLimitTip" xml:space="preserve">从点击 ｢{key=LinkStart}｣ 开始计时，到达上限后触发一次手动停止。
 {key=CheckBoxesNotSavedAsNull}。</system:String>
     <system:String x:Key="RunDurationLimitExecutePostActions">停止后执行 ｢{key=PostActionsSettings}｣ 中的动作</system:String>
     <system:String x:Key="RunDurationLimitReached">已达到运行时长上限（{0} 分钟），停止任务</system:String>

--- a/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
+++ b/src/MaaWpfGui/Res/Localizations/zh-tw.xaml
@@ -596,7 +596,7 @@ D:\
     <system:String x:Key="EndsWithScript">結束後腳本</system:String>
     <system:String x:Key="EndsWithScriptPlaceholder">範例："C:\1.cmd" -noWindow</system:String>
     <system:String x:Key="CopilotWithScript">自動戰鬥時啟用上述腳本</system:String>
-    <system:String x:Key="ManualStopWithScript">手動暫停時啟用上述腳本</system:String>
+    <system:String x:Key="ManualStopWithScript">手動停止時啟用上述腳本</system:String>
     <system:String x:Key="BlockSleep">執行任務時阻止休眠</system:String>
     <system:String x:Key="BlockSleepWithScreenOn">阻止休眠時保持螢幕常亮</system:String>
     <system:String x:Key="ScreencapCost">截圖耗時 min/avg/max(ms): {0:#,#} / {1:#,#} / {2:#,#} ({3})</system:String>
@@ -2063,7 +2063,7 @@ DEBUG 目錄下儲存的圖片有數量限制，超出後會自動清理舊圖�
     <system:String x:Key="TaskStallWarning">任務日誌輸出已超過 {0} 分鐘無更新（當前已停滯 {1} 分鐘）。請確認任務是否正常運行，若任務正常可忽略此提示，若無回應則可能需要手動干預。</system:String>
     <system:String x:Key="RunDurationLimitEnabled">限制單次運行時長</system:String>
     <system:String x:Key="RunDurationLimitMinutes">運行時長上限（分鐘）</system:String>
-    <system:String x:Key="RunDurationLimitTip" xml:space="preserve">從點擊 ｢{key=LinkStart}｣ 開始計時，到達上限後自動停止任務，並依下方選項決定是否執行 ｢{key=PostActionsSettings}｣ 中的動作（如退出遊戲、關閉模擬器、關機）。
+    <system:String x:Key="RunDurationLimitTip" xml:space="preserve">從點擊 ｢{key=LinkStart}｣ 開始計時，到達上限後觸發一次手動停止。
 {key=CheckBoxesNotSavedAsNull}。</system:String>
     <system:String x:Key="RunDurationLimitExecutePostActions">停止後執行 ｢{key=PostActionsSettings}｣ 中的動作</system:String>
     <system:String x:Key="RunDurationLimitReached">已達到運行時長上限（{0} 分鐘），停止任務</system:String>

--- a/src/MaaWpfGui/Services/HotKeys/MaaHotKeyActionHandler.cs
+++ b/src/MaaWpfGui/Services/HotKeys/MaaHotKeyActionHandler.cs
@@ -70,7 +70,7 @@ public class MaaHotKeyActionHandler : IMaaHotKeyActionHandler
         }
         else
         {
-            _ = Instances.TaskQueueViewModel.Stop();
+            _ = Instances.TaskQueueViewModel.StopManuallyAsync();
 
             if (Application.Current.MainWindow == null ||
                 Application.Current.MainWindow.WindowState != WindowState.Minimized)

--- a/src/MaaWpfGui/Services/RemoteControl/RemoteControlService.cs
+++ b/src/MaaWpfGui/Services/RemoteControl/RemoteControlService.cs
@@ -722,7 +722,6 @@ public class RemoteControlService
             if (count == 0)
             {
                 Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("UnselectedTask"));
-                _runningState.SetIdle(true);
                 Instances.TaskQueueViewModel.SetStopped();
                 return;
             }

--- a/src/MaaWpfGui/Services/RemoteControl/RemoteControlService.cs
+++ b/src/MaaWpfGui/Services/RemoteControl/RemoteControlService.cs
@@ -470,15 +470,9 @@ public class RemoteControlService
 
                 case "StopTask":
                     {
-                        await Task.Run(() => {
-                            if (!Instances.AsstProxy.AsstStop())
-                            {
-                                // 无法确定当前的界面，找不到借用的UI位置，因此只能Log
-                                Log.Logger.Error("Failed to stop Asst.");
-                            }
-                        });
-
+                        // 远控停止与界面手动停止同语义（结束脚本按当前任务链的开关闭合）；
                         // 无需等待，甩出任务即可返回，远端应该用心跳来确认界面卡死和取消是否成功。
+                        _ = Instances.TaskQueueViewModel.StopManuallyAsync();
                         break;
                     }
 

--- a/src/MaaWpfGui/States/RunningState.cs
+++ b/src/MaaWpfGui/States/RunningState.cs
@@ -416,8 +416,10 @@ public class RunningState
         {
             while (!CanInterrupt())
             {
-                var remaining = deadline - DateTime.UtcNow;
-                if (remaining <= TimeSpan.Zero)
+                // 无限等待须传 InfiniteTimeSpan：deadline 为 DateTime.MaxValue 时的差值远超
+                // Task.WaitAsync(TimeSpan) 的上限，直接传剩余时间会抛 ArgumentOutOfRangeException
+                var remaining = timeout < 0 ? Timeout.InfiniteTimeSpan : deadline - DateTime.UtcNow;
+                if (timeout >= 0 && remaining <= TimeSpan.Zero)
                 {
                     _logger.Information("Idle not reached before timeout.");
                     return false;

--- a/src/MaaWpfGui/States/RunningState.cs
+++ b/src/MaaWpfGui/States/RunningState.cs
@@ -316,10 +316,7 @@ public class RunningState
             _logger.Information("InterruptLock: depth={Depth} (called from {Caller})", newValue, caller);
         }
 
-        if (Volatile.Read(ref _interruptLockDepth) <= 0)
-        {
-            SignalCanInterrupt();
-        }
+        SignalCanInterrupt();
     }
 
     /// <summary>

--- a/src/MaaWpfGui/States/RunningState.cs
+++ b/src/MaaWpfGui/States/RunningState.cs
@@ -315,6 +315,11 @@ public class RunningState
         {
             _logger.Information("InterruptLock: depth={Depth} (called from {Caller})", newValue, caller);
         }
+
+        if (Volatile.Read(ref _interruptLockDepth) <= 0)
+        {
+            SignalCanInterrupt();
+        }
     }
 
     /// <summary>
@@ -329,6 +334,19 @@ public class RunningState
     /// </summary>
     /// <returns>空闲且中断未锁定返回 <see langword="true"/>，否则返回 <see langword="false"/>。</returns>
     public bool CanInterrupt() => GetIdle() && !IsInterruptLocked();
+
+    // 等待可打断的广播信号；状态跃迁或中断锁归零且恰好可打断时置位换新，等待方被即时唤醒
+    private TaskCompletionSource _canInterruptSignal = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+    private void SignalCanInterrupt()
+    {
+        if (!CanInterrupt())
+        {
+            return;
+        }
+
+        Interlocked.Exchange(ref _canInterruptSignal, new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously)).TrySetResult();
+    }
 
     private bool _inited;
 
@@ -381,27 +399,57 @@ public class RunningState
     private void RaiseStateChanged(StateSnapshot oldState)
     {
         StateChanged?.Invoke(this, new(oldState, _idle, _inited, _stopping));
+        SignalCanInterrupt();
     }
 
     /// <summary>
-    /// 等待状态变为闲置
+    /// 等待状态变为闲置（可打断），状态广播即时唤醒，无轮询。
     /// </summary>
-    /// <param name="time">查询间隔(ms)</param>
     /// <param name="confirmInterval">确认间隔(ms)</param>
-    /// <param name="confirmTimes">确认次数</param>
-    /// <returns>Task</returns>
-    public async Task UntilIdleAsync(int time = 1000, int confirmInterval = 1000, int confirmTimes = 3)
+    /// <param name="confirmTimes">确认次数；0 表示等到可打断即返回，不防抖确认</param>
+    /// <param name="timeout">总等待上限(ms)；小于 0（如 <see cref="Timeout.Infinite"/>）表示无限等待</param>
+    /// <returns>是否在超时内等到闲置；false 表示超时放弃</returns>
+    public async Task<bool> UntilIdleAsync(int confirmInterval = 1000, int confirmTimes = 3, int timeout = Timeout.Infinite)
     {
+        var deadline = timeout < 0 ? DateTime.MaxValue : DateTime.UtcNow.AddMilliseconds(timeout);
         while (true)
         {
             while (!CanInterrupt())
             {
-                await Task.Delay(time);
+                var remaining = deadline - DateTime.UtcNow;
+                if (remaining <= TimeSpan.Zero)
+                {
+                    _logger.Information("Idle not reached before timeout.");
+                    return false;
+                }
+
+                // 读取信号与挂起之间广播可能已置位，挂起前双查兜底
+                var signal = Volatile.Read(ref _canInterruptSignal);
+                if (CanInterrupt())
+                {
+                    break;
+                }
+
+                try
+                {
+                    await signal.Task.WaitAsync(remaining);
+                }
+                catch (TimeoutException)
+                {
+                    _logger.Information("Idle not reached before timeout.");
+                    return false;
+                }
             }
 
             int confirmed = 0;
             while (confirmed < confirmTimes)
             {
+                if (DateTime.UtcNow >= deadline)
+                {
+                    _logger.Information("Idle not confirmed before timeout.");
+                    return false;
+                }
+
                 await Task.Delay(confirmInterval);
 
                 if (CanInterrupt())
@@ -418,7 +466,7 @@ public class RunningState
             if (confirmed >= confirmTimes)
             {
                 _logger.Information("Idle state confirmed after {ConfirmTimes} checks.", confirmTimes);
-                return;
+                return true;
             }
         }
     }

--- a/src/MaaWpfGui/ViewModels/Dialogs/VersionUpdateDialogViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/Dialogs/VersionUpdateDialogViewModel.cs
@@ -1046,7 +1046,7 @@ public class VersionUpdateDialogViewModel : Screen
         {
             if (FakeUpdateHelper.HasPendingFakeUpdate)
             {
-                await _runningState.UntilIdleAsync(1000);
+                await _runningState.UntilIdleAsync();
                 _ = FakeUpdateHelper.Updating();
                 return;
             }
@@ -1055,7 +1055,7 @@ public class VersionUpdateDialogViewModel : Screen
             return;
         }
 
-        await _runningState.UntilIdleAsync(10000);
+        await _runningState.UntilIdleAsync();
 
         var result = MessageBoxHelper.Show(
             description,

--- a/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
@@ -2107,22 +2107,12 @@ public partial class CopilotViewModel : Screen
 
         AddLog(LocalizationHelper.GetString("Stopping"));
 
-        // 结束脚本须 CopilotWithScript 与 ManualStopWithScript 同时开启（同主任务队列的手动停止语义）
-        var runScript = SettingsViewModel.GameSettings.CopilotWithScript && SettingsViewModel.GameSettings.ManualStopWithScript;
-        if (Instances.AsstProxy.AsstRunning())
+        // 停止目标恒为 copilot（连接中、Core 未运行无链信息可判的阶段也由入口显式声明）；
+        // 停止完成后发射结束脚本，须 ｢自动战斗时启用上述脚本｣ 与 ｢手动停止时启用上述脚本｣ 同时开启
+        var stopped = await Instances.TaskQueueViewModel.StopManuallyAsync(isCopilot: true);
+        if (stopped)
         {
-            // Core 运行中：复用主任务队列的手动停止核心，等回调恢复状态后发射脚本
-            await Instances.TaskQueueViewModel.StopManuallyAsync(runScript);
-        }
-        else
-        {
-            // Core 未运行（如连接中）时没有回调，等不到 Idle；
-            // 仅置停止中，状态恢复交给 Start 流程稍后的 Stopping 拦截分支，脚本在此直接发射
-            await Instances.TaskQueueViewModel.Stop();
-            if (runScript)
-            {
-                await Instances.TaskQueueViewModel.RunStopScriptOnceAsync();
-            }
+            AddLog(LocalizationHelper.GetString("Stopped"));
         }
     }
 

--- a/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
@@ -1843,7 +1843,7 @@ public partial class CopilotViewModel : Screen
         // 统一前置校验：先按 CopilotTabIndex 分发，再判断对应选项（UseCopilotList 等）
         if (!await ValidateStartAsync())
         {
-            _runningState.SetIdle(true);
+            Instances.TaskQueueViewModel.SetStopped();
             return;
         }
 
@@ -1851,14 +1851,16 @@ public partial class CopilotViewModel : Screen
 
         if (!await ConnectToEmulatorAsync())
         {
+            // Core 从未 start，Stop() 的轮询立即结束、走不到超时强制 SetStopped，需显式收尾
             await Stop();
+            Instances.TaskQueueViewModel.SetStopped();
             return;
         }
 
         // 连接期间用户可能已点停止，需在此处拦截
         if (_runningState.GetStopping())
         {
-            Instances.TaskQueueViewModel.SetStopped(SettingsViewModel.GameSettings.CopilotWithScript);
+            Instances.TaskQueueViewModel.SetStopped();
             AddLog(LocalizationHelper.GetString("Stopped"));
             return;
         }
@@ -1888,7 +1890,7 @@ public partial class CopilotViewModel : Screen
                 _logger.Warning("Failed to stop Asst");
             }
 
-            _runningState.SetIdle(true);
+            Instances.TaskQueueViewModel.SetStopped();
             AddLog(LocalizationHelper.GetString("CopilotFileReadError"), UiLogColor.Error, showTime: false);
         }
     }
@@ -2091,13 +2093,46 @@ public partial class CopilotViewModel : Screen
     // }
 
     /// <summary>
-    /// Stops copilot.
+    /// 手动停止 copilot。
     /// UI 绑定的方法
+    /// </summary>
+    /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+    [UsedImplicitly]
+    public async Task ManualStop()
+    {
+        if (_runningState.GetStopping() || _runningState.GetIdle())
+        {
+            return;
+        }
+
+        AddLog(LocalizationHelper.GetString("Stopping"));
+
+        // 结束脚本须 CopilotWithScript 与 ManualStopWithScript 同时开启（同主任务队列的手动停止语义）
+        var runScript = SettingsViewModel.GameSettings.CopilotWithScript && SettingsViewModel.GameSettings.ManualStopWithScript;
+        if (Instances.AsstProxy.AsstRunning())
+        {
+            // Core 运行中：复用主任务队列的手动停止核心，等回调恢复状态后发射脚本
+            await Instances.TaskQueueViewModel.StopManuallyAsync(runScript);
+        }
+        else
+        {
+            // Core 未运行（如连接中）时没有回调，等不到 Idle；
+            // 仅置停止中，状态恢复交给 Start 流程稍后的 Stopping 拦截分支，脚本在此直接发射
+            await Instances.TaskQueueViewModel.Stop();
+            if (runScript)
+            {
+                await Instances.TaskQueueViewModel.RunStopScriptOnceAsync();
+            }
+        }
+    }
+
+    /// <summary>
+    /// 内部收尾停止：仅通知 Core 停止并等待，不发射结束脚本（连接失败等启动链路调用）。
     /// </summary>
     /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
     public async Task Stop()
     {
-        // 等待 Core 实际停止；回调或超时自动 SetStopped（脚本由 proxy 回调按 CopilotWithScript 设置判断）
+        // 等待 Core 实际停止；回调或超时自动 SetStopped，结束脚本不经此发射
         AddLog(LocalizationHelper.GetString("Stopping"));
         await Instances.TaskQueueViewModel.Stop();
         if (_runningState.GetIdle() && !_runningState.GetStopping())

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -468,172 +468,186 @@ public class TaskQueueViewModel : Screen
     }
 
     /// <summary>
-    /// Checks after completion.
+    /// 自然完成后的收尾：执行结束脚本后执行完成后动作。仅由 <see cref="AsstProxy"/> 的
+    /// <c>AllTasksCompleted</c> 回调调用，结束脚本恒执行。
     /// </summary>
-    /// <param name="runEndsWithScript">是否执行结束脚本；为 false 时等待本次停止中 SetStopped 启动的结束脚本执行完毕</param>
     /// <returns>Task</returns>
-    public async Task CheckAfterCompleted(bool runEndsWithScript = true)
+    public async Task CheckAfterCompleted()
     {
         RunningState.Instance.LockInterrupt();
         try
         {
-            if (runEndsWithScript)
-            {
-                await Task.Run(() => SettingsViewModel.GameSettings.RunScript("EndsWithScript"));
-            }
-            else
-            {
-                await (Volatile.Read(ref _stopHandling)?.Task ?? Task.CompletedTask);
-            }
-
-            var actions = PostActionSetting;
-            _logger.Information("Post actions: " + actions.ActionDescription);
-
-            if (actions.BackToAndroidHome)
-            {
-                Instances.AsstProxy.AsstBackToHome();
-                await Task.Delay(1000);
-            }
-
-            if (actions.ExitArknights)
-            {
-                var clientType = SettingsViewModel.GameSettings.ClientType;
-                if (!Instances.AsstProxy.AsstStartCloseDown(clientType))
-                {
-                    AddLog(LocalizationHelper.GetString("CloseArknightsFailed"), UiLogColor.Error);
-                }
-
-                await Task.Delay(1000);
-            }
-
-            if (actions.ExitEmulator && !SettingsViewModel.ConnectSettings.IsPCConnectConfig)
-            {
-                DoKillEmulator();
-                await Task.Delay(1000);
-            }
-
-            if (actions.ExitSelf && !(actions.Hibernate || actions.Shutdown || actions.Sleep))
-            {
-                Bootstrapper.Shutdown();
-            }
-
-            if (actions.Hibernate)
-            {
-                if (actions.IfNoOtherMaa && HasOtherMaa())
-                {
-                    Bootstrapper.Shutdown();
-                }
-                else
-                {
-                    await DoHibernate();
-                }
-            }
-
-            if (actions.Shutdown)
-            {
-                if (actions.IfNoOtherMaa && HasOtherMaa())
-                {
-                    Bootstrapper.Shutdown();
-                }
-                else
-                {
-                    await DoShutDown();
-                }
-            }
-
-            if (actions.Sleep)
-            {
-                if (actions.IfNoOtherMaa && HasOtherMaa())
-                {
-                    Bootstrapper.Shutdown();
-                }
-                else
-                {
-                    await DoSleep();
-                }
-            }
-
-            if (actions.ExitSelf)
-            {
-                Bootstrapper.Shutdown();
-            }
-
-            actions.LoadPostActions();
-            return;
-
-            bool HasOtherMaa()
-            {
-                var processesCount = Process.GetProcessesByName("MAA").Length;
-                _logger.Information("MAA processes count: {ProcessesCount}", processesCount);
-                return processesCount > 1;
-            }
-
-            void DoKillEmulator()
-            {
-                if (!EmulatorHelper.KillEmulatorModeSwitcher())
-                {
-                    AddLog(LocalizationHelper.GetString("ExitEmulatorFailed"), UiLogColor.Error);
-                }
-            }
-
-            async Task DoHibernate()
-            {
-                actions.LoadPostActions();
-
-                await Execute.OnUIThreadAsync(() => Instances.MainWindowManager?.Show());
-                if (await TimerCanceledAsync(
-                        LocalizationHelper.GetString("Hibernate"),
-                        LocalizationHelper.GetString("HibernatePrompt"),
-                        LocalizationHelper.GetString("Cancel"),
-                        60))
-                {
-                    return;
-                }
-
-                _logger.Information("Hibernate not canceled, proceeding to hibernate.");
-                PowerManagement.Hibernate();
-            }
-
-            async Task DoShutDown()
-            {
-                PowerManagement.Shutdown();
-
-                await Execute.OnUIThreadAsync(() => Instances.MainWindowManager?.Show());
-                if (await TimerCanceledAsync(
-                        LocalizationHelper.GetString("Shutdown"),
-                        LocalizationHelper.GetString("AboutToShutdown"),
-                        LocalizationHelper.GetString("Cancel"),
-                        60))
-                {
-                    PowerManagement.AbortShutdown();
-                    return;
-                }
-
-                _logger.Information("Shutdown not canceled, proceeding to exit application.");
-                Bootstrapper.Shutdown();
-            }
-
-            async Task DoSleep()
-            {
-                actions.LoadPostActions();
-
-                await Execute.OnUIThreadAsync(() => Instances.MainWindowManager?.Show());
-                if (await TimerCanceledAsync(
-                        LocalizationHelper.GetString("Sleep"),
-                        LocalizationHelper.GetString("SleepPrompt"),
-                        LocalizationHelper.GetString("Cancel"),
-                        60))
-                {
-                    return;
-                }
-
-                _logger.Information("Sleep not canceled, proceeding to sleep.");
-                PowerManagement.Sleep();
-            }
+            await RunStopScriptOnceAsync();
+            await RunPostActionsCoreAsync();
         }
         finally
         {
             RunningState.Instance.UnlockInterrupt();
+        }
+    }
+
+    /// <summary>
+    /// 手动停止路径（时长上限到点）的完成后动作；结束脚本已由 <see cref="StopManuallyAsync"/> 按开关发射。
+    /// </summary>
+    /// <returns>Task</returns>
+    private async Task RunPostActionsAfterManualStopAsync()
+    {
+        RunningState.Instance.LockInterrupt();
+        try
+        {
+            await RunPostActionsCoreAsync();
+        }
+        finally
+        {
+            RunningState.Instance.UnlockInterrupt();
+        }
+    }
+
+    private async Task RunPostActionsCoreAsync()
+    {
+        var actions = PostActionSetting;
+        _logger.Information("Post actions: " + actions.ActionDescription);
+
+        if (actions.BackToAndroidHome)
+        {
+            Instances.AsstProxy.AsstBackToHome();
+            await Task.Delay(1000);
+        }
+
+        if (actions.ExitArknights)
+        {
+            var clientType = SettingsViewModel.GameSettings.ClientType;
+            if (!Instances.AsstProxy.AsstStartCloseDown(clientType))
+            {
+                AddLog(LocalizationHelper.GetString("CloseArknightsFailed"), UiLogColor.Error);
+            }
+
+            await Task.Delay(1000);
+        }
+
+        if (actions.ExitEmulator && !SettingsViewModel.ConnectSettings.IsPCConnectConfig)
+        {
+            DoKillEmulator();
+            await Task.Delay(1000);
+        }
+
+        if (actions.ExitSelf && !(actions.Hibernate || actions.Shutdown || actions.Sleep))
+        {
+            Bootstrapper.Shutdown();
+        }
+
+        if (actions.Hibernate)
+        {
+            if (actions.IfNoOtherMaa && HasOtherMaa())
+            {
+                Bootstrapper.Shutdown();
+            }
+            else
+            {
+                await DoHibernate();
+            }
+        }
+
+        if (actions.Shutdown)
+        {
+            if (actions.IfNoOtherMaa && HasOtherMaa())
+            {
+                Bootstrapper.Shutdown();
+            }
+            else
+            {
+                await DoShutDown();
+            }
+        }
+
+        if (actions.Sleep)
+        {
+            if (actions.IfNoOtherMaa && HasOtherMaa())
+            {
+                Bootstrapper.Shutdown();
+            }
+            else
+            {
+                await DoSleep();
+            }
+        }
+
+        if (actions.ExitSelf)
+        {
+            Bootstrapper.Shutdown();
+        }
+
+        actions.LoadPostActions();
+        return;
+
+        bool HasOtherMaa()
+        {
+            var processesCount = Process.GetProcessesByName("MAA").Length;
+            _logger.Information("MAA processes count: {ProcessesCount}", processesCount);
+            return processesCount > 1;
+        }
+
+        void DoKillEmulator()
+        {
+            if (!EmulatorHelper.KillEmulatorModeSwitcher())
+            {
+                AddLog(LocalizationHelper.GetString("ExitEmulatorFailed"), UiLogColor.Error);
+            }
+        }
+
+        async Task DoHibernate()
+        {
+            actions.LoadPostActions();
+
+            await Execute.OnUIThreadAsync(() => Instances.MainWindowManager?.Show());
+            if (await TimerCanceledAsync(
+                    LocalizationHelper.GetString("Hibernate"),
+                    LocalizationHelper.GetString("HibernatePrompt"),
+                    LocalizationHelper.GetString("Cancel"),
+                    60))
+            {
+                return;
+            }
+
+            _logger.Information("Hibernate not canceled, proceeding to hibernate.");
+            PowerManagement.Hibernate();
+        }
+
+        async Task DoShutDown()
+        {
+            PowerManagement.Shutdown();
+
+            await Execute.OnUIThreadAsync(() => Instances.MainWindowManager?.Show());
+            if (await TimerCanceledAsync(
+                    LocalizationHelper.GetString("Shutdown"),
+                    LocalizationHelper.GetString("AboutToShutdown"),
+                    LocalizationHelper.GetString("Cancel"),
+                    60))
+            {
+                PowerManagement.AbortShutdown();
+                return;
+            }
+
+            _logger.Information("Shutdown not canceled, proceeding to exit application.");
+            Bootstrapper.Shutdown();
+        }
+
+        async Task DoSleep()
+        {
+            actions.LoadPostActions();
+
+            await Execute.OnUIThreadAsync(() => Instances.MainWindowManager?.Show());
+            if (await TimerCanceledAsync(
+                    LocalizationHelper.GetString("Sleep"),
+                    LocalizationHelper.GetString("SleepPrompt"),
+                    LocalizationHelper.GetString("Cancel"),
+                    60))
+            {
+                return;
+            }
+
+            _logger.Information("Sleep not canceled, proceeding to sleep.");
+            PowerManagement.Sleep();
         }
     }
 
@@ -656,10 +670,10 @@ public class TaskQueueViewModel : Screen
                 Instances.Data.ClearCache();
             }
 
-            // 进入运行或停止中时重置停止处理权
+            // 进入运行或停止中时重置结束脚本发射权
             if ((e.OldState.Idle && !e.NewState.Idle) || (!e.OldState.Stopping && e.NewState.Stopping))
             {
-                Interlocked.Exchange(ref _stopHandling, null);
+                Interlocked.Exchange(ref _stopScriptLaunched, 0);
             }
 
             if (e.NewState.Idle && _runDurationLimitOnce)
@@ -889,15 +903,15 @@ public class TaskQueueViewModel : Screen
                 return;
             }
 
-            await Stop();
-            SetStopped();
+            // 到点视为一次手动停止（设置开且肉鸽战斗中时前面已等待过战斗结束），结束脚本受 ManualStopWithScript 控制
+            await StopManuallyAsync(SettingsViewModel.GameSettings.ManualStopWithScript);
 
             if (!executePostActions)
             {
                 return;
             }
 
-            await CheckAfterCompleted(runEndsWithScript: !SettingsViewModel.GameSettings.ManualStopWithScript);
+            await RunPostActionsAfterManualStopAsync();
         }
         catch (Exception ex)
         {
@@ -1908,7 +1922,6 @@ public class TaskQueueViewModel : Screen
         if (!connected && SettingsViewModel.ConnectSettings.IsPCConnectConfig)
         {
             AddLog(errMsg, UiLogColor.Error);
-            _runningState.SetIdle(true);
             SetStopped();
             return false;
         }
@@ -1983,7 +1996,6 @@ public class TaskQueueViewModel : Screen
         }
 
         AddLog(errMsg, UiLogColor.Error);
-        _runningState.SetIdle(true);
         SetStopped();
         return false;
     }
@@ -2244,7 +2256,6 @@ public class TaskQueueViewModel : Screen
         if (count == 0)
         {
             AddLog(LocalizationHelper.GetString("UnselectedTask"));
-            _runningState.SetIdle(true);
             Instances.AsstProxy.AsstStop();
             SetStopped();
             return;
@@ -2305,7 +2316,7 @@ public class TaskQueueViewModel : Screen
             return;
         }
 
-        _ = Stop();
+        _ = StopManuallyAsync(SettingsViewModel.GameSettings.ManualStopWithScript);
         AchievementTrackerHelper.Instance.Unlock(AchievementIds.TacticalRetreat);
 
         if (_taskStartTime is null)
@@ -2327,15 +2338,16 @@ public class TaskQueueViewModel : Screen
     /// <para>超时后会自动调用 <see cref="SetStopped"/> 强制恢复 UI 状态。</para>
     /// <para>Notifies Core to stop the current task and waits for completion.</para>
     /// <para>Normally Core sends <c>TaskChainStopped</c> callback after stopping, and <see cref="AsstProxy"/> calls <see cref="SetStopped"/> to reset UI state.</para>
-    /// <para>If Core was not invoked via task chain (e.g. Peep), no callback will be received; caller must manually call <see cref="SetStopped"/> after <see cref="Stop"/>.</para>
+    /// <para>If Core was not invoked via task chain (e.g. Peep), no callback will be received; caller must manually call <see cref="SetStopped"/> after calling <see cref="Stop"/>.</para>
     /// <para>On timeout, <see cref="SetStopped"/> is called automatically to force-reset UI state.</para>
     /// </summary>
     /// <param name="timeout">Timeout millisecond</param>
-    /// <returns>A <see cref="Task"/>
+    /// <returns>
+    /// 是否在超时内确认 Core 停止；<see langword="false"/> 表示超时后由强制收口恢复。
     /// <para>尝试等待 core 成功停止运行，默认超时时间一分钟</para>
     /// <para>Try to wait for the core to stop running, the default timeout is one minute</para>
     /// </returns>
-    public async Task Stop(int timeout = 60 * 1000)
+    public async Task<bool> Stop(int timeout = 60 * 1000)
     {
         _runningState.SetStopping(true);
         AddLog(LocalizationHelper.GetString("Stopping"), splitMode: LogCardSplitMode.Both);
@@ -2359,7 +2371,10 @@ public class TaskQueueViewModel : Screen
             _logger.Warning("Stop timeout, force resetting UI state");
             AddLog(LocalizationHelper.GetString("StopTimeout") + "\n" + LocalizationHelper.GetString("RestartRecommendation"), UiLogColor.Error);
             SetStopped();
+            return false;
         }
+
+        return true;
     }
 
     // UI 绑定的方法
@@ -2368,15 +2383,8 @@ public class TaskQueueViewModel : Screen
     {
         Waiting = true;
         AddLog(LocalizationHelper.GetString("Waiting"));
-        if (RoguelikeTask.RoguelikeDelayAbortUntilCombatComplete)
-        {
-            await WaitUntilRoguelikeCombatComplete();
-
-            if (Instances.AsstProxy.AsstRunning() && !_runningState.GetStopping())
-            {
-                await Stop();
-            }
-        }
+        await WaitUntilRoguelikeCombatComplete();
+        await StopManuallyAsync(SettingsViewModel.GameSettings.ManualStopWithScript);
     }
 
     /// <summary>
@@ -2394,15 +2402,69 @@ public class TaskQueueViewModel : Screen
 
     public bool RoguelikeInCombatAndShowWait { get => field; set => SetAndNotify(ref field, value); }
 
-    // 本次停止的处理权，进入运行或停止中时重置为 null；其 Task 在 SetStopped 启动的结束脚本执行完毕后完成
-    private TaskCompletionSource? _stopHandling;
+    // 手动停止的结束脚本发射权，进入运行或停止中时重置；多个手动入口并发时保证只发射一次
+    private int _stopScriptLaunched;
 
     /// <summary>
-    /// 重置 UI 状态为已停止。
+    /// 按 Interlocked 标志去重地执行一次结束脚本（EndsWithScript）。手动停止各入口与自然完成
+    /// 回调共享发射权，手动停止与自然完成赛跑时只执行一次。
     /// </summary>
-    /// <param name="runStopScript">是否执行结束脚本。</param>
+    /// <param name="showLog">是否在任务日志记录脚本执行。</param>
+    /// <returns>Task</returns>
+    public async Task RunStopScriptOnceAsync(bool showLog = true)
+    {
+        if (Interlocked.CompareExchange(ref _stopScriptLaunched, 1, 0) is not 0)
+        {
+            return;
+        }
+
+        await Task.Run(() => SettingsViewModel.GameSettings.RunScript("EndsWithScript", showLog));
+    }
+
+    /// <summary>
+    /// 手动停止核心：等待 Core 停止、UI 状态恢复（TaskChainStopped 回调，或 Stop 超时强制）后，
+    /// 按 <paramref name="runScript"/> 发射结束脚本。
+    /// 所有手动语义入口（手动停止 / 等待并停止 / 时长上限 / copilot 手动停止）收敛到此；
+    /// 非手动场景（异常停止、挤停、启动失败等）直接调用 <see cref="Stop"/> 与 <see cref="SetStopped"/>，不发射脚本。
+    /// </summary>
+    /// <param name="runScript">结束脚本的发射条件（由各入口按自身开关组合传入）。</param>
+    /// <returns>Task</returns>
+    public async Task StopManuallyAsync(bool runScript)
+    {
+        if (Stopping || _runningState.GetIdle())
+        {
+            return;
+        }
+
+        // 等 Idle 是等「本次停止完成」：Stop() 正常出口不置 Idle（收口归异步在途的 TaskChainStopped 回调）；
+        // 启动链路进行中点停止则要等链路走到下一个 Stopping 检查点（模拟器等待等环节每秒检查，通常秒级，
+        // 开始前脚本阶段则要等脚本跑完、可任意长）；超时出口已自行强制置位，此处立即通过。
+        // timeout 不针对现有场景（均有收口方），仅防御未来出现无收口方的情况
+        var stoppedWithinTimeout = await Stop();
+        if (!await _runningState.UntilIdleAsync(confirmTimes: 0, timeout: 600_000))
+        {
+            _logger.Warning("Manual stop: idle not reached before wait limit, skip stop script");
+            return;
+        }
+
+        // 等待窗口内新一轮可能已开始，放弃本次发射；Stop() 超时强制收口时 Core 挂死仍在运行，仍应发射，
+        // 用是否超时区分这两种 AsstRunning == true 的情况
+        if (stoppedWithinTimeout && Instances.AsstProxy.AsstRunning())
+        {
+            return;
+        }
+
+        if (runScript)
+        {
+            await RunStopScriptOnceAsync();
+        }
+    }
+
+    /// <summary>
+    /// 重置 UI 状态为已停止（仅重置状态，不执行结束脚本；脚本发射归 <see cref="StopManuallyAsync"/> 与自然完成回调）。
+    /// </summary>
     /// <returns>是否实际执行了状态重置（false 表示被幂等保护跳过）。</returns>
-    public bool SetStopped(bool runStopScript = true)
+    public bool SetStopped()
     {
         // 幂等保护：已经空闲且不在停止中，跳过
         // 防止超时 SetStopped 后 Core 延迟回调再次触发导致打断新任务
@@ -2411,32 +2473,7 @@ public class TaskQueueViewModel : Screen
             return false;
         }
 
-        // 回调与到点停止等可能并发调用，CAS 抢占处理权，保证只处理一次
-        var handling = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
-        if (Interlocked.CompareExchange(ref _stopHandling, handling, null) is not null)
-        {
-            return false;
-        }
-
         SleepManagement.AllowSleep();
-        if (runStopScript && SettingsViewModel.GameSettings.ManualStopWithScript)
-        {
-            Task.Run(() => {
-                try
-                {
-                    SettingsViewModel.GameSettings.RunScript("EndsWithScript");
-                }
-                finally
-                {
-                    handling.TrySetResult();
-                }
-            });
-        }
-        else
-        {
-            handling.TrySetResult();
-        }
-
         if (!_runningState.GetIdle() || _runningState.GetStopping())
         {
             AddLog(LocalizationHelper.GetString("Stopped"), splitMode: LogCardSplitMode.Both);
@@ -2446,7 +2483,6 @@ public class TaskQueueViewModel : Screen
         _runningState.SetStopping(false);
         _runningState.SetIdle(true);
 
-        // 只抑制“本轮任务期间”的自动开启；任务结束后应允许下一轮自动开启 LiveView。
         return true;
     }
 

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -944,7 +944,7 @@ public class TaskQueueViewModel : Screen
         var delayTime = CalculateRandomDelay();
         _ = Task.Run(async () => {
             await Task.Delay(delayTime);
-            await _runningState.UntilIdleAsync(60000);
+            await _runningState.UntilIdleAsync();
             await UpdateDatePromptAndStagesWeb();
             _isUpdatingDatePrompt = false;
         });

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -670,8 +670,8 @@ public class TaskQueueViewModel : Screen
                 Instances.Data.ClearCache();
             }
 
-            // 进入运行或停止中时重置结束脚本发射权
-            if ((e.OldState.Idle && !e.NewState.Idle) || (!e.OldState.Stopping && e.NewState.Stopping))
+            // 每轮运行开始（离开空闲）时重置结束脚本发射权；停止中不重置，避免把已合法发射的标志清零导致二次发射
+            if (e.OldState.Idle && !e.NewState.Idle)
             {
                 Interlocked.Exchange(ref _stopScriptLaunched, 0);
             }
@@ -903,10 +903,10 @@ public class TaskQueueViewModel : Screen
                 return;
             }
 
-            // 到点视为一次手动停止（设置开且肉鸽战斗中时前面已等待过战斗结束），结束脚本受 ManualStopWithScript 控制
-            await StopManuallyAsync(SettingsViewModel.GameSettings.ManualStopWithScript);
+            // 到点视为一次手动停止（设置开且肉鸽战斗中时前面已等待过战斗结束），结束脚本按当前任务链的开关闭合
+            var stopped = await StopManuallyAsync();
 
-            if (!executePostActions)
+            if (!stopped || !executePostActions)
             {
                 return;
             }
@@ -2316,7 +2316,7 @@ public class TaskQueueViewModel : Screen
             return;
         }
 
-        _ = StopManuallyAsync(SettingsViewModel.GameSettings.ManualStopWithScript);
+        _ = StopManuallyAsync();
         AchievementTrackerHelper.Instance.Unlock(AchievementIds.TacticalRetreat);
 
         if (_taskStartTime is null)
@@ -2384,7 +2384,7 @@ public class TaskQueueViewModel : Screen
         Waiting = true;
         AddLog(LocalizationHelper.GetString("Waiting"));
         await WaitUntilRoguelikeCombatComplete();
-        await StopManuallyAsync(SettingsViewModel.GameSettings.ManualStopWithScript);
+        await StopManuallyAsync();
     }
 
     /// <summary>
@@ -2402,7 +2402,7 @@ public class TaskQueueViewModel : Screen
 
     public bool RoguelikeInCombatAndShowWait { get => field; set => SetAndNotify(ref field, value); }
 
-    // 手动停止的结束脚本发射权，进入运行或停止中时重置；多个手动入口并发时保证只发射一次
+    // 手动停止的结束脚本发射权，每轮运行开始（离开空闲）时重置；多个手动入口并发时保证只发射一次
     private int _stopScriptLaunched;
 
     /// <summary>
@@ -2422,19 +2422,30 @@ public class TaskQueueViewModel : Screen
     }
 
     /// <summary>
+    /// 按当前任务链判定停止目标后执行 <see cref="StopManuallyAsync(bool)"/>；
+    /// Core 未运行（如启动链路中的连接、开始前脚本阶段）时无链信息，按非 copilot 处理。
+    /// </summary>
+    /// <returns>是否完整走完本次手动停止。</returns>
+    public Task<bool> StopManuallyAsync() => StopManuallyAsync(Instances.AsstProxy.IsCopilotTaskChainRunning);
+
+    /// <summary>
     /// 手动停止核心：等待 Core 停止、UI 状态恢复（TaskChainStopped 回调，或 Stop 超时强制）后，
-    /// 按 <paramref name="runScript"/> 发射结束脚本。
-    /// 所有手动语义入口（手动停止 / 等待并停止 / 时长上限 / copilot 手动停止）收敛到此；
+    /// 按停止目标发射结束脚本——非 copilot 链须 ｢手动停止时启用上述脚本｣ 开启，
+    /// copilot 链还须 ｢自动战斗时启用上述脚本｣ 同时开启。
+    /// 所有手动语义入口（手动停止 / 等待并停止 / 时长上限 / 热键 / 远控 StopTask / copilot 停止按钮）收敛到此；
     /// 非手动场景（异常停止、挤停、启动失败等）直接调用 <see cref="Stop"/> 与 <see cref="SetStopped"/>，不发射脚本。
     /// </summary>
-    /// <param name="runScript">结束脚本的发射条件（由各入口按自身开关组合传入）。</param>
-    /// <returns>Task</returns>
-    public async Task StopManuallyAsync(bool runScript)
+    /// <param name="isCopilot">停止目标是否 copilot 任务。</param>
+    /// <returns>是否完整走完本次手动停止（等到空闲且未被新一轮运行抢占）；false 时调用方不应再执行后续动作。</returns>
+    public async Task<bool> StopManuallyAsync(bool isCopilot)
     {
         if (Stopping || _runningState.GetIdle())
         {
-            return;
+            return false;
         }
+
+        var runScript = SettingsViewModel.GameSettings.ManualStopWithScript
+            && (!isCopilot || SettingsViewModel.GameSettings.CopilotWithScript);
 
         // 等 Idle 是等「本次停止完成」：Stop() 正常出口不置 Idle（收口归异步在途的 TaskChainStopped 回调）；
         // 启动链路进行中点停止则要等链路走到下一个 Stopping 检查点（模拟器等待等环节每秒检查，通常秒级，
@@ -2444,20 +2455,22 @@ public class TaskQueueViewModel : Screen
         if (!await _runningState.UntilIdleAsync(confirmTimes: 0, timeout: 600_000))
         {
             _logger.Warning("Manual stop: idle not reached before wait limit, skip stop script");
-            return;
+            return false;
         }
 
         // 等待窗口内新一轮可能已开始，放弃本次发射；Stop() 超时强制收口时 Core 挂死仍在运行，仍应发射，
         // 用是否超时区分这两种 AsstRunning == true 的情况
         if (stoppedWithinTimeout && Instances.AsstProxy.AsstRunning())
         {
-            return;
+            return false;
         }
 
         if (runScript)
         {
             await RunStopScriptOnceAsync();
         }
+
+        return true;
     }
 
     /// <summary>

--- a/src/MaaWpfGui/Views/UI/CopilotView.xaml
+++ b/src/MaaWpfGui/Views/UI/CopilotView.xaml
@@ -208,7 +208,7 @@
                             <Button
                                 Width="120"
                                 Height="50"
-                                Command="{s:Action Stop}"
+                                Command="{s:Action ManualStop}"
                                 Content="{DynamicResource Stop}"
                                 IsEnabled="{c:Binding 'Inited and !Stopping'}"
                                 Visibility="{c:Binding !Idle}" />


### PR DESCRIPTION
## 改动内容

停止链路重构：`SetStopped` 回归无参纯状态收口，结束脚本（EndsWithScript）的发射按语义来源归属到明确的主人。

### 语义模型

- **自然结束恒跑脚本**：主队列由 `CheckAfterCompleted` 执行（先脚本后完成后动作的顺序保证不变）；copilot 由 `AllTasksCompleted` 回调按 ｢自动战斗时启用上述脚本｣ 控制，维持现状。
- **手动停止受开关控制**：手动停止 / 等待并停止 / 运行时长上限到点 / copilot 停止按钮统一收敛到停止核心 `StopManuallyAsync`——等待 Core 停止、状态收口完成后按各入口的开关组合发射脚本；copilot 入口须 ｢自动战斗时启用上述脚本｣ 与 ｢手动停止时启用上述脚本｣ 同时开启（同现状）。发射经 Interlocked 标志去重，多入口并发与手动停止/自然完成赛跑时只执行一次。
- **其他一切停止不跑脚本**：MuMu 保活/截图增强异常停止、定时强停挤停、AsstStart 失败兜底、启动失败类（连接失败 / 未选任务 / 序列化失败 / 无 core 任务）、Peep 与小游戏工具类。

### 行为变化（用户可感知）

1. ｢手动停止时启用上述脚本｣ 关 + 时长上限到点：脚本不再执行（原经 CheckAfterCompleted 补跑），完成后动作仍按子开关执行。
2. 开关开 + MuMu 保活/截图增强异常停止：脚本不再执行（原经 SetStopped 顺带执行）。
3. 开关开 + 定时强停挤停：脚本不再执行（原经 SetStopped 顺带执行）。
4. 启动失败类场景（含 copilot 校验/连接/作业启动失败）：日志多一条 ｢已停止｣；copilot 连接失败不再卡 ｢停止中｣（顺手修复原有缺陷）。
5. 手动停止的脚本时序：从 ｢SetStopped 收口时 fire-and-forget｣ 变为 ｢停止完成后发射｣，语义等价、时序略延后。
6. 主界面停止按钮停止 copilot 运行中任务时，脚本发射条件由 ｢自动战斗｣+｢手动停止｣ 双开关变为仅 ｢手动停止｣ 单开关（TaskChainStopped 回调的任务链类型特判删除后，该场景走主界面入口的条件）。

### 附带改动

- `RunningState.UntilIdleAsync` 改为状态广播（TaskCompletionSource）即时唤醒，删除轮询间隔参数，新增超时上限与 ｢不防抖确认｣ 模式，返回是否超时；各调用方适配。
- 启动失败分支删除前置 `SetIdle(true)`，统一经 `SetStopped` 全流程收口（含 RCS 同步）。
- 文案五语言同步：｢手动暂停时启用上述脚本｣ → ｢手动停止时启用上述脚本｣；时长上限提示改为 ｢到达上限后触发一次手动停止｣。

## Sourcery 总结

重构停止流程，将状态最终确定与结束脚本执行分离，并统一任务运行和 Copilot 运行中的手动停止行为。

Bug 修复：
- 防止 Copilot 连接失败一直停留在停止状态，并通过 stopped 状态统一完成启动失败的最终处理。
- 防止结束脚本在异常停止、强制停止和启动失败时运行，除非这些情况源自符合条件的手动停止流程。

改进：
- 统一手动停止、等待后停止、时长限制和 Copilot 停止流程中的手动停止处理逻辑：仅在停止完成后执行结束脚本，并避免并发触发导致重复执行。
- 恢复仅将 SetStopped 用于状态最终确定，并将自然完成脚本保留在自然完成处理逻辑中。
- 使用事件驱动通知替代空闲状态轮询，支持可选的免确认检查、超时报告以及布尔值完成结果。

文档：
- 更新所有受支持语言中的本地化停止脚本设置和时长限制相关提示。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

重构停止流程，使状态能够独立完成最终处理，并且仅在符合条件的手动停止或任务自然完成时执行结束脚本。

Bug 修复：
- 防止在异常停止、强制停止或启动失败停止时运行结束脚本，同时修复 Copilot 连接失败后可能一直卡在停止状态的问题。

增强功能：
- 将停止状态最终处理与结束脚本执行分离，并统一处理任务、Copilot、超时、快捷键和远程控制流程中的手动停止。
- 确保手动停止完成后结束脚本仅执行一次，并根据活动任务类型和用户设置判断执行条件。
- 将空闲状态轮询替换为事件驱动的等待机制，支持立即检查、确认、超时报告和完成结果。

文档：
- 更新手动停止结束脚本设置和运行时长限制行为的本地化文本。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor stopping flows to finalize state independently and execute end scripts only for eligible manual stops or natural task completion.

Bug Fixes:
- Prevent end scripts from running for abnormal, forced, or startup-failure stops, while fixing Copilot connection failures that could remain stuck in the stopping state.

Enhancements:
- Separate stopped-state finalization from end-script execution and consolidate manual stop handling across task, Copilot, timeout, hotkey, and remote-control flows.
- Ensure end scripts execute only once after manual stopping completes, with conditions based on the active task type and user settings.
- Replace idle-state polling with event-driven waiting that supports immediate checks, confirmation, timeout reporting, and completion results.

Documentation:
- Update localized text for the manual-stop end-script setting and run-duration limit behavior.

</details>

</details>