### PR TITLE
fix: 关卡信息展开页面下，未知的凶戾合并计算为普通作战

### DIFF
--- a/resource/roguelike/BlackFlow/node_execution.json
+++ b/resource/roguelike/BlackFlow/node_execution.json
@@ -524,10 +524,6 @@
             "node_type": "expedition"
         },
         {
-            "text": "未知的凶戾",
-            "node_type": "hide_battle"
-        },
-        {
             "text": "未知的诡秘",
             "node_type": "hide_invisible"
         },

--- a/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowSession.cpp
+++ b/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowSession.cpp
@@ -1533,10 +1533,17 @@ PreviewDisposition BlackFlowSession::accept_preview(MovePreview preview, std::st
         preview.reachability = PreviewReachability::InsufficientActionPoints;
     }
     const PreviewReachability reachability = preview.reachability;
+    const MoveCandidate proposal = m_transaction->proposal();
+    const Node* existing = proposal.target == InvalidNodeId ? nullptr : m_map.snapshot().find_node(proposal.target);
+    if (preview.reachability == PreviewReachability::Reachable && existing != nullptr &&
+        existing->type == NodeType::HideBattle && preview.displayed_type == NodeType::BattleNormal) {
+        preview.displayed_type = existing->type;
+        preview.displayed_name = existing->name;
+        preview.identity_revealed = existing->identity_revealed;
+    }
     if (!m_transaction->record_preview(preview, error)) {
         return PreviewDisposition::Failed;
     }
-    const MoveCandidate proposal = m_transaction->proposal();
     if (m_transaction->stage() == MoveTransactionStage::Cancelled) {
         m_unreachable_actions.emplace(proposal.action_id);
         m_verified_move_arc.reset();
@@ -1571,7 +1578,6 @@ PreviewDisposition BlackFlowSession::accept_preview(MovePreview preview, std::st
     }
 
     bool changed = false;
-    const Node* existing = proposal.target == InvalidNodeId ? nullptr : m_map.snapshot().find_node(proposal.target);
     if (proposal.controllable && existing == nullptr) {
         if (error != nullptr) {
             *error = "preview target disappeared from normalized map";

--- a/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowTaskPort.cpp
+++ b/src/MaaCore/Task/Roguelike/BlackFlow/BlackFlowTaskPort.cpp
@@ -371,7 +371,7 @@ MoveConfirmationStatus BlackFlowTaskPort::confirm(
     }
 
     entered_page = {};
-    if (transaction.preview()->identity_revealed) {
+    if (transaction.preview()->identity_revealed || transaction.preview()->displayed_type == NodeType::HideBattle) {
         return MoveConfirmationStatus::Succeeded;
     }
     return classify_entered_page(m_task_context->capture(), entered_page, error) ? MoveConfirmationStatus::Succeeded


### PR DESCRIPTION
“未知的凶戾”节点在移动预览中识别到“作战”时，会被当作普通作战更新身份，触发取消预览和重新规划。再次识别地图后，节点恢复为隐藏作战，导致重复打开、取消预览。

当地图目标为隐藏作战、预览识别为普通作战时，保留原节点身份并接受预览；移动确认成功后跳过隐藏作战的入场分类，继续沿作战页面流程执行。移动预览 OCR 候选移除“未知的凶戾”，地图识别保持不变。

不调整roi，一是为了留容错，二是避免把所有战斗关卡的名字都写进json里、增加维护成本。
ocr是从上到下返回的，所以没法加正则（issue中识别到的是“未知的凶”）

<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/c8081caa-8410-4c25-a3bc-0eed95366d0e" />


## 设计记录
BlackFlowSession.cpp  的处理，放在了 record_preview() 之前。这样事务保存的预览、后面的检查，以及提交时的页面身份解析，使用的是同一份修正后的数据。若只在局部比较时忽略类型差异，后续仍可能读取事务中保存的 BattleNormal

恢复 displayed_type、displayed_name、identity_revealed 三个字段是必要的，因为后面的 changed 条件会逐一比较这三项。当前处理使它们与地图节点保持一致，在费用相同、其余检查通过的情况下，不会因这次预览修改地图版本或要求取消重规划。

提前取得 existing 指针没有引入生命周期问题。两次使用之间的 record_preview() 只更新事务自身，不修改地图容器。

<br>
<br>

BlackFlowTaskPort.cpp 里，确认完传入空的 EnteredPageObservation 是设计。resolve_page_identity() 会采用事务预览中的类型和名称，因此得到 HideBattle；现有 combat 路由包含 hide_battle，对应的 Page-Combat 接着进入 QuickFormation。所以能够接上既有作战流程。

fix: #17826

## Sourcery 总结

稳定对暂时被识别为普通战斗的隐藏战斗节点的移动预览和确认流程。

Bug 修复：
- 防止移动预览期间被误识别为普通战斗的隐藏战斗节点触发不必要的预览取消和重新规划。
- 移动确认成功后跳过重复的隐藏战斗入口分类，使现有战斗流程能够继续执行。

增强功能：
- 接受可到达的预览时，如果将隐藏战斗识别为普通战斗，则保留地图节点的身份。
- 从移动预览的 OCR 候选项中移除隐藏战斗标签，同时保持地图识别不变。

<details>
<summary>Original summary in English</summary>

## Sourcery 总结

稳定对暂时被识别为普通战斗的隐藏战斗节点进行移动预览和确认处理。

错误修复：
- 防止隐藏战斗节点在移动预览期间被误识别为普通战斗，从而触发不必要的预览取消和重新规划。
- 确认移动进入隐藏战斗后，继续现有的战斗流程，而不重复进行隐藏战斗进入分类。

增强功能：
- 当预览将隐藏战斗节点识别为普通战斗时，保留其地图身份，同时将预览 OCR 候选项限制为通用战斗标签。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Stabilize movement preview and confirmation handling for hidden battle nodes that are temporarily recognized as normal battles.

Bug Fixes:
- Prevent hidden battle nodes misidentified as normal battles during movement previews from triggering unnecessary preview cancellation and replanning.
- Continue the existing combat flow after confirming movement into a hidden battle without repeating hidden-battle entry classification.

Enhancements:
- Preserve the map identity of hidden battle nodes when previews recognize them as normal battles, while limiting preview OCR candidates to the generic battle label.

</details>

</details>