### PR TITLE
fix: 发布前审查问题修复

### DIFF
--- a/src/MaaCore/Task/Infrast/InfrastScore.cpp
+++ b/src/MaaCore/Task/Infrast/InfrastScore.cpp
@@ -688,7 +688,7 @@ CombinationScore score_mfg(const std::vector<const ScoreOper*>& opers, const Sco
             else if (icon == "bskill_man_spd_veen") {   // 手艺人：维伊
                 base += 0.299;                          // 认为训练室三级
             }
-            else if (icon == "bskill_man_spd_veen") {   // 社群的意义：维伊
+            else if (icon == "bskill_man_p3r") {        // 社群的意义：结城理
                 base += 0.25;                           // 暂不考虑其他SEES干员挂件
             }
             else if (icon == "bskill_man_spd_reduce") { // 模糊视线：铅踝

--- a/src/MaaUpdater/main.cpp
+++ b/src/MaaUpdater/main.cpp
@@ -2096,12 +2096,15 @@ int wmain(int argc, wchar_t* argv[])
             }
 
             WriteLog((L"Installing new file: " + sourcePath + L" -> " + targetPath).c_str());
-            installationModified = true;
 
             bool installOk = false;
             DWORD sourceAttr = GetFileAttributesW(sourcePath.c_str());
             bool isSourceFile = (sourceAttr != INVALID_FILE_ATTRIBUTES) &&
                                 !(sourceAttr & FILE_ATTRIBUTE_DIRECTORY);
+
+            // 确认源存在后才算真正开始动文件：源缺失导致的失败尚未改动安装，
+            // 不置位以免误写失败标志，让完好的安装被 GUI 误判为资源损坏
+            installationModified = true;
 
             if (isSourceFile) {
                 // Use atomic file replacement for individual files

--- a/src/MaaUpdater/main.cpp
+++ b/src/MaaUpdater/main.cpp
@@ -1879,6 +1879,9 @@ int wmain(int argc, wchar_t* argv[])
     bool shouldRelaunch = false;
     bool success = false;
     std::wstring failureReason;
+    // 是否已开始改动安装文件（备份旧文件 / 写入新文件）；
+    // 预检失败未动任何文件、失败后回滚完整恢复时均保持 false，用于收紧失败标志的写入
+    bool installationModified = false;
     HANDLE hUpdateMutex = nullptr;
     // Copied from plan for CreateProcess after a successful update.
     std::vector<std::wstring> relaunchArgs;
@@ -2045,6 +2048,7 @@ int wmain(int argc, wchar_t* argv[])
             }
 
             WriteLog((L"Removing and backing up: " + targetPath + L" -> " + backupPath).c_str());
+            installationModified = true;
             bool backupOk = isFullPackage
                 ? RecycleAndBackupPath(targetPath, backupPath)
                 : MoveExistingPathToBackup(targetPath, backupPath);
@@ -2080,6 +2084,7 @@ int wmain(int argc, wchar_t* argv[])
                 }
 
                 WriteLog((L"Backing up existing entry: " + targetPath).c_str());
+                installationModified = true;
                 bool backupOk = IsRecycleAndReplaceDirectory(rel)
                     ? RecycleAndBackupDirectory(targetPath, backupPath)
                     : MoveExistingPathToBackup(targetPath, backupPath);
@@ -2091,6 +2096,7 @@ int wmain(int argc, wchar_t* argv[])
             }
 
             WriteLog((L"Installing new file: " + sourcePath + L" -> " + targetPath).c_str());
+            installationModified = true;
 
             bool installOk = false;
             DWORD sourceAttr = GetFileAttributesW(sourcePath.c_str());
@@ -2152,6 +2158,7 @@ int wmain(int argc, wchar_t* argv[])
 
         // Attempt rollback: restore files that were already backed up
         WriteLog(L"Update failed, attempting rollback from backup directory.");
+        bool rollbackComplete = true;
         for (const std::wstring& rel : removeList) {
             std::wstring targetPath, backupPath;
             if (!TryResolvePathUnderRoot(rootDir, rel, targetPath) ||
@@ -2160,7 +2167,12 @@ int wmain(int argc, wchar_t* argv[])
             }
             if (PathExistsW(backupPath) && !PathExistsW(targetPath)) {
                 WriteLog((L"Rollback: restoring " + backupPath + L" -> " + targetPath).c_str());
-                MovePathEntry(backupPath, targetPath);
+                if (!MovePathEntry(backupPath, targetPath)) {
+                    rollbackComplete = false;
+                }
+            } else if (PathExistsW(backupPath)) {
+                // 新文件已就位而旧文件仍在备份：回滚不覆盖已就位的文件，安装仍处于混合状态
+                rollbackComplete = false;
             }
         }
         for (const std::wstring& rel : moveList) {
@@ -2171,8 +2183,16 @@ int wmain(int argc, wchar_t* argv[])
             }
             if (PathExistsW(backupPath) && !PathExistsW(targetPath)) {
                 WriteLog((L"Rollback: restoring " + backupPath + L" -> " + targetPath).c_str());
-                MovePathEntry(backupPath, targetPath);
+                if (!MovePathEntry(backupPath, targetPath)) {
+                    rollbackComplete = false;
+                }
+            } else if (PathExistsW(backupPath)) {
+                rollbackComplete = false;
             }
+        }
+        if (rollbackComplete) {
+            installationModified = false;
+            WriteLog(L"Rollback complete, installation restored to its pre-update state.");
         }
     } while (false);
 
@@ -2180,10 +2200,14 @@ int wmain(int argc, wchar_t* argv[])
     // On failure: write failure status
     // ------------------------------------------------------------------
     if (!success && !failureReason.empty()) {
-        // Convert wstring reason to UTF-8 for file
-        std::string utf8Reason;
-        if (TryConvertWideToUtf8(failureReason, utf8Reason)) {
-            WriteUtf8File(failureStatusFile, utf8Reason);
+        // 失败标志仅用于标记安装可能已损坏（半更新状态）；预检失败（未动任何文件）
+        // 与回滚完整恢复的情况不写，避免完好的安装被 GUI 误判为资源损坏后拦截全部任务
+        if (installationModified) {
+            // Convert wstring reason to UTF-8 for file
+            std::string utf8Reason;
+            if (TryConvertWideToUtf8(failureReason, utf8Reason)) {
+                WriteUtf8File(failureStatusFile, utf8Reason);
+            }
         }
         if (PathExistsW(successStatusFile))
             DeleteFileW(successStatusFile.c_str());

--- a/src/MaaUpdater/main.cpp
+++ b/src/MaaUpdater/main.cpp
@@ -1879,8 +1879,8 @@ int wmain(int argc, wchar_t* argv[])
     bool shouldRelaunch = false;
     bool success = false;
     std::wstring failureReason;
-    // 是否已开始改动安装文件（备份旧文件 / 写入新文件）；
-    // 预检失败未动任何文件、失败后回滚完整恢复时均保持 false，用于收紧失败标志的写入
+    // 是否已开始改动安装文件（备份旧文件 / 写入新文件）；预检失败未动任何文件时保持
+    // false。进入应用阶段后不再回退该标志，失败后回滚无论是否完整恢复均按已改动处理
     bool installationModified = false;
     HANDLE hUpdateMutex = nullptr;
     // Copied from plan for CreateProcess after a successful update.
@@ -2158,7 +2158,6 @@ int wmain(int argc, wchar_t* argv[])
 
         // Attempt rollback: restore files that were already backed up
         WriteLog(L"Update failed, attempting rollback from backup directory.");
-        bool rollbackComplete = true;
         for (const std::wstring& rel : removeList) {
             std::wstring targetPath, backupPath;
             if (!TryResolvePathUnderRoot(rootDir, rel, targetPath) ||
@@ -2167,12 +2166,7 @@ int wmain(int argc, wchar_t* argv[])
             }
             if (PathExistsW(backupPath) && !PathExistsW(targetPath)) {
                 WriteLog((L"Rollback: restoring " + backupPath + L" -> " + targetPath).c_str());
-                if (!MovePathEntry(backupPath, targetPath)) {
-                    rollbackComplete = false;
-                }
-            } else if (PathExistsW(backupPath)) {
-                // 新文件已就位而旧文件仍在备份：回滚不覆盖已就位的文件，安装仍处于混合状态
-                rollbackComplete = false;
+                MovePathEntry(backupPath, targetPath);
             }
         }
         for (const std::wstring& rel : moveList) {
@@ -2183,16 +2177,8 @@ int wmain(int argc, wchar_t* argv[])
             }
             if (PathExistsW(backupPath) && !PathExistsW(targetPath)) {
                 WriteLog((L"Rollback: restoring " + backupPath + L" -> " + targetPath).c_str());
-                if (!MovePathEntry(backupPath, targetPath)) {
-                    rollbackComplete = false;
-                }
-            } else if (PathExistsW(backupPath)) {
-                rollbackComplete = false;
+                MovePathEntry(backupPath, targetPath);
             }
-        }
-        if (rollbackComplete) {
-            installationModified = false;
-            WriteLog(L"Rollback complete, installation restored to its pre-update state.");
         }
     } while (false);
 
@@ -2200,8 +2186,8 @@ int wmain(int argc, wchar_t* argv[])
     // On failure: write failure status
     // ------------------------------------------------------------------
     if (!success && !failureReason.empty()) {
-        // 失败标志仅用于标记安装可能已损坏（半更新状态）；预检失败（未动任何文件）
-        // 与回滚完整恢复的情况不写，避免完好的安装被 GUI 误判为资源损坏后拦截全部任务
+        // 失败标志仅用于标记安装可能已损坏（半更新状态）；预检失败（未动任何文件）不写，
+        // 避免完好的安装被 GUI 误判为资源损坏后拦截全部任务
         if (installationModified) {
             // Convert wstring reason to UTF-8 for file
             std::string utf8Reason;

--- a/src/MaaUpdater/main.cpp
+++ b/src/MaaUpdater/main.cpp
@@ -2102,9 +2102,11 @@ int wmain(int argc, wchar_t* argv[])
             bool isSourceFile = (sourceAttr != INVALID_FILE_ATTRIBUTES) &&
                                 !(sourceAttr & FILE_ATTRIBUTE_DIRECTORY);
 
-            // 确认源存在后才算真正开始动文件：源缺失导致的失败尚未改动安装，
-            // 不置位以免误写失败标志，让完好的安装被 GUI 误判为资源损坏
-            installationModified = true;
+            // 源存在（文件或目录）才会真正开始改动安装；源缺失（如被杀软隔离）的条目
+            // 最多创建空父目录即失败，不置位以免误写失败标志，让完好的安装被 GUI 误判为资源损坏
+            if (sourceAttr != INVALID_FILE_ATTRIBUTES) {
+                installationModified = true;
+            }
 
             if (isSourceFile) {
                 // Use atomic file replacement for individual files

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -1298,15 +1298,6 @@ public class AsstProxy
         {
             case AsstMsg.TaskChainStopped:
                 {
-                    // 归属校验：迟到的旧轮回调（如 Stop 超时强收后 Core 复活补发）taskId 不在本轮
-                    // 任务集合中，跳过收口以免把新运行的 Idle/归属清掉；Core 侧异常恢复路径补发的
-                    // 消息不带 taskid（解析为 0），仍放行
-                    if (taskId != 0 && !_tasksStatus.ContainsKey(taskId))
-                    {
-                        _logger.Warning("TaskChainStopped of stale task {TaskId} not in current run, skip", taskId);
-                        break;
-                    }
-
                     Instances.TaskQueueViewModel.SetStopped();
                 }
 
@@ -3322,15 +3313,6 @@ public class AsstProxy
     private readonly ObservableDictionary<AsstTaskId, (TaskType Type, TaskStatus Status)> _tasksStatus = [];
 
     public IReadOnlyDictionary<AsstTaskId, (TaskType Type, TaskStatus Status)> TasksStatus => new Dictionary<AsstTaskId, (TaskType, TaskStatus)>(_tasksStatus);
-
-    /// <summary>
-    /// 清空任务状态表。强制收口（TaskQueueViewModel.SetStopped 等不再等待 Core 回调的路径）时调用，
-    /// 使残留的旧 taskId 无法通过 <c>TaskChainStopped</c> 的归属校验。
-    /// </summary>
-    public void ClearTasksStatus()
-    {
-        _tasksStatus.Clear();
-    }
 
     public delegate void TaskStatusDelegate(int taskId, TaskItemStatus status);
 

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -704,6 +704,7 @@ public class AsstProxy
         }
 
         // 停止超时强收后 Core 状态不可信：重启前不进入启动自动运行
+        // 进程内实际不可达（Init 仅进程启动时调用一次，置位必然晚于它），保留作与 IsResourceBroken 对称的防御
         if (Bootstrapper.RequiresRestart)
         {
             _logger.Information("Skip startup auto-run: restart required");

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -703,6 +703,13 @@ public class AsstProxy
             return;
         }
 
+        // 停止超时强收后 Core 状态不可信：重启前不进入启动自动运行
+        if (Bootstrapper.RequiresRestart)
+        {
+            _logger.Information("Skip startup auto-run: restart required");
+            return;
+        }
+
         // TODO: 之后把这个 OnUIThread 拆出来
         // ReSharper disable once AsyncVoidLambda
         Execute.OnUIThread(

--- a/src/MaaWpfGui/Main/AsstProxy.cs
+++ b/src/MaaWpfGui/Main/AsstProxy.cs
@@ -1298,6 +1298,15 @@ public class AsstProxy
         {
             case AsstMsg.TaskChainStopped:
                 {
+                    // 归属校验：迟到的旧轮回调（如 Stop 超时强收后 Core 复活补发）taskId 不在本轮
+                    // 任务集合中，跳过收口以免把新运行的 Idle/归属清掉；Core 侧异常恢复路径补发的
+                    // 消息不带 taskid（解析为 0），仍放行
+                    if (taskId != 0 && !_tasksStatus.ContainsKey(taskId))
+                    {
+                        _logger.Warning("TaskChainStopped of stale task {TaskId} not in current run, skip", taskId);
+                        break;
+                    }
+
                     Instances.TaskQueueViewModel.SetStopped();
                 }
 
@@ -3313,6 +3322,15 @@ public class AsstProxy
     private readonly ObservableDictionary<AsstTaskId, (TaskType Type, TaskStatus Status)> _tasksStatus = [];
 
     public IReadOnlyDictionary<AsstTaskId, (TaskType Type, TaskStatus Status)> TasksStatus => new Dictionary<AsstTaskId, (TaskType, TaskStatus)>(_tasksStatus);
+
+    /// <summary>
+    /// 清空任务状态表。强制收口（TaskQueueViewModel.SetStopped 等不再等待 Core 回调的路径）时调用，
+    /// 使残留的旧 taskId 无法通过 <c>TaskChainStopped</c> 的归属校验。
+    /// </summary>
+    public void ClearTasksStatus()
+    {
+        _tasksStatus.Clear();
+    }
 
     public delegate void TaskStatusDelegate(int taskId, TaskItemStatus status);
 

--- a/src/MaaWpfGui/Main/Bootstrapper.cs
+++ b/src/MaaWpfGui/Main/Bootstrapper.cs
@@ -1040,8 +1040,9 @@ public class Bootstrapper : Bootstrapper<RootViewModel>
 
     /// <summary>
     /// Gets a value indicating whether the current session must restart before running new tasks.
-    /// 停止超时强收后 Core 状态不可信（可能仍挂起并补发迟到回调），置位后所有任务入口均被拦截，
-    /// 禁止开始新任务。进程内标志，重启进程即解除。
+    /// 停止超时强收后 Core 状态不可信（可能仍挂起并补发迟到回调），置位后禁止开始新任务，
+    /// 拦截主队列 LinkStartWithTasks（热键/托盘/定时等汇入于此）、Copilot 启动、远程控制 LinkStart
+    /// 与启动自动运行（AsstProxy.Init）。进程内标志，重启进程即解除。
     /// </summary>
     public static bool RequiresRestart => _requiresRestart;
 

--- a/src/MaaWpfGui/Main/Bootstrapper.cs
+++ b/src/MaaWpfGui/Main/Bootstrapper.cs
@@ -1051,6 +1051,31 @@ public class Bootstrapper : Bootstrapper<RootViewModel>
     /// </summary>
     public static void MarkRequiresRestart() => _requiresRestart = true;
 
+#nullable enable
+
+    /// <summary>
+    /// 获取当前禁止开始新任务的原因文案；null 表示可启动。所有下发 Core 任务的入口统一经此判定：
+    /// 资源损坏（缺任务时 Core 进程直接崩溃）优先于需重启（停止超时后 Core 状态不可信）。
+    /// </summary>
+    /// <returns>拦截原因的本地化文案；可启动时为 null。</returns>
+    public static string? TryGetTaskBlockReason()
+    {
+        if (IsResourceBroken)
+        {
+            _logger.Warning("Task blocked: resource broken");
+            return LocalizationHelper.GetString("ResourceBrokenTaskBlocked");
+        }
+
+        if (RequiresRestart)
+        {
+            _logger.Warning("Task blocked: restart required");
+            return LocalizationHelper.GetString("RestartRecommendation");
+        }
+
+        return null;
+    }
+#nullable restore
+
     /// <summary>
     /// 在完整 GUI 尚未初始化前，应用待处理更新后立即重启。
     /// 若当前进程已带 <see cref="SkipStartupAutoRunArg"/>，则原样转发给下一进程。

--- a/src/MaaWpfGui/Main/Bootstrapper.cs
+++ b/src/MaaWpfGui/Main/Bootstrapper.cs
@@ -1036,6 +1036,20 @@ public class Bootstrapper : Bootstrapper<RootViewModel>
     /// </summary>
     public static void MarkResourceBroken() => _isResourceBroken = true;
 
+    private static bool _requiresRestart;
+
+    /// <summary>
+    /// Gets a value indicating whether the current session must restart before running new tasks.
+    /// 停止超时强收后 Core 状态不可信（可能仍挂起并补发迟到回调），置位后所有任务入口均被拦截，
+    /// 禁止开始新任务。进程内标志，重启进程即解除。
+    /// </summary>
+    public static bool RequiresRestart => _requiresRestart;
+
+    /// <summary>
+    /// 标记本会话需重启后才能继续任务。在 Stop 超时强收时调用。
+    /// </summary>
+    public static void MarkRequiresRestart() => _requiresRestart = true;
+
     /// <summary>
     /// 在完整 GUI 尚未初始化前，应用待处理更新后立即重启。
     /// 若当前进程已带 <see cref="SkipStartupAutoRunArg"/>，则原样转发给下一进程。

--- a/src/MaaWpfGui/Services/PendingUpdateApplier.cs
+++ b/src/MaaWpfGui/Services/PendingUpdateApplier.cs
@@ -388,7 +388,8 @@ internal static partial class PendingUpdateApplier
 
     /// <summary>
     /// 读取外部更新器写入的失败状态。标志文件只读不删：须跨启动持久保留
-    /// （避免用户忽略提示后重启导致半更新状态无人提醒），直至完整包安装时随根目录清场移除。
+    /// （避免用户忽略提示后重启导致半更新状态无人提醒），直至完整包安装时随根目录清场、
+    /// 或注册新更新包时（注册即代表用户已着手修复，旧失败原因失效）移除。
     /// 读取同时会清空待应用更新包配置（沿用旧消费语义：失败后不再自动重试该包）。
     /// </summary>
     /// <param name="failureReason">更新器写入的 UTF-8 失败原因，读取失败时为 <c>null</c>。</param>
@@ -910,7 +911,7 @@ internal static partial class PendingUpdateApplier
         }
     }
 
-    private static void SafeDeleteFile(string filePath)
+    private static void SafeDeleteFile(string filePath, string fileDescription = "pending update package")
     {
         try
         {
@@ -921,7 +922,7 @@ internal static partial class PendingUpdateApplier
         }
         catch (Exception ex)
         {
-            _logger.Warning(ex, "Failed to delete pending update package: {FilePath}", filePath);
+            _logger.Warning(ex, "Failed to delete {FileDescription}: {FilePath}", fileDescription, filePath);
         }
     }
 
@@ -968,6 +969,10 @@ internal static partial class PendingUpdateApplier
         }
 
         ConfigFactory.Root.Update.UpdatePackage = packagePath;
+
+        // 注册新包即代表用户已着手修复（拖入本地包、自动修复下载完整包等），旧失败原因失效；
+        // 标志不删的话，下次启动 TryReadDelegatedUpdateFailure 会连刚注册的包一起清空，形成死循环
+        SafeDeleteFile(DelegatedUpdateFailureStatusFilePath, "delegated update failure state");
     }
 
     private static void ClearPendingUpdatePackageState()

--- a/src/MaaWpfGui/Services/PendingUpdateApplier.cs
+++ b/src/MaaWpfGui/Services/PendingUpdateApplier.cs
@@ -432,6 +432,16 @@ internal static partial class PendingUpdateApplier
     }
 
     /// <summary>
+    /// 删除委托更新失败标志，供所有注册新更新包的路径统一调用。
+    /// 注册即代表用户已着手修复（手动下载完整包、拖入本地包等），旧失败原因失效；
+    /// 标志不删的话，下次启动 <see cref="TryReadDelegatedUpdateFailure"/> 会连刚注册的包一起清空，形成死循环。
+    /// </summary>
+    public static void ClearDelegatedUpdateFailureState()
+    {
+        SafeDeleteFile(DelegatedUpdateFailureStatusFilePath, "delegated update failure state");
+    }
+
+    /// <summary>
     /// 将更新器写入的英文失败原因映射为本地化的展示文案。
     /// </summary>
     /// <param name="failureReason">更新器写入的失败原因。</param>
@@ -970,9 +980,7 @@ internal static partial class PendingUpdateApplier
 
         ConfigFactory.Root.Update.UpdatePackage = packagePath;
 
-        // 注册新包即代表用户已着手修复（拖入本地包、自动修复下载完整包等），旧失败原因失效；
-        // 标志不删的话，下次启动 TryReadDelegatedUpdateFailure 会连刚注册的包一起清空，形成死循环
-        SafeDeleteFile(DelegatedUpdateFailureStatusFilePath, "delegated update failure state");
+        ClearDelegatedUpdateFailureState();
     }
 
     private static void ClearPendingUpdatePackageState()

--- a/src/MaaWpfGui/Services/RemoteControl/RemoteControlService.cs
+++ b/src/MaaWpfGui/Services/RemoteControl/RemoteControlService.cs
@@ -26,6 +26,7 @@ using MaaWpfGui.Configuration.Single.MaaTask;
 using MaaWpfGui.Constants;
 using MaaWpfGui.Constants.Enums;
 using MaaWpfGui.Helper;
+using MaaWpfGui.Main;
 using MaaWpfGui.States;
 using MaaWpfGui.ViewModels.UI;
 using MaaWpfGui.ViewModels.UserControl.Settings;
@@ -551,6 +552,14 @@ public class RemoteControlService
     private async Task LinkStart(IEnumerable<string> originalNames)
     {
         await _runningState.UntilIdleAsync();
+
+        // 停止超时强收后 Core 状态不可信（可能仍挂起并补发迟到回调），重启前禁止新开任务
+        if (Bootstrapper.RequiresRestart)
+        {
+            Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("RestartRecommendation"), UiLogColor.Error);
+            Log.Logger.Warning("RemoteControl LinkStart blocked: restart required");
+            return;
+        }
 
         _runningState.BeginRun(RunOwner.TaskQueue);
 

--- a/src/MaaWpfGui/Services/RemoteControl/RemoteControlService.cs
+++ b/src/MaaWpfGui/Services/RemoteControl/RemoteControlService.cs
@@ -553,11 +553,10 @@ public class RemoteControlService
     {
         await _runningState.UntilIdleAsync();
 
-        // 停止超时强收后 Core 状态不可信（可能仍挂起并补发迟到回调），重启前禁止新开任务
-        if (Bootstrapper.RequiresRestart)
+        if (Bootstrapper.TryGetTaskBlockReason() is { } reason)
         {
-            Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("RestartRecommendation"), UiLogColor.Error);
-            Log.Logger.Warning("RemoteControl LinkStart blocked: restart required");
+            Instances.TaskQueueViewModel.AddLog(reason, UiLogColor.Error);
+            Log.Logger.Warning("RemoteControl LinkStart blocked");
             return;
         }
 

--- a/src/MaaWpfGui/Services/Web/HttpService.cs
+++ b/src/MaaWpfGui/Services/Web/HttpService.cs
@@ -88,7 +88,11 @@ public class HttpService : IHttpService
             {
                 foreach (var kvp in extraHeader)
                 {
-                    request.Headers.Add(kvp.Key, kvp.Value);
+                    // Add 对含 “/” “=” 等字符的值抛 FormatException 且异常消息带原值，凭据类 header 会明文泄漏进日志
+                    if (!request.Headers.TryAddWithoutValidation(kvp.Key, kvp.Value))
+                    {
+                        _logger.Warning("Failed to add external header: {Header}", kvp.Key);
+                    }
                 }
             }
 
@@ -153,7 +157,11 @@ public class HttpService : IHttpService
         {
             foreach (var kvp in extraHeader)
             {
-                request.Headers.Add(kvp.Key, kvp.Value);
+                // Add 对含 “/” “=” 等字符的值抛 FormatException 且异常消息带原值，凭据类 header 会明文泄漏进日志
+                if (!request.Headers.TryAddWithoutValidation(kvp.Key, kvp.Value))
+                {
+                    _logger.Warning("Failed to add external header: {Header}", kvp.Key);
+                }
             }
         }
 

--- a/src/MaaWpfGui/ViewModels/Dialogs/VersionUpdateDialogViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/Dialogs/VersionUpdateDialogViewModel.cs
@@ -147,6 +147,13 @@ public class VersionUpdateDialogViewModel : Screen
         get; set {
             SetAndNotify(ref field, value);
             ConfigFactory.Root.Update.UpdatePackage = value;
+
+            // 非空赋值即注册新更新包（FakeUpdate / MaaApi / MirrorChyan 下载链都经此 setter 直写配置，不经 RegisterPendingUpdatePackage），须同步删失败标志防死循环；
+            // 空值（失败后的配置残留、资产名缺失）不删，保留标志供 AsstProxy.Init 启动期检测弹修复窗
+            if (!string.IsNullOrWhiteSpace(value))
+            {
+                PendingUpdateApplier.ClearDelegatedUpdateFailureState();
+            }
         }
     } = ConfigFactory.Root.Update.UpdatePackage;
 

--- a/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
@@ -1817,10 +1817,9 @@ public partial class CopilotViewModel : Screen
     [UsedImplicitly]
     public async Task Start()
     {
-        // 停止超时强收后 Core 状态不可信（可能仍挂起并补发迟到回调），重启前禁止新开任务
-        if (Bootstrapper.RequiresRestart)
+        if (Bootstrapper.TryGetTaskBlockReason() is { } reason)
         {
-            AddLog(LocalizationHelper.GetString("RestartRecommendation"), UiLogColor.Error);
+            AddLog(reason, UiLogColor.Error);
             return;
         }
 

--- a/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/CopilotViewModel.cs
@@ -1817,6 +1817,13 @@ public partial class CopilotViewModel : Screen
     [UsedImplicitly]
     public async Task Start()
     {
+        // 停止超时强收后 Core 状态不可信（可能仍挂起并补发迟到回调），重启前禁止新开任务
+        if (Bootstrapper.RequiresRestart)
+        {
+            AddLog(LocalizationHelper.GetString("RestartRecommendation"), UiLogColor.Error);
+            return;
+        }
+
         /*
         if (_form)
         {

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -2122,19 +2122,10 @@ public class TaskQueueViewModel : Screen
         _taskStartTime = DateTime.Now;
         ClearLog();
 
-        // Core 资源损坏待修复期间任务不可启动，覆盖热键/托盘/远程等入口（启动自动运行在 AsstProxy 另有前置拦截）
-        if (Bootstrapper.IsResourceBroken)
+        // 拦截判定收敛于 Bootstrapper.TryGetTaskBlockReason；热键/托盘/远程等入口汇入于此（启动自动运行在 AsstProxy 另有前置检查）
+        if (Bootstrapper.TryGetTaskBlockReason() is { } reason)
         {
-            AddLog(LocalizationHelper.GetString("ResourceBrokenTaskBlocked"), UiLogColor.Error);
-            _logger.Warning("LinkStart blocked: resource broken");
-            return;
-        }
-
-        // 停止超时强收后需重启才能再次开任务，同样覆盖热键/托盘/远程等入口
-        if (Bootstrapper.RequiresRestart)
-        {
-            AddLog(LocalizationHelper.GetString("RestartRecommendation"), UiLogColor.Error);
-            _logger.Warning("LinkStart blocked: restart required");
+            AddLog(reason, UiLogColor.Error);
             return;
         }
 

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -2502,10 +2502,6 @@ public class TaskQueueViewModel : Screen
             return false;
         }
 
-        // 本轮到此收口，清掉任务状态表；否则强收残留的旧 taskId 会让 Core 迟到补发的
-        // TaskChainStopped 通过归属校验，打断此后已开始的新运行
-        Instances.AsstProxy.ClearTasksStatus();
-
         SleepManagement.AllowSleep();
         if (!_runningState.GetIdle() || _runningState.GetStopping())
         {

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -2435,7 +2435,7 @@ public class TaskQueueViewModel : Screen
 
     /// <summary>
     /// 手动停止核心：等待 Core 停止、UI 状态恢复（TaskChainStopped 回调，或 Stop 超时强制）后，
-    /// 按运行归属发射结束脚本——非 copilot 须 ｢手动停止时启用上述脚本｣ 开启，
+    /// 按运行归属发射结束脚本（仅主任务队列与 copilot 归属）——非 copilot 须 ｢手动停止时启用上述脚本｣ 开启，
     /// copilot 还须 ｢自动战斗时启用上述脚本｣ 同时开启。归属在开始入口声明，跨页停止也能正确判定。
     /// 所有手动语义入口（手动停止 / 等待并停止 / 时长上限 / 热键 / 远控 StopTask / 各页停止按钮）收敛到此；
     /// 非手动场景（异常停止、挤停、启动失败等）直接调用 <see cref="Stop"/> 与 <see cref="SetStopped"/>，不发射脚本。
@@ -2448,9 +2448,9 @@ public class TaskQueueViewModel : Screen
             return false;
         }
 
-        // 归属 None（连接测试、单独等模拟器等非任务语境的运行）不发射结束脚本
+        // 仅主任务队列与 copilot 发射结束脚本；小游戏/工具箱轮次从不跑开始脚本，各停止入口统一不发
         var owner = _runningState.Owner;
-        var runScript = owner != RunOwner.None
+        var runScript = owner is RunOwner.TaskQueue or RunOwner.Copilot
             && SettingsViewModel.GameSettings.ManualStopWithScript
             && (owner != RunOwner.Copilot || SettingsViewModel.GameSettings.CopilotWithScript);
 

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -2502,6 +2502,10 @@ public class TaskQueueViewModel : Screen
             return false;
         }
 
+        // 本轮到此收口，清掉任务状态表；否则强收残留的旧 taskId 会让 Core 迟到补发的
+        // TaskChainStopped 通过归属校验，打断此后已开始的新运行
+        Instances.AsstProxy.ClearTasksStatus();
+
         SleepManagement.AllowSleep();
         if (!_runningState.GetIdle() || _runningState.GetStopping())
         {

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -2474,7 +2474,16 @@ public class TaskQueueViewModel : Screen
 
         if (runScript)
         {
-            await RunStopScriptOnceAsync();
+            // 脚本运行期间持有 InterruptLock，防止等待空闲的自动更新安装/定时启动放行打断收尾
+            RunningState.Instance.LockInterrupt();
+            try
+            {
+                await RunStopScriptOnceAsync();
+            }
+            finally
+            {
+                RunningState.Instance.UnlockInterrupt();
+            }
         }
 
         return true;

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -2130,6 +2130,14 @@ public class TaskQueueViewModel : Screen
             return;
         }
 
+        // 停止超时强收后需重启才能再次开任务，同样覆盖热键/托盘/远程等入口
+        if (Bootstrapper.RequiresRestart)
+        {
+            AddLog(LocalizationHelper.GetString("RestartRecommendation"), UiLogColor.Error);
+            _logger.Warning("LinkStart blocked: restart required");
+            return;
+        }
+
         Instances.OverlayViewModel.LogItemsSource = LogItemViewModels;
 
         var buildDateTimeLong = VersionUpdateSettingsUserControlModel.BuildDateTimeCurrentCultureString;
@@ -2379,6 +2387,9 @@ public class TaskQueueViewModel : Screen
             // 超时：Core 未在超时内停止，强制恢复 UI 状态
             _logger.Warning("Stop timeout, force resetting UI state");
             AddLog(LocalizationHelper.GetString("StopTimeout") + "\n" + LocalizationHelper.GetString("RestartRecommendation"), UiLogColor.Error);
+
+            // Core 可能仍挂起并补发迟到 TaskChainStopped，若此后放行新任务，回调会把新运行的归属清掉，故重启前禁止再开任务
+            Bootstrapper.MarkRequiresRestart();
             SetStopped();
             return false;
         }

--- a/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/TaskQueueViewModel.cs
@@ -505,6 +505,12 @@ public class TaskQueueViewModel : Screen
 
     private async Task RunPostActionsCoreAsync()
     {
+        // per-run 幂等：时长上限到点停止与 AllTasksCompleted 自然完成赛跑时只执行一次
+        if (Interlocked.CompareExchange(ref _postActionsLaunched, 1, 0) is not 0)
+        {
+            return;
+        }
+
         var actions = PostActionSetting;
         _logger.Information("Post actions: " + actions.ActionDescription);
 
@@ -672,10 +678,11 @@ public class TaskQueueViewModel : Screen
                 Instances.Data.ClearCache();
             }
 
-            // 每轮运行开始（离开空闲）时重置结束脚本发射权；停止中不重置，避免把已合法发射的标志清零导致二次发射
+            // 每轮运行开始（离开空闲）时重置结束脚本与完成后动作的发射权；停止中不重置，避免把已合法发射的标志清零导致二次发射
             if (e.OldState.Idle && !e.NewState.Idle)
             {
                 Interlocked.Exchange(ref _stopScriptLaunched, 0);
+                Interlocked.Exchange(ref _postActionsLaunched, 0);
             }
 
             if (e.NewState.Idle && _runDurationLimitOnce)
@@ -2406,6 +2413,9 @@ public class TaskQueueViewModel : Screen
 
     // 手动停止的结束脚本发射权，每轮运行开始（离开空闲）时重置；多个手动入口并发时保证只发射一次
     private int _stopScriptLaunched;
+
+    // 完成后动作发射权，每轮运行开始（离开空闲）时重置；时长上限停止与自然完成赛跑时保证只执行一次
+    private int _postActionsLaunched;
 
     /// <summary>
     /// 按 Interlocked 标志去重地执行一次结束脚本（EndsWithScript）。手动停止各入口与自然完成

--- a/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
@@ -343,6 +343,12 @@ public class ToolboxViewModel : Screen
     [UsedImplicitly]
     public async Task RecruitStartCalc()
     {
+        if (Bootstrapper.TryGetTaskBlockReason() is { } reason)
+        {
+            RecruitInfo = reason;
+            return;
+        }
+
         string errMsg = string.Empty;
         RecruitInfo = LocalizationHelper.GetString("ConnectingToEmulator");
         _runningState.BeginRun(RunOwner.Toolbox);
@@ -1151,6 +1157,12 @@ public class ToolboxViewModel : Screen
     [UsedImplicitly]
     public async Task StartDepot()
     {
+        if (Bootstrapper.TryGetTaskBlockReason() is { } reason)
+        {
+            DepotInfo = reason;
+            return;
+        }
+
         _runningState.BeginRun(RunOwner.Toolbox);
         string errMsg = string.Empty;
         DepotInfo = LocalizationHelper.GetString("ConnectingToEmulator");
@@ -1788,8 +1800,16 @@ public class ToolboxViewModel : Screen
     [UsedImplicitly]
     public async Task StartOperBox()
     {
+        // 只拦 Core 本地识别分支；一图流 API 拉取不发 Core 任务，不受限
+        var useYituliuApi = SettingsViewModel.ThirdPartyServiceSettings.EnableOperBoxYituliuApi;
+        if (!useYituliuApi && Bootstrapper.TryGetTaskBlockReason() is { } reason)
+        {
+            OperBoxInfo = reason;
+            return;
+        }
+
         _runningState.BeginRun(RunOwner.Toolbox);
-        if (SettingsViewModel.ThirdPartyServiceSettings.EnableOperBoxYituliuApi)
+        if (useYituliuApi)
         {
             await StartOperBoxFromYituliuApiAsync();
             _runningState.SetIdle(true);
@@ -2084,6 +2104,12 @@ public class ToolboxViewModel : Screen
 
     public async Task StartGacha(bool once = true)
     {
+        if (Bootstrapper.TryGetTaskBlockReason() is { } reason)
+        {
+            GachaInfo = reason;
+            return;
+        }
+
         _runningState.BeginRun(RunOwner.Toolbox);
 
         string errMsg = string.Empty;
@@ -3094,6 +3120,12 @@ public class ToolboxViewModel : Screen
 
     private async Task StartMiniGameAsync()
     {
+        if (Bootstrapper.TryGetTaskBlockReason() is { } reason)
+        {
+            Instances.TaskQueueViewModel.AddLog(reason, UiLogColor.Error);
+            return;
+        }
+
         var isPixelPaint = IsPixelPaintSelected;
         if (isPixelPaint && (_pixelPaintResult == null || _pixelPaintResult.Groups.Count == 0))
         {

--- a/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
+++ b/src/MaaWpfGui/ViewModels/UI/ToolboxViewModel.cs
@@ -1730,6 +1730,7 @@ public class ToolboxViewModel : Screen
         {
             _logger.Error("Failed to load operator box from yituliu open-api: {Message}", e.Message);
             OperBoxInfo = LocalizationHelper.GetString("YituliuTokenNetworkError");
+            Instances.TaskQueueViewModel.AddLog(OperBoxInfo, UiLogColor.Error);
             return false;
         }
     }

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/InfrastSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/InfrastSettingsUserControlModel.cs
@@ -103,7 +103,7 @@ public class InfrastSettingsUserControlModel : TaskSettingsViewModel, InfrastSet
             {
                 if (!set.Contains(room))
                 {
-                    list.Add(new InfrastTask.RoomInfo(room, room == InfrastRoomType.AssistantChange));
+                    list.Add(new InfrastTask.RoomInfo(room, false));
                 }
             }
             SetTaskConfig<InfrastTask>(t => t.RoomList.SequenceEqual(list), t => t.RoomList = list);

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/UserDataUpdateSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/UserDataUpdateSettingsUserControlModel.cs
@@ -27,6 +27,7 @@ using MaaWpfGui.Helper;
 using MaaWpfGui.Services;
 using MaaWpfGui.Utilities.ValueType;
 using MaaWpfGui.ViewModels.UI;
+using Serilog;
 using Stylet;
 using static MaaWpfGui.Main.AsstProxy;
 
@@ -34,6 +35,8 @@ namespace MaaWpfGui.ViewModels.UserControl.TaskQueue;
 
 public class UserDataUpdateSettingsUserControlModel : TaskSettingsViewModel, UserDataUpdateSettingsUserControlModel.ISerialize
 {
+    private static readonly ILogger _logger = Log.ForContext<UserDataUpdateSettingsUserControlModel>();
+
     static UserDataUpdateSettingsUserControlModel()
     {
         Instance = new();
@@ -186,10 +189,19 @@ public class UserDataUpdateSettingsUserControlModel : TaskSettingsViewModel, Use
     /// <returns>Task</returns>
     private static async Task SyncOperBoxFromYituliuApiAsync(BaseTask baseTask)
     {
-        var success = await Instances.ToolboxViewModel.StartOperBoxFromYituliuApiAsync();
-        if (success)
+        var success = false;
+        try
         {
-            Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("YituliuOperBoxCompleted"), UiLogColor.Info, splitMode: TaskQueueViewModel.LogCardSplitMode.Both);
+            success = await Instances.ToolboxViewModel.StartOperBoxFromYituliuApiAsync();
+            if (success)
+            {
+                Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("YituliuOperBoxCompleted"), UiLogColor.Info, splitMode: TaskQueueViewModel.LogCardSplitMode.Both);
+            }
+        }
+        catch (Exception e)
+        {
+            // 调用方 fire-and-forget 不 await，异常若无人观察，下方条目状态更新不会执行而永远停在运行中
+            _logger.Error(e, "Failed to sync operator box from yituliu open-api");
         }
 
         var index = ConfigFactory.CurrentConfig.TaskQueue.IndexOf(baseTask);

--- a/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/UserDataUpdateSettingsUserControlModel.cs
+++ b/src/MaaWpfGui/ViewModels/UserControl/TaskQueue/UserDataUpdateSettingsUserControlModel.cs
@@ -202,6 +202,10 @@ public class UserDataUpdateSettingsUserControlModel : TaskSettingsViewModel, Use
         {
             // 调用方 fire-and-forget 不 await，异常若无人观察，下方条目状态更新不会执行而永远停在运行中
             _logger.Error(e, "Failed to sync operator box from yituliu open-api");
+
+            // 内层已 catch 并 return false，正常失败不会抛到这里；此处只接内层 try 之前的意外异常，
+            // 补用户可见反馈与内层兜底 catch 一致
+            Instances.TaskQueueViewModel.AddLog(LocalizationHelper.GetString("YituliuTokenNetworkError"), UiLogColor.Error);
         }
 
         var index = ConfigFactory.CurrentConfig.TaskQueue.IndexOf(baseTask);


### PR DESCRIPTION
对 v6.17.5..dev-v2 的发布前审查发现的问题修复。

## 更新失败链路

- 注册新更新包时清除更新失败标志，修复 ｢更新失败 → 自动修复下载完整包 → 重启后待装包被清空 → 修复死循环｣
- 更新器仅在实际改动过安装文件后失败才写失败标志：预检失败（另一实例运行、盘符根目录安装、计划文件缺失）不再把完好的安装标记为资源损坏并拦截全部任务

## 停止与完成链路

- 停止超时强收后需重启才能再次开始任务，防止 Core 补发的迟到 TaskChainStopped 回调打断新运行、导致完成后动作静默丢失
- 完成后动作按轮次幂等，运行时长上限到点停止与自然完成赛跑时不再双执行
- 手动停止的结束脚本执行期间持有中断锁，防止等待空闲的自动更新安装/定时启动打断收尾
- 结束脚本仅对主任务队列与 copilot 归属发射，小游戏/工具箱轮次各停止入口行为统一

## 一图流干员识别

- 意外异常补队列日志与任务条目状态反馈，fire-and-forget 链路异常不再静默
- 外部请求头改用 TryAddWithoutValidation，凭据不再随异常消息泄漏进日志

## 其他

- 基建副手换人房间补全时默认不启用，未解锁副手的账号不再每次收菜静默重试
- 修正 ｢社群的意义｣ 技能效率分支的 icon（原条件与上一分支重复导致不可达）

## Sourcery 摘要

加强更新恢复和任务生命周期处理，同时改进错误报告并修正基础设施助手配置。

错误修复：
- 防止更新预检查失败将正常安装标记为损坏，并在注册新的更新包时清除过时的失败状态。
- 停止超时后要求应用重启，以防止延迟回调破坏后续任务运行。
- 确保每次运行中完成后操作和手动停止脚本最多执行一次，同时防止脚本清理期间被中断。
- 将停止脚本限制为任务队列和 copilot 运行，并统一其他运行类型的停止行为。
- 在任务日志中显示操作员框同步失败，并确保即发即弃的错误不会使任务卡在进行中状态。
- 修正基础设施助手变更技能图标，并为新完成的房间条目禁用自动助手变更。

增强功能：
- 改进外部标头处理，避免凭据泄露到异常日志中。
- 增加对意外操作员框加载失败的错误可见性。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

强化更新恢复和任务生命周期处理，提升操作错误的可见性，并修正基础设施助手配置。

错误修复：
- 防止更新预检查失败将原本健康的安装标记为损坏，并在注册新更新包时清除过期的失败状态。
- 停止超时后要求重启应用，以防延迟回调干扰后续任务。
- 确保每次任务运行中，完成操作和手动停止脚本最多执行一次，同时防止停止脚本清理过程被中断。
- 将手动停止脚本限制为主任务队列和 copilot 运行，并统一其他运行类型的停止行为。
- 在任务日志中显示操作盒同步失败，并防止意外的 fire-and-forget 错误导致任务卡在进行中状态。
- 修正基础设施助手变更效果的技能图标映射。
- 默认禁用新添加基础设施房间的助手变更。

增强功能：
- 改进外部请求标头处理，防止格式错误的凭据值泄漏到异常日志中。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

强化更新恢复和任务生命周期处理，同时提升错误可见性并修正基础设施助手的默认设置。

错误修复：
- 防止更新预检失败将正常安装标记为损坏，并在注册新的更新包时清除过期的失败状态。
- 强制停止超时后要求应用重启，以防延迟回调干扰后续任务。
- 确保完成操作和手动停止脚本在每次任务运行中最多执行一次，防止停止脚本清理过程被中断，并将脚本限制为仅在主任务和 copilot 运行中执行。
- 显示操作员盒同步失败，并防止即发即弃的错误导致任务条目卡在进行中状态。
- 默认禁用新添加基础设施房间的助手变更，并修正“Meaning of Community”技能的图标映射。

增强功能：
- 集中处理损坏资源和需要重启的会话的任务启动拦截，覆盖任务、copilot、远程控制、工具箱和自动启动入口。
- 处理外部请求标头，同时避免通过验证异常或日志暴露凭据值。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

强化更新恢复和任务生命周期处理，同时提升错误可见性并修正基础设施助手默认设置。

错误修复：
- 防止更新前置检查失败将健康安装标记为损坏，并在注册新的更新包时清除过时的失败状态。
- 强制停止超时后要求应用重启，以防止延迟回调干扰后续运行。
- 确保完成操作和手动停止脚本在每次运行中最多执行一次，防止脚本清理被中断，并将脚本限制为仅在主任务和 copilot 运行中执行。
- 当资源损坏或需要重启时，统一阻止任务、copilot、远程控制、工具箱和自动启动入口启动任务。
- 显示操作员盒同步失败，并防止异步错误导致更新条目一直处于进行中状态。
- 默认禁用新添加基础设施房间中的助手变更，并修正 Meaning of Community 技能图标映射。

改进：
- 处理外部请求标头，避免通过验证异常或日志暴露凭据值。

<details>
<summary>Original summary in English</summary>

## Sourcery 摘要

加强更新恢复和任务生命周期安全性，同时提升错误可见性并改进基础设施助手的默认设置。

错误修复：
- 防止更新预检查失败将正常安装标记为损坏；注册新的更新包时清除过时的失败状态；并将回滚和失败报告限制为修改过安装文件的更新。
- 强制停止超时后要求应用重启，以防止延迟回调干扰后续运行。
- 确保完成操作和手动停止脚本在每次运行中最多执行一次；避免停止脚本的清理过程被中断；并将脚本限制为主任务和 copilot 运行。
- 防止在资源损坏或需要重启时启动被阻止的任务入口点，并向用户显示操作员箱同步失败信息。
- 修正基础设施助手技能图标映射，并默认禁用新添加房间中的助手变更。

增强功能：
- 改进外部请求标头处理，同时避免在验证错误或日志中暴露凭据值。
- 统一任务、copilot、远程控制、工具箱和自动启动流程中的任务启动阻止检查。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

强化更新恢复和任务生命周期处理，同时提升错误可见性并改进基础设施助手的默认设置。

Bug 修复：
- 防止更新前置检查失败将正常安装标记为损坏；注册新的更新包时清除过期的失败状态；并将回滚和失败报告限制为实际修改了安装文件的更新。
- 强制停止超时后要求重启应用，以防延迟回调干扰后续任务。
- 确保每次任务运行中，完成操作和手动停止脚本最多执行一次；保护停止脚本清理流程不被中断；并将脚本执行限制在主任务和 copilot 运行中。
- 当资源损坏或需要重启时，统一阻止任务启动；并向用户显示 operator-box 同步失败信息。
- 将新添加的基础设施房间默认设置为禁用助手更改，并修正 Meaning of Community 技能图标映射。

改进：
- 改进外部请求标头处理，避免格式错误的凭据值泄露到异常日志中。
- 提高 fire-and-forget operator-box 同步过程中意外错误的可见性。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Harden update recovery and task lifecycle handling while improving error visibility and infrastructure assistant defaults.

Bug Fixes:
- Prevent failed update prechecks from marking healthy installations as corrupted, clear stale failure state when a new update package is registered, and limit rollback and failure reporting to updates that modified installation files.
- Require an application restart after a forced stop timeout to prevent delayed callbacks from disrupting subsequent tasks.
- Ensure completion actions and manual stop scripts run at most once per task run, protect stop-script cleanup from interruption, and limit scripts to main task and copilot runs.
- Apply consistent task-start blocking when resources are broken or a restart is required, and surface operator-box synchronization failures to users.
- Default newly added infrastructure rooms to assistant-change disabled and correct the Meaning of Community skill icon mapping.

Enhancements:
- Improve external request-header handling so malformed credential values do not leak into exception logs.
- Increase visibility of unexpected errors in fire-and-forget operator-box synchronization.

</details>

</details>

</details>

</details>

</details>

</details>